### PR TITLE
Add prod/dev environment split, fix beartype, and configure Zed LSP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,7 +96,6 @@ cython_debug/
 # IDE
 .idea/
 .vscode/
-.zed/
 
 # Package top-level data directories (downloaded assets, not Python package data/)
 packages/monoprior/data/

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,33 @@
+{
+  "languages": {
+    "Python": {
+      "code_actions_on_format": {
+        "source.organizeImports.ruff": true
+      },
+      "formatter": {
+        "language_server": {
+          "name": "ruff"
+        }
+      },
+      "language_servers": ["!basedpyright", "ruff", "!ty", "pyrefly", "!pyright", "!pylsp", "..."]
+    }
+  },
+  "lsp": {
+    "pyrefly": {
+      "binary": {
+        "path": ".pixi/envs/dev/bin/pyrefly",
+        "arguments": ["lsp"]
+      },
+      "settings": {
+        "python": {
+          "pythonPath": ".pixi/envs/dev/bin/python"
+        }
+      }
+    },
+    "ruff": {
+      "binary": {
+        "path": ".pixi/envs/dev/bin/ruff"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,119 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+A **Pixi workspace monorepo** of computer vision projects. Each package lives in `packages/<name>/` with its own Python module, CLI tools, and tests. All Pixi configuration (deps, tasks, environments) lives in the root `pixi.toml` — per-package `pyproject.toml` files only have standard Python packaging metadata.
+
+## Packages & Environments
+
+Each package has a **prod** environment (for running demos/apps) and a **dev** environment (adds ruff, pytest, beartype, pyrefly):
+
+| Package | Prod env | Dev env | Module path | GPU |
+|---|---|---|---|---|
+| monoprior | `monoprior` | `monoprior-dev` | `packages/monoprior/monopriors/` | CUDA 12.9 |
+| wilor-nano | `wilor` | `wilor-dev` | `packages/wilor-nano/src/wilor_nano/` | CUDA 12.9 |
+| sam3d-body-rerun | `sam3d` | `sam3d-dev` | `packages/sam3d-body-rerun/src/sam3d_body/` | CUDA 12.9 |
+| sam3-rerun | `sam3-rerun` | `sam3-rerun-dev` | `packages/sam3-rerun/src/sam3_rerun/` | CUDA 12.9 |
+| robocap-slam | `robocap` | `robocap-dev` | `packages/robocap-slam/robocap_slam/` | None (CPU) |
+
+## Common Commands
+
+Always specify the environment with `-e`:
+
+```bash
+# Install an environment
+pixi install -e monoprior        # prod only
+pixi install -e monoprior-dev    # dev (includes ruff, pytest, beartype, pyrefly)
+
+# List tasks for an environment
+pixi task list -e monoprior-dev
+
+# Lint, typecheck, test (unified task names across all *-dev envs)
+pixi run -e monoprior-dev lint
+pixi run -e monoprior-dev typecheck
+pixi run -e monoprior-dev tests
+
+pixi run -e robocap-dev lint
+pixi run -e robocap-dev typecheck
+pixi run -e robocap-dev tests
+
+# Run a single test file
+pixi run -e monoprior-dev -- pytest tests/test_specific.py -q
+
+# Run demos (prod env is sufficient)
+pixi run -e monoprior relative-depth
+pixi run -e robocap robocap-track
+```
+
+Dev tasks (`lint`, `typecheck`, `tests`) are unified — same name in every `*-dev` environment. Demo/app tasks live in the package's own feature and work in both prod and dev envs.
+
+## Architecture
+
+### pixi.toml Feature Composition
+
+Dependencies are organized as composable **features** in root `pixi.toml`:
+
+- **`common`** — shared deps all envs get (numpy, opencv, rerun-sdk, gradio, jaxtyping, etc.)
+- **`cuda`** — CUDA 12.9 toolkit + PyTorch GPU
+- **`dev`** — ruff, pytest, beartype, pyrefly, hypothesis + sets `PIXI_DEV_MODE=1`
+- **Per-package features** — package-specific deps, editable install, tasks (with `cwd = "packages/<dir>"`) + sets `PACKAGE_DIR`
+
+Each environment has its own **solve-group** for independent dependency resolution. Prod/dev pairs share the same solve-group (no extra resolution cost). Per-package features can **tighten** common's loose version constraints.
+
+### Beartype Activation
+
+Beartype is activated conditionally via `PIXI_DEV_MODE` (set by the `dev` feature's activation env):
+```python
+import os
+if os.environ.get("PIXI_DEV_MODE") == "1":
+    from beartype.claw import beartype_this_package
+    beartype_this_package()
+```
+
+This means beartype only runs in `*-dev` environments. No try/except needed since beartype is always available when `PIXI_DEV_MODE` is set.
+
+### Package Internal Structure
+
+Each package follows roughly:
+```
+packages/<name>/
+  pyproject.toml          # [project], [build-system], [tool.ruff], [tool.pyrefly]
+  <module>/
+    __init__.py           # Beartype activation (conditional on PIXI_DEV_MODE)
+    apis/                 # High-level inference interfaces
+    models/               # Model implementations
+    data/                 # Data loading (often a git submodule)
+    gradio_ui/            # Gradio components (if applicable)
+  tools/                  # CLI scripts (demos/ and apps/ subdirs)
+  tests/
+```
+
+### Key External Dependencies
+
+- **simplecv** (git dep) — camera parameters, Rerun logging utilities, shared across packages (pinned to different revs per package)
+- **rerun-sdk** — 3D visualization, deeply integrated in all inference pipelines
+- **gradio + gradio-rerun** — interactive web UIs with embedded Rerun viewer
+- **moge** (Microsoft) — depth and surface normal prediction (requires `no-build-isolation`)
+- **tyro** — CLI argument parsing from dataclass configs
+
+### Ruff Config (consistent across packages)
+
+- Line length: 150
+- Rules: E, F, UP, B, SIM, I
+- Ignored: E501 (line too long), F722/F821 (jaxtyping compatibility), UP037/UP040, SIM901
+
+### Dependency Overrides
+
+Workspace-level `[pypi-options.dependency-overrides]` in root `pixi.toml` overrides transitive dependency pins (gradio, rerun-sdk, iopath, fsspec). Check these when debugging version conflicts.
+
+## Gotchas
+
+- **Never use pip** — all dependency management goes through Pixi
+- **`hf download` not `huggingface-cli`** — conda's huggingface_hub provides `hf`, not `huggingface-cli`
+- **Download tasks are idempotent** — they check `test -d data/...` before downloading
+- **gradio from PyPI, not conda** — conda's gradio package has missing transitive deps
+- **`moge` needs no-build-isolation** — it requires torch at build time (configured in `[pypi-options]`)
+- **sam3d-body-rerun uses `tool/` (singular)** not `tools/` for its CLI scripts
+- **Dev tasks use `$PACKAGE_DIR`** — each package feature sets `PACKAGE_DIR` via activation env, dev tasks `cd $PACKAGE_DIR` before running

--- a/README.md
+++ b/README.md
@@ -4,27 +4,33 @@ A pixi workspace containing multiple computer vision example projects, each with
 
 ## Packages
 
-| Package | Environment | Python | GPU | Description |
-|---|---|---|---|---|
-| [monoprior](packages/monoprior/) | `monoprior` | 3.12 | CUDA 12.8 | Monocular geometric priors (depth, normals) |
-| [wilor-nano](packages/wilor-nano/) | `wilor` | 3.12 | CUDA 12.8 | Hand pose estimation |
-| [sam3d-body-rerun](packages/sam3d-body-rerun/) | `sam3d` | 3.12 | CUDA 12.9 | 3D body segmentation with SAM + Rerun |
-| [robocap-slam](packages/robocap-slam/) | `robocap` | 3.10 | None | Multi-camera visual odometry & SLAM |
+| Package | Prod env | Dev env | Python | GPU | Description |
+|---|---|---|---|---|---|
+| [monoprior](packages/monoprior/) | `monoprior` | `monoprior-dev` | 3.12 | CUDA 12.9 | Monocular geometric priors (depth, normals) |
+| [wilor-nano](packages/wilor-nano/) | `wilor` | `wilor-dev` | 3.12 | CUDA 12.9 | Hand pose estimation |
+| [sam3d-body-rerun](packages/sam3d-body-rerun/) | `sam3d` | `sam3d-dev` | 3.12 | CUDA 12.9 | 3D body segmentation with SAM + Rerun |
+| [sam3-rerun](packages/sam3-rerun/) | `sam3-rerun` | `sam3-rerun-dev` | 3.12 | CUDA 12.9 | SAM3 video segmentation with Rerun |
+| [robocap-slam](packages/robocap-slam/) | `robocap` | `robocap-dev` | 3.10 | None | Multi-camera visual odometry & SLAM |
 
 ## Quick start
 
 ```bash
-pixi install -e robocap        # Install one environment
-pixi run -e robocap robocap-track  # Run a task
+pixi install -e robocap            # Install prod environment
+pixi run -e robocap robocap-track  # Run a demo task
+
+pixi install -e robocap-dev        # Install dev environment (adds ruff, pytest, beartype, pyrefly)
+pixi run -e robocap-dev lint       # Lint
+pixi run -e robocap-dev typecheck  # Typecheck
+pixi run -e robocap-dev tests      # Run tests
 ```
 
 ## Listing tasks
 
-Use `-e` to filter tasks by environment (recommended — without it you see all ~30 tasks):
+Use `-e` to filter tasks by environment (recommended — without it you see all tasks):
 
 ```bash
-pixi task list -e robocap
-pixi task list -e sam3d
+pixi task list -e robocap       # Demo/app tasks only
+pixi task list -e robocap-dev   # Demo/app tasks + lint, typecheck, tests
 ```
 
 ## Running from a package subdirectory
@@ -49,16 +55,16 @@ The root `pixi.toml` is structured around **features** that compose into **envir
 [pypi-options]                  # Workspace-level: no-build-isolation, dependency-overrides
 
 [feature.common]                # Shared base deps (all envs get these)
-[feature.cuda128]               # CUDA 12.8 toolkit
-[feature.cuda129]               # CUDA 12.9 toolkit
-[feature.dev-tools]             # ruff, pytest, beartype, pyrefly, hypothesis
+[feature.cuda]                  # CUDA 12.9 toolkit + PyTorch GPU
+[feature.dev]                   # ruff, pytest, beartype, pyrefly, hypothesis + PIXI_DEV_MODE=1
 
-[feature.monoprior]             # Package-specific: conda deps, pypi deps, tasks
+[feature.monoprior]             # Package-specific: conda deps, pypi deps, tasks, PACKAGE_DIR
 [feature.wilor]                 #   "
 [feature.sam3d]                 #   "
+[feature.sam3-rerun]            #   "
 [feature.robocap]               #   "
 
-[environments]                  # Compose features into named environments
+[environments]                  # Compose features into named environments (prod + dev per package)
 ```
 
 ### Features
@@ -69,28 +75,35 @@ The root `pixi.toml` is structured around **features** that compose into **envir
 |---|---|
 | av, rerun-sdk (>=0.28.1,<0.29), py-opencv, numpy, pyserde, jaxtyping, hf-transfer, scipy, huggingface_hub, tqdm | gradio, gradio-rerun |
 
-**`cuda128`** / **`cuda129`** — Named CUDA features with the full toolkit (compiler, cudnn, cublas, etc.). Attached to environments that need GPU. Adding a future CUDA version is a new root feature, not a per-package change.
+**`cuda`** — CUDA 12.9 toolkit with the full set of libraries (compiler, cudnn, cublas, etc.) and PyTorch GPU. Attached to environments that need GPU.
 
-**`dev-tools`** — ruff, pytest, beartype, pyrefly, hypothesis, types-tqdm. Included in every environment so there's no need for separate dev environments.
+**`dev`** — ruff, pytest, beartype, pyrefly, hypothesis, types-tqdm. Sets `PIXI_DEV_MODE=1` via activation env. Provides unified `lint`, `typecheck`, and `tests` tasks that use `$PACKAGE_DIR` (set by each package feature).
 
-**Per-package features** (`monoprior`, `wilor`, `sam3d`, `robocap`) contain:
+**Per-package features** (`monoprior`, `wilor`, `sam3d`, `sam3-rerun`, `robocap`) contain:
 - Python version pin
 - Deps that **override** common (e.g. `jaxtyping = "<0.3.0"` tightens common's `"*"`)
 - Deps **not** in common (package-specific libraries)
 - Editable install of the package itself
 - Git/PyPI dependencies (simplecv, torch, etc.)
-- All tasks with `cwd = "packages/<dir>"` for correct path resolution
+- Demo/app tasks with `cwd = "packages/<dir>"` for correct path resolution
+- `PACKAGE_DIR` activation env (used by dev tasks)
 
 ### Environments and solve-groups
 
-Each environment has its own **solve-group**, so dependency versions are resolved independently:
+Each package has a **prod** and **dev** environment sharing the same **solve-group**:
 
 ```toml
 [environments]
-monoprior = { features = ["common", "cuda128", "monoprior", "dev-tools"], solve-group = "monoprior", no-default-feature = true }
-wilor     = { features = ["common", "cuda128", "wilor",     "dev-tools"], solve-group = "wilor",     no-default-feature = true }
-sam3d     = { features = ["common", "cuda129", "sam3d",     "dev-tools"], solve-group = "sam3d",     no-default-feature = true }
-robocap   = { features = ["common",            "robocap",   "dev-tools"], solve-group = "robocap",   no-default-feature = true }
+monoprior      = { features = ["common", "cuda", "monoprior"],              solve-group = "monoprior",  no-default-feature = true }
+monoprior-dev  = { features = ["common", "cuda", "monoprior", "dev"],       solve-group = "monoprior",  no-default-feature = true }
+wilor          = { features = ["common", "cuda", "wilor"],                  solve-group = "wilor",      no-default-feature = true }
+wilor-dev      = { features = ["common", "cuda", "wilor", "dev"],           solve-group = "wilor",      no-default-feature = true }
+sam3d          = { features = ["common", "cuda", "sam3d"],                  solve-group = "sam3d",      no-default-feature = true }
+sam3d-dev      = { features = ["common", "cuda", "sam3d", "dev"],           solve-group = "sam3d",      no-default-feature = true }
+sam3-rerun     = { features = ["common", "cuda", "sam3-rerun"],             solve-group = "sam3-rerun", no-default-feature = true }
+sam3-rerun-dev = { features = ["common", "cuda", "sam3-rerun", "dev"],      solve-group = "sam3-rerun", no-default-feature = true }
+robocap        = { features = ["common", "robocap"],                        solve-group = "robocap",    no-default-feature = true }
+robocap-dev    = { features = ["common", "robocap", "dev"],                 solve-group = "robocap",    no-default-feature = true }
 ```
 
 `no-default-feature = true` means the root `[dependencies]` (empty) is not included — each env is fully defined by its features.
@@ -145,32 +158,30 @@ The conda `huggingface_hub` package provides the `hf` binary, not `huggingface-c
 ### Run demos
 
 ```bash
-pixi run -e monoprior monoprior-polycam-inference  # Downloads data first
+pixi run -e monoprior polycam-inference    # Downloads data first
 pixi run -e wilor wilor-image-example
-pixi run -e sam3d sam3d-app                        # Gradio UI
-pixi run -e robocap robocap-track-slam             # Downloads data first
+pixi run -e sam3d sam3d-app                # Gradio UI
+pixi run -e robocap robocap-track-slam     # Downloads data first
 ```
 
-### Lint & typecheck
+### Lint, typecheck & test
 
-Every package has `<pkg>-lint` and `<pkg>-typecheck` tasks:
-
-```bash
-pixi run -e robocap robocap-lint
-pixi run -e robocap robocap-typecheck
-```
-
-### Run tests
+All dev tasks use unified names in `*-dev` environments:
 
 ```bash
-pixi run -e monoprior monoprior-tests
-pixi run -e wilor wilor-tests
+pixi run -e monoprior-dev lint
+pixi run -e monoprior-dev typecheck
+pixi run -e monoprior-dev tests
+
+pixi run -e wilor-dev lint
+pixi run -e robocap-dev typecheck
 ```
 
 ## Project structure
 
 ```
 pixi.toml                         # Workspace manifest (features, envs, tasks, deps)
+pyrefly.toml                      # Root pyrefly config (for IDE/Zed LSP)
 .gitignore                        # Merged patterns from all packages
 packages/
   monoprior/
@@ -187,10 +198,17 @@ packages/
     pyproject.toml
     src/sam3d_body/               # Python package (includes sam3d_body/data/ submodule)
     tool/                         # CLI scripts (note: singular "tool")
+    tests/
+  sam3-rerun/
+    pyproject.toml
+    src/sam3_rerun/
+    tools/
+    tests/
   robocap-slam/
     pyproject.toml
     robocap_slam/                 # Python package (includes robocap_slam/data/ submodule)
     tools/
+    tests/
 ```
 
 ## Adding a new package
@@ -201,7 +219,10 @@ packages/
 4. Add a new feature in root `pixi.toml`:
    - `[feature.<name>.dependencies]` — Python pin + package-specific conda deps
    - `[feature.<name>.pypi-dependencies]` — editable install + git deps
-   - `[feature.<name>.tasks.*]` — tasks with `cwd = "packages/<name>"`
-5. Add an environment in `[environments]` composing common + cuda (if needed) + package + dev-tools
+   - `[feature.<name>.activation.env]` — set `PACKAGE_DIR = "packages/<name>"`
+   - `[feature.<name>.tasks.*]` — demo/app tasks with `cwd = "packages/<name>"`
+5. Add two environments in `[environments]`:
+   - `<name> = { features = ["common", "cuda", "<name>"], solve-group = "<name>", no-default-feature = true }`
+   - `<name>-dev = { features = ["common", "cuda", "<name>", "dev"], solve-group = "<name>", no-default-feature = true }`
 6. Add `packages/<name>/data/` to `.gitignore`
-7. Run `pixi install -e <name>` to verify
+7. Run `pixi install -e <name>-dev` to verify

--- a/packages/monoprior/monopriors/__init__.py
+++ b/packages/monoprior/monopriors/__init__.py
@@ -1,3 +1,6 @@
-from beartype.claw import beartype_this_package
+import os
 
-beartype_this_package()
+if os.environ.get("PIXI_DEV_MODE") == "1":
+    from beartype.claw import beartype_this_package
+
+    beartype_this_package()

--- a/packages/monoprior/tests/test_import.py
+++ b/packages/monoprior/tests/test_import.py
@@ -1,0 +1,5 @@
+"""Smoke test: verify the monopriors package can be imported."""
+
+
+def test_import_monopriors() -> None:
+    import monopriors  # noqa: F401

--- a/packages/robocap-slam/pyproject.toml
+++ b/packages/robocap-slam/pyproject.toml
@@ -27,3 +27,7 @@ ignore = [
     "UP037",  # Remove quotes false positive with jaxtyping
     "UP040",  # Beartype requires TypeAlias, not PEP 695 type
 ]
+
+[tool.pyrefly]
+project-includes = ["**/*"]
+project-excludes = ["**/node_modules", "**/__pycache__", "**/*venv/**/*"]

--- a/packages/robocap-slam/robocap_slam/__init__.py
+++ b/packages/robocap-slam/robocap_slam/__init__.py
@@ -2,10 +2,7 @@
 
 import os
 
-if os.environ.get("PIXI_ENVIRONMENT_NAME") == "dev":
-    try:
-        from beartype.claw import beartype_this_package
+if os.environ.get("PIXI_DEV_MODE") == "1":
+    from beartype.claw import beartype_this_package
 
-        beartype_this_package()
-    except ImportError:
-        pass
+    beartype_this_package()

--- a/packages/robocap-slam/tests/test_import.py
+++ b/packages/robocap-slam/tests/test_import.py
@@ -1,0 +1,5 @@
+"""Smoke test: verify the robocap_slam package can be imported."""
+
+
+def test_import_robocap_slam() -> None:
+    import robocap_slam  # noqa: F401

--- a/packages/sam3-rerun/src/sam3_rerun/__init__.py
+++ b/packages/sam3-rerun/src/sam3_rerun/__init__.py
@@ -1,12 +1,6 @@
 import os
 
-# Only enable beartype when running in the 'dev' environment
-# Check the PIXI_ENVIRONMENT_NAME environment variable set by pixi
-if os.environ.get("PIXI_ENVIRONMENT_NAME") == "dev":
-    try:
-        from beartype.claw import beartype_this_package
+if os.environ.get("PIXI_DEV_MODE") == "1":
+    from beartype.claw import beartype_this_package
 
-        beartype_this_package()
-    except ImportError:
-        # beartype not available even in dev environment
-        pass
+    beartype_this_package()

--- a/packages/sam3-rerun/tests/test_import.py
+++ b/packages/sam3-rerun/tests/test_import.py
@@ -1,0 +1,5 @@
+"""Smoke test: verify the sam3_rerun package can be imported."""
+
+
+def test_import_sam3_rerun() -> None:
+    import sam3_rerun  # noqa: F401

--- a/packages/sam3d-body-rerun/src/sam3d_body/__init__.py
+++ b/packages/sam3d-body-rerun/src/sam3d_body/__init__.py
@@ -1,12 +1,6 @@
 import os
 
-# Only enable beartype when running in the 'dev' environment
-# Check the PIXI_ENVIRONMENT_NAME environment variable set by pixi
-if os.environ.get("PIXI_ENVIRONMENT_NAME") == "dev":
-    try:
-        from beartype.claw import beartype_this_package
+if os.environ.get("PIXI_DEV_MODE") == "1":
+    from beartype.claw import beartype_this_package
 
-        beartype_this_package()
-    except ImportError:
-        # beartype not available even in dev environment
-        pass
+    beartype_this_package()

--- a/packages/sam3d-body-rerun/tests/test_import.py
+++ b/packages/sam3d-body-rerun/tests/test_import.py
@@ -1,0 +1,5 @@
+"""Smoke test: verify the sam3d_body package can be imported."""
+
+
+def test_import_sam3d_body() -> None:
+    import sam3d_body  # noqa: F401

--- a/packages/wilor-nano/pyproject.toml
+++ b/packages/wilor-nano/pyproject.toml
@@ -44,3 +44,7 @@ ignore = [
     "F821",  # Forward annotation false positive from jaxtyping. Should be caught by pyright.
     "UP037",
 ]
+
+[tool.pyrefly]
+project-includes = ["**/*"]
+project-excludes = ["**/node_modules", "**/__pycache__", "**/*venv/**/*"]

--- a/packages/wilor-nano/src/wilor_nano/__init__.py
+++ b/packages/wilor-nano/src/wilor_nano/__init__.py
@@ -1,12 +1,6 @@
 import os
 
-# Only enable beartype when running in the 'dev' environment
-# Check the PIXI_ENVIRONMENT_NAME environment variable set by pixi
-if os.environ.get("PIXI_ENVIRONMENT_NAME") == "dev":
-    try:
-        from beartype.claw import beartype_this_package
+if os.environ.get("PIXI_DEV_MODE") == "1":
+    from beartype.claw import beartype_this_package
 
-        beartype_this_package()
-    except ImportError:
-        # beartype not available even in dev environment
-        pass
+    beartype_this_package()

--- a/pixi.toml
+++ b/pixi.toml
@@ -65,16 +65,35 @@ libnvjitlink = "*"
 pytorch-gpu = ">=2.8.0"
 torchvision = "*"
 
-# ─── dev-tools feature (shared across all envs) ────────────────────────────
-[feature.dev-tools.dependencies]
+# ─── ide feature (standalone dev env for Zed/IDE tooling) ────────────────────
+[feature.ide.dependencies]
+python = "3.12.*"
+
+# ─── dev feature (shared across all *-dev envs) ─────────────────────────────
+[feature.dev.dependencies]
 ruff = "*"
 pytest = ">=8.0.0,<9"
 beartype = ">=0.22.9"
 pyrefly = "*"
 hypothesis = "*"
 
-[feature.dev-tools.pypi-dependencies]
+[feature.dev.pypi-dependencies]
 types-tqdm = "*"
+
+[feature.dev.activation.env]
+PIXI_DEV_MODE = "1"
+
+[feature.dev.tasks.lint]
+cmd = "cd $PACKAGE_DIR && ruff check ."
+description = "Lint the package"
+
+[feature.dev.tasks.typecheck]
+cmd = "cd $PACKAGE_DIR && pyrefly check"
+description = "Typecheck the package"
+
+[feature.dev.tasks.tests]
+cmd = "cd $PACKAGE_DIR && pytest -q"
+description = "Run package tests"
 
 # ═══════════════════════════════════════════════════════════════════════════
 # monoprior
@@ -101,6 +120,9 @@ monopriors = { path = "packages/monoprior", editable = true }
 simplecv = { git = "https://github.com/pablovela5620/simplecv.git", rev = "ab88369f5d0353ffb245de6d5981b0aede0930d7" }
 vggt = { git = "https://github.com/pablovela5620/vggt.git", rev = "5ed6ec88a951f27959f73bc72eb4b6dc7a028b0c" }
 moge = { git = "https://github.com/microsoft/MoGe.git" }
+
+[feature.monoprior.activation.env]
+PACKAGE_DIR = "packages/monoprior"
 
 # ── Download tasks (hidden, used as depends-on) ─────────────────────────
 [feature.monoprior.tasks._download-single-image]
@@ -185,7 +207,7 @@ cmd = "python tools/apps/calibration_app.py"
 cwd = "packages/monoprior"
 description = "Launch Gradio multiview calibration UI"
 
-# ── Utility & dev tasks ─────────────────────────────────────────────────
+# ── Utility tasks ────────────────────────────────────────────────────────
 [feature.monoprior.tasks.build-wheel]
 cmd = "python -m pip install build && python -m build"
 cwd = "packages/monoprior"
@@ -198,21 +220,6 @@ cwd = "packages/monoprior"
 cmd = "python tools/utils/upload_to_hf.py"
 depends-on = ["build-wheel"]
 cwd = "packages/monoprior"
-
-[feature.monoprior.tasks.tests]
-cmd = "pytest -q"
-cwd = "packages/monoprior"
-description = "Run monoprior test suite"
-
-[feature.monoprior.tasks.lint]
-cmd = "ruff check ."
-cwd = "packages/monoprior"
-description = "Lint monoprior"
-
-[feature.monoprior.tasks.typecheck]
-cmd = "pyrefly check"
-cwd = "packages/monoprior"
-description = "Typecheck monoprior"
 
 # ═══════════════════════════════════════════════════════════════════════════
 # wilor-nano
@@ -228,6 +235,9 @@ wilor_nano = { path = "packages/wilor-nano", editable = true }
 simplecv = { git = "https://github.com/pablovela5620/simplecv.git", rev = "31cc852429cc292959f30c0277010ec57caa6caf" }
 rtmlib = { git = "https://github.com/pablovela5620/rtmlib.git", rev = "98bca2193c39b349034b280803b54c9ee58f7c68" }
 
+[feature.wilor.activation.env]
+PACKAGE_DIR = "packages/wilor-nano"
+
 [feature.wilor.tasks.wilor-image-example]
 cmd = "python tools/wilor_inference.py --image-path assets/img.png"
 cwd = "packages/wilor-nano"
@@ -237,21 +247,6 @@ description = "Run WiLoR inference on example image"
 cmd = "python tools/wilor_inference.py --video-path assets/video.mp4"
 cwd = "packages/wilor-nano"
 description = "Run WiLoR inference on example video"
-
-[feature.wilor.tasks.wilor-tests]
-cmd = "pytest -q"
-cwd = "packages/wilor-nano"
-description = "Run wilor-nano test suite"
-
-[feature.wilor.tasks.wilor-lint]
-cmd = "ruff check ."
-cwd = "packages/wilor-nano"
-description = "Lint wilor-nano"
-
-[feature.wilor.tasks.wilor-typecheck]
-cmd = "pyrefly check"
-cwd = "packages/wilor-nano"
-description = "Typecheck wilor-nano"
 
 # ═══════════════════════════════════════════════════════════════════════════
 # sam3d-body-rerun
@@ -276,6 +271,9 @@ natsort = ">=8.4"
 datasets = ">=2.20"
 fsspec = ">=2025.3"
 kernels = ">=0.11.3"
+
+[feature.sam3d.activation.env]
+PACKAGE_DIR = "packages/sam3d-body-rerun"
 
 [feature.sam3d.tasks.sam3d-app]
 cmd = "python tool/gradio_sam3d_body.py"
@@ -324,16 +322,6 @@ cwd = "packages/sam3d-body-rerun"
 depends-on = ["sam3d-download-hocap-sample"]
 description = "Multiview 3D body mesh fitting with per-camera estimation"
 
-[feature.sam3d.tasks.sam3d-lint]
-cmd = "ruff check ."
-cwd = "packages/sam3d-body-rerun"
-description = "Lint sam3d-body-rerun"
-
-[feature.sam3d.tasks.sam3d-typecheck]
-cmd = "pyrefly check"
-cwd = "packages/sam3d-body-rerun"
-description = "Typecheck sam3d-body-rerun"
-
 # ═══════════════════════════════════════════════════════════════════════════
 # sam3-rerun
 # ═══════════════════════════════════════════════════════════════════════════
@@ -345,6 +333,9 @@ jaxtyping = "<0.3.0"
 sam3-rerun = { path = "packages/sam3-rerun", editable = true }
 simplecv = { git = "https://github.com/pablovela5620/simplecv.git", rev = "804e95c588b4af5be50874288eb8929ef2450f74" }
 spaces = ">=0.43.0"
+
+[feature.sam3-rerun.activation.env]
+PACKAGE_DIR = "packages/sam3-rerun"
 
 [feature.sam3-rerun.tasks.sam3-video-batch]
 cmd = "python tools/demos/video_batch.py"
@@ -371,16 +362,6 @@ cmd = "python tools/apps/sam3_annotated_app.py"
 cwd = "packages/sam3-rerun"
 description = "Launch SAM3 segmentation Gradio app with annotated image"
 
-[feature.sam3-rerun.tasks.sam3-rerun-lint]
-cmd = "ruff check ."
-cwd = "packages/sam3-rerun"
-description = "Lint sam3-rerun"
-
-[feature.sam3-rerun.tasks.sam3-rerun-typecheck]
-cmd = "pyrefly check"
-cwd = "packages/sam3-rerun"
-description = "Typecheck sam3-rerun"
-
 # ═══════════════════════════════════════════════════════════════════════════
 # robocap-slam
 # ═══════════════════════════════════════════════════════════════════════════
@@ -398,6 +379,9 @@ pip = ">=25.1.1,<26"
 robocap-slam = { path = "packages/robocap-slam", editable = true }
 simplecv = { git = "https://github.com/pablovela5620/simplecv.git", branch = "main" }
 tyro = ">=0.9,<1"
+
+[feature.robocap.activation.env]
+PACKAGE_DIR = "packages/robocap-slam"
 
 [feature.robocap.tasks.robocap-download-example]
 cmd = """test -d data/robocap/f408193e6447b3b0_session_14 || hf download pablovela5620/robocap-example --repo-type dataset --local-dir data/robocap"""
@@ -417,22 +401,18 @@ cwd = "packages/robocap-slam"
 depends-on = ["robocap-download-example"]
 description = "Run multicamera visual SLAM on Robocap data"
 
-[feature.robocap.tasks.robocap-lint]
-cmd = "ruff check ."
-cwd = "packages/robocap-slam"
-description = "Lint robocap-slam"
-
-[feature.robocap.tasks.robocap-typecheck]
-cmd = "pyrefly check"
-cwd = "packages/robocap-slam"
-description = "Typecheck robocap-slam"
-
 # ═══════════════════════════════════════════════════════════════════════════
 # Environments
 # ═══════════════════════════════════════════════════════════════════════════
 [environments]
-monoprior = { features = ["common", "cuda", "monoprior", "dev-tools"], solve-group = "monoprior", no-default-feature = true }
-wilor = { features = ["common", "cuda", "wilor", "dev-tools"], solve-group = "wilor", no-default-feature = true }
-sam3d = { features = ["common", "cuda", "sam3d", "dev-tools"], solve-group = "sam3d", no-default-feature = true }
-sam3-rerun = { features = ["common", "cuda", "sam3-rerun", "dev-tools"], solve-group = "sam3-rerun", no-default-feature = true }
-robocap = { features = ["common", "robocap", "dev-tools"], solve-group = "robocap", no-default-feature = true }
+dev            = { features = ["ide", "dev"],                               solve-group = "dev",        no-default-feature = true }
+monoprior      = { features = ["common", "cuda", "monoprior"],              solve-group = "monoprior",  no-default-feature = true }
+monoprior-dev  = { features = ["common", "cuda", "monoprior", "dev"],       solve-group = "monoprior",  no-default-feature = true }
+wilor          = { features = ["common", "cuda", "wilor"],                  solve-group = "wilor",      no-default-feature = true }
+wilor-dev      = { features = ["common", "cuda", "wilor", "dev"],           solve-group = "wilor",      no-default-feature = true }
+sam3d          = { features = ["common", "cuda", "sam3d"],                  solve-group = "sam3d",      no-default-feature = true }
+sam3d-dev      = { features = ["common", "cuda", "sam3d", "dev"],           solve-group = "sam3d",      no-default-feature = true }
+sam3-rerun     = { features = ["common", "cuda", "sam3-rerun"],             solve-group = "sam3-rerun", no-default-feature = true }
+sam3-rerun-dev = { features = ["common", "cuda", "sam3-rerun", "dev"],      solve-group = "sam3-rerun", no-default-feature = true }
+robocap        = { features = ["common", "robocap"],                        solve-group = "robocap",    no-default-feature = true }
+robocap-dev    = { features = ["common", "robocap", "dev"],                 solve-group = "robocap",    no-default-feature = true }

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -1,0 +1,9 @@
+[tool.pyrefly]
+project-includes = [
+    "packages/monoprior/monopriors/**/*",
+    "packages/wilor-nano/src/**/*",
+    "packages/sam3d-body-rerun/src/**/*",
+    "packages/sam3-rerun/src/**/*",
+    "packages/robocap-slam/robocap_slam/**/*",
+]
+project-excludes = ["**/node_modules", "**/__pycache__", "**/*venv/**/*"]


### PR DESCRIPTION
Restructure pixi.toml to separate prod and dev environments per package (e.g. monoprior + monoprior-dev) sharing solve-groups. Consolidate 12 duplicated lint/typecheck/tests tasks into 3 unified dev tasks that use a $PACKAGE_DIR activation variable. Add a lightweight `dev` environment for Zed IDE tooling.

Fix beartype activation in all 5 __init__.py files — was checking for a "dev" env name that never existed. Now uses PIXI_DEV_MODE=1, set only in *-dev environments.

Add root pyrefly.toml and .zed/settings.json so Zed finds pyrefly/ruff binaries. Add [tool.pyrefly] to wilor-nano and robocap-slam pyproject.toml. Add import smoke tests for 4 packages that had none.