### PR TITLE
Add mv-api multiview exo/ego pipeline package (Vibe Kanban)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ packages/wilor-nano/data/
 packages/sam3d-body-rerun/data/
 packages/sam3-rerun/data/
 packages/robocap-slam/data/
+packages/mv-api/data/
 packages/pysfm/data/
 packages/gsplat-rust-renderer/data/
 packages/*/outputs/

--- a/packages/mv-api/README.md
+++ b/packages/mv-api/README.md
@@ -1,0 +1,86 @@
+# mv-api
+
+Multiview exo/ego pose estimation and calibration workflows for Rerun `.rrd` captures, packaged for the `examples-monorepo`.
+
+This first pass brings in the RRD-centered surfaces from upstream `mv-api` and aligns them to this repo's package, dependency, and task conventions. The retained workflows are:
+
+- full exo/ego RRD pipeline
+- exo-only calibration
+- batch exo calibration
+- Gradio RRD app
+- CLI smoke client for the Gradio queue flow
+
+Deferred from this first pass:
+
+- label UI
+- face blur service
+- video-only and hand-only experimental entrypoints
+- upstream standalone Pixi environments
+
+## Quick Start
+
+```bash
+pixi run -e mv-api mv-api-full-pipeline-app
+```
+
+Use another terminal to exercise the queue client:
+
+```bash
+pixi run -e mv-api mv-api-rrd-client -- --help
+```
+
+## Tasks
+
+```bash
+pixi task list -e mv-api
+pixi task list -e mv-api-dev
+```
+
+Primary tasks:
+
+- `mv-api-full-pipeline-app`: Launch the Gradio app for `.rrd` inputs
+- `mv-api-rrd-client`: Submit a job to a running Gradio app
+- `mv-api-exo-only-calib`: Run exo-only calibration directly
+- `mv-api-batch-calib`: Batch-calibrate episode trees
+- `mv-api-validate`: Validate retained imports, tools, and app construction
+
+## Layout
+
+```text
+packages/mv-api/
+├── src/mv_api/
+│   ├── api/
+│   │   ├── full_exoego_pipeline.py
+│   │   ├── exo_only_calibration.py
+│   │   └── batch_calibration.py
+│   ├── gradio_ui/
+│   │   └── full_pipeline_rrd_ui.py
+│   ├── hand_keypoints.py
+│   ├── multiview_pose_estimator.py
+│   ├── robust_triangulate.py
+│   └── coco133_layers.py
+├── tools/
+│   ├── app_full_pipeline_rrd.py
+│   ├── run_rrd_client_example.py
+│   ├── run_exo_only_calib.py
+│   ├── batch_exo_calib_client.py
+│   └── validate_mv_api.py
+└── tests/
+```
+
+## Development
+
+```bash
+pixi install -e mv-api-dev
+pixi run -e mv-api-dev lint
+pixi run -e mv-api-dev tests
+pixi run -e mv-api-dev mv-api-validate
+```
+
+## Notes
+
+- This package uses the monorepo's shared `common`, `cuda`, and `dev` features rather than carrying upstream's standalone `pixi.toml`.
+- `monopriors` and `wilor-nano` are resolved from local monorepo packages via `tool.uv.sources`.
+- No example dataset is bundled in the first pass; the app and tools expect user-provided `.rrd` data.
+
+See [docs/state-machine.md](docs/state-machine.md) for the workflow diagram and script inventory.

--- a/packages/mv-api/docs/state-machine.md
+++ b/packages/mv-api/docs/state-machine.md
@@ -1,0 +1,59 @@
+# mv-api State Machine
+
+## First-Pass Workflow
+
+```mermaid
+stateDiagram-v2
+    [*] --> EntryPoint
+    EntryPoint --> FullPipelineApp
+    EntryPoint --> RRDClient
+    EntryPoint --> ExoOnlyCalib
+    EntryPoint --> BatchCalib
+
+    FullPipelineApp --> ResolveRRD
+    RRDClient --> SubmitGradioJob
+    SubmitGradioJob --> FullPipelineApp
+
+    ResolveRRD --> BuildConfig
+    ExoOnlyCalib --> LoadSequence
+    BatchCalib --> DiscoverEpisodes
+    DiscoverEpisodes --> LoadSequence
+
+    BuildConfig --> LoadSequence
+    LoadSequence --> ExtractFrames
+    ExtractFrames --> CalibrateViews
+    CalibrateViews --> TrackPose
+    TrackPose --> LogToRerun
+    LogToRerun --> WriteRRD
+    WriteRRD --> ReturnArtifacts
+    ReturnArtifacts --> [*]
+```
+
+## Script Inventory
+
+| Script | Main API | Inputs | Outputs |
+| --- | --- | --- | --- |
+| `tools/app_full_pipeline_rrd.py` | `build_full_pipeline_rrd_block()` | uploaded or local `.rrd`, optional `max_frames` | temporary output `.rrd` streamed to embedded Rerun viewer |
+| `tools/run_rrd_client_example.py` | Gradio `/run_rrd_pipeline` endpoint | Gradio URL, `.rrd` path, optional `max_frames` | queued job submission plus output `.rrd` path |
+| `tools/run_exo_only_calib.py` | `mv_api.api.exo_only_calibration.main()` | dataset config + calibration config via Tyro | calibration logs and optional saved `.rrd` |
+| `tools/batch_exo_calib_client.py` | `run_batch_calibration()` | sequence path or cut root | calibrated episode `.rrd` files and manifest updates |
+| `tools/validate_mv_api.py` | validation harness | installed package environment | import, CLI help, and app-construction checks |
+
+## Inputs and Outputs
+
+- `full_exoego_pipeline.py`
+  - Input: calibrated or calibratable exo/ego `.rrd` capture
+  - Output: logged pose, cameras, and optional fused geometry in a new `.rrd`
+- `exo_only_calibration.py`
+  - Input: single `.rrd` episode plus frame-selection / calibration options
+  - Output: aligned exo camera poses, triangulated body keypoints, optional saved `.rrd`
+- `batch_calibration.py`
+  - Input: directory tree of episode `.rrd` files
+  - Output: per-episode calibrated `.rrd` files and manifest state
+
+## Non-Goals in This Import
+
+- Labeling workflow state and callbacks
+- Face blurring and transcoding flows
+- Hand-only and video-only auxiliary pipelines
+- Upstream standalone packaging and Docker workflows

--- a/packages/mv-api/pyproject.toml
+++ b/packages/mv-api/pyproject.toml
@@ -1,0 +1,40 @@
+[project]
+authors = [{ name = "pablo vela", email = "pablovela5620@gmail.com" }]
+dependencies = [
+    # common: numpy, scipy, jaxtyping, rerun-sdk, gradio, gradio-rerun,
+    #         huggingface_hub, hf-transfer, tqdm, pyserde, av, opencv
+    # cuda: pytorch-gpu, torchvision
+    "einops>=0.8.0,<0.9",
+    "monopriors>=0.3.2",
+    "wilor-nano>=0.1.0",
+    "httpx",
+    "gradio-client",
+]
+description = "Multiview exo/ego pose estimation and calibration workflows for the examples monorepo"
+name = "mv-api"
+requires-python = ">= 3.12"
+version = "0.1.0"
+
+[tool.uv.sources]
+monopriors = { path = "../monoprior", editable = true }
+wilor-nano = { path = "../wilor-nano", editable = true }
+
+[build-system]
+build-backend = "hatchling.build"
+requires = ["hatchling"]
+
+[tool.pytest.ini_options]
+markers = ["slow: dataset-backed or longer-running validation checks"]
+
+[tool.ruff]
+line-length = 150
+
+[tool.ruff.lint]
+select = ["E", "F", "UP", "B", "SIM", "I"]
+ignore = [
+    "E501",
+    "F722",
+    "F821",
+    "UP037",
+    "UP040",
+]

--- a/packages/mv-api/src/mv_api/__init__.py
+++ b/packages/mv-api/src/mv_api/__init__.py
@@ -1,0 +1,14 @@
+import os
+
+if os.environ.get("PIXI_DEV_MODE") == "1":
+    try:
+        from beartype.claw import beartype_this_package
+
+        beartype_this_package()
+    except ImportError:
+        pass
+
+__all__ = [
+    "api",
+    "gradio_ui",
+]

--- a/packages/mv-api/src/mv_api/api/batch_calibration.py
+++ b/packages/mv-api/src/mv_api/api/batch_calibration.py
@@ -1,0 +1,768 @@
+"""Batch calibration for processing multiple episodes directly.
+
+Bypasses Gradio API overhead by invoking ExoOnlyCalibService directly.
+This module contains the core logic; CLI wrapper is in tools/batch_exo_calib_client.py.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Literal, cast
+
+import numpy as np
+import rerun as rr
+import rerun.blueprint as rrb
+from jaxtyping import Float, Float32, Int, UInt8
+from numpy import ndarray
+from simplecv.apis.view_exoego import (
+    LogPaths,
+    SceneSetupResult,
+    log_environment_mesh,
+    log_exoego_batch,
+    setup_scene,
+)
+from simplecv.data.exo.base_exo import BaseExoSequence
+from simplecv.data.exoego.base_exoego import BaseExoEgoSequence
+from simplecv.data.exoego.rrd_exoego import RRDExoEgoConfig
+from simplecv.rerun_log_utils import log_pinhole
+from simplecv.video_io import MultiVideoReader, TorchCodecMultiVideoReader
+
+from mv_api.api.exo_only_calibration import (
+    ExoCalibResult,
+    ExoOnlyCalibService,
+    ExoOnlyCalibServiceConfig,
+    create_exo_ego_blueprint,
+    get_frame_timestamps_from_reader,
+    get_target_frame_idx,
+    set_annotation_context,
+)
+
+
+@dataclass
+class EpisodeInfo:
+    """Metadata for a single episode."""
+
+    rrd_path: Path
+    """Path to the source episode RRD file."""
+    calibrated_path: Path
+    """Path where calibrated RRD will be saved."""
+    sequence_id: str
+    """Parent sequence identifier."""
+
+    @property
+    def is_calibrated(self) -> bool:
+        """Check if calibrated output already exists."""
+        return self.calibrated_path.exists()
+
+
+@dataclass
+class ManifestEntry:
+    """Status entry for a single episode in the manifest."""
+
+    episode_path: str
+    calibrated_path: str
+    status: str  # 'pending', 'success', 'error'
+    error_message: str | None = None
+    calibrated_at: str | None = None
+
+
+@dataclass
+class SequenceManifest:
+    """Progress tracking manifest for a sequence."""
+
+    sequence_id: str
+    created_at: str
+    updated_at: str
+    episodes: dict[str, ManifestEntry] = field(default_factory=dict)
+
+    def save(self, manifest_path: Path) -> None:
+        """Write manifest to disk."""
+        data: dict[str, Any] = {
+            "sequence_id": self.sequence_id,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "episodes": {
+                k: {
+                    "episode_path": v.episode_path,
+                    "calibrated_path": v.calibrated_path,
+                    "status": v.status,
+                    "error_message": v.error_message,
+                    "calibrated_at": v.calibrated_at,
+                }
+                for k, v in self.episodes.items()
+            },
+        }
+        manifest_path.write_text(json.dumps(data, indent=2))
+
+    @classmethod
+    def load_or_create(cls, manifest_path: Path, sequence_id: str) -> SequenceManifest:
+        """Load existing manifest or create new one."""
+        now: str = datetime.now().isoformat()
+        if manifest_path.exists():
+            data: dict[str, Any] = json.loads(manifest_path.read_text())
+            episodes: dict[str, ManifestEntry] = {}
+            for k, v in data.get("episodes", {}).items():
+                episodes[k] = ManifestEntry(
+                    episode_path=v["episode_path"],
+                    calibrated_path=v["calibrated_path"],
+                    status=v["status"],
+                    error_message=v.get("error_message"),
+                    calibrated_at=v.get("calibrated_at"),
+                )
+            return cls(
+                sequence_id=data["sequence_id"],
+                created_at=data["created_at"],
+                updated_at=now,
+                episodes=episodes,
+            )
+        return cls(sequence_id=sequence_id, created_at=now, updated_at=now)
+
+
+@dataclass
+class BatchCalibConfig:
+    """Configuration for batch exo calibration."""
+
+    cut_root: Path | None = None
+    """Root directory containing all sequences (processes everything)."""
+
+    sequence_path: Path | None = None
+    """Path to a single sequence to process (alternative to cut_root)."""
+
+    skip_tsdf_fusion: bool = True
+    """Skip TSDF mesh fusion for faster processing (extrinsics only)."""
+
+    frame_selection: Literal["middle", "first", "last"] | int = "middle"
+    """Which frame to process for calibration."""
+
+    dry_run: bool = False
+    """If True, discover episodes but don't actually calibrate."""
+
+    inplace: bool = True
+    """Append calibration to original RRD (fast) vs create new -calibrated.rrd (safe)."""
+
+
+ProgressCallback = Callable[[str], None]
+"""Callback for progress messages: (message: str) -> None."""
+
+
+def discover_episodes_in_sequence(sequence_path: Path) -> list[EpisodeInfo]:
+    """Find all episode RRD files in a sequence directory."""
+    episodes_dir: Path = sequence_path / "episodes"
+    if not episodes_dir.exists():
+        return []
+
+    episode_infos: list[EpisodeInfo] = []
+    sequence_id: str = sequence_path.name
+
+    for episode_dir in sorted(episodes_dir.iterdir()):
+        if not episode_dir.is_dir():
+            continue
+        rrd_path: Path = episode_dir / f"{episode_dir.name}.rrd"
+        if not rrd_path.exists():
+            continue
+        calibrated_path: Path = episode_dir / f"{episode_dir.name}-calibrated.rrd"
+        episode_infos.append(
+            EpisodeInfo(
+                rrd_path=rrd_path,
+                calibrated_path=calibrated_path,
+                sequence_id=sequence_id,
+            )
+        )
+
+    return episode_infos
+
+
+def discover_all_sequences(cut_root: Path) -> list[Path]:
+    """Find all sequence directories under cut root."""
+    sequences: list[Path] = []
+    # Structure: cut/{date}/{sequence_id}/episodes/
+    for date_dir in sorted(cut_root.iterdir()):
+        if not date_dir.is_dir():
+            continue
+        for sequence_dir in sorted(date_dir.iterdir()):
+            if not sequence_dir.is_dir():
+                continue
+            if (sequence_dir / "episodes").exists():
+                sequences.append(sequence_dir)
+    return sequences
+
+
+@rr.thread_local_stream("batch_exo_calib")
+def calibrate_episode_direct(
+    service: ExoOnlyCalibService,
+    episode: EpisodeInfo,
+    config: BatchCalibConfig,
+    progress_callback: ProgressCallback | None = None,
+) -> tuple[bool, str | None]:
+    """Calibrate a single episode directly using the service.
+
+    This bypasses Gradio API overhead by invoking the service directly.
+
+    Args:
+        service: Pre-loaded calibration service.
+        episode: Episode metadata.
+        config: Calibration configuration.
+        progress_callback: Optional callback for progress messages.
+
+    Returns:
+        Tuple of (success, error_message). error_message is None on success.
+    """
+
+    def _log(msg: str) -> None:
+        if progress_callback:
+            progress_callback(msg)
+        else:
+            print(msg)
+
+    try:
+        _log(f"  Loading: {episode.rrd_path.name}")
+
+        # Create temp file for output
+        with tempfile.NamedTemporaryFile(prefix="exo_calib_", suffix=".rrd", delete=False) as temp_file:
+            output_path: Path = Path(temp_file.name)
+
+        # Configure Rerun to save to temp file
+        rr.save(str(output_path))
+
+        parent_log_path: Path = Path("world")
+        timeline: str = "video_time"
+
+        # Load dataset
+        dataset_cfg: RRDExoEgoConfig = RRDExoEgoConfig(rrd_path=episode.rrd_path)
+        exoego_sequence: BaseExoEgoSequence = dataset_cfg.setup()
+        exo_sequence_obj: object | None = exoego_sequence.exo_sequence
+        if exo_sequence_obj is None:
+            return False, "Dataset setup failed to provide an exo sequence."
+        exo_sequence: BaseExoSequence = cast(BaseExoSequence, exo_sequence_obj)
+
+        # Setup Rerun
+        rr.log("/", exoego_sequence.world_coordinate_system, static=True)
+        set_annotation_context(recording=None)
+
+        # Setup scene
+        scene_setup_result: SceneSetupResult = setup_scene(
+            exoego_sequence,
+            parent_log_path=parent_log_path,
+            timeline=timeline,
+            log_ego=True,
+            log_exo=True,
+        )
+        log_paths: LogPaths = scene_setup_result.log_paths
+        shortest_timestamp: Int[ndarray, "n_frames"] = scene_setup_result.shortest_timestamp
+
+        # Log GT data if available
+        if exoego_sequence.exoego_labels is not None:
+            log_exoego_batch(
+                exoego_sequence,
+                parent_log_path=parent_log_path,
+                timeline=timeline,
+                shortest_timestamp=shortest_timestamp,
+                log_ego=True,
+                log_exo=False,
+                log_mano=True,
+            )
+
+        if exoego_sequence.environment_mesh is not None:
+            log_environment_mesh(exoego_sequence, parent_log_path)
+
+        # Send blueprint
+        exo_video_log_paths: list[Path] = log_paths.exo_video_log_paths or []
+        ego_video_log_paths: list[Path] = log_paths.ego_video_log_paths or []
+        blueprint: rrb.Blueprint = create_exo_ego_blueprint(
+            exo_video_log_paths=exo_video_log_paths if exo_video_log_paths else None,
+            ego_video_log_paths=ego_video_log_paths if ego_video_log_paths else None,
+        )
+        rr.send_blueprint(blueprint)
+
+        _log("  Extracting frames...")
+
+        # Extract frames
+        exo_mv_reader: MultiVideoReader | TorchCodecMultiVideoReader = exo_sequence.exo_video_readers
+        exo_frame_timestamps_list: list[Int[ndarray, "num_frames"]] = [
+            get_frame_timestamps_from_reader(reader) for reader in exo_mv_reader.video_readers
+        ]
+        min_exo_ts: Int[ndarray, "num_frames"] = min(
+            exo_frame_timestamps_list, key=lambda arr: int(arr.shape[0])
+        )
+        total_frames: int = len(min_exo_ts)
+        frame_idx: int = get_target_frame_idx(config.frame_selection, total_frames)
+        timestamp_ns: int = int(min_exo_ts[frame_idx])
+
+        # Load BGR frames
+        bgr_list: list[UInt8[ndarray, "H W 3"]] = []
+        for reader in exo_mv_reader.video_readers:
+            frame_obj: Any = reader[frame_idx]
+            if frame_obj is None:
+                return False, f"Missing exo frame at index {frame_idx}."
+            frame_array: UInt8[ndarray, "H W 3"] = np.asarray(frame_obj, dtype=np.uint8)
+            bgr_list.append(frame_array)
+
+        # Extract GT keypoints
+        gt_xyzc: Float32[ndarray, "133 4"] | None = None
+        if exoego_sequence.exoego_labels is not None:
+            gt_xyzc_stack: Float[ndarray, "n_frames 133 4"] = exoego_sequence.exoego_labels.xyzc_stack
+            if frame_idx < len(gt_xyzc_stack):
+                gt_xyzc = gt_xyzc_stack[frame_idx].astype(np.float32, copy=True)
+
+        rr.set_time(timeline=timeline, duration=np.timedelta64(timestamp_ns, "ns"))
+
+        _log("  Calibrating...")
+
+        # Run calibration
+        result: ExoCalibResult = service(
+            bgr_list=bgr_list,
+            gt_xyzc=gt_xyzc,
+            skip_tsdf_fusion=config.skip_tsdf_fusion,
+            align_to_ego=True,
+        )
+
+        # Log camera poses
+        for pinhole, exo_log_path in zip(result.pinhole_list, exo_video_log_paths, strict=True):
+            cam_log_path: Path = exo_log_path.parent.parent
+            log_pinhole(camera=pinhole, cam_log_path=cam_log_path, image_plane_distance=0.1, static=True)
+
+        # Move temp file to final location
+        import shutil
+
+        shutil.move(str(output_path), str(episode.calibrated_path))
+        _log(f"  ✓ Saved: {episode.calibrated_path.name}")
+
+        return True, None
+
+    except Exception as e:
+        error_msg: str = f"{type(e).__name__}: {e}"
+        _log(f"  ✗ Error: {error_msg}")
+        return False, error_msg
+
+
+def calibrate_episode_inplace(
+    service: ExoOnlyCalibService,
+    episode: EpisodeInfo,
+    config: BatchCalibConfig,
+    progress_callback: ProgressCallback | None = None,
+) -> tuple[bool, ExoCalibResult | str | None]:
+    """Calibrate and append extrinsics to original RRD (in-place).
+
+    This is ~3x faster than full relay because it only writes extrinsics
+    (~100KB) rather than the entire dataset (~300MB).
+
+    Args:
+        service: Pre-loaded calibration service.
+        episode: Episode metadata.
+        config: Calibration configuration.
+        progress_callback: Optional callback for progress messages.
+
+    Returns:
+        Tuple of (success, ExoCalibResult if success else error_message).
+    """
+
+    def _log(msg: str) -> None:
+        if progress_callback:
+            progress_callback(msg)
+        else:
+            print(msg)
+
+    try:
+        _log(f"  Loading: {episode.rrd_path.name}")
+
+        # Load original RRD to get app_id and recording_id
+        original_recording: Any = rr.recording.load_recording(episode.rrd_path)
+        app_id: str = original_recording.application_id()
+        rec_id: str = original_recording.recording_id()
+
+        # Load dataset for calibration
+        dataset_cfg: RRDExoEgoConfig = RRDExoEgoConfig(rrd_path=episode.rrd_path)
+        exoego_sequence: BaseExoEgoSequence = dataset_cfg.setup()
+        exo_sequence_obj: object | None = exoego_sequence.exo_sequence
+        if exo_sequence_obj is None:
+            return False, "Dataset setup failed to provide an exo sequence."
+        exo_sequence: BaseExoSequence = cast(BaseExoSequence, exo_sequence_obj)
+
+        # Get exo camera paths from dataset video names (works even without calibration)
+        exo_video_names: list[str] = exo_sequence.exo_video_names
+        exo_cam_paths: list[Path] = [Path("world/exo") / name for name in exo_video_names]
+
+        # Extract frames for calibration
+        _log("  Extracting frames...")
+        exo_mv_reader: MultiVideoReader | TorchCodecMultiVideoReader = exo_sequence.exo_video_readers
+        exo_frame_timestamps_list: list[Int[ndarray, "num_frames"]] = [
+            get_frame_timestamps_from_reader(reader) for reader in exo_mv_reader.video_readers
+        ]
+        min_exo_ts: Int[ndarray, "num_frames"] = min(
+            exo_frame_timestamps_list, key=lambda arr: int(arr.shape[0])
+        )
+        total_frames: int = len(min_exo_ts)
+        frame_idx: int = get_target_frame_idx(config.frame_selection, total_frames)
+
+        # Load BGR frames
+        bgr_list: list[UInt8[ndarray, "H W 3"]] = []
+        for reader in exo_mv_reader.video_readers:
+            frame_obj: Any = reader[frame_idx]
+            if frame_obj is None:
+                return False, f"Missing exo frame at index {frame_idx}."
+            frame_array: UInt8[ndarray, "H W 3"] = np.asarray(frame_obj, dtype=np.uint8)
+            bgr_list.append(frame_array)
+
+        # Extract GT keypoints for alignment
+        gt_xyzc: Float32[ndarray, "133 4"] | None = None
+        if exoego_sequence.exoego_labels is not None:
+            gt_xyzc_stack: Float[ndarray, "n_frames 133 4"] = exoego_sequence.exoego_labels.xyzc_stack
+            if frame_idx < len(gt_xyzc_stack):
+                gt_xyzc = gt_xyzc_stack[frame_idx].astype(np.float32, copy=True)
+
+        _log("  Calibrating...")
+
+        # Run calibration
+        result: ExoCalibResult = service(
+            bgr_list=bgr_list,
+            gt_xyzc=gt_xyzc,
+            skip_tsdf_fusion=config.skip_tsdf_fusion,
+            align_to_ego=True,
+        )
+
+        # Create patch RRD with only extrinsics
+        with tempfile.NamedTemporaryFile(prefix="exo_calib_patch_", suffix=".rrd", delete=False) as temp_file:
+            patch_path: Path = Path(temp_file.name)
+
+        # Initialize new recording with SAME app_id and recording_id
+        rec: rr.RecordingStream = rr.RecordingStream(application_id=app_id, recording_id=rec_id)
+        rec.save(str(patch_path))
+
+        # Log only extrinsics (static Transform3D at each camera)
+        for pinhole, cam_path in zip(result.pinhole_list, exo_cam_paths, strict=True):
+            log_pinhole(camera=pinhole, cam_log_path=cam_path, image_plane_distance=0.1, static=True, recording=rec)
+
+        # Flush the recording
+        del rec
+
+        # Append patch to original RRD file
+        import shutil
+
+        with open(episode.rrd_path, "ab") as orig_file, open(patch_path, "rb") as patch_file:
+            shutil.copyfileobj(patch_file, orig_file)
+
+        # Clean up patch file
+        patch_path.unlink()
+
+        _log(f"  ✓ Appended: {episode.rrd_path.name}")
+        return True, result  # Return result for propagation
+
+    except Exception as e:
+        error_msg: str = f"{type(e).__name__}: {e}"
+        _log(f"  ✗ Error: {error_msg}")
+        return False, None
+
+
+def propagate_extrinsics_to_episode(
+    calibration_result: ExoCalibResult,
+    exo_cam_paths: list[Path],
+    episode: EpisodeInfo,
+    progress_callback: ProgressCallback | None = None,
+) -> tuple[bool, str | None]:
+    """Propagate existing calibration extrinsics to an episode (no recalibration).
+
+    This is much faster than calibrate_episode_inplace because it skips:
+    - Dataset loading
+    - Video frame extraction
+    - MV calibration (VGGT+MoGe)
+    - Pose estimation
+
+    Only loads RRD metadata and appends extrinsics patch.
+
+    Args:
+        calibration_result: Previously computed calibration result.
+        exo_cam_paths: Camera entity paths (e.g., ['world/exo/Dragon-413A7CC1', ...]).
+        episode: Target episode to patch.
+        progress_callback: Optional callback for progress messages.
+
+    Returns:
+        Tuple of (success, error_message).
+    """
+
+    def _log(msg: str) -> None:
+        if progress_callback:
+            progress_callback(msg)
+        else:
+            print(msg)
+
+    try:
+        _log(f"  Propagating: {episode.rrd_path.name}")
+
+        # Load original RRD to get app_id and recording_id
+        original_recording: Any = rr.recording.load_recording(episode.rrd_path)
+        app_id: str = original_recording.application_id()
+        rec_id: str = original_recording.recording_id()
+
+        # Create patch RRD with extrinsics
+        with tempfile.NamedTemporaryFile(prefix="exo_calib_patch_", suffix=".rrd", delete=False) as temp_file:
+            patch_path: Path = Path(temp_file.name)
+
+        rec: rr.RecordingStream = rr.RecordingStream(application_id=app_id, recording_id=rec_id)
+        rec.save(str(patch_path))
+
+        for pinhole, cam_path in zip(calibration_result.pinhole_list, exo_cam_paths, strict=True):
+            log_pinhole(camera=pinhole, cam_log_path=cam_path, image_plane_distance=0.1, static=True, recording=rec)
+
+        del rec
+
+        # Append to original
+        import shutil
+
+        with open(episode.rrd_path, "ab") as orig_file, open(patch_path, "rb") as patch_file:
+            shutil.copyfileobj(patch_file, orig_file)
+
+        patch_path.unlink()
+
+        _log(f"  ✓ Propagated: {episode.rrd_path.name}")
+        return True, None
+
+    except Exception as e:
+        error_msg: str = f"{type(e).__name__}: {e}"
+        _log(f"  ✗ Error: {error_msg}")
+        return False, error_msg
+
+
+def process_sequence(
+    service: ExoOnlyCalibService,
+    sequence_path: Path,
+    config: BatchCalibConfig,
+    progress_callback: ProgressCallback | None = None,
+) -> tuple[int, int]:
+    """Process all episodes in a sequence.
+
+    Args:
+        service: Pre-loaded calibration service.
+        sequence_path: Path to sequence directory.
+        config: Batch calibration configuration.
+        progress_callback: Optional callback for progress messages.
+
+    Returns:
+        Tuple of (success_count, error_count).
+    """
+
+    def _log(msg: str) -> None:
+        if progress_callback:
+            progress_callback(msg)
+        else:
+            print(msg)
+
+    sequence_id: str = sequence_path.name
+    _log(f"\n{'='*60}")
+    _log(f"Processing sequence: {sequence_id}")
+    _log(f"{'='*60}")
+
+    episodes: list[EpisodeInfo] = discover_episodes_in_sequence(sequence_path)
+    if not episodes:
+        _log("  No episodes found.")
+        return 0, 0
+
+    _log(f"  Found {len(episodes)} episode(s)")
+    if config.inplace:
+        _log("  Mode: calibrate-once-propagate (fast)")
+
+    # Load or create manifest
+    manifest_path: Path = sequence_path / "calibration_manifest.json"
+    manifest: SequenceManifest = SequenceManifest.load_or_create(manifest_path, sequence_id)
+
+    success_count: int = 0
+    error_count: int = 0
+
+    # For calibrate-once-propagate: store the result and cam paths from first episode
+    sequence_calib_result: ExoCalibResult | None = None
+    sequence_exo_cam_paths: list[Path] | None = None
+
+    for i, episode in enumerate(episodes):
+        episode_name: str = episode.rrd_path.stem
+
+        # Skip if already calibrated (check file exists OR manifest says success)
+        if episode.is_calibrated:
+            existing_entry: ManifestEntry | None = manifest.episodes.get(episode_name)
+            if existing_entry and existing_entry.status == "success":
+                _log(f"  Skipping (already calibrated): {episode_name}")
+                success_count += 1
+                continue
+
+        # Initialize manifest entry
+        manifest.episodes[episode_name] = ManifestEntry(
+            episode_path=str(episode.rrd_path),
+            calibrated_path=str(episode.calibrated_path),
+            status="pending",
+        )
+
+        if config.dry_run:
+            action: str = "calibrate" if i == 0 or not config.inplace else "propagate"
+            _log(f"  [DRY RUN] Would {action}: {episode_name}")
+            continue
+
+        # Calibrate or propagate
+        success: bool = False
+        error_msg: str | None = None
+
+        if config.inplace:
+            # Calibrate-once-propagate strategy
+            if sequence_calib_result is None or sequence_exo_cam_paths is None:
+                # First episode: run full calibration and capture cam paths
+                # Load dataset to get camera paths
+                dataset_cfg: RRDExoEgoConfig = RRDExoEgoConfig(rrd_path=episode.rrd_path)
+                exoego_sequence: BaseExoEgoSequence = dataset_cfg.setup()
+                exo_seq: BaseExoSequence | None = exoego_sequence.exo_sequence
+                if exo_seq is not None:
+                    sequence_exo_cam_paths = [Path("world/exo") / n for n in exo_seq.exo_video_names]
+
+                success_result: tuple[bool, ExoCalibResult | str | None] = calibrate_episode_inplace(
+                    service, episode, config, progress_callback=progress_callback
+                )
+                success = success_result[0]
+                if success and isinstance(success_result[1], ExoCalibResult):
+                    sequence_calib_result = success_result[1]
+                elif not success:
+                    error_msg = str(success_result[1]) if success_result[1] else "Unknown error"
+            else:
+                # Subsequent episodes: propagate extrinsics only
+                prop_result: tuple[bool, str | None] = propagate_extrinsics_to_episode(
+                    sequence_calib_result, sequence_exo_cam_paths, episode, progress_callback=progress_callback
+                )
+                success = prop_result[0]
+                error_msg = prop_result[1]
+        else:
+            # Full relay mode: calibrate every episode
+            success, error_msg = calibrate_episode_direct(
+                service, episode, config, progress_callback=progress_callback
+            )
+
+        # Update manifest
+        now: str = datetime.now().isoformat()
+        if success:
+            manifest.episodes[episode_name].status = "success"
+            manifest.episodes[episode_name].calibrated_at = now
+            success_count += 1
+        else:
+            manifest.episodes[episode_name].status = "error"
+            manifest.episodes[episode_name].error_message = error_msg
+            error_count += 1
+
+        manifest.updated_at = now
+        manifest.save(manifest_path)
+
+    return success_count, error_count
+
+
+class BatchCalibService:
+    """Service for batch calibrating multiple episodes.
+
+    Loads ExoOnlyCalibService once at construction, then processes
+    multiple episodes without reloading models.
+    """
+
+    config: BatchCalibConfig
+    """Batch calibration configuration."""
+    _calib_service: ExoOnlyCalibService
+    """Cached calibration service with loaded models."""
+
+    def __init__(
+        self,
+        config: BatchCalibConfig,
+        service_config: ExoOnlyCalibServiceConfig | None = None,
+    ) -> None:
+        """Initialize batch service with cached models.
+
+        Args:
+            config: Batch calibration configuration.
+            service_config: Optional calibration service configuration.
+        """
+        self.config = config
+        if service_config is None:
+            from monopriors.apis.multiview_calibration import MultiViewCalibratorConfig
+
+            from mv_api.multiview_pose_estimator import MultiviewBodyTrackerConfig
+
+            service_config = ExoOnlyCalibServiceConfig(
+                calib_config=MultiViewCalibratorConfig(segment_people=False),
+                tracker_config=MultiviewBodyTrackerConfig(),
+            )
+        print("[BatchCalibService] Loading models...")
+        self._calib_service = ExoOnlyCalibService(service_config)
+        print("[BatchCalibService] Ready.")
+
+    def run(
+        self,
+        progress_callback: ProgressCallback | None = None,
+    ) -> tuple[int, int]:
+        """Run batch calibration on configured sequences.
+
+        Args:
+            progress_callback: Optional callback for progress messages.
+
+        Returns:
+            Tuple of (total_success, total_error).
+        """
+
+        def _log(msg: str) -> None:
+            if progress_callback:
+                progress_callback(msg)
+            else:
+                print(msg)
+
+        # Determine which sequences to process
+        sequences: list[Path]
+        if self.config.sequence_path is not None:
+            sequences = [self.config.sequence_path]
+        elif self.config.cut_root is not None:
+            sequences = discover_all_sequences(self.config.cut_root)
+        else:
+            msg: str = "Must specify either sequence_path or cut_root"
+            raise ValueError(msg)
+
+        _log(f"Found {len(sequences)} sequence(s) to process")
+
+        if self.config.dry_run:
+            _log("[DRY RUN MODE - no calibrations will be performed]")
+
+        # Process each sequence
+        total_success: int = 0
+        total_error: int = 0
+
+        for sequence_path in sequences:
+            success: int
+            error: int
+            success, error = process_sequence(
+                self._calib_service,
+                sequence_path,
+                self.config,
+                progress_callback=progress_callback,
+            )
+            total_success += success
+            total_error += error
+
+        # Summary
+        _log(f"\n{'='*60}")
+        _log("BATCH CALIBRATION COMPLETE")
+        _log(f"{'='*60}")
+        _log(f"  Successful: {total_success}")
+        _log(f"  Errors:     {total_error}")
+        _log(f"{'='*60}")
+
+        return total_success, total_error
+
+
+def run_batch_calibration(config: BatchCalibConfig) -> None:
+    """CLI entry point for batch calibration.
+
+    Args:
+        config: Batch calibration configuration from CLI.
+    """
+    service: BatchCalibService = BatchCalibService(config)
+    total_success: int
+    total_error: int
+    total_success, total_error = service.run()
+
+    # Exit with error code if any failures
+    if total_error > 0:
+        import sys
+
+        sys.exit(1)

--- a/packages/mv-api/src/mv_api/api/exo_only_calibration.py
+++ b/packages/mv-api/src/mv_api/api/exo_only_calibration.py
@@ -1,0 +1,821 @@
+"""Exo-only single-frame calibration and pose estimation.
+
+Performs multiview calibration and body pose estimation using only exo cameras
+from an RRD dataset on a single frame. Extracts GT keypoints from ExoEgoLabels
+for later Umeyama alignment. Also logs ego cameras for visualization (but does
+not use them for calibration).
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from timeit import default_timer as timer
+from typing import Any, Literal, cast
+
+import cv2
+import numpy as np
+import open3d as o3d
+import rerun as rr
+import rerun.blueprint as rrb
+import torch
+from jaxtyping import Bool, Float, Float32, Int, UInt8
+from monopriors.apis.multiview_calibration import MultiViewCalibrator, MultiViewCalibratorConfig, MVCalibResults
+from numpy import ndarray
+from simplecv.apis.view_exoego import LogPaths, SceneSetupResult, log_environment_mesh, log_exoego_batch, setup_scene
+from simplecv.camera_parameters import Extrinsics, PinholeParameters
+from simplecv.configs.exoego_dataset_configs import AnnotatedExoEgoDatasetUnion
+from simplecv.data.exo.base_exo import BaseExoSequence
+from simplecv.data.exoego.base_exoego import BaseExoEgoSequence
+from simplecv.data.skeleton.coco_133 import (
+    COCO_133_ID2NAME,
+    COCO_133_IDS,
+    COCO_133_LINKS,
+    FACE_IDX,
+    LEFT_HAND_IDX,
+    RIGHT_HAND_IDX,
+)
+from simplecv.ops.tsdf_depth_fuser import Open3DScaleInvariantFuser
+from simplecv.rerun_custom_types import Points3DWithConfidence, confidence_scores_to_rgb
+from simplecv.rerun_log_utils import RerunTyroConfig, log_pinhole
+from simplecv.video_io import MultiVideoReader, TorchCodecMultiVideoReader
+
+from mv_api.coco133_layers import (
+    COCO133_LAYER_COLORS,
+    COCO133_LAYER_LABELS,
+    Coco133AnnotationLayer,
+)
+from mv_api.multiview_pose_estimator import MultiviewBodyTracker, MultiviewBodyTrackerConfig, MVHistory
+
+np.set_printoptions(suppress=True)
+
+device: str = "cuda" if torch.cuda.is_available() else "cpu"
+
+
+@dataclass(slots=True)
+class UmeyamaResult:
+    """Similarity transform mapping exo world to ego/quest world."""
+
+    ego_T_exo: Float32[ndarray, "4 4"]
+    """4x4 transform: ego_points = ego_T_exo @ exo_points."""
+    n_matches: int
+    """Number of valid keypoint correspondences used."""
+    rms_error_m: float
+    """Root mean square alignment error in meters."""
+
+
+@dataclass(slots=True)
+class ExoCalibResult:
+    """Result of exo-only calibration and pose estimation."""
+
+    exo_xyzc: Float32[ndarray, "133 4"]
+    """Triangulated 3D COCO-133 keypoints from exo cameras (original, before alignment)."""
+    aligned_xyzc: Float32[ndarray, "133 4"] | None
+    """Triangulated keypoints after Umeyama alignment to ego world."""
+    gt_xyzc: Float32[ndarray, "133 4"] | None
+    """GT keypoints from ExoEgoLabels (if available)."""
+    pinhole_list: list[PinholeParameters]
+    """Calibrated exo cameras (aligned to ego world if align_to_ego=True)."""
+    frame_idx: int
+    """Frame index that was processed."""
+    timestamp_ns: int
+    """Timestamp of processed frame."""
+    umeyama_result: UmeyamaResult | None
+    """Umeyama alignment result (if alignment was performed)."""
+    # TSDF fused mesh data
+    mesh_vertex_positions: Float32[ndarray, "num_vertices 3"] | None = None
+    """Vertex positions for TSDF fused mesh."""
+    mesh_triangle_indices: Int[ndarray, "num_faces 3"] | None = None
+    """Triangle indices for TSDF fused mesh."""
+    mesh_vertex_normals: Float32[ndarray, "num_vertices 3"] | None = None
+    """Per-vertex normals for TSDF fused mesh."""
+    mesh_vertex_colors: Float32[ndarray, "num_vertices 3"] | None = None
+    """Per-vertex colors for TSDF fused mesh (0-1 range)."""
+
+
+@dataclass(slots=True)
+class TimingReport:
+    """Timing breakdown for pipeline stages."""
+
+    dataset_load_s: float = 0.0
+    scene_setup_s: float = 0.0
+    frame_load_s: float = 0.0
+    mv_calibration_s: float = 0.0
+    tsdf_fusion_s: float = 0.0
+    pose_estimation_s: float = 0.0
+    logging_s: float = 0.0
+    total_s: float = 0.0
+
+    def print_report(self) -> None:
+        """Print timing breakdown to console."""
+        print("\n" + "=" * 50)
+        print("[exo_only_calib] TIMING REPORT")
+        print("=" * 50)
+        print(f"  Dataset load:     {self.dataset_load_s:6.2f}s")
+        print(f"  Scene setup:      {self.scene_setup_s:6.2f}s")
+        print(f"  Frame loading:    {self.frame_load_s:6.2f}s")
+        print(f"  MV Calibration:   {self.mv_calibration_s:6.2f}s")
+        print(f"  TSDF Fusion:      {self.tsdf_fusion_s:6.2f}s")
+        print(f"  Pose Estimation:  {self.pose_estimation_s:6.2f}s")
+        print(f"  Logging:          {self.logging_s:6.2f}s")
+        print("-" * 50)
+        print(f"  TOTAL:            {self.total_s:6.2f}s")
+        print("=" * 50 + "\n")
+
+
+def _umeyama_transform(
+    *,
+    src_points: Float[ndarray, "n 3"],
+    dst_points: Float[ndarray, "n 3"],
+    allow_scaling: bool = False,
+    eps: float = 1e-9,
+) -> Float32[ndarray, "4 4"]:
+    """Compute the similarity transform aligning src_points to dst_points.
+
+    The returned transform follows the right-to-left convention:
+        dst_points ≈ (dst_T_src[:3, :3] @ src_points.T).T + dst_T_src[:3, 3]
+
+    Args:
+        src_points: Source XYZ coordinates (e.g., triangulated exo keypoints).
+        dst_points: Target XYZ coordinates (e.g., GT ego/quest keypoints).
+        allow_scaling: If True, estimate an isotropic scale factor; otherwise fix scale=1.
+        eps: Small value guarding against degenerate variance.
+
+    Returns:
+        dst_T_src: 4x4 homogeneous transform representing the similarity.
+    """
+    if src_points.shape != dst_points.shape:
+        msg: str = f"Source and destination shapes must match; got {src_points.shape} vs {dst_points.shape}"
+        raise ValueError(msg)
+
+    n_points: int = int(src_points.shape[0])
+    if n_points < 3:
+        msg = f"Umeyama transform requires at least 3 correspondences; received {n_points}"
+        raise ValueError(msg)
+
+    src_f64: Float[ndarray, "n 3"] = src_points.astype(np.float64, copy=False)
+    dst_f64: Float[ndarray, "n 3"] = dst_points.astype(np.float64, copy=False)
+
+    src_mean: Float[ndarray, "3"] = np.mean(src_f64, axis=0)
+    dst_mean: Float[ndarray, "3"] = np.mean(dst_f64, axis=0)
+
+    src_centered: Float[ndarray, "n 3"] = src_f64 - src_mean
+    dst_centered: Float[ndarray, "n 3"] = dst_f64 - dst_mean
+
+    covariance: Float[ndarray, "3 3"] = (dst_centered.T @ src_centered) / float(n_points)
+
+    u: Float[ndarray, "3 3"]
+    singular_vals: Float[ndarray, "3"]
+    vt: Float[ndarray, "3 3"]
+    u, singular_vals, vt = np.linalg.svd(covariance)
+
+    reflection: Float[ndarray, "3"] = np.ones(3, dtype=np.float64)
+    if np.linalg.det(u) * np.linalg.det(vt) < 0:
+        reflection = np.array([1.0, 1.0, -1.0], dtype=np.float64)
+
+    dst_R_src: Float[ndarray, "3 3"] = u @ np.diag(reflection) @ vt
+
+    src_var: float = float(np.mean(np.sum(src_centered**2, axis=1)))
+    if src_var <= eps:
+        msg = f"Source variance too small for stable Umeyama estimation (variance={src_var})"
+        raise ValueError(msg)
+
+    scale: float = 1.0
+    if allow_scaling:
+        scale = float(np.sum(singular_vals * reflection) / src_var)
+
+    dst_t_src: Float[ndarray, "3"] = dst_mean - scale * (dst_R_src @ src_mean)
+
+    dst_T_src: Float[ndarray, "4 4"] = np.eye(4, dtype=np.float64)
+    dst_T_src[:3, :3] = scale * dst_R_src
+    dst_T_src[:3, 3] = dst_t_src
+
+    return dst_T_src.astype(np.float32)
+
+
+def get_target_frame_idx(
+    frame_selection: Literal["middle", "first", "last"] | int,
+    total_frames: int,
+) -> int:
+    """Compute target frame index from selection mode."""
+    if isinstance(frame_selection, int):
+        return min(max(0, frame_selection), total_frames - 1)
+    if frame_selection == "middle":
+        return total_frames // 2
+    if frame_selection == "first":
+        return 0
+    if frame_selection == "last":
+        return total_frames - 1
+    msg: str = f"Unknown frame_selection: {frame_selection}"
+    raise ValueError(msg)
+
+
+def create_exo_ego_blueprint(
+    exo_video_log_paths: list[Path] | None = None,
+    ego_video_log_paths: list[Path] | None = None,
+    max_exo_videos_to_log: int = 8,
+) -> rrb.Blueprint:
+    """Create Rerun blueprint matching view_exoego.py style.
+
+    Layout: 3D view with ego tabs on right, exo tabs below.
+    """
+    main_view: rrb.ContainerLike = rrb.Spatial3DView(
+        origin="/",
+        name="3D View",
+        line_grid=rrb.archetypes.LineGrid3D(visible=False),
+    )
+
+    # Ego views on the right (vertical stack of tabs)
+    if ego_video_log_paths is not None:
+        ego_view: rrb.Vertical = rrb.Vertical(
+            contents=[
+                rrb.Tabs(
+                    rrb.Spatial2DView(origin=f"{video_log_path.parent}"),
+                )
+                for video_log_path in ego_video_log_paths
+            ]
+        )
+        main_view = rrb.Horizontal(
+            contents=[main_view, ego_view],
+            column_shares=[4, 1],
+        )
+
+    # Exo views below (horizontal row of tabs)
+    if exo_video_log_paths is not None:
+        exo_view: rrb.Horizontal = rrb.Horizontal(
+            contents=[
+                rrb.Tabs(
+                    rrb.Spatial2DView(origin=f"{video_log_path.parent}"),
+                )
+                for video_log_path in exo_video_log_paths[:max_exo_videos_to_log]
+            ]
+        )
+        main_view = rrb.Vertical(
+            contents=[main_view, exo_view],
+            row_shares=[4, 1],
+        )
+
+    blueprint: rrb.Blueprint = rrb.Blueprint(main_view, collapse_panels=True)
+    return blueprint
+
+
+def set_annotation_context(*, recording: rr.RecordingStream | None) -> None:
+    """Set annotation context with layer-specific colors for GT and estimated keypoints."""
+    keypoint_infos: list[rr.AnnotationInfo] = [
+        rr.AnnotationInfo(id=id, label=name) for id, name in COCO_133_ID2NAME.items()
+    ]
+    class_descriptions: list[rr.ClassDescription] = []
+    for layer in (
+        Coco133AnnotationLayer.GT,
+        Coco133AnnotationLayer.RAW_2D,
+        Coco133AnnotationLayer.TRIANGULATED_3D,
+    ):
+        label: str = COCO133_LAYER_LABELS[layer]
+        color: tuple[int, int, int] = COCO133_LAYER_COLORS[layer]
+        class_descriptions.append(
+            rr.ClassDescription(
+                info=rr.AnnotationInfo(id=int(layer), label=label, color=color),
+                keypoint_annotations=keypoint_infos,
+                keypoint_connections=COCO_133_LINKS,
+            )
+        )
+    rr.log(
+        "/",
+        rr.AnnotationContext(class_descriptions),
+        static=True,
+        recording=recording,
+    )
+
+
+def get_frame_timestamps_from_reader(video_reader: Any) -> Int[ndarray, "num_frames"]:
+    """Compute frame timestamps (ns) from video reader metadata."""
+    fps: float = video_reader.fps
+    frame_cnt: int = video_reader.frame_cnt
+    ns_per_frame: float = 1e9 / fps
+    timestamps: Int[ndarray, "num_frames"] = (np.arange(frame_cnt) * ns_per_frame).astype(np.int64)
+    return timestamps
+
+
+# Pre-computed upper-body + hands + face filter indices for COCO-133
+_UPPER_BODY_IDX: Int[ndarray, "_"] = np.array([5, 6, 7, 8, 9, 10])
+WB_UPPER_BODY_IDS: Int[ndarray, "_"] = np.concatenate(
+    [_UPPER_BODY_IDX, FACE_IDX, LEFT_HAND_IDX, RIGHT_HAND_IDX]
+)
+"""Upper body, face, and hand keypoint indices for filtering COCO-133."""
+
+
+@dataclass
+class ExoOnlyCalibServiceConfig:
+    """Configuration for persistent calibration service with cached models.
+
+    This config is tyro-compatible for CLI configuration with reasonable defaults.
+    Note: filter_body_idxes is not configurable via CLI (uses WB_UPPER_BODY_IDS constant).
+    """
+
+    calib_config: MultiViewCalibratorConfig = field(default_factory=MultiViewCalibratorConfig)
+    """Multi-view calibration parameters (VGGT + MoGe depth refinement)."""
+    tracker_config: MultiviewBodyTrackerConfig = field(default_factory=MultiviewBodyTrackerConfig)
+    """Body pose tracker configuration (YOLOX + RTMPose)."""
+    parent_log_path: Path = field(default_factory=lambda: Path("world"))
+    """Root path for Rerun logging entity hierarchy."""
+
+
+@dataclass
+class ExoOnlyCalibConfig:
+    """Configuration for exo-only calibration CLI.
+
+    Composes service config with dataset and Rerun options for CLI usage.
+    """
+
+    rr_config: RerunTyroConfig
+    """Rerun logging configuration (spawn viewer, save RRD, etc.)."""
+    dataset: AnnotatedExoEgoDatasetUnion
+    """RRD dataset to load exo sequence from."""
+    service_config: ExoOnlyCalibServiceConfig = field(default_factory=ExoOnlyCalibServiceConfig)
+    """Service configuration for models and calibration parameters."""
+    frame_selection: Literal["middle", "first", "last"] | int = "middle"
+    """Which frame to process for calibration."""
+    skip_tsdf_fusion: bool = False
+    """Skip TSDF mesh fusion for faster processing (no mesh output)."""
+    align_to_ego: bool = True
+    """Align exo cameras to ego world using Umeyama on hand keypoints."""
+
+
+class ExoOnlyCalibService:
+    """Persistent service holding cached calibrator and tracker models.
+
+    Instantiate once at application startup, then call repeatedly to process
+    image batches without reloading models.
+
+    The service focuses on calibration + pose estimation + alignment.
+    Dataset loading and Rerun setup are the caller's responsibility.
+    """
+
+    config: ExoOnlyCalibServiceConfig
+    """Service configuration."""
+    mv_calibrator: MultiViewCalibrator
+    """Cached multiview calibrator (VGGT + MoGe)."""
+    pose_tracker: MultiviewBodyTracker
+    """Cached body pose tracker (YOLOX + RTMPose)."""
+
+    def __init__(self, config: ExoOnlyCalibServiceConfig) -> None:
+        """Load models during construction."""
+        self.config = config
+        print("[ExoOnlyCalibService] Loading MultiViewCalibrator...")
+        self.mv_calibrator = MultiViewCalibrator(
+            parent_log_path=config.parent_log_path,
+            config=config.calib_config,
+        )
+        print("[ExoOnlyCalibService] Loading MultiviewBodyTracker...")
+        self.pose_tracker = MultiviewBodyTracker(
+            config.tracker_config,
+            filter_body_idxes=WB_UPPER_BODY_IDS,
+        )
+        print("[ExoOnlyCalibService] Models loaded and ready.")
+
+    def __call__(
+        self,
+        *,
+        bgr_list: list[UInt8[ndarray, "H W 3"]],
+        gt_xyzc: Float32[ndarray, "133 4"] | None = None,
+        skip_tsdf_fusion: bool = False,
+        align_to_ego: bool = True,
+        recording: rr.RecordingStream | None = None,
+    ) -> ExoCalibResult:
+        """Execute calibration and pose estimation on a batch of BGR images.
+
+        Args:
+            bgr_list: List of BGR images from exo cameras (same frame, different views).
+            gt_xyzc: Optional GT keypoints for Umeyama alignment (133 COCO keypoints with confidence).
+            skip_tsdf_fusion: Skip TSDF mesh fusion for faster processing.
+            align_to_ego: Align exo cameras to ego world using Umeyama (requires gt_xyzc).
+            recording: Optional Rerun recording stream for model-internal logging.
+
+        Returns:
+            ExoCalibResult containing calibrated cameras, triangulated keypoints,
+            and optional aligned keypoints.
+        """
+        timing: TimingReport = TimingReport()
+        pipeline_start: float = timer()
+
+        # Convert BGR to RGB for calibrator
+        t0: float = timer()
+        rgb_list: list[UInt8[ndarray, "H W 3"]] = [
+            np.asarray(cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB), dtype=np.uint8) for bgr in bgr_list
+        ]
+        timing.frame_load_s = timer() - t0
+
+        # =============================================
+        # 1. Run multiview calibration
+        # =============================================
+        t0 = timer()
+        mv_calib_results: MVCalibResults = self.mv_calibrator(rgb_list=rgb_list)
+        pinhole_param_list: list[PinholeParameters] = mv_calib_results.pinhole_param_list
+        timing.mv_calibration_s = timer() - t0
+        print(f"[ExoOnlyCalibService] MV Calibration in {timing.mv_calibration_s:.2f}s")
+
+        # Assign camera names
+        for i, cam in enumerate(pinhole_param_list):
+            cam.name = f"camera_{i}"
+
+        # Get pointcloud for TSDF initialization (needed for bounds)
+        pcd: o3d.geometry.PointCloud = mv_calib_results.pcd
+
+        # =============================================
+        # 2. TSDF Fusion - generates mesh for visualization
+        # =============================================
+        mesh_vertex_positions: Float32[ndarray, "num_vertices 3"] | None = None
+        mesh_triangle_indices: Int[ndarray, "num_faces 3"] | None = None
+        mesh_vertex_normals: Float32[ndarray, "num_vertices 3"] | None = None
+        mesh_vertex_colors: Float32[ndarray, "num_vertices 3"] | None = None
+
+        if not skip_tsdf_fusion and mv_calib_results.depth_list and mv_calib_results.pinhole_param_list:
+            t0 = timer()
+            depth_fuser: Open3DScaleInvariantFuser = Open3DScaleInvariantFuser(grid_resolution=512)
+            reference_points: Float32[ndarray, "num_points 3"] = np.asarray(pcd.points, dtype=np.float32)
+            depth_fuser.initialise_from_points(reference_points)
+            for depth_map, pinhole_param, rgb in zip(
+                mv_calib_results.depth_list,
+                mv_calib_results.pinhole_param_list,
+                rgb_list,
+                strict=True,
+            ):
+                depth_fuser.fuse_frame(depth_hw=depth_map, pinhole=pinhole_param, rgb_hw3=rgb)
+
+            gt_mesh: o3d.geometry.TriangleMesh = depth_fuser.get_mesh()
+            gt_mesh.compute_vertex_normals()
+            mesh_vertex_positions = np.asarray(gt_mesh.vertices, dtype=np.float32)
+            mesh_triangle_indices = np.asarray(gt_mesh.triangles, dtype=np.int32)
+            mesh_vertex_normals = np.asarray(gt_mesh.vertex_normals, dtype=np.float32)
+            mesh_vertex_colors = np.asarray(gt_mesh.vertex_colors, dtype=np.float32)
+            timing.tsdf_fusion_s = timer() - t0
+            print(f"[ExoOnlyCalibService] TSDF Fusion in {timing.tsdf_fusion_s:.2f}s")
+
+        # =============================================
+        # 3. Body pose estimation
+        # =============================================
+        t0 = timer()
+        mv_output: MVHistory = self.pose_tracker(
+            bgr_list=bgr_list,
+            pinhole_list=pinhole_param_list,
+            pred_state=MVHistory(),
+            recording=recording,
+        )
+        timing.pose_estimation_s = timer() - t0
+        print(f"[ExoOnlyCalibService] Pose estimation in {timing.pose_estimation_s:.2f}s")
+
+        # Get triangulated keypoints
+        exo_xyzc: Float32[ndarray, "133 4"] = (
+            mv_output.xyzc_t.astype(np.float32, copy=True)
+            if mv_output.xyzc_t is not None
+            else np.full((133, 4), np.nan, dtype=np.float32)
+        )
+
+        # =============================================
+        # 4. Umeyama alignment (exo -> ego using hands)
+        # =============================================
+        aligned_xyzc: Float32[ndarray, "133 4"] | None = None
+        umeyama_result: UmeyamaResult | None = None
+
+        if align_to_ego and gt_xyzc is not None:
+            # Extract hand keypoints only
+            hand_idx: Int[ndarray, "_"] = np.concatenate([LEFT_HAND_IDX, RIGHT_HAND_IDX])
+            exo_hands: Float32[ndarray, "n_hands 4"] = exo_xyzc[hand_idx]
+            gt_hands: Float32[ndarray, "n_hands 4"] = gt_xyzc[hand_idx]
+
+            # Find valid correspondences
+            valid_mask: Bool[ndarray, "n_hands"] = (
+                np.isfinite(exo_hands[:, :3]).all(axis=1)
+                & np.isfinite(gt_hands[:, :3]).all(axis=1)
+                & (exo_hands[:, 3] > 0.0)
+                & (gt_hands[:, 3] > 0.0)
+            )
+            n_valid: int = int(np.count_nonzero(valid_mask))
+
+            if n_valid >= 3:
+                src_points: Float[ndarray, "n 3"] = exo_hands[valid_mask, :3].astype(np.float64)
+                dst_points: Float[ndarray, "n 3"] = gt_hands[valid_mask, :3].astype(np.float64)
+
+                # Compute Umeyama transform
+                ego_T_exo: Float32[ndarray, "4 4"] = _umeyama_transform(
+                    src_points=src_points,
+                    dst_points=dst_points,
+                    allow_scaling=True,
+                )
+
+                # Compute alignment error
+                src_h: Float[ndarray, "n 4"] = np.concatenate(
+                    [src_points, np.ones((n_valid, 1), dtype=np.float64)], axis=1
+                )
+                aligned_src: Float[ndarray, "n 3"] = (ego_T_exo @ src_h.T).T[:, :3]
+                residuals: Float[ndarray, "n"] = np.linalg.norm(aligned_src - dst_points, axis=1)
+                rms_error: float = float(np.sqrt(np.mean(residuals**2)))
+
+                umeyama_result = UmeyamaResult(
+                    ego_T_exo=ego_T_exo,
+                    n_matches=n_valid,
+                    rms_error_m=rms_error,
+                )
+                print(f"[ExoOnlyCalibService] Umeyama alignment: {n_valid} matches, RMS = {rms_error * 1000:.2f}mm")
+
+                # Extract scale
+                scale: float = float(np.linalg.norm(ego_T_exo[:3, 0]))
+                print(f"[ExoOnlyCalibService] Umeyama scale factor: {scale:.4f}")
+
+                # Isometric transform for cameras
+                ego_R_exo: Float32[ndarray, "3 3"] = (ego_T_exo[:3, :3] / scale).astype(np.float32)
+                ego_t_exo: Float32[ndarray, "3"] = ego_T_exo[:3, 3].astype(np.float32)
+
+                # Transform all keypoints to ego world
+                exo_xyz_h: Float[ndarray, "133 4"] = np.concatenate(
+                    [exo_xyzc[:, :3], np.ones((133, 1), dtype=np.float32)], axis=1
+                )
+                aligned_xyz: Float32[ndarray, "133 3"] = (ego_T_exo @ exo_xyz_h.T).T[:, :3].astype(np.float32)
+                aligned_xyzc = np.concatenate([aligned_xyz, exo_xyzc[:, 3:4]], axis=1).astype(np.float32)
+
+                # Transform exo camera extrinsics to ego world
+                for i, cam in enumerate(pinhole_param_list):
+                    world_T_cam_old: Float[ndarray, "4 4"] = cam.extrinsics.world_T_cam
+                    world_R_cam_new: Float[ndarray, "3 3"] = ego_R_exo @ world_T_cam_old[:3, :3]
+                    world_t_cam_new: Float[ndarray, "3"] = scale * (ego_R_exo @ world_T_cam_old[:3, 3]) + ego_t_exo
+                    new_extrinsics: Extrinsics = Extrinsics(
+                        world_R_cam=world_R_cam_new.astype(np.float32),
+                        world_t_cam=world_t_cam_new.astype(np.float32),
+                    )
+                    pinhole_param_list[i] = PinholeParameters(
+                        name=cam.name,
+                        intrinsics=cam.intrinsics,
+                        extrinsics=new_extrinsics,
+                        distortion=cam.distortion,
+                    )
+
+                # Transform mesh vertices to ego world
+                if mesh_vertex_positions is not None:
+                    n_verts: int = mesh_vertex_positions.shape[0]
+                    verts_h: Float[ndarray, "n_verts 4"] = np.concatenate(
+                        [mesh_vertex_positions, np.ones((n_verts, 1), dtype=np.float32)], axis=1
+                    )
+                    mesh_vertex_positions = (ego_T_exo @ verts_h.T).T[:, :3].astype(np.float32)
+
+                    # Transform normals (rotation only, no translation or scaling)
+                    if mesh_vertex_normals is not None:
+                        mesh_vertex_normals = (ego_R_exo @ mesh_vertex_normals.T).T.astype(np.float32)
+            else:
+                print(f"[ExoOnlyCalibService] Not enough hand correspondences ({n_valid}) for Umeyama")
+
+        timing.total_s = timer() - pipeline_start
+        timing.print_report()
+
+        return ExoCalibResult(
+            exo_xyzc=exo_xyzc,
+            aligned_xyzc=aligned_xyzc,
+            gt_xyzc=gt_xyzc,
+            pinhole_list=pinhole_param_list,
+            frame_idx=0,  # Caller should track this
+            timestamp_ns=0,  # Caller should track this
+            umeyama_result=umeyama_result,
+            mesh_vertex_positions=mesh_vertex_positions,
+            mesh_triangle_indices=mesh_triangle_indices,
+            mesh_vertex_normals=mesh_vertex_normals,
+            mesh_vertex_colors=mesh_vertex_colors,
+        )
+
+
+def main(config: ExoOnlyCalibConfig) -> None:
+    """CLI entry point for exo-only calibration.
+
+    Handles dataset loading, Rerun setup, and delegates calibration to
+    ExoOnlyCalibService with pre-loaded data.
+    """
+
+    parent_log_path: Path = config.service_config.parent_log_path
+    timeline: str = "video_time"
+
+    # Create one-shot service using pre-configured service config
+    service: ExoOnlyCalibService = ExoOnlyCalibService(config.service_config)
+
+    # Load dataset
+    exoego_sequence: BaseExoEgoSequence = config.dataset.setup()
+    exo_sequence_obj: object | None = exoego_sequence.exo_sequence
+    if exo_sequence_obj is None:
+        msg: str = "Dataset setup failed to provide an exo sequence."
+        raise ValueError(msg)
+    exo_sequence: BaseExoSequence = cast(BaseExoSequence, exo_sequence_obj)
+
+    # Setup Rerun
+    rr.log("/", exoego_sequence.world_coordinate_system, static=True)
+    set_annotation_context(recording=None)
+
+    # Setup scene
+    scene_setup_result: SceneSetupResult = setup_scene(
+        exoego_sequence,
+        parent_log_path=parent_log_path,
+        timeline=timeline,
+        log_ego=True,
+        log_exo=True,
+    )
+    log_paths: LogPaths = scene_setup_result.log_paths
+    shortest_timestamp: Int[ndarray, "n_frames"] = scene_setup_result.shortest_timestamp
+
+    # Log GT data if available
+    if exoego_sequence.exoego_labels is not None:
+        log_exoego_batch(
+            exoego_sequence,
+            parent_log_path=parent_log_path,
+            timeline=timeline,
+            shortest_timestamp=shortest_timestamp,
+            log_ego=True,
+            log_exo=False,
+            log_mano=True,
+        )
+
+    if exoego_sequence.environment_mesh is not None:
+        log_environment_mesh(exoego_sequence, parent_log_path)
+
+    # Send blueprint
+    exo_video_log_paths: list[Path] = log_paths.exo_video_log_paths or []
+    ego_video_log_paths: list[Path] = log_paths.ego_video_log_paths or []
+    blueprint: rrb.Blueprint = create_exo_ego_blueprint(
+        exo_video_log_paths=exo_video_log_paths if exo_video_log_paths else None,
+        ego_video_log_paths=ego_video_log_paths if ego_video_log_paths else None,
+    )
+    rr.send_blueprint(blueprint)
+
+    # Extract frames
+    exo_mv_reader: MultiVideoReader | TorchCodecMultiVideoReader = exo_sequence.exo_video_readers
+    exo_frame_timestamps_list: list[Int[ndarray, "num_frames"]] = [
+        get_frame_timestamps_from_reader(reader) for reader in exo_mv_reader.video_readers
+    ]
+    min_exo_ts: Int[ndarray, "num_frames"] = min(
+        exo_frame_timestamps_list, key=lambda arr: int(arr.shape[0])
+    )
+    total_frames: int = len(min_exo_ts)
+    frame_idx: int = get_target_frame_idx(config.frame_selection, total_frames)
+    timestamp_ns: int = int(min_exo_ts[frame_idx])
+
+    # Load BGR frames
+    bgr_list: list[UInt8[ndarray, "H W 3"]] = []
+    for reader in exo_mv_reader.video_readers:
+        frame_obj: Any = reader[frame_idx]
+        if frame_obj is None:
+            msg = f"Missing exo frame at index {frame_idx}."
+            raise ValueError(msg)
+        frame_array: UInt8[ndarray, "H W 3"] = np.asarray(frame_obj, dtype=np.uint8)
+        bgr_list.append(frame_array)
+
+    # Extract GT keypoints
+    gt_xyzc: Float32[ndarray, "133 4"] | None = None
+    if exoego_sequence.exoego_labels is not None:
+        gt_xyzc_stack: Float[ndarray, "n_frames 133 4"] = exoego_sequence.exoego_labels.xyzc_stack
+        if frame_idx < len(gt_xyzc_stack):
+            gt_xyzc = gt_xyzc_stack[frame_idx].astype(np.float32, copy=True)
+
+    rr.set_time(timeline=timeline, duration=np.timedelta64(timestamp_ns, "ns"))
+
+    # Run calibration
+    result: ExoCalibResult = service(
+        bgr_list=bgr_list,
+        gt_xyzc=gt_xyzc,
+        skip_tsdf_fusion=config.skip_tsdf_fusion,
+        align_to_ego=config.align_to_ego,
+    )
+
+    # Log calibration results to Rerun
+    _log_calibration_results(
+        result=result,
+        parent_log_path=parent_log_path,
+        exo_video_log_paths=exo_video_log_paths,
+        filter_body_idxes=WB_UPPER_BODY_IDS,
+        conf_thresh=service.pose_tracker.config.keypoint_threshold,
+    )
+
+
+def _log_calibration_results(
+    result: ExoCalibResult,
+    parent_log_path: Path,
+    exo_video_log_paths: list[Path],
+    filter_body_idxes: Int[ndarray, "_"],
+    conf_thresh: float,
+    recording: rr.RecordingStream | None = None,
+) -> None:
+    """Log calibration results to Rerun."""
+    # Log camera poses
+    for pinhole, exo_log_path in zip(result.pinhole_list, exo_video_log_paths, strict=True):
+        cam_log_path: Path = exo_log_path.parent.parent
+        log_pinhole(
+            camera=pinhole,
+            cam_log_path=cam_log_path,
+            image_plane_distance=0.1,
+            static=True,
+            recording=recording,
+        )
+
+    # Log aligned keypoints if available
+    if result.aligned_xyzc is not None:
+        aligned_conf: Float32[ndarray, "n_kpts"] = result.aligned_xyzc[:, 3]
+        aligned_rgb_stack: UInt8[ndarray, "1 n_kpts 3"] = confidence_scores_to_rgb(
+            aligned_conf[np.newaxis, :, np.newaxis]
+        )
+        aligned_rgb: UInt8[ndarray, "n_kpts 3"] = aligned_rgb_stack[0]
+
+        top_half_mask: Bool[ndarray, "_"] = np.isin(np.arange(133), filter_body_idxes)
+        aligned_vis_xyz: Float32[ndarray, "n_kpts 3"] = result.aligned_xyzc[:, :3].copy()
+        aligned_vis_xyz[~top_half_mask, :] = np.nan
+        aligned_vis_xyz[aligned_conf < conf_thresh, :] = np.nan
+
+        rr.log(
+            str(parent_log_path / "exo_aligned" / "coco133_xyz"),
+            Points3DWithConfidence(
+                positions=aligned_vis_xyz,
+                confidences=aligned_conf,
+                class_ids=int(Coco133AnnotationLayer.TRIANGULATED_3D),
+                keypoint_ids=COCO_133_IDS,
+                show_labels=False,
+                colors=aligned_rgb,
+            ),
+            static=True,
+            recording=recording,
+        )
+
+    # Log TSDF fused mesh if available
+    if result.mesh_vertex_positions is not None and result.mesh_triangle_indices is not None:
+        mesh_colors: UInt8[ndarray, "n_verts 3"] | None = None
+        if result.mesh_vertex_colors is not None:
+            # Convert from [0,1] float to [0,255] uint8
+            mesh_colors = (result.mesh_vertex_colors * 255).astype(np.uint8)
+
+        rr.log(
+            str(parent_log_path / "tsdf_mesh"),
+            rr.Mesh3D(
+                vertex_positions=result.mesh_vertex_positions,
+                triangle_indices=result.mesh_triangle_indices,
+                vertex_normals=result.mesh_vertex_normals,
+                vertex_colors=mesh_colors,
+            ),
+            static=True,
+            recording=recording,
+        )
+
+
+def run_exo_only_calibration(
+    config: ExoOnlyCalibConfig,
+    recording: rr.RecordingStream | None = None,
+) -> ExoCalibResult:
+    """Execute exo-only calibration and pose estimation on a single frame.
+
+    .. deprecated::
+        Use ExoOnlyCalibService for better performance. This function
+        creates a new service instance on each call, loading models from scratch.
+
+    Args:
+        config: Pipeline configuration.
+        recording: Optional Rerun recording stream.
+
+    Returns:
+        ExoCalibResult containing triangulated keypoints and GT labels.
+    """
+    # Create one-shot service using pre-configured service config
+    service: ExoOnlyCalibService = ExoOnlyCalibService(config.service_config)
+
+    # Load dataset
+    exoego_sequence: BaseExoEgoSequence = config.dataset.setup()
+    exo_sequence_obj: object | None = exoego_sequence.exo_sequence
+    if exo_sequence_obj is None:
+        msg: str = "Dataset setup failed to provide an exo sequence."
+        raise ValueError(msg)
+    exo_sequence: BaseExoSequence = cast(BaseExoSequence, exo_sequence_obj)
+
+    # Extract frames
+    exo_mv_reader: MultiVideoReader | TorchCodecMultiVideoReader = exo_sequence.exo_video_readers
+    exo_frame_timestamps_list: list[Int[ndarray, "num_frames"]] = [
+        get_frame_timestamps_from_reader(reader) for reader in exo_mv_reader.video_readers
+    ]
+    min_exo_ts: Int[ndarray, "num_frames"] = min(
+        exo_frame_timestamps_list, key=lambda arr: int(arr.shape[0])
+    )
+    total_frames: int = len(min_exo_ts)
+    frame_idx: int = get_target_frame_idx(config.frame_selection, total_frames)
+
+    # Load BGR frames
+    bgr_list: list[UInt8[ndarray, "H W 3"]] = []
+    for reader in exo_mv_reader.video_readers:
+        frame_obj: Any = reader[frame_idx]
+        if frame_obj is None:
+            msg = f"Missing exo frame at index {frame_idx}."
+            raise ValueError(msg)
+        frame_array: UInt8[ndarray, "H W 3"] = np.asarray(frame_obj, dtype=np.uint8)
+        bgr_list.append(frame_array)
+
+    # Extract GT keypoints
+    gt_xyzc: Float32[ndarray, "133 4"] | None = None
+    if exoego_sequence.exoego_labels is not None:
+        gt_xyzc_stack: Float[ndarray, "n_frames 133 4"] = exoego_sequence.exoego_labels.xyzc_stack
+        if frame_idx < len(gt_xyzc_stack):
+            gt_xyzc = gt_xyzc_stack[frame_idx].astype(np.float32, copy=True)
+
+    # Run calibration
+    return service(
+        bgr_list=bgr_list,
+        gt_xyzc=gt_xyzc,
+        skip_tsdf_fusion=config.skip_tsdf_fusion,
+        align_to_ego=config.align_to_ego,
+        recording=recording,
+    )

--- a/packages/mv-api/src/mv_api/api/full_exoego_pipeline.py
+++ b/packages/mv-api/src/mv_api/api/full_exoego_pipeline.py
@@ -1,0 +1,826 @@
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from timeit import default_timer as timer
+from typing import Any, cast
+
+import cv2
+import numpy as np
+import open3d as o3d
+import rerun as rr
+import rerun.blueprint as rrb
+import torch
+from jaxtyping import Bool, Float, Float32, Int, UInt8
+from monopriors.apis.multiview_calibration import MultiViewCalibrator, MultiViewCalibratorConfig, MVCalibResults
+from numpy import ndarray
+from simplecv.apis.view_exoego import (
+    LogPaths,
+    SceneSetupResult,
+    setup_scene,
+)
+from simplecv.camera_parameters import Intrinsics, PinholeParameters
+from simplecv.configs.exoego_dataset_configs import AnnotatedExoEgoDatasetUnion
+from simplecv.data.ego.base_ego import BaseEgoSequence
+from simplecv.data.exo.base_exo import BaseExoSequence
+from simplecv.data.exoego.base_exoego import BaseExoEgoSequence
+from simplecv.data.skeleton.coco_133 import (
+    COCO_133_ID2NAME,
+    COCO_133_IDS,
+    COCO_133_LINKS,
+    FACE_IDX,
+    LEFT_HAND_IDX,
+    RIGHT_HAND_IDX,
+)
+from simplecv.ops.pc_utils import estimate_voxel_size
+from simplecv.ops.triangulate import proj_3d_vectorized
+from simplecv.ops.tsdf_depth_fuser import Open3DScaleInvariantFuser
+from simplecv.rerun_custom_types import Points2DWithConfidence, Points3DWithConfidence, confidence_scores_to_rgb
+from simplecv.rerun_log_utils import RerunTyroConfig, log_pinhole
+from simplecv.video_io import MultiVideoReader, TorchCodecMultiVideoReader
+from tqdm import tqdm
+
+from mv_api.coco133_layers import (
+    COCO133_LAYER_COLORS,
+    COCO133_LAYER_LABELS,
+    COCO133_PREDICTION_LAYER_TO_PATH,
+    Coco133AnnotationLayer,
+)
+from mv_api.hand_keypoints import FinalWilorPred, HandKeypointDetectorConfig, WilorHandKeypointDetector
+from mv_api.multiview_pose_estimator import MultiviewBodyTracker, MultiviewBodyTrackerConfig, MVHistory
+
+np.set_printoptions(suppress=True)
+
+SUPPORTED_IMAGE_EXTENSIONS = (".png", ".jpg", ".jpeg")
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
+# Target resolution for calibration (width, height) - ensures all depth maps have same shape
+CALIB_TARGET_RESOLUTION: tuple[int, int] = (1280, 720)
+
+
+def resize_images_to_common_resolution(
+    images: list[UInt8[ndarray, "H W 3"]],
+    target_size: tuple[int, int] | None = None,
+) -> list[UInt8[ndarray, "H W 3"]]:
+    """Resize all images to a common resolution for multi-view processing.
+
+    Args:
+        images: List of RGB images with potentially varying resolutions.
+        target_size: Optional (width, height) tuple. If None, uses first image's size.
+
+    Returns:
+        List of resized images with uniform resolution.
+    """
+    if not images:
+        return images
+
+    if target_size is None:
+        # Use first image's resolution
+        h, w = images[0].shape[:2]
+        target_size = (w, h)
+
+    resized: list[UInt8[ndarray, "H W 3"]] = []
+    target_w, target_h = target_size
+    for img in images:
+        h, w = img.shape[:2]
+        if w == target_w and h == target_h:
+            resized.append(img)
+        else:
+            resized_img: UInt8[ndarray, "H W 3"] = cv2.resize(
+                img, (target_w, target_h), interpolation=cv2.INTER_LINEAR
+            ).astype(np.uint8)
+            resized.append(resized_img)
+    return resized
+
+
+def create_view_container(
+    *,
+    ego_video_log_paths: list[Path] | None = None,
+    exo_video_log_paths: list[Path] | None = None,
+    max_ego_videos_to_log: int = 4,
+    max_exo_videos_to_log: int = 8,
+) -> rrb.ContainerLike:
+    """Create a Rerun blueprint for visualizing ego- and exo-centric streams.
+
+    Args:
+        ego_video_log_paths (list[Path] | None): Optional set of ego video entity
+            roots; each path becomes a tabbed 2D view alongside the spatial view.
+        exo_video_log_paths (list[Path] | None): Optional set of exo video entity
+            roots; each path becomes a tabbed 2D view beneath the spatial view.
+        max_exo_videos_to_log (Literal[4, 8]): Maximum number of exo video panels
+            to materialize when ``exo_video_log_paths`` is provided.
+        max_ego_videos_to_log (Literal[4, 8]): Maximum number of ego video panels
+            to materialize when ``ego_video_log_paths`` is provided.
+
+    Returns:
+        rrb.Blueprint: Assembled layout containing the configured views.
+    """
+    main_view = rrb.Spatial3DView(
+        origin="/",
+        contents=[
+            "+ $origin/**",
+            "- /world/gt/env_pointcloud",  # hide raw point clouds by default
+        ],
+        line_grid=rrb.archetypes.LineGrid3D(visible=False),
+    )
+
+    if ego_video_log_paths is not None:
+        ego_view = rrb.Vertical(
+            contents=[
+                rrb.Tabs(
+                    rrb.Spatial2DView(origin=f"{video_log_path.parent}"),
+                )
+                for video_log_path in ego_video_log_paths[:max_ego_videos_to_log]
+            ]
+        )
+        main_view = rrb.Horizontal(
+            contents=[main_view, ego_view],
+            column_shares=[4, 1],
+        )
+
+    if exo_video_log_paths is not None:
+        exo_view = rrb.Horizontal(
+            contents=[
+                rrb.Tabs(
+                    rrb.Spatial2DView(origin=f"{video_log_path.parent}"),
+                )
+                for video_log_path in exo_video_log_paths[:max_exo_videos_to_log]
+            ]
+        )
+        main_view = rrb.Vertical(
+            contents=[main_view, exo_view],
+            row_shares=[4, 1],
+        )
+
+    final_view = rrb.Horizontal(
+        contents=[main_view],
+        column_shares=[4, 1],
+    )
+
+    return final_view
+
+
+def compute_square_bbox(
+    hand_uv: Float32[ndarray, "21 2"],
+    *,
+    intrinsics: Intrinsics,
+    expansion_ratio: float,
+) -> Float32[ndarray, "4"] | None:
+    """Return an expanded square XYXY bbox from finite 2D keypoints or ``None`` if invalid."""
+    if not np.isfinite(hand_uv).all():
+        return None
+
+    min_xy: Float32[ndarray, "2"] = np.nanmin(hand_uv, axis=0).astype(np.float32, copy=False)
+    max_xy: Float32[ndarray, "2"] = np.nanmax(hand_uv, axis=0).astype(np.float32, copy=False)
+
+    side_length: float = float(max(max_xy[0] - min_xy[0], max_xy[1] - min_xy[1]))
+    if not np.isfinite(side_length) or side_length <= 0.0:
+        return None
+
+    center_xy: Float32[ndarray, "2"] = ((min_xy + max_xy) / np.float32(2.0)).astype(np.float32, copy=False)
+    half_side: float = 0.5 * side_length * (1.0 + expansion_ratio)
+    if half_side <= 0.0:
+        return None
+
+    x1: float = float(center_xy[0] - half_side)
+    y1: float = float(center_xy[1] - half_side)
+    x2: float = float(center_xy[0] + half_side)
+    y2: float = float(center_xy[1] + half_side)
+
+    if intrinsics.width is not None:
+        width_limit: float = float(intrinsics.width - 1)
+        x1 = float(np.clip(x1, 0.0, width_limit))
+        x2 = float(np.clip(x2, 0.0, width_limit))
+    if intrinsics.height is not None:
+        height_limit: float = float(intrinsics.height - 1)
+        y1 = float(np.clip(y1, 0.0, height_limit))
+        y2 = float(np.clip(y2, 0.0, height_limit))
+
+    if x2 <= x1 or y2 <= y1:
+        return None
+
+    xyxy: Float32[ndarray, "4"] = np.array([x1, y1, x2, y2], dtype=np.float32)
+    return xyxy
+
+
+def set_annotation_context(*, recording: rr.RecordingStream | None) -> None:
+    keypoint_infos: list[rr.AnnotationInfo] = [
+        rr.AnnotationInfo(id=id, label=name) for id, name in COCO_133_ID2NAME.items()
+    ]
+    class_descriptions: list[rr.ClassDescription] = []
+    for layer in (
+        Coco133AnnotationLayer.GT,
+        Coco133AnnotationLayer.RAW_2D,
+        Coco133AnnotationLayer.TRACKED_2D,
+        Coco133AnnotationLayer.PROJECTED_2D,
+        Coco133AnnotationLayer.OPTIMIZED_2D,
+    ):
+        label: str = COCO133_LAYER_LABELS[layer]
+        color: tuple[int, int, int] = COCO133_LAYER_COLORS[layer]
+        class_descriptions.append(
+            rr.ClassDescription(
+                info=rr.AnnotationInfo(id=int(layer), label=label, color=color),
+                keypoint_annotations=keypoint_infos,
+                keypoint_connections=COCO_133_LINKS,
+            )
+        )
+    rr.log(
+        "/",
+        rr.AnnotationContext(class_descriptions),
+        static=True,
+        recording=recording,
+    )
+
+
+def timestamp_to_frame_index(time_ns: int, frame_timestamps_ns: Int[ndarray, "num_frames"]) -> int:
+    """Map a timestamp (ns) to the closest frame idx at-or-before that time.
+
+    The mapping mirrors how VideoFrameReference columns are generated from
+    AssetVideo.read_frame_timestamps_nanos().
+    """
+
+    idx: int = int(np.searchsorted(frame_timestamps_ns, time_ns, side="right") - 1)
+    return max(0, min(idx, len(frame_timestamps_ns) - 1))
+
+
+def frame_index_to_timestamp(frame_timestamps_ns: Int[ndarray, "num_frames"], frame_index: int) -> int:
+    """Return the nanosecond timestamp associated with a frame index."""
+    if frame_index < 0 or frame_index >= int(frame_timestamps_ns.shape[0]):
+        msg = f"frame_index {frame_index} is outside the valid range [0, {frame_timestamps_ns.shape[0] - 1}]"
+        raise IndexError(msg)
+    timestamp_ns: int = int(frame_timestamps_ns[frame_index])
+    return timestamp_ns
+
+
+def get_frame_timestamps_from_reader(video_reader: Any) -> Int[ndarray, "num_frames"]:
+    """Compute frame timestamps (ns) from video reader metadata.
+
+    Works with both TorchCodecVideoReader (for RRD in-memory blobs) and VideoReader.
+    """
+    fps: float = video_reader.fps
+    frame_cnt: int = video_reader.frame_cnt
+    # Compute timestamps: frame_idx * (1e9 ns / fps)
+    ns_per_frame: float = 1e9 / fps
+    timestamps: Int[ndarray, "num_frames"] = (np.arange(frame_cnt) * ns_per_frame).astype(np.int64)
+    return timestamps
+
+
+def predict_kpts3d_from_calibrated_videos(
+    exo_video_readers: MultiVideoReader | TorchCodecMultiVideoReader,
+    exo_cam_list: list[PinholeParameters],
+    pose_tracker: MultiviewBodyTracker,
+    top_half_mask: Bool[ndarray, "_"],
+    shortest_timestamp: Int[ndarray, "num_frames"],
+    parent_log_path: Path,
+    max_frames: int | None = None,
+    recording: rr.RecordingStream | None = None,
+) -> list[Float32[ndarray, "n_kpts 4"]]:
+    Pall: Float32[ndarray, "n_views 3 4"] = np.stack([cam.projection_matrix for cam in exo_cam_list]).astype(np.float32)
+    exo_frame_timestamps_list: list[Int[ndarray, "num_frames"]] = [
+        get_frame_timestamps_from_reader(reader) for reader in exo_video_readers.video_readers
+    ]
+
+    pbar: object = tqdm(
+        shortest_timestamp,
+        total=len(shortest_timestamp) if max_frames is None else min(len(shortest_timestamp), max_frames),
+    )
+    pbar_iter: Iterable[int] = cast(Iterable[int], pbar)
+    conf_thresh: float = pose_tracker.config.keypoint_threshold
+    mv_output: MVHistory = MVHistory()
+    xyzc_list: list[Float32[ndarray, "n_kpts 4"]] = []
+    triangulated_class_id: int = int(Coco133AnnotationLayer.TRIANGULATED_3D)
+    for ts_idx, timestamp in enumerate(pbar_iter):
+        if max_frames is not None and ts_idx >= max_frames:
+            break
+        # Anchor logging on a shared nanosecond timeline so 24 fps ego clips and 30 fps exo clips stay synchronized in the viewer.
+        rr.set_time(timeline="video_time", duration=np.timedelta64(int(timestamp), "ns"))
+        # Convert the unified timestamp into per-camera frame indices to absorb fps drift across exo recordings.
+        frame_indices: list[int] = [
+            timestamp_to_frame_index(time_ns=int(timestamp), frame_timestamps_ns=frame_timestamps)
+            for frame_timestamps in exo_frame_timestamps_list
+        ]
+        bgr_list: list[UInt8[ndarray, "H W 3"]] = []
+        for video_reader, frame_idx in zip(exo_video_readers.video_readers, frame_indices, strict=True):
+            frame_raw: object = video_reader[frame_idx]
+            if frame_raw is None:
+                raise ValueError(f"Missing frame for index {frame_idx} in multi-view reader.")
+            frame_array: UInt8[ndarray, "H W 3"] = np.asarray(frame_raw, dtype=np.uint8)
+            if frame_array.ndim != 3 or frame_array.shape[2] != 3:
+                raise ValueError(f"Expected frame with shape (*, *, 3), got {frame_array.shape} for index {frame_idx}.")
+            bgr_list.append(frame_array)
+        mv_output: MVHistory = pose_tracker(
+            bgr_list=bgr_list,
+            pinhole_list=exo_cam_list,
+            pred_state=mv_output,
+            recording=recording,
+        )
+
+        xyzc_list.append(mv_output.xyzc_t if mv_output.xyzc_t is not None else np.full((133, 4), np.nan))
+        # send 3d keypoints
+        if mv_output.xyzc_t is None:
+            continue
+
+        vis_xyz: Float32[ndarray, "n_kpts 3"] = mv_output.xyzc_t[:, :3].copy()
+        vis_scores_3d: Float32[ndarray, "n_kpts"] = mv_output.xyzc_t[:, 3].copy()  # noqa: UP037
+        # filter to only include the desired keypoints
+        vis_xyz[~top_half_mask, :] = np.nan
+        vis_scores_3d[~top_half_mask] = np.nan
+        # filter out low-confidence keypoints
+        vis_xyz[vis_scores_3d < conf_thresh, :] = np.nan
+        vis_scores_3d[vis_scores_3d < conf_thresh] = np.nan
+        # get hands idx and check their average confidence
+        left_hand_conf = vis_scores_3d[LEFT_HAND_IDX].mean()
+        right_hand_conf = vis_scores_3d[RIGHT_HAND_IDX].mean()
+        # if either hand is below 0.6 confidence, remove all hand keypoints
+        if left_hand_conf < conf_thresh:
+            vis_xyz[LEFT_HAND_IDX, :] = np.nan
+            vis_scores_3d[LEFT_HAND_IDX] = np.nan
+        if right_hand_conf < conf_thresh:
+            vis_xyz[RIGHT_HAND_IDX, :] = np.nan
+            vis_scores_3d[RIGHT_HAND_IDX] = np.nan
+
+        confidence_rgb_stack: UInt8[ndarray, "1 n_kpts 3"] = confidence_scores_to_rgb(
+            vis_scores_3d[np.newaxis, :, np.newaxis]
+        )
+        confidence_rgb: UInt8[ndarray, "n_kpts 3"] = confidence_rgb_stack[0]
+
+        rr.log(
+            str(parent_log_path / "gt" / "coco133_xyz"),
+            Points3DWithConfidence(
+                positions=vis_xyz,
+                confidences=vis_scores_3d,
+                class_ids=triangulated_class_id,
+                keypoint_ids=COCO_133_IDS,
+                show_labels=False,
+                colors=confidence_rgb,
+            ),
+            recording=recording,
+        )
+        # project 3d keypoints into 2d and log
+        xyz_hom: Float32[ndarray, "n_kpts 4"] = np.concatenate(
+            [vis_xyz, np.ones((vis_xyz.shape[0], 1), dtype=np.float32)], axis=1
+        )
+        xyz_hom_stack: Float32[ndarray, "1 n_kpts 4"] = np.stack([xyz_hom], axis=0)
+        uv_exo_stack: Float[ndarray, "1 n_views 133 2"] = proj_3d_vectorized(xyz_hom=xyz_hom_stack, P=Pall)
+        uv_exo: Float32[ndarray, "n_views 133 2"] = uv_exo_stack[0]
+        for uv_view, exo_cam in zip(uv_exo, exo_cam_list, strict=True):
+            uv: Float32[ndarray, "133 2"] = uv_view.astype(np.float32, copy=True)
+            confidences_view: Float32[ndarray, "133"] = vis_scores_3d.astype(np.float32, copy=True)
+
+            pinhole_log_path = parent_log_path / "exo" / exo_cam.name / "pinhole"
+            confidence_rgb_view_stack: UInt8[ndarray, "1 n_kpts 3"] = confidence_scores_to_rgb(
+                confidences_view[np.newaxis, :, np.newaxis]
+            )
+            confidence_rgb_view: UInt8[ndarray, "n_kpts 3"] = confidence_rgb_view_stack[0]
+            rr.log(
+                str(pinhole_log_path / "gt" / "coco133_uv"),
+                Points2DWithConfidence(
+                    positions=uv,
+                    confidences=confidences_view,
+                    class_ids=triangulated_class_id,
+                    keypoint_ids=COCO_133_IDS,
+                    show_labels=False,
+                    colors=confidence_rgb_view,
+                ),
+                recording=recording,
+            )
+        # Mask out keypoints not in the top half to avoid visualizing irrelevant or missing data.
+        mv_output.xyzc_t[~top_half_mask, :] = np.nan
+
+    return xyzc_list
+
+
+@dataclass
+class RRDPipelineConfig:
+    rr_config: RerunTyroConfig
+    """Configuration for rerun logging."""
+    dataset: AnnotatedExoEgoDatasetUnion
+    """Dataset factory capable of producing an annotated ``BaseExoEgoSequence``."""
+    calib_confg: MultiViewCalibratorConfig = field(default_factory=MultiViewCalibratorConfig)
+    """Parameters forwarded to the multi-view calibrator."""
+    tracker_config: MultiviewBodyTrackerConfig = field(default_factory=MultiviewBodyTrackerConfig)
+    """Configuration for the multiview body tracker."""
+    calib_ts_nano: int | None = None
+    """Optional nanosecond timestamp used to select calibration frames for cameras and MANO."""
+    max_frames: int | None = None
+    """Maximum number of frames to process. If None, all frames are processed."""
+
+
+def main(config: RRDPipelineConfig) -> None:
+    """Preserve the Tyro CLI entry point while delegating to the reusable pipeline helper."""
+    run_full_exoego_pipeline(config=config, recording=None)
+
+
+def run_full_exoego_pipeline(config: RRDPipelineConfig, recording: rr.RecordingStream | None = None) -> None:
+    """Execute the Exo/Ego pipeline; split from main so UI backends can supply explicit Rerun recordings."""
+    parent_log_path = Path("world")
+    timeline = "video_time"
+    projected_variant: str = COCO133_PREDICTION_LAYER_TO_PATH[Coco133AnnotationLayer.PROJECTED_2D]
+    projected_class_id: int = int(Coco133AnnotationLayer.PROJECTED_2D)
+
+    ###################
+    # 0. Parse inputs #
+    ###################
+    exoego_sequence: BaseExoEgoSequence = config.dataset.setup()  # one-liner
+    rr.log("/", exoego_sequence.world_coordinate_system, static=True, recording=recording)
+    set_annotation_context(recording=recording)
+
+    parent_log_path = Path("world")
+    timeline: str = "video_time"
+
+    scene_setup_result: SceneSetupResult = setup_scene(
+        exoego_sequence,
+        parent_log_path=parent_log_path,
+        timeline=timeline,
+        log_ego=True,
+        log_exo=True,
+        recording=recording,
+    )
+    log_paths: LogPaths = scene_setup_result.log_paths
+    shortest_timestamp: Int[ndarray, "n_frames"] = scene_setup_result.shortest_timestamp
+
+    exo_video_log_paths_opt: list[Path] | None = log_paths.exo_video_log_paths
+    if exo_video_log_paths_opt is None:
+        raise ValueError("Scene setup must return exo video log paths.")
+    ego_video_log_paths_opt: list[Path] | None = log_paths.ego_video_log_paths
+    if ego_video_log_paths_opt is None:
+        raise ValueError("Scene setup must return ego video log paths.")
+
+    exo_video_log_paths: list[Path] = list(exo_video_log_paths_opt)
+    ego_video_log_paths: list[Path] = list(ego_video_log_paths_opt)
+
+    final_container: rrb.ContainerLike = create_view_container(
+        exo_video_log_paths=exo_video_log_paths,
+        ego_video_log_paths=ego_video_log_paths,
+    )
+    blueprint = rrb.Blueprint(
+        final_container,
+        collapse_panels=True,
+    )
+    # Blueprint routing still relies on global stream; callers providing a recording
+    # should ensure it is set active before invoking this pipeline.
+    rr.send_blueprint(blueprint, recording=recording)
+
+    exo_sequence_obj: object = exoego_sequence.exo_sequence
+    if exo_sequence_obj is None:
+        raise ValueError("Dataset setup failed to provide an exo sequence.")
+    ego_sequence_obj: object = exoego_sequence.ego_sequence
+    if ego_sequence_obj is None:
+        raise ValueError("Dataset setup failed to provide an ego sequence.")
+
+    exo_sequence: BaseExoSequence = cast(BaseExoSequence, exo_sequence_obj)
+    ego_sequence: BaseEgoSequence = cast(BaseEgoSequence, ego_sequence_obj)
+
+    exo_mv_reader: MultiVideoReader | TorchCodecMultiVideoReader = exo_sequence.exo_video_readers
+    ego_mv_reader: MultiVideoReader | TorchCodecMultiVideoReader = ego_sequence.ego_video_readers
+    if shortest_timestamp.size == 0:
+        raise ValueError("Scene setup returned no timestamps to derive calibration frame.")
+
+    ##############################################
+    # 1. Load calibration frames from all videos #
+    ##############################################
+    calib_timestamp_ns: int = int(shortest_timestamp[-1]) if config.calib_ts_nano is None else int(config.calib_ts_nano)
+    ego_camera_names: list[str] = [path.parent.parent.name for path in ego_video_log_paths]
+    ego_rgb_indices: list[int] = [
+        idx for idx, camera_name in enumerate(ego_camera_names) if "rgb" in camera_name.lower()
+    ]
+    ego_rgb_index_set: set[int] = set(ego_rgb_indices)
+    ego_rgb_video_log_paths: list[Path] = [ego_video_log_paths[idx] for idx in ego_rgb_indices]
+
+    # load the exo frames first
+    # Need to get ts list as exo and ego can have different fps and drift
+    exo_frame_timestamp_list: list[Int[ndarray, "num_frames"]] = [
+        get_frame_timestamps_from_reader(reader) for reader in exo_mv_reader.video_readers
+    ]
+    exo_calib_indices: list[int] = [
+        timestamp_to_frame_index(time_ns=calib_timestamp_ns, frame_timestamps_ns=frame_timestamps)
+        for frame_timestamps in exo_frame_timestamp_list
+    ]
+    bgr_list_exo: list[UInt8[ndarray, "H W 3"]] = []
+    for reader, frame_idx in zip(exo_mv_reader.video_readers, exo_calib_indices, strict=True):
+        frame_obj: Any = reader[frame_idx]
+        if frame_obj is None:
+            raise ValueError(f"Missing exo frame at index {frame_idx}.")
+        frame_array_untyped: np.ndarray = np.asarray(frame_obj, dtype=np.uint8)
+        frame_array: UInt8[ndarray, "H W 3"] = frame_array_untyped
+        if frame_array.ndim != 3 or frame_array.shape[2] != 3:
+            raise ValueError(f"Expected BGR frame with shape (*, *, 3), got {frame_array.shape} at index {frame_idx}.")
+        bgr_list_exo.append(frame_array)
+
+    # ego frames next, but only the rgb cameras
+    ego_frame_timestamp_list: list[Int[ndarray, "num_frames"]] = [
+        get_frame_timestamps_from_reader(reader) for reader in ego_mv_reader.video_readers
+    ]
+    ego_calib_indices: list[int] = [
+        timestamp_to_frame_index(time_ns=calib_timestamp_ns, frame_timestamps_ns=frame_timestamps)
+        for frame_timestamps in ego_frame_timestamp_list
+    ]
+    bgr_list_ego: list[UInt8[ndarray, "H W 3"]] = []
+    if ego_rgb_indices:
+        for camera_idx, reader in enumerate(ego_mv_reader.video_readers):
+            if camera_idx not in ego_rgb_index_set:
+                continue
+            frame_idx: int = ego_calib_indices[camera_idx]
+            frame_obj: Any = reader[frame_idx]
+            if frame_obj is None:
+                raise ValueError(f"Missing ego frame at index {frame_idx} for camera {camera_idx}.")
+            frame_array_untyped: np.ndarray = np.asarray(frame_obj, dtype=np.uint8)
+            frame_array: UInt8[ndarray, "H W 3"] = frame_array_untyped
+            if frame_array.ndim != 3 or frame_array.shape[2] != 3:
+                raise ValueError(
+                    f"Expected BGR frame with shape (*, *, 3), got {frame_array.shape} at index {frame_idx}."
+                )
+            bgr_list_ego.append(frame_array)
+
+    # convert all to rgb
+    rgb_list_exo: list[UInt8[ndarray, "H W 3"]] = []
+    for bgr in bgr_list_exo:
+        rgb_frame: UInt8[ndarray, "H W 3"] = np.asarray(cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB), dtype=np.uint8)
+        if rgb_frame.ndim != 3 or rgb_frame.shape[2] != 3:
+            raise ValueError(f"Expected RGB frame with shape (*, *, 3), got {rgb_frame.shape}.")
+        rgb_list_exo.append(rgb_frame)
+
+    rgb_list_ego: list[UInt8[ndarray, "H W 3"]] = []
+    for bgr in bgr_list_ego:
+        rgb_frame: UInt8[ndarray, "H W 3"] = np.asarray(cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB), dtype=np.uint8)
+        if rgb_frame.ndim != 3 or rgb_frame.shape[2] != 3:
+            raise ValueError(f"Expected RGB frame with shape (*, *, 3), got {rgb_frame.shape}.")
+        rgb_list_ego.append(rgb_frame)
+
+    rgb_list: list[UInt8[ndarray, "H W 3"]] = [*rgb_list_exo, *rgb_list_ego]
+
+    # Resize all images to common resolution for depth map stacking in calibrator
+    rgb_list = resize_images_to_common_resolution(rgb_list, target_size=CALIB_TARGET_RESOLUTION)
+
+    input_log_paths: list[Path] = [*exo_video_log_paths, *ego_rgb_video_log_paths]
+    exo_ts: Int[ndarray, "num_frames"] = shortest_timestamp
+
+    ############################
+    # 2. Calibrate Exo Cameras #
+    ############################
+    start: float = timer()
+
+    rr.set_time(timeline=timeline, duration=np.timedelta64(0, "ns"), recording=recording)
+    hand_kpt_detector: WilorHandKeypointDetector = WilorHandKeypointDetector(
+        cfg=HandKeypointDetectorConfig(verbose=False)
+    )
+
+    mv_calibrator: MultiViewCalibrator = MultiViewCalibrator(parent_log_path=parent_log_path, config=config.calib_confg)
+    mv_calib_results: MVCalibResults = mv_calibrator(rgb_list=rgb_list)
+
+    pinhole_param_list: list[PinholeParameters] = mv_calib_results.pinhole_param_list
+    exo_pinhole_param_list: list[PinholeParameters] = pinhole_param_list[: len(rgb_list_exo)]
+    ego_pinhole_param_list: list[PinholeParameters] = pinhole_param_list[len(rgb_list_exo) :]
+    # replace cam names with those from the dataset for easier identification
+    for cam, log_path in zip(exo_pinhole_param_list, exo_video_log_paths, strict=True):
+        cam.name = log_path.parent.parent.name
+    for cam, log_path in zip(ego_pinhole_param_list, ego_rgb_video_log_paths, strict=True):
+        cam.name = log_path.parent.parent.name
+
+    assert len(exo_pinhole_param_list) == len(rgb_list_exo)
+    assert len(ego_pinhole_param_list) == len(rgb_list_ego)
+
+    pcd: o3d.geometry.PointCloud = mv_calib_results.pcd
+    # Automatically determine optimal voxel size based on point cloud characteristics
+    voxel_size: float = estimate_voxel_size(np.asarray(pcd.points, dtype=np.float32), target_points=50_000)
+    pcd_ds = pcd.voxel_down_sample(voxel_size)
+
+    for pinhole, input_log_path in zip(pinhole_param_list, input_log_paths, strict=True):
+        cam_log_path: Path = input_log_path.parent.parent
+        log_pinhole(camera=pinhole, cam_log_path=cam_log_path, image_plane_distance=0.1, static=True)
+
+    filtered_points: Float[ndarray, "final_points 3"] = np.asarray(pcd_ds.points, dtype=np.float32)
+    filtered_colors: Float[ndarray, "final_points 3"] = np.asarray(pcd_ds.colors, dtype=np.float32)
+
+    rr.log(
+        str(parent_log_path / "gt" / "env_pointcloud"),
+        rr.Points3D(
+            filtered_points,
+            colors=filtered_colors,
+        ),
+        static=True,
+        recording=recording,
+    )
+    #####################################
+    # 3. Fuse Depths into TSDF Mesh     #
+    #####################################
+    if mv_calib_results.depth_list and mv_calib_results.pinhole_param_list:
+        depth_fuser = Open3DScaleInvariantFuser(grid_resolution=512)
+        reference_points: Float32[ndarray, "num_points 3"] = np.asarray(pcd.points, dtype=np.float32)
+        depth_fuser.initialise_from_points(reference_points)
+
+        for depth_map, pinhole_param, rgb in zip(
+            mv_calib_results.depth_list,
+            mv_calib_results.pinhole_param_list,
+            rgb_list,
+            strict=True,
+        ):
+            depth_fuser.fuse_frame(depth_hw=depth_map, pinhole=pinhole_param, rgb_hw3=rgb)
+
+        gt_mesh: o3d.geometry.TriangleMesh = depth_fuser.get_mesh()
+        gt_mesh.compute_vertex_normals()
+
+        vertex_positions: Float32[ndarray, "num_vertices 3"] = np.asarray(gt_mesh.vertices, dtype=np.float32)
+        triangle_indices: Int[ndarray, "num_faces 3"] = np.asarray(gt_mesh.triangles, dtype=np.int32)
+
+        vertex_normals: Float32[ndarray, "num_vertices 3"] = np.asarray(gt_mesh.vertex_normals, dtype=np.float32)
+        vertex_colors: Float32[ndarray, "num_vertices 3"] = np.asarray(gt_mesh.vertex_colors, dtype=np.float32)
+
+        rr.log(
+            str(parent_log_path / "gt" / "env_mesh"),
+            rr.Mesh3D(
+                vertex_positions=vertex_positions,
+                triangle_indices=triangle_indices,
+                vertex_normals=vertex_normals,
+                vertex_colors=vertex_colors,
+            ),
+            static=True,
+            recording=recording,
+        )
+
+    if exo_mv_reader is not None and exo_ts is not None:
+        #########################################################
+        # 5. Predict exo keypoints from calibrated video frames #
+        #########################################################
+        upper_body_filter_idx: Int[ndarray, "_"] = np.array([5, 6, 7, 8, 9, 10])
+        wb_upper_body_filter_idx: Int[ndarray, "_"] = np.concatenate(
+            [upper_body_filter_idx, FACE_IDX, LEFT_HAND_IDX, RIGHT_HAND_IDX]
+        )
+        # Create a boolean mask for all rows
+        top_half_mask: Bool[ndarray, "_"] = np.isin(np.arange(133), wb_upper_body_filter_idx)
+        pose_tracker = MultiviewBodyTracker(config.tracker_config, filter_body_idxes=wb_upper_body_filter_idx)
+
+        xyzc_list: list[Float32[ndarray, "n_kpts 4"]] = predict_kpts3d_from_calibrated_videos(
+            exo_video_readers=exo_mv_reader,
+            exo_cam_list=exo_pinhole_param_list,
+            pose_tracker=pose_tracker,
+            top_half_mask=top_half_mask,
+            shortest_timestamp=exo_ts,
+            parent_log_path=parent_log_path,
+            max_frames=config.max_frames,
+            recording=recording,
+        )
+        bbox_expansion_percentage: float = 0.25
+        keypoint_threshold: float = pose_tracker.config.keypoint_threshold
+        #########################################################
+        # 6. Predict ego keypoints from calibrated video frames #
+        #########################################################
+        if len(xyzc_list) > 0 and len(ego_pinhole_param_list) > 0:
+            Pall_ego: Float32[ndarray, "n_views 3 4"] = np.stack(
+                [cam.projection_matrix for cam in ego_pinhole_param_list]
+            ).astype(np.float32)
+
+            for idx, xyzc in enumerate(xyzc_list):
+                rr.set_time(timeline=timeline, duration=np.timedelta64(int(exo_ts[idx]), "ns"), recording=recording)
+                bgr_list_ego: list[UInt8[ndarray, "H W 3"]] = []
+                for camera_idx, frame in enumerate(ego_mv_reader[idx]):
+                    if camera_idx not in ego_rgb_index_set:
+                        continue
+                    if frame is None:
+                        raise ValueError(f"Missing ego frame at batch index {camera_idx} for timestamp index {idx}.")
+                    frame_array: UInt8[ndarray, "H W 3"] = np.asarray(frame, dtype=np.uint8)
+                    if frame_array.ndim != 3 or frame_array.shape[2] != 3:
+                        raise ValueError(
+                            f"Expected BGR frame with shape (*, *, 3), got {frame_array.shape} at index {camera_idx}."
+                        )
+                    bgr_list_ego.append(frame_array)
+
+                if len(bgr_list_ego) != len(ego_pinhole_param_list):
+                    msg = (
+                        "Filtered ego frame count does not match calibrated ego cameras: "
+                        f"{len(bgr_list_ego)} vs {len(ego_pinhole_param_list)}."
+                    )
+                    raise ValueError(msg)
+
+                if xyzc is None:
+                    continue
+                vis_xyz: Float32[ndarray, "n_kpts=133 3"] = xyzc[:, :3].copy()
+                vis_scores_3d: Float32[ndarray, "n_kpts=133"] = xyzc[:, 3].copy()  # noqa: UP037
+                # filter to only include the desired keypoints
+                vis_xyz[~top_half_mask, :] = np.nan
+                vis_scores_3d[~top_half_mask] = np.nan
+                # filter out low-confidence keypoints
+                vis_xyz[vis_scores_3d < keypoint_threshold, :] = np.nan
+                vis_scores_3d[vis_scores_3d < keypoint_threshold] = np.nan
+
+                # project 3d keypoints into 2d
+                xyz_hom: Float32[ndarray, "n_kpts=133 4"] = np.concatenate(
+                    [vis_xyz, np.ones((vis_xyz.shape[0], 1), dtype=np.float32)], axis=1
+                )
+                xyz_hom_stack: Float32[ndarray, "n_frames=1 n_kpts=133 4"] = np.stack([xyz_hom], axis=0)
+                uv_ego_stack: Float[ndarray, "n_frames=1 n_views n_kpts=133 2"] = proj_3d_vectorized(
+                    xyz_hom=xyz_hom_stack, P=Pall_ego
+                )
+                uv_ego: Float32[ndarray, "n_views n_kpts=133 2"] = uv_ego_stack[0]
+
+                for view_idx, (uv_view, ego_cam) in enumerate(zip(uv_ego, ego_pinhole_param_list, strict=True)):
+                    pinhole_log_path: Path = parent_log_path / "ego" / ego_cam.name / "pinhole"
+                    uv: Float32[ndarray, "n_kpts=133 2"] = uv_view.astype(np.float32, copy=True)
+                    projection_matrix: Float32[ndarray, "3 4"] = ego_cam.projection_matrix.astype(
+                        np.float32, copy=False
+                    )
+                    homog_cam: Float32[ndarray, "n_kpts=133 3"] = np.einsum("ij,nj->ni", projection_matrix, xyz_hom)
+                    depth_cam: Float32[ndarray, "n_kpts=133"] = homog_cam[:, 2]
+                    # Reject keypoints with non-positive homogeneous depth (behind the camera).
+                    invalid_depth_mask: Bool[ndarray, "n_kpts=133"] = np.logical_or(
+                        ~np.isfinite(depth_cam),
+                        depth_cam <= 0.0,
+                    )
+                    uv[invalid_depth_mask, :] = np.nan
+                    # filter out keypoints that are out of bounds
+                    # uv = filter_out_of_bounds_keypoints(uv, ego_cam, margin_percentage=0.0)
+                    invalid_uv_mask: Bool[ndarray, "n_kpts=133"] = np.any(~np.isfinite(uv), axis=1)
+
+                    confidences_view: Float32[ndarray, "n_kpts=133"] = vis_scores_3d.astype(np.float32, copy=True)
+                    confidences_view[invalid_uv_mask] = np.nan
+                    rgb_hw3: UInt8[ndarray, "H W 3"] = bgr_list_ego[view_idx][..., ::-1]
+
+                    left_bbox_infer: Float32[ndarray, "4"] | None = compute_square_bbox(
+                        uv[LEFT_HAND_IDX, :],
+                        intrinsics=ego_cam.intrinsics,
+                        expansion_ratio=bbox_expansion_percentage,
+                    )
+                    if left_bbox_infer is not None:
+                        xyxy_left: Float32[ndarray, "1 4"] = left_bbox_infer[np.newaxis, :]
+                        wilor_left: FinalWilorPred = hand_kpt_detector(
+                            rgb_hw3=rgb_hw3,
+                            xyxy=xyxy_left,
+                            handedness="left",
+                        )
+                        left_uv_pred: Float32[ndarray, "1 21 2"] = wilor_left.pred_keypoints_2d.astype(
+                            np.float32, copy=False
+                        )
+                        uv[LEFT_HAND_IDX, :] = left_uv_pred[0]
+
+                    right_bbox_infer: Float32[ndarray, "4"] | None = compute_square_bbox(
+                        uv[RIGHT_HAND_IDX, :],
+                        intrinsics=ego_cam.intrinsics,
+                        expansion_ratio=bbox_expansion_percentage,
+                    )
+                    if right_bbox_infer is not None:
+                        xyxy_right: Float32[ndarray, "1 4"] = right_bbox_infer[np.newaxis, :]
+                        wilor_right: FinalWilorPred = hand_kpt_detector(
+                            rgb_hw3=rgb_hw3,
+                            xyxy=xyxy_right,
+                            handedness="right",
+                        )
+                        right_uv_pred: Float32[ndarray, "1 21 2"] = wilor_right.pred_keypoints_2d.astype(
+                            np.float32, copy=False
+                        )
+                        uv[RIGHT_HAND_IDX, :] = right_uv_pred[0]
+
+                    left_bbox_log: Float32[ndarray, "4"] | None = compute_square_bbox(
+                        uv[LEFT_HAND_IDX, :],
+                        intrinsics=ego_cam.intrinsics,
+                        expansion_ratio=bbox_expansion_percentage,
+                    )
+                    if left_bbox_log is not None:
+                        lh_xyxy: Float32[ndarray, "4"] = left_bbox_log.astype(np.float32, copy=False)
+                        rr.log(
+                            f"{pinhole_log_path}/video/left_hand_bbox",
+                            rr.Boxes2D(array=lh_xyxy, array_format=rr.Box2DFormat.XYXY),
+                            recording=recording,
+                        )
+                    else:
+                        rr.log(
+                            f"{pinhole_log_path}/video/left_hand_bbox",
+                            rr.Clear(recursive=True),
+                            recording=recording,
+                        )
+
+                    right_bbox_log: Float32[ndarray, "4"] | None = compute_square_bbox(
+                        uv[RIGHT_HAND_IDX, :],
+                        intrinsics=ego_cam.intrinsics,
+                        expansion_ratio=bbox_expansion_percentage,
+                    )
+                    if right_bbox_log is not None:
+                        rh_xyxy: Float32[ndarray, "4"] = right_bbox_log.astype(np.float32, copy=False)
+                        rr.log(
+                            f"{pinhole_log_path}/video/right_hand_bbox",
+                            rr.Boxes2D(array=rh_xyxy, array_format=rr.Box2DFormat.XYXY),
+                            recording=recording,
+                        )
+                    else:
+                        rr.log(
+                            f"{pinhole_log_path}/video/right_hand_bbox",
+                            rr.Clear(recursive=True),
+                            recording=recording,
+                        )
+
+                    confidence_rgb_view_stack: UInt8[ndarray, "1 n_kpts 3"] = confidence_scores_to_rgb(
+                        confidences_view[np.newaxis, :, np.newaxis]
+                    )
+                    confidence_rgb_view: UInt8[ndarray, "n_kpts 3"] = confidence_rgb_view_stack[0]
+                    rr.log(
+                        str(pinhole_log_path / "pred" / "coco133_uv" / projected_variant),
+                        Points2DWithConfidence(
+                            positions=uv,
+                            confidences=confidences_view,
+                            class_ids=projected_class_id,
+                            keypoint_ids=COCO_133_IDS,
+                            show_labels=False,
+                            colors=confidence_rgb_view,
+                        ),
+                        recording=recording,
+                    )
+
+    print(f"Inference completed in {timer() - start:.2f} seconds")

--- a/packages/mv-api/src/mv_api/coco133_layers.py
+++ b/packages/mv-api/src/mv_api/coco133_layers.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from enum import IntEnum
+from typing import Final
+
+
+class Coco133AnnotationLayer(IntEnum):
+    """Semantic layers used when logging COCO-133 keypoints."""
+
+    GT = 0
+    RAW_2D = 1
+    TRACKED_2D = 2
+    PROJECTED_2D = 3
+    OPTIMIZED_2D = 4
+    TRIANGULATED_3D = 5
+
+
+COCO133_LAYER_LABELS: Final[dict[Coco133AnnotationLayer, str]] = {
+    Coco133AnnotationLayer.GT: "coco133_gt",
+    Coco133AnnotationLayer.RAW_2D: "coco133_raw2d",
+    Coco133AnnotationLayer.TRACKED_2D: "coco133_tracked2d",
+    Coco133AnnotationLayer.PROJECTED_2D: "coco133_projected2d",
+    Coco133AnnotationLayer.OPTIMIZED_2D: "coco133_optimized2d",
+    Coco133AnnotationLayer.TRIANGULATED_3D: "coco133_triangulated3d",
+}
+
+# Skeleton link colours should avoid the red/yellow/green spectrum that encodes per-keypoint confidence.
+COCO133_LAYER_COLORS: Final[dict[Coco133AnnotationLayer, tuple[int, int, int]]] = {
+    Coco133AnnotationLayer.GT: (30, 64, 255),  # deep blue for annotated ground truth
+    Coco133AnnotationLayer.RAW_2D: (59, 130, 246),  # azure
+    Coco133AnnotationLayer.TRACKED_2D: (165, 105, 255),  # violet
+    Coco133AnnotationLayer.PROJECTED_2D: (217, 70, 239),  # magenta
+    Coco133AnnotationLayer.OPTIMIZED_2D: (148, 163, 255),  # periwinkle
+    Coco133AnnotationLayer.TRIANGULATED_3D: (14, 165, 233),  # cyan to distinguish derived 3d results
+}
+
+COCO133_PREDICTION_LAYER_TO_PATH: Final[dict[Coco133AnnotationLayer, str]] = {
+    Coco133AnnotationLayer.RAW_2D: "raw",
+    Coco133AnnotationLayer.TRACKED_2D: "tracked",
+    Coco133AnnotationLayer.PROJECTED_2D: "projected",
+    Coco133AnnotationLayer.OPTIMIZED_2D: "optimized",
+}
+
+
+class Coco133RoiLayer(IntEnum):
+    """Semantic regions-of-interest used for auxiliary COCO-133 overlays."""
+
+    LEFT_HAND = 100
+    RIGHT_HAND = 101
+    FULL_BODY = 102
+    FACE = 103
+
+
+COCO133_ROI_LABELS: Final[dict[Coco133RoiLayer, str]] = {
+    Coco133RoiLayer.LEFT_HAND: "left_hand",
+    Coco133RoiLayer.RIGHT_HAND: "right_hand",
+    Coco133RoiLayer.FULL_BODY: "full_body",
+    Coco133RoiLayer.FACE: "face",
+}
+
+
+COCO133_ROI_COLORS: Final[dict[Coco133RoiLayer, tuple[int, int, int]]] = {
+    Coco133RoiLayer.LEFT_HAND: (16, 185, 129),  # teal
+    Coco133RoiLayer.RIGHT_HAND: (249, 115, 22),  # orange
+    Coco133RoiLayer.FULL_BODY: (59, 130, 246),  # azure
+    Coco133RoiLayer.FACE: (236, 72, 153),  # pink
+}

--- a/packages/mv-api/src/mv_api/gradio_ui/full_pipeline_rrd_ui.py
+++ b/packages/mv-api/src/mv_api/gradio_ui/full_pipeline_rrd_ui.py
@@ -1,0 +1,138 @@
+"""Gradio UI for executing the full exo/ego pipeline directly from RRD inputs."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import gradio as gr
+import rerun as rr
+from gradio.data_classes import FileData
+from gradio_rerun import Rerun
+from monopriors.apis.multiview_calibration import MultiViewCalibratorConfig
+from simplecv.data.exoego.rrd_exoego import RRDExoEgoConfig
+from simplecv.rerun_log_utils import RerunTyroConfig
+
+from mv_api.api.full_exoego_pipeline import RRDPipelineConfig, run_full_exoego_pipeline
+
+EXAMPLE_RRD_PATH: Path = Path("/mnt/8tb/data/exoego-self-collected/gus/statisOrangePNP_av1.rrd")
+INPUT_TAB_ID: str = "rrd_input_tab"
+OUTPUT_TAB_ID: str = "rrd_output_tab"
+
+
+def _resolve_rrd_path(rrd_input: FileData | str | None) -> Path:
+    """Normalize a Gradio file input to a filesystem path."""
+    if rrd_input is None:
+        raise ValueError("No RRD file available. Upload or pick an example first.")
+
+    if isinstance(rrd_input, FileData):
+        rrd_path_str: str | None = rrd_input.path
+        if rrd_path_str is None:
+            raise ValueError("Uploaded RRD input is missing a backing path on disk.")
+        rrd_path: Path = Path(rrd_path_str)
+        return rrd_path
+
+    rrd_path = Path(rrd_input)
+    return rrd_path
+
+
+def cleanup_temp_rrds(pending_cleanup: list[str]) -> None:
+    """Remove temporary RRD artefacts created during UI interactions."""
+    for temp_path_str in pending_cleanup:
+        temp_path: Path = Path(temp_path_str)
+        if temp_path.exists():
+            os.unlink(temp_path)
+
+
+@rr.thread_local_stream("rerun_full_pipeline_rrd")
+def run_rrd_pipeline(
+    rrd_input: FileData | str | None,
+    max_frames: int | float | None,
+    pending_cleanup: list[str],
+    progress: gr.Progress | None = None,
+) -> tuple[str, str]:
+    """Execute the full pipeline against an uploaded RRD and return a temporary RRD for the viewer."""
+    if progress is None:
+        progress = gr.Progress()
+
+    progress(0.0, desc="Preparing pipeline inputs")
+    rrd_path: Path = _resolve_rrd_path(rrd_input)
+
+    with tempfile.NamedTemporaryFile(prefix="full_pipeline_", suffix=".rrd", delete=False) as temp_file:
+        pending_cleanup.append(temp_file.name)
+        rr_config: RerunTyroConfig = RerunTyroConfig(save=Path(temp_file.name))
+
+        dataset_cfg: RRDExoEgoConfig = RRDExoEgoConfig(rrd_path=rrd_path)
+        max_frames_sanitized: int | None
+        if max_frames is None:
+            max_frames_sanitized = None
+        else:
+            candidate_frames: int = int(max_frames)
+            max_frames_sanitized = candidate_frames if candidate_frames > 0 else None
+        pipeline_config: RRDPipelineConfig = RRDPipelineConfig(
+            rr_config=rr_config,
+            calib_confg=MultiViewCalibratorConfig(segment_people=False),
+            dataset=dataset_cfg,
+            max_frames=max_frames_sanitized,
+        )
+
+        progress(0.2, desc="Running full exo/ego pipeline")
+        run_full_exoego_pipeline(config=pipeline_config)
+
+    progress(1.0, desc="Pipeline complete")
+    return temp_file.name, temp_file.name
+
+
+def build_full_pipeline_rrd_block() -> None:
+    """Create the Gradio layout for the RRD-based full pipeline experience."""
+    pending_cleanup: gr.State = gr.State([], time_to_live=10, delete_callback=cleanup_temp_rrds)
+
+    with gr.Row():  # noqa: SIM117 - nested layout contexts keep column scopes inside the row
+        with gr.Column(scale=1), gr.Tabs(selected=INPUT_TAB_ID) as io_tabs:
+            with gr.TabItem("Input RRD", id=INPUT_TAB_ID):
+                rrd_file: gr.File = gr.File(file_types=[".rrd"], label="Upload or select RRD file")
+                max_frames: gr.Number = gr.Number(
+                    label="Max frames (optional, leave blank for all)",
+                    value=None,
+                    precision=0,
+                )
+                run_button: gr.Button = gr.Button("Run Full Pipeline")
+                example_rows: list[list[str]] = []
+                if EXAMPLE_RRD_PATH.exists():
+                    example_rows.append([str(EXAMPLE_RRD_PATH)])
+                if example_rows:
+                    gr.Examples(
+                        examples=example_rows,
+                        inputs=[rrd_file],
+                        cache_examples=False,
+                    )
+            with gr.TabItem("Output Viewer", id=OUTPUT_TAB_ID):
+                output_rrd_file: gr.File = gr.File(label="Generated RRD output will appear here", interactive=False)
+
+        with gr.Column(scale=5):
+            viewer: Rerun = Rerun(
+                streaming=True,
+                panel_states={
+                    "time": "collapsed",
+                    "blueprint": "hidden",
+                    "selection": "hidden",
+                },
+                height=800,
+            )
+
+        def _select_output_tab() -> gr.Tabs:
+            return gr.Tabs(selected=OUTPUT_TAB_ID)
+
+    run_button.click(
+        _select_output_tab,
+        inputs=None,
+        outputs=[io_tabs],
+    ).then(
+        run_rrd_pipeline,
+        inputs=[rrd_file, max_frames, pending_cleanup],
+        outputs=[viewer, output_rrd_file],
+    )
+
+
+__all__ = ["build_full_pipeline_rrd_block", "run_rrd_pipeline", "cleanup_temp_rrds", "EXAMPLE_RRD_PATH"]

--- a/packages/mv-api/src/mv_api/hand_keypoints.py
+++ b/packages/mv-api/src/mv_api/hand_keypoints.py
@@ -1,0 +1,309 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, TypedDict
+
+import cv2
+import numpy as np
+import torch
+from huggingface_hub import hf_hub_download
+from jaxtyping import Float, Int, Num, UInt8
+from numpy import ndarray
+from rtmlib.tools.pose_estimation.rtmpose import RTMPose
+from serde import from_dict, serde
+from skimage.filters import gaussian
+from wilor_nano.models.refinement_net import RefineNetOutput
+from wilor_nano.models.wilor import WiLor
+from wilor_nano.utils import utils
+
+
+@dataclass
+class HandKeypointDetectorConfig:
+    verbose: bool
+    hf_wilor_repo_id: str = "pablovela5620/wilor-nano"
+    focal_length: int = 5000
+    image_size: int = 256
+    device: Literal["auto", "cuda", "cpu"] = "auto"
+
+
+class RefineNetNPOutput(TypedDict):
+    """
+    TypedDict for the output of RefineNet.
+
+    This defines the structure and types of the dictionary returned by the RefineNet forward method.
+    """
+
+    global_orient: Float[torch.Tensor, "batch"]
+    hand_pose: Float[torch.Tensor, "batch 15 3"]
+    betas: Float[torch.Tensor, "batch 10"]
+    pred_cam: Float[torch.Tensor, "batch 3"]
+
+
+@serde
+class RawWilorPred:
+    """WiLor/RefineNet raw predictions for one hand (batch=1), model space."""
+
+    global_orient: Float[ndarray, "batch=1 1 3"]
+    """Root wrist global orientation (axis–angle, radians), shape (1, 1, 3)."""
+    hand_pose: Float[ndarray, "batch=1 15 3"]
+    """Local joint rotations for 15 MANO joints (axis–angle), shape (1, 15, 3)."""
+    betas: Float[ndarray, "batch=1 10"]
+    """MANO shape coefficients, shape (1, 10)."""
+    pred_cam: Float[ndarray, "batch=1 3"]
+    """Weak‑perspective camera in crop coords [s, tx, ty], shape (1, 3)."""
+    pred_keypoints_3d: Float[ndarray, "batch=1 n_joints=21 3"]
+    """21 MANO joints in model space, shape (1, 21, 3)."""
+    pred_vertices: Float[ndarray, "batch=1 n_verts=778 3"]
+    """778 MANO mesh vertices in model space, shape (1, 778, 3)."""
+
+
+@serde
+class FinalWilorPred:
+    """Per‑hand predictions post‑processed to a canonical right‑hand frame."""
+
+    global_orient: Float[ndarray, "batch=1 1 3"]
+    """Canonicalized root orientation (axis–angle), shape (1, 1, 3)."""
+    hand_pose: Float[ndarray, "batch=1 15 3"]
+    """Canonicalized joint rotations (axis–angle), shape (1, 15, 3)."""
+    betas: Float[ndarray, "batch=1 10"]
+    """MANO shape coefficients, shape (1, 10)."""
+    pred_cam: Float[ndarray, "batch=1 3"]
+    """Weak‑perspective cam [s, tx, ty] in crop coords (handedness‑corrected), shape (1, 3)."""
+    pred_cam_t_full: Float[ndarray, "batch=1 3"]
+    """Full‑image translation for perspective projection, shape (1, 3)."""
+    scaled_focal_length: float
+    """Focal length scaled from crop size to full image (scalar)."""
+    pred_keypoints_3d: Float[ndarray, "batch=1 n_joints=21 3"]
+    """Canonicalized 3D joints in model space, shape (1, 21, 3)."""
+    pred_vertices: Float[ndarray, "batch=1 n_verts=778 3"]
+    """Canonicalized MANO mesh vertices in model space, shape (1, 778, 3)."""
+    pred_keypoints_2d: Float[ndarray, "batch=1 n_joints=21 2"]
+    """2D pixel coordinates in the original image, shape (1, 21, 2)."""
+    confidence_2d: Float[ndarray, "batch=1 n_joints=21"]
+    """2D keypoint confidence scores, shape (1, 21)."""
+
+
+class RTMPoseHandKeypointDetector:
+    def __init__(
+        self,
+        cfg: HandKeypointDetectorConfig,
+        *,
+        device: Literal["cuda", "cpu"] | None = None,
+    ) -> None:
+        self.cfg: HandKeypointDetectorConfig = cfg
+        self._device: Literal["cuda", "cpu"] = (
+            device if device is not None else ("cuda" if torch.cuda.is_available() else "cpu")
+        )
+        self.init_model()
+
+    def init_model(self) -> None:
+        url: str = "https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/rtmpose-m_simcc-hand5_pt-aic-coco_210e-256x256-74fb594_20230320.zip"
+        pose_input_size: tuple[int, int] = (256, 256)
+        self.hand_model = RTMPose(onnx_model=url, model_input_size=pose_input_size, device=self._device)
+
+    def __call__(
+        self, image: np.ndarray, xyxy: list[list[float]] | None = None
+    ) -> tuple[Float[ndarray, "batch=1 n_kpts=21 2"], Float[ndarray, "batch=1 n_kpts=21"]]:
+        bbox_list: list[list[float]] = xyxy if xyxy is not None else []
+        rtmpose_output: tuple[Float[ndarray, "batch=1 n_kpts=21 2"], Float[ndarray, "batch=1 n_kpts=21"]] = (
+            self.hand_model(image, bboxes=bbox_list)
+        )
+        keypoints: Float[ndarray, "batch=1 n_kpts=21 2"] = rtmpose_output[0]
+        scores: Float[ndarray, "batch=1 n_kpts=21"] = rtmpose_output[1]
+        return keypoints, scores
+
+
+class WilorHandKeypointDetector:
+    def __init__(self, cfg: HandKeypointDetectorConfig) -> None:
+        self.cfg: HandKeypointDetectorConfig = cfg
+        self.init_model()
+
+    def init_model(self) -> None:
+        device_type: Literal["cuda", "cpu"] = (
+            "cuda" if torch.cuda.is_available() else "cpu"
+        ) if self.cfg.device == "auto" else self.cfg.device
+
+        self.device = torch.device(device_type)
+        self.dtype = torch.float16 if device_type == "cuda" else torch.float32
+
+        wilor_pretrained_dir: Path = Path(__file__).parent.parent.resolve()
+        mano_mean_path: Path = wilor_pretrained_dir / "pretrained_models" / "mano_mean_params.npz"
+        if not mano_mean_path.exists():
+            hf_hub_download(
+                repo_id=self.cfg.hf_wilor_repo_id,
+                subfolder="pretrained_models",
+                filename="mano_mean_params.npz",
+                local_dir=wilor_pretrained_dir,
+            )
+
+        mano_model_path: Path = wilor_pretrained_dir / "pretrained_models" / "mano_clean" / "MANO_RIGHT.pkl"
+        if not mano_model_path.exists():
+            hf_hub_download(
+                repo_id=self.cfg.hf_wilor_repo_id,
+                subfolder="pretrained_models/mano_clean",
+                filename="MANO_RIGHT.pkl",
+                local_dir=wilor_pretrained_dir,
+            )
+        self.wilor_model = WiLor(
+            mano_root_dir=mano_model_path.parent,
+            mano_mean_path=mano_mean_path,
+            focal_length=self.cfg.focal_length,
+            image_size=self.cfg.image_size,
+        )
+        wilor_model_path: Path = wilor_pretrained_dir / "pretrained_models" / "wilor_final.ckpt"
+        if not wilor_model_path.exists():
+            hf_hub_download(
+                repo_id=self.cfg.hf_wilor_repo_id,
+                subfolder="pretrained_models",
+                filename="wilor_final.ckpt",
+                local_dir=wilor_pretrained_dir,
+            )
+        # wilor model for keypoint predictions, does not provide confidence values, so these are gotten from the rtmpose hand model
+        state_dict: dict[str, torch.Tensor] = torch.load(wilor_model_path, map_location=self.device)["state_dict"]
+        self.wilor_model.load_state_dict(state_dict, strict=False)
+        self.wilor_model.eval()
+        self.wilor_model.to(self.device, dtype=self.dtype)
+
+        rtmpose_device: Literal["cuda", "cpu"] = "cuda" if self.device.type == "cuda" else "cpu"
+        self.hand_confidence_model = RTMPoseHandKeypointDetector(self.cfg, device=rtmpose_device)
+
+    @torch.no_grad()
+    def __call__(
+        self,
+        rgb_hw3: UInt8[ndarray, "H W 3"],
+        xyxy: Float[np.ndarray, "1 4"],
+        handedness: Literal["left", "right"],
+        rescale_factor: float = 2.5,
+    ) -> FinalWilorPred:
+        center: Float[ndarray, "1 2"] = (xyxy[:, 2:4] + xyxy[:, 0:2]) / 2.0
+        scale: Float[ndarray, "1 2"] = rescale_factor * (xyxy[:, 2:4] - xyxy[:, 0:2])
+        img_patches_list: list[ndarray] = []
+        img_size: Int[ndarray, "2"] = np.array([rgb_hw3.shape[1], rgb_hw3.shape[0]])
+
+        bbox_size: float = float(scale[0].max())
+        patch_width: int = self.cfg.image_size
+        patch_height: int = self.cfg.image_size
+        flip: bool = handedness == "left"
+        box_center: Float[ndarray, "2"] = center[0]
+
+        cvimg: Float[np.ndarray, "h w 3"] = rgb_hw3.copy().astype(np.float32)
+        # Blur image to avoid aliasing artifacts
+        downsampling_factor: float = (bbox_size * 1.0) / patch_width
+        downsampling_factor: float = downsampling_factor / 2.0
+        if downsampling_factor > 1.1:
+            cvimg = gaussian(cvimg, sigma=(downsampling_factor - 1) / 2, channel_axis=2, preserve_range=True)
+
+        patch_output: tuple[Float[ndarray, "h=256 w=256 3"], Float[ndarray, "2 3"]] = utils.generate_image_patch_cv2(
+            cvimg,
+            int(box_center[0]),
+            int(box_center[1]),
+            int(bbox_size),
+            int(bbox_size),
+            int(patch_width),
+            int(patch_height),
+            flip,
+            1.0,
+            0,
+            border_mode=cv2.BORDER_CONSTANT,
+        )
+        img_patch_cv: Float[ndarray, "h=256 w=256 3"] = patch_output[0]
+        img_patches_list.append(img_patch_cv)
+        img_patches_np: Num[np.ndarray, "n_dets=1 h=256 w=256 3"] = np.stack(img_patches_list)
+        img_patches: Float[torch.Tensor, "n_dets=1 h=256 w=256 3"] = torch.from_numpy(img_patches_np).to(
+            device=self.device, dtype=self.dtype
+        )
+        # Run the WiLor model: outputs are PyTorch tensors keyed by component name
+        wilor_output_raw: RefineNetOutput = self.wilor_model(img_patches)
+
+        # Optional shape/type sanity check (e.g., with a serde-typed container).
+        # Converts tensors to numpy for validation/logging, does not alter wilor_output_raw.
+        raw_wilor_preds: RawWilorPred = from_dict(
+            RawWilorPred, {k: v.cpu().float().numpy() for k, v in wilor_output_raw.items()}
+        )
+        # estimate the confidence of the keypoints using the rtmpose hand model
+        conf_tuple: tuple[Float[ndarray, "batch=1 n_kpts=21 2"], Float[ndarray, "batch=1 n_kpts=21"]] = (
+            self.hand_confidence_model(rgb_hw3, xyxy.tolist())
+        )
+
+        confidence_2d: Float[ndarray, "batch=1 n_kpts=21"] = conf_tuple[1]
+
+        final_preds: FinalWilorPred = self.post_process(
+            raw_wilor_preds=raw_wilor_preds,
+            handedness=handedness,
+            box_center=box_center,
+            bbox_size=bbox_size,
+            img_size=img_size,
+            confidence_2d=confidence_2d,
+        )
+
+        return final_preds
+
+    def post_process(
+        self,
+        *,
+        raw_wilor_preds: RawWilorPred,
+        handedness: Literal["left", "right"],
+        box_center: Float[ndarray, "2"],
+        bbox_size: float,
+        img_size: Int[ndarray, "2"],
+        confidence_2d: Float[ndarray, "batch=1 n_kpts=21"],
+    ) -> FinalWilorPred:
+        # Unpack for clarity; do not mutate inputs
+        pred_cam_in: Float[ndarray, "batch=1 3"] = raw_wilor_preds.pred_cam
+        pred_kpts3d_in: Float[ndarray, "batch=1 n_joints=21 3"] = raw_wilor_preds.pred_keypoints_3d
+        pred_verts_in: Float[ndarray, "batch=1 n_verts=778 3"] = raw_wilor_preds.pred_vertices
+        global_orient_in: Float[ndarray, "batch=1 1 3"] = raw_wilor_preds.global_orient
+        hand_pose_in: Float[ndarray, "batch=1 15 3"] = raw_wilor_preds.hand_pose
+
+        # Adjust weak-perspective camera for handedness: cam = [s, tx, ty]
+        sx: int = 1 if handedness == "right" else -1  # +1 for right hand, -1 for left hand
+        pred_cam: Float[ndarray, "batch=1 3"] = pred_cam_in.copy()
+        pred_cam[:, 1] = sx * pred_cam[:, 1]
+
+        # Mirror to canonical frame for left hand
+        if handedness == "left":
+            pred_keypoints_3d: Float[ndarray, "batch=1 n_joints=21 3"] = pred_kpts3d_in.copy()
+            pred_keypoints_3d[:, :, 0] = -pred_keypoints_3d[:, :, 0]
+            pred_vertices: Float[ndarray, "batch=1 n_verts=778 3"] = pred_verts_in.copy()
+            pred_vertices[:, :, 0] = -pred_vertices[:, :, 0]
+
+            # Rotation vectors (axis-angle): [x, y, z] -> [x, -y, -z]
+            global_orient: Float[ndarray, "batch=1 1 3"] = np.concatenate(
+                (global_orient_in[:, :, 0:1], -global_orient_in[:, :, 1:3]), axis=-1
+            )
+            hand_pose: Float[ndarray, "batch=1 15 3"] = np.concatenate(
+                (hand_pose_in[:, :, 0:1], -hand_pose_in[:, :, 1:3]), axis=-1
+            )
+        else:
+            pred_keypoints_3d = pred_kpts3d_in.copy()
+            pred_vertices = pred_verts_in.copy()
+            global_orient = global_orient_in.copy()
+            hand_pose = hand_pose_in.copy()
+
+        # Scale focal length from model crop size (image_size) to full image resolution
+        scaled_focal_length: float = self.cfg.focal_length / self.cfg.image_size * img_size.max()
+
+        # Lift weak-perspective cam to full-image translation for projection to 2D
+        pred_cam_t_full: Float[ndarray, "batch=1 3"] = utils.cam_crop_to_full(
+            pred_cam, box_center[None], bbox_size, img_size[None], scaled_focal_length
+        )
+
+        # Project 3D joints to 2D pixel coordinates in the original image
+        pred_keypoints_2d: Float[ndarray, "batch=1 n_joints=21 2"] = utils.perspective_projection(
+            pred_keypoints_3d,
+            translation=pred_cam_t_full,
+            focal_length=np.array([scaled_focal_length] * 2)[None],
+            camera_center=img_size[None] / 2,
+        )
+
+        return FinalWilorPred(
+            global_orient=global_orient,
+            hand_pose=hand_pose,
+            betas=raw_wilor_preds.betas.copy(),
+            pred_cam=pred_cam,
+            pred_cam_t_full=pred_cam_t_full,
+            scaled_focal_length=scaled_focal_length,
+            pred_keypoints_3d=pred_keypoints_3d,
+            pred_vertices=pred_vertices,
+            pred_keypoints_2d=pred_keypoints_2d,
+            confidence_2d=confidence_2d,
+        )

--- a/packages/mv-api/src/mv_api/multiview_pose_estimator.py
+++ b/packages/mv-api/src/mv_api/multiview_pose_estimator.py
@@ -1,0 +1,495 @@
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+import rerun as rr
+from einops import rearrange
+from jaxtyping import Bool, Float, Float32, Float64, Int, UInt8
+from numpy import ndarray
+from rtmlib import YOLOX, RTMPose
+from simplecv.camera_parameters import PinholeParameters
+from simplecv.data.skeleton.coco_133 import COCO_133_IDS, LEFT_HAND_IDX, RIGHT_HAND_IDX
+from simplecv.ops.triangulate import batch_triangulate, projectN3
+from simplecv.rerun_custom_types import Points2DWithConfidence, confidence_scores_to_rgb
+
+from mv_api.coco133_layers import COCO133_PREDICTION_LAYER_TO_PATH, Coco133AnnotationLayer
+from mv_api.hand_keypoints import FinalWilorPred, HandKeypointDetectorConfig, WilorHandKeypointDetector
+
+WILOR_CONFIDENCE_THRESHOLD: float = 0.5
+WILOR_BBOX_EXPANSION_RATIO: float = 0.25
+
+
+def project_multiview(
+    xyzc: Float[ndarray, "n_kpts 4"],
+    Pall: Float[ndarray, "n_views 3 4"],
+) -> Float[ndarray, "n_views n_kpts 3"]:
+    """
+    Projects 3D keypoints (with confidence) to 2D image coordinates for multiple views.
+    Handles potential division by zero by outputting NaN for those keypoints.
+
+    Args:
+        xyzc: Array of 3D keypoints and confidence scores (n_kpts, 4).
+              The 4th column is confidence, used for masking, not projection.
+        Pall: Array of projection matrices for each view (n_views, 3, 4).
+
+    Returns:
+        Array of projected 2D keypoints (u, v, w) for each view (n_views, n_kpts, 3).
+        The third component 'w' is the depth scale factor, multiplied by the original
+        confidence mask (0 or 1). Keypoints with original confidence <= 0 will have w=0.
+        Keypoints where perspective division involved division by near-zero w' will have
+        NaN values for u and v.
+    """
+    n_kpts = xyzc.shape[0]
+    # Store original confidences for masking later
+    original_conf = xyzc[:, 3].copy()
+
+    # --- Vectorized Version ---
+    # 1. Prepare homogeneous coordinates for 3D points (n_kpts, 4)
+    #    We use xyz coordinates and append 1.
+    kp3d_h = np.hstack((xyzc[:, :3], np.ones((n_kpts, 1), dtype=xyzc.dtype)))  # Shape: (K, 4)
+
+    # 2. Perform matrix multiplication for all views at once.
+    #    Using einsum: 'vmn,kn->vkm'
+    #    Pall (V, 3, 4), kp3d_h (K, 4) -> kp2d_h (V, K, 3)
+    #    kp2d_h[v, k, :] contains the (u', v', w') for view v, keypoint k
+    kp2d_h = np.einsum("vmn,kn->vkm", Pall, kp3d_h, optimize=True)  # Shape: (V, K, 3)
+
+    # 3. Perform perspective division (handle division by zero by setting to NaN)
+    #    Extract w' (the depth scale factor) -> Shape (V, K, 1)
+    w_prime = kp2d_h[..., 2:3]  # Keep last dimension
+
+    #    Define mask for valid divisions (where w' is not close to zero)
+    valid_division_mask = np.abs(w_prime) > 1e-8  # Shape: (V, K, 1)
+
+    #    Calculate u = u'/w', v = v'/w'. Suppress warnings for division by zero.
+    with np.errstate(divide="ignore", invalid="ignore"):
+        uv_raw_division = kp2d_h[..., :2] / w_prime  # Shape: (V, K, 2)
+
+    #    Use the mask to keep valid results and set others to NaN.
+    #    The mask (V, K, 1) broadcasts correctly against (V, K, 2).
+    uv_normalized = np.where(valid_division_mask, uv_raw_division, np.nan)  # Shape: (V, K, 2)
+
+    # 4. Combine normalized uv with the original w' (depth scale)
+    #    Concatenate along the last axis.
+    kp2ds = np.concatenate((uv_normalized, w_prime), axis=-1)  # Shape: (V, K, 3)
+
+    # 5. Apply the original confidence mask to the 'w' component.
+    #    Keypoints with confidence <= 0 should have their w component zeroed out.
+    #    This uses the confidence stored *before* it was potentially modified.
+    confidence_mask = (original_conf[:, None] > 0.0).astype(kp2ds.dtype)  # Shape: (K, 1)
+    # Broadcast mask (K, 1) to (V, K, 1) and multiply element-wise with w' column
+    kp2ds[..., 2:3] *= confidence_mask  # Modifies the last column in place
+
+    return kp2ds
+
+
+@dataclass
+class MVHistory:
+    """Keeps track of the previous two timesteps of 3D keypoints."""
+
+    xyzc_t: Float32[ndarray, "n_kpts=133 4"] | None = None
+    """current frame (t); ``None`` when unavailable."""
+    xyzc_t1: Float32[ndarray, "n_kpts=133 4"] | None = None
+    """previous frame (t-1); ``None`` when unavailable."""
+    uvc_t: Float32[ndarray, "n_views n_kpts=133 3"] | None = None
+    """Current per-view 2D detections (u, v, confidence)."""
+    uvc_extrap: Float32[ndarray, "n_views n_kpts=133 3"] | None = None
+    """Per-view 2D projections derived from the temporally extrapolated 3D keypoints."""
+
+
+@dataclass(frozen=True, slots=True)
+class ModelAssets:
+    """Model assets for detector and pose estimators."""
+
+    det: str
+    """Download URL or local path to the YOLOX ONNX model."""
+    det_input_size: tuple[int, int]
+    """Input width-height pair expected by YOLOX."""
+    pose: str
+    """Download URL or local path to the RTMPose ONNX model."""
+    pose_input_size: tuple[int, int]
+    """Input width-height pair expected by RTMPose."""
+
+
+MODE: dict[str, ModelAssets] = {
+    "performance": ModelAssets(
+        det="https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/yolox_x_8xb8-300e_humanart-a39d44ed.zip",
+        det_input_size=(640, 640),
+        pose="https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/rtmpose-x_simcc-body7_pt-body7_700e-384x288-71d7b7e9_20230629.zip",
+        pose_input_size=(288, 384),
+    ),
+    "lightweight": ModelAssets(
+        det="https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/yolox_tiny_8xb8-300e_humanart-6f3252f9.zip",
+        det_input_size=(416, 416),
+        pose="https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/rtmpose-s_simcc-body7_pt-body7_420e-256x192-acd4a1ef_20230504.zip",
+        pose_input_size=(192, 256),
+    ),
+    "balanced": ModelAssets(
+        det="https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/yolox_m_8xb8-300e_humanart-c2c7a14a.zip",
+        det_input_size=(640, 640),
+        pose="https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/rtmpose-m_simcc-body7_pt-body7_420e-256x192-e48f03d0_20230504.zip",
+        pose_input_size=(192, 256),
+    ),
+    "wholebody": ModelAssets(
+        det="https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/yolox_m_8xb8-300e_humanart-c2c7a14a.zip",
+        det_input_size=(640, 640),
+        pose="https://download.openmmlab.com/mmpose/v1/projects/rtmw/onnx_sdk/rtmw-dw-x-l_simcc-cocktail14_270e-256x192_20231122.zip",
+        pose_input_size=(192, 256),
+    ),
+}
+
+
+@dataclass
+class MultiviewBodyTrackerConfig:
+    """Configuration options for the multiview body tracker runtime."""
+
+    mode: Literal["lightweight", "balanced", "performance", "wholebody"] = "wholebody"
+    """Preset selecting detector and pose assets tuned for latency versus accuracy."""
+    backend: Literal["onnxruntime"] = "onnxruntime"
+    """Inference backend used to execute ONNX models."""
+    device: Literal["cpu", "cuda"] = "cuda"
+    """Hardware accelerator requested by the ONNX runtime backend."""
+    keypoint_threshold: float = 0.7
+    """Minimum 2D keypoint confidence required for a detection to be kept."""
+    cams_for_detection_idx: list[int] | None = None
+    """Subset of camera indices to run detection on; ``None`` evaluates every view."""
+    use_wilor: bool = False
+    """Whether to use Wilor-Nano for hand keypoints instead of RTMPose."""
+    perform_tracking: bool = True
+    """Whether to extrapolate poses from historical frames to assist detection."""
+    verbose: bool = False
+    """Enables additional debug logging when ``True``."""
+
+
+class MultiviewBodyTracker:
+    def __init__(
+        self,
+        config: MultiviewBodyTrackerConfig,
+        filter_body_idxes: Int[ndarray, "idx"] | None = None,
+    ) -> None:
+        """Optional index list restricting which detected bodies propagate downstream."""
+        self.config: MultiviewBodyTrackerConfig = config
+        self.num_keypoints: int = 133  # Default number of keypoints for pose estimation
+        self.filter_body_idxes: Int[ndarray, "idx"] = (
+            filter_body_idxes if filter_body_idxes is not None else np.arange(self.num_keypoints, dtype=np.intp)
+        )
+
+        assets: ModelAssets = MODE[config.mode]
+        pose: str = assets.pose
+        pose_input_size: tuple[int, int] = assets.pose_input_size
+
+        det: str = assets.det
+        det_input_size: tuple[int, int] = assets.det_input_size
+        self.det_model = YOLOX(det, model_input_size=det_input_size, backend=config.backend, device=config.device)
+        self.pose_model = RTMPose(
+            pose,
+            model_input_size=pose_input_size,
+            to_openpose=False,
+            backend=config.backend,
+            device=config.device,
+        )
+        self.keypoint_threshold: float = config.keypoint_threshold
+        self.hand_keypoint_engine: WilorHandKeypointDetector | None = None
+        if self.config.use_wilor:
+            self.hand_keypoint_engine = WilorHandKeypointDetector(HandKeypointDetectorConfig(verbose=False))
+
+        self.tracked: bool = False
+
+    def __call__(
+        self,
+        *,
+        bgr_list: list[UInt8[ndarray, "H W 3"]],
+        pinhole_list: list[PinholeParameters],
+        pred_state: MVHistory,
+        recording: rr.RecordingStream | None = None,
+    ) -> MVHistory:
+        """
+        Assumes to be only one person in the image, take the highest score person
+        """
+        # filter out the cameras that are not used for detection if provided
+        Pall: Float32[ndarray, "n_views 3 4"] = np.array(
+            [pinhole.projection_matrix for pinhole in pinhole_list], dtype=np.float32
+        )
+        if self.config.cams_for_detection_idx is not None:
+            Pall: Float32[ndarray, "n_views 3 4"] = np.array([Pall[i] for i in self.config.cams_for_detection_idx])
+
+        ##################################################################################
+        # if we have keypoints from previous two timesteps, then use them to extrapolate #
+        # the 3d keypoints which we can project to 2d and use for detection              #
+        ##################################################################################
+        xyzc_extrap: Float32[ndarray, "n_kpts 4"] | None = None
+        bboxes_extrap: Float32[ndarray, "n_views 4"] | None = None
+        tracked_confidences: Float32[ndarray, "n_kpts"] | None = None
+        pred_state.uvc_extrap = None
+        if (pred_state.xyzc_t1 is not None and pred_state.xyzc_t is not None) and self.config.perform_tracking:
+            xyzc_extrap = self.extrapolate_3d_keypoints(xyzc_t=pred_state.xyzc_t, xyzc_t1=pred_state.xyzc_t1)
+            # project the extrapolated 3d keypoints to 2d
+            uvc_extrap_float: Float[ndarray, "n_views n_kpts 3"] = projectN3(xyzc_extrap, Pall)
+            uvc_extrap: Float32[ndarray, "n_views n_kpts 3"] = np.asarray(uvc_extrap_float, dtype=np.float32)
+            pred_state.uvc_extrap = uvc_extrap
+            tracked_confidences = np.clip(xyzc_extrap[:, 3].astype(np.float32, copy=True), 0.0, 1.0)
+
+            uv_max: Float[ndarray, "n_views 2"] = np.nanmax(uvc_extrap[:, :, 0:2], axis=1)
+            uv_min: Float[ndarray, "n_views 2"] = np.nanmin(uvc_extrap[:, :, 0:2], axis=1)
+            bboxes_extrap = np.concatenate([uv_min, uv_max], axis=1).astype(np.float32)
+
+        uvc_list: list[Float32[ndarray, "n_kpts 3"]] = []
+        for image_idx, bgr in enumerate(bgr_list):
+            if xyzc_extrap is not None and bboxes_extrap is not None:
+                bboxes: Float32[ndarray, "n_dets 4"] = rearrange(bboxes_extrap[image_idx], "B -> 1 B")
+            else:
+                det_output: np.ndarray | tuple[np.ndarray, ...] = self.det_model(bgr)
+                if isinstance(det_output, tuple):
+                    det_bboxes_np: np.ndarray = det_output[0]
+                else:
+                    det_bboxes_np = det_output
+                bboxes: Float32[ndarray, "n_dets 4"] = np.asarray(det_bboxes_np, dtype=np.float32)
+
+            match bboxes.shape[0]:
+                # No detections, set outputs to None for this view
+                case 0:
+                    uvc_list.append(np.zeros((self.num_keypoints, 3)).astype(np.float32))
+                case _:
+                    # Select the detection with the highest score (assumes bboxes are sorted by score).
+                    # If not sorted, you should select the bbox with the highest score here.
+                    bboxes: Float32[ndarray, "1 4"] = bboxes[0:1]
+
+                    bbox_list: list[list[float]] = bboxes.astype(np.float32).tolist()
+                    pose_output: tuple[
+                        Float64[ndarray, "n_dets n_kpts=133 2"], Float32[ndarray, "n_dets n_kpts=133"]
+                    ] = self.pose_model(bgr, bboxes=bbox_list)
+                    keypoints: Float64[ndarray, "n_dets n_kpts=133 2"] = pose_output[0]
+                    scores: Float32[ndarray, "n_dets n_kpts=133"] = pose_output[1]
+
+                    filtered_keypoints, filtered_scores = self.filter_kpt_outputs(keypoints.astype(np.float32), scores)
+                    # filtered_scores = filtered_scores.astype(np.float32, copy=True)
+                    # filtered_scores[filtered_scores < self.config.keypoint_threshold] = 0.0
+                    # filtered_scores[filtered_scores >= self.config.keypoint_threshold] = 1.0
+
+                    if self.config.use_wilor:
+                        filtered_keypoints = self._refine_hand_keypoints_with_wilor(
+                            bgr=bgr,
+                            keypoints=filtered_keypoints,
+                            confidences=filtered_scores,
+                        )
+
+                    if self.config.verbose:
+                        self._log_uvc_layer(
+                            view_idx=image_idx,
+                            pinhole=pinhole_list[image_idx],
+                            keypoints=filtered_keypoints,
+                            confidences=filtered_scores,
+                            layer=Coco133AnnotationLayer.RAW_2D,
+                            mask_below_threshold=True,
+                            recording=recording,
+                        )
+                        if tracked_confidences is not None and pred_state.uvc_extrap is not None:
+                            tracked_uv: Float32[ndarray, "n_kpts 2"] = pred_state.uvc_extrap[image_idx, :, 0:2]
+                            self._log_uvc_layer(
+                                view_idx=image_idx,
+                                pinhole=pinhole_list[image_idx],
+                                keypoints=tracked_uv,
+                                confidences=tracked_confidences,
+                                layer=Coco133AnnotationLayer.TRACKED_2D,
+                                mask_below_threshold=False,
+                                recording=recording,
+                            )
+
+                    # can't be nan as it messes with triangulation
+                    # filtered_scores[filtered_scores < self.keypoint_threshold] = 0
+                    # filtered_scores[filtered_scores >= self.keypoint_threshold] = 1
+                    uvc: Float32[ndarray, "n_kpts 3"] = np.concatenate(
+                        [filtered_keypoints, filtered_scores[:, None]], axis=1
+                    )
+                    uvc_list.append(uvc)
+
+        multiview_uvc: Float32[ndarray, "n_views n_kpts 3"] = np.stack(uvc_list).astype(np.float32)
+        pred_state.uvc_t = multiview_uvc
+        xyzc: Float64[ndarray, "n_kpts 4"] = batch_triangulate(
+            keypoints_2d=multiview_uvc,
+            projection_matrices=Pall,
+            min_views=2,
+        )
+
+        filtered_xyzc = xyzc[self.filter_body_idxes]
+        # check if more than half the keypoints are below the threshold, if so, don't track
+        if np.sum(filtered_xyzc[:, 3] > self.config.keypoint_threshold) < filtered_xyzc.shape[0] / 2:
+            pred_state.xyzc_t = None
+            pred_state.xyzc_t1 = None
+
+        pred_state.xyzc_t1 = pred_state.xyzc_t
+        pred_state.xyzc_t = xyzc.astype(np.float32)
+
+        return pred_state
+
+    def _log_uvc_layer(
+        self,
+        *,
+        view_idx: int,
+        pinhole: PinholeParameters,
+        keypoints: Float32[ndarray, "n_kpts 2"],
+        confidences: Float32[ndarray, "n_kpts"],
+        layer: Coco133AnnotationLayer,
+        mask_below_threshold: bool,
+        recording: rr.RecordingStream | None,
+    ) -> None:
+        """Log a COCO-133 2D layer for a single view."""
+
+        try:
+            view_name_attr: str | None = pinhole.name  # type: ignore[attr-defined]
+        except AttributeError:
+            view_name_attr = None
+        view_name: str = view_name_attr if view_name_attr else f"view_{view_idx}"
+
+        filtered_keypoints: Float32[ndarray, "n_kpts 2"]
+        filtered_confidences: Float32[ndarray, "n_kpts"]
+        if mask_below_threshold:
+            min_conf: float = float(self.config.keypoint_threshold)
+            visibility_mask: Bool[ndarray, "n_kpts"] = confidences >= min_conf
+            filtered_keypoints = np.where(
+                visibility_mask[:, None],
+                keypoints,
+                np.nan,
+            ).astype(np.float32, copy=False)
+            filtered_confidences = np.where(
+                visibility_mask,
+                confidences,
+                0.0,
+            ).astype(np.float32, copy=False)
+        else:
+            filtered_keypoints = keypoints.astype(np.float32, copy=False)
+            filtered_confidences = confidences.astype(np.float32, copy=False)
+
+        finite_mask: Bool[ndarray, "n_kpts"] = np.isfinite(filtered_keypoints[:, 0]) & np.isfinite(
+            filtered_keypoints[:, 1]
+        )
+        filtered_keypoints = np.where(finite_mask[:, None], filtered_keypoints, np.nan)
+        filtered_confidences = np.where(finite_mask, filtered_confidences, 0.0)
+
+        confidence_rgb: UInt8[ndarray, "n_kpts 3"] = confidence_scores_to_rgb(
+            filtered_confidences[np.newaxis, :, np.newaxis]
+        )[0]
+        layer_segment: str = COCO133_PREDICTION_LAYER_TO_PATH[layer]
+
+        rr.log(
+            f"/world/exo/{view_name}/pinhole/pred/coco133_uv/{layer_segment}",
+            Points2DWithConfidence(
+                positions=filtered_keypoints,
+                confidences=filtered_confidences,
+                class_ids=int(layer),
+                keypoint_ids=COCO_133_IDS,
+                show_labels=False,
+                colors=confidence_rgb,
+            ),
+            recording=recording,
+        )
+
+    def _refine_hand_keypoints_with_wilor(
+        self,
+        *,
+        bgr: UInt8[ndarray, "H W 3"],
+        keypoints: Float32[ndarray, "n_kpts 2"],
+        confidences: Float32[ndarray, "n_kpts"],
+    ) -> Float32[ndarray, "n_kpts 2"]:
+        engine = self.hand_keypoint_engine
+        if engine is None:
+            return keypoints
+
+        refined_keypoints: Float32[ndarray, "n_kpts 2"] = keypoints.copy()
+        height: int = bgr.shape[0]
+        width: int = bgr.shape[1]
+        rgb_hw3: UInt8[ndarray, "H W 3"] = bgr[..., ::-1]
+        score_threshold: float = max(self.config.keypoint_threshold, WILOR_CONFIDENCE_THRESHOLD)
+
+        for hand_indices_raw, handedness in ((LEFT_HAND_IDX, "left"), (RIGHT_HAND_IDX, "right")):
+            hand_indices: np.ndarray = np.asarray(hand_indices_raw, dtype=np.intp)
+            hand_uv: Float32[ndarray, "hand 2"] = refined_keypoints[hand_indices, :].copy()
+            hand_scores: Float32[ndarray, "hand"] = confidences[hand_indices]
+
+            low_conf_mask: np.ndarray = np.asarray(hand_scores < score_threshold, dtype=bool)
+            hand_uv[low_conf_mask, :] = np.nan
+
+            bbox: Float32[ndarray, "4"] | None = self._compute_hand_bbox(
+                hand_uv=hand_uv,
+                image_shape=(height, width),
+                expansion_ratio=WILOR_BBOX_EXPANSION_RATIO,
+            )
+            if bbox is None:
+                continue
+
+            xyxy: Float32[ndarray, "1 4"] = bbox[np.newaxis, :]
+            wilor_pred: FinalWilorPred = engine(rgb_hw3=rgb_hw3, xyxy=xyxy, handedness=handedness)
+            pred_uv: Float32[ndarray, "1 21 2"] = wilor_pred.pred_keypoints_2d.astype(np.float32, copy=False)
+
+            refined_hand_uv: Float32[ndarray, "21 2"] = pred_uv[0]
+            refined_hand_uv[:, 0] = np.clip(refined_hand_uv[:, 0], 0.0, float(width - 1))
+            refined_hand_uv[:, 1] = np.clip(refined_hand_uv[:, 1], 0.0, float(height - 1))
+
+            refined_keypoints[hand_indices, :] = refined_hand_uv
+
+        return refined_keypoints
+
+    @staticmethod
+    def _compute_hand_bbox(
+        *,
+        hand_uv: Float32[ndarray, "hand 2"],
+        image_shape: tuple[int, int],
+        expansion_ratio: float,
+    ) -> Float32[ndarray, "4"] | None:
+        valid_mask: np.ndarray = np.isfinite(hand_uv[:, 0]) & np.isfinite(hand_uv[:, 1])
+        if not bool(np.any(valid_mask)):
+            return None
+
+        valid_uv: Float32[ndarray, "valid 2"] = hand_uv[valid_mask, :]
+        min_xy: Float32[ndarray, "2"] = np.nanmin(valid_uv, axis=0).astype(np.float32, copy=False)
+        max_xy: Float32[ndarray, "2"] = np.nanmax(valid_uv, axis=0).astype(np.float32, copy=False)
+
+        side_length: float = float(max(max_xy[0] - min_xy[0], max_xy[1] - min_xy[1]))
+        if not np.isfinite(side_length) or side_length <= 0.0:
+            return None
+
+        center_xy: Float32[ndarray, "2"] = ((min_xy + max_xy) * 0.5).astype(np.float32, copy=False)
+        half_side: float = 0.5 * side_length * (1.0 + expansion_ratio)
+        if half_side <= 0.0:
+            return None
+
+        x1: float = float(center_xy[0] - half_side)
+        y1: float = float(center_xy[1] - half_side)
+        x2: float = float(center_xy[0] + half_side)
+        y2: float = float(center_xy[1] + half_side)
+
+        height, width = image_shape
+        x1 = float(np.clip(x1, 0.0, float(width - 1)))
+        x2 = float(np.clip(x2, 0.0, float(width - 1)))
+        y1 = float(np.clip(y1, 0.0, float(height - 1)))
+        y2 = float(np.clip(y2, 0.0, float(height - 1)))
+
+        if x2 <= x1 or y2 <= y1:
+            return None
+
+        bbox: Float32[ndarray, "4"] = np.array([x1, y1, x2, y2], dtype=np.float32)
+        return bbox
+
+    def extrapolate_3d_keypoints(
+        self, xyzc_t: Float32[ndarray, "n_kpts 4"], xyzc_t1: Float32[ndarray, "n_kpts 4"]
+    ) -> Float32[ndarray, "n_kpts 4"]:
+        """
+        Extrapolates 3D keypoints with confidence scores using data from
+        the previous two timesteps (t-1 and t-2).
+        """
+        # extrapolate 3d keypoints from the previous frames
+        xyzc_extrap = 2 * xyzc_t - xyzc_t1
+        return xyzc_extrap
+
+    def filter_kpt_outputs(
+        self,
+        keypoints: Float32[ndarray, "n_dets n_kpts 2"],
+        scores: Float32[ndarray, "n_dets n_kpts"],
+    ) -> tuple[Float32[ndarray, "n_kpts 2"], Float32[ndarray, "n_kpts"]]:
+        """
+        Filter keypoints based on the highest score
+        """
+        max_scores: Float32[ndarray, "n_dets"] = scores.max(axis=1)
+        max_idx = max_scores.argmax()
+
+        return keypoints[max_idx], scores[max_idx]

--- a/packages/mv-api/src/mv_api/robust_triangulate.py
+++ b/packages/mv-api/src/mv_api/robust_triangulate.py
@@ -1,0 +1,185 @@
+from itertools import combinations
+
+import numpy as np
+from einops import rearrange
+from jaxtyping import Float, Int
+from numpy import ndarray
+
+
+def batch_triangulate(
+    keypoints_2d: Float[ndarray, "n_views n_kpts 3"],
+    projection_matrices: Float[ndarray, "n_views 3 4"],
+    min_views: int = 2,
+) -> Float[ndarray, "n_kpts 4"]:
+    """
+    Camera MUST be in OPENCV convention
+    """
+    num_joints: int = keypoints_2d.shape[1]
+
+    # Count views where each joint is visible
+    visibility_count: Int[ndarray, "n_kpts"] = (keypoints_2d[:, :, -1] > 0).sum(axis=0)  # noqa: UP037
+    valid_joints = np.where(visibility_count >= min_views)[0]
+
+    # Filter keypoints by valid joints
+    filtered_keypoints: Float[ndarray, "n_views n_kpts 3"] = keypoints_2d[:, valid_joints]
+    conf3d = filtered_keypoints[:, :, -1].sum(axis=0) / visibility_count[valid_joints]
+
+    P0: Float[ndarray, "1 n_views 4"] = projection_matrices[None, :, 0, :]
+    P1: Float[ndarray, "1 n_views 4"] = projection_matrices[None, :, 1, :]
+    P2: Float[ndarray, "1 n_views 4"] = projection_matrices[None, :, 2, :]
+
+    # x-coords homogenous
+    u: Float[ndarray, "n_kpts n_views 1"] = rearrange(filtered_keypoints[..., 0], "c j -> j c 1")
+    uP2: Float[ndarray, "n_kpts n_views 4"] = u * P2
+
+    # y-coords homogenous
+    v: Float[ndarray, "n_kpts n_views 1"] = rearrange(filtered_keypoints[..., 1], "c j -> j c 1")
+    vP2: Float[ndarray, "n_kpts n_views 4"] = v * P2
+
+    confidences: Float[ndarray, "n_kpts n_views 1"] = rearrange(filtered_keypoints[..., 2], "c j -> j c 1")
+
+    Au: Float[ndarray, "n_kpts n_views 4"] = confidences * (uP2 - P0)
+    Av: Float[ndarray, "n_kpts n_views 4"] = confidences * (vP2 - P1)
+    A: Float[ndarray, "n_kpts _ 4"] = np.hstack([Au, Av])
+
+    # Solve using SVD
+    _, _, Vh = np.linalg.svd(A)
+    triangulated_points = Vh[:, -1, :]
+    triangulated_points /= triangulated_points[:, 3, None]
+
+    # Construct result
+    result: Float[ndarray, "n_kpts 4"] = np.zeros((num_joints, 4))
+    # convert from homogenous to euclidean and add confidence
+    result[valid_joints, :3] = triangulated_points[:, :3]
+    result[valid_joints, 3] = conf3d
+
+    return result
+
+
+def _project_points(
+    xyz1: Float[ndarray, "4"],
+    P: Float[ndarray, "3 4"],
+) -> tuple[Float[ndarray, "2"], float]:
+    """Project a single homogeneous 3D point with a single projection matrix.
+
+    Returns (uv, depth) where depth is the third homogeneous component before
+    normalization. Camera MUST be in OPENCV convention.
+    """
+    x_proj: Float[ndarray, "3"] = (P @ xyz1)  # type: ignore[assignment]
+    z: float = float(x_proj[2])
+    uv: Float[ndarray, "2"] = (x_proj[:2] / x_proj[2]).astype(np.float64)
+    return uv, z
+
+
+def robust_batch_triangulate(
+    keypoints_2d: Float[ndarray, "n_views n_kpts 3"],
+    projection_matrices: Float[ndarray, "n_views 3 4"],
+    min_views: int = 2,
+    reproj_error_thresh: float = 3.0,
+    init_subset: int = 3,
+) -> Float[ndarray, "n_kpts 4"]:
+    """Robustly triangulate 3D keypoints across multiple views.
+
+    - Uses a RANSAC-like strategy per keypoint:
+      1) enumerate small view subsets (2- or 3-view) as hypotheses
+      2) score by reprojection error over all visible views
+      3) re-triangulate with inliers and return the refined result
+
+    Args:
+        keypoints_2d: (n_views, n_kpts, 3) with (u, v, conf)
+        projection_matrices: (n_views, 3, 4) projection matrices (OPENCV)
+        min_views: minimum number of inlier views required to accept a 3D point
+        reproj_error_thresh: inlier pixel threshold for reprojection error
+        init_subset: initial hypothesis subset size (2 or 3 are typical)
+
+    Returns:
+        xyzc: (n_kpts, 4) with (x,y,z,confidence)
+    """
+    n_views: int = keypoints_2d.shape[0]
+    n_kpts: int = keypoints_2d.shape[1]
+
+    init_subset = max(2, min(init_subset, n_views))
+
+    result: Float[ndarray, "n_kpts 4"] = np.zeros((n_kpts, 4), dtype=np.float64)
+
+    # Precompute which views see each keypoint
+    visibility: Int[ndarray, "n_views n_kpts"] = (keypoints_2d[..., 2] > 0).astype(np.int32)
+
+    for j in range(n_kpts):
+        visible_views_idx: Int[ndarray, "n_vis"] = np.where(visibility[:, j] > 0)[0]
+        if visible_views_idx.size < min_views:
+            # Not enough views; leave as zeros
+            continue
+
+        # Prepare per-view arrays for this keypoint
+        uv_all: Float[ndarray, "n_vis 2"] = keypoints_2d[visible_views_idx, j, :2].astype(np.float64)
+        conf_all: Float[ndarray, "n_vis"] = keypoints_2d[visible_views_idx, j, 2].astype(np.float64)
+        P_all: Float[ndarray, "n_vis 3 4"] = projection_matrices[visible_views_idx]
+
+        best_inliers: list[int] | None = None
+        best_X: Float[ndarray, "4"] | None = None
+
+        # Enumerate hypotheses from small subsets of views
+        subset_size: int = min(init_subset, visible_views_idx.size)
+        for subset in combinations(range(visible_views_idx.size), subset_size):
+            # Triangulate using the subset via the existing batch_triangulate
+            sub_idx = np.array(subset, dtype=np.int32)
+            kpts_subset: Float[ndarray, "m 1 3"] = np.zeros((sub_idx.size, 1, 3), dtype=np.float64)
+            kpts_subset[:, 0, :2] = uv_all[sub_idx]
+            kpts_subset[:, 0, 2] = conf_all[sub_idx]
+
+            P_subset: Float[ndarray, "m 3 4"] = P_all[sub_idx]
+            Xj: Float[ndarray, "4"] = batch_triangulate(kpts_subset, P_subset, min_views=subset_size)[0]
+            # If degenerate (confidence == 0), skip
+            if not np.isfinite(Xj[:3]).all():
+                continue
+            Xh: Float[ndarray, "4"] = np.concatenate([Xj[:3], np.array([1.0])]).astype(np.float64)  # homogeneous
+
+            # Score over all visible views
+            errors: list[float] = []
+            inliers: list[int] = []
+            for vi, P in enumerate(P_all):
+                uv_pred, depth = _project_points(Xh, P)
+                # Ignore points behind the camera for inlier counting
+                if depth <= 0:
+                    errors.append(np.inf)
+                    continue
+                err = float(np.linalg.norm(uv_pred - uv_all[vi]))
+                errors.append(err)
+                if err <= reproj_error_thresh:
+                    inliers.append(vi)
+
+            if len(inliers) >= (best_inliers or []).__len__():
+                best_inliers = inliers
+                best_X = Xh
+
+        # If no good hypothesis found, fallback to naive triangulation with all visible views
+        if best_inliers is None or len(best_inliers) < min_views:
+            kpts_all: Float[ndarray, "m 1 3"] = np.zeros((visible_views_idx.size, 1, 3), dtype=np.float64)
+            kpts_all[:, 0, :2] = uv_all
+            kpts_all[:, 0, 2] = conf_all
+            X_naive: Float[ndarray, "4"] = batch_triangulate(kpts_all, P_all, min_views=min_views)[0]
+            if np.isfinite(X_naive[:3]).all():
+                result[j, :3] = X_naive[:3]
+                # average conf of visible views
+                result[j, 3] = float(conf_all.mean())
+            continue
+
+        # Refine using inliers
+        inlier_idx = np.array(best_inliers, dtype=np.int32)
+        kpts_in: Float[ndarray, "m 1 3"] = np.zeros((inlier_idx.size, 1, 3), dtype=np.float64)
+        kpts_in[:, 0, :2] = uv_all[inlier_idx]
+        kpts_in[:, 0, 2] = conf_all[inlier_idx]
+        P_in: Float[ndarray, "m 3 4"] = P_all[inlier_idx]
+
+        X_refined: Float[ndarray, "4"] = batch_triangulate(kpts_in, P_in, min_views=min_views)[0]
+        if np.isfinite(X_refined[:3]).all():
+            result[j, :3] = X_refined[:3]
+            result[j, 3] = float(conf_all[inlier_idx].mean())
+        else:
+            # Fallback to best hypothesis if refinement failed
+            assert best_X is not None
+            result[j, :3] = best_X[:3]
+            result[j, 3] = float(conf_all[inlier_idx].mean())
+
+    return result

--- a/packages/mv-api/tests/test_batch_calibration.py
+++ b/packages/mv-api/tests/test_batch_calibration.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from mv_api.api.batch_calibration import ManifestEntry, SequenceManifest, discover_episodes_in_sequence
+
+
+def test_discover_episodes_in_sequence(tmp_path: Path) -> None:
+    sequence_path = tmp_path / "seq_001"
+    episode_dir = sequence_path / "episodes" / "episode_001"
+    episode_dir.mkdir(parents=True)
+    (episode_dir / "episode_001.rrd").write_bytes(b"rrd")
+
+    episodes = discover_episodes_in_sequence(sequence_path)
+
+    assert len(episodes) == 1
+    assert episodes[0].rrd_path == episode_dir / "episode_001.rrd"
+    assert episodes[0].calibrated_path == episode_dir / "episode_001-calibrated.rrd"
+    assert episodes[0].sequence_id == "seq_001"
+
+
+def test_sequence_manifest_roundtrip(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    manifest = SequenceManifest.load_or_create(manifest_path, "seq_001")
+    manifest.episodes["episode_001"] = ManifestEntry(
+        episode_path="episode.rrd",
+        calibrated_path="episode-calibrated.rrd",
+        status="success",
+        calibrated_at="2026-04-07T00:00:00",
+    )
+
+    manifest.save(manifest_path)
+    loaded = SequenceManifest.load_or_create(manifest_path, "seq_001")
+
+    payload = json.loads(manifest_path.read_text())
+    assert payload["sequence_id"] == "seq_001"
+    assert loaded.episodes["episode_001"].status == "success"

--- a/packages/mv-api/tests/test_exo_calib_service.py
+++ b/packages/mv-api/tests/test_exo_calib_service.py
@@ -1,0 +1,103 @@
+"""Unit tests for ExoOnlyCalibService and Umeyama transform."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from jaxtyping import Float32
+from numpy import ndarray
+
+from mv_api.api.exo_only_calibration import (
+    WB_UPPER_BODY_IDS,
+    _umeyama_transform,
+)
+
+
+class TestUmeyamaTransform:
+    """Tests for the _umeyama_transform function."""
+
+    def test_identity_when_points_match(self) -> None:
+        """When source and destination are identical, result should be identity."""
+        pts: Float32[ndarray, "5 3"] = np.random.randn(5, 3).astype(np.float32)
+        transform: Float32[ndarray, "4 4"] = _umeyama_transform(
+            src_points=pts, dst_points=pts, allow_scaling=False
+        )
+        # Should be close to identity
+        expected: Float32[ndarray, "4 4"] = np.eye(4, dtype=np.float32)
+        np.testing.assert_allclose(transform, expected, atol=1e-5)
+
+    def test_translation_only(self) -> None:
+        """Test that pure translation is recovered."""
+        src: Float32[ndarray, "4 3"] = np.array(
+            [[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=np.float32
+        )
+        offset: Float32[ndarray, "3"] = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        dst: Float32[ndarray, "4 3"] = src + offset
+
+        transform: Float32[ndarray, "4 4"] = _umeyama_transform(
+            src_points=src, dst_points=dst, allow_scaling=False
+        )
+
+        # Translation should be recovered
+        np.testing.assert_allclose(transform[:3, 3], offset, atol=1e-5)
+        # Rotation should be identity
+        np.testing.assert_allclose(transform[:3, :3], np.eye(3), atol=1e-5)
+
+    def test_rotation_is_recovered(self) -> None:
+        """Test that 90-degree rotation around Z is recovered."""
+        src: Float32[ndarray, "4 3"] = np.array(
+            [[1, 0, 0], [0, 1, 0], [-1, 0, 0], [0, -1, 0]], dtype=np.float32
+        )
+        # Rotate 90 degrees about Z: (x, y, z) -> (-y, x, z)
+        dst: Float32[ndarray, "4 3"] = np.array(
+            [[0, 1, 0], [-1, 0, 0], [0, -1, 0], [1, 0, 0]], dtype=np.float32
+        )
+
+        transform: Float32[ndarray, "4 4"] = _umeyama_transform(
+            src_points=src, dst_points=dst, allow_scaling=False
+        )
+
+        # Apply transform and check alignment
+        src_h: Float32[ndarray, "4 4"] = np.hstack([src, np.ones((4, 1), dtype=np.float32)])
+        aligned: Float32[ndarray, "4 3"] = (transform @ src_h.T).T[:, :3]
+        np.testing.assert_allclose(aligned, dst, atol=1e-5)
+
+    def test_scaling_is_recovered(self) -> None:
+        """Test that isotropic scaling is recovered when allow_scaling=True."""
+        src: Float32[ndarray, "4 3"] = np.array(
+            [[1, 0, 0], [0, 1, 0], [-1, 0, 0], [0, -1, 0]], dtype=np.float32
+        )
+        scale: float = 2.0
+        dst: Float32[ndarray, "4 3"] = src * scale
+
+        transform: Float32[ndarray, "4 4"] = _umeyama_transform(
+            src_points=src, dst_points=dst, allow_scaling=True
+        )
+
+        # Apply transform and check alignment
+        src_h: Float32[ndarray, "4 4"] = np.hstack([src, np.ones((4, 1), dtype=np.float32)])
+        aligned: Float32[ndarray, "4 3"] = (transform @ src_h.T).T[:, :3]
+        np.testing.assert_allclose(aligned, dst, atol=1e-5)
+
+    def test_insufficient_points_raises(self) -> None:
+        """Umeyama requires at least 3 points."""
+        src: Float32[ndarray, "2 3"] = np.array([[0, 0, 0], [1, 0, 0]], dtype=np.float32)
+        dst: Float32[ndarray, "2 3"] = src.copy()
+
+        with pytest.raises(ValueError, match="at least 3 correspondences"):
+            _umeyama_transform(src_points=src, dst_points=dst)
+
+
+class TestWBUpperBodyIDs:
+    """Verify the precomputed filter indices constant."""
+
+    def test_contains_expected_indices(self) -> None:
+        """WB_UPPER_BODY_IDS should contain upper body, face, and hand keypoints."""
+        # Upper body: 5, 6, 7, 8, 9, 10 (shoulders, elbows, wrists)
+        for idx in [5, 6, 7, 8, 9, 10]:
+            assert idx in WB_UPPER_BODY_IDS
+
+    def test_no_lower_body(self) -> None:
+        """WB_UPPER_BODY_IDS should not contain lower body keypoints (11-16)."""
+        for idx in [11, 12, 13, 14, 15, 16]:
+            assert idx not in WB_UPPER_BODY_IDS

--- a/packages/mv-api/tests/test_gradio_ui.py
+++ b/packages/mv-api/tests/test_gradio_ui.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from mv_api.gradio_ui import full_pipeline_rrd_ui as ui
+
+
+def test_cleanup_temp_rrds_removes_existing_files(tmp_path: Path) -> None:
+    output = tmp_path / "output.rrd"
+    output.write_bytes(b"rrd")
+
+    ui.cleanup_temp_rrds([str(output)])
+
+    assert not output.exists()
+
+
+def test_run_rrd_pipeline_uses_sanitized_config(monkeypatch: object, tmp_path: Path) -> None:
+    captured: dict[str, object] = {}
+
+    class DummyDatasetConfig:
+        def __init__(self, *, rrd_path: Path) -> None:
+            captured["rrd_path"] = rrd_path
+
+    class DummyCalibratorConfig:
+        def __init__(self, *, segment_people: bool) -> None:
+            captured["segment_people"] = segment_people
+
+    class DummyPipelineConfig:
+        def __init__(self, *, rr_config: object, calib_confg: object, dataset: object, max_frames: int | None) -> None:
+            self.rr_config = rr_config
+            self.calib_confg = calib_confg
+            self.dataset = dataset
+            self.max_frames = max_frames
+
+    def fake_run_full_exoego_pipeline(*, config: object) -> None:
+        captured["config"] = config
+
+    monkeypatch.setattr(ui, "RRDExoEgoConfig", DummyDatasetConfig)
+    monkeypatch.setattr(ui, "MultiViewCalibratorConfig", DummyCalibratorConfig)
+    monkeypatch.setattr(ui, "RRDPipelineConfig", DummyPipelineConfig)
+    monkeypatch.setattr(ui, "run_full_exoego_pipeline", fake_run_full_exoego_pipeline)
+
+    input_rrd = tmp_path / "input.rrd"
+    input_rrd.write_bytes(b"rrd")
+    pending_cleanup: list[str] = []
+
+    viewer_rrd, download_rrd = ui.run_rrd_pipeline(str(input_rrd), 0, pending_cleanup)
+
+    assert viewer_rrd == download_rrd
+    assert Path(viewer_rrd).exists()
+    assert pending_cleanup == [viewer_rrd]
+    assert captured["rrd_path"] == input_rrd
+    assert captured["segment_people"] is False
+
+    config = captured["config"]
+    assert config is not None
+    assert config.max_frames is None

--- a/packages/mv-api/tests/test_import.py
+++ b/packages/mv-api/tests/test_import.py
@@ -1,0 +1,12 @@
+"""Smoke tests for the mv_api package surface."""
+
+
+def test_import_mv_api() -> None:
+    import mv_api  # noqa: F401
+
+
+def test_import_retained_modules() -> None:
+    import mv_api.api.batch_calibration  # noqa: F401
+    import mv_api.api.exo_only_calibration  # noqa: F401
+    import mv_api.api.full_exoego_pipeline  # noqa: F401
+    import mv_api.gradio_ui.full_pipeline_rrd_ui  # noqa: F401

--- a/packages/mv-api/tests/test_robust_triangulate.py
+++ b/packages/mv-api/tests/test_robust_triangulate.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+from jaxtyping import Float
+from numpy import ndarray
+
+from mv_api.robust_triangulate import batch_triangulate, robust_batch_triangulate
+
+
+def _load_hocap_root() -> Path | None:
+    # Try common env vars or fallbacks
+    candidates = [
+        os.environ.get("HOCAP_ROOT"),
+        os.environ.get("MV_API_HOCAP_ROOT"),
+        str(Path("/mnt/8tb/data/hocap/datasets")),
+        str(Path("data/hocap")),
+        str(Path("data/hocap-datasets")),
+    ]
+    for c in candidates:
+        if not c:
+            continue
+        p = Path(c)
+        if p.exists():
+            return p
+    return None
+
+
+def _build_hocap_from_config(root: Path) -> tuple[Float[ndarray, "n_views 3 4"], Float[ndarray, "133 4"]]:
+    """Use simplecv dataset config to build Pall and ground-truth xyzc for a frame."""
+    from simplecv.data.exoego.hocap import HocapConfig
+
+    # Pick the first available sequence to avoid hardcoding
+    seq_dir, subject_id, seq_name = _pick_first_sequence(root)
+    assert seq_dir.exists()
+
+    cfg = HocapConfig(root_directory=root, subject_id=subject_id, sequence_name=seq_name)
+    exoego_sequence = cfg.setup()
+    exo_sequence = exoego_sequence.exo_sequence
+    assert exo_sequence is not None
+
+    Pall: Float[ndarray, "n_views 3 4"] = np.array([cam.projection_matrix for cam in exo_sequence.exo_cam_list])
+    labels = exoego_sequence.exoego_labels
+    assert labels is not None
+    xyzc_gt: Float[ndarray, "133 4"] = labels.xyzc_stack[0]
+    return Pall, xyzc_gt
+
+
+def _pick_first_sequence(root: Path) -> tuple[Path, str, str]:
+    # Return (sequence_dir, subject_id, sequence_name)
+    subjects = sorted([p for p in root.glob("subject_*") if p.is_dir()])
+    assert subjects, f"No subject_* dirs under {root}"
+    for subj in subjects:
+        seqs = sorted([p for p in subj.iterdir() if p.is_dir()])
+        if not seqs:
+            continue
+        return seqs[0], subj.name.split("_")[-1], seqs[0].name
+    raise AssertionError("No sequences found in HoCap root")
+
+
+    # No longer needed: ground truth comes from exoego_sequence.exoego_labels
+    raise NotImplementedError
+
+
+def _project_uvc(Pall: Float[ndarray, "n_views 3 4"], xyzc: Float[ndarray, "133 4"]) -> Float[ndarray, "n_views 133 3"]:
+    n_views = Pall.shape[0]
+    uvc = np.zeros((n_views, 133, 3), dtype=np.float64)
+    for i in range(n_views):
+        P = Pall[i]
+        X = np.hstack([xyzc[:, :3], np.ones((133, 1))])
+        x = (P @ X.T).T
+        z = x[:, 2:3]
+        uv = x[:, :2] / z
+        # mark invisible if behind camera
+        vis = (z[:, 0] > 0) & (xyzc[:, 3] > 0)
+        uvc[i, :, 0:2] = uv
+        uvc[i, ~vis, 2] = 0.0
+        uvc[i, vis, 2] = 1.0
+    return uvc
+
+
+def _median_3d_error(pred: Float[ndarray, "133 4"], gt: Float[ndarray, "133 4"]) -> float:
+    mask = gt[:, 3] > 0
+    if not np.any(mask):
+        return np.inf
+    return float(np.median(np.linalg.norm(pred[mask, :3] - gt[mask, :3], axis=-1)))
+
+
+@pytest.mark.slow
+def test_hocap_robust_beats_naive_with_outliers():
+    root = _load_hocap_root()
+    if root is None:
+        pytest.skip("HoCap dataset root not found; set HOCAP_ROOT to run this test")
+
+    Pall, xyzc_gt = _build_hocap_from_config(root)
+
+    uvc = _project_uvc(Pall, xyzc_gt)
+    # Introduce outliers in two views (shift all joints by 50px)
+    uvc[0, :, 0:2] += 50.0
+    uvc[1, :, 0:2] += 50.0
+
+    naive: Float[ndarray, "133 4"] = batch_triangulate(uvc, Pall, min_views=2)
+    robust: Float[ndarray, "133 4"] = robust_batch_triangulate(uvc, Pall, min_views=2, reproj_error_thresh=5.0, init_subset=2)
+
+    naive_med = _median_3d_error(naive, xyzc_gt)
+    robust_med = _median_3d_error(robust, xyzc_gt)
+
+    assert robust_med < naive_med, f"robust should beat naive: robust={robust_med:.3f} naive={naive_med:.3f}"
+
+
+@pytest.mark.slow
+def test_hocap_robust_matches_naive_without_outliers():
+    root = _load_hocap_root()
+    if root is None:
+        pytest.skip("HoCap dataset root not found; set HOCAP_ROOT to run this test")
+
+    Pall, xyzc_gt = _build_hocap_from_config(root)
+    uvc = _project_uvc(Pall, xyzc_gt)
+
+    naive: Float[ndarray, "133 4"] = batch_triangulate(uvc, Pall, min_views=2)
+    robust: Float[ndarray, "133 4"] = robust_batch_triangulate(uvc, Pall, min_views=2, reproj_error_thresh=5.0, init_subset=2)
+
+    naive_med = _median_3d_error(naive, xyzc_gt)
+    robust_med = _median_3d_error(robust, xyzc_gt)
+
+    assert abs(naive_med - robust_med) < 1e-3

--- a/packages/mv-api/tools/app_full_pipeline_rrd.py
+++ b/packages/mv-api/tools/app_full_pipeline_rrd.py
@@ -1,0 +1,26 @@
+import os
+
+import gradio as gr
+
+from mv_api.gradio_ui.full_pipeline_rrd_ui import EXAMPLE_RRD_PATH, build_full_pipeline_rrd_block
+
+title = "# Full Exo/Ego Pipeline (RRD Input)"
+GRADIO_SERVER_NAME: str = os.environ.get("GRADIO_SERVER_NAME", "0.0.0.0")
+GRADIO_SERVER_PORT: int = int(os.environ.get("GRADIO_SERVER_PORT", "7860"))
+GRADIO_ROOT_PATH: str | None = os.environ.get("GRADIO_ROOT_PATH") or None
+
+with gr.Blocks() as demo:
+    gr.Markdown(title)
+    build_full_pipeline_rrd_block()
+
+
+if __name__ == "__main__":
+    launch_kwargs: dict[str, object] = {
+        "server_name": GRADIO_SERVER_NAME,
+        "server_port": GRADIO_SERVER_PORT,
+    }
+    if EXAMPLE_RRD_PATH.exists():
+        launch_kwargs["allowed_paths"] = [str(EXAMPLE_RRD_PATH.parent)]
+    if GRADIO_ROOT_PATH:
+        launch_kwargs["root_path"] = GRADIO_ROOT_PATH
+    demo.queue().launch(**launch_kwargs)

--- a/packages/mv-api/tools/batch_exo_calib_client.py
+++ b/packages/mv-api/tools/batch_exo_calib_client.py
@@ -1,0 +1,11 @@
+"""CLI entry point for batch exo calibration.
+
+Thin wrapper around mv_api.api.batch_calibration for CLI usage.
+"""
+
+import tyro
+
+from mv_api.api.batch_calibration import BatchCalibConfig, run_batch_calibration
+
+if __name__ == "__main__":
+    run_batch_calibration(tyro.cli(BatchCalibConfig))

--- a/packages/mv-api/tools/run_exo_only_calib.py
+++ b/packages/mv-api/tools/run_exo_only_calib.py
@@ -1,0 +1,6 @@
+import tyro
+
+from mv_api.api.exo_only_calibration import ExoOnlyCalibConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(ExoOnlyCalibConfig))

--- a/packages/mv-api/tools/run_rrd_client_example.py
+++ b/packages/mv-api/tools/run_rrd_client_example.py
@@ -1,0 +1,93 @@
+"""Call the Gradio RRD pipeline locally and report progress."""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+import tyro
+from gradio_client import Client, handle_file
+from gradio_client.client import Job
+from gradio_client.utils import StatusUpdate
+
+DEFAULT_GRADIO_URL: str = "http://127.0.0.1:7860/"
+DEFAULT_RRD_PATH: Path = Path("/mnt/8tb/data/exoego-self-collected/gus/statisOrangePNP_av1.rrd")
+
+
+@dataclass
+class RRDClientConfig:
+    """Configuration for the RRD client smoke test."""
+
+    gradio_url: str = DEFAULT_GRADIO_URL
+    """Base URL for the Gradio server to target."""
+
+    rrd_path: Path = DEFAULT_RRD_PATH
+    """Absolute path to the RRD file that will be uploaded."""
+
+    max_frames: int = 10
+    """Maximum number of frames to process (use 0 or negative for all)."""
+
+    poll_interval_seconds: float = 2.0
+    """Time to wait between queue status checks."""
+
+    bearer_token: str | None = None
+    """Optional bearer token to attach as `Authorization: Bearer …`."""
+
+    http_timeout_seconds: float | None = None
+    """Override the HTTPX timeout in seconds when targeting slow endpoints."""
+
+
+def main(config: RRDClientConfig) -> None:
+    """Submit the pipeline job and stream queue/progress updates."""
+    bearer_token: str | None = config.bearer_token or os.environ.get("MV_API_LIGHTNING_TOKEN")
+
+    timeout_seconds: float | None = config.http_timeout_seconds
+    if timeout_seconds is None:
+        timeout_env: str | None = os.environ.get("MV_API_HTTP_TIMEOUT")
+        if timeout_env:
+            try:
+                timeout_seconds = float(timeout_env)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid MV_API_HTTP_TIMEOUT value: {timeout_env}"
+                ) from exc
+
+    if timeout_seconds is not None and timeout_seconds <= 0:
+        timeout_seconds = None
+
+    headers: dict[str, str] | None = None
+    if bearer_token:
+        headers = {"Authorization": f"Bearer {bearer_token}"}
+
+    httpx_kwargs: dict[str, object] | None = None
+    if timeout_seconds is not None:
+        timeout: httpx.Timeout = httpx.Timeout(timeout_seconds, connect=timeout_seconds)
+        httpx_kwargs = {"timeout": timeout}
+
+    client: Client = Client(config.gradio_url, headers=headers, httpx_kwargs=httpx_kwargs)
+    job: Job = client.submit(
+        rrd_input=handle_file(str(config.rrd_path)),
+        max_frames=None if config.max_frames <= 0 else config.max_frames,
+        api_name="/run_rrd_pipeline",
+    )
+    print("Submitted job; polling queue status…")
+
+    while not job.done():
+        status: StatusUpdate = job.status()
+        rank: int | None = status.rank
+        queue_size: int | None = status.queue_size
+        eta_seconds: float | None = status.eta
+        eta_display: str = f"{eta_seconds:.1f}s" if eta_seconds is not None else "n/a"
+        print(f"  position {rank}/{queue_size}, estimated wait {eta_display}")
+        time.sleep(config.poll_interval_seconds)
+
+    result = job.result()
+    print("Pipeline completed.")
+    print(f"Output RRD: {result}")
+
+
+if __name__ == "__main__":
+    main(tyro.cli(RRDClientConfig))

--- a/packages/mv-api/tools/validate_mv_api.py
+++ b/packages/mv-api/tools/validate_mv_api.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import importlib
+import runpy
+import subprocess
+import sys
+from pathlib import Path
+
+PACKAGE_DIR: Path = Path(__file__).resolve().parent.parent
+
+MODULES: tuple[str, ...] = (
+    "mv_api",
+    "mv_api.api.full_exoego_pipeline",
+    "mv_api.api.exo_only_calibration",
+    "mv_api.api.batch_calibration",
+    "mv_api.gradio_ui.full_pipeline_rrd_ui",
+)
+
+TOOLS_WITH_HELP: tuple[str, ...] = (
+    "tools/run_rrd_client_example.py",
+    "tools/run_exo_only_calib.py",
+    "tools/batch_exo_calib_client.py",
+)
+
+
+def _run_checked(args: list[str]) -> None:
+    subprocess.run(args, cwd=PACKAGE_DIR, check=True)
+
+
+def main() -> None:
+    for module_name in MODULES:
+        importlib.import_module(module_name)
+
+    for rel_path in TOOLS_WITH_HELP:
+        _run_checked([sys.executable, rel_path, "--help"])
+
+    runpy.run_path(str(PACKAGE_DIR / "tools" / "app_full_pipeline_rrd.py"), run_name="mv_api_app_validation")
+    print("mv-api validation completed successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pixi.lock
+++ b/pixi.lock
@@ -28207,7 +28207,7 @@ packages:
   - pytorch-lightning>=2.5.1,<3
   - diffusers[torch]>=0.32.2
   - timm>=1.0.15,<2
-  - sam3-rerun @ file:///var/tmp/vibe-kanban/worktrees/f0c3-lietorch-in-ai-d/examples-monorepo/packages/sam3-rerun
+  - sam3-rerun @ file:///var/tmp/vibe-kanban/worktrees/6712-multiview-pose-e/examples-monorepo/packages/sam3-rerun
   requires_python: '>=3.11.0'
 - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
   name: more-itertools
@@ -33640,7 +33640,7 @@ packages:
   version: 0.1.0
   sha256: 6010c475dca8016b74cdbd14fec5a399b674644eb3797dd861ad6c4670702b67
   requires_dist:
-  - monopriors @ file:///var/tmp/vibe-kanban/worktrees/f0c3-lietorch-in-ai-d/examples-monorepo/packages/monoprior
+  - monopriors @ file:///var/tmp/vibe-kanban/worktrees/6712-multiview-pose-e/examples-monorepo/packages/monoprior
   requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/88/1b/ffa0335499343894648fa92cd655978a65de0f2c6fc2ddca9fe6b6f9c242/rerun_sdk-0.30.2-cp310-abi3-manylinux_2_28_aarch64.whl
   name: rerun-sdk
@@ -34159,8 +34159,8 @@ packages:
   - omegaconf>=2.3.0,<3
   - termcolor>=3.2.0,<4
   - spaces>=0.43.0
-  - monopriors @ file:///var/tmp/vibe-kanban/worktrees/f0c3-lietorch-in-ai-d/examples-monorepo/packages/monoprior
-  - sam3-rerun @ file:///var/tmp/vibe-kanban/worktrees/f0c3-lietorch-in-ai-d/examples-monorepo/packages/sam3-rerun
+  - monopriors @ file:///var/tmp/vibe-kanban/worktrees/6712-multiview-pose-e/examples-monorepo/packages/monoprior
+  - sam3-rerun @ file:///var/tmp/vibe-kanban/worktrees/6712-multiview-pose-e/examples-monorepo/packages/sam3-rerun
   requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/f4/a2/70401a107d6d7466d64b466927e6b96fcefa99d57494b972608e2f8be50f/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
   name: scikit-image
@@ -36991,7 +36991,7 @@ packages:
   sha256: 040445160e2ce50aa6695f139ee7258a27456ec50ee1fbcc9351b9e46aa686b5
   requires_dist:
   - einops>=0.8.1,<0.9
-  - monopriors @ file:///var/tmp/vibe-kanban/worktrees/f0c3-lietorch-in-ai-d/examples-monorepo/packages/monoprior
+  - monopriors @ file:///var/tmp/vibe-kanban/worktrees/6712-multiview-pose-e/examples-monorepo/packages/monoprior
   requires_python: '>=3.11'
 - conda: https://prefix.dev/conda-forge/linux-64/vlfeat-0.9.21-hd590300_1.conda
   sha256: f3fca24ef6a327072378dd654eba37c6a6da15499ca212eb20b0af422c1ad4c5

--- a/pixi.lock
+++ b/pixi.lock
@@ -4395,6 +4395,1208 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: ./packages/monoprior
       - pypi: ./packages/sam3-rerun
+  mv-api:
+    channels:
+    - url: https://prefix.dev/ai-demos/
+    - url: https://prefix.dev/conda-forge/
+    indexes:
+    - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
+    packages:
+      linux-64:
+      - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/assimp-6.0.3-hecf2907_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/av-17.0.0-py312h46547aa_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.9.3-hef928c7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.13-h2c9d079_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.1-h8b1a151_9.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-event-stream-0.5.7-h28f887f_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.10.7-ha8fc4e3_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.23.3-hdaf4b65_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-mqtt-0.13.3-hc63082f_11.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.11.3-h06ab39a_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-h8b1a151_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.7-h8b1a151_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-crt-cpp-0.35.4-h8824e59_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.606-h20b40b1_10.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/azure-core-cpp-1.16.2-h206d751_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/azure-identity-cpp-1.13.3-hed0cdb0_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/azure-storage-blobs-cpp-12.16.0-hdd73cc9_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/azure-storage-common-cpp-12.12.0-ha7a2c86_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.14.0-h52c5a47_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/backports.zstd-1.3.0-py312h90b7ffd_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/beartype-0.22.9-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils-2.45.1-default_h4852527_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_102.conda
+      - conda: https://prefix.dev/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/brotli-1.2.0-hed03a55_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/brotli-bin-1.2.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/brotli-python-1.2.0-py312hdb49522_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/brunsli-0.1-hd1e3526_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-blosc2-2.23.1-hc31b594_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-compiler-1.11.0-h4d9bdce_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/casefy-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/charls-2.4.3-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cli11-2.6.2-h54a6638_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/click-8.3.2-pyhc90fa1f_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cccl_linux-64-12.9.27-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-compiler-12.9.1-hbad6d8a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-crt-12.9.86-h69a702a_6.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-crt-dev_linux-64-12.9.86-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-crt-tools-12.9.86-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-12.9.79-h5888daf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-dev-12.9.79-h5888daf_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart-dev_linux-64-12.9.79-h3f2d84a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-static-12.9.79-h5888daf_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart-static_linux-64-12.9.79-h3f2d84a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart_linux-64-12.9.79-h3f2d84a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cuobjdump-12.9.82-hffce074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cupti-12.9.79-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cuxxfilt-12.9.82-hffce074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-driver-dev-12.9.79-h5888daf_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-driver-dev_linux-64-12.9.79-h3f2d84a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-12.9.86-hcdd1206_6.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-nvcc-dev_linux-64-12.9.86-he91c749_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-impl-12.9.86-h85509e4_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-tools-12.9.86-he02047a_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc_linux-64-12.9.86-he0b4e1d_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvdisasm-12.9.88-hffce074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvml-dev-12.9.79-hffce074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvprune-12.9.82-hffce074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvrtc-12.9.86-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvrtc-dev-12.9.86-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvtx-12.9.79-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvtx-dev-12.9.79-ha770c72_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-nvvm-dev_linux-64-12.9.86-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvvm-impl-12.9.86-h4bc722e_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvvm-tools-12.9.86-h4bc722e_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-profiler-api-12.9.79-h7938cbb_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-version-12.9-h4f385c5_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cudnn-9.10.2.21-hbcb9cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cusparselt-0.8.1.1-h58dd1b1_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cxx-compiler-1.11.0-hfcd1e18_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/dash-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/dataclasses-0.8-pyhc8e2a94_3.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/datasets-4.8.4-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/dill-0.4.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/eigen-abi-5.0.1.80-hf414acd_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/embree-4.4.1-ha751380_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/eval_type_backport-0.3.1-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-8.0.1-gpl_h43fde53_912.conda
+      - conda: https://prefix.dev/conda-forge/noarch/filelock-3.25.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/flask-3.1.3-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fmt-12.1.0-hff5e90c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fontconfig-2.17.1-h27c8c51_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fonttools-4.62.0-py312h8a5da7c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/freetype-py-2.5.1-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/frozendict-2.4.7-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/frozenlist-1.7.0-py312h447239a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/fsspec-2026.2.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc-14.3.0-h0dff253_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-hbdf3cc3_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-14.3.0-h298d278_23.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gl2ps-1.4.2-h36e74d4_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/glew-2.3.0-h71661d4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/glfw-3.4-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/glslang-16.2.0-hfd11570_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gmpy2-2.3.0-py312hcaba1f9_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx-14.3.0-h76987e4_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-h2185e75_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-14.3.0-h91b0f8e_23.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha4f8f14_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-14.1.0-h6083320_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_108.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hf-transfer-0.1.9-py312h914ccca_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hf-xet-1.4.3-py310hb823017_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/huggingface_hub-1.9.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.3.6-py312h40df4bb_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/imageio-2.37.0-pyhfb79c49_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/imath-3.2.2-hde8ca8f_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/intel-gmmlib-22.10.0-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/intel-media-driver-25.3.4-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/itsdangerous-2.2.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/jasper-4.2.9-h1588d4d_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jaxtyping-0.2.36-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/jsoncpp-1.9.6-hf42df4d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/kiwisolver-1.5.0-py312h0a2e395_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lcms2-2.18-h0c24ade_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/level-zero-1.28.2-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20250512.1-cxx17_hba17884_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-23.0.0-h258748b_2_cuda.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-acero-23.0.0-h635bf11_2_cuda.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-compute-23.0.0-h8c2c5c3_2_cuda.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-23.0.0-h635bf11_2_cuda.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-substrait-23.0.0-h3f74fd7_2_cuda.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libass-0.17.4-h96ad9f0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libavif16-1.4.1-hcfa2d63_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-6_h5875eb1_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libboost-1.88.0-hd24cca6_7.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcap-2.77-hd0affe5_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-6_hfef963f_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libclang-cpp22.1-22.1.0-default_h99862b1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libclang13-22.1.0-default_h746c552_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/libcublas-12.9.1.4-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcublas-dev-12.9.1.4-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudnn-9.10.2.21-hf7e9902_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudnn-dev-9.10.2.21-h58dd1b1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudss-0.7.1.4-h58dd1b1_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudss-dev-0.7.1.4-hee47b17_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufft-11.4.1.4-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufft-dev-11.4.1.4-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufile-1.14.1.1-hbc026e6_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufile-dev-1.14.1.1-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurand-10.3.10.19-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurand-dev-10.3.10.19-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.19.0-hcf29cc6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusolver-11.7.5.82-h676940d_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusolver-dev-11.7.5.82-h676940d_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusparse-12.5.10.65-hecca717_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusparse-dev-12.5.10.65-hecca717_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_118.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.86.4-h6548e54_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-2.39.0-hdb79228_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-storage-2.39.0-hdbdcf42_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgrpc-1.73.1-h3288cfb_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhwy-1.3.0-h4c17acf_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libjxl-0.11.2-ha09017c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-6_h5e43f62_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-6_hdba1596_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libllvm20-20.1.8-hf7376ad_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libllvm22-22.1.2-hf7376ad_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblzf-3.6-hb9d3cd8_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmagma-2.9.0-ha7672b3_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnetcdf-4.10.0-nompi_hb6f1874_103.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvjitlink-12.9.86-hecca717_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvjpeg-12.4.0.76-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvptxcompiler-dev-12.9.86-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libnvptxcompiler-dev_linux-64-12.9.86-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopencv-4.13.0-qt6_py312h15557d8_605.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopengl-devel-1.7.0-ha4b6fd6_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopentelemetry-cpp-1.21.0-hb9b0907_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopentelemetry-cpp-headers-1.21.0-ha770c72_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-2025.4.1-hb56ce9e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-batch-plugin-2025.4.1-hd85de46_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-plugin-2025.4.1-hd85de46_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-hetero-plugin-2025.4.1-hd41364c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2025.4.1-hb56ce9e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2025.4.1-hb56ce9e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-npu-plugin-2025.4.1-hb56ce9e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-ir-frontend-2025.4.1-hd41364c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-onnx-frontend-2025.4.1-h1862bb8_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-paddle-frontend-2025.4.1-h1862bb8_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-pytorch-frontend-2025.4.1-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.4.1-h0767aad_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2025.4.1-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libparquet-23.0.0-h7376487_2_cuda.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpng-1.6.56-h421ea60_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpq-18.3-h9abb657_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libprotobuf-6.31.1-h49aed37_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libre2-11-2025.11.05-h7b12aa8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/librsvg-2.62.1-h4c96295_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsodium-1.0.21-h280c20c_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_118.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsystemd0-257.13-hd0affe5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libtheora-1.1.1-h4ab18f5_1006.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libthrift-0.22.0-h454ac66_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libtinyobjloader-2.0.0rc13-h54a6638_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libtorch-2.10.0-cuda129_mkl_he24fa84_301.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libudev1-257.13-hd0affe5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liburing-2.14-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libutf8proc-2.11.3-hfe17d71_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libva-2.23.0-he1eb515_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvpl-2.15.0-h54a6638_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvpx-1.15.2-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvulkan-loader-1.4.341.0-h5279c79_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.13.1-hca5e8e5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.2-hca6bf5a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.15.2-he237659_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libzopfli-1.0.3-h9c3ff4c_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/llvm-openmp-22.1.2-h4922eb0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/matplotlib-base-3.10.8-py312he3d6523_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mesalib-25.0.5-h57bcd07_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mkl-2025.3.1-h0e700b2_10.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.1.2-py312hd9148b4_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/multidict-6.7.1-py312h8a5da7c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/multiprocess-0.70.19-py312h5253ce2_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/narwhals-2.19.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/natsort-8.4.0-pyhcf101f3_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/nccl-2.29.3.1-h4d09622_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.4.3-py312h33ff503_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/open3d-0.19.0-py312h0042587_13.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/opencl-headers-2025.06.13-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openexr-3.4.9-h40f6f1d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openjph-0.26.3-h8d634f6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openldap-2.6.10-hbde042b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/optree-0.19.0-py312hd9148b4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/orc-2.2.2-h19cb568_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pandas-3.0.2-py312h8ecdadd_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pillow-12.2.0-py312h50c33e8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/plotly-6.6.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/plum-dispatch-2.8.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/proj-9.8.0-he0df7b0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/propcache-0.3.1-py312h178313f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/py-opencv-4.13.0-qt6_py312h598be00_605.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyarrow-23.0.0-py312h7900ff3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyarrow-core-23.0.0-py312hfa4fb80_0_cuda.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-3.0.3-pyhfe8187e_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-global-3.0.3-pyh648e204_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pyglet-2.1.14-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pyopengl-3.1.10-pyha804496_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pyrender-0.1.45-pyh8a188c0_3.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/pyserde-0.29.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.12.13-hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/python-xxhash-3.6.0-py312h0d868a3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pytorch-2.10.0-cuda129_mkl_py312_hcddf9c5_301.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pytorch-gpu-2.10.0-cuda129_mkl_h0d04637_301.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pywavelets-1.9.0-py312h4f23490_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/qt6-main-6.10.2-pl5321h16c4a6b_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/rav1e-0.8.1-h1fbca29_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/rdma-core-61.0-h192683f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/re2-2025.11.05-h5301d42_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/regex-2026.4.4-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/retrying-1.4.2-pyhe01879c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.6.2-he8a4886_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/safetensors-0.7.0-py312h0ccc70a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/scikit-image-0.24.0-py312hf9745cd_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sdl3-3.4.4-hdeec2a5_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/shaderc-2025.5-h3e344bc_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/shtab-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/spirv-tools-2025.5-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sqlite-3.52.0-h04a0ce9_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-4.0.1-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tifffile-2026.3.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tokenizers-0.22.2-py312hf875000_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/torchvision-0.25.0-cuda129_py312_h69a17e1_4.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/transformers-5.5.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/trimesh-4.11.5-pyh7b2049a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/triton-3.6.0-cuda129py312h811769c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typeguard-2.13.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/typer-0.24.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tyro-0.9.1-pyhff2d567_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/utfcpp-4.09-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/viskores-1.1.0-cuda12.9_h14fae2a_.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/vtk-base-9.6.0-py312h64f160b_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/werkzeug-3.1.8-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wslink-2.5.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.47-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxinerama-1.1.6-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxshmfence-1.3.3-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xxhash-0.8.3-hb47aa4a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/yarl-1.23.0-py312h8a5da7c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zeromq-4.3.5-h41580af_10.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zfp-1.0.1-h909a3a2_5.conda
+      - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - pypi: https://files.pythonhosted.org/packages/7e/46/02ac5e262d4af18054b3e922b2baedbb2a03289ee792162de60a865defc5/accelerate-1.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/df/d8/ce9386e6d76ea79e61dee15e62aa48cff6be69e89246b0ac4a11857cb02c/aiobotocore-3.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dc/95/1ec57df6c52152fb4c776da5fbb2896f19af52de3776899d91e7140e7654/aria2p-0.12.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/35/bf/9cad857b630c840738003eb24c1adb63490a1024ec40a9dcc3a753300c38/asciimatics-1.15.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e3/37/0c0c90361c8a1b9e6c75222ca24ae12996a298c0e18822a72ab229c37207/botocore-1.42.84-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/34/71/1ea5a7352ae516d5512d17babe7e1b87d9db5150b21f794b1377eac1edc0/cryptography-46.0.6-cp311-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/6e/cf/c88130a6a32fc76f2711160a2a0ab8b4fac9df9682fdd988a479122c3512/daggr-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/00/ba/8d8aa1df96e0666752e5c9d406d440495df2014d315b2a95bbef9856b23e/datafusion-50.1.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/9c/dd/51c38785ce5e1c287b5ad17ba550edaaaffce0deb0da4857019c6700fbaf/diffusers-0.37.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/84/a4/5caa2de7f917a04ada20018eccf60d6cc6145b0199d55ca3711b0fc08312/fastapi-0.135.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fa/89/bf2adbdbb90dab8b465d7a489e0a291e9153bf7b1db2b90ea4fa3c4bf16f/fastcore-1.12.34-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/55/56/dd3669eccebb6d8ac81e624542ebd53fe6f08e1b8f2f8d50aeb7e3b83f99/ffmpy-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ed/1f/95cb961341bf33e534a472672ef4916c90046dc3c57b1442f5586dda72f1/geffnet-1.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/32/ba/9ccb80650e5bd61e739f16f33aec3bb290a80f314631be8f7dc0a2b22b5f/glcontext-3.0.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/38/3c/1568ee82f0e4308612aaf964168e93b7f2adb64c3e77b7877fd397e773bf/gradio-6.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c2/49/86b919727b5d6574528d5d9e67c6455bb707a3654abc87d61d7f1d742395/gradio_client-2.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/be/6d/8db85a26fcdc9658198744485623ee1be87de555155112421c487119709d/gradio_rerun-0.30.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/28/27/3d6dcadc8a3214d8522c1e7f6a19554e33659be44546d44a2f7572ac7d2a/groovy-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/84/a6/b3965e1e146ef5762870bbe76117876ceba51a201e18cc31f5703e454596/httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/82/9707c7b0336bca53b75f52fc350956a93da66eb6be632b370bc933216fb4/icecream-2.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/25/f4/ead6e0e37209b07c9baa3e984ccdb0348ca370b77cea3aaea8ddbb097e00/lightning_utilities-0.15.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c0/84/c87be2b1c58172ed64c2207f1dd116003a84087a9c5112ceb8e37a2233b9/lovely_numpy-0.2.20-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d7/96/bcb5141eae24474d80b8157b0c3055d25fa75f9804d4abb4a514695bbba9/moderngl-5.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: git+https://github.com/microsoft/MoGe.git#07444410f1e33f402353b99d6ccd26bd31e469e8
+      - pypi: https://files.pythonhosted.org/packages/d8/f4/5e52c7319b8087acef603ed6e50dc325c02eaa999355414830468611f13c/more_itertools-11.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/b7/ec1cbc6b297a808c513f59f501656389623fc09ad6a58c640851289c7854/nh3-0.3.4-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/12/60/17ed502ab8258e36b6caf478974994f15691c73e3c46abf82a2ec63e9eda/omnidata_tools-0.0.23-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/ab/5b68110e0460d73fad814d5bd11c7b1ddcce5c37b10177eb264d6a36e331/onnxruntime-1.24.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/5b3fd4748cf7ed291eae541a37e426efc20ea04cb6e6a05768304ab0aa41/onnxruntime_gpu-1.24.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/37/87/5ddeb7fc1fbd9004aeccab08426f34c81a5b4c25c7061281862b015fce2b/orjson-3.11.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/29/c028a0731e202035f0e2e0bfbf1a3e46ad6c628cbb17f6f1cc9eea5d9ff1/pathlib_abc-0.5.2-py3-none-any.whl
+      - pypi: git+https://github.com/EasternJournalist/pipeline.git#866f059d2a05cde05e4a52211ec5051fd5f276d6
+      - pypi: https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/1f/73c53fcbfb0b5a78f91176df41945ca466e71e9d9d836e5c522abda39ee7/pydantic-2.11.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/5c/fe9f95abd5eaedfa69f31e450f7e2768bef121dbdf25bcddee2cd3087a16/pyfiglet-1.0.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/73/89930efabd4da63cea44a3f438aeb753d600123570e6d6264e763617a9ce/python_multipart-0.0.24-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0e/93/c8c361bf0a2fe50f828f32def460e8b8a14b93955d3fd302b1a9b63b19e4/pytorch_lightning-2.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c5/89/182ef62bff3d9f190dd2e024b28cf0513ac7a83bc15b979e052c46c41f64/rerun_sdk-0.30.2-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/55/bd/dd56edc2680df7658c7bdeeb58270ab35dfcdc0e2670899ce9771604b436/roma-1.5.6-py3-none-any.whl
+      - pypi: git+https://github.com/pablovela5620/rtmlib.git?rev=98bca2193c39b349034b280803b54c9ee58f7c68#98bca2193c39b349034b280803b54c9ee58f7c68
+      - pypi: https://files.pythonhosted.org/packages/57/e1/64c264db50b68de8a438b60ceeb921b2f22da3ebb7ad6255150225d0beac/s3fs-2026.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/a3/0f0b7d78e2f1eb9e8e1afbff1d2bff8d60144aee17aca51c065b516743dd/safehttpx-0.1.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl
+      - pypi: git+https://github.com/pablovela5620/simplecv.git?tag=v0.7.2#17c226dd405cc040b00f48c67bd18072d312527a
+      - pypi: https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6f/e9/bebf3d50e3fc847378988235f87c37ad3ac26d386041ab915d15e92025cd/timm-1.0.26-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c3/a2/c7f6ebf546f8f644edf0f999aa98ece106986a77a7b922316bf6414ff825/torchmetrics-1.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/76/08/744f31ba3d9fd2f484b2da8e9d2084f8b7bde3d1f8b7c51b1989d66c8994/ultralytics-8.3.162-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/c7/fb42228bb05473d248c110218ffb8b1ad2f76728ed8699856e5af21112ad/ultralytics_thop-2.0.18-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dd/1a/5d9a402b39ec892d856bbdd9db502ff73ce28cdf4aff72eb1ce1d6843506/universal_pathlib-0.3.10-py3-none-any.whl
+      - pypi: git+https://github.com/EasternJournalist/utils3d.git#3fab839f0be9931dac7c8488eb0e1600c236e183
+      - pypi: https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: git+https://github.com/pablovela5620/vggt.git?rev=5ed6ec88a951f27959f73bc72eb4b6dc7a028b0c#5ed6ec88a951f27959f73bc72eb4b6dc7a028b0c
+      - pypi: https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: ./packages/monoprior
+      - pypi: ./packages/mv-api
+      - pypi: ./packages/sam3-rerun
+      - pypi: ./packages/wilor-nano
+  mv-api-dev:
+    channels:
+    - url: https://prefix.dev/ai-demos/
+    - url: https://prefix.dev/conda-forge/
+    indexes:
+    - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
+    packages:
+      linux-64:
+      - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/assimp-6.0.3-hecf2907_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/av-17.0.0-py312h46547aa_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.9.3-hef928c7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.13-h2c9d079_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.1-h8b1a151_9.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-event-stream-0.5.7-h28f887f_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.10.7-ha8fc4e3_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.23.3-hdaf4b65_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-mqtt-0.13.3-hc63082f_11.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.11.3-h06ab39a_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-h8b1a151_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.7-h8b1a151_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-crt-cpp-0.35.4-h8824e59_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.606-h20b40b1_10.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/azure-core-cpp-1.16.2-h206d751_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/azure-identity-cpp-1.13.3-hed0cdb0_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/azure-storage-blobs-cpp-12.16.0-hdd73cc9_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/azure-storage-common-cpp-12.12.0-ha7a2c86_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.14.0-h52c5a47_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/backports.zstd-1.3.0-py312h90b7ffd_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/beartype-0.22.9-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils-2.45.1-default_h4852527_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_102.conda
+      - conda: https://prefix.dev/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/brotli-1.2.0-hed03a55_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/brotli-bin-1.2.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/brotli-python-1.2.0-py312hdb49522_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/brunsli-0.1-hd1e3526_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-blosc2-2.23.1-hc31b594_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-compiler-1.11.0-h4d9bdce_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/casefy-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/charls-2.4.3-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cli11-2.6.2-h54a6638_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/click-8.3.2-pyhc90fa1f_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cccl_linux-64-12.9.27-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-compiler-12.9.1-hbad6d8a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-crt-12.9.86-h69a702a_6.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-crt-dev_linux-64-12.9.86-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-crt-tools-12.9.86-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-12.9.79-h5888daf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-dev-12.9.79-h5888daf_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart-dev_linux-64-12.9.79-h3f2d84a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-static-12.9.79-h5888daf_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart-static_linux-64-12.9.79-h3f2d84a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart_linux-64-12.9.79-h3f2d84a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cuobjdump-12.9.82-hffce074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cupti-12.9.79-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cuxxfilt-12.9.82-hffce074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-driver-dev-12.9.79-h5888daf_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-driver-dev_linux-64-12.9.79-h3f2d84a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-12.9.86-hcdd1206_6.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-nvcc-dev_linux-64-12.9.86-he91c749_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-impl-12.9.86-h85509e4_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-tools-12.9.86-he02047a_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc_linux-64-12.9.86-he0b4e1d_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvdisasm-12.9.88-hffce074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvml-dev-12.9.79-hffce074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvprune-12.9.82-hffce074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvrtc-12.9.86-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvrtc-dev-12.9.86-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvtx-12.9.79-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvtx-dev-12.9.79-ha770c72_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-nvvm-dev_linux-64-12.9.86-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvvm-impl-12.9.86-h4bc722e_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvvm-tools-12.9.86-h4bc722e_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-profiler-api-12.9.79-h7938cbb_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-version-12.9-h4f385c5_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cudnn-9.10.2.21-hbcb9cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cusparselt-0.8.1.1-h58dd1b1_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cxx-compiler-1.11.0-hfcd1e18_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/dash-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/dataclasses-0.8-pyhc8e2a94_3.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/datasets-4.8.4-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/dill-0.4.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/eigen-abi-5.0.1.80-hf414acd_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/embree-4.4.1-ha751380_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/eval_type_backport-0.3.1-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-8.0.1-gpl_h43fde53_912.conda
+      - conda: https://prefix.dev/conda-forge/noarch/filelock-3.25.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/flask-3.1.3-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fmt-12.1.0-hff5e90c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fontconfig-2.17.1-h27c8c51_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fonttools-4.62.0-py312h8a5da7c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/freetype-py-2.5.1-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/frozendict-2.4.7-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/frozenlist-1.7.0-py312h447239a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/fsspec-2026.2.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc-14.3.0-h0dff253_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-hbdf3cc3_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-14.3.0-h298d278_23.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gl2ps-1.4.2-h36e74d4_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/glew-2.3.0-h71661d4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/glfw-3.4-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/glslang-16.2.0-hfd11570_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gmpy2-2.3.0-py312hcaba1f9_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx-14.3.0-h76987e4_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-h2185e75_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-14.3.0-h91b0f8e_23.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha4f8f14_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-14.1.0-h6083320_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_108.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hf-transfer-0.1.9-py312h914ccca_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hf-xet-1.4.3-py310hb823017_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/huggingface_hub-1.9.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.151.11-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.3.6-py312h40df4bb_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/imageio-2.37.0-pyhfb79c49_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/imath-3.2.2-hde8ca8f_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/intel-gmmlib-22.10.0-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/intel-media-driver-25.3.4-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/itsdangerous-2.2.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/jasper-4.2.9-h1588d4d_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jaxtyping-0.2.36-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/jsoncpp-1.9.6-hf42df4d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/kiwisolver-1.5.0-py312h0a2e395_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lcms2-2.18-h0c24ade_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/level-zero-1.28.2-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20250512.1-cxx17_hba17884_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-23.0.0-h258748b_2_cuda.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-acero-23.0.0-h635bf11_2_cuda.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-compute-23.0.0-h8c2c5c3_2_cuda.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-23.0.0-h635bf11_2_cuda.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-substrait-23.0.0-h3f74fd7_2_cuda.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libass-0.17.4-h96ad9f0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libavif16-1.4.1-hcfa2d63_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-6_h5875eb1_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libboost-1.88.0-hd24cca6_7.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcap-2.77-hd0affe5_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-6_hfef963f_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libclang-cpp22.1-22.1.0-default_h99862b1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libclang13-22.1.0-default_h746c552_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/libcublas-12.9.1.4-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcublas-dev-12.9.1.4-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudnn-9.10.2.21-hf7e9902_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudnn-dev-9.10.2.21-h58dd1b1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudss-0.7.1.4-h58dd1b1_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudss-dev-0.7.1.4-hee47b17_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufft-11.4.1.4-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufft-dev-11.4.1.4-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufile-1.14.1.1-hbc026e6_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufile-dev-1.14.1.1-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurand-10.3.10.19-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurand-dev-10.3.10.19-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.19.0-hcf29cc6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusolver-11.7.5.82-h676940d_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusolver-dev-11.7.5.82-h676940d_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusparse-12.5.10.65-hecca717_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusparse-dev-12.5.10.65-hecca717_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_118.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.86.4-h6548e54_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-2.39.0-hdb79228_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-storage-2.39.0-hdbdcf42_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgrpc-1.73.1-h3288cfb_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhwy-1.3.0-h4c17acf_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libjxl-0.11.2-ha09017c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-6_h5e43f62_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-6_hdba1596_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libllvm20-20.1.8-hf7376ad_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libllvm22-22.1.2-hf7376ad_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblzf-3.6-hb9d3cd8_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmagma-2.9.0-ha7672b3_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnetcdf-4.10.0-nompi_hb6f1874_103.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvjitlink-12.9.86-hecca717_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvjpeg-12.4.0.76-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvptxcompiler-dev-12.9.86-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libnvptxcompiler-dev_linux-64-12.9.86-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopencv-4.13.0-qt6_py312h15557d8_605.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopengl-devel-1.7.0-ha4b6fd6_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopentelemetry-cpp-1.21.0-hb9b0907_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopentelemetry-cpp-headers-1.21.0-ha770c72_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-2025.4.1-hb56ce9e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-batch-plugin-2025.4.1-hd85de46_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-plugin-2025.4.1-hd85de46_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-hetero-plugin-2025.4.1-hd41364c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2025.4.1-hb56ce9e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2025.4.1-hb56ce9e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-npu-plugin-2025.4.1-hb56ce9e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-ir-frontend-2025.4.1-hd41364c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-onnx-frontend-2025.4.1-h1862bb8_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-paddle-frontend-2025.4.1-h1862bb8_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-pytorch-frontend-2025.4.1-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.4.1-h0767aad_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2025.4.1-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libparquet-23.0.0-h7376487_2_cuda.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpng-1.6.56-h421ea60_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpq-18.3-h9abb657_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libprotobuf-6.31.1-h49aed37_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libre2-11-2025.11.05-h7b12aa8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/librsvg-2.62.1-h4c96295_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsodium-1.0.21-h280c20c_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_118.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsystemd0-257.13-hd0affe5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libtheora-1.1.1-h4ab18f5_1006.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libthrift-0.22.0-h454ac66_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libtinyobjloader-2.0.0rc13-h54a6638_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libtorch-2.10.0-cuda129_mkl_he24fa84_301.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libudev1-257.13-hd0affe5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liburing-2.14-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libutf8proc-2.11.3-hfe17d71_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libva-2.23.0-he1eb515_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvpl-2.15.0-h54a6638_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvpx-1.15.2-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvulkan-loader-1.4.341.0-h5279c79_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.13.1-hca5e8e5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.2-hca6bf5a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.15.2-he237659_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libzopfli-1.0.3-h9c3ff4c_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/llvm-openmp-22.1.2-h4922eb0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/matplotlib-base-3.10.8-py312he3d6523_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mesalib-25.0.5-h57bcd07_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mkl-2025.3.1-h0e700b2_10.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.1.2-py312hd9148b4_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/multidict-6.7.1-py312h8a5da7c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/multiprocess-0.70.19-py312h5253ce2_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/narwhals-2.19.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/natsort-8.4.0-pyhcf101f3_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/nccl-2.29.3.1-h4d09622_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.4.3-py312h33ff503_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/open3d-0.19.0-py312h0042587_13.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/opencl-headers-2025.06.13-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openexr-3.4.9-h40f6f1d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openjph-0.26.3-h8d634f6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openldap-2.6.10-hbde042b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/optree-0.19.0-py312hd9148b4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/orc-2.2.2-h19cb568_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pandas-3.0.2-py312h8ecdadd_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pillow-12.2.0-py312h50c33e8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/plotly-6.6.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/plum-dispatch-2.8.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/proj-9.8.0-he0df7b0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/propcache-0.3.1-py312h178313f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/py-opencv-4.13.0-qt6_py312h598be00_605.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyarrow-23.0.0-py312h7900ff3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyarrow-core-23.0.0-py312hfa4fb80_0_cuda.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-3.0.3-pyhfe8187e_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-global-3.0.3-pyh648e204_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pyglet-2.1.14-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pyopengl-3.1.10-pyha804496_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyrefly-0.60.0-h2b88eb6_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pyrender-0.1.45-pyh8a188c0_3.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/pyserde-0.29.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.12.13-hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/python-xxhash-3.6.0-py312h0d868a3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pytorch-2.10.0-cuda129_mkl_py312_hcddf9c5_301.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pytorch-gpu-2.10.0-cuda129_mkl_h0d04637_301.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pywavelets-1.9.0-py312h4f23490_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/qt6-main-6.10.2-pl5321h16c4a6b_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/rav1e-0.8.1-h1fbca29_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/rdma-core-61.0-h192683f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/re2-2025.11.05-h5301d42_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/regex-2026.4.4-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/retrying-1.4.2-pyhe01879c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ruff-0.15.9-h7805a7d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.6.2-he8a4886_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/safetensors-0.7.0-py312h0ccc70a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/scikit-image-0.24.0-py312hf9745cd_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sdl3-3.4.4-hdeec2a5_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/shaderc-2025.5-h3e344bc_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/shtab-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/spirv-tools-2025.5-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sqlite-3.52.0-h04a0ce9_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-4.0.1-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tifffile-2026.3.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tokenizers-0.22.2-py312hf875000_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/torchvision-0.25.0-cuda129_py312_h69a17e1_4.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/transformers-5.5.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/trimesh-4.11.5-pyh7b2049a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/triton-3.6.0-cuda129py312h811769c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typeguard-2.13.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/typer-0.24.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tyro-0.9.1-pyhff2d567_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/utfcpp-4.09-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/viskores-1.1.0-cuda12.9_h14fae2a_.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/vtk-base-9.6.0-py312h64f160b_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/werkzeug-3.1.8-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wslink-2.5.6-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.47-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxinerama-1.1.6-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxshmfence-1.3.3-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xxhash-0.8.3-hb47aa4a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/yarl-1.23.0-py312h8a5da7c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zeromq-4.3.5-h41580af_10.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zfp-1.0.1-h909a3a2_5.conda
+      - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - pypi: https://files.pythonhosted.org/packages/7e/46/02ac5e262d4af18054b3e922b2baedbb2a03289ee792162de60a865defc5/accelerate-1.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/df/d8/ce9386e6d76ea79e61dee15e62aa48cff6be69e89246b0ac4a11857cb02c/aiobotocore-3.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dc/95/1ec57df6c52152fb4c776da5fbb2896f19af52de3776899d91e7140e7654/aria2p-0.12.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/35/bf/9cad857b630c840738003eb24c1adb63490a1024ec40a9dcc3a753300c38/asciimatics-1.15.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e3/37/0c0c90361c8a1b9e6c75222ca24ae12996a298c0e18822a72ab229c37207/botocore-1.42.84-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/34/71/1ea5a7352ae516d5512d17babe7e1b87d9db5150b21f794b1377eac1edc0/cryptography-46.0.6-cp311-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/6e/cf/c88130a6a32fc76f2711160a2a0ab8b4fac9df9682fdd988a479122c3512/daggr-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/00/ba/8d8aa1df96e0666752e5c9d406d440495df2014d315b2a95bbef9856b23e/datafusion-50.1.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/9c/dd/51c38785ce5e1c287b5ad17ba550edaaaffce0deb0da4857019c6700fbaf/diffusers-0.37.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/84/a4/5caa2de7f917a04ada20018eccf60d6cc6145b0199d55ca3711b0fc08312/fastapi-0.135.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fa/89/bf2adbdbb90dab8b465d7a489e0a291e9153bf7b1db2b90ea4fa3c4bf16f/fastcore-1.12.34-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/55/56/dd3669eccebb6d8ac81e624542ebd53fe6f08e1b8f2f8d50aeb7e3b83f99/ffmpy-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ed/1f/95cb961341bf33e534a472672ef4916c90046dc3c57b1442f5586dda72f1/geffnet-1.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/32/ba/9ccb80650e5bd61e739f16f33aec3bb290a80f314631be8f7dc0a2b22b5f/glcontext-3.0.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/38/3c/1568ee82f0e4308612aaf964168e93b7f2adb64c3e77b7877fd397e773bf/gradio-6.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c2/49/86b919727b5d6574528d5d9e67c6455bb707a3654abc87d61d7f1d742395/gradio_client-2.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/be/6d/8db85a26fcdc9658198744485623ee1be87de555155112421c487119709d/gradio_rerun-0.30.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/28/27/3d6dcadc8a3214d8522c1e7f6a19554e33659be44546d44a2f7572ac7d2a/groovy-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/84/a6/b3965e1e146ef5762870bbe76117876ceba51a201e18cc31f5703e454596/httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/82/9707c7b0336bca53b75f52fc350956a93da66eb6be632b370bc933216fb4/icecream-2.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/25/f4/ead6e0e37209b07c9baa3e984ccdb0348ca370b77cea3aaea8ddbb097e00/lightning_utilities-0.15.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c0/84/c87be2b1c58172ed64c2207f1dd116003a84087a9c5112ceb8e37a2233b9/lovely_numpy-0.2.20-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d7/96/bcb5141eae24474d80b8157b0c3055d25fa75f9804d4abb4a514695bbba9/moderngl-5.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: git+https://github.com/microsoft/MoGe.git#07444410f1e33f402353b99d6ccd26bd31e469e8
+      - pypi: https://files.pythonhosted.org/packages/d8/f4/5e52c7319b8087acef603ed6e50dc325c02eaa999355414830468611f13c/more_itertools-11.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/b7/ec1cbc6b297a808c513f59f501656389623fc09ad6a58c640851289c7854/nh3-0.3.4-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/12/60/17ed502ab8258e36b6caf478974994f15691c73e3c46abf82a2ec63e9eda/omnidata_tools-0.0.23-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/ab/5b68110e0460d73fad814d5bd11c7b1ddcce5c37b10177eb264d6a36e331/onnxruntime-1.24.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/5b3fd4748cf7ed291eae541a37e426efc20ea04cb6e6a05768304ab0aa41/onnxruntime_gpu-1.24.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/37/87/5ddeb7fc1fbd9004aeccab08426f34c81a5b4c25c7061281862b015fce2b/orjson-3.11.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/29/c028a0731e202035f0e2e0bfbf1a3e46ad6c628cbb17f6f1cc9eea5d9ff1/pathlib_abc-0.5.2-py3-none-any.whl
+      - pypi: git+https://github.com/EasternJournalist/pipeline.git#866f059d2a05cde05e4a52211ec5051fd5f276d6
+      - pypi: https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/1f/73c53fcbfb0b5a78f91176df41945ca466e71e9d9d836e5c522abda39ee7/pydantic-2.11.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/5c/fe9f95abd5eaedfa69f31e450f7e2768bef121dbdf25bcddee2cd3087a16/pyfiglet-1.0.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/73/89930efabd4da63cea44a3f438aeb753d600123570e6d6264e763617a9ce/python_multipart-0.0.24-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0e/93/c8c361bf0a2fe50f828f32def460e8b8a14b93955d3fd302b1a9b63b19e4/pytorch_lightning-2.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c5/89/182ef62bff3d9f190dd2e024b28cf0513ac7a83bc15b979e052c46c41f64/rerun_sdk-0.30.2-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/55/bd/dd56edc2680df7658c7bdeeb58270ab35dfcdc0e2670899ce9771604b436/roma-1.5.6-py3-none-any.whl
+      - pypi: git+https://github.com/pablovela5620/rtmlib.git?rev=98bca2193c39b349034b280803b54c9ee58f7c68#98bca2193c39b349034b280803b54c9ee58f7c68
+      - pypi: https://files.pythonhosted.org/packages/57/e1/64c264db50b68de8a438b60ceeb921b2f22da3ebb7ad6255150225d0beac/s3fs-2026.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/a3/0f0b7d78e2f1eb9e8e1afbff1d2bff8d60144aee17aca51c065b516743dd/safehttpx-0.1.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl
+      - pypi: git+https://github.com/pablovela5620/simplecv.git?tag=v0.7.2#17c226dd405cc040b00f48c67bd18072d312527a
+      - pypi: https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6f/e9/bebf3d50e3fc847378988235f87c37ad3ac26d386041ab915d15e92025cd/timm-1.0.26-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c3/a2/c7f6ebf546f8f644edf0f999aa98ece106986a77a7b922316bf6414ff825/torchmetrics-1.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/51/65/3853bb6bac5ae789dc7e28781154705c27859eccc8e46282c3f36780f5f5/types_requests-2.33.0.20260402-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4f/73/a6cf75de5be376d7b57ce6c934ae9bc90aa5be6ada4ac50a99ecbdf9763e/types_tqdm-4.67.3.20260402-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/76/08/744f31ba3d9fd2f484b2da8e9d2084f8b7bde3d1f8b7c51b1989d66c8994/ultralytics-8.3.162-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/c7/fb42228bb05473d248c110218ffb8b1ad2f76728ed8699856e5af21112ad/ultralytics_thop-2.0.18-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dd/1a/5d9a402b39ec892d856bbdd9db502ff73ce28cdf4aff72eb1ce1d6843506/universal_pathlib-0.3.10-py3-none-any.whl
+      - pypi: git+https://github.com/EasternJournalist/utils3d.git#3fab839f0be9931dac7c8488eb0e1600c236e183
+      - pypi: https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: git+https://github.com/pablovela5620/vggt.git?rev=5ed6ec88a951f27959f73bc72eb4b6dc7a028b0c#5ed6ec88a951f27959f73bc72eb4b6dc7a028b0c
+      - pypi: https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: ./packages/monoprior
+      - pypi: ./packages/mv-api
+      - pypi: ./packages/sam3-rerun
+      - pypi: ./packages/wilor-nano
   prompt-da:
     channels:
     - url: https://prefix.dev/ai-demos/
@@ -13589,6 +14791,21 @@ packages:
   - wrapt>=1.10.10,<3.0.0
   - httpx>=0.25.1,<0.29 ; extra == 'httpx'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/df/d8/ce9386e6d76ea79e61dee15e62aa48cff6be69e89246b0ac4a11857cb02c/aiobotocore-3.4.0-py3-none-any.whl
+  name: aiobotocore
+  version: 3.4.0
+  sha256: 26290eb6830ea92d8a6f5f90b56e9f5cedd6d126074d5db63b195e281d982465
+  requires_dist:
+  - aiohttp>=3.12.0,<4.0.0
+  - aioitertools>=0.5.1,<1.0.0
+  - botocore>=1.42.79,<1.42.85
+  - python-dateutil>=2.1,<3.0.0
+  - jmespath>=0.7.1,<2.0.0
+  - multidict>=6.0.0,<7.0.0
+  - typing-extensions>=4.14.0,<5.0.0 ; python_full_version < '3.11'
+  - wrapt>=1.10.10,<3.0.0
+  - httpx>=0.25.1,<0.29 ; extra == 'httpx'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl
   name: aiofiles
   version: 24.1.0
@@ -13760,6 +14977,27 @@ packages:
   - pkg:pypi/aiohttp?source=hash-mapping
   size: 1036705
   timestamp: 1775000791489
+- conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
+  sha256: 52f4d07b10fe4a1ded570b0708594d2d9075223e1dd94d0c5988eb71f724a5f2
+  md5: 68edaee7692efb8bbef5e95375090189
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aiohappyeyeballs >=2.5.0
+  - aiosignal >=1.4.0
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - libgcc >=14
+  - multidict >=4.5,<7.0
+  - propcache >=0.2.0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - yarl >=1.17.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/aiohttp?source=hash-mapping
+  size: 1034187
+  timestamp: 1775000054521
 - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
   name: aioitertools
   version: 0.13.0
@@ -14298,6 +15536,22 @@ packages:
   purls: []
   size: 134426
   timestamp: 1774274932726
+- conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.9.3-hef928c7_0.conda
+  sha256: d9c5babed03371448bb0dc91a1573c80d278d1222a3b0accef079ed112e584f9
+  md5: bdd464b33f6540ed70845b946c11a7b8
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-http >=0.10.7,<0.10.8.0a0
+  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - aws-c-cal >=0.9.13,<0.9.14.0a0
+  - aws-c-io >=0.23.3,<0.23.4.0a0
+  - aws-c-common >=0.12.6,<0.12.7.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 133443
+  timestamp: 1764765235190
 - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.9.6-hb9c0fe4_1.conda
   sha256: 84f9e2f83d9d93da551e0058c651015dd4bfd84256c6293db01130911c5e0f12
   md5: b1143a5b5a03ee174b3f3f7c49df3c09
@@ -14375,6 +15629,18 @@ packages:
   purls: []
   size: 263061
   timestamp: 1763585722720
+- conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.1-h8b1a151_9.conda
+  sha256: 96edccb326b8c653c8eb95a356e01d4aba159da1a97999577b7dd74461b040b4
+  md5: f7ec84186dfe7a9e3a9f9e5a4d023e75
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.12.6,<0.12.7.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 22272
+  timestamp: 1764593718823
 - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-h8b1a151_0.conda
   sha256: 1838bdc077b77168416801f4715335b65e9223f83641a2c28644f8acd8f9db0e
   md5: f16f498641c9e05b645fe65902df661a
@@ -14398,6 +15664,21 @@ packages:
   purls: []
   size: 23531
   timestamp: 1767790896527
+- conda: https://prefix.dev/conda-forge/linux-64/aws-c-event-stream-0.5.7-h28f887f_1.conda
+  sha256: a5b151db1c8373b6ca2dacea65bc8bda02791a43685eebfa4ea987bb1a758ca9
+  md5: 7b8e3f846353b75db163ad93248e5f9d
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-io >=0.23.3,<0.23.4.0a0
+  - aws-c-common >=0.12.6,<0.12.7.0a0
+  - aws-checksums >=0.2.7,<0.2.8.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 58806
+  timestamp: 1764675439822
 - conda: https://prefix.dev/conda-forge/linux-64/aws-c-event-stream-0.5.9-h841be55_2.conda
   sha256: 179610f3c76238ca5fc4578384381bfd297e0ae1b96f6be52220c51f66b38131
   md5: 7e1ea1a67435a32e04305fda877acd1e
@@ -14457,6 +15738,21 @@ packages:
   purls: []
   size: 225868
   timestamp: 1774270031584
+- conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.10.7-ha8fc4e3_5.conda
+  sha256: 5527224d6e0813e37426557d38cb04fed3753d6b1e544026cfbe2654f5e556be
+  md5: 3028f20dacafc00b22b88b324c8956cc
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.9.13,<0.9.14.0a0
+  - aws-c-io >=0.23.3,<0.23.4.0a0
+  - aws-c-compression >=0.3.1,<0.3.2.0a0
+  - aws-c-common >=0.12.6,<0.12.7.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 224580
+  timestamp: 1764675497060
 - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-http-0.10.10-hff59a30_0.conda
   sha256: 545cd493a703c25dcd68e5722f0cf744d0361d37a72d490e35bb8470d4c9b483
   md5: b8e2306553cacbfaac3f3d4597fa86f9
@@ -14471,6 +15767,20 @@ packages:
   purls: []
   size: 214395
   timestamp: 1771421357757
+- conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.23.3-hdaf4b65_5.conda
+  sha256: 07d7f2a4493ada676084c3f4313da1fab586cf0a7302572c5d8dde6606113bf4
+  md5: 132e8f8f40f0ffc0bbde12bb4e8dd1a1
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.12.6,<0.12.7.0a0
+  - s2n >=1.6.2,<1.6.3.0a0
+  - aws-c-cal >=0.9.13,<0.9.14.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 181361
+  timestamp: 1765168239856
 - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.26.1-h3ca20c3_1.conda
   sha256: 4cf207817f480b7c663c30e7245424228597d54e045226cea4eeb92c786bd506
   md5: c9aa75692f24cce182c3ecd001a1a595
@@ -14511,6 +15821,20 @@ packages:
   purls: []
   size: 185971
   timestamp: 1773328895499
+- conda: https://prefix.dev/conda-forge/linux-64/aws-c-mqtt-0.13.3-hc63082f_11.conda
+  sha256: fb102b0346a1f5c4f3bb680ec863c529b0333fa4119d78768c3e8a5d1cc2c812
+  md5: 6a653aefdc5d83a4f959869d1759e6e3
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-io >=0.23.3,<0.23.4.0a0
+  - aws-c-http >=0.10.7,<0.10.8.0a0
+  - aws-c-common >=0.12.6,<0.12.7.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 216454
+  timestamp: 1764681745427
 - conda: https://prefix.dev/conda-forge/linux-64/aws-c-mqtt-0.14.0-ha25ca29_1.conda
   sha256: 2e9f2fc6ca8aa993b4962dbae711df69e8091b6a691bdcef8c8398dc81f923d7
   md5: a827b063719f5aac504d06ac77cc3125
@@ -14538,6 +15862,24 @@ packages:
   purls: []
   size: 194929
   timestamp: 1771458019542
+- conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.11.3-h06ab39a_1.conda
+  sha256: 8de2292329dce2fd512413d83988584d616582442a07990f67670f9bc793a98b
+  md5: 3689a4290319587e3b54a4f9e68f70c8
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.12.6,<0.12.7.0a0
+  - openssl >=3.5.4,<4.0a0
+  - aws-c-io >=0.23.3,<0.23.4.0a0
+  - aws-c-http >=0.10.7,<0.10.8.0a0
+  - aws-c-auth >=0.9.3,<0.9.4.0a0
+  - aws-checksums >=0.2.7,<0.2.8.0a0
+  - aws-c-cal >=0.9.13,<0.9.14.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 151382
+  timestamp: 1765174166541
 - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.11.5-h6d69fc9_5.conda
   sha256: c15869656f5fbebe27cc5aa58b23831f75d85502d324fedd7ee7e552c79b495d
   md5: 4c5c16bf1133dcfe100f33dd4470998e
@@ -14626,6 +15968,18 @@ packages:
   purls: []
   size: 101435
   timestamp: 1771063496927
+- conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.7-h8b1a151_5.conda
+  sha256: a8693d2e06903a09e98fe724ed5ec32e7cd1b25c405d754f0ab7efb299046f19
+  md5: 68da5b56dde41e172b7b24f071c4b392
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - aws-c-common >=0.12.6,<0.12.7.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 76915
+  timestamp: 1764593731486
 - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-checksums-0.2.10-h6f28e42_0.conda
   sha256: c8c7743eb555f9cfc541aa7ebfa23992e74cac0b6f4bac13a4a62851016e6f16
   md5: 17dbd98b7b170b74b8434428c3a442bc
@@ -14637,6 +15991,27 @@ packages:
   purls: []
   size: 99788
   timestamp: 1771063483611
+- conda: https://prefix.dev/conda-forge/linux-64/aws-crt-cpp-0.35.4-h8824e59_0.conda
+  sha256: 524fc8aa2645e5701308b865bf5c523257feabc6dfa7000cb8207ccfbb1452a1
+  md5: 113b9d9913280474c0868b0e290c0326
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - aws-c-event-stream >=0.5.7,<0.5.8.0a0
+  - aws-c-common >=0.12.6,<0.12.7.0a0
+  - aws-c-cal >=0.9.13,<0.9.14.0a0
+  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - aws-c-io >=0.23.3,<0.23.4.0a0
+  - aws-c-auth >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.10.7,<0.10.8.0a0
+  - aws-c-mqtt >=0.13.3,<0.13.4.0a0
+  - aws-c-s3 >=0.11.3,<0.11.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 408804
+  timestamp: 1765200263609
 - conda: https://prefix.dev/conda-forge/linux-64/aws-crt-cpp-0.37.3-hb153662_0.conda
   sha256: 25897c312a2fb52a1c36083d810ce11a3bb69bae23c31cd572d9629857547a56
   md5: 9ce778ddbd927385bf145224e291e2a1
@@ -14678,6 +16053,23 @@ packages:
   purls: []
   size: 326786
   timestamp: 1771983349150
+- conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.606-h20b40b1_10.conda
+  sha256: e0d81b7dd6d054d457a1c54d17733d430d96dc5ca9b2ca69a72eb41c3fc8c9bf
+  md5: 937d1d4c233adc6eeb2ac3d6e9a73e53
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libcurl >=8.17.0,<9.0a0
+  - aws-c-common >=0.12.6,<0.12.7.0a0
+  - aws-crt-cpp >=0.35.4,<0.35.5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - aws-c-event-stream >=0.5.7,<0.5.8.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 3472674
+  timestamp: 1765257107074
 - conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.747-h133b1ee_1.conda
   sha256: ac6090e6ab8cc2c927e7f62d90918de169cdd35e580fab8a95dc5d5ba8515fd0
   md5: 36afc05aac7c7f516749cdd3b5e978d9
@@ -15147,6 +16539,17 @@ packages:
   - urllib3>=1.25.4,!=2.2.0,<3 ; python_full_version >= '3.10'
   - awscrt==0.31.2 ; extra == 'crt'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/e3/37/0c0c90361c8a1b9e6c75222ca24ae12996a298c0e18822a72ab229c37207/botocore-1.42.84-py3-none-any.whl
+  name: botocore
+  version: 1.42.84
+  sha256: 15f3fe07dfa6545e46a60c4b049fe2bdf63803c595ae4a4eec90e8f8172764f3
+  requires_dist:
+  - jmespath>=0.7.1,<2.0.0
+  - python-dateutil>=2.1,<3.0.0
+  - urllib3>=1.25.4,<1.27 ; python_full_version < '3.10'
+  - urllib3>=1.25.4,!=2.2.0,<3 ; python_full_version >= '3.10'
+  - awscrt==0.31.2 ; extra == 'crt'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/fa/93/e8c04e80e82391a6e51f218ca49720f64236bc824e92152a2633b74cf7ab/braceexpand-0.1.7-py2.py3-none-any.whl
   name: braceexpand
   version: 0.1.7
@@ -15263,6 +16666,21 @@ packages:
   - pkg:pypi/brotli?source=hash-mapping
   size: 373800
   timestamp: 1764017545385
+- conda: https://prefix.dev/conda-forge/linux-64/brunsli-0.1-hd1e3526_2.conda
+  sha256: b4831ac06bb65561342cedf3d219cf9b096f20b8d62cda74f0177dffed79d4d5
+  md5: 5948f4fead433c6e5c46444dbfb01162
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 168501
+  timestamp: 1761758949420
 - conda: https://prefix.dev/ai-demos/linux-64/brush-0.3.0-hcc556be_0.conda
   sha256: c287a1ad398aaa950ca84c25e14b8905383f9d952e019168a3b758fb289fef09
   md5: 116af9c2977dfe0478d8197b083de341
@@ -15313,6 +16731,21 @@ packages:
   purls: []
   size: 217215
   timestamp: 1765214743735
+- conda: https://prefix.dev/conda-forge/linux-64/c-blosc2-2.23.1-hc31b594_0.conda
+  sha256: b6ce82ebe3cf24e70179bd656eacfa97ce9df9a500f2cec6843043466a5e6af8
+  md5: 68ceffc6cadae61846a207cae60de094
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - lz4-c >=1.10.0,<1.11.0a0
+  - zlib-ng >=2.3.3,<2.4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 353899
+  timestamp: 1772620395951
 - conda: https://prefix.dev/conda-forge/linux-64/c-compiler-1.11.0-h4d9bdce_0.conda
   sha256: 8e7a40f16400d7839c82581410aa05c1f8324a693c9d50079f8c50dc9fb241f0
   md5: abd85120de1187b0d1ec305c2173c71b
@@ -15545,6 +16978,18 @@ packages:
   - pkg:pypi/cffi?source=hash-mapping
   size: 295716
   timestamp: 1761202958833
+- conda: https://prefix.dev/conda-forge/linux-64/charls-2.4.3-hecca717_0.conda
+  sha256: 53504e965499b4845ca3dc63d5905d5a1e686fcb9ab17e83c018efa479e787d0
+  md5: 937ca49a245fcf2b88d51b6b52959426
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 161768
+  timestamp: 1772712510770
 - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
   sha256: b32f8362e885f1b8417bac2b3da4db7323faa12d5db62b7fd6691c02d60d6f59
   md5: a22d1fd9bf98827e280a02875d9a007a
@@ -15578,6 +17023,17 @@ packages:
   - pkg:pypi/charset-normalizer?source=compressed-mapping
   size: 58510
   timestamp: 1773660086450
+- conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
+  sha256: 3f9483d62ce24ecd063f8a5a714448445dc8d9e201147c46699fc0033e824457
+  md5: a9167b9571f3baa9d448faa2139d1089
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/charset-normalizer?source=compressed-mapping
+  size: 58872
+  timestamp: 1775127203018
 - conda: https://prefix.dev/conda-forge/linux-64/clang-22.1.0-default_cfg_hcbb2b3e_0.conda
   sha256: 0d9742b0b96fabbe31a412903f1b9de6548cc65cce39d78c1d845a2156480d1b
   md5: feae0bebfd6f906118d713872ee396d8
@@ -15692,6 +17148,18 @@ packages:
   - pkg:pypi/click?source=hash-mapping
   size: 97676
   timestamp: 1764518652276
+- conda: https://prefix.dev/conda-forge/noarch/click-8.3.2-pyhc90fa1f_0.conda
+  sha256: 526d434cf5390310f40f34ea6ec4f0c225cdf1e419010e624d399b13b2059f0f
+  md5: 4d18bc3af7cfcea97bd817164672a08c
+  depends:
+  - __unix
+  - python
+  - python >=3.10
+  license: BSD-3-Clause
+  purls:
+  - pkg:pypi/click?source=compressed-mapping
+  size: 98253
+  timestamp: 1775578217828
 - conda: https://prefix.dev/conda-forge/linux-64/cmake-4.3.0-hc85cc9f_0.conda
   sha256: 77ac1115fb713dfc058b9d0eefd889610db62184e74dbe7eabd2a8c3c3a31ab1
   md5: 59c51e8455a594f1a78a307d9d94fde7
@@ -17084,6 +18552,33 @@ packages:
   - nibabel>=5.3.2 ; extra == 'nibabel'
   - ipyniivue==2.4.2 ; extra == 'nibabel'
   requires_python: '>=3.10.0'
+- conda: https://prefix.dev/conda-forge/noarch/datasets-4.8.4-pyhcf101f3_0.conda
+  sha256: 99fb8e4d7a6f917d9e77465ea8f3bc54ba264dff08768396d4c13b7c685f0493
+  md5: bf2a6e8e95d10045645f749424a47bee
+  depends:
+  - python >=3.10
+  - filelock
+  - numpy >=1.17
+  - pyarrow >=21.0.0
+  - dill >=0.3.0,<0.4.2
+  - pandas
+  - requests >=2.32.2
+  - httpx <1.0.0
+  - tqdm >=4.66.3
+  - python-xxhash
+  - multiprocess <0.70.20
+  - fsspec >=2023.1.0,<=2026.2.0
+  - huggingface_hub >=0.25.0,<2.0
+  - packaging
+  - pyyaml >=5.1
+  - aiohttp
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/datasets?source=compressed-mapping
+  size: 378228
+  timestamp: 1774277522516
 - conda: https://prefix.dev/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
   sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
   md5: 418c6ca5929a611cbd69204907a83995
@@ -17268,6 +18763,101 @@ packages:
   - jaxlib>=0.4.1 ; extra == 'dev'
   - flax>=0.4.1 ; extra == 'dev'
   requires_python: '>=3.10.0'
+- pypi: https://files.pythonhosted.org/packages/9c/dd/51c38785ce5e1c287b5ad17ba550edaaaffce0deb0da4857019c6700fbaf/diffusers-0.37.1-py3-none-any.whl
+  name: diffusers
+  version: 0.37.1
+  sha256: 0537c0b28cb53cf39d6195489bcf8f833986df556c10f5e28ab7427b86fc8b90
+  requires_dist:
+  - importlib-metadata
+  - filelock
+  - httpx<1.0.0
+  - huggingface-hub>=0.34.0,<2.0
+  - numpy
+  - regex!=2019.12.17
+  - requests
+  - safetensors>=0.3.1
+  - pillow
+  - bitsandbytes>=0.43.3 ; extra == 'bitsandbytes'
+  - accelerate>=0.31.0 ; extra == 'bitsandbytes'
+  - urllib3<=2.0.0 ; extra == 'dev'
+  - isort>=5.5.4 ; extra == 'dev'
+  - ruff==0.9.10 ; extra == 'dev'
+  - hf-doc-builder>=0.3.0 ; extra == 'dev'
+  - compel==0.1.8 ; extra == 'dev'
+  - ftfy ; extra == 'dev'
+  - gitpython<3.1.19 ; extra == 'dev'
+  - datasets ; extra == 'dev'
+  - jinja2 ; extra == 'dev'
+  - invisible-watermark>=0.2.0 ; extra == 'dev'
+  - librosa ; extra == 'dev'
+  - parameterized ; extra == 'dev'
+  - protobuf>=3.20.3,<4 ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  - pytest-timeout ; extra == 'dev'
+  - pytest-xdist ; extra == 'dev'
+  - requests-mock==1.10.0 ; extra == 'dev'
+  - safetensors>=0.3.1 ; extra == 'dev'
+  - sentencepiece>=0.1.91,!=0.1.92 ; extra == 'dev'
+  - scipy ; extra == 'dev'
+  - tiktoken>=0.7.0 ; extra == 'dev'
+  - torchsde ; extra == 'dev'
+  - torchvision ; extra == 'dev'
+  - transformers>=4.41.2 ; extra == 'dev'
+  - phonemizer ; extra == 'dev'
+  - accelerate>=0.31.0 ; extra == 'dev'
+  - tensorboard ; extra == 'dev'
+  - peft>=0.17.0 ; extra == 'dev'
+  - timm ; extra == 'dev'
+  - torch>=1.4 ; extra == 'dev'
+  - jax>=0.4.1 ; extra == 'dev'
+  - jaxlib>=0.4.1 ; extra == 'dev'
+  - flax>=0.4.1 ; extra == 'dev'
+  - hf-doc-builder>=0.3.0 ; extra == 'docs'
+  - jax>=0.4.1 ; extra == 'flax'
+  - jaxlib>=0.4.1 ; extra == 'flax'
+  - flax>=0.4.1 ; extra == 'flax'
+  - gguf>=0.10.0 ; extra == 'gguf'
+  - accelerate>=0.31.0 ; extra == 'gguf'
+  - nvidia-modelopt[hf]>=0.33.1 ; extra == 'nvidia-modelopt'
+  - optimum-quanto>=0.2.6 ; extra == 'optimum-quanto'
+  - accelerate>=0.31.0 ; extra == 'optimum-quanto'
+  - urllib3<=2.0.0 ; extra == 'quality'
+  - isort>=5.5.4 ; extra == 'quality'
+  - ruff==0.9.10 ; extra == 'quality'
+  - hf-doc-builder>=0.3.0 ; extra == 'quality'
+  - compel==0.1.8 ; extra == 'test'
+  - ftfy ; extra == 'test'
+  - gitpython<3.1.19 ; extra == 'test'
+  - datasets ; extra == 'test'
+  - jinja2 ; extra == 'test'
+  - invisible-watermark>=0.2.0 ; extra == 'test'
+  - librosa ; extra == 'test'
+  - parameterized ; extra == 'test'
+  - protobuf>=3.20.3,<4 ; extra == 'test'
+  - pytest ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - requests-mock==1.10.0 ; extra == 'test'
+  - safetensors>=0.3.1 ; extra == 'test'
+  - sentencepiece>=0.1.91,!=0.1.92 ; extra == 'test'
+  - scipy ; extra == 'test'
+  - tiktoken>=0.7.0 ; extra == 'test'
+  - torchsde ; extra == 'test'
+  - torchvision ; extra == 'test'
+  - transformers>=4.41.2 ; extra == 'test'
+  - phonemizer ; extra == 'test'
+  - torch>=1.4 ; extra == 'torch'
+  - accelerate>=0.31.0 ; extra == 'torch'
+  - torchao>=0.7.0 ; extra == 'torchao'
+  - accelerate>=0.31.0 ; extra == 'torchao'
+  - accelerate>=0.31.0 ; extra == 'training'
+  - datasets ; extra == 'training'
+  - protobuf>=3.20.3,<4 ; extra == 'training'
+  - tensorboard ; extra == 'training'
+  - jinja2 ; extra == 'training'
+  - peft>=0.17.0 ; extra == 'training'
+  - timm ; extra == 'training'
+  requires_python: '>=3.10.0'
 - pypi: https://files.pythonhosted.org/packages/50/3d/9373ad9c56321fdab5b41197068e1d8c25883b3fea29dd361f9b55116869/dill-0.4.0-py3-none-any.whl
   name: dill
   version: 0.4.0
@@ -17442,6 +19032,19 @@ packages:
   purls: []
   size: 9506863
   timestamp: 1763127235152
+- conda: https://prefix.dev/conda-forge/linux-64/embree-4.4.1-ha751380_0.conda
+  sha256: 980a5bc837266bf2ba02ecc47d82d8e7cd9bf7b6aa2ebe1da961f44b9dac1b5c
+  md5: 190d81ffebcd24e80985b7675f734ff3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - tbb >=2022.3.0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 10037828
+  timestamp: 1775474308749
 - conda: https://prefix.dev/conda-forge/noarch/eval_type_backport-0.3.1-pyha770c72_0.conda
   sha256: 454f03ac61295b2bca852913af54248cfb9c1a9d2e057f3b5574d552255cda61
   md5: 9cb8eae2a1f3e4a2cb8c53559abf6d75
@@ -18685,6 +20288,18 @@ packages:
   purls: []
   size: 28918
   timestamp: 1774728910114
+- conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-14.3.0-h298d278_23.conda
+  sha256: b535da55f53ed0e44a366295dad325b242958fb3d91ba84b0173bfae28b39793
+  md5: b6090b005c6e1947e897c926caac1286
+  depends:
+  - gcc_impl_linux-64 14.3.0.*
+  - binutils_linux-64
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 28912
+  timestamp: 1775508892545
 - conda: https://prefix.dev/conda-forge/linux-64/gdk-pixbuf-2.44.4-h2b0a6b4_0.conda
   sha256: f47222f58839bcc77c15f11a8814c1d8cb8080c5ca6ba83398a12b640fd3c85c
   md5: c379d67c686fb83475c1a6ed41cc41ff
@@ -19362,6 +20977,19 @@ packages:
   purls: []
   size: 27468
   timestamp: 1774728910114
+- conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-14.3.0-h91b0f8e_23.conda
+  sha256: 8a6a78d354fd259906b2f01f5c29c4f9e42878fa870eadc20f7251d4554a4445
+  md5: 12d093c7df954a01b396a748442bd5cb
+  depends:
+  - gxx_impl_linux-64 14.3.0.*
+  - gcc_linux-64 ==14.3.0 h298d278_23
+  - binutils_linux-64
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 27479
+  timestamp: 1775508892545
 - conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-14.3.0-he467f4b_21.conda
   sha256: 1e07c197e0779fa9105e59cd55a835ded96bfde59eb169439736a89b27b48e5d
   md5: 7b51f4ff82eeb1f386bfee20a7bed3ed
@@ -19419,6 +21047,22 @@ packages:
   - pkg:pypi/h5py?source=hash-mapping
   size: 1290741
   timestamp: 1764016665782
+- conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha4f8f14_102.conda
+  sha256: de9ec9b1b01b90f2da2d896a5835a2fd8049859aff0c6331ca4594327ec79a8b
+  md5: b270340809d19ae40ff9913f277b803a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cached-property
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - libgcc >=14
+  - numpy >=1.23,<3
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  purls:
+  - pkg:pypi/h5py?source=hash-mapping
+  size: 1335314
+  timestamp: 1775581269364
 - conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-12.2.0-h15599e2_0.conda
   sha256: 6bd8b22beb7d40562b2889dc68232c589ff0d11a5ad3addd41a8570d11f039d9
   md5: b8690f53007e9b5ee2c2178dd4ac778c
@@ -19498,6 +21142,26 @@ packages:
   purls: []
   size: 2384060
   timestamp: 1774276284520
+- conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-14.1.0-h6083320_0.conda
+  sha256: 22c4f6df7eb4684a4b60e62de84211e7d80a0df2d7cfdbbd093a73650e3f2d45
+  md5: ca8a94b613db5d805c3d2498a7c30997
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - graphite2 >=1.3.14,<2.0a0
+  - icu >=78.3,<79.0a0
+  - libexpat >=2.7.5,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libglib >=2.86.4,<3.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 2338203
+  timestamp: 1775569314754
 - conda: https://prefix.dev/conda-forge/linux-aarch64/harfbuzz-13.1.1-h1134a53_0.conda
   sha256: 519585a32a9374d2ff0ca93139665e65061117b70156f6c94ce8bc5b5b47c687
   md5: 46a7a399537501c4501be18a9f871976
@@ -20089,6 +21753,27 @@ packages:
   - pkg:pypi/huggingface-hub?source=hash-mapping
   size: 391023
   timestamp: 1774459679038
+- conda: https://prefix.dev/conda-forge/noarch/huggingface_hub-1.9.1-pyhd8ed1ab_0.conda
+  sha256: b0e08e25325480baf93ce0de61ec0982d403ebfef99ca1bb0e9c322250740622
+  md5: eb2923c683c6dfcfa56e290ce119a4c9
+  depends:
+  - filelock >=3.10.0
+  - fsspec >=2023.5.0
+  - hf-xet >=1.4.3,<2.0.0
+  - httpx >=0.23.0,<1
+  - packaging >=20.9
+  - python >=3.10
+  - pyyaml >=5.1
+  - requests
+  - tqdm >=4.42.1
+  - typer
+  - typing-extensions >=3.7.4.3
+  - typing_extensions >=4.1.0
+  license: Apache-2.0
+  purls:
+  - pkg:pypi/huggingface-hub?source=compressed-mapping
+  size: 400596
+  timestamp: 1775580606838
 - pypi: https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl
   name: humanfriendly
   version: '10.0'
@@ -20125,6 +21810,22 @@ packages:
   - pkg:pypi/hypothesis?source=hash-mapping
   size: 377455
   timestamp: 1774752946761
+- conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.151.11-pyha770c72_0.conda
+  sha256: c4457ea4762d408381bb4bcb1c48f5ac1611fd2b1da8a42f98302e5dc472f2e3
+  md5: cee36c1f34fd9a8332f70e7c9c90917e
+  depends:
+  - attrs >=22.2.0
+  - click >=7.0
+  - exceptiongroup >=1.0.0
+  - python >=3.10
+  - setuptools
+  - sortedcontainers >=2.1.0,<3.0.0
+  license: MPL-2.0
+  license_family: MOZILLA
+  purls:
+  - pkg:pypi/hypothesis?source=hash-mapping
+  size: 377987
+  timestamp: 1775414205134
 - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.151.9-pyha770c72_0.conda
   sha256: 1555bc18d732eb0e006d14ad546a7dd34b014c76bc0e2f19dee14b68132ae71b
   md5: 619894788d63f3d5c0327fa28cc04a4d
@@ -20261,6 +21962,52 @@ packages:
   - pkg:pypi/idna?source=hash-mapping
   size: 50721
   timestamp: 1760286526795
+- conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.3.6-py312h40df4bb_1.conda
+  sha256: 412f3a5e6da358505a3014d8f2bc7be648b7fcced4ccc92b3d061e960a2e4215
+  md5: 6350061e5007b0c030810705a491cf2e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - blosc >=1.21.6,<2.0a0
+  - brunsli >=0.1,<1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-blosc2 >=2.23.1,<2.24.0a0
+  - charls >=2.4.3,<2.5.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - jxrlib >=1.1,<1.2.0a0
+  - lcms2 >=2.18,<3.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libaec >=1.1.5,<2.0a0
+  - libavif16 >=1.4.0,<2.0a0
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.2,<4.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.2,<6.0a0
+  - libpng >=1.6.55,<1.7.0a0
+  - libstdcxx >=14
+  - libtiff >=4.7.1,<4.8.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - libzopfli >=1.0.3,<1.1.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - numpy >=1.23,<3
+  - openjpeg >=2.5.4,<3.0a0
+  - openjph >=0.26.3,<0.27.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - snappy >=1.2.2,<1.3.0a0
+  - zfp >=1.0.1,<2.0a0
+  - zlib-ng >=2.3.3,<2.4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/imagecodecs?source=hash-mapping
+  size: 2075890
+  timestamp: 1772886186047
 - conda: https://prefix.dev/conda-forge/noarch/imageio-2.37.0-pyhfb79c49_0.conda
   sha256: 8ef69fa00c68fad34a3b7b260ea774fda9bd9274fd706d3baffb9519fd0063fe
   md5: b5577bc2212219566578fd5af9993af6
@@ -21305,6 +23052,29 @@ packages:
   - pytest>=7.4 ; extra == 'test'
   - pytest-cov>=4.1 ; extra == 'test'
   requires_python: '>=3.7'
+- conda: https://prefix.dev/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+  sha256: 1a88069ac61d2756ccaf26a6c206ab4d56610fb054bd2fffb5df4cd0744ab78e
+  md5: 75932da6f03a6bef32b70a51e991f6eb
+  depends:
+  - packaging
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/lazy-loader?source=hash-mapping
+  size: 14883
+  timestamp: 1772817374026
+- conda: https://prefix.dev/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
+  sha256: 42adb08ded0662114a3146627b24d2cd5eba3bfc3ed424374bac869cdc1745a9
+  md5: 4c8327180586e7b1cd8b6815fc8827f1
+  depends:
+  - lazy-loader 0.5 pyhd8ed1ab_0
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 7565
+  timestamp: 1772817387506
 - conda: https://prefix.dev/conda-forge/linux-64/lcms2-2.18-h0c24ade_0.conda
   sha256: 836ec4b895352110335b9fdcfa83a8dcdbe6c5fb7c06c4929130600caea91c0a
   md5: 6f2e2c8f58160147c4d1c6f4c14cbac4
@@ -21549,6 +23319,45 @@ packages:
   purls: []
   size: 9424323
   timestamp: 1772139338305
+- conda: https://prefix.dev/conda-forge/linux-64/libarrow-23.0.0-h258748b_2_cuda.conda
+  build_number: 2
+  sha256: 6443b25aaae157d4bd767de0e73faf40334d2f11bde8732f876216291eb939e6
+  md5: c364f39d8a924797157da59d8cdd6b97
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-crt-cpp >=0.35.4,<0.35.5.0a0
+  - aws-sdk-cpp >=1.11.606,<1.11.607.0a0
+  - azure-core-cpp >=1.16.2,<1.16.3.0a0
+  - azure-identity-cpp >=1.13.3,<1.13.4.0a0
+  - azure-storage-blobs-cpp >=12.16.0,<12.16.1.0a0
+  - azure-storage-files-datalake-cpp >=12.14.0,<12.14.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20250512.1,<20250513.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libgcc >=14
+  - libgoogle-cloud >=2.39.0,<2.40.0a0
+  - libgoogle-cloud-storage >=2.39.0,<2.40.0a0
+  - libopentelemetry-cpp >=1.21.0,<1.22.0a0
+  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - orc >=2.2.2,<2.2.3.0a0
+  - snappy >=1.2.2,<1.3.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - __cuda
+  constrains:
+  - parquet-cpp <0.0a0
+  - apache-arrow-proc =*=cuda
+  - arrow-cpp <0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 6486895
+  timestamp: 1770440459831
 - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-20.0.0-h85f239b_39_cpu.conda
   build_number: 39
   sha256: 5580a246d315ad106ec9df43a20adfff7a9064308f952571fde3916767800a2b
@@ -21603,6 +23412,21 @@ packages:
   purls: []
   size: 669145
   timestamp: 1772139426044
+- conda: https://prefix.dev/conda-forge/linux-64/libarrow-acero-23.0.0-h635bf11_2_cuda.conda
+  build_number: 2
+  sha256: 2d375ae77653ef0cc9b70ebc9d87e7d3bd6cc4cb2700c5c538521931f3483efd
+  md5: b1f327dae633933118765c113fd3ecd0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 23.0.0 h258748b_2_cuda
+  - libarrow-compute 23.0.0 h8c2c5c3_2_cuda
+  - libgcc >=14
+  - libstdcxx >=14
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 612384
+  timestamp: 1770440620357
 - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-acero-20.0.0-hb326ee9_39_cpu.conda
   build_number: 39
   sha256: b71df69d9f82c166fdfd0ac81d646e44339f7cd354cfcbb6e7f666518119ce55
@@ -21616,6 +23440,23 @@ packages:
   purls: []
   size: 636768
   timestamp: 1773268622558
+- conda: https://prefix.dev/conda-forge/linux-64/libarrow-compute-23.0.0-h8c2c5c3_2_cuda.conda
+  build_number: 2
+  sha256: 0a87b2d585e1f2c37161d3c15881f6d123e383813a5cefc61899447b5c3c2416
+  md5: 7846ea1f43ef6beb04749b5dffd6e4da
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 23.0.0 h258748b_2_cuda
+  - libgcc >=14
+  - libre2-11 >=2025.8.12
+  - libstdcxx >=14
+  - libutf8proc >=2.11.3,<2.12.0a0
+  - re2
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 3007830
+  timestamp: 1770440521926
 - conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-20.0.0-h635bf11_38_cpu.conda
   build_number: 38
   sha256: e3dbe91311f79e3b7ecd92026e03b50a13e3b05eb161bc494af9320d730a1282
@@ -21632,6 +23473,23 @@ packages:
   purls: []
   size: 637558
   timestamp: 1772139591277
+- conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-23.0.0-h635bf11_2_cuda.conda
+  build_number: 2
+  sha256: bc14166ef76974c7bf4587baab2d95acd223ccf2d875f7885cce9b6e621973b8
+  md5: fa0aa202043167a22dd7638c08004cb2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 23.0.0 h258748b_2_cuda
+  - libarrow-acero 23.0.0 h635bf11_2_cuda
+  - libarrow-compute 23.0.0 h8c2c5c3_2_cuda
+  - libgcc >=14
+  - libparquet 23.0.0 h7376487_2_cuda
+  - libstdcxx >=14
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 611958
+  timestamp: 1770440686787
 - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-dataset-20.0.0-hb326ee9_39_cpu.conda
   build_number: 39
   sha256: 46301c312242a63c6ba6bb745915d3fb7842e62d54d20d22d62e3f0ffa8edb48
@@ -21666,6 +23524,25 @@ packages:
   purls: []
   size: 529245
   timestamp: 1772139698613
+- conda: https://prefix.dev/conda-forge/linux-64/libarrow-substrait-23.0.0-h3f74fd7_2_cuda.conda
+  build_number: 2
+  sha256: f1cdff662d277039e8b70ebbaae0572ce97ddd35a065313da09a234acca48003
+  md5: cf0b0682dadc05c597b11ff24ae6c0b7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20250512.1,<20250513.0a0
+  - libarrow 23.0.0 h258748b_2_cuda
+  - libarrow-acero 23.0.0 h635bf11_2_cuda
+  - libarrow-dataset 23.0.0 h635bf11_2_cuda
+  - libgcc >=14
+  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libstdcxx >=14
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 520453
+  timestamp: 1770440708760
 - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-substrait-20.0.0-hf29bd21_39_cpu.conda
   build_number: 39
   sha256: 43994845457ec802a1b860dfba09702bf45f043e1b51474a8e5b0e9c3e35b781
@@ -23440,6 +25317,26 @@ packages:
   purls: []
   size: 1307253
   timestamp: 1770461665848
+- conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-2.39.0-hdb79228_0.conda
+  sha256: d3341cf69cb02c07bbd1837968f993da01b7bd467e816b1559a3ca26c1ff14c5
+  md5: a2e30ccd49f753fd30de0d30b1569789
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20250512.1,<20250513.0a0
+  - libcurl >=8.14.1,<9.0a0
+  - libgcc >=14
+  - libgrpc >=1.73.1,<1.74.0a0
+  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libstdcxx >=14
+  - openssl >=3.5.1,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.39.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 1307909
+  timestamp: 1752048413383
 - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-2.39.0-h73f8e24_1.conda
   sha256: 09ff7bf7374d620bb2675a96ca56a3c7963558fe1d780bfbee5359036018937c
   md5: b2fa52220f9e98f74625eb8bfcc56c4e
@@ -23459,6 +25356,24 @@ packages:
   purls: []
   size: 1294918
   timestamp: 1770462056773
+- conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-storage-2.39.0-hdbdcf42_0.conda
+  sha256: 59eb8365f0aee384f2f3b2a64dcd454f1a43093311aa5f21a8bb4bd3c79a6db8
+  md5: bd21962ff8a9d1ce4720d42a35a4af40
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libgcc >=14
+  - libgoogle-cloud 2.39.0 hdb79228_0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 804189
+  timestamp: 1752048589800
 - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-storage-2.39.0-hdbdcf42_1.conda
   sha256: 2cce946ebf40b0b5fdb3e82c8a9f90ca28cd62abd281b20713067cc69a75c441
   md5: 384a1730ea66a72692e377cb45996d61
@@ -23494,6 +25409,28 @@ packages:
   purls: []
   size: 750245
   timestamp: 1770462239980
+- conda: https://prefix.dev/conda-forge/linux-64/libgrpc-1.73.1-h3288cfb_1.conda
+  sha256: bc9d32af6167b1f5bcda216dc44eddcb27f3492440571ab12f6e577472a05e34
+  md5: ff63bb12ac31c176ff257e3289f20770
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.34.5,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20250512.1,<20250513.0a0
+  - libgcc >=14
+  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libre2-11 >=2025.8.12
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.4,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.73.1
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 8349777
+  timestamp: 1761058442526
 - conda: https://prefix.dev/conda-forge/linux-64/libgrpc-1.78.0-h1d1128b_1.conda
   sha256: f6861217d6c4bf96283738ba8d55782fccb577513a6cd346abc60cf88d1795df
   md5: 66055700c90b50c0405a4e515bb4fe3c
@@ -24698,6 +26635,59 @@ packages:
   - pkg:pypi/opencv-python-headless?source=hash-mapping
   size: 33412356
   timestamp: 1774790748050
+- conda: https://prefix.dev/conda-forge/linux-64/libopencv-4.13.0-qt6_py312h15557d8_605.conda
+  sha256: 1d60b64a03c72b7e1599c155f28b6283bf058c49cdccbbfc3ee3274491afb799
+  md5: 22aa8da9bbc843e85c41beb88e0bbfd9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - ffmpeg >=8.0.1,<9.0a0
+  - harfbuzz >=13.2.1
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - imath >=3.2.2,<3.2.3.0a0
+  - jasper >=4.2.9,<5.0a0
+  - libavif16 >=1.4.1,<2.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libexpat >=2.7.5,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libgl >=1.7.0,<2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libjpeg-turbo >=3.1.2,<4.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-auto-batch-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-auto-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-hetero-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-intel-cpu-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-intel-gpu-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-intel-npu-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-ir-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-onnx-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-paddle-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-pytorch-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-tensorflow-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-tensorflow-lite-frontend >=2025.4.1,<2025.4.2.0a0
+  - libpng >=1.6.56,<1.7.0a0
+  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libstdcxx >=14
+  - libtiff >=4.7.1,<4.8.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - numpy >=1.23,<3
+  - openexr >=3.4.8,<3.5.0a0
+  - qt6-main >=6.10.2,<6.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/opencv-python?source=hash-mapping
+  - pkg:pypi/opencv-python-headless?source=hash-mapping
+  size: 33387941
+  timestamp: 1774790658966
 - conda: https://prefix.dev/conda-forge/linux-64/libopencv-4.13.0-qt6_py312h46ef85d_603.conda
   sha256: 55d71d9d74b7142f4ebe63dd10965a04bd4afbdcf1578a6ab7f82e83367de965
   md5: 8c71ca8dad98329ec1587dd1d8fcd7a6
@@ -25003,6 +26993,26 @@ packages:
   purls: []
   size: 896630
   timestamp: 1770452315175
+- conda: https://prefix.dev/conda-forge/linux-64/libopentelemetry-cpp-1.21.0-hb9b0907_1.conda
+  sha256: ba9b09066f9abae9b4c98ffedef444bbbf4c068a094f6c77d70ef6f006574563
+  md5: 1c0320794855f457dea27d35c4c71e23
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20250512.1,<20250513.0a0
+  - libcurl >=8.14.1,<9.0a0
+  - libgrpc >=1.73.1,<1.74.0a0
+  - libopentelemetry-cpp-headers 1.21.0 ha770c72_1
+  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - nlohmann_json
+  - prometheus-cpp >=1.3.0,<1.4.0a0
+  constrains:
+  - cpp-opentelemetry-sdk =1.21.0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 885397
+  timestamp: 1751782709380
 - conda: https://prefix.dev/conda-forge/linux-aarch64/libopentelemetry-cpp-1.21.0-hd82aec3_2.conda
   sha256: cfbf3612fae44404ccd41c3cff080df7f420bdf58ababe2d89fabdcf08d9a760
   md5: 4d44b36691f8a3ab92eacb9a4a860ece
@@ -25023,6 +27033,14 @@ packages:
   purls: []
   size: 890817
   timestamp: 1770452367008
+- conda: https://prefix.dev/conda-forge/linux-64/libopentelemetry-cpp-headers-1.21.0-ha770c72_1.conda
+  sha256: b3a1b36d5f92fbbfd7b6426982a99561bdbd7e4adbafca1b7f127c9a5ab0a60f
+  md5: 9e298d76f543deb06eb0f3413675e13a
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 363444
+  timestamp: 1751782679053
 - conda: https://prefix.dev/conda-forge/linux-64/libopentelemetry-cpp-headers-1.21.0-ha770c72_2.conda
   sha256: b2b2122f214c417851ba280009aea040e546665c43de737690c2610055a255e3
   md5: 253e70376a8ae74f9d99d44712b3e087
@@ -25915,6 +27933,22 @@ packages:
   purls: []
   size: 1266608
   timestamp: 1772139554392
+- conda: https://prefix.dev/conda-forge/linux-64/libparquet-23.0.0-h7376487_2_cuda.conda
+  build_number: 2
+  sha256: b97e076c60f017810d38a411547f4fd7ae014e1b8c6a0ec189ffcb531319a41a
+  md5: 1e2a463be2b1248c214b246fa14b72f6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 23.0.0 h258748b_2_cuda
+  - libgcc >=14
+  - libstdcxx >=14
+  - libthrift >=0.22.0,<0.22.1.0a0
+  - openssl >=3.5.5,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 1391834
+  timestamp: 1770440597070
 - conda: https://prefix.dev/conda-forge/linux-aarch64/libparquet-20.0.0-h87079af_39_cpu.conda
   build_number: 39
   sha256: 8e41f03c3ca07c20f7992f83093c6c453c0787045f40eb27f759516f4897a810
@@ -26153,6 +28187,22 @@ packages:
   purls: []
   size: 213122
   timestamp: 1768190028309
+- conda: https://prefix.dev/conda-forge/linux-64/libre2-11-2025.11.05-h7b12aa8_0.conda
+  sha256: eb5d5ef4d12cdf744e0f728b35bca910843c8cf1249f758cf15488ca04a21dbb
+  md5: a30848ebf39327ea078cf26d114cff53
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20250512.1,<20250513.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - re2 2025.11.05.*
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 211099
+  timestamp: 1762397758105
 - conda: https://prefix.dev/conda-forge/linux-aarch64/libre2-11-2025.11.05-hc5e897d_1.conda
   sha256: 74c0bfb8ac4d725584b45d0ea885bd3faa3b50f6cdfabef421e1b6c4c7844a7f
   md5: 08f9cbede3e01bc1c51e4dd0267d585f
@@ -26680,6 +28730,18 @@ packages:
   purls: []
   size: 488407
   timestamp: 1762022048105
+- conda: https://prefix.dev/conda-forge/linux-64/libtinyobjloader-2.0.0rc13-h54a6638_1.conda
+  sha256: 2cf1250f6f0bdd18aa306409a603773c7fa1fa0420256146069d90cdbf1166b6
+  md5: e917f96a823429dadffd61e949221333
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 95820
+  timestamp: 1773673273941
 - conda: https://prefix.dev/conda-forge/linux-64/libtorch-2.10.0-cpu_mkl_h7058990_103.conda
   sha256: 92d93119edc7a058987a72984e07a434f999031fcc7a0c851d28cb87c372128a
   md5: 2df90510834746b1f52c5299bc99a81f
@@ -27500,6 +29562,17 @@ packages:
   purls: []
   size: 69833
   timestamp: 1774072605429
+- conda: https://prefix.dev/conda-forge/linux-64/libzopfli-1.0.3-h9c3ff4c_0.tar.bz2
+  sha256: ff94f30b2e86cbad6296cf3e5804d442d9e881f7ba8080d92170981662528c6e
+  md5: c66fe2d123249af7651ebde8984c51c2
+  depends:
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 168074
+  timestamp: 1607309189989
 - conda: https://prefix.dev/ai-demos/linux-64/lietorch-0.3.0-hb0f4dca_0.conda
   sha256: 4e3544434fe8650e75e98c1c3b1c065aa69b5fac24612159700f24b4a8293262
   md5: 2fc721dd77ea1f01449187d8e36d6871
@@ -28450,6 +30523,21 @@ packages:
   requires_dist:
   - dill>=0.4.1
   requires_python: '>=3.9'
+- conda: https://prefix.dev/conda-forge/linux-64/multiprocess-0.70.19-py312h5253ce2_0.conda
+  sha256: 12e6f7a136ddd7e254d79e18f8815d268967a22e66617b377599fe51dc1269f6
+  md5: 7efbcffe0c84f219ae981478106c55f5
+  depends:
+  - python
+  - dill >=0.4.1
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/multiprocess?source=hash-mapping
+  size: 368525
+  timestamp: 1769086764893
 - conda: https://prefix.dev/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
   sha256: d09c47c2cf456de5c09fa66d2c3c5035aa1fa228a1983a433c47b876aa16ce90
   md5: 37293a85a0f4f77bbd9cf7aaefc62609
@@ -28461,6 +30549,17 @@ packages:
   - pkg:pypi/munkres?source=hash-mapping
   size: 15851
   timestamp: 1749895533014
+- pypi: ./packages/mv-api
+  name: mv-api
+  version: 0.1.0
+  sha256: 9cefe997d4fb6205ea8edfe8bd5b7a266b825a19e87e0445c08c60997cc31b8e
+  requires_dist:
+  - einops>=0.8.0,<0.9
+  - monopriors @ file:///var/tmp/vibe-kanban/worktrees/6712-multiview-pose-e/examples-monorepo/packages/monoprior
+  - wilor-nano @ file:///var/tmp/vibe-kanban/worktrees/6712-multiview-pose-e/examples-monorepo/packages/wilor-nano
+  - httpx
+  - gradio-client
+  requires_python: '>=3.12'
 - conda: https://prefix.dev/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
   sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
   md5: e9c622e0d00fa24a6292279af3ab6d06
@@ -28519,6 +30618,18 @@ packages:
   - pkg:pypi/narwhals?source=compressed-mapping
   size: 280459
   timestamp: 1774380620329
+- conda: https://prefix.dev/conda-forge/noarch/narwhals-2.19.0-pyhcf101f3_0.conda
+  sha256: cac1f5236e9d7d1d90d733254bb26948b7c1b22cfbaffc6ebad3ebe9435f26b1
+  md5: b94cbc2227cdca1e9a65d7ad4ee636c1
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/narwhals?source=compressed-mapping
+  size: 281869
+  timestamp: 1775500139138
 - pypi: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
   name: natsort
   version: 8.4.0
@@ -29034,6 +31145,22 @@ packages:
   - nvidia-curand-cu12~=10.0 ; extra == 'cuda'
   - nvidia-cudnn-cu12~=9.0 ; extra == 'cudnn'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/d0/2c/5b3fd4748cf7ed291eae541a37e426efc20ea04cb6e6a05768304ab0aa41/onnxruntime_gpu-1.24.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: onnxruntime-gpu
+  version: 1.24.4
+  sha256: eb0e38f0c1ef3b76ae0081c8e51eed20dd8925aa916f0fc6f9b8b17d05610e99
+  requires_dist:
+  - flatbuffers
+  - numpy>=1.21.6
+  - packaging
+  - protobuf
+  - sympy
+  - nvidia-cuda-nvrtc-cu12~=12.0 ; extra == 'cuda'
+  - nvidia-cuda-runtime-cu12~=12.0 ; extra == 'cuda'
+  - nvidia-cufft-cu12~=11.0 ; extra == 'cuda'
+  - nvidia-curand-cu12~=10.0 ; extra == 'cuda'
+  - nvidia-cudnn-cu12~=9.0 ; extra == 'cudnn'
+  requires_python: '>=3.11'
 - conda: https://prefix.dev/conda-forge/linux-64/open3d-0.19.0-py311hfc4ff73_12.conda
   sha256: e6061c8cb64898b09fa95f7f6aa30b664d7ef40f618338d8e02f2c928f93ae0b
   md5: 8199a4a8692cd982c390817baf9de8c1
@@ -29078,6 +31205,50 @@ packages:
   - pkg:pypi/open3d-cpu?source=hash-mapping
   size: 10512463
   timestamp: 1772689671809
+- conda: https://prefix.dev/conda-forge/linux-64/open3d-0.19.0-py312h0042587_13.conda
+  sha256: 02048334c3e5460ba729658f2298c24ffd9d99a41e6b4e367adafd6912f0c62b
+  md5: f2bf302427fe3a3778c49cf78a490474
+  depends:
+  - numpy
+  - python
+  - plotly
+  - dash
+  - _openmp_mutex >=4.5
+  - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - libpng >=1.6.56,<1.7.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libjpeg-turbo >=3.1.2,<4.0a0
+  - xorg-libxfixes >=6.0.2,<7.0a0
+  - assimp >=6.0.3,<6.0.4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - qt6-main >=6.10.2,<6.11.0a0
+  - glew >=2.3.0,<2.4.0a0
+  - libglx >=1.7.0,<2.0a0
+  - liblzf >=3.6,<3.7.0a0
+  - python_abi 3.12.* *_cp312
+  - glfw >=3.4,<4.0a0
+  - vtk-base >=9.6.0,<9.6.1.0a0
+  - embree >=4.4.0,<4.5.0a0
+  - libgl >=1.7.0,<2.0a0
+  - tbb >=2022.3.0
+  - libtinyobjloader ==2.0.0rc13
+  - jsoncpp >=1.9.6,<1.9.7.0a0
+  - libcurl >=8.19.0,<9.0a0
+  - fmt >=12.1.0,<12.2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - pybind11-abi ==11
+  - zeromq >=4.3.5,<4.4.0a0
+  - qhull >=2020.2,<2020.3.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/open3d-cpu?source=hash-mapping
+  size: 11368179
+  timestamp: 1775160361847
 - conda: https://prefix.dev/conda-forge/linux-64/open3d-0.19.0-py312h4e08d8e_12.conda
   sha256: 13674df530df0bd9fec6bbe8fdf5386bcaac578666d74274c8674fadd594d3ca
   md5: f0c90f80b7702c75039bdba7c33d3d5e
@@ -29208,6 +31379,22 @@ packages:
   purls: []
   size: 1217976
   timestamp: 1774561006856
+- conda: https://prefix.dev/conda-forge/linux-64/openexr-3.4.9-h40f6f1d_0.conda
+  sha256: 930187c0fa5df54ac504d078f6aac64dfe6b101ca8952cae88d0d3825490d67c
+  md5: c702e499f1a80315ac41df8dd5c785bf
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - openjph >=0.26.3,<0.27.0a0
+  - imath >=3.2.2,<3.2.3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1217847
+  timestamp: 1775504236214
 - conda: https://prefix.dev/conda-forge/linux-aarch64/openexr-3.4.6-hd0c962a_0.conda
   sha256: 049c3884af3f770d60e348abf253cf5d41d174d9068ee583b590122aa9ff0d84
   md5: 4e67c6e32982faacff191606815bb836
@@ -29476,6 +31663,24 @@ packages:
   - pkg:pypi/optree?source=hash-mapping
   size: 450061
   timestamp: 1771868416502
+- conda: https://prefix.dev/conda-forge/linux-64/orc-2.2.2-h19cb568_0.conda
+  sha256: 84cfe4e11d3186c0c369f111700e978c849fb9e4ab7ed031acbe3663daacd141
+  md5: a98b8d7cfdd20004f1bdd1a51cb22c58
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - snappy >=1.2.2,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 1317120
+  timestamp: 1768247825733
 - conda: https://prefix.dev/conda-forge/linux-64/orc-2.2.2-hbb90d81_1.conda
   sha256: c59d22c4e555c09259c52da96f1576797fcb4fba5665073e9c1907393309172d
   md5: 9269175175f18091b8844c8e9f213205
@@ -30256,6 +32461,63 @@ packages:
   - pkg:pypi/pandas?source=hash-mapping
   size: 15099922
   timestamp: 1759266031115
+- conda: https://prefix.dev/conda-forge/linux-64/pandas-3.0.2-py312h8ecdadd_0.conda
+  sha256: 4aad0f99a06e799acdd46af0df8f7c8273164cabce8b5c94a44b012b7d1a30a6
+  md5: 42050f82a0c0f6fa23eda3d93b251c18
+  depends:
+  - python
+  - numpy >=1.26.0
+  - python-dateutil >=2.8.2
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  constrains:
+  - adbc-driver-postgresql >=1.2.0
+  - adbc-driver-sqlite >=1.2.0
+  - beautifulsoup4 >=4.12.3
+  - blosc >=1.21.3
+  - bottleneck >=1.4.2
+  - fastparquet >=2024.11.0
+  - fsspec >=2024.10.0
+  - gcsfs >=2024.10.0
+  - html5lib >=1.1
+  - hypothesis >=6.116.0
+  - jinja2 >=3.1.5
+  - lxml >=5.3.0
+  - matplotlib >=3.9.3
+  - numba >=0.60.0
+  - numexpr >=2.10.2
+  - odfpy >=1.4.1
+  - openpyxl >=3.1.5
+  - psycopg2 >=2.9.10
+  - pyarrow >=13.0.0
+  - pyiceberg >=0.8.1
+  - pymysql >=1.1.1
+  - pyqt5 >=5.15.9
+  - pyreadstat >=1.2.8
+  - pytables >=3.10.1
+  - pytest >=8.3.4
+  - pytest-xdist >=3.6.1
+  - python-calamine >=0.3.0
+  - pytz >=2024.2
+  - pyxlsb >=1.0.10
+  - qtpy >=2.4.2
+  - scipy >=1.14.1
+  - s3fs >=2024.10.0
+  - sqlalchemy >=2.0.36
+  - tabulate >=0.9.0
+  - xarray >=2024.10.0
+  - xlrd >=2.0.1
+  - xlsxwriter >=3.2.0
+  - zstandard >=0.23.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pandas?source=compressed-mapping
+  size: 14849233
+  timestamp: 1774916580467
 - conda: https://prefix.dev/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
   sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
   md5: 457c2c8c08e54905d6954e79cb5b5db9
@@ -31284,6 +33546,20 @@ packages:
   purls: []
   size: 1154629
   timestamp: 1774790878017
+- conda: https://prefix.dev/conda-forge/linux-64/py-opencv-4.13.0-qt6_py312h598be00_605.conda
+  sha256: 8bb23a204ca5962574d268fba09e2b1037b28fe220f68da50917fcf33a42f7f6
+  md5: 49afef75bde82685f42442597cfe858f
+  depends:
+  - libopencv 4.13.0 qt6_py312h15557d8_605
+  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - numpy >=1.23,<3
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 1154705
+  timestamp: 1774790781461
 - conda: https://prefix.dev/conda-forge/linux-aarch64/py-opencv-4.13.0-qt6_py310h3fd2d00_603.conda
   sha256: ae87846571797572d5663d7c9f817ffdcb9a326e7c5b16a5858a97c66a16fde3
   md5: 15bc123f2e6d3aee96c7596a4e3870b9
@@ -31365,6 +33641,22 @@ packages:
   purls: []
   size: 32630
   timestamp: 1770445339960
+- conda: https://prefix.dev/conda-forge/linux-64/pyarrow-23.0.0-py312h7900ff3_0.conda
+  sha256: a188741519a763aeb2ca3da6cc6ef1ec80915a2f1ea51402369dd4f06279968f
+  md5: 37143c8f2ee5efeae94e09654d284350
+  depends:
+  - libarrow-acero 23.0.0.*
+  - libarrow-dataset 23.0.0.*
+  - libarrow-substrait 23.0.0.*
+  - libparquet 23.0.0.*
+  - pyarrow-core 23.0.0 *_0_*
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 27287
+  timestamp: 1769291578069
 - conda: https://prefix.dev/conda-forge/linux-aarch64/pyarrow-20.0.0-py310hbbe02a8_2.conda
   sha256: 3ce85c50deff831406e56d4f349af0a0da4ec914222f9fa8d7836146a98c5ea8
   md5: c58ba47b3d5c4d853eafcdba60af946b
@@ -31402,6 +33694,27 @@ packages:
   - pkg:pypi/pyarrow?source=hash-mapping
   size: 4627949
   timestamp: 1770445353
+- conda: https://prefix.dev/conda-forge/linux-64/pyarrow-core-23.0.0-py312hfa4fb80_0_cuda.conda
+  sha256: f0f8389263a090e08abb2ce0d2dd39946af2b527e01f58500ebb90873290fadd
+  md5: bb8c1e37b9ef486ea92a486e217e7ba1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 23.0.0.* *cuda
+  - libarrow-compute 23.0.0.* *cuda
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - numpy >=1.23,<3
+  - apache-arrow-proc * cuda
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/pyarrow?source=hash-mapping
+  size: 4867438
+  timestamp: 1770672654983
 - conda: https://prefix.dev/conda-forge/linux-aarch64/pyarrow-core-20.0.0-py310h27f34b2_2_cpu.conda
   build_number: 2
   sha256: 16cbc6265b8a8d7b2f402f3542753e24dc39cbe311e70d8148e97a67fc74da5b
@@ -31697,6 +34010,19 @@ packages:
   - pkg:pypi/pyglet?source=hash-mapping
   size: 725938
   timestamp: 1770169149613
+- conda: https://prefix.dev/conda-forge/noarch/pyglet-2.1.14-pyhd8ed1ab_0.conda
+  sha256: 9436a5bdcf63c215a9b4c0bc7be4ba16dae43a714cd15c2133ca851c588279ac
+  md5: 85911d1b0c7ffe28189b6d461915ad9c
+  depends:
+  - ffmpeg >=4.0.0
+  - freetype
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pyglet?source=hash-mapping
+  size: 728286
+  timestamp: 1775384075243
 - conda: https://prefix.dev/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
   sha256: 5577623b9f6685ece2697c6eb7511b4c9ac5fb607c9babc2646c811b428fd46a
   md5: 6b6ece66ebcae2d5f326c77ef2c5a066
@@ -31879,6 +34205,19 @@ packages:
   purls: []
   size: 10763689
   timestamp: 1775087090059
+- conda: https://prefix.dev/conda-forge/linux-64/pyrefly-0.60.0-h2b88eb6_0.conda
+  sha256: 5476200a1a001084988ff7bf1f6b76de520c40eea30525789ae867b98ddf3d2d
+  md5: 71425e5fa1ea8de96cffc210f7e9c3ef
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 10787929
+  timestamp: 1775513380916
 - conda: https://prefix.dev/conda-forge/linux-aarch64/pyrefly-0.56.0-h7baeb35_0.conda
   sha256: 8021cbd0de5798087b87924d3f658f8f2a3ffc52b7b8ae4fdab45d89b4c8c49e
   md5: bdada61553047eef69911c76df201b3c
@@ -32241,6 +34580,11 @@ packages:
   version: 0.0.22
   sha256: 2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/a3/73/89930efabd4da63cea44a3f438aeb753d600123570e6d6264e763617a9ce/python_multipart-0.0.24-py3-none-any.whl
+  name: python-multipart
+  version: 0.0.24
+  sha256: 9b110a98db707df01a53c194f0af075e736a770dc5058089650d70b4a182f950
+  requires_python: '>=3.10'
 - conda: https://prefix.dev/conda-forge/noarch/python-tzdata-2025.3-pyhd8ed1ab_0.conda
   sha256: 467134ef39f0af2dbb57d78cb3e4821f01003488d331a8dd7119334f4f47bfbd
   md5: 7ead57407430ba33f681738905278d03
@@ -32252,6 +34596,21 @@ packages:
   - pkg:pypi/tzdata?source=hash-mapping
   size: 143542
   timestamp: 1765719982349
+- conda: https://prefix.dev/conda-forge/linux-64/python-xxhash-3.6.0-py312h0d868a3_1.conda
+  sha256: c21a54fc11f87b456eee8f525060b60d3bea2b942a85fa1b06241271a80ed7a8
+  md5: 1cfb9b04c827219597def32c22fb9ca2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - xxhash >=0.8.3,<0.8.4.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/xxhash?source=hash-mapping
+  size: 24108
+  timestamp: 1762516371604
 - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.10-8_cp310.conda
   build_number: 8
   sha256: 7ad76fa396e4bde336872350124c0819032a9e8a0a40590744ff9527b54351c1
@@ -32450,6 +34809,66 @@ packages:
   - pkg:pypi/torch?source=hash-mapping
   size: 24479674
   timestamp: 1772315696423
+- conda: https://prefix.dev/conda-forge/linux-64/pytorch-2.10.0-cuda129_mkl_py312_hcddf9c5_301.conda
+  sha256: 48641c33b146d893dbe1b1ca93073888ebb08a78e5e25b4405bed717773c1501
+  md5: 6d701f8169901907ef0e06a40da51f60
+  depends:
+  - __cuda
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex * *_llvm
+  - _openmp_mutex >=4.5
+  - cuda-cudart >=12.9.79,<13.0a0
+  - cuda-cupti >=12.9.79,<13.0a0
+  - cuda-nvrtc >=12.9.86,<13.0a0
+  - cuda-nvtx >=12.9.79,<13.0a0
+  - cuda-version >=12.9,<13
+  - filelock
+  - fmt >=12.1.0,<12.2.0a0
+  - fsspec
+  - jinja2
+  - libabseil * cxx17*
+  - libabseil >=20250512.1,<20250513.0a0
+  - libblas * *mkl
+  - libcblas >=3.11.0,<4.0a0
+  - libcublas >=12.9.1.4,<13.0a0
+  - libcudnn >=9.10.2.21,<10.0a0
+  - libcudss >=0.7.1.4,<0.7.2.0a0
+  - libcufft >=11.4.1.4,<12.0a0
+  - libcufile >=1.14.1.1,<2.0a0
+  - libcurand >=10.3.10.19,<11.0a0
+  - libcusolver >=11.7.5.82,<12.0a0
+  - libcusparse >=12.5.10.65,<13.0a0
+  - libgcc >=14
+  - libmagma >=2.9.0,<2.9.1.0a0
+  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libstdcxx >=14
+  - libtorch 2.10.0 cuda129_mkl_he24fa84_301
+  - libuv >=1.51.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - llvm-openmp >=21.1.8
+  - mkl >=2025.3.0,<2026.0a0
+  - nccl >=2.29.2.1,<3.0a0
+  - networkx
+  - numpy >=1.23,<3
+  - optree >=0.13.0
+  - pybind11
+  - pybind11-abi 11
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - setuptools
+  - sleef >=3.9.0,<4.0a0
+  - sympy >=1.13.3
+  - triton 3.6.0
+  - typing_extensions >=4.10.0
+  constrains:
+  - pytorch-gpu 2.10.0
+  - pytorch-cpu <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/torch?source=hash-mapping
+  size: 27284845
+  timestamp: 1769743646578
 - conda: https://prefix.dev/conda-forge/linux-64/pytorch-2.8.0-cuda129_mkl_py312_had1c889_302.conda
   sha256: f589327e0cb5d8658c77df9c3f87e0798c2775485682c35b2bd6a0ea0b528ee7
   md5: ec360db89efeedc51c34c7b3473b55af
@@ -32725,6 +35144,22 @@ packages:
   version: 0.1.0
   sha256: d4135e44a60bcdda18583c60dee92a790daa42561237c70525a35134072c1edc
   requires_python: '>=3.12'
+- conda: https://prefix.dev/conda-forge/linux-64/pywavelets-1.9.0-py312h4f23490_2.conda
+  sha256: 5616729dbb1bfc21e8acc2c8f4d5e32b5e017e45e1e8f763dee8cac4c38f890b
+  md5: ab856c36638ab1acf90e70349c525cf9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - numpy >=1.23,<3
+  - numpy >=1.25,<3
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pywavelets?source=hash-mapping
+  size: 3676871
+  timestamp: 1762595062404
 - conda: https://prefix.dev/conda-forge/linux-64/pyyaml-6.0.3-py310h3406613_1.conda
   sha256: f23de6cc72541c6081d3d27482dbc9fc5dd03be93126d9155f06d0cf15d6e90e
   md5: 2160894f57a40d2d629a34ee8497795f
@@ -33426,6 +35861,16 @@ packages:
   purls: []
   size: 1268666
   timestamp: 1769154883613
+- conda: https://prefix.dev/conda-forge/linux-64/re2-2025.11.05-h5301d42_0.conda
+  sha256: 2f225ddf4a274743045aded48053af65c31721e797a45beed6774fdc783febfb
+  md5: 0227d04521bc3d28c7995c7e1f99a721
+  depends:
+  - libre2-11 2025.11.05 h7b12aa8_0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 27316
+  timestamp: 1762397780316
 - conda: https://prefix.dev/conda-forge/linux-64/re2-2025.11.05-h5301d42_1.conda
   sha256: 3fc684b81631348540e9a42f6768b871dfeab532d3f47d5c341f1f83e2a2b2b2
   md5: 66a715bc01c77d43aca1f9fcb13dde3c
@@ -33550,6 +35995,20 @@ packages:
   - pkg:pypi/regex?source=hash-mapping
   size: 411253
   timestamp: 1774742151604
+- conda: https://prefix.dev/conda-forge/linux-64/regex-2026.4.4-py312h4c3975b_0.conda
+  sha256: f2af90e06f2821c9bc9cc90e7346451586ddd08de7ad6bfd85b867f92e1e188e
+  md5: 83b5e0585164a81913418a4512f29175
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0 AND CNRI-Python
+  license_family: PSF
+  purls:
+  - pkg:pypi/regex?source=compressed-mapping
+  size: 411140
+  timestamp: 1775259323073
 - conda: https://prefix.dev/conda-forge/linux-aarch64/regex-2026.2.28-py310h5b55623_0.conda
   sha256: 93bccc55c5e351672052c9bf7a352cd7b911d3a1b53c57e78400e6dcbe694d79
   md5: f9f1ae025412efd098e7f58577845a79
@@ -33910,6 +36369,22 @@ packages:
   - pkg:pypi/ruff?source=compressed-mapping
   size: 9233459
   timestamp: 1774602134378
+- conda: https://prefix.dev/conda-forge/linux-64/ruff-0.15.9-h7805a7d_0.conda
+  noarch: python
+  sha256: da5b2a8e2a1c25209fb74126da0f271f21e099f2354a46d7fb1e4f927a15a290
+  md5: d820fa7f8798399fc73ef03fb55756be
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ruff?source=compressed-mapping
+  size: 9232676
+  timestamp: 1775177456692
 - conda: https://prefix.dev/conda-forge/linux-aarch64/ruff-0.15.5-he9a2e21_0.conda
   noarch: python
   sha256: 7f3de3fe5a104ddc41da7e1f15d10a83b13d712d622ca10a3e6eacfcaa9af2f5
@@ -33993,6 +36468,18 @@ packages:
   purls: []
   size: 38400767
   timestamp: 1771008857576
+- conda: https://prefix.dev/conda-forge/linux-64/s2n-1.6.2-he8a4886_1.conda
+  sha256: dec76e9faa3173579d34d226dbc91892417a80784911daf8e3f0eb9bad19d7a6
+  md5: bade189a194e66b93c03021bd36c337b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - openssl >=3.5.4,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 394197
+  timestamp: 1765160261434
 - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.0-ha63dd3a_1.conda
   sha256: 37b2d9768f205f497f5af48cc9e83ca8a5e15c9ba5493f6c0835fff9a6503e66
   md5: f9bb0a7187f2e25b19cde17aa8c846c4
@@ -34227,6 +36714,40 @@ packages:
   - pytest-faulthandler ; extra == 'test'
   - pytest-doctestplus>=1.6.0 ; extra == 'test'
   requires_python: '>=3.11'
+- conda: https://prefix.dev/conda-forge/linux-64/scikit-image-0.24.0-py312hf9745cd_3.conda
+  sha256: c6f7ac0e13eeb2d99148ac2cb625f136694f5d5acf669b9439cf7f9b75447c53
+  md5: 3612f99c589d51c363c8b90c0bcf3a18
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - imageio >=2.27
+  - lazy_loader >=0.2
+  - libgcc >=13
+  - libstdcxx >=13
+  - networkx >=2.8
+  - numpy >=1.19,<3
+  - packaging >=21
+  - pillow >=9.0.1
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - pywavelets >=1.1.1
+  - scipy >=1.8
+  - tifffile >=2022.8.12
+  constrains:
+  - cytoolz >=0.11.0
+  - scikit-learn >=1.0
+  - matplotlib-base >=3.5
+  - numpy >=1.23
+  - astropy >=5.0
+  - dask-core >=2021.1.0
+  - toolz >=0.10.0
+  - pooch >=1.6.0
+  - cloudpickle >=0.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/scikit-image?source=hash-mapping
+  size: 11168744
+  timestamp: 1729814366911
 - conda: https://prefix.dev/conda-forge/linux-64/scikit-learn-1.8.0-np2py311ha15b03d_1.conda
   sha256: 1b28c914e59b0e346fef3574c192ea919c710784a9b5a4eff640fb81825a91a9
   md5: 20166c092c5a5093bbaca59925d573a3
@@ -34529,6 +37050,36 @@ packages:
   purls: []
   size: 2138749
   timestamp: 1771668185803
+- conda: https://prefix.dev/conda-forge/linux-64/sdl3-3.4.4-hdeec2a5_0.conda
+  sha256: 4acc06278e14ea9394d50debd0d47006b6daf135749471e2d0f1f30cc602bdd8
+  md5: 78f56b31513ee775c3e72a744bd26a7e
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - wayland >=1.25.0,<2.0a0
+  - xorg-libxi >=1.8.2,<2.0a0
+  - xorg-libxscrnsaver >=1.2.4,<2.0a0
+  - libudev1 >=257.13
+  - xorg-libxtst >=1.2.5,<2.0a0
+  - libxkbcommon >=1.13.1,<2.0a0
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - libdrm >=2.4.125,<2.5.0a0
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libxfixes >=6.0.2,<7.0a0
+  - liburing >=2.14,<2.15.0a0
+  - libvulkan-loader >=1.4.341.0,<2.0a0
+  - libusb >=1.0.29,<2.0a0
+  - libunwind >=1.8.3,<1.9.0a0
+  - dbus >=1.16.2,<2.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - libegl >=1.7.0,<2.0a0
+  license: Zlib
+  purls: []
+  size: 2143141
+  timestamp: 1775266679380
 - conda: https://prefix.dev/conda-forge/linux-aarch64/sdl3-3.4.2-had2c13b_0.conda
   sha256: 17aad2e3439d6d778bf995134f37e442a8420adc740457f43d647d4dbf0b10fe
   md5: c667298eebd2296ace8cb07dbbba95c0
@@ -35219,6 +37770,21 @@ packages:
   - xarray ; extra == 'test'
   - zarr>=3.1.5 ; extra == 'test'
   requires_python: '>=3.11'
+- conda: https://prefix.dev/conda-forge/noarch/tifffile-2026.3.3-pyhd8ed1ab_0.conda
+  sha256: da24795c3000566167fbb51c0933acd7a46fe2661375ad4d8a1748aab2bc9537
+  md5: cecacab21bc8f4ed17fac11bc8b08cf0
+  depends:
+  - imagecodecs >=2025.11.11
+  - numpy >=1.19.2
+  - python >=3.11
+  constrains:
+  - matplotlib-base >=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/tifffile?source=hash-mapping
+  size: 193137
+  timestamp: 1772701074188
 - pypi: https://files.pythonhosted.org/packages/ef/50/de09f69a74278a16f08f1d562047a2d6713783765ee3c6971881a2b21a3f/timm-1.0.25-py3-none-any.whl
   name: timm
   version: 1.0.25
@@ -35431,7 +37997,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/tomli?source=compressed-mapping
+  - pkg:pypi/tomli?source=hash-mapping
   size: 21561
   timestamp: 1774492402955
 - pypi: https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl
@@ -36150,6 +38716,27 @@ packages:
   - pkg:pypi/transformers?source=hash-mapping
   size: 3800298
   timestamp: 1774581475089
+- conda: https://prefix.dev/conda-forge/noarch/transformers-5.5.0-pyhd8ed1ab_0.conda
+  sha256: c402e3432b34240e9491ea238fe11350e246d9d0d76d8bff78c529210f927ef1
+  md5: 533ef570c1be5baccd65a3d7520d9546
+  depends:
+  - filelock
+  - huggingface_hub >=1.3.0,<2.0
+  - numpy >=1.17
+  - packaging >=20.0
+  - python >=3.10
+  - pyyaml >=5.1
+  - regex !=2019.12.17
+  - requests
+  - safetensors >=0.4.1
+  - tokenizers >=0.22,<=0.23
+  - tqdm >=4.27
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/transformers?source=compressed-mapping
+  size: 3799006
+  timestamp: 1775157561592
 - pypi: https://files.pythonhosted.org/packages/3c/b9/da09903ea53b677a58ba770112de6fe8b2acb8b4cd9bffae4ff6cfe7c072/trimesh-4.11.2-py3-none-any.whl
   name: trimesh
   version: 4.11.2
@@ -36478,6 +39065,22 @@ packages:
   - pkg:pypi/typer?source=hash-mapping
   size: 117860
   timestamp: 1771292312899
+- conda: https://prefix.dev/conda-forge/noarch/typer-0.24.1-pyhcf101f3_0.conda
+  sha256: 859aec3457a4d6dd6e4a68d9f4ad4216ce05e1a1a94d244f10629848de77739b
+  md5: 0bb9dfbe0806165f4960331a0ac05ab5
+  depends:
+  - annotated-doc >=0.0.2
+  - click >=8.2.1
+  - python >=3.10
+  - rich >=12.3.0
+  - shellingham >=1.3.0
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/typer?source=compressed-mapping
+  size: 116134
+  timestamp: 1775138098187
 - conda: https://prefix.dev/conda-forge/noarch/typer-slim-0.24.0-pyhcf101f3_0.conda
   sha256: 50db0bc6556667f2f26e9b08f9da9b5de0a02f075bd9ca8724e32df86a822788
   md5: 143f46bdcb6b202bed14d33d27616c1e
@@ -36874,6 +39477,22 @@ packages:
   name: uvicorn
   version: 0.43.0
   sha256: 46fac64f487fd968cd999e5e49efbbe64bd231b5bd8b4a0b482a23ebce499620
+  requires_dist:
+  - click>=7.0
+  - h11>=0.8
+  - typing-extensions>=4.0 ; python_full_version < '3.11'
+  - colorama>=0.4 ; sys_platform == 'win32' and extra == 'standard'
+  - httptools>=0.6.3 ; extra == 'standard'
+  - python-dotenv>=0.13 ; extra == 'standard'
+  - pyyaml>=5.1 ; extra == 'standard'
+  - uvloop>=0.15.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32' and extra == 'standard'
+  - watchfiles>=0.20 ; extra == 'standard'
+  - websockets>=10.4 ; extra == 'standard'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl
+  name: uvicorn
+  version: 0.44.0
+  sha256: ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89
   requires_dist:
   - click>=7.0
   - h11>=0.8
@@ -37436,6 +40055,19 @@ packages:
   - pkg:pypi/werkzeug?source=compressed-mapping
   size: 258058
   timestamp: 1774357640759
+- conda: https://prefix.dev/conda-forge/noarch/werkzeug-3.1.8-pyhcf101f3_0.conda
+  sha256: 5108c1bf2f0512e5c9dc8191e31b144c23b7cf0e73423a246173006002368d79
+  md5: 3eeca039e7316268627f4116da9df64c
+  depends:
+  - markupsafe >=2.1.1
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/werkzeug?source=compressed-mapping
+  size: 258232
+  timestamp: 1775160081069
 - conda: https://prefix.dev/conda-forge/noarch/wheel-0.46.3-pyhd8ed1ab_0.conda
   sha256: d6cf2f0ebd5e09120c28ecba450556ce553752652d91795442f0e70f837126ae
   md5: bdbd7385b4a67025ac2dba4ef8cb6a8f
@@ -38162,6 +40794,17 @@ packages:
   version: 3.6.0
   sha256: 49e03e6fe2cac4a1bc64952dd250cf0dbc5ef4ebb7b8d96bce82e2de163c82a2
   requires_python: '>=3.7'
+- conda: https://prefix.dev/conda-forge/linux-64/xxhash-0.8.3-hb47aa4a_0.conda
+  sha256: 08e12f140b1af540a6de03dd49173c0e5ae4ebc563cabdd35ead0679835baf6f
+  md5: 607e13a8caac17f9a664bcab5302ce06
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 108219
+  timestamp: 1746457673761
 - pypi: https://files.pythonhosted.org/packages/38/4f/fe9a4d472aa867878ce3bb7efb16654c5d63672b86dc0e6e953a67018433/yacs-0.1.8-py3-none-any.whl
   name: yacs
   version: 0.1.8

--- a/pixi.toml
+++ b/pixi.toml
@@ -462,6 +462,66 @@ depends-on = ["robocap-download-example"]
 description = "Run multicamera visual SLAM on Robocap data"
 
 # ═══════════════════════════════════════════════════════════════════════════
+# mv-api
+# ═══════════════════════════════════════════════════════════════════════════
+[feature.mv-api.dependencies]
+python = "3.12.*"
+open3d = ">=0.19.0,<0.20"
+tyro = ">=0.9.1,<0.10"
+natsort = ">=8.4.0,<9"
+h5py = ">=3.13.0,<4"
+scikit-image = ">=0.24.0,<0.25"
+dill = ">=0.4.0,<0.5"
+trimesh = "*"
+pyrender = "*"
+datasets = ">=4.0.0"
+
+[feature.mv-api.pypi-dependencies]
+mv-api = { path = "packages/mv-api", editable = true }
+rtmlib = { git = "https://github.com/pablovela5620/rtmlib.git", rev = "98bca2193c39b349034b280803b54c9ee58f7c68" }
+vggt = { git = "https://github.com/pablovela5620/vggt.git", rev = "5ed6ec88a951f27959f73bc72eb4b6dc7a028b0c" }
+moge = { git = "https://github.com/microsoft/MoGe.git" }
+
+[feature.mv-api.target.linux-64.pypi-dependencies]
+onnxruntime-gpu = ">=1.23.2,<2"
+
+[feature.mv-api.target.linux-aarch64.pypi-dependencies]
+onnxruntime = ">=1.23.2,<2"
+
+[feature.mv-api.activation.env]
+PACKAGE_DIR = "packages/mv-api"
+
+[feature.mv-api.tasks.mv-api-exo-only-calib]
+cmd = "python tools/run_exo_only_calib.py"
+cwd = "packages/mv-api"
+description = "Run exo-only calibration on an exo/ego dataset"
+
+[feature.mv-api.tasks.mv-api-batch-calib]
+cmd = "python tools/batch_exo_calib_client.py"
+cwd = "packages/mv-api"
+description = "Batch-calibrate episode trees of exo/ego .rrd captures"
+
+[feature.mv-api.tasks.mv-api-validate-imports]
+cmd = "python -c \"import mv_api, mv_api.api.batch_calibration, mv_api.api.exo_only_calibration, mv_api.api.full_exoego_pipeline, mv_api.gradio_ui.full_pipeline_rrd_ui\""
+cwd = "packages/mv-api"
+description = "Smoke-test retained mv-api imports"
+
+[feature.mv-api.tasks.mv-api-validate]
+cmd = "python tools/validate_mv_api.py"
+cwd = "packages/mv-api"
+description = "Validate retained mv-api tools and app construction"
+
+[feature.mv-api-demo.tasks.mv-api-full-pipeline-app]
+cmd = "python tools/app_full_pipeline_rrd.py"
+cwd = "packages/mv-api"
+description = "Launch the RRD-based full exo/ego Gradio app"
+
+[feature.mv-api-demo.tasks.mv-api-rrd-client]
+cmd = "python tools/run_rrd_client_example.py"
+cwd = "packages/mv-api"
+description = "Submit a smoke-test job to a running mv-api Gradio app"
+
+# ═══════════════════════════════════════════════════════════════════════════
 # pysfm
 # ═══════════════════════════════════════════════════════════════════════════
 [feature.pysfm.dependencies]
@@ -1052,6 +1112,18 @@ robocap-dev = { features = [
     "robocap",
     "dev",
 ], solve-group = "robocap", no-default-feature = true }
+mv-api = { features = [
+    "common",
+    "cuda",
+    "mv-api",
+    "mv-api-demo",
+], solve-group = "mv-api", no-default-feature = true }
+mv-api-dev = { features = [
+    "common",
+    "cuda",
+    "mv-api",
+    "dev",
+], solve-group = "mv-api", no-default-feature = true }
 pysfm = { features = [
     "common",
     "cuda",


### PR DESCRIPTION
## Summary

This PR imports the upstream `mv-api` project into the monorepo as a new package under `packages/mv-api` and adapts it to the repo's existing package, dependency, task, and validation patterns.

## What changed

- Added a new `packages/mv-api` package with the first-pass retained surface from upstream:
  - full exo/ego RRD pipeline
  - exo-only calibration
  - batch calibration
  - Gradio RRD app
  - CLI smoke-test client
- Added package metadata and local dependency wiring in `packages/mv-api/pyproject.toml`.
- Added monorepo-native docs:
  - `packages/mv-api/README.md`
  - `packages/mv-api/docs/state-machine.md`
- Added validation and test coverage for the retained surface:
  - import smoke tests
  - gradio pipeline smoke coverage
  - batch calibration manifest/discovery coverage
  - existing calibration and triangulation tests
  - `tools/validate_mv_api.py`
- Wired the package into the root `pixi.toml` with:
  - `mv-api` and `mv-api-dev` environments
  - `mv-api-full-pipeline-app`
  - `mv-api-rrd-client`
  - `mv-api-exo-only-calib`
  - `mv-api-batch-calib`
  - `mv-api-validate`
- Updated `.gitignore` for package-local data and refreshed `pixi.lock` for the new environment solve.

## Why these changes were made

The task was to bring `https://github.com/pablovela5620/mv-api` into the examples monorepo as a proper package, align its dependencies with the rest of the repo, and add a validation script plus documentation that makes the package's scripts and I/O easier to understand.

Instead of copying upstream packaging directly, this PR converts `mv-api` into a monorepo-native package so it can reuse the repo's shared `common`, `cuda`, and `dev` features, work with local packages like `monopriors` and `wilor-nano`, and expose root `pixi` tasks that match the rest of the repository.

## Important implementation details

- The import is intentionally scoped to the RRD-centered workflow first. It keeps the core multiview pose and calibration flows, and defers unrelated or less stable upstream surfaces such as the label UI, face blur flow, and other auxiliary entrypoints.
- Local monorepo dependencies are declared via normal package dependencies plus `tool.uv.sources`, rather than keeping upstream git-based references for packages that already live in this repo.
- The package uses the shared `PACKAGE_DIR` + root `dev` task pattern, so linting, tests, and typechecking work the same way as other packages in the monorepo.
- The new state machine doc summarizes the package entrypoints, the script inventory, and the input/output flow for the retained first-pass workflows.
- The validation path is explicit: the new package includes both pytest coverage and a dedicated `mv-api-validate` task for retained imports, CLI help smoke checks, and app construction checks.

## Validation

Ran successfully:

- `pixi run -e mv-api-dev lint`
- `pixi run -e mv-api-dev tests`
- `pixi run -e mv-api-dev mv-api-validate`

This PR was written using [Vibe Kanban](https://vibekanban.com)
