### PR TITLE
Gravity Align Reconstruction

### DIFF
--- a/packages/pysfm/pysfm/apis/pycolmap_recon.py
+++ b/packages/pysfm/pysfm/apis/pycolmap_recon.py
@@ -23,6 +23,8 @@ from jaxtyping import Float32, Float64, UInt8
 from numpy import ndarray
 from serde import field, serde
 from serde.json import to_json
+from simplecv.camera_orient_utils import auto_orient_and_center_poses
+from simplecv.ops.conventions import CameraConventions, convert_pose
 from simplecv.rerun_log_utils import RerunTyroConfig
 from simplecv.video_io import MultiVideoReader
 
@@ -493,6 +495,25 @@ def log_rig_reconstruction(result: RigReconResult, parent_log_path: Path) -> Non
     from pysfm.apis.sfm_reconstruction import _extract_intrinsics, _extract_visible_keypoints
 
     rec: pycolmap.Reconstruction = pycolmap.Reconstruction(str(result.rig_model_dir))
+
+    # -- Compute gravity-alignment transform from camera poses ----------------
+    world_T_cam_list: list[Float64[ndarray, "4 4"]] = []
+    for image in rec.images.values():
+        world_from_cam: pycolmap.Rigid3d = image.cam_from_world().inverse()
+        world_T_cam_cv: Float64[ndarray, "4 4"] = np.eye(4, dtype=np.float64)
+        world_T_cam_cv[:3, :3] = world_from_cam.rotation.matrix()
+        world_T_cam_cv[:3, 3] = world_from_cam.translation
+        world_T_cam_list.append(world_T_cam_cv)
+
+    if world_T_cam_list:
+        world_T_cam_batch: Float64[ndarray, "N 4 4"] = np.stack(world_T_cam_list)
+        world_T_cam_gl: Float64[ndarray, "N 4 4"] = convert_pose(world_T_cam_batch, CameraConventions.CV, CameraConventions.GL)
+        orient_transform: Float64[ndarray, "3 4"] = auto_orient_and_center_poses(
+            world_T_cam_gl, method="up", center_method="poses"
+        ).transform
+        orient_R: Float64[ndarray, "3 3"] = orient_transform[:3, :3]
+        orient_t: Float64[ndarray, "3"] = orient_transform[:3, 3]
+        rr.log("/", rr.Transform3D(mat3x3=orient_R, translation=orient_t), static=True)
 
     # -- Static 3D point cloud ------------------------------------------------
     xyz_list: list[Float64[ndarray, "3"]] = []

--- a/packages/pysfm/pysfm/apis/pycolmap_recon.py
+++ b/packages/pysfm/pysfm/apis/pycolmap_recon.py
@@ -497,23 +497,24 @@ def log_rig_reconstruction(result: RigReconResult, parent_log_path: Path) -> Non
     rec: pycolmap.Reconstruction = pycolmap.Reconstruction(str(result.rig_model_dir))
 
     # -- Compute gravity-alignment transform from camera poses ----------------
-    world_T_cam_list: list[Float64[ndarray, "4 4"]] = []
+    world_T_cam_all: list[Float64[ndarray, "4 4"]] = []
     for image in rec.images.values():
         world_from_cam: pycolmap.Rigid3d = image.cam_from_world().inverse()
         world_T_cam_cv: Float64[ndarray, "4 4"] = np.eye(4, dtype=np.float64)
         world_T_cam_cv[:3, :3] = world_from_cam.rotation.matrix()
         world_T_cam_cv[:3, 3] = world_from_cam.translation
-        world_T_cam_list.append(world_T_cam_cv)
+        world_T_cam_all.append(world_T_cam_cv)
 
-    if world_T_cam_list:
-        world_T_cam_batch: Float64[ndarray, "N 4 4"] = np.stack(world_T_cam_list)
+    # Compute orient transform (3x4) that gravity-aligns the scene.
+    orient_44: Float64[ndarray, "4 4"] = np.eye(4, dtype=np.float64)
+    if world_T_cam_all:
+        world_T_cam_batch: Float64[ndarray, "N 4 4"] = np.stack(world_T_cam_all)
         world_T_cam_gl: Float64[ndarray, "N 4 4"] = convert_pose(world_T_cam_batch, CameraConventions.CV, CameraConventions.GL)
-        orient_transform: Float64[ndarray, "3 4"] = auto_orient_and_center_poses(
+        orient_34: Float64[ndarray, "3 4"] = auto_orient_and_center_poses(
             world_T_cam_gl, method="up", center_method="poses"
         ).transform
-        orient_R: Float64[ndarray, "3 3"] = orient_transform[:3, :3]
-        orient_t: Float64[ndarray, "3"] = orient_transform[:3, 3]
-        rr.log(f"{parent_log_path}", rr.Transform3D(mat3x3=orient_R, translation=orient_t), static=True)
+        orient_44[:3, :] = orient_34
+        logger.info("Gravity-alignment transform computed (det=%.4f)", np.linalg.det(orient_44[:3, :3]))
 
     # -- Static 3D point cloud ------------------------------------------------
     xyz_list: list[Float64[ndarray, "3"]] = []
@@ -523,14 +524,15 @@ def log_rig_reconstruction(result: RigReconResult, parent_log_path: Path) -> Non
         rgb_list.append(point.color)
 
     if xyz_list:
-        points3d_xyz: Float32[ndarray, "N 3"] = np.array(xyz_list, dtype=np.float32)
+        points3d_xyz: Float64[ndarray, "N 3"] = np.array(xyz_list, dtype=np.float64)
         points3d_rgb: UInt8[ndarray, "N 3"] = np.array(rgb_list, dtype=np.uint8)
+        # Apply gravity-alignment directly to point positions.
+        points3d_oriented: Float32[ndarray, "N 3"] = (orient_44[:3, :3] @ points3d_xyz.T + orient_44[:3, 3:]).T.astype(np.float32)
         rr.log(
             f"{parent_log_path}/point_cloud",
             rr.Points3D(
-                positions=points3d_xyz,
+                positions=points3d_oriented,
                 colors=points3d_rgb,
-                # radii=np.full(points3d_xyz.shape[0], 0.005, dtype=np.float32),
             ),
             static=True,
         )
@@ -564,16 +566,14 @@ def log_rig_reconstruction(result: RigReconResult, parent_log_path: Path) -> Non
             _image_id, image = cam_images[cam_name][frame_idx]
             camera_path: str = f"{parent_log_path}/{cam_name}"
 
-            # Transform (world_T_cam)
+            # Transform (world_T_cam), gravity-aligned
             world_from_cam: pycolmap.Rigid3d = image.cam_from_world().inverse()
-            R: Float64[ndarray, "3 3"] = world_from_cam.rotation.matrix()
-            t: Float64[ndarray, "3"] = world_from_cam.translation
-
             world_T_cam: Float64[ndarray, "4 4"] = np.eye(4, dtype=np.float64)
-            world_T_cam[:3, :3] = R
-            world_T_cam[:3, 3] = t
+            world_T_cam[:3, :3] = world_from_cam.rotation.matrix()
+            world_T_cam[:3, 3] = world_from_cam.translation
+            oriented_T_cam: Float64[ndarray, "4 4"] = orient_44 @ world_T_cam
 
-            rr.log(camera_path, rr.Transform3D(mat3x3=world_T_cam[:3, :3], translation=world_T_cam[:3, 3]))
+            rr.log(camera_path, rr.Transform3D(mat3x3=oriented_T_cam[:3, :3], translation=oriented_T_cam[:3, 3]))
 
             # Pinhole camera — ref camera is green, others are gray.
             cam: pycolmap.Camera = image.camera

--- a/packages/pysfm/pysfm/apis/pycolmap_recon.py
+++ b/packages/pysfm/pysfm/apis/pycolmap_recon.py
@@ -513,7 +513,7 @@ def log_rig_reconstruction(result: RigReconResult, parent_log_path: Path) -> Non
         ).transform
         orient_R: Float64[ndarray, "3 3"] = orient_transform[:3, :3]
         orient_t: Float64[ndarray, "3"] = orient_transform[:3, 3]
-        rr.log("/", rr.Transform3D(mat3x3=orient_R, translation=orient_t), static=True)
+        rr.log(f"{parent_log_path}", rr.Transform3D(mat3x3=orient_R, translation=orient_t), static=True)
 
     # -- Static 3D point cloud ------------------------------------------------
     xyz_list: list[Float64[ndarray, "3"]] = []
@@ -645,7 +645,7 @@ def main(cli_config: RigReconCLIConfig) -> None:
         collapse_panels=True,
     )
     rr.send_blueprint(blueprint)
-    rr.log(f"{parent_log_path}", rr.ViewCoordinates.RDF, static=True)
+    rr.log("/", rr.ViewCoordinates.RFU, static=True)
 
     # 3. Log the reconstruction
     log_rig_reconstruction(result, parent_log_path)

--- a/packages/pysfm/pysfm/apis/pycolmap_recon.py
+++ b/packages/pysfm/pysfm/apis/pycolmap_recon.py
@@ -462,9 +462,12 @@ def create_rig_blueprint(parent_log_path: Path, camera_names: list[str]) -> rrb.
     """
     import rerun.blueprint as rrb
 
+    # Origin must be an ancestor of parent_log_path (not parent_log_path
+    # itself) so that the gravity-alignment Transform3D logged on
+    # parent_log_path is visible in the view.
     view_3d: rrb.Spatial3DView = rrb.Spatial3DView(
-        origin=f"{parent_log_path}",
-        contents=["+ $origin/**"],
+        origin="/",
+        contents=[f"+ {parent_log_path}/**"],
     )
 
     # 2D view for the first camera — user can switch via entity panel.
@@ -483,11 +486,17 @@ def log_rig_reconstruction(result: RigReconResult, parent_log_path: Path) -> Non
     """Load the final rig reconstruction and log it to Rerun.
 
     Computes a gravity-alignment transform from the camera poses using
-    ``auto_orient_and_center_poses`` (method="up"), then applies it directly
-    to the 3D point cloud and per-camera poses before logging.  This avoids
-    relying on Rerun's ``Transform3D`` hierarchy which does not compose
-    correctly when a static parent transform is combined with dynamic child
-    camera transforms.
+    ``auto_orient_and_center_poses`` (method="up") and logs it as a static
+    ``Transform3D`` on ``parent_log_path``.  Rerun's transform hierarchy then
+    applies it to the entire scene (point cloud, camera frustums, images,
+    keypoints).
+
+    .. note::
+
+        The Spatial3DView **must** have its ``origin`` set to an ancestor of
+        ``parent_log_path`` (e.g. ``"/"``) for the gravity-alignment transform
+        to be visible.  If ``origin`` equals ``parent_log_path``, the view
+        renders from that entity's perspective and the transform is invisible.
 
     Logs 3D point cloud (static), then per-camera frustums, images, and
     keypoints over a timeline.
@@ -505,8 +514,9 @@ def log_rig_reconstruction(result: RigReconResult, parent_log_path: Path) -> Non
 
     # -- Compute gravity-alignment transform from camera poses ----------------
     # Extract all world_T_cam poses, convert CV→GL (required by
-    # auto_orient_and_center_poses), compute the orient rotation+centering,
-    # then apply it directly to points and cameras below.
+    # auto_orient_and_center_poses), then log the resulting rotation+centering
+    # as a static Transform3D on parent_log_path so that Rerun's hierarchy
+    # applies it to all children (point cloud, cameras, etc.).
     world_T_cam_all: list[Float64[ndarray, "4 4"]] = []
     for image in rec.images.values():
         world_from_cam: pycolmap.Rigid3d = image.cam_from_world().inverse()
@@ -515,15 +525,20 @@ def log_rig_reconstruction(result: RigReconResult, parent_log_path: Path) -> Non
         world_T_cam_cv[:3, 3] = world_from_cam.translation
         world_T_cam_all.append(world_T_cam_cv)
 
-    orient_44: Float64[ndarray, "4 4"] = np.eye(4, dtype=np.float64)
     if world_T_cam_all:
         world_T_cam_batch: Float64[ndarray, "N 4 4"] = np.stack(world_T_cam_all)
         world_T_cam_gl: Float64[ndarray, "N 4 4"] = convert_pose(world_T_cam_batch, CameraConventions.CV, CameraConventions.GL)
         orient_34: Float64[ndarray, "3 4"] = auto_orient_and_center_poses(
             world_T_cam_gl, method="up", center_method="poses"
         ).transform
-        orient_44[:3, :] = orient_34
-        logger.info("Gravity-alignment transform computed (det=%.4f)", np.linalg.det(orient_44[:3, :3]))
+        orient_R: Float64[ndarray, "3 3"] = orient_34[:, :3]
+        orient_t: Float64[ndarray, "3"] = orient_34[:, 3]
+        rr.log(
+            f"{parent_log_path}",
+            rr.Transform3D(mat3x3=orient_R, translation=orient_t),
+            static=True,
+        )
+        logger.info("Gravity-alignment transform logged on '%s' (det=%.4f)", parent_log_path, np.linalg.det(orient_R))
 
     # -- Static 3D point cloud ------------------------------------------------
     xyz_list: list[Float64[ndarray, "3"]] = []
@@ -533,14 +548,12 @@ def log_rig_reconstruction(result: RigReconResult, parent_log_path: Path) -> Non
         rgb_list.append(point.color)
 
     if xyz_list:
-        points3d_xyz: Float64[ndarray, "N 3"] = np.array(xyz_list, dtype=np.float64)
+        points3d_xyz: Float32[ndarray, "N 3"] = np.array(xyz_list, dtype=np.float32)
         points3d_rgb: UInt8[ndarray, "N 3"] = np.array(rgb_list, dtype=np.uint8)
-        # Apply gravity-alignment directly to point positions.
-        points3d_oriented: Float32[ndarray, "N 3"] = (orient_44[:3, :3] @ points3d_xyz.T + orient_44[:3, 3:]).T.astype(np.float32)
         rr.log(
             f"{parent_log_path}/point_cloud",
             rr.Points3D(
-                positions=points3d_oriented,
+                positions=points3d_xyz,
                 colors=points3d_rgb,
             ),
             static=True,
@@ -575,14 +588,14 @@ def log_rig_reconstruction(result: RigReconResult, parent_log_path: Path) -> Non
             _image_id, image = cam_images[cam_name][frame_idx]
             camera_path: str = f"{parent_log_path}/{cam_name}"
 
-            # Transform (world_T_cam), gravity-aligned
+            # Transform (world_T_cam) — raw COLMAP pose; gravity-alignment
+            # is handled by the parent Transform3D on parent_log_path.
             world_from_cam: pycolmap.Rigid3d = image.cam_from_world().inverse()
             world_T_cam: Float64[ndarray, "4 4"] = np.eye(4, dtype=np.float64)
             world_T_cam[:3, :3] = world_from_cam.rotation.matrix()
             world_T_cam[:3, 3] = world_from_cam.translation
-            oriented_T_cam: Float64[ndarray, "4 4"] = orient_44 @ world_T_cam
 
-            rr.log(camera_path, rr.Transform3D(mat3x3=oriented_T_cam[:3, :3], translation=oriented_T_cam[:3, 3]))
+            rr.log(camera_path, rr.Transform3D(mat3x3=world_T_cam[:3, :3], translation=world_T_cam[:3, 3]))
 
             # Pinhole camera — ref camera is green, others are gray.
             cam: pycolmap.Camera = image.camera

--- a/packages/pysfm/pysfm/apis/pycolmap_recon.py
+++ b/packages/pysfm/pysfm/apis/pycolmap_recon.py
@@ -482,6 +482,13 @@ def create_rig_blueprint(parent_log_path: Path, camera_names: list[str]) -> rrb.
 def log_rig_reconstruction(result: RigReconResult, parent_log_path: Path) -> None:
     """Load the final rig reconstruction and log it to Rerun.
 
+    Computes a gravity-alignment transform from the camera poses using
+    ``auto_orient_and_center_poses`` (method="up"), then applies it directly
+    to the 3D point cloud and per-camera poses before logging.  This avoids
+    relying on Rerun's ``Transform3D`` hierarchy which does not compose
+    correctly when a static parent transform is combined with dynamic child
+    camera transforms.
+
     Logs 3D point cloud (static), then per-camera frustums, images, and
     keypoints over a timeline.
 
@@ -497,6 +504,9 @@ def log_rig_reconstruction(result: RigReconResult, parent_log_path: Path) -> Non
     rec: pycolmap.Reconstruction = pycolmap.Reconstruction(str(result.rig_model_dir))
 
     # -- Compute gravity-alignment transform from camera poses ----------------
+    # Extract all world_T_cam poses, convert CV→GL (required by
+    # auto_orient_and_center_poses), compute the orient rotation+centering,
+    # then apply it directly to points and cameras below.
     world_T_cam_all: list[Float64[ndarray, "4 4"]] = []
     for image in rec.images.values():
         world_from_cam: pycolmap.Rigid3d = image.cam_from_world().inverse()
@@ -505,7 +515,6 @@ def log_rig_reconstruction(result: RigReconResult, parent_log_path: Path) -> Non
         world_T_cam_cv[:3, 3] = world_from_cam.translation
         world_T_cam_all.append(world_T_cam_cv)
 
-    # Compute orient transform (3x4) that gravity-aligns the scene.
     orient_44: Float64[ndarray, "4 4"] = np.eye(4, dtype=np.float64)
     if world_T_cam_all:
         world_T_cam_batch: Float64[ndarray, "N 4 4"] = np.stack(world_T_cam_all)
@@ -645,6 +654,7 @@ def main(cli_config: RigReconCLIConfig) -> None:
         collapse_panels=True,
     )
     rr.send_blueprint(blueprint)
+    # Gravity-aligned data has Z-up; tell the viewer accordingly.
     rr.log("/", rr.ViewCoordinates.RFU, static=True)
 
     # 3. Log the reconstruction

--- a/pixi.lock
+++ b/pixi.lock
@@ -32320,7 +32320,7 @@ packages:
   - pytorch-lightning>=2.5.1,<3
   - diffusers[torch]>=0.32.2
   - timm>=1.0.15,<2
-  - sam3-rerun @ file:///var/tmp/vibe-kanban/worktrees/3d9f-look-at-packages/examples-monorepo/packages/sam3-rerun
+  - sam3-rerun @ file:///var/tmp/vibe-kanban/worktrees/722c-i-want-to-work-o/examples-monorepo/packages/sam3-rerun
   requires_python: '>=3.11.0'
 - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
   name: more-itertools
@@ -37520,7 +37520,7 @@ packages:
   version: 0.1.0
   sha256: 6010c475dca8016b74cdbd14fec5a399b674644eb3797dd861ad6c4670702b67
   requires_dist:
-  - monopriors @ file:///var/tmp/vibe-kanban/worktrees/3d9f-look-at-packages/examples-monorepo/packages/monoprior
+  - monopriors @ file:///var/tmp/vibe-kanban/worktrees/722c-i-want-to-work-o/examples-monorepo/packages/monoprior
   requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/88/1b/ffa0335499343894648fa92cd655978a65de0f2c6fc2ddca9fe6b6f9c242/rerun_sdk-0.30.2-cp310-abi3-manylinux_2_28_aarch64.whl
   name: rerun-sdk
@@ -37937,8 +37937,8 @@ packages:
   - omegaconf>=2.3.0,<3
   - termcolor>=3.2.0,<4
   - spaces>=0.43.0
-  - monopriors @ file:///var/tmp/vibe-kanban/worktrees/3d9f-look-at-packages/examples-monorepo/packages/monoprior
-  - sam3-rerun @ file:///var/tmp/vibe-kanban/worktrees/3d9f-look-at-packages/examples-monorepo/packages/sam3-rerun
+  - monopriors @ file:///var/tmp/vibe-kanban/worktrees/722c-i-want-to-work-o/examples-monorepo/packages/monoprior
+  - sam3-rerun @ file:///var/tmp/vibe-kanban/worktrees/722c-i-want-to-work-o/examples-monorepo/packages/sam3-rerun
   requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/b3/2b/c70120a6880579fb42b91567ad79feb4772f7be72e8d52fec403a3dde0c6/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl
   name: scikit-image
@@ -40777,7 +40777,7 @@ packages:
   sha256: 040445160e2ce50aa6695f139ee7258a27456ec50ee1fbcc9351b9e46aa686b5
   requires_dist:
   - einops>=0.8.1,<0.9
-  - monopriors @ file:///var/tmp/vibe-kanban/worktrees/3d9f-look-at-packages/examples-monorepo/packages/monoprior
+  - monopriors @ file:///var/tmp/vibe-kanban/worktrees/722c-i-want-to-work-o/examples-monorepo/packages/monoprior
   requires_python: '>=3.11'
 - conda: https://prefix.dev/conda-forge/linux-64/vlfeat-0.9.21-hd590300_1.conda
   sha256: f3fca24ef6a327072378dd654eba37c6a6da15499ca212eb20b0af422c1ad4c5


### PR DESCRIPTION
makes the reconstruction aligned with gravity and look a lot better

This pull request enhances the logging and visualization of rig reconstructions in `pycolmap_recon.py` by introducing automatic gravity alignment of the reconstructed scene and updating the Rerun view configuration to reflect this change. The most important changes are grouped below:

**Gravity Alignment and Scene Transformations:**

* Added computation of a gravity-alignment transform using `auto_orient_and_center_poses` (with method="up") applied to all camera poses, ensuring the entire scene (point cloud, cameras, images, keypoints) is consistently oriented in the viewer. The transform is logged as a static `Transform3D` on `parent_log_path`.
* Updated documentation and comments to clarify the importance of setting the Rerun `Spatial3DView` origin to an ancestor of `parent_log_path` (typically `"/"`) so that the gravity-alignment transform is visible and applies to all relevant entities. [[1]](diffhunk://#diff-7f7040b02cd74d6a288c16c8d3d4443d61ff1a7644388f6208435b9a3fcc7af8R465-R470) [[2]](diffhunk://#diff-7f7040b02cd74d6a288c16c8d3d4443d61ff1a7644388f6208435b9a3fcc7af8R488-R500)

**View and Coordinate System Updates:**

* Changed the Rerun `Spatial3DView` origin from `parent_log_path` to `"/"` and updated its contents to ensure proper transform application and visibility in the viewer.
* Updated the main entrypoint to log the coordinate system as Z-up (`RFU`) at the root (`"/"`), matching the gravity-aligned data convention.

**Other Improvements:**

* Added necessary imports for gravity alignment and camera convention utilities.
* Clarified in comments that the per-camera transforms are raw COLMAP poses and that gravity alignment is handled by the parent transform.
* Minor cleanup of commented code in point cloud logging.