### PR TITLE
Fix MASt3R-SLAM backend camera refresh and clean up checks (Vibe Kanban)

### DIFF
--- a/packages/gsplat-rust-renderer/pyproject.toml
+++ b/packages/gsplat-rust-renderer/pyproject.toml
@@ -22,3 +22,9 @@ ignore = [
     "UP037",  # Remove quotes false positive with jaxtyping
     "UP040",  # Beartype requires TypeAlias, not PEP 695 type
 ]
+
+[tool.vulture]
+paths = ["gsplat_rust_renderer", "tests", "tools"]
+exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modules/*", "*/.ruff_cache/*"]
+sort_by_size = true
+min_confidence = 60

--- a/packages/mast3r-slam/docs/bottleneck-analysis.md
+++ b/packages/mast3r-slam/docs/bottleneck-analysis.md
@@ -1,220 +1,145 @@
 # MASt3R-SLAM Bottleneck Analysis
 
-This note is the current optimization brief for MASt3R-SLAM. It summarizes the latest end-to-end profiling on the current async-logging codepath and is meant to answer a simple question: what is still taking time in the real pipeline?
+This note is the current optimization brief for MASt3R-SLAM. It is written for someone new to the repo and focuses on what we have measured, what is already known to be slow, and what to do next.
 
 ## Pipeline Overview
 
-MASt3R-SLAM runs as two cooperating processes plus one logger thread:
+MASt3R-SLAM runs as two cooperating processes:
 
-```text
+```
 Frontend / tracker                    Backend / optimizer
 ┌──────────────────────────────┐      ┌──────────────────────────────┐
 │ every frame:                 │      │ every new keyframe:          │
 │ 1. read + resize image       │      │ 1. retrieval query           │
 │ 2. create frame state        │      │ 2. symmetric MASt3R matching │
 │ 3. run tracking inference    │ ───▶ │ 3. add factor-graph edges    │
-│ 4. estimate current pose     │      │ 4. run global optimization   │
-│ 5. enqueue log snapshots     │      │ 5. publish updated poses     │
+│ 4. estimate current pose     │      │ 4. run global optimization    │
+│ 5. log to Rerun              │      │ 5. publish updated poses      │
 └──────────────────────────────┘      └──────────────────────────────┘
-                 │
-                 ▼
-         Async logger thread
-         ┌──────────────────────────────┐
-         │ 1. consume events            │
-         │ 2. JPEG / pointmap work      │
-         │ 3. log current frame         │
-         │ 4. log keyframe/map updates  │
-         └──────────────────────────────┘
 ```
 
-The frontend must keep up with incoming frames. The backend only wakes up when a new keyframe is queued. The logger thread is off the frontend critical path, but it can still be a major consumer of total runtime and viewer throughput.
+The frontend is responsible for keeping up with incoming frames. The backend is responsible for heavier map-building work that happens when a frame becomes a keyframe.
 
 ## What We Measured
 
-The current measurements were collected with a temporary profiling harness that:
+The benchmark artifacts live under [packages/mast3r-slam/benchmark](/var/tmp/vibe-kanban/worktrees/f711-mast3r-slam-infe/examples-monorepo/packages/mast3r-slam/benchmark). The most useful runs are:
 
-- monkeypatched timing counters into the frontend, backend, and async logger
-- captured `cProfile` dumps for the frontend process and backend subprocess
-- wrote all artifacts to `/tmp/mast3r_profile/out`
-- left the checked-in code untouched
+| Run | FPS | Avg frame time | Avg logging time |
+|---|---:|---:|---:|
+| `fast-full` | 5.51 | 181.45 ms | 56.54 ms |
+| `fast-no-logging-full` | 7.88 | 126.98 ms | 0.00 ms |
+| `base-full` | 5.51 | 181.51 ms | 54.72 ms |
+| `base-no-logging-full` | 8.51 | 117.53 ms | 0.00 ms |
 
-The four main runs were:
+The headline result is simple:
 
-| Run | Dataset | Config | Wall time | Frames | Keyframes | FPS |
-|---|---|---|---:|---:|---:|---:|
-| `fast-apt` | `normal-apt-tour.mp4` | `fast.yaml` | `82.35 s` | `504` | `88` | `6.12` |
-| `base-apt` | `normal-apt-tour.mp4` | `base.yaml` | `360.49 s` | `2523` | `97` | `7.00` |
-| `fast-livingroom` | `livingroom-tour.mp4` | `fast.yaml` | `51.31 s` | `361` | `51` | `7.03` |
-| `base-livingroom` | `livingroom-tour.mp4` | `base.yaml` | `222.14 s` | `1807` | `45` | `8.13` |
-
-Two important interpretation notes:
-
-- Frontend, backend, and logger overlap in time, so their percentages do not add to 100%.
-- The backend spends a lot of time asleep, which means it is often waiting for the frontend rather than setting end-to-end throughput.
-
-## Normalized Timing Table
-
-This table is the most useful high-level summary:
-
-| Run | Tracking s/frame | Snapshot ms/frame | Logger ms/frame | Backend known ms/keyframe |
-|---|---:|---:|---:|---:|
-| `fast-apt` | `0.074` | `7.56` | `99.60` | `375.45` |
-| `base-apt` | `0.088` | `8.82` | `129.03` | `726.48` |
-| `fast-livingroom` | `0.066` | `4.64` | `93.30` | `294.88` |
-| `base-livingroom` | `0.075` | `5.15` | `111.53` | `397.87` |
-
-Interpretation:
-
-- Frontend snapshot creation is relatively cheap.
-- Frontend tracking is consistently expensive.
-- Logger work is still very large, especially on `base`.
-- Backend work per keyframe is substantial, but because keyframes are sparse the backend is not always the end-to-end limiter.
+- Logging is a major source of slowdown in the default logged path.
+- Disabling logging recovers about `+2.36 FPS` on `fast` and `+3.00 FPS` on `base`.
+- Once logging is removed, the frontend becomes much more stable.
+- After that, the main remaining bottleneck on `base` is backend scaling, especially MASt3R pair construction and global optimization.
 
 ## Current Bottlenecks
 
-### 1. Async logging is still a major bottleneck
+### 1. Rerun logging overhead in the default configuration
 
-The async logger removed the old synchronous blocking on the tracking thread, but it did **not** make logging cheap overall.
+This is the main avoidable bottleneck in the current user-facing pipeline.
 
-Evidence:
+Why we know this:
 
-- Logger work is still about `93-129 ms/frame` across the four measured runs.
-- On `base-apt`, logger cumulative time is `325.53 s` versus `222.66 s` in tracking.
-- On `base-livingroom`, logger cumulative time is `201.53 s` versus `136.35 s` in tracking.
+- `fast` improved from `5.51 FPS` to `7.88 FPS` when logging was disabled.
+- `base` improved from `5.51 FPS` to `8.51 FPS` when logging was disabled.
+- The logged runs spend roughly `55 ms/frame` in logging alone.
 
-The important correction to the old conclusion is:
+What is still expensive in the current logging path:
 
-- logging is no longer synchronous on the frontend hot path
-- but logging is still one of the largest consumers of total work in the system
+- current-camera RGB, pointmap, depth, and confidence are produced every frame
+- camera path is rebuilt from full history every frame
+- factor-graph edge geometry is rebuilt from the full edge set
+- `last_keyframe` image and maps are relogged every frame
+- array conversion and image compression happen synchronously on the tracking thread
 
-### 2. The biggest logger hotspot is current-frame image/map logging
+One important update: keyframe pose logging is already better than it used to be. The code now uses dirty keyframe pose updates instead of relogging every keyframe transform every frame. That helped, but it was not enough to remove the main logging cost.
 
-The dominant logger cost is not backend camera pose refresh. It is the repeated current-frame path:
+### 2. Backend MASt3R pair construction
 
-- current-frame camera logging
-- pointmap/depth/confidence conversion
-- current-frame and last-keyframe image logging
-
-Measured logger breakdown:
-
-| Run | Current-frame handler | Map-update handler | Pointmap/confidence | Camera relog |
-|---|---:|---:|---:|---:|
-| `fast-apt` | `26.85 s` | `8.11 s` | `6.52 s` | `3.12 s` |
-| `base-apt` | `198.01 s` | `18.44 s` | `83.01 s` | `6.25 s` |
-| `fast-livingroom` | `19.97 s` | `4.34 s` | `4.58 s` | `1.37 s` |
-| `base-livingroom` | `121.44 s` | `7.82 s` | `58.94 s` | `2.83 s` |
-
-This matters because it narrows the optimization target:
-
-- lightweight backend camera refresh was the right fix for pose-update overhead
-- but it is not the main remaining logging cost
-- the current-frame path is the main logging hotspot now
-
-### 3. Frontend tracking inference is the other persistent top bottleneck
-
-Across all runs, the hottest frontend stack is:
-
-1. `tracker.py:51(track)`
-2. `mast3r_utils.py:412(mast3r_match_asymmetric)`
-3. `mast3r_utils.py:365(mast3r_asymmetric_inference)`
-4. decoder / positional-embedding heavy model code
+The backend still spends most of its time building new factors for incoming keyframes. In practice, this is dominated by decoder work plus dense matching.
 
 Evidence:
 
-- `fast-apt`: tracking totals `37.17 s`
-- `base-apt`: tracking totals `222.66 s`
-- `fast-livingroom`: tracking totals `23.84 s`
-- `base-livingroom`: tracking totals `136.35 s`
+- `fast-no-logging-full`: backend `add_factors` averages `139.13 ms`
+- `base-no-logging-full`: backend `add_factors` averages `181.44 ms`
 
-This is steady, unavoidable compute in the current design and remains one of the biggest places to win time if model-side changes are acceptable.
+This is the main backend bottleneck once logging is out of the way.
 
-### 4. Backend work matters, but often overlaps rather than dominating
+### 3. Backend global optimization growth
 
-The backend’s measured active work per keyframe is still real:
+On longer runs, backend optimization time grows with the map.
 
-| Run | Retrieval | Add factors | GN solve |
-|---|---:|---:|---:|
-| `fast-apt` | `1.56 s` | `14.76 s` | `16.72 s` |
-| `base-apt` | `2.32 s` | `19.67 s` | `48.48 s` |
-| `fast-livingroom` | `0.90 s` | `8.09 s` | `6.05 s` |
-| `base-livingroom` | `1.04 s` | `8.40 s` | `8.46 s` |
+Evidence:
 
-But the backend also spends a lot of cumulative time in `time.sleep`:
+- `base-no-logging-full`: backend `global_opt` averages `167.24 ms`
+- `base-full`: backend task time grows by about `4.48 ms` per keyframe
 
-- `fast-apt`: `35.57 s`
-- `base-apt`: `261.50 s`
-- `fast-livingroom`: `23.41 s`
-- `base-livingroom`: `183.23 s`
+At `base` resolution, global optimization is nearly as expensive as pair construction. That means backend scaling, not just frontend logging, becomes a real problem on long sequences.
 
-That means the backend is frequently idle, waiting for new keyframes from the frontend. So:
+### 4. Tracking cost
 
-- backend cost is important
-- backend cost is not always the throughput limiter
-- on many runs, frontend + logger work are the stronger practical bottlenecks
+Tracking is not the main source of the large logged-vs-no-logging gap, but it is still a meaningful steady-state cost.
 
-### 5. Backend scaling is still most visible on `base-apt`
+Evidence:
 
-`base-apt` is still the clearest backend-stress case:
+- `fast-no-logging-full`: avg tracking time `82.58 ms`
+- `base-no-logging-full`: avg tracking time `90.06 ms`
 
-- `solve_GN_rays`: `48.48 s`
-- `add_factors`: `19.67 s`
-- `torch.cuda.synchronize`: about `40.25 s` inside the backend profile
-
-So the older intuition about backend scaling was not wrong, but it was incomplete. The current picture is:
-
-- backend optimization is expensive on harder `base` runs
-- logger and frontend costs are still large enough that backend is not the whole story
+This matters, but it is not the first thing to optimize while the logged path is still paying large synchronous visualization costs.
 
 ## What Has Already Changed
 
 Several useful changes are already in the repo:
 
-- Async logging moved expensive Rerun work off the tracking thread.
-- Backend camera refresh now uses lightweight pose-only refresh events instead of full dirty-keyframe snapshots.
-- Dirty keyframe pose updates are used instead of relogging all keyframe poses every frame.
-- The latest temporary profiler harness measured frontend, logger, and backend separately without modifying tracked files.
+- Deep frontend/backend benchmark instrumentation was added.
+- Full benchmark outputs were committed for `fast`, `base`, and no-logging variants.
+- A `--disable-logging` benchmark mode was added so logging cost can be isolated directly.
+- Keyframe pose logging was improved to use dirty updates rather than relogging every keyframe pose each frame.
 
-## Updated Conclusions
+These changes were enough to prove that logging overhead was real and to quantify its impact.
 
-The old summary "`logging is no longer a bottleneck`" is too strong and should be considered outdated.
+## Logging Optimization — Completed
 
-The current picture is:
+Logging has been moved off the tracking critical path via `AsyncRerunLogger` (a dedicated background thread). See `async_logger.py` and `log_events.py`.
 
-- Async logging was a major win for frontend responsiveness.
-- Logging is still one of the largest total costs in the system.
-- The main remaining logging hotspot is the current-frame path, especially pointmap/depth/confidence work.
-- Frontend tracking inference is the other consistent top bottleneck.
-- Backend pair construction and Gauss-Newton are still expensive, especially on `base-apt`, but the backend is often idle and therefore not always the end-to-end limiter.
+Measured result on `example-base` (full video, 512px, live viewer):
+
+| Version | Wall time | Speedup |
+|---|---|---|
+| Synchronous logging | 12m17s | — |
+| Async logger thread | 4m30s | **2.73x** |
+
+What the async logger does:
+
+1. The pipeline thread creates lightweight CPU snapshots (frozen dataclass events) and enqueues them.
+2. The logger thread consumes events and does all the expensive work: JPEG compression, focal estimation, pointmap conversion, `rr.log()` calls.
+3. Current-frame events are droppable (viewer shows previous frame if the logger is behind). Structural events (new keyframes, pose updates, edges) are never dropped.
+4. The logger only logs keyframe image/pointcloud data once (on creation), and only updates poses when dirty.
+5. Blueprint is refreshed only when keyframe count changes.
+
+The implementation preserves the same viewer experience while supporting time-varying camera models (intrinsics are re-estimated per frame in the logger thread).
 
 ## Recommended Next Steps
 
-1. Optimize current-frame logging first.
-   The highest-value targets are:
-   - current image logging
-   - current pointmap/depth/confidence logging
-   - last-keyframe 2D-panel relogging
+1. ~~Optimize the logging path first.~~ **Done.** See "Logging Optimization — Completed" above.
 
-2. Keep backend camera refresh lightweight.
-   The pose-only refresh path was the right direction and should not be regressed back to full dirty-keyframe replay.
+2. ~~Rerun the full logged benchmarks.~~ **Done.** The logged path now runs at 2.73x the sync baseline.
 
-3. Then focus on frontend tracking inference.
-   The main candidates are:
-   - decoder-side optimization
-   - AMP / BF16 where safe
-   - reducing expensive per-frame model work
+3. Focus on backend pair construction.
+   The first candidates are decoder-side improvements such as AMP/BF16, `torch.compile`, and reducing backend pair volume.
 
-4. After that, optimize backend scaling on the hardest runs.
-   The main candidates are:
-   - reduce pair volume
-   - reduce solve frequency
-   - local/sliding-window optimization
-   - investigate backend synchronization overhead on `base-apt`
+4. Then reduce backend optimization scaling.
+   The main candidates are sliding-window or local-subgraph optimization and solving less often.
 
 ## Bottom Line
 
-If you are looking at MASt3R-SLAM performance today, the most accurate short summary is:
+If you are looking at MASt3R-SLAM performance for the first time, the current picture is:
 
-- async logging fixed the worst synchronous frontend blockage
-- the logger is still expensive, especially for current-frame map visualization
-- frontend tracking inference is still a major cost
-- backend optimization matters, but it is not the only bottleneck and is often not the immediate throughput limiter
+- Logging has been moved to an async background thread and is no longer a bottleneck.
+- The main remaining bottleneck is backend scaling: decoder-heavy pair construction and global optimization on larger maps.

--- a/packages/mast3r-slam/docs/bottleneck-analysis.md
+++ b/packages/mast3r-slam/docs/bottleneck-analysis.md
@@ -1,145 +1,220 @@
 # MASt3R-SLAM Bottleneck Analysis
 
-This note is the current optimization brief for MASt3R-SLAM. It is written for someone new to the repo and focuses on what we have measured, what is already known to be slow, and what to do next.
+This note is the current optimization brief for MASt3R-SLAM. It summarizes the latest end-to-end profiling on the current async-logging codepath and is meant to answer a simple question: what is still taking time in the real pipeline?
 
 ## Pipeline Overview
 
-MASt3R-SLAM runs as two cooperating processes:
+MASt3R-SLAM runs as two cooperating processes plus one logger thread:
 
-```
+```text
 Frontend / tracker                    Backend / optimizer
 ┌──────────────────────────────┐      ┌──────────────────────────────┐
 │ every frame:                 │      │ every new keyframe:          │
 │ 1. read + resize image       │      │ 1. retrieval query           │
 │ 2. create frame state        │      │ 2. symmetric MASt3R matching │
 │ 3. run tracking inference    │ ───▶ │ 3. add factor-graph edges    │
-│ 4. estimate current pose     │      │ 4. run global optimization    │
-│ 5. log to Rerun              │      │ 5. publish updated poses      │
+│ 4. estimate current pose     │      │ 4. run global optimization   │
+│ 5. enqueue log snapshots     │      │ 5. publish updated poses     │
 └──────────────────────────────┘      └──────────────────────────────┘
+                 │
+                 ▼
+         Async logger thread
+         ┌──────────────────────────────┐
+         │ 1. consume events            │
+         │ 2. JPEG / pointmap work      │
+         │ 3. log current frame         │
+         │ 4. log keyframe/map updates  │
+         └──────────────────────────────┘
 ```
 
-The frontend is responsible for keeping up with incoming frames. The backend is responsible for heavier map-building work that happens when a frame becomes a keyframe.
+The frontend must keep up with incoming frames. The backend only wakes up when a new keyframe is queued. The logger thread is off the frontend critical path, but it can still be a major consumer of total runtime and viewer throughput.
 
 ## What We Measured
 
-The benchmark artifacts live under [packages/mast3r-slam/benchmark](/var/tmp/vibe-kanban/worktrees/f711-mast3r-slam-infe/examples-monorepo/packages/mast3r-slam/benchmark). The most useful runs are:
+The current measurements were collected with a temporary profiling harness that:
 
-| Run | FPS | Avg frame time | Avg logging time |
-|---|---:|---:|---:|
-| `fast-full` | 5.51 | 181.45 ms | 56.54 ms |
-| `fast-no-logging-full` | 7.88 | 126.98 ms | 0.00 ms |
-| `base-full` | 5.51 | 181.51 ms | 54.72 ms |
-| `base-no-logging-full` | 8.51 | 117.53 ms | 0.00 ms |
+- monkeypatched timing counters into the frontend, backend, and async logger
+- captured `cProfile` dumps for the frontend process and backend subprocess
+- wrote all artifacts to `/tmp/mast3r_profile/out`
+- left the checked-in code untouched
 
-The headline result is simple:
+The four main runs were:
 
-- Logging is a major source of slowdown in the default logged path.
-- Disabling logging recovers about `+2.36 FPS` on `fast` and `+3.00 FPS` on `base`.
-- Once logging is removed, the frontend becomes much more stable.
-- After that, the main remaining bottleneck on `base` is backend scaling, especially MASt3R pair construction and global optimization.
+| Run | Dataset | Config | Wall time | Frames | Keyframes | FPS |
+|---|---|---|---:|---:|---:|---:|
+| `fast-apt` | `normal-apt-tour.mp4` | `fast.yaml` | `82.35 s` | `504` | `88` | `6.12` |
+| `base-apt` | `normal-apt-tour.mp4` | `base.yaml` | `360.49 s` | `2523` | `97` | `7.00` |
+| `fast-livingroom` | `livingroom-tour.mp4` | `fast.yaml` | `51.31 s` | `361` | `51` | `7.03` |
+| `base-livingroom` | `livingroom-tour.mp4` | `base.yaml` | `222.14 s` | `1807` | `45` | `8.13` |
+
+Two important interpretation notes:
+
+- Frontend, backend, and logger overlap in time, so their percentages do not add to 100%.
+- The backend spends a lot of time asleep, which means it is often waiting for the frontend rather than setting end-to-end throughput.
+
+## Normalized Timing Table
+
+This table is the most useful high-level summary:
+
+| Run | Tracking s/frame | Snapshot ms/frame | Logger ms/frame | Backend known ms/keyframe |
+|---|---:|---:|---:|---:|
+| `fast-apt` | `0.074` | `7.56` | `99.60` | `375.45` |
+| `base-apt` | `0.088` | `8.82` | `129.03` | `726.48` |
+| `fast-livingroom` | `0.066` | `4.64` | `93.30` | `294.88` |
+| `base-livingroom` | `0.075` | `5.15` | `111.53` | `397.87` |
+
+Interpretation:
+
+- Frontend snapshot creation is relatively cheap.
+- Frontend tracking is consistently expensive.
+- Logger work is still very large, especially on `base`.
+- Backend work per keyframe is substantial, but because keyframes are sparse the backend is not always the end-to-end limiter.
 
 ## Current Bottlenecks
 
-### 1. Rerun logging overhead in the default configuration
+### 1. Async logging is still a major bottleneck
 
-This is the main avoidable bottleneck in the current user-facing pipeline.
-
-Why we know this:
-
-- `fast` improved from `5.51 FPS` to `7.88 FPS` when logging was disabled.
-- `base` improved from `5.51 FPS` to `8.51 FPS` when logging was disabled.
-- The logged runs spend roughly `55 ms/frame` in logging alone.
-
-What is still expensive in the current logging path:
-
-- current-camera RGB, pointmap, depth, and confidence are produced every frame
-- camera path is rebuilt from full history every frame
-- factor-graph edge geometry is rebuilt from the full edge set
-- `last_keyframe` image and maps are relogged every frame
-- array conversion and image compression happen synchronously on the tracking thread
-
-One important update: keyframe pose logging is already better than it used to be. The code now uses dirty keyframe pose updates instead of relogging every keyframe transform every frame. That helped, but it was not enough to remove the main logging cost.
-
-### 2. Backend MASt3R pair construction
-
-The backend still spends most of its time building new factors for incoming keyframes. In practice, this is dominated by decoder work plus dense matching.
+The async logger removed the old synchronous blocking on the tracking thread, but it did **not** make logging cheap overall.
 
 Evidence:
 
-- `fast-no-logging-full`: backend `add_factors` averages `139.13 ms`
-- `base-no-logging-full`: backend `add_factors` averages `181.44 ms`
+- Logger work is still about `93-129 ms/frame` across the four measured runs.
+- On `base-apt`, logger cumulative time is `325.53 s` versus `222.66 s` in tracking.
+- On `base-livingroom`, logger cumulative time is `201.53 s` versus `136.35 s` in tracking.
 
-This is the main backend bottleneck once logging is out of the way.
+The important correction to the old conclusion is:
 
-### 3. Backend global optimization growth
+- logging is no longer synchronous on the frontend hot path
+- but logging is still one of the largest consumers of total work in the system
 
-On longer runs, backend optimization time grows with the map.
+### 2. The biggest logger hotspot is current-frame image/map logging
+
+The dominant logger cost is not backend camera pose refresh. It is the repeated current-frame path:
+
+- current-frame camera logging
+- pointmap/depth/confidence conversion
+- current-frame and last-keyframe image logging
+
+Measured logger breakdown:
+
+| Run | Current-frame handler | Map-update handler | Pointmap/confidence | Camera relog |
+|---|---:|---:|---:|---:|
+| `fast-apt` | `26.85 s` | `8.11 s` | `6.52 s` | `3.12 s` |
+| `base-apt` | `198.01 s` | `18.44 s` | `83.01 s` | `6.25 s` |
+| `fast-livingroom` | `19.97 s` | `4.34 s` | `4.58 s` | `1.37 s` |
+| `base-livingroom` | `121.44 s` | `7.82 s` | `58.94 s` | `2.83 s` |
+
+This matters because it narrows the optimization target:
+
+- lightweight backend camera refresh was the right fix for pose-update overhead
+- but it is not the main remaining logging cost
+- the current-frame path is the main logging hotspot now
+
+### 3. Frontend tracking inference is the other persistent top bottleneck
+
+Across all runs, the hottest frontend stack is:
+
+1. `tracker.py:51(track)`
+2. `mast3r_utils.py:412(mast3r_match_asymmetric)`
+3. `mast3r_utils.py:365(mast3r_asymmetric_inference)`
+4. decoder / positional-embedding heavy model code
 
 Evidence:
 
-- `base-no-logging-full`: backend `global_opt` averages `167.24 ms`
-- `base-full`: backend task time grows by about `4.48 ms` per keyframe
+- `fast-apt`: tracking totals `37.17 s`
+- `base-apt`: tracking totals `222.66 s`
+- `fast-livingroom`: tracking totals `23.84 s`
+- `base-livingroom`: tracking totals `136.35 s`
 
-At `base` resolution, global optimization is nearly as expensive as pair construction. That means backend scaling, not just frontend logging, becomes a real problem on long sequences.
+This is steady, unavoidable compute in the current design and remains one of the biggest places to win time if model-side changes are acceptable.
 
-### 4. Tracking cost
+### 4. Backend work matters, but often overlaps rather than dominating
 
-Tracking is not the main source of the large logged-vs-no-logging gap, but it is still a meaningful steady-state cost.
+The backend’s measured active work per keyframe is still real:
 
-Evidence:
+| Run | Retrieval | Add factors | GN solve |
+|---|---:|---:|---:|
+| `fast-apt` | `1.56 s` | `14.76 s` | `16.72 s` |
+| `base-apt` | `2.32 s` | `19.67 s` | `48.48 s` |
+| `fast-livingroom` | `0.90 s` | `8.09 s` | `6.05 s` |
+| `base-livingroom` | `1.04 s` | `8.40 s` | `8.46 s` |
 
-- `fast-no-logging-full`: avg tracking time `82.58 ms`
-- `base-no-logging-full`: avg tracking time `90.06 ms`
+But the backend also spends a lot of cumulative time in `time.sleep`:
 
-This matters, but it is not the first thing to optimize while the logged path is still paying large synchronous visualization costs.
+- `fast-apt`: `35.57 s`
+- `base-apt`: `261.50 s`
+- `fast-livingroom`: `23.41 s`
+- `base-livingroom`: `183.23 s`
+
+That means the backend is frequently idle, waiting for new keyframes from the frontend. So:
+
+- backend cost is important
+- backend cost is not always the throughput limiter
+- on many runs, frontend + logger work are the stronger practical bottlenecks
+
+### 5. Backend scaling is still most visible on `base-apt`
+
+`base-apt` is still the clearest backend-stress case:
+
+- `solve_GN_rays`: `48.48 s`
+- `add_factors`: `19.67 s`
+- `torch.cuda.synchronize`: about `40.25 s` inside the backend profile
+
+So the older intuition about backend scaling was not wrong, but it was incomplete. The current picture is:
+
+- backend optimization is expensive on harder `base` runs
+- logger and frontend costs are still large enough that backend is not the whole story
 
 ## What Has Already Changed
 
 Several useful changes are already in the repo:
 
-- Deep frontend/backend benchmark instrumentation was added.
-- Full benchmark outputs were committed for `fast`, `base`, and no-logging variants.
-- A `--disable-logging` benchmark mode was added so logging cost can be isolated directly.
-- Keyframe pose logging was improved to use dirty updates rather than relogging every keyframe pose each frame.
+- Async logging moved expensive Rerun work off the tracking thread.
+- Backend camera refresh now uses lightweight pose-only refresh events instead of full dirty-keyframe snapshots.
+- Dirty keyframe pose updates are used instead of relogging all keyframe poses every frame.
+- The latest temporary profiler harness measured frontend, logger, and backend separately without modifying tracked files.
 
-These changes were enough to prove that logging overhead was real and to quantify its impact.
+## Updated Conclusions
 
-## Logging Optimization — Completed
+The old summary "`logging is no longer a bottleneck`" is too strong and should be considered outdated.
 
-Logging has been moved off the tracking critical path via `AsyncRerunLogger` (a dedicated background thread). See `async_logger.py` and `log_events.py`.
+The current picture is:
 
-Measured result on `example-base` (full video, 512px, live viewer):
-
-| Version | Wall time | Speedup |
-|---|---|---|
-| Synchronous logging | 12m17s | — |
-| Async logger thread | 4m30s | **2.73x** |
-
-What the async logger does:
-
-1. The pipeline thread creates lightweight CPU snapshots (frozen dataclass events) and enqueues them.
-2. The logger thread consumes events and does all the expensive work: JPEG compression, focal estimation, pointmap conversion, `rr.log()` calls.
-3. Current-frame events are droppable (viewer shows previous frame if the logger is behind). Structural events (new keyframes, pose updates, edges) are never dropped.
-4. The logger only logs keyframe image/pointcloud data once (on creation), and only updates poses when dirty.
-5. Blueprint is refreshed only when keyframe count changes.
-
-The implementation preserves the same viewer experience while supporting time-varying camera models (intrinsics are re-estimated per frame in the logger thread).
+- Async logging was a major win for frontend responsiveness.
+- Logging is still one of the largest total costs in the system.
+- The main remaining logging hotspot is the current-frame path, especially pointmap/depth/confidence work.
+- Frontend tracking inference is the other consistent top bottleneck.
+- Backend pair construction and Gauss-Newton are still expensive, especially on `base-apt`, but the backend is often idle and therefore not always the end-to-end limiter.
 
 ## Recommended Next Steps
 
-1. ~~Optimize the logging path first.~~ **Done.** See "Logging Optimization — Completed" above.
+1. Optimize current-frame logging first.
+   The highest-value targets are:
+   - current image logging
+   - current pointmap/depth/confidence logging
+   - last-keyframe 2D-panel relogging
 
-2. ~~Rerun the full logged benchmarks.~~ **Done.** The logged path now runs at 2.73x the sync baseline.
+2. Keep backend camera refresh lightweight.
+   The pose-only refresh path was the right direction and should not be regressed back to full dirty-keyframe replay.
 
-3. Focus on backend pair construction.
-   The first candidates are decoder-side improvements such as AMP/BF16, `torch.compile`, and reducing backend pair volume.
+3. Then focus on frontend tracking inference.
+   The main candidates are:
+   - decoder-side optimization
+   - AMP / BF16 where safe
+   - reducing expensive per-frame model work
 
-4. Then reduce backend optimization scaling.
-   The main candidates are sliding-window or local-subgraph optimization and solving less often.
+4. After that, optimize backend scaling on the hardest runs.
+   The main candidates are:
+   - reduce pair volume
+   - reduce solve frequency
+   - local/sliding-window optimization
+   - investigate backend synchronization overhead on `base-apt`
 
 ## Bottom Line
 
-If you are looking at MASt3R-SLAM performance for the first time, the current picture is:
+If you are looking at MASt3R-SLAM performance today, the most accurate short summary is:
 
-- Logging has been moved to an async background thread and is no longer a bottleneck.
-- The main remaining bottleneck is backend scaling: decoder-heavy pair construction and global optimization on larger maps.
+- async logging fixed the worst synchronous frontend blockage
+- the logger is still expensive, especially for current-frame map visualization
+- frontend tracking inference is still a major cost
+- backend optimization matters, but it is not the only bottleneck and is often not the immediate throughput limiter

--- a/packages/mast3r-slam/mast3r_slam/api/inference.py
+++ b/packages/mast3r-slam/mast3r_slam/api/inference.py
@@ -386,7 +386,7 @@ def run_slam_pipeline(
             # ── Async logging: create events and enqueue ──────────────────
             # 1. Collect structural changes (non-droppable)
             new_kfs: list[KeyframeSnapshot] = []
-            pose_updates: list[tuple[int, Float32[ndarray, "8"]]] = []
+            updated_keyframes: list[KeyframeSnapshot] = []
             edge_pos: tuple[Float32[ndarray, "n 3"], Float32[ndarray, "n 3"]] | None = None
             orient_data: tuple[Float32[ndarray, "3 3"], Float32[ndarray, "3"]] | None = None
 
@@ -401,17 +401,14 @@ def run_slam_pipeline(
                     kf_idx_dirty: int = int(idx_val)
                     if new_kf_idx is not None and kf_idx_dirty == new_kf_idx:
                         continue
-                    sim3_cpu: Float32[ndarray, "8"] = (
-                        keyframes.world_sim3_cam[kf_idx_dirty, 0].cpu().numpy().astype(np.float32)
-                    )
-                    pose_updates.append((kf_idx_dirty, sim3_cpu))
+                    updated_keyframes.append(snapshot_keyframe(keyframes[kf_idx_dirty], kf_idx_dirty))
 
             # Edge update: resnapshot when edge count changes OR when poses
             # were refined (global optimization moves endpoints without
             # adding/removing factors).
             with states.lock:
                 current_edge_count: int = len(states.edges_ii)
-            if current_edge_count != prev_edge_count or pose_updates:
+            if current_edge_count != prev_edge_count or updated_keyframes:
                 edge_pos = snapshot_edges(states, keyframes)
                 prev_edge_count = current_edge_count
 
@@ -422,10 +419,10 @@ def run_slam_pipeline(
                 orient_data = compute_orient(keyframes, n_kf)
                 last_orient_n_kf = n_kf
 
-            if new_kfs or pose_updates or edge_pos is not None or orient_data is not None:
+            if new_kfs or updated_keyframes or edge_pos is not None or orient_data is not None:
                 event_queue.put(LogMapUpdate(
                     frame_idx=i, timestamp_ns=ts_ns,
-                    new_keyframes=new_kfs, pose_updates=pose_updates,
+                    new_keyframes=new_kfs, updated_keyframes=updated_keyframes,
                     edge_positions=edge_pos, orient=orient_data,
                 ))
 

--- a/packages/mast3r-slam/mast3r_slam/api/inference.py
+++ b/packages/mast3r-slam/mast3r_slam/api/inference.py
@@ -386,7 +386,7 @@ def run_slam_pipeline(
             # ── Async logging: create events and enqueue ──────────────────
             # 1. Collect structural changes (non-droppable)
             new_kfs: list[KeyframeSnapshot] = []
-            updated_keyframes: list[KeyframeSnapshot] = []
+            pose_updates: list[tuple[int, Float32[ndarray, "8"]]] = []
             edge_pos: tuple[Float32[ndarray, "n 3"], Float32[ndarray, "n 3"]] | None = None
             orient_data: tuple[Float32[ndarray, "3 3"], Float32[ndarray, "3"]] | None = None
 
@@ -401,14 +401,17 @@ def run_slam_pipeline(
                     kf_idx_dirty: int = int(idx_val)
                     if new_kf_idx is not None and kf_idx_dirty == new_kf_idx:
                         continue
-                    updated_keyframes.append(snapshot_keyframe(keyframes[kf_idx_dirty], kf_idx_dirty))
+                    sim3_cpu: Float32[ndarray, "8"] = (
+                        keyframes.world_sim3_cam[kf_idx_dirty, 0].cpu().numpy().astype(np.float32)
+                    )
+                    pose_updates.append((kf_idx_dirty, sim3_cpu))
 
             # Edge update: resnapshot when edge count changes OR when poses
             # were refined (global optimization moves endpoints without
             # adding/removing factors).
             with states.lock:
                 current_edge_count: int = len(states.edges_ii)
-            if current_edge_count != prev_edge_count or updated_keyframes:
+            if current_edge_count != prev_edge_count or pose_updates:
                 edge_pos = snapshot_edges(states, keyframes)
                 prev_edge_count = current_edge_count
 
@@ -419,10 +422,10 @@ def run_slam_pipeline(
                 orient_data = compute_orient(keyframes, n_kf)
                 last_orient_n_kf = n_kf
 
-            if new_kfs or updated_keyframes or edge_pos is not None or orient_data is not None:
+            if new_kfs or pose_updates or edge_pos is not None or orient_data is not None:
                 event_queue.put(LogMapUpdate(
                     frame_idx=i, timestamp_ns=ts_ns,
-                    new_keyframes=new_kfs, updated_keyframes=updated_keyframes,
+                    new_keyframes=new_kfs, pose_updates=pose_updates,
                     edge_positions=edge_pos, orient=orient_data,
                 ))
 

--- a/packages/mast3r-slam/mast3r_slam/api/inference.py
+++ b/packages/mast3r-slam/mast3r_slam/api/inference.py
@@ -110,8 +110,6 @@ class InferenceConfig:
     """Path to the input dataset or video file."""
     config: str = "config/base.yaml"
     """Path to the SLAM config YAML file."""
-    save_as: str = "default"
-    """Subdirectory name for saving results under ``logs/``."""
     no_viz: bool = False
     """If True, skip launching visualisation processes."""
     img_size: Literal[224, 512] = 512
@@ -343,9 +341,9 @@ def run_slam_pipeline(
                     # Normal tracking: match this frame against the last keyframe,
                     # estimate its relative pose via Gauss-Newton, and decide
                     # whether the overlap is low enough to warrant a new keyframe.
-                    match_info: list
+                    _match_info: list
                     try_reloc: bool
-                    add_new_kf, match_info, try_reloc = tracker.track(frame)
+                    add_new_kf, _match_info, try_reloc = tracker.track(frame)
                     if try_reloc:
                         # Too few matches — tracking is lost, switch to reloc mode.
                         states.set_mode(Mode.RELOC)

--- a/packages/mast3r-slam/mast3r_slam/api/inference.py
+++ b/packages/mast3r-slam/mast3r_slam/api/inference.py
@@ -386,27 +386,29 @@ def run_slam_pipeline(
             # ── Async logging: create events and enqueue ──────────────────
             # 1. Collect structural changes (non-droppable)
             new_kfs: list[KeyframeSnapshot] = []
-            pose_updates: list[tuple[int, Float32[ndarray, "8"]]] = []
+            updated_keyframes: list[KeyframeSnapshot] = []
             edge_pos: tuple[Float32[ndarray, "n 3"], Float32[ndarray, "n 3"]] | None = None
             orient_data: tuple[Float32[ndarray, "3 3"], Float32[ndarray, "3"]] | None = None
 
+            new_kf_idx: int | None = None
             if add_new_kf:
-                new_kfs.append(snapshot_keyframe(frame, len(keyframes) - 1))
+                new_kf_idx = len(keyframes) - 1
+                new_kfs.append(snapshot_keyframe(frame, new_kf_idx))
 
             dirty_idx: Int[Tensor, "n_dirty"] = keyframes.get_dirty_idx()
             if dirty_idx.numel() > 0:
                 for idx_val in dirty_idx.tolist():
-                    sim3_cpu: Float32[ndarray, "8"] = (
-                        keyframes.world_sim3_cam[idx_val, 0].cpu().numpy().astype(np.float32)
-                    )
-                    pose_updates.append((int(idx_val), sim3_cpu))
+                    kf_idx_dirty: int = int(idx_val)
+                    if new_kf_idx is not None and kf_idx_dirty == new_kf_idx:
+                        continue
+                    updated_keyframes.append(snapshot_keyframe(keyframes[kf_idx_dirty], kf_idx_dirty))
 
             # Edge update: resnapshot when edge count changes OR when poses
             # were refined (global optimization moves endpoints without
             # adding/removing factors).
             with states.lock:
                 current_edge_count: int = len(states.edges_ii)
-            if current_edge_count != prev_edge_count or pose_updates:
+            if current_edge_count != prev_edge_count or updated_keyframes:
                 edge_pos = snapshot_edges(states, keyframes)
                 prev_edge_count = current_edge_count
 
@@ -417,10 +419,10 @@ def run_slam_pipeline(
                 orient_data = compute_orient(keyframes, n_kf)
                 last_orient_n_kf = n_kf
 
-            if new_kfs or pose_updates or edge_pos is not None or orient_data is not None:
+            if new_kfs or updated_keyframes or edge_pos is not None or orient_data is not None:
                 event_queue.put(LogMapUpdate(
                     frame_idx=i, timestamp_ns=ts_ns,
-                    new_keyframes=new_kfs, pose_updates=pose_updates,
+                    new_keyframes=new_kfs, updated_keyframes=updated_keyframes,
                     edge_positions=edge_pos, orient=orient_data,
                 ))
 
@@ -571,7 +573,10 @@ def relocalization(
                 rr.log("/world/logs", rr.TextLog("Relocalized successfully", level="INFO"))
                 successful_loop_closure = True
                 # Copy the pose from the matched keyframe as initial estimate.
-                keyframes.world_sim3_cam[n_kf - 1] = keyframes.world_sim3_cam[kf_idx[0]].clone()
+                keyframes.update_world_sim3_cams(
+                    lietorch.Sim3(keyframes.world_sim3_cam[kf_idx[0]].clone()),
+                    torch.tensor([n_kf - 1], device=keyframes.world_sim3_cam.device, dtype=torch.long),
+                )
             else:
                 keyframes.pop_last()
                 rr.log("/world/logs", rr.TextLog("Failed to relocalize", level="WARN"))

--- a/packages/mast3r-slam/mast3r_slam/async_logger.py
+++ b/packages/mast3r-slam/mast3r_slam/async_logger.py
@@ -90,6 +90,8 @@ def snapshot_current_frame(
     last_kf_rgb: Float32[ndarray, "H W 3"] | None = None
     last_kf_X_canon: Float32[ndarray, "hw 3"] | None = None
     last_kf_C: Float32[ndarray, "hw 1"] | None = None
+    # Track keyframe identity separately so the logger can skip redundant
+    # /last_keyframe RGB relogs when only its map/confidence changed.
     last_kf_idx: int | None = None
     if keyframes is not None:
         with keyframes.lock:
@@ -411,6 +413,7 @@ class AsyncRerunLogger:
         color_model: rr.ColorModel,
         channel_datatype: rr.datatypes.ChannelDatatype,
     ) -> None:
+        # Log static image metadata once so per-frame updates only send buffers.
         if image_path in self._logged_image_formats:
             return
         rr.log(
@@ -428,6 +431,7 @@ class AsyncRerunLogger:
         self._logged_image_formats.add(image_path)
 
     def _ensure_depth_format(self, depth_path: str, *, width: int, height: int, meter: float = 1000.0) -> None:
+        # Same idea as _ensure_image_format(), but for depth images.
         if depth_path in self._logged_image_formats:
             return
         rr.log(
@@ -457,6 +461,8 @@ class AsyncRerunLogger:
         )
         rr.log(
             image_path,
+            # Buffer-only updates benchmarked better than rebuilding/compressing
+            # full Image archetypes every frame.
             rr.Image.from_fields(buffer=rgb_uint8.reshape(-1)),
         )
         return rgb_uint8
@@ -535,6 +541,8 @@ class AsyncRerunLogger:
             channel_datatype=rr.datatypes.ChannelDatatype.U8,
         )
 
+        # Keep the same logged content, but reuse the static formats above so
+        # each frame only ships raw buffers.
         rr.log(pointmap_path, rr.Image.from_fields(buffer=pointmap_uint8.reshape(-1)))
         rr.log(depth_path, rr.DepthImage.from_fields(buffer=depth_uint16_mm.view(np.uint8).reshape(-1)))
         rr.log(confidence_path, rr.Image.from_fields(buffer=confidence_uint8.reshape(-1)))
@@ -590,6 +598,8 @@ class AsyncRerunLogger:
         if event.last_kf_rgb is not None:
             lk_path: str = f"{self._parent_log_path}/last_keyframe"
             if event.last_kf_idx != self._last_kf_idx:
+                # RGB is static for a given keyframe; only resend it when the
+                # "last keyframe" identity changes.
                 self._log_rgb_image(lk_path, event.last_kf_rgb)
             if event.last_kf_X_canon is not None and event.last_kf_C is not None:
                 h_lk: int = event.last_kf_rgb.shape[0]
@@ -713,6 +723,8 @@ class AsyncRerunLogger:
             frame_id=kf_idx,
         )
         extrinsics = frame_to_extrinsics(frame)
+        # Backend pose refinement only changes the camera transform; relogging
+        # the full pinhole stack was correct but measurably slower.
         rr.log(
             kf_cam_log_path,
             rr.Transform3D(

--- a/packages/mast3r-slam/mast3r_slam/async_logger.py
+++ b/packages/mast3r-slam/mast3r_slam/async_logger.py
@@ -514,9 +514,9 @@ class AsyncRerunLogger:
         for kf_snapshot in event.new_keyframes:
             self._log_new_keyframe(kf_snapshot)
 
-        # Pose updates from backend
-        for kf_idx, world_sim3_cam_data in event.pose_updates:
-            self._log_pose_update(kf_idx, world_sim3_cam_data)
+        # Dirty keyframes from backend updates
+        for keyframe in event.updated_keyframes:
+            self._relog_keyframe_camera(keyframe)
 
         # Factor graph edges
         if event.edge_positions is not None:
@@ -599,37 +599,23 @@ class AsyncRerunLogger:
             kf.img_shape[0], kf.img_shape[1],
         )
 
-    def _log_pose_update(self, kf_idx: int, world_sim3_cam_data: Float32[ndarray, "8"]) -> None:
-        """Update a keyframe's camera transform after backend refinement."""
-        kf_cam_log_path: str = f"{self._parent_log_path}/keyframes/keyframe-{kf_idx}"
+    def _relog_keyframe_camera(self, kf: KeyframeSnapshot) -> None:
+        """Replay the full keyframe camera update after backend refinement."""
+        kf_cam_log_path: str = f"{self._parent_log_path}/keyframes/keyframe-{kf.kf_idx}"
 
-        # Reconstruct pose only (no X_canon needed for just the transform)
         frame: Frame = snapshot_to_frame(
-            world_sim3_cam_data,
-            rgb=np.zeros((1, 1, 3), dtype=np.float32),
-            X_canon=None, C=None,
-            img_shape=(1, 1),
-            frame_id=kf_idx,
+            kf.world_sim3_cam_data, kf.rgb, kf.X_canon, kf.C,
+            kf.img_shape, frame_id=kf.kf_idx,
+        )
+        pinhole = frame_to_pinhole(frame)
+        log_pinhole(
+            camera=pinhole,
+            cam_log_path=Path(kf_cam_log_path),
+            image_plane_distance=self._image_plane_distance,
         )
 
-        # We need X_canon for focal estimation in frame_to_pinhole, but
-        # for pose-only updates we use frame_to_extrinsics directly and
-        # skip intrinsics (the camera image/focal was logged once in
-        # _log_new_keyframe and doesn't change).
-        extrinsics = frame_to_extrinsics(frame)
-        # Log only the transform, not the full pinhole
-        assert extrinsics.world_R_cam is not None
-        assert extrinsics.world_t_cam is not None
-        assert extrinsics.cam_R_world is not None
-        assert extrinsics.cam_t_world is not None
-        rr.log(
-            kf_cam_log_path,
-            rr.Transform3D(
-                mat3x3=extrinsics.cam_R_world,
-                translation=extrinsics.cam_t_world,
-                from_parent=True,
-            ),
-        )
+        if kf.kf_idx == self._last_kf_idx:
+            self._log_last_keyframe(kf)
 
     def _log_edges(
         self,

--- a/packages/mast3r-slam/mast3r_slam/async_logger.py
+++ b/packages/mast3r-slam/mast3r_slam/async_logger.py
@@ -32,7 +32,6 @@ import rerun as rr
 import torch
 from jaxtyping import Bool, Float, Float32, Int, UInt8, UInt16
 from numpy import ndarray
-from simplecv.camera_parameters import PinholeParameters
 from simplecv.camera_orient_utils import auto_orient_and_center_poses
 from simplecv.rerun_log_utils import log_pinhole
 from torch import Tensor
@@ -90,13 +89,7 @@ def snapshot_current_frame(
     last_kf_rgb: Float32[ndarray, "H W 3"] | None = None
     last_kf_X_canon: Float32[ndarray, "hw 3"] | None = None
     last_kf_C: Float32[ndarray, "hw 1"] | None = None
-    # Track keyframe identity separately so the logger can skip redundant
-    # /last_keyframe RGB relogs when only its map/confidence changed.
-    last_kf_idx: int | None = None
     if keyframes is not None:
-        with keyframes.lock:
-            if len(keyframes) > 0:
-                last_kf_idx = len(keyframes) - 1
         last_kf: Frame | None = keyframes.last_keyframe()
         if last_kf is not None:
             last_kf_rgb = last_kf.rgb.numpy().astype(np.float32)
@@ -116,7 +109,6 @@ def snapshot_current_frame(
         last_kf_rgb=last_kf_rgb,
         last_kf_X_canon=last_kf_X_canon,
         last_kf_C=last_kf_C,
-        last_kf_idx=last_kf_idx,
     )
 
 
@@ -286,8 +278,6 @@ class AsyncRerunLogger:
         # Internal visualization state
         self._path_list: list[list[float]] = []
         self._logged_keyframes: set[int] = set()
-        self._keyframe_pinhole_static: dict[int, PinholeParameters] = {}
-        self._logged_image_formats: set[str] = set()
         self._last_kf_idx: int = -1
         self._last_blueprint_n_kf: int = -1
         self._n_keyframes: int = 0
@@ -404,66 +394,12 @@ class AsyncRerunLogger:
 
     # ── Image helpers ─────────────────────────────────────────────────
 
-    def _ensure_image_format(
-        self,
-        image_path: str,
-        *,
-        width: int,
-        height: int,
-        color_model: rr.ColorModel,
-        channel_datatype: rr.datatypes.ChannelDatatype,
-    ) -> None:
-        # Log static image metadata once so per-frame updates only send buffers.
-        if image_path in self._logged_image_formats:
-            return
-        rr.log(
-            image_path,
-            rr.Image.from_fields(
-                format=rr.components.ImageFormat(
-                    width=width,
-                    height=height,
-                    color_model=color_model,
-                    channel_datatype=channel_datatype,
-                ),
-            ),
-            static=True,
-        )
-        self._logged_image_formats.add(image_path)
-
-    def _ensure_depth_format(self, depth_path: str, *, width: int, height: int, meter: float = 1000.0) -> None:
-        # Same idea as _ensure_image_format(), but for depth images.
-        if depth_path in self._logged_image_formats:
-            return
-        rr.log(
-            depth_path,
-            rr.DepthImage.from_fields(
-                format=rr.components.ImageFormat(
-                    width=width,
-                    height=height,
-                    color_model=rr.ColorModel.L,
-                    channel_datatype=rr.datatypes.ChannelDatatype.U16,
-                ),
-                meter=meter,
-            ),
-            static=True,
-        )
-        self._logged_image_formats.add(depth_path)
-
     def _log_rgb_image(self, image_path: str, rgb: Float32[ndarray, "H W 3"]) -> UInt8[ndarray, "H W 3"]:
-        """Convert [0,1] float RGB to uint8 and log via buffer-only updates."""
+        """Convert [0,1] float RGB to uint8, JPEG-compress, and log."""
         rgb_uint8: UInt8[ndarray, "H W 3"] = (rgb * 255).astype(np.uint8)
-        self._ensure_image_format(
-            image_path,
-            width=rgb_uint8.shape[1],
-            height=rgb_uint8.shape[0],
-            color_model=rr.ColorModel.RGB,
-            channel_datatype=rr.datatypes.ChannelDatatype.U8,
-        )
         rr.log(
             image_path,
-            # Buffer-only updates benchmarked better than rebuilding/compressing
-            # full Image archetypes every frame.
-            rr.Image.from_fields(buffer=rgb_uint8.reshape(-1)),
+            rr.Image(image=rgb_uint8, color_model=rr.ColorModel.RGB).compress(jpeg_quality=75),
         )
         return rgb_uint8
 
@@ -486,14 +422,15 @@ class AsyncRerunLogger:
         depth_mm: Float32[ndarray, "H W"] = np.clip(depth_meters * 1000.0, 0.0, float(np.iinfo(np.uint16).max))
         return depth_mm.astype(np.uint16)
 
-    def _prepare_pointmap_and_confidence_buffers(
+    def _log_pointmap_and_confidence(
         self,
         X_canon: Float32[ndarray, "hw 3"],
         C: Float32[ndarray, "hw 1"],
+        log_path: str,
         height: int,
         width: int,
-    ) -> tuple[UInt8[ndarray, "H W 3"], UInt16[ndarray, "H W"], UInt8[ndarray, "H W"]]:
-        """Prepare pointmap/depth/confidence visualization buffers."""
+    ) -> None:
+        """Log pointmap depth, pointmap image, and confidence to Rerun."""
         pointmap_hw3: Float32[ndarray, "H W 3"] = X_canon.reshape(height, width, 3).astype(np.float32)
         pointmap_hw3 = np.nan_to_num(pointmap_hw3, nan=0.0, posinf=0.0, neginf=0.0)
         depth_hw: Float32[ndarray, "H W"] = np.maximum(pointmap_hw3[..., 2], 0.0)
@@ -506,46 +443,9 @@ class AsyncRerunLogger:
         pointmap_uint8: UInt8[ndarray, "H W 3"] = self._normalize_to_uint8(pointmap_hw3)
         depth_uint16_mm: UInt16[ndarray, "H W"] = self._depth_meters_to_uint16_mm(filtered_depth_hw)
 
-        return pointmap_uint8, depth_uint16_mm, confidence_uint8
-
-    def _log_pointmap_and_confidence(
-        self,
-        X_canon: Float32[ndarray, "hw 3"],
-        C: Float32[ndarray, "hw 1"],
-        log_path: str,
-        height: int,
-        width: int,
-    ) -> None:
-        """Log pointmap depth, pointmap image, and confidence to Rerun."""
-        pointmap_uint8, depth_uint16_mm, confidence_uint8 = self._prepare_pointmap_and_confidence_buffers(
-            X_canon, C, height, width,
-        )
-
-        pointmap_path = f"{log_path}/pointmap"
-        depth_path = f"{log_path}/pointmap_depth"
-        confidence_path = f"{log_path}/confidence"
-
-        self._ensure_image_format(
-            pointmap_path,
-            width=width,
-            height=height,
-            color_model=rr.ColorModel.RGB,
-            channel_datatype=rr.datatypes.ChannelDatatype.U8,
-        )
-        self._ensure_depth_format(depth_path, width=width, height=height)
-        self._ensure_image_format(
-            confidence_path,
-            width=width,
-            height=height,
-            color_model=rr.ColorModel.L,
-            channel_datatype=rr.datatypes.ChannelDatatype.U8,
-        )
-
-        # Keep the same logged content, but reuse the static formats above so
-        # each frame only ships raw buffers.
-        rr.log(pointmap_path, rr.Image.from_fields(buffer=pointmap_uint8.reshape(-1)))
-        rr.log(depth_path, rr.DepthImage.from_fields(buffer=depth_uint16_mm.view(np.uint8).reshape(-1)))
-        rr.log(confidence_path, rr.Image.from_fields(buffer=confidence_uint8.reshape(-1)))
+        rr.log(f"{log_path}/pointmap", rr.Image(pointmap_uint8, color_model=rr.ColorModel.RGB).compress())
+        rr.log(f"{log_path}/pointmap_depth", rr.DepthImage(depth_uint16_mm, meter=1000.0).compress())
+        rr.log(f"{log_path}/confidence", rr.Image(confidence_uint8, color_model=rr.ColorModel.L).compress())
 
     # ── Event handlers ────────────────────────────────────────────────
 
@@ -597,10 +497,7 @@ class AsyncRerunLogger:
         # active keyframe's pointmap/confidence, so relog it every frame.
         if event.last_kf_rgb is not None:
             lk_path: str = f"{self._parent_log_path}/last_keyframe"
-            if event.last_kf_idx != self._last_kf_idx:
-                # RGB is static for a given keyframe; only resend it when the
-                # "last keyframe" identity changes.
-                self._log_rgb_image(lk_path, event.last_kf_rgb)
+            self._log_rgb_image(lk_path, event.last_kf_rgb)
             if event.last_kf_X_canon is not None and event.last_kf_C is not None:
                 h_lk: int = event.last_kf_rgb.shape[0]
                 w_lk: int = event.last_kf_rgb.shape[1]
@@ -617,9 +514,9 @@ class AsyncRerunLogger:
         for kf_snapshot in event.new_keyframes:
             self._log_new_keyframe(kf_snapshot)
 
-        # Dirty keyframe pose updates from backend
-        for kf_idx, world_sim3_cam_data in event.pose_updates:
-            self._relog_keyframe_camera(kf_idx, world_sim3_cam_data)
+        # Dirty keyframes from backend updates
+        for keyframe in event.updated_keyframes:
+            self._relog_keyframe_camera(keyframe)
 
         # Factor graph edges
         if event.edge_positions is not None:
@@ -663,11 +560,6 @@ class AsyncRerunLogger:
             cam_log_path=Path(kf_cam_log_path),
             image_plane_distance=self._image_plane_distance,
         )
-        self._keyframe_pinhole_static[kf.kf_idx] = PinholeParameters(
-            name=pinhole.name,
-            extrinsics=pinhole.extrinsics,
-            intrinsics=pinhole.intrinsics,
-        )
 
         # RGB image
         kf_rgb_uint8: UInt8[ndarray, "H W 3"] = self._log_rgb_image(
@@ -707,32 +599,23 @@ class AsyncRerunLogger:
             kf.img_shape[0], kf.img_shape[1],
         )
 
-    def _relog_keyframe_camera(self, kf_idx: int, world_sim3_cam_data: Float32[ndarray, "8"]) -> None:
-        """Replay a keyframe transform update after backend refinement."""
-        kf_cam_log_path: str = f"{self._parent_log_path}/keyframes/keyframe-{kf_idx}"
-        cached_pinhole: PinholeParameters | None = self._keyframe_pinhole_static.get(kf_idx)
-        if cached_pinhole is None:
-            return
+    def _relog_keyframe_camera(self, kf: KeyframeSnapshot) -> None:
+        """Replay the full keyframe camera update after backend refinement."""
+        kf_cam_log_path: str = f"{self._parent_log_path}/keyframes/keyframe-{kf.kf_idx}"
 
         frame: Frame = snapshot_to_frame(
-            world_sim3_cam_data,
-            rgb=np.zeros((1, 1, 3), dtype=np.float32),
-            X_canon=None,
-            C=None,
-            img_shape=(1, 1),
-            frame_id=kf_idx,
+            kf.world_sim3_cam_data, kf.rgb, kf.X_canon, kf.C,
+            kf.img_shape, frame_id=kf.kf_idx,
         )
-        extrinsics = frame_to_extrinsics(frame)
-        # Backend pose refinement only changes the camera transform; relogging
-        # the full pinhole stack was correct but measurably slower.
-        rr.log(
-            kf_cam_log_path,
-            rr.Transform3D(
-                translation=extrinsics.cam_t_world,
-                mat3x3=extrinsics.cam_R_world,
-                from_parent=True,
-            ),
+        pinhole = frame_to_pinhole(frame)
+        log_pinhole(
+            camera=pinhole,
+            cam_log_path=Path(kf_cam_log_path),
+            image_plane_distance=self._image_plane_distance,
         )
+
+        if kf.kf_idx == self._last_kf_idx:
+            self._log_last_keyframe(kf)
 
     def _log_edges(
         self,

--- a/packages/mast3r-slam/mast3r_slam/async_logger.py
+++ b/packages/mast3r-slam/mast3r_slam/async_logger.py
@@ -90,7 +90,11 @@ def snapshot_current_frame(
     last_kf_rgb: Float32[ndarray, "H W 3"] | None = None
     last_kf_X_canon: Float32[ndarray, "hw 3"] | None = None
     last_kf_C: Float32[ndarray, "hw 1"] | None = None
+    last_kf_idx: int | None = None
     if keyframes is not None:
+        with keyframes.lock:
+            if len(keyframes) > 0:
+                last_kf_idx = len(keyframes) - 1
         last_kf: Frame | None = keyframes.last_keyframe()
         if last_kf is not None:
             last_kf_rgb = last_kf.rgb.numpy().astype(np.float32)
@@ -110,6 +114,7 @@ def snapshot_current_frame(
         last_kf_rgb=last_kf_rgb,
         last_kf_X_canon=last_kf_X_canon,
         last_kf_C=last_kf_C,
+        last_kf_idx=last_kf_idx,
     )
 
 
@@ -280,6 +285,7 @@ class AsyncRerunLogger:
         self._path_list: list[list[float]] = []
         self._logged_keyframes: set[int] = set()
         self._keyframe_pinhole_static: dict[int, PinholeParameters] = {}
+        self._logged_image_formats: set[str] = set()
         self._last_kf_idx: int = -1
         self._last_blueprint_n_kf: int = -1
         self._n_keyframes: int = 0
@@ -396,12 +402,62 @@ class AsyncRerunLogger:
 
     # ── Image helpers ─────────────────────────────────────────────────
 
-    def _log_rgb_image(self, image_path: str, rgb: Float32[ndarray, "H W 3"]) -> UInt8[ndarray, "H W 3"]:
-        """Convert [0,1] float RGB to uint8, JPEG-compress, and log."""
-        rgb_uint8: UInt8[ndarray, "H W 3"] = (rgb * 255).astype(np.uint8)
+    def _ensure_image_format(
+        self,
+        image_path: str,
+        *,
+        width: int,
+        height: int,
+        color_model: rr.ColorModel,
+        channel_datatype: rr.datatypes.ChannelDatatype,
+    ) -> None:
+        if image_path in self._logged_image_formats:
+            return
         rr.log(
             image_path,
-            rr.Image(image=rgb_uint8, color_model=rr.ColorModel.RGB).compress(jpeg_quality=75),
+            rr.Image.from_fields(
+                format=rr.components.ImageFormat(
+                    width=width,
+                    height=height,
+                    color_model=color_model,
+                    channel_datatype=channel_datatype,
+                ),
+            ),
+            static=True,
+        )
+        self._logged_image_formats.add(image_path)
+
+    def _ensure_depth_format(self, depth_path: str, *, width: int, height: int, meter: float = 1000.0) -> None:
+        if depth_path in self._logged_image_formats:
+            return
+        rr.log(
+            depth_path,
+            rr.DepthImage.from_fields(
+                format=rr.components.ImageFormat(
+                    width=width,
+                    height=height,
+                    color_model=rr.ColorModel.L,
+                    channel_datatype=rr.datatypes.ChannelDatatype.U16,
+                ),
+                meter=meter,
+            ),
+            static=True,
+        )
+        self._logged_image_formats.add(depth_path)
+
+    def _log_rgb_image(self, image_path: str, rgb: Float32[ndarray, "H W 3"]) -> UInt8[ndarray, "H W 3"]:
+        """Convert [0,1] float RGB to uint8 and log via buffer-only updates."""
+        rgb_uint8: UInt8[ndarray, "H W 3"] = (rgb * 255).astype(np.uint8)
+        self._ensure_image_format(
+            image_path,
+            width=rgb_uint8.shape[1],
+            height=rgb_uint8.shape[0],
+            color_model=rr.ColorModel.RGB,
+            channel_datatype=rr.datatypes.ChannelDatatype.U8,
+        )
+        rr.log(
+            image_path,
+            rr.Image.from_fields(buffer=rgb_uint8.reshape(-1)),
         )
         return rgb_uint8
 
@@ -424,15 +480,14 @@ class AsyncRerunLogger:
         depth_mm: Float32[ndarray, "H W"] = np.clip(depth_meters * 1000.0, 0.0, float(np.iinfo(np.uint16).max))
         return depth_mm.astype(np.uint16)
 
-    def _log_pointmap_and_confidence(
+    def _prepare_pointmap_and_confidence_buffers(
         self,
         X_canon: Float32[ndarray, "hw 3"],
         C: Float32[ndarray, "hw 1"],
-        log_path: str,
         height: int,
         width: int,
-    ) -> None:
-        """Log pointmap depth, pointmap image, and confidence to Rerun."""
+    ) -> tuple[UInt8[ndarray, "H W 3"], UInt16[ndarray, "H W"], UInt8[ndarray, "H W"]]:
+        """Prepare pointmap/depth/confidence visualization buffers."""
         pointmap_hw3: Float32[ndarray, "H W 3"] = X_canon.reshape(height, width, 3).astype(np.float32)
         pointmap_hw3 = np.nan_to_num(pointmap_hw3, nan=0.0, posinf=0.0, neginf=0.0)
         depth_hw: Float32[ndarray, "H W"] = np.maximum(pointmap_hw3[..., 2], 0.0)
@@ -445,9 +500,44 @@ class AsyncRerunLogger:
         pointmap_uint8: UInt8[ndarray, "H W 3"] = self._normalize_to_uint8(pointmap_hw3)
         depth_uint16_mm: UInt16[ndarray, "H W"] = self._depth_meters_to_uint16_mm(filtered_depth_hw)
 
-        rr.log(f"{log_path}/pointmap", rr.Image(pointmap_uint8, color_model=rr.ColorModel.RGB).compress())
-        rr.log(f"{log_path}/pointmap_depth", rr.DepthImage(depth_uint16_mm, meter=1000.0).compress())
-        rr.log(f"{log_path}/confidence", rr.Image(confidence_uint8, color_model=rr.ColorModel.L).compress())
+        return pointmap_uint8, depth_uint16_mm, confidence_uint8
+
+    def _log_pointmap_and_confidence(
+        self,
+        X_canon: Float32[ndarray, "hw 3"],
+        C: Float32[ndarray, "hw 1"],
+        log_path: str,
+        height: int,
+        width: int,
+    ) -> None:
+        """Log pointmap depth, pointmap image, and confidence to Rerun."""
+        pointmap_uint8, depth_uint16_mm, confidence_uint8 = self._prepare_pointmap_and_confidence_buffers(
+            X_canon, C, height, width,
+        )
+
+        pointmap_path = f"{log_path}/pointmap"
+        depth_path = f"{log_path}/pointmap_depth"
+        confidence_path = f"{log_path}/confidence"
+
+        self._ensure_image_format(
+            pointmap_path,
+            width=width,
+            height=height,
+            color_model=rr.ColorModel.RGB,
+            channel_datatype=rr.datatypes.ChannelDatatype.U8,
+        )
+        self._ensure_depth_format(depth_path, width=width, height=height)
+        self._ensure_image_format(
+            confidence_path,
+            width=width,
+            height=height,
+            color_model=rr.ColorModel.L,
+            channel_datatype=rr.datatypes.ChannelDatatype.U8,
+        )
+
+        rr.log(pointmap_path, rr.Image.from_fields(buffer=pointmap_uint8.reshape(-1)))
+        rr.log(depth_path, rr.DepthImage.from_fields(buffer=depth_uint16_mm.view(np.uint8).reshape(-1)))
+        rr.log(confidence_path, rr.Image.from_fields(buffer=confidence_uint8.reshape(-1)))
 
     # ── Event handlers ────────────────────────────────────────────────
 
@@ -499,7 +589,8 @@ class AsyncRerunLogger:
         # active keyframe's pointmap/confidence, so relog it every frame.
         if event.last_kf_rgb is not None:
             lk_path: str = f"{self._parent_log_path}/last_keyframe"
-            self._log_rgb_image(lk_path, event.last_kf_rgb)
+            if event.last_kf_idx != self._last_kf_idx:
+                self._log_rgb_image(lk_path, event.last_kf_rgb)
             if event.last_kf_X_canon is not None and event.last_kf_C is not None:
                 h_lk: int = event.last_kf_rgb.shape[0]
                 w_lk: int = event.last_kf_rgb.shape[1]
@@ -607,7 +698,7 @@ class AsyncRerunLogger:
         )
 
     def _relog_keyframe_camera(self, kf_idx: int, world_sim3_cam_data: Float32[ndarray, "8"]) -> None:
-        """Replay a keyframe camera update after backend refinement using cached intrinsics."""
+        """Replay a keyframe transform update after backend refinement."""
         kf_cam_log_path: str = f"{self._parent_log_path}/keyframes/keyframe-{kf_idx}"
         cached_pinhole: PinholeParameters | None = self._keyframe_pinhole_static.get(kf_idx)
         if cached_pinhole is None:
@@ -622,15 +713,13 @@ class AsyncRerunLogger:
             frame_id=kf_idx,
         )
         extrinsics = frame_to_extrinsics(frame)
-        pinhole = PinholeParameters(
-            name=cached_pinhole.name,
-            extrinsics=extrinsics,
-            intrinsics=cached_pinhole.intrinsics,
-        )
-        log_pinhole(
-            camera=pinhole,
-            cam_log_path=Path(kf_cam_log_path),
-            image_plane_distance=self._image_plane_distance,
+        rr.log(
+            kf_cam_log_path,
+            rr.Transform3D(
+                translation=extrinsics.cam_t_world,
+                mat3x3=extrinsics.cam_R_world,
+                from_parent=True,
+            ),
         )
 
     def _log_edges(

--- a/packages/mast3r-slam/mast3r_slam/async_logger.py
+++ b/packages/mast3r-slam/mast3r_slam/async_logger.py
@@ -280,7 +280,6 @@ class AsyncRerunLogger:
         self._path_list: list[list[float]] = []
         self._logged_keyframes: set[int] = set()
         self._keyframe_pinhole_static: dict[int, PinholeParameters] = {}
-        self._last_kf_idx: int = -1
         self._last_blueprint_n_kf: int = -1
         self._n_keyframes: int = 0
         self._conf_thresh: int = 7
@@ -294,7 +293,7 @@ class AsyncRerunLogger:
         self.start()
         return self
 
-    def __exit__(self, exc_type: type | None, exc_val: BaseException | None, exc_tb: object) -> None:
+    def __exit__(self, _exc_type: type | None, _exc_val: BaseException | None, _exc_tb: object) -> None:
         """Send LogTerminate, join the thread, and warn if it outlives the timeout."""
         # Use a bounded put so we don't deadlock if the logger thread
         # crashed and the queue is full.
@@ -610,8 +609,6 @@ class AsyncRerunLogger:
 
         # Update last-keyframe 2D view
         self._log_last_keyframe(kf)
-        self._last_kf_idx = kf.kf_idx
-
     def _log_last_keyframe(self, kf: KeyframeSnapshot) -> None:
         """Log the last keyframe's image and pointmap to the 2D view."""
         lk_path: str = f"{self._parent_log_path}/last_keyframe"

--- a/packages/mast3r-slam/mast3r_slam/async_logger.py
+++ b/packages/mast3r-slam/mast3r_slam/async_logger.py
@@ -32,6 +32,7 @@ import rerun as rr
 import torch
 from jaxtyping import Bool, Float, Float32, Int, UInt8, UInt16
 from numpy import ndarray
+from simplecv.camera_parameters import PinholeParameters
 from simplecv.camera_orient_utils import auto_orient_and_center_poses
 from simplecv.rerun_log_utils import log_pinhole
 from torch import Tensor
@@ -278,6 +279,7 @@ class AsyncRerunLogger:
         # Internal visualization state
         self._path_list: list[list[float]] = []
         self._logged_keyframes: set[int] = set()
+        self._keyframe_pinhole_static: dict[int, PinholeParameters] = {}
         self._last_kf_idx: int = -1
         self._last_blueprint_n_kf: int = -1
         self._n_keyframes: int = 0
@@ -514,9 +516,9 @@ class AsyncRerunLogger:
         for kf_snapshot in event.new_keyframes:
             self._log_new_keyframe(kf_snapshot)
 
-        # Dirty keyframes from backend updates
-        for keyframe in event.updated_keyframes:
-            self._relog_keyframe_camera(keyframe)
+        # Dirty keyframe pose updates from backend
+        for kf_idx, world_sim3_cam_data in event.pose_updates:
+            self._relog_keyframe_camera(kf_idx, world_sim3_cam_data)
 
         # Factor graph edges
         if event.edge_positions is not None:
@@ -560,6 +562,11 @@ class AsyncRerunLogger:
             cam_log_path=Path(kf_cam_log_path),
             image_plane_distance=self._image_plane_distance,
         )
+        self._keyframe_pinhole_static[kf.kf_idx] = PinholeParameters(
+            name=pinhole.name,
+            extrinsics=pinhole.extrinsics,
+            intrinsics=pinhole.intrinsics,
+        )
 
         # RGB image
         kf_rgb_uint8: UInt8[ndarray, "H W 3"] = self._log_rgb_image(
@@ -599,23 +606,32 @@ class AsyncRerunLogger:
             kf.img_shape[0], kf.img_shape[1],
         )
 
-    def _relog_keyframe_camera(self, kf: KeyframeSnapshot) -> None:
-        """Replay the full keyframe camera update after backend refinement."""
-        kf_cam_log_path: str = f"{self._parent_log_path}/keyframes/keyframe-{kf.kf_idx}"
+    def _relog_keyframe_camera(self, kf_idx: int, world_sim3_cam_data: Float32[ndarray, "8"]) -> None:
+        """Replay a keyframe camera update after backend refinement using cached intrinsics."""
+        kf_cam_log_path: str = f"{self._parent_log_path}/keyframes/keyframe-{kf_idx}"
+        cached_pinhole: PinholeParameters | None = self._keyframe_pinhole_static.get(kf_idx)
+        if cached_pinhole is None:
+            return
 
         frame: Frame = snapshot_to_frame(
-            kf.world_sim3_cam_data, kf.rgb, kf.X_canon, kf.C,
-            kf.img_shape, frame_id=kf.kf_idx,
+            world_sim3_cam_data,
+            rgb=np.zeros((1, 1, 3), dtype=np.float32),
+            X_canon=None,
+            C=None,
+            img_shape=(1, 1),
+            frame_id=kf_idx,
         )
-        pinhole = frame_to_pinhole(frame)
+        extrinsics = frame_to_extrinsics(frame)
+        pinhole = PinholeParameters(
+            name=cached_pinhole.name,
+            extrinsics=extrinsics,
+            intrinsics=cached_pinhole.intrinsics,
+        )
         log_pinhole(
             camera=pinhole,
             cam_log_path=Path(kf_cam_log_path),
             image_plane_distance=self._image_plane_distance,
         )
-
-        if kf.kf_idx == self._last_kf_idx:
-            self._log_last_keyframe(kf)
 
     def _log_edges(
         self,

--- a/packages/mast3r-slam/mast3r_slam/async_logger.py
+++ b/packages/mast3r-slam/mast3r_slam/async_logger.py
@@ -32,6 +32,7 @@ import rerun as rr
 import torch
 from jaxtyping import Bool, Float, Float32, Int, UInt8, UInt16
 from numpy import ndarray
+from simplecv.camera_parameters import PinholeParameters
 from simplecv.camera_orient_utils import auto_orient_and_center_poses
 from simplecv.rerun_log_utils import log_pinhole
 from torch import Tensor
@@ -278,6 +279,7 @@ class AsyncRerunLogger:
         # Internal visualization state
         self._path_list: list[list[float]] = []
         self._logged_keyframes: set[int] = set()
+        self._keyframe_pinhole_static: dict[int, PinholeParameters] = {}
         self._last_kf_idx: int = -1
         self._last_blueprint_n_kf: int = -1
         self._n_keyframes: int = 0
@@ -514,9 +516,9 @@ class AsyncRerunLogger:
         for kf_snapshot in event.new_keyframes:
             self._log_new_keyframe(kf_snapshot)
 
-        # Dirty keyframes from backend updates
-        for keyframe in event.updated_keyframes:
-            self._relog_keyframe_camera(keyframe)
+        # Dirty keyframe pose updates from backend
+        for kf_idx, world_sim3_cam_data in event.pose_updates:
+            self._relog_keyframe_camera(kf_idx, world_sim3_cam_data)
 
         # Factor graph edges
         if event.edge_positions is not None:
@@ -560,6 +562,11 @@ class AsyncRerunLogger:
             cam_log_path=Path(kf_cam_log_path),
             image_plane_distance=self._image_plane_distance,
         )
+        self._keyframe_pinhole_static[kf.kf_idx] = PinholeParameters(
+            name=pinhole.name,
+            extrinsics=pinhole.extrinsics,
+            intrinsics=pinhole.intrinsics,
+        )
 
         # RGB image
         kf_rgb_uint8: UInt8[ndarray, "H W 3"] = self._log_rgb_image(
@@ -599,23 +606,31 @@ class AsyncRerunLogger:
             kf.img_shape[0], kf.img_shape[1],
         )
 
-    def _relog_keyframe_camera(self, kf: KeyframeSnapshot) -> None:
-        """Replay the full keyframe camera update after backend refinement."""
-        kf_cam_log_path: str = f"{self._parent_log_path}/keyframes/keyframe-{kf.kf_idx}"
-
+    def _relog_keyframe_camera(self, kf_idx: int, world_sim3_cam_data: Float32[ndarray, "8"]) -> None:
+        """Replay a keyframe camera update after backend refinement using cached intrinsics."""
+        kf_cam_log_path: str = f"{self._parent_log_path}/keyframes/keyframe-{kf_idx}"
+        cached_pinhole: PinholeParameters | None = self._keyframe_pinhole_static.get(kf_idx)
+        if cached_pinhole is None:
+            return
         frame: Frame = snapshot_to_frame(
-            kf.world_sim3_cam_data, kf.rgb, kf.X_canon, kf.C,
-            kf.img_shape, frame_id=kf.kf_idx,
+            world_sim3_cam_data,
+            rgb=np.zeros((1, 1, 3), dtype=np.float32),
+            X_canon=None,
+            C=None,
+            img_shape=(1, 1),
+            frame_id=kf_idx,
         )
-        pinhole = frame_to_pinhole(frame)
+        extrinsics = frame_to_extrinsics(frame)
+        pinhole = PinholeParameters(
+            name=cached_pinhole.name,
+            extrinsics=extrinsics,
+            intrinsics=cached_pinhole.intrinsics,
+        )
         log_pinhole(
             camera=pinhole,
             cam_log_path=Path(kf_cam_log_path),
             image_plane_distance=self._image_plane_distance,
         )
-
-        if kf.kf_idx == self._last_kf_idx:
-            self._log_last_keyframe(kf)
 
     def _log_edges(
         self,

--- a/packages/mast3r-slam/mast3r_slam/async_logger.py
+++ b/packages/mast3r-slam/mast3r_slam/async_logger.py
@@ -32,8 +32,8 @@ import rerun as rr
 import torch
 from jaxtyping import Bool, Float, Float32, Int, UInt8, UInt16
 from numpy import ndarray
-from simplecv.camera_parameters import PinholeParameters
 from simplecv.camera_orient_utils import auto_orient_and_center_poses
+from simplecv.camera_parameters import PinholeParameters
 from simplecv.rerun_log_utils import log_pinhole
 from torch import Tensor
 
@@ -304,8 +304,7 @@ class AsyncRerunLogger:
             # Queue is stuck — the logger thread is likely dead.
             if self._error is not None:
                 warnings.warn(
-                    f"Async logger thread crashed: {self._error}. "
-                    f"{self._queue.qsize()} events were not processed.",
+                    f"Async logger thread crashed: {self._error}. {self._queue.qsize()} events were not processed.",
                     stacklevel=2,
                 )
             return
@@ -457,8 +456,12 @@ class AsyncRerunLogger:
 
         # Reconstruct Frame for frame_to_pinhole()
         frame: Frame = snapshot_to_frame(
-            event.world_sim3_cam_data, event.rgb, event.X_canon, event.C,
-            event.img_shape, frame_id=event.frame_idx,
+            event.world_sim3_cam_data,
+            event.rgb,
+            event.X_canon,
+            event.C,
+            event.img_shape,
+            frame_id=event.frame_idx,
         )
 
         cam_log_path: str = f"{self._parent_log_path}/current_camera"
@@ -471,15 +474,18 @@ class AsyncRerunLogger:
 
         # RGB image
         rgb_uint8: UInt8[ndarray, "H W 3"] = self._log_rgb_image(
-            f"{cam_log_path}/pinhole/image", event.rgb,
+            f"{cam_log_path}/pinhole/image",
+            event.rgb,
         )
 
         # Pointmap, depth, confidence
         if event.X_canon is not None and event.C is not None:
             self._log_pointmap_and_confidence(
-                event.X_canon, event.C,
+                event.X_canon,
+                event.C,
                 f"{cam_log_path}/pinhole",
-                rgb_uint8.shape[0], rgb_uint8.shape[1],
+                rgb_uint8.shape[0],
+                rgb_uint8.shape[1],
             )
 
         # Camera path
@@ -504,8 +510,11 @@ class AsyncRerunLogger:
                 h_lk: int = event.last_kf_rgb.shape[0]
                 w_lk: int = event.last_kf_rgb.shape[1]
                 self._log_pointmap_and_confidence(
-                    event.last_kf_X_canon, event.last_kf_C,
-                    lk_path, h_lk, w_lk,
+                    event.last_kf_X_canon,
+                    event.last_kf_C,
+                    lk_path,
+                    h_lk,
+                    w_lk,
                 )
 
     def _handle_map_update(self, event: LogMapUpdate) -> None:
@@ -551,8 +560,12 @@ class AsyncRerunLogger:
 
         # Reconstruct Frame for frame_to_pinhole()
         frame: Frame = snapshot_to_frame(
-            kf.world_sim3_cam_data, kf.rgb, kf.X_canon, kf.C,
-            kf.img_shape, frame_id=kf.kf_idx,
+            kf.world_sim3_cam_data,
+            kf.rgb,
+            kf.X_canon,
+            kf.C,
+            kf.img_shape,
+            frame_id=kf.kf_idx,
         )
 
         # Camera transform
@@ -570,18 +583,21 @@ class AsyncRerunLogger:
 
         # RGB image
         kf_rgb_uint8: UInt8[ndarray, "H W 3"] = self._log_rgb_image(
-            f"{kf_cam_log_path}/pinhole/image", kf.rgb,
+            f"{kf_cam_log_path}/pinhole/image",
+            kf.rgb,
         )
 
         # Pointmap + confidence
         self._log_pointmap_and_confidence(
-            kf.X_canon, kf.C,
+            kf.X_canon,
+            kf.C,
             f"{kf_cam_log_path}/pinhole",
-            kf.img_shape[0], kf.img_shape[1],
+            kf.img_shape[0],
+            kf.img_shape[1],
         )
 
         # Confidence-filtered point cloud
-        mask: Bool[ndarray, "hw"] = (kf.C.squeeze() > self._conf_thresh)
+        mask: Bool[ndarray, "hw"] = kf.C.squeeze() > self._conf_thresh
         positions: Float32[ndarray, "num_points 3"] = kf.X_canon
         colors: UInt8[ndarray, "num_points 3"] = kf_rgb_uint8.reshape(-1, 3)
         rr.log(
@@ -601,9 +617,11 @@ class AsyncRerunLogger:
         lk_path: str = f"{self._parent_log_path}/last_keyframe"
         self._log_rgb_image(lk_path, kf.rgb)
         self._log_pointmap_and_confidence(
-            kf.X_canon, kf.C,
+            kf.X_canon,
+            kf.C,
             lk_path,
-            kf.img_shape[0], kf.img_shape[1],
+            kf.img_shape[0],
+            kf.img_shape[1],
         )
 
     def _relog_keyframe_camera(self, kf_idx: int, world_sim3_cam_data: Float32[ndarray, "8"]) -> None:

--- a/packages/mast3r-slam/mast3r_slam/backend_lifecycle.py
+++ b/packages/mast3r-slam/mast3r_slam/backend_lifecycle.py
@@ -105,9 +105,9 @@ class SlamBackend:
 
     def __exit__(
         self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
+        _exc_type: type[BaseException] | None,
+        _exc_val: BaseException | None,
+        _exc_tb: TracebackType | None,
     ) -> None:
         self._shutdown_backend()
         self._shutdown_manager()

--- a/packages/mast3r-slam/mast3r_slam/dataloader.py
+++ b/packages/mast3r-slam/mast3r_slam/dataloader.py
@@ -41,7 +41,6 @@ class MonocularDataset(torch.utils.data.Dataset):
         """Filesystem path to the dataset root, or None for live sources (webcam, realsense)."""
         self.camera_intrinsics = None  # Intrinsics | None — forward ref, typed by subclasses
         self.use_calibration: bool = config["use_calib"]
-        self.save_results: bool = True
 
     def __len__(self) -> int:
         """Return the number of frames in the dataset."""
@@ -225,7 +224,6 @@ class Webcam(MonocularDataset):
         self.dataset_path = None
         # load webcam using opencv
         self.cap = cv2.VideoCapture(-1)
-        self.save_results: bool = False
 
     def __len__(self) -> int:
         return 999999
@@ -423,7 +421,7 @@ def load_dataset(
     if "7-scenes" in split_dataset_type:
         return SevenScenesDataset(dataset_path, img_size)
     if "realsense" in split_dataset_type:
-        return RealsenseDataset(img_size)
+        raise NotImplementedError("RealSense input is not implemented in mast3r-slam.")
     if "webcam" in split_dataset_type:
         return Webcam(img_size)
 

--- a/packages/mast3r-slam/mast3r_slam/frame.py
+++ b/packages/mast3r-slam/mast3r_slam/frame.py
@@ -553,6 +553,7 @@ class SharedKeyframes:
         """
         with self.lock:
             self.world_sim3_cam[idx] = world_sim3_cams.data
+            self.is_dirty[idx] = True
 
     def get_dirty_idx(self) -> Int[Tensor, "n_dirty"]:
         """Return indices of keyframes modified since the last call, then clear the dirty flags.

--- a/packages/mast3r-slam/mast3r_slam/frame.py
+++ b/packages/mast3r-slam/mast3r_slam/frame.py
@@ -390,16 +390,6 @@ class SharedStates:
         with self.lock:
             self.mode.value = mode
 
-    def pause(self) -> None:
-        """Pause the system (backend will idle until unpaused)."""
-        with self.lock:
-            self.paused.value = 1
-
-    def unpause(self) -> None:
-        """Unpause the system."""
-        with self.lock:
-            self.paused.value = 0
-
     def is_paused(self) -> bool:
         """Return whether the system is currently paused."""
         with self.lock:
@@ -575,13 +565,3 @@ class SharedKeyframes:
         assert config["use_calib"]
         with self.lock:
             self.K[:] = K
-
-    def get_intrinsics(self) -> Float[Tensor, "3 3"]:
-        """Return the shared camera intrinsic matrix (requires ``use_calib`` config).
-
-        Returns:
-            The 3x3 intrinsic matrix tensor.
-        """
-        assert config["use_calib"]
-        with self.lock:
-            return self.K

--- a/packages/mast3r-slam/mast3r_slam/global_opt.py
+++ b/packages/mast3r-slam/mast3r_slam/global_opt.py
@@ -88,7 +88,6 @@ class FactorGraph:
         self.valid_match_i: Bool[Tensor, "..."] = torch.as_tensor([], dtype=torch.bool, device=self.device)
         self.Q_ii2jj: Float32[Tensor, "..."] = torch.as_tensor([], dtype=torch.float32, device=self.device)
         self.Q_jj2ii: Float32[Tensor, "..."] = torch.as_tensor([], dtype=torch.float32, device=self.device)
-        self.window_size: float = self.cfg["window_size"]
 
         self.K: Float[Tensor, "3 3"] | None = K
 

--- a/packages/mast3r-slam/mast3r_slam/gradio/mast3r_slam_ui.py
+++ b/packages/mast3r-slam/mast3r_slam/gradio/mast3r_slam_ui.py
@@ -92,7 +92,7 @@ def streaming_mast3r_slam_fn(
     global active_states
 
     stream = rr.binary_stream()
-    recording: rr.RecordingStream = rr.get_thread_local_data_recording()
+    recording: rr.RecordingStream | None = rr.get_thread_local_data_recording()
 
     try:
         video_path: Path = Path(video_file)

--- a/packages/mast3r-slam/mast3r_slam/image_types.py
+++ b/packages/mast3r-slam/mast3r_slam/image_types.py
@@ -16,4 +16,3 @@ def _is_rgb_normalized(rgb: ndarray) -> bool:
 
 
 RgbNormalized = Annotated[Float[ndarray, "h w 3"], Is[_is_rgb_normalized]]
-BgrNormalized = Annotated[Float[ndarray, "h w 3"], Is[_is_rgb_normalized]]

--- a/packages/mast3r-slam/mast3r_slam/log_events.py
+++ b/packages/mast3r-slam/mast3r_slam/log_events.py
@@ -61,7 +61,7 @@ class LogCurrentFrame:
     last_kf_C: Float32[ndarray, "hw 1"] | None = None
     """Last keyframe confidence (tracker continuously updates it)."""
     last_kf_idx: int | None = None
-    """Index of the current last keyframe, or None if no keyframes exist."""
+    """Index of the current last keyframe, used to avoid resending unchanged last-KF RGB."""
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/mast3r-slam/mast3r_slam/log_events.py
+++ b/packages/mast3r-slam/mast3r_slam/log_events.py
@@ -77,8 +77,8 @@ class LogMapUpdate:
     """Video timestamp in nanoseconds, or None if not from MP4."""
     new_keyframes: list[KeyframeSnapshot] = field(default_factory=list)
     """Newly created keyframes this iteration (empty if none)."""
-    pose_updates: list[tuple[int, Float32[ndarray, "8"]]] = field(default_factory=list)
-    """(kf_idx, world_sim3_cam_data) pairs for backend-refined poses."""
+    updated_keyframes: list[KeyframeSnapshot] = field(default_factory=list)
+    """Dirty keyframes whose camera entities must be replayed after backend refinement."""
     edge_positions: tuple[Float32[ndarray, "n 3"], Float32[ndarray, "n 3"]] | None = None
     """(positions_i, positions_j) for factor graph edges, or None if unchanged."""
     orient: tuple[Float32[ndarray, "3 3"], Float32[ndarray, "3"]] | None = None

--- a/packages/mast3r-slam/mast3r_slam/log_events.py
+++ b/packages/mast3r-slam/mast3r_slam/log_events.py
@@ -60,6 +60,8 @@ class LogCurrentFrame:
     """Last keyframe pointmap (tracker continuously updates it)."""
     last_kf_C: Float32[ndarray, "hw 1"] | None = None
     """Last keyframe confidence (tracker continuously updates it)."""
+    last_kf_idx: int | None = None
+    """Index of the current last keyframe, or None if no keyframes exist."""
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/mast3r-slam/mast3r_slam/log_events.py
+++ b/packages/mast3r-slam/mast3r_slam/log_events.py
@@ -60,8 +60,6 @@ class LogCurrentFrame:
     """Last keyframe pointmap (tracker continuously updates it)."""
     last_kf_C: Float32[ndarray, "hw 1"] | None = None
     """Last keyframe confidence (tracker continuously updates it)."""
-    last_kf_idx: int | None = None
-    """Index of the current last keyframe, used to avoid resending unchanged last-KF RGB."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -79,8 +77,8 @@ class LogMapUpdate:
     """Video timestamp in nanoseconds, or None if not from MP4."""
     new_keyframes: list[KeyframeSnapshot] = field(default_factory=list)
     """Newly created keyframes this iteration (empty if none)."""
-    pose_updates: list[tuple[int, Float32[ndarray, "8"]]] = field(default_factory=list)
-    """(kf_idx, world_sim3_cam_data) pairs for backend-refined poses."""
+    updated_keyframes: list[KeyframeSnapshot] = field(default_factory=list)
+    """Dirty keyframes whose camera entities must be replayed after backend refinement."""
     edge_positions: tuple[Float32[ndarray, "n 3"], Float32[ndarray, "n 3"]] | None = None
     """(positions_i, positions_j) for factor graph edges, or None if unchanged."""
     orient: tuple[Float32[ndarray, "3 3"], Float32[ndarray, "3"]] | None = None

--- a/packages/mast3r-slam/mast3r_slam/log_events.py
+++ b/packages/mast3r-slam/mast3r_slam/log_events.py
@@ -77,8 +77,8 @@ class LogMapUpdate:
     """Video timestamp in nanoseconds, or None if not from MP4."""
     new_keyframes: list[KeyframeSnapshot] = field(default_factory=list)
     """Newly created keyframes this iteration (empty if none)."""
-    updated_keyframes: list[KeyframeSnapshot] = field(default_factory=list)
-    """Dirty keyframes whose camera entities must be replayed after backend refinement."""
+    pose_updates: list[tuple[int, Float32[ndarray, "8"]]] = field(default_factory=list)
+    """(kf_idx, world_sim3_cam_data) pairs for backend-refined poses."""
     edge_positions: tuple[Float32[ndarray, "n 3"], Float32[ndarray, "n 3"]] | None = None
     """(positions_i, positions_j) for factor graph edges, or None if unchanged."""
     orient: tuple[Float32[ndarray, "3 3"], Float32[ndarray, "3"]] | None = None

--- a/packages/mast3r-slam/mast3r_slam/mast3r_utils.py
+++ b/packages/mast3r-slam/mast3r_slam/mast3r_utils.py
@@ -133,55 +133,6 @@ def downsample(
     return X, C, D, Q
 
 
-@torch.inference_mode()
-def mast3r_symmetric_inference(
-    model: AsymmetricMASt3R, frame_i: Frame, frame_j: Frame
-) -> tuple[
-    Float[Tensor, "4 h w 3"],
-    Float[Tensor, "4 h w"],
-    Float[Tensor, "4 h w d"],
-    Float[Tensor, "4 h w"],
-]:
-    """Run symmetric two-frame MASt3R inference.
-
-    Encodes both frames (lazily, caching features on the frame objects), then
-    decodes in both directions (i->j and j->i) to produce four sets of 3D
-    point maps, confidence, descriptors, and descriptor confidence.
-
-    The output ordering along dim 0 is ``[res_ii, res_ji, res_jj, res_ij]``.
-
-    Args:
-        model: The MASt3R model.
-        frame_i: First frame (features cached on ``frame_i.feat``).
-        frame_j: Second frame (features cached on ``frame_j.feat``).
-
-    Returns:
-        A tuple ``(X, C, D, Q)`` each of shape ``(4, h, w, ...)``.
-    """
-    if frame_i.feat is None:
-        frame_i.feat, frame_i.pos, _ = model._encode_image(frame_i.rgb_tensor, frame_i.img_true_shape)
-    if frame_j.feat is None:
-        frame_j.feat, frame_j.pos, _ = model._encode_image(frame_j.rgb_tensor, frame_j.img_true_shape)
-
-    assert frame_i.pos is not None
-    assert frame_j.pos is not None
-    feat1, feat2 = frame_i.feat, frame_j.feat
-    pos1, pos2 = frame_i.pos, frame_j.pos
-    shape1, shape2 = frame_i.img_true_shape, frame_j.img_true_shape
-
-    res11, res21 = decoder(model, feat1, feat2, pos1, pos2, shape1, shape2)
-    res22, res12 = decoder(model, feat2, feat1, pos2, pos1, shape2, shape1)
-    res = [res11, res21, res22, res12]
-    X, C, D, Q = zip(
-        *[(r["pts3d"][0], r["conf"][0], r["desc"][0], r["desc_conf"][0]) for r in res],
-        strict=False,
-    )
-    # 4xhxwxc
-    X, C, D, Q = torch.stack(X), torch.stack(C), torch.stack(D), torch.stack(Q)
-    X, C, D, Q = downsample(X, C, D, Q)
-    return X, C, D, Q
-
-
 # NOTE: Assumes img shape the same
 @torch.inference_mode()
 def mast3r_decode_symmetric_batch(

--- a/packages/mast3r-slam/mast3r_slam/nerfstudio_utils.py
+++ b/packages/mast3r-slam/mast3r_slam/nerfstudio_utils.py
@@ -171,6 +171,10 @@ def save_kf_to_nerfstudio(
 
     # use the last keyframe to estimate camera intrinsics
     intrinsics = frame_to_intri(keyframe, camera_conventions="RDF")
+    assert intrinsics.fl_x is not None
+    assert intrinsics.fl_y is not None
+    assert intrinsics.cx is not None
+    assert intrinsics.cy is not None
     # save to nerfstudio format, assumes no distortion
     ns_data: NerfstudioData = NerfstudioData(
         w=w,

--- a/packages/mast3r-slam/mast3r_slam/rerun_log_utils.py
+++ b/packages/mast3r-slam/mast3r_slam/rerun_log_utils.py
@@ -124,7 +124,6 @@ class RerunLogger:
 
         self.path_list: list[list[float]] = []
         self.keyframe_logged_list: list[int] = []
-        self.num_keyframes_logged: int = 0
         self.conf_thresh: int = 7
         self.image_plane_distance: float = 0.2
         # Number of keyframes used in the last orientation update.

--- a/packages/mast3r-slam/mast3r_slam/retrieval_database.py
+++ b/packages/mast3r-slam/mast3r_slam/retrieval_database.py
@@ -137,11 +137,10 @@ class RetrievalDatabase(Retriever):
         """
         step_params: dict = self.asmk.params.get("query_ivf")
 
-        images2: Float[ndarray, "..."]
         ranks: Float[ndarray, "..."]
         scores: Float[ndarray, "..."]
         topk: Int64[ndarray, "..."]
-        images2, ranks, scores, topk = self.accumulate_scores(
+        _images2, ranks, scores, topk = self.accumulate_scores(
             self.asmk.codebook,
             self.ivf_builder.kernel,
             self.ivf_builder.ivf,
@@ -197,7 +196,7 @@ class RetrievalDatabase(Retriever):
 
     def accumulate_scores(
         self,
-        cdb: Any,
+        _cdb: Any,
         kern: Any,
         ivf: Any,
         qvecs: Float32[ndarray, "n_local d"],
@@ -208,7 +207,7 @@ class RetrievalDatabase(Retriever):
         inverted_file and parameters.
 
         Args:
-            cdb: ASMK codebook.
+            _cdb: ASMK codebook.
             kern: ASMK kernel.
             ivf: ASMK inverted file.
             qvecs: 2-D array of local descriptors.

--- a/packages/mast3r-slam/pyproject.toml
+++ b/packages/mast3r-slam/pyproject.toml
@@ -31,3 +31,9 @@ line-length = 150
 [tool.ruff.lint]
 select = ["E", "F", "UP", "B", "SIM", "I"]
 ignore = ["E501", "F722", "F821", "UP037", "UP040"]
+
+[tool.vulture]
+paths = ["mast3r_slam", "tests", "tools"]
+exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modules/*", "*/thirdparty/*", "*/.ruff_cache/*"]
+sort_by_size = true
+min_confidence = 60

--- a/packages/mast3r-slam/pyproject.toml
+++ b/packages/mast3r-slam/pyproject.toml
@@ -35,5 +35,6 @@ ignore = ["E501", "F722", "F821", "UP037", "UP040"]
 [tool.vulture]
 paths = ["mast3r_slam", "tests", "tools"]
 exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modules/*", "*/thirdparty/*", "*/.ruff_cache/*"]
+ignore_names = ["RerunLogger", "log_frame", "pytestmark", "colmap_im_id", "k1", "k2", "p2", "camera_model", "applied_transform", "allow_tf32"]
 sort_by_size = true
 min_confidence = 60

--- a/packages/mast3r-slam/tests/test_mojo_vs_cuda.py
+++ b/packages/mast3r-slam/tests/test_mojo_vs_cuda.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import lietorch
 import pytest
 import torch
+from torch import Tensor
 
 cuda_backends = pytest.importorskip("mast3r_slam._backends", reason="CUDA backends not built")
 mojo_backends = pytest.importorskip("mast3r_slam_mojo_backends", reason="Mojo backends not built")
@@ -206,7 +207,22 @@ def test_refine_matches_batched_f16_matches_cuda() -> None:
 # ══════════════════════════════════════════════════════════════════════════════
 
 
-def _make_representative_rays_inputs() -> tuple[torch.Tensor | float | int, ...]:
+def _make_representative_rays_inputs() -> tuple[
+    Tensor,
+    Tensor,
+    Tensor,
+    Tensor,
+    Tensor,
+    Tensor,
+    Tensor,
+    Tensor,
+    float,
+    float,
+    float,
+    float,
+    int,
+    float,
+]:
     """Build one synthetic GN rays fixture shaped like the real base workload."""
     torch.manual_seed(1)
     n_poses = 10
@@ -264,14 +280,20 @@ def _make_representative_rays_inputs() -> tuple[torch.Tensor | float | int, ...]
 
 def test_gauss_newton_rays_matches_cuda_on_representative_base_shape() -> None:
     """Full GN solve: poses and increments should match CUDA within tolerance."""
-    args = _make_representative_rays_inputs()
+    twc, xs, cs, ii, jj, idx, valid, q, sigma_ray, sigma_dist, c_thresh, q_thresh, max_iter, delta_thresh = (
+        _make_representative_rays_inputs()
+    )
 
-    twc_cuda = args[0].clone()
-    dx_cuda = cuda_backends.gauss_newton_rays(twc_cuda, *args[1:])[0]
+    twc_cuda = twc.clone()
+    dx_cuda = cuda_backends.gauss_newton_rays(
+        twc_cuda, xs, cs, ii, jj, idx, valid, q, sigma_ray, sigma_dist, c_thresh, q_thresh, max_iter, delta_thresh
+    )[0]
     _sync()
 
-    twc_mojo = args[0].clone()
-    dx_mojo = mojo_backends.gauss_newton_rays((twc_mojo, *args[1:]))[0]
+    twc_mojo = twc.clone()
+    dx_mojo = mojo_backends.gauss_newton_rays(
+        (twc_mojo, xs, cs, ii, jj, idx, valid, q, sigma_ray, sigma_dist, c_thresh, q_thresh, max_iter, delta_thresh)
+    )[0]
     _sync()
 
     assert torch.allclose(dx_mojo, dx_cuda, atol=POSE_ATOL, rtol=POSE_RTOL)

--- a/packages/mast3r-slam/tests/test_shared_keyframes.py
+++ b/packages/mast3r-slam/tests/test_shared_keyframes.py
@@ -1,0 +1,40 @@
+"""SharedKeyframes regression tests."""
+
+import multiprocessing as mp
+
+import lietorch
+import torch
+
+from mast3r_slam.frame import Frame, SharedKeyframes
+
+
+def test_update_world_sim3_cams_marks_keyframes_dirty() -> None:
+    """Backend pose updates must mark keyframes dirty for async camera replay."""
+    manager = mp.Manager()
+    try:
+        h, w = 16, 16
+        keyframes = SharedKeyframes(manager, h, w, buffer=4, device="cpu")
+        frame = Frame(
+            frame_id=0,
+            rgb_tensor=torch.zeros(1, 3, h, w),
+            img_shape=torch.tensor([[h, w]], dtype=torch.int),
+            img_true_shape=torch.tensor([[h, w]], dtype=torch.int),
+            rgb=torch.zeros(h, w, 3),
+            world_sim3_cam=lietorch.Sim3.Identity(1, device="cpu"),
+            X_canon=torch.zeros(h * w, 3),
+            C=torch.ones(h * w, 1),
+            feat=torch.zeros(1, 1, keyframes.feat_dim),
+            pos=torch.zeros(1, 1, 2, dtype=torch.long),
+        )
+        keyframes.append(frame)
+
+        # Clear the dirty bit from the initial append so this only checks backend writes.
+        keyframes.get_dirty_idx()
+
+        updated_pose = lietorch.Sim3(torch.tensor([[[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0]]], dtype=torch.float32))
+        keyframes.update_world_sim3_cams(updated_pose, torch.tensor([0], dtype=torch.long))
+
+        dirty_idx = keyframes.get_dirty_idx()
+        assert dirty_idx.tolist() == [0]
+    finally:
+        manager.shutdown()

--- a/packages/mast3r-slam/tools/bench_kernels.py
+++ b/packages/mast3r-slam/tools/bench_kernels.py
@@ -31,6 +31,8 @@ from __future__ import annotations
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass
+from importlib import import_module
+from typing import Any
 
 import lietorch
 import torch
@@ -38,17 +40,16 @@ from torch import Tensor
 
 # ── Backend imports ───────────────────────────────────────────────────────────
 
-try:
-    from mast3r_slam import _backends as cuda_be
-except ImportError:
-    print("ERROR: mast3r_slam._backends not found. Run: pixi run -e mast3r-slam _build-cuda-kernels")
-    sys.exit(1)
+def _import_required_module(module_name: str, install_hint: str) -> Any:
+    try:
+        return import_module(module_name)
+    except ImportError:
+        print(f"ERROR: {module_name} not found. Run: {install_hint}")
+        sys.exit(1)
 
-try:
-    import mast3r_slam_mojo_backends as mojo_be
-except ImportError:
-    print("ERROR: mast3r_slam_mojo_backends not found. Run: pixi run -e mast3r-slam _build-mojo-kernels")
-    sys.exit(1)
+
+cuda_be: Any = _import_required_module("mast3r_slam._backends", "pixi run -e mast3r-slam _build-cuda-kernels")
+mojo_be: Any = _import_required_module("mast3r_slam_mojo_backends", "pixi run -e mast3r-slam _build-mojo-kernels")
 
 assert torch.cuda.is_available(), "CUDA not available"
 DEVICE: torch.device = torch.device("cuda")
@@ -62,10 +63,6 @@ class BenchResult:
     """Timing statistics from a kernel benchmark."""
 
     median_ms: float
-    mean_ms: float
-    std_ms: float
-    min_ms: float
-    max_ms: float
 
 
 def bench(fn: Callable[..., object], warmup: int = 50, runs: int = 500) -> BenchResult:
@@ -87,10 +84,6 @@ def bench(fn: Callable[..., object], warmup: int = 50, runs: int = 500) -> Bench
     t: Tensor = torch.tensor(timings)
     return BenchResult(
         median_ms=float(t.median()),
-        mean_ms=float(t.mean()),
-        std_ms=float(t.std()),
-        min_ms=float(t.min()),
-        max_ms=float(t.max()),
     )
 
 
@@ -169,6 +162,35 @@ def make_gn_rays_data(
     return twc, xs, cs, ii, jj, idx, valid, q
 
 
+def make_gn_runner(
+    backend: Any,
+    twc: Tensor,
+    xs: Tensor,
+    cs: Tensor,
+    ii: Tensor,
+    jj: Tensor,
+    idx: Tensor,
+    valid: Tensor,
+    q: Tensor,
+    sigma_ray: float,
+    sigma_dist: float,
+    c_thresh: float,
+    q_thresh: float,
+    max_iter: int,
+    delta_thresh: float,
+) -> Callable[[], object]:
+    """Capture one GN rays benchmark configuration into a zero-argument runner."""
+
+    def run() -> object:
+        t_copy: Tensor = twc.clone()
+        args = (t_copy, xs, cs, ii, jj, idx, valid, q, sigma_ray, sigma_dist, c_thresh, q_thresh, max_iter, delta_thresh)
+        if backend is mojo_be:
+            return backend.gauss_newton_rays(args)
+        return backend.gauss_newton_rays(*args)
+
+    return run
+
+
 # ── Main ──────────────────────────────────────────────────────────────────────
 
 
@@ -236,13 +258,12 @@ def main() -> None:
         max_iter: int = 10
         delta_thresh: float = 1e-6
 
-        def run_cuda(_t=twc.clone(), _x=xs, _c=cs, _i=ii, _j=jj, _idx=idx, _v=valid, _q=q) -> object:
-            t_copy: Tensor = _t.clone()
-            return cuda_be.gauss_newton_rays(t_copy, _x, _c, _i, _j, _idx, _v, _q, sigma_ray, sigma_dist, c_thresh, q_thresh, max_iter, delta_thresh)
-
-        def run_mojo(_t=twc.clone(), _x=xs, _c=cs, _i=ii, _j=jj, _idx=idx, _v=valid, _q=q) -> object:
-            t_copy: Tensor = _t.clone()
-            return mojo_be.gauss_newton_rays((t_copy, _x, _c, _i, _j, _idx, _v, _q, sigma_ray, sigma_dist, c_thresh, q_thresh, max_iter, delta_thresh))
+        run_cuda = make_gn_runner(
+            cuda_be, twc, xs, cs, ii, jj, idx, valid, q, sigma_ray, sigma_dist, c_thresh, q_thresh, max_iter, delta_thresh
+        )
+        run_mojo = make_gn_runner(
+            mojo_be, twc, xs, cs, ii, jj, idx, valid, q, sigma_ray, sigma_dist, c_thresh, q_thresh, max_iter, delta_thresh
+        )
 
         cuda_r = bench(run_cuda, warmup=10, runs=50)
         mojo_r = bench(run_mojo, warmup=10, runs=50)

--- a/packages/monoprior/pyproject.toml
+++ b/packages/monoprior/pyproject.toml
@@ -45,3 +45,9 @@ ignore = [
     "F821",  # Forward annotation false positive from jaxtyping. Should be caught by pyright.
     "UP037", # Remove quotes from type, false positive when using jaxtyping
 ]
+
+[tool.vulture]
+paths = ["monopriors", "tests", "tools"]
+exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modules/*", "*/third_party/*"]
+sort_by_size = true
+min_confidence = 60

--- a/packages/prompt-da/pyproject.toml
+++ b/packages/prompt-da/pyproject.toml
@@ -23,3 +23,9 @@ line-length = 150
 [tool.ruff.lint]
 select = ["E", "F", "UP", "B", "SIM", "I"]
 ignore = ["E501", "F722", "F821", "UP037"]
+
+[tool.vulture]
+paths = ["src/rerun_prompt_da", "tests", "tools"]
+exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modules/*"]
+sort_by_size = true
+min_confidence = 60

--- a/packages/pysfm/pyproject.toml
+++ b/packages/pysfm/pyproject.toml
@@ -22,3 +22,9 @@ ignore = [
     "UP037",  # jaxtyping with type quotes
     "UP040",  # beartype compatibility
 ]
+
+[tool.vulture]
+paths = ["pysfm", "tests", "tools"]
+exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modules/*"]
+sort_by_size = true
+min_confidence = 60

--- a/packages/pyvrs-viewer/pyproject.toml
+++ b/packages/pyvrs-viewer/pyproject.toml
@@ -25,3 +25,9 @@ ignore = [
     "UP037",  # Remove quotes false positive with jaxtyping
     "UP040",  # Beartype requires TypeAlias, not PEP 695 type
 ]
+
+[tool.vulture]
+paths = ["src/pyvrs_viewer", "tests", "tools"]
+exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modules/*", "*/thirdparty/*"]
+sort_by_size = true
+min_confidence = 60

--- a/packages/robocap-slam/pyproject.toml
+++ b/packages/robocap-slam/pyproject.toml
@@ -28,3 +28,8 @@ ignore = [
     "UP040",  # Beartype requires TypeAlias, not PEP 695 type
 ]
 
+[tool.vulture]
+paths = ["robocap_slam", "tests", "tools"]
+exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modules/*"]
+sort_by_size = true
+min_confidence = 60

--- a/packages/sam3-rerun/pyproject.toml
+++ b/packages/sam3-rerun/pyproject.toml
@@ -19,3 +19,8 @@ line-length = 150
 select = ["E", "F", "UP", "B", "SIM", "I"]
 ignore = ["E501", "F722", "F821", "UP037", "UP040"]
 
+[tool.vulture]
+paths = ["src/sam3_rerun", "tests", "tools"]
+exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modules/*"]
+sort_by_size = true
+min_confidence = 60

--- a/packages/sam3d-body-rerun/pyproject.toml
+++ b/packages/sam3d-body-rerun/pyproject.toml
@@ -62,3 +62,8 @@ ignore = [
 
 ]
 
+[tool.vulture]
+paths = ["src/sam3d_body", "tests"]
+exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modules/*"]
+sort_by_size = true
+min_confidence = 60

--- a/packages/vistadream/pyproject.toml
+++ b/packages/vistadream/pyproject.toml
@@ -31,3 +31,9 @@ ignore = [
     "F821",  # Forward annotation false positive from jaxtyping. Should be caught by pyright.
     "UP037", # Remove quotes from type, false positive when using jaxtyping
 ]
+
+[tool.vulture]
+paths = ["src/vistadream", "tests", "tools"]
+exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modules/*"]
+sort_by_size = true
+min_confidence = 60

--- a/packages/wilor-nano/pyproject.toml
+++ b/packages/wilor-nano/pyproject.toml
@@ -43,3 +43,9 @@ ignore = [
     "F821",  # Forward annotation false positive from jaxtyping. Should be caught by pyright.
     "UP037",
 ]
+
+[tool.vulture]
+paths = ["src/wilor_nano", "tests", "tools"]
+exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modules/*"]
+sort_by_size = true
+min_confidence = 60

--- a/pixi.lock
+++ b/pixi.lock
@@ -28028,7 +28028,7 @@ packages:
 - pypi: ./packages/mast3r-slam
   name: mast3r-slam
   version: 0.0.1
-  sha256: 0b4aee916e8c2d2ec59834b954b865bab6ed3ddfd96e6b98de4f430965955f93
+  sha256: 3091afd1d4d4491d11ccebbecd42f36766cc0264340c6f06546a7fa54352534c
   requires_dist:
   - einops
   - natsort

--- a/pixi.lock
+++ b/pixi.lock
@@ -3152,296 +3152,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b0/be/d7c88cd9293c859fc74b232abdc65a229bb953997995d6912fc85af18323/wrapt-2.1.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bb/1f/e9cfd801a3f9190bf3e759c422bbfd2247db9d7f3d54a56ecde70137791a/zstandard-0.25.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: ./packages/mast3r-slam
-  mast3r-slam-mojo-build:
-    channels:
-    - url: https://conda.modular.com/max-nightly/
-    - url: https://conda.anaconda.org/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
-    packages:
-      linux-64:
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiofiles-25.1.0-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/asgiref-3.11.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/av-17.0.0-py311hf24c605_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.3.0-py311h6b1f9c4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py311h66f275b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.2-pyhc90fa1f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.15-py311hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.8.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.3.0-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.135.3-hbd727af_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.23-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.135.3-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.0.1-gpl_hcddb375_914.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.17.1-h27c8c51_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/gguf-0.17.1-pyhc364b38_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/glslang-16.2.0-h96af755_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/googleapis-common-protos-1.74.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.80.0-py311h3aa0767_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.1.0-h6083320_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hf-transfer-0.1.9-py311he4d9500_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hf-xet-1.4.3-py310hb823017_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/httptools-0.7.1-py311h49ec1c0_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-1.9.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/intel-gmmlib-22.10.0-hb700be7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/intel-media-driver-26.1.5-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.18-h0c24ade_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.28.2-hb700be7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.4-h96ad9f0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-6_h4a7cf45_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-hd0affe5_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-6_h0358290_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.4-h6548e54_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.80.0-h1d1128b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwy-1.3.0-h4c17acf_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.2-ha09017c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-6_h47877c9_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.32-pthreads_h94d23a6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2026.0.0-hb56ce9e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2026.0.0-hd85de46_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2026.0.0-hd85de46_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2026.0.0-hd41364c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2026.0.0-hb56ce9e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2026.0.0-hb56ce9e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2026.0.0-hb56ce9e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2026.0.0-hd41364c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2026.0.0-h7a07914_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2026.0.0-h7a07914_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2026.0.0-hecca717_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2026.0.0-h78e8023_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2026.0.0-hecca717_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.57-h421ea60_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.33.5-h2b00c02_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h0dc7533_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.1-h4c96295_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsentencepiece-0.2.1-h432359f_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.21-h280c20c_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.13-hd0affe5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.13-hd0affe5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liburing-2.14-hb700be7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.23.0-he1eb515_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpl-2.16.0-h54a6638_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.15.2-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.341.0-h5279c79_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.1-hca5e8e5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.2-hca6bf5a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.2-he237659_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/llguidance-1.7.0-py310hc9716df_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py311h3778330_1.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/max-26.3.0.dev2026040905-3.11release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/max-core-26.3.0.dev2026040905-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/max-pipelines-26.3.0.dev2026040905-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.3.0.dev2026040905-release.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/modular-26.3.0.dev2026040905-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-0.26.3.0.dev2026040905-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-0.26.3.0.dev2026040905-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-0.26.3.0.dev2026040905-release.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgspec-0.21.0-py311h49ec1c0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py311h2e04523_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-api-1.35.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-exporter-otlp-proto-common-1.35.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-exporter-otlp-proto-http-1.35.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-exporter-prometheus-0.56b0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-proto-1.35.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-sdk-1.35.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-semantic-conventions-0.56b0-pyh3cfb1c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.2.0-py311hf88fc01_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.24.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-6.33.5-py311h3f0a9aa_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py311haee01d2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py311h902ca64_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.13.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyinstrument-5.1.2-py311h49ec1c0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.15-hd63d673_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.11.15-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.24-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py311h3778330_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py311h57d2397_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h5301d42_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2026.4.4-py311h49ec1c0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-toolkit-0.19.7-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/safetensors-0.7.0-py311hc8fb587_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py311hbe70eeb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.4.4-hdeec2a5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sentencepiece-0.2.1-ha8de79c_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sentencepiece-python-0.2.1-py311he27d5e9_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sentencepiece-spm-0.2.1-h432359f_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/shaderc-2025.5-h718be3e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/spirv-tools-2026.1-hb700be7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sse-starlette-3.3.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/starlette-1.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-4.0.1-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/taskgroup-0.2.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tiktoken-0.12.0-py311h9a14573_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tokenizers-0.22.2-py311ha21528d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.5-py311h49ec1c0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/transformers-5.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.24.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.44.0-pyhc90fa1f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.44.0-h4457471_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/uvloop-0.22.1-py311h49ec1c0_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-1.1.1-py311hc8fb587_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/websockets-16.0-py311haee01d2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.1.2-py311h49ec1c0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.47-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h41580af_10.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
   monoprior:
     channels:
     - url: https://prefix.dev/ai-demos/
@@ -13702,19 +13412,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/66/3e/868e5c3364b6cee19ff3e1a122194fa4ce51def02c61023970442162859e/yarl-1.23.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: ./packages/wilor-nano
 packages:
-- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-  build_number: 20
-  sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
-  md5: a9f577daf3de00bca7c3c76c0ecbd1de
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgomp >=7.5.0
-  constrains:
-  - openmp_impl <0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 28948
-  timestamp: 1770939786096
 - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
   sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
@@ -13764,16 +13461,6 @@ packages:
   purls: []
   size: 8293
   timestamp: 1764092286102
-- conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-  sha256: a3967b937b9abf0f2a99f3173fa4630293979bd1644709d89580e7c62a544661
-  md5: aaa2a381ccc56eac91d63b6c1240312f
-  depends:
-  - cpython
-  - python-gil
-  license: MIT
-  license_family: MIT
-  size: 8191
-  timestamp: 1744137672556
 - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
   sha256: a3967b937b9abf0f2a99f3173fa4630293979bd1644709d89580e7c62a544661
   md5: aaa2a381ccc56eac91d63b6c1240312f
@@ -13924,16 +13611,6 @@ packages:
   version: 24.1.0
   sha256: b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5
   requires_python: '>=3.8'
-- conda: https://conda.anaconda.org/conda-forge/noarch/aiofiles-25.1.0-pyhcf101f3_1.conda
-  sha256: f37288164cf28b916b184b0a5e89225e17af0e0c9bcd4d0dc39e5a597fcfeed1
-  md5: a6435dc39a8031d33d6d52859913e939
-  depends:
-  - python >=3.10
-  - python
-  license: Apache-2.0
-  license_family: APACHE
-  size: 24824
-  timestamp: 1767290524894
 - pypi: https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl
   name: aiohappyeyeballs
   version: 2.6.1
@@ -14128,16 +13805,6 @@ packages:
   - pkg:pypi/aiosignal?source=hash-mapping
   size: 13688
   timestamp: 1751626573984
-- conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
-  sha256: d88aa7ae766cf584e180996e92fef2aa7d8e0a0a5ab1d4d49c32390c1b5fff31
-  md5: dcdc58c15961dbf17a0621312b01f5cb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  license_family: GPL
-  size: 584660
-  timestamp: 1768327524772
 - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
   sha256: d88aa7ae766cf584e180996e92fef2aa7d8e0a0a5ab1d4d49c32390c1b5fff31
   md5: dcdc58c15961dbf17a0621312b01f5cb
@@ -14159,16 +13826,6 @@ packages:
   purls: []
   size: 615729
   timestamp: 1768327548407
-- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
-  sha256: cc9fbc50d4ee7ee04e49ee119243e6f1765750f0fd0b4d270d5ef35461b643b1
-  md5: 52be5139047efadaeeb19c6a5103f92a
-  depends:
-  - python >=3.10
-  - python
-  license: MIT
-  license_family: MIT
-  size: 14222
-  timestamp: 1762868213144
 - conda: https://prefix.dev/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
   sha256: cc9fbc50d4ee7ee04e49ee119243e6f1765750f0fd0b4d270d5ef35461b643b1
   md5: 52be5139047efadaeeb19c6a5103f92a
@@ -14188,16 +13845,6 @@ packages:
   requires_dist:
   - typing-extensions>=4.0.0 ; python_full_version < '3.9'
   requires_python: '>=3.8'
-- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
-  sha256: e0ea1ba78fbb64f17062601edda82097fcf815012cf52bb704150a2668110d48
-  md5: 2934f256a8acfe48f6ebb4fce6cde29c
-  depends:
-  - python >=3.9
-  - typing-extensions >=4.0.0
-  license: MIT
-  license_family: MIT
-  size: 18074
-  timestamp: 1733247158254
 - conda: https://prefix.dev/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
   sha256: e0ea1ba78fbb64f17062601edda82097fcf815012cf52bb704150a2668110d48
   md5: 2934f256a8acfe48f6ebb4fce6cde29c
@@ -14216,23 +13863,6 @@ packages:
   sha256: f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b
   requires_dist:
   - typing ; python_full_version < '3.5'
-- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
-  sha256: f09aed24661cd45ba54a43772504f05c0698248734f9ae8cd289d314ac89707e
-  md5: af2df4b9108808da3dc76710fe50eae2
-  depends:
-  - exceptiongroup >=1.0.2
-  - idna >=2.8
-  - python >=3.10
-  - typing_extensions >=4.5
-  - python
-  constrains:
-  - trio >=0.32.0
-  - uvloop >=0.22.1
-  - winloop >=0.2.3
-  license: MIT
-  license_family: MIT
-  size: 146764
-  timestamp: 1774359453364
 - conda: https://prefix.dev/conda-forge/noarch/anyio-4.12.1-pyhcf101f3_0.conda
   sha256: eb0c4e2b24f1fbefaf96ce6c992c6bd64340bc3c06add4d7415ab69222b201da
   md5: 11a2b8c732d215d977998ccd69a9d5e8
@@ -14269,16 +13899,6 @@ packages:
   - pkg:pypi/anyio?source=compressed-mapping
   size: 146764
   timestamp: 1774359453364
-- conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
-  sha256: b08ef033817b5f9f76ce62dfcac7694e7b6b4006420372de22494503decac855
-  md5: 346722a0be40f6edc53f12640d301338
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 2706396
-  timestamp: 1718551242397
 - conda: https://prefix.dev/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
   sha256: b08ef033817b5f9f76ce62dfcac7694e7b6b4006420372de22494503decac855
   md5: 346722a0be40f6edc53f12640d301338
@@ -14398,17 +14018,6 @@ packages:
   - wcwidth
   - pywin32 ; sys_platform == 'win32'
   requires_python: '>=3.8'
-- conda: https://conda.anaconda.org/conda-forge/noarch/asgiref-3.11.1-pyhcf101f3_0.conda
-  sha256: aaeeaf5129981ac0a50c7615458687a606cebfa259a0a94ed94096645ee0d61c
-  md5: 91781fff6c1b3775c47a06b5f5a8f4f1
-  depends:
-  - python >=3.10
-  - typing_extensions >=4
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 28381
-  timestamp: 1770273198327
 - conda: packages/asmk
   name: asmk
   version: 0.1.0
@@ -14546,22 +14155,6 @@ packages:
   purls: []
   size: 12470
   timestamp: 1757263511335
-- conda: https://conda.anaconda.org/conda-forge/linux-64/av-17.0.0-py311hf24c605_0.conda
-  sha256: 4e7d269a59cf2b0e91f661f061b05e134731ec38d78345d69b87a0cf856277de
-  md5: 232ec8fbda0155ab1ba68e8a7c6d368c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - ffmpeg >=8.0.1,<9.0a0
-  - libgcc >=14
-  - numpy >=1.22
-  - numpy >=1.23,<3
-  - pillow
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1296549
-  timestamp: 1773532419813
 - conda: https://prefix.dev/conda-forge/linux-64/av-15.1.0-py312h46547aa_1.conda
   sha256: 560507b8b60dd80325790106ff308821968e70f6c7cb73e3c35a1584cd589680
   md5: 86a2fcb2732224846909a77ea8af7fc7
@@ -15290,15 +14883,6 @@ packages:
   - pkg:pypi/babel?source=compressed-mapping
   size: 7684321
   timestamp: 1772555330347
-- conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
-  sha256: f334115c6b0c6c2cd0d28595365f205ec7eaa60bcc5ff91a75d7245f728be820
-  md5: a38b801f2bcc12af80c2e02a9e4ce7d9
-  depends:
-  - python >=3.9
-  license: MIT
-  license_family: MIT
-  size: 18816
-  timestamp: 1733771192649
 - pypi: https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl
   name: backports-tarfile
   version: 1.2.0
@@ -15316,18 +14900,6 @@ packages:
   - jaraco-test ; extra == 'testing'
   - pytest!=8.0.* ; extra == 'testing'
   requires_python: '>=3.8'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.3.0-py311h6b1f9c4_0.conda
-  sha256: 246e50ec7fc222875c6ecfa3feab77f5661dc43e26397bc01d9e0310e3cd48a0
-  md5: adda5ef2a74c9bdb338ff8a51192898a
-  depends:
-  - python
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python_abi 3.11.* *_cp311
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-3-Clause AND MIT AND EPL-2.0
-  size: 244920
-  timestamp: 1767044984647
 - conda: https://prefix.dev/conda-forge/linux-64/backports.zstd-1.3.0-py310h69bd2ac_0.conda
   sha256: 6660be15a45175c98f750b8bbc3fd07e0da36043624b376de49769bd14a0a16f
   md5: 276a3ddf300498921601822e3b407088
@@ -15634,21 +15206,6 @@ packages:
   purls: []
   size: 21021
   timestamp: 1764017221344
-- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py311h66f275b_1.conda
-  sha256: c36eb061d9ead85f97644cfb740d485dba9b8823357f35c17851078e95e975c1
-  md5: 86daecb8e4ed1042d5dc6efbe0152590
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  constrains:
-  - libbrotlicommon 1.2.0 hb03c661_1
-  license: MIT
-  license_family: MIT
-  size: 367573
-  timestamp: 1764017405384
 - conda: https://prefix.dev/conda-forge/linux-64/brotli-python-1.2.0-py310hba01987_1.conda
   sha256: f036fe554d902549f86689a9650a0996901d5c9242b0a1e3fbfe6dbccd2ae011
   md5: 393fca4557fbd2c4d995dcb89f569048
@@ -15742,16 +15299,6 @@ packages:
   license: Apache-2.0
   size: 78137443
   timestamp: 1772897253667
-- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-  sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
-  md5: d2ffd7602c02f2b316fd921d39876885
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: bzip2-1.0.6
-  license_family: BSD
-  size: 260182
-  timestamp: 1771350215188
 - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
   sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
   md5: d2ffd7602c02f2b316fd921d39876885
@@ -15773,16 +15320,6 @@ packages:
   purls: []
   size: 192412
   timestamp: 1771350241232
-- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
-  sha256: cc9accf72fa028d31c2a038460787751127317dcfa991f8d1f1babf216bb454e
-  md5: 920bb03579f15389b9e512095ad995b7
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 207882
-  timestamp: 1765214722852
 - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
   sha256: cc9accf72fa028d31c2a038460787751127317dcfa991f8d1f1babf216bb454e
   md5: 920bb03579f15389b9e512095ad995b7
@@ -15816,14 +15353,6 @@ packages:
   purls: []
   size: 6693
   timestamp: 1753098721814
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
-  sha256: 67cc7101b36421c5913a1687ef1b99f85b5d6868da3abbf6ec1a4181e79782fc
-  md5: 4492fd26db29495f0ba23f146cd5638d
-  depends:
-  - __unix
-  license: ISC
-  size: 147413
-  timestamp: 1772006283803
 - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
   sha256: 67cc7101b36421c5913a1687ef1b99f85b5d6868da3abbf6ec1a4181e79782fc
   md5: 4492fd26db29495f0ba23f146cd5638d
@@ -15855,32 +15384,6 @@ packages:
   - pkg:pypi/cached-property?source=hash-mapping
   size: 11065
   timestamp: 1615209567874
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
-  sha256: 06525fa0c4e4f56e771a3b986d0fdf0f0fc5a3270830ee47e127a5105bde1b9a
-  md5: bb6c4808bfa69d6f7f6b07e5846ced37
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - fontconfig >=2.15.0,<3.0a0
-  - fonts-conda-ecosystem
-  - icu >=78.1,<79.0a0
-  - libexpat >=2.7.3,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - libgcc >=14
-  - libglib >=2.86.3,<3.0a0
-  - libpng >=1.6.53,<1.7.0a0
-  - libstdcxx >=14
-  - libxcb >=1.17.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pixman >=0.46.4,<1.0a0
-  - xorg-libice >=1.1.2,<2.0a0
-  - xorg-libsm >=1.2.6,<2.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxrender >=0.9.12,<0.10.0a0
-  license: LGPL-2.1-only or MPL-1.1
-  size: 989514
-  timestamp: 1766415934926
 - conda: https://prefix.dev/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
   sha256: 3bd6a391ad60e471de76c0e9db34986c4b5058587fbf2efa5a7f54645e28c2c7
   md5: 09262e66b19567aff4f592fb53b28760
@@ -16009,14 +15512,6 @@ packages:
   purls: []
   size: 1697114
   timestamp: 1765446496987
-- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
-  sha256: a6b118fd1ed6099dc4fc03f9c492b88882a780fadaef4ed4f93dc70757713656
-  md5: 765c4d97e877cdbbb88ff33152b86125
-  depends:
-  - python >=3.10
-  license: ISC
-  size: 151445
-  timestamp: 1772001170301
 - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
   sha256: a6b118fd1ed6099dc4fc03f9c492b88882a780fadaef4ed4f93dc70757713656
   md5: 765c4d97e877cdbbb88ff33152b86125
@@ -16078,15 +15573,6 @@ packages:
   - pkg:pypi/cffi?source=hash-mapping
   size: 295716
   timestamp: 1761202958833
-- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
-  sha256: 3f9483d62ce24ecd063f8a5a714448445dc8d9e201147c46699fc0033e824457
-  md5: a9167b9571f3baa9d448faa2139d1089
-  depends:
-  - python >=3.10
-  license: MIT
-  license_family: MIT
-  size: 58872
-  timestamp: 1775127203018
 - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
   sha256: b32f8362e885f1b8417bac2b3da4db7323faa12d5db62b7fd6691c02d60d6f59
   md5: a22d1fd9bf98827e280a02875d9a007a
@@ -16232,17 +15718,6 @@ packages:
   purls: []
   size: 99051
   timestamp: 1772207728613
-- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.2-pyhc90fa1f_0.conda
-  sha256: 526d434cf5390310f40f34ea6ec4f0c225cdf1e419010e624d399b13b2059f0f
-  md5: 4d18bc3af7cfcea97bd817164672a08c
-  depends:
-  - __unix
-  - python
-  - python >=3.10
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 98253
-  timestamp: 1775578217828
 - conda: https://prefix.dev/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
   sha256: 38cfe1ee75b21a8361c8824f5544c3866f303af1762693a178266d7f198e8715
   md5: ea8a6c3256897cc31263de9f455e25d9
@@ -16675,16 +16150,6 @@ packages:
   - pkg:pypi/contourpy?source=compressed-mapping
   size: 320386
   timestamp: 1769155979897
-- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.15-py311hd8ed1ab_0.conda
-  noarch: generic
-  sha256: 4811072ccc369c80cb94156fb96fa234db1b90120c0859dc173bea42d49a57b5
-  md5: bf0d09d5c2b61aaf7b11c551c8545cfa
-  depends:
-  - python >=3.11,<3.12.0a0
-  - python_abi * *_cp311
-  license: Python-2.0
-  size: 48036
-  timestamp: 1772730257686
 - conda: https://prefix.dev/conda-forge/noarch/cpython-3.10.20-py310hd8ed1ab_0.conda
   noarch: generic
   sha256: a1c44d450ca670741396fd8ed91ce346b0f14b584b192076dda8fe9b6add22d5
@@ -17703,15 +17168,6 @@ packages:
   - nibabel>=5.3.2 ; extra == 'nibabel'
   - ipyniivue==2.4.2 ; extra == 'nibabel'
   requires_python: '>=3.10.0'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
-  sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
-  md5: 418c6ca5929a611cbd69204907a83995
-  depends:
-  - libgcc-ng >=12
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 760229
-  timestamp: 1685695754230
 - conda: https://prefix.dev/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
   sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
   md5: 418c6ca5929a611cbd69204907a83995
@@ -17732,19 +17188,6 @@ packages:
   purls: []
   size: 347363
   timestamp: 1685696690003
-- conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
-  sha256: 8bb557af1b2b7983cf56292336a1a1853f26555d9c6cecf1e5b2b96838c9da87
-  md5: ce96f2f470d39bd96ce03945af92e280
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
-  - libglib >=2.86.2,<3.0a0
-  - libexpat >=2.7.3,<3.0a0
-  license: AFL-2.1 OR GPL-2.0-or-later
-  size: 447649
-  timestamp: 1764536047944
 - conda: https://prefix.dev/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
   sha256: 8bb557af1b2b7983cf56292336a1a1853f26555d9c6cecf1e5b2b96838c9da87
   md5: ce96f2f470d39bd96ce03945af92e280
@@ -17809,16 +17252,6 @@ packages:
   - pkg:pypi/defusedxml?source=hash-mapping
   size: 24062
   timestamp: 1615232388757
-- conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_1.conda
-  sha256: 7d57a7b8266043ffb99d092ebc25e89a0a2490bed4146b9432c83c2c476fa94d
-  md5: 5498feb783ab29db6ca8845f68fa0f03
-  depends:
-  - python >=3.10
-  - wrapt <3,>=1.10
-  license: MIT
-  license_family: MIT
-  size: 15896
-  timestamp: 1768934186726
 - pypi: https://files.pythonhosted.org/packages/f7/55/586a3a2b9c95f371c9c3cb048c3cac15aedcce8d6d53ebd6bbc46860722d/diffusers-0.37.0-py3-none-any.whl
   name: diffusers
   version: 0.37.0
@@ -17947,25 +17380,6 @@ packages:
   - pkg:pypi/dill?source=hash-mapping
   size: 95462
   timestamp: 1768863743943
-- conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.8.0-pyhcf101f3_0.conda
-  sha256: ef1e7b8405997ed3d6e2b6722bd7088d4a8adf215e7c88335582e65651fb4e05
-  md5: d73fdc05f10693b518f52c994d748c19
-  depends:
-  - python >=3.10,<4.0.0
-  - sniffio
-  - python
-  constrains:
-  - aioquic >=1.2.0
-  - cryptography >=45
-  - httpcore >=1.0.0
-  - httpx >=0.28.0
-  - h2 >=4.2.0
-  - idna >=3.10
-  - trio >=0.30
-  - wmi >=1.5.1
-  license: ISC
-  size: 196500
-  timestamp: 1757292856922
 - conda: https://prefix.dev/conda-forge/noarch/docker-pycreds-0.4.0-py_0.tar.bz2
   sha256: 2ba7e3e4f75e07b42246b4ba8569c983ecbdcda47b1b900632858a23d91826f2
   md5: c69f19038efee4eb534623610d0c2053
@@ -18099,24 +17513,6 @@ packages:
   - pkg:pypi/einops?source=hash-mapping
   size: 58171
   timestamp: 1769426991573
-- conda: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.3.0-pyhd8ed1ab_0.conda
-  sha256: c37320864c35ef996b0e02e289df6ee89582d6c8e233e18dc9983375803c46bb
-  md5: 3bc0ac31178387e8ed34094d9481bfe8
-  depends:
-  - dnspython >=2.0.0
-  - idna >=2.0.0
-  - python >=3.10
-  license: Unlicense
-  size: 46767
-  timestamp: 1756221480106
-- conda: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.3.0-hd8ed1ab_0.conda
-  sha256: 6a518e00d040fcad016fb2dde29672aa3476cd9ae33ea5b7b257222e66037d89
-  md5: 2452e434747a6b742adc5045f2182a8e
-  depends:
-  - email-validator >=2.3.0,<2.3.1.0a0
-  license: Unlicense
-  size: 7077
-  timestamp: 1756221480651
 - conda: https://prefix.dev/conda-forge/linux-64/embree-4.4.0-ha751380_1.conda
   sha256: aabfa509404b2e3df9aa28b2304465822d709761fdac0b0a262b07eb6a1b425e
   md5: 69603afa88336a2c836721dc980b742e
@@ -18179,15 +17575,6 @@ packages:
   - pyqt6 ; extra == 'gui'
   - rerun-sdk>=0.28.0 ; extra == 'rerun'
   requires_python: '>=3.10'
-- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-  sha256: ee6cf346d017d954255bbcbdb424cddea4d14e4ed7e9813e429db1d795d01144
-  md5: 8e662bd460bda79b1ea39194e3c4c9ab
-  depends:
-  - python >=3.10
-  - typing_extensions >=4.6.0
-  license: MIT and PSF-2.0
-  size: 21333
-  timestamp: 1763918099466
 - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
   sha256: ee6cf346d017d954255bbcbdb424cddea4d14e4ed7e9813e429db1d795d01144
   md5: 8e662bd460bda79b1ea39194e3c4c9ab
@@ -18360,61 +17747,6 @@ packages:
   - pydantic-settings>=2.0.0 ; extra == 'all'
   - pydantic-extra-types>=2.0.0 ; extra == 'all'
   requires_python: '>=3.10'
-- conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.135.3-hbd727af_0.conda
-  sha256: 076958a26a7429f0f21324f17d93f005e95e1927d2c0742a84426aa138236af4
-  md5: b19a746ffc6b4fd78a571a3229aa7997
-  depends:
-  - fastapi-core ==0.135.3 pyhcf101f3_0
-  - email_validator
-  - fastapi-cli
-  - httpx
-  - jinja2
-  - pydantic-settings
-  - pydantic-extra-types
-  - python-multipart
-  - uvicorn-standard
-  license: MIT
-  license_family: MIT
-  size: 4813
-  timestamp: 1775065681410
-- conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.23-pyhcf101f3_0.conda
-  sha256: cb60fc8c96dcd2a6335914d4d6d7d5f5549c9e1ff4533be28ba699e648babf37
-  md5: 442ec6511754418c87a84bc1dc0c5384
-  depends:
-  - python >=3.10
-  - rich-toolkit >=0.14.8
-  - tomli >=2.0.0
-  - typer >=0.15.1
-  - uvicorn-standard >=0.15.0
-  - python
-  license: MIT
-  license_family: MIT
-  size: 18920
-  timestamp: 1771293215825
-- conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.135.3-pyhcf101f3_0.conda
-  sha256: a3d8d44e7b6519eac6b57faaf1c872f8865b125cf6ecb50d2d09467c558294c5
-  md5: 1ed2eb0553d0b601604e20af3db2d9f9
-  depends:
-  - python >=3.10
-  - annotated-doc >=0.0.2
-  - starlette >=0.46.0
-  - typing_extensions >=4.8.0
-  - typing-inspection >=0.4.2
-  - pydantic >=2.9.0
-  - python
-  constrains:
-  - email_validator >=2.0.0
-  - fastapi-cli >=0.0.8
-  - httpx >=0.23.0,<1.0.0
-  - jinja2 >=3.1.5
-  - pydantic-extra-types >=2.0.0
-  - pydantic-settings >=2.0.0
-  - python-multipart >=0.0.18
-  - uvicorn-standard >=0.12.0
-  license: MIT
-  license_family: MIT
-  size: 95900
-  timestamp: 1775065681410
 - pypi: https://files.pythonhosted.org/packages/9e/f3/25c1bfe7d3825b2290e91be1ac4b467bd166634b65a11c800b7cdbda2ff4/fastcore-1.12.23-py3-none-any.whl
   name: fastcore
   version: 1.12.23
@@ -18500,69 +17832,6 @@ packages:
   - plum-dispatch ; extra == 'dev'
   - toolslm ; extra == 'dev'
   requires_python: '>=3.10'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.0.1-gpl_hcddb375_914.conda
-  sha256: 0d465b145eb7166d6a3989f0befe790789624604945f53de767b169b1832c088
-  md5: f0e9f1452786e2b32907e8d9a6b3c752
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.15.3,<1.3.0a0
-  - aom >=3.9.1,<3.10.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.17.1,<3.0a0
-  - fonts-conda-ecosystem
-  - gmp >=6.3.0,<7.0a0
-  - harfbuzz >=12.3.2
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.4,<0.17.5.0a0
-  - libexpat >=2.7.4,<3.0a0
-  - libfreetype >=2.14.2
-  - libfreetype6 >=2.14.2
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - libjxl >=0.11,<1.0a0
-  - liblzma >=5.8.2,<6.0a0
-  - libopenvino >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-auto-batch-plugin >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-auto-plugin >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-hetero-plugin >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-intel-cpu-plugin >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-intel-gpu-plugin >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-intel-npu-plugin >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-ir-frontend >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-onnx-frontend >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-paddle-frontend >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-pytorch-frontend >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-tensorflow-frontend >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2026.0.0,<2026.0.1.0a0
-  - libopus >=1.6.1,<2.0a0
-  - librsvg >=2.60.2,<3.0a0
-  - libstdcxx >=14
-  - libva >=2.23.0,<3.0a0
-  - libvorbis >=1.3.7,<1.4.0a0
-  - libvpl >=2.16.0,<2.17.0a0
-  - libvpx >=1.15.2,<1.16.0a0
-  - libvulkan-loader >=1.4.341.0,<2.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libzlib >=1.3.1,<2.0a0
-  - openh264 >=2.6.0,<2.6.1.0a0
-  - openssl >=3.5.5,<4.0a0
-  - pulseaudio-client >=17.0,<17.1.0a0
-  - sdl2 >=2.32.56,<3.0a0
-  - shaderc >=2025.5,<2025.6.0a0
-  - svt-av1 >=4.0.1,<4.0.2.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  - xorg-libx11 >=1.8.13,<2.0a0
-  constrains:
-  - __cuda  >=12.8
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 12485347
-  timestamp: 1773008832077
 - conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-7.1.1-gpl_hbbdf940_911.conda
   sha256: fdbec8d65b252c08a73ee418eb5b0a4d05579556b432d715adde7f783562e9b4
   md5: fe3678db2768972f0351eb8604bc3ca8
@@ -18817,14 +18086,6 @@ packages:
   requires_dist:
   - psutil>=5.8.0 ; extra == 'psutil'
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.2-pyhd8ed1ab_0.conda
-  sha256: dddea9ec53d5e179de82c24569d41198f98db93314f0adae6b15195085d5567f
-  md5: f58064cec97b12a7136ebb8a6f8a129b
-  depends:
-  - python >=3.10
-  license: Unlicense
-  size: 25845
-  timestamp: 1773314012590
 - conda: https://prefix.dev/conda-forge/noarch/filelock-3.25.0-pyhd8ed1ab_0.conda
   sha256: 55162ec0ff4e22d8f762b3e774f08f79f234ba37ab5e64d7a1421ed9216a222c
   md5: 49a92015e912176999ae81bea11ea778
@@ -18917,13 +18178,6 @@ packages:
   purls: []
   size: 197671
   timestamp: 1767681179883
-- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-  sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
-  md5: 0c96522c6bdaed4b1566d11387caaf45
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 397370
-  timestamp: 1566932522327
 - conda: https://prefix.dev/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
   md5: 0c96522c6bdaed4b1566d11387caaf45
@@ -18932,13 +18186,6 @@ packages:
   purls: []
   size: 397370
   timestamp: 1566932522327
-- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-  sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
-  md5: 34893075a5c9e55cdafac56607368fc6
-  license: OFL-1.1
-  license_family: Other
-  size: 96530
-  timestamp: 1620479909603
 - conda: https://prefix.dev/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
   sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
   md5: 34893075a5c9e55cdafac56607368fc6
@@ -18947,13 +18194,6 @@ packages:
   purls: []
   size: 96530
   timestamp: 1620479909603
-- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-  sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
-  md5: 4d59c254e01d9cde7957100457e2d5fb
-  license: OFL-1.1
-  license_family: Other
-  size: 700814
-  timestamp: 1620479612257
 - conda: https://prefix.dev/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
   sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
   md5: 4d59c254e01d9cde7957100457e2d5fb
@@ -18962,13 +18202,6 @@ packages:
   purls: []
   size: 700814
   timestamp: 1620479612257
-- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-  sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
-  md5: 49023d73832ef61042f6a237cb2687e7
-  license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
-  license_family: Other
-  size: 1620504
-  timestamp: 1727511233259
 - conda: https://prefix.dev/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
   sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
   md5: 49023d73832ef61042f6a237cb2687e7
@@ -18977,21 +18210,6 @@ packages:
   purls: []
   size: 1620504
   timestamp: 1727511233259
-- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.17.1-h27c8c51_0.conda
-  sha256: aa4a44dba97151221100a637c7f4bde619567afade9c0265f8e1c8eed8d7bd8c
-  md5: 867127763fbe935bab59815b6e0b7b5c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libexpat >=2.7.4,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - libgcc >=14
-  - libuuid >=2.41.3,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 270705
-  timestamp: 1771382710863
 - conda: https://prefix.dev/conda-forge/linux-64/fontconfig-2.17.1-h27c8c51_0.conda
   sha256: aa4a44dba97151221100a637c7f4bde619567afade9c0265f8e1c8eed8d7bd8c
   md5: 867127763fbe935bab59815b6e0b7b5c
@@ -19023,15 +18241,6 @@ packages:
   purls: []
   size: 279044
   timestamp: 1771382728182
-- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-  sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-  md5: fee5683a3f04bd15cbd8318b096a27ab
-  depends:
-  - fonts-conda-forge
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3667
-  timestamp: 1566974674465
 - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
   sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
   md5: fee5683a3f04bd15cbd8318b096a27ab
@@ -19042,18 +18251,6 @@ packages:
   purls: []
   size: 3667
   timestamp: 1566974674465
-- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
-  sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
-  md5: a7970cd949a077b7cb9696379d338681
-  depends:
-  - font-ttf-ubuntu
-  - font-ttf-inconsolata
-  - font-ttf-dejavu-sans-mono
-  - font-ttf-source-code-pro
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 4059
-  timestamp: 1762351264405
 - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
   sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
   md5: a7970cd949a077b7cb9696379d338681
@@ -19397,15 +18594,6 @@ packages:
   - pkg:pypi/freetype-py?source=hash-mapping
   size: 65269
   timestamp: 1733689682410
-- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
-  sha256: 858283ff33d4c033f4971bf440cebff217d5552a5222ba994c49be990dacd40d
-  md5: f9f81ea472684d75b9dd8d0b328cf655
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  size: 61244
-  timestamp: 1757438574066
 - conda: https://prefix.dev/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
   sha256: 858283ff33d4c033f4971bf440cebff217d5552a5222ba994c49be990dacd40d
   md5: f9f81ea472684d75b9dd8d0b328cf655
@@ -19503,15 +18691,6 @@ packages:
   - pkg:pypi/frozenlist?source=hash-mapping
   size: 55037
   timestamp: 1752167383781
-- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.3.0-pyhd8ed1ab_0.conda
-  sha256: b4a7aec32167502dd4a2d1fb1208c63760828d7111339aa5b305b2d776afa70f
-  md5: c18d2ba7577cdc618a20d45f1e31d14b
-  depends:
-  - python >=3.10
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 148973
-  timestamp: 1774699581537
 - conda: https://prefix.dev/conda-forge/noarch/fsspec-2026.2.0-pyhd8ed1ab_0.conda
   sha256: 239b67edf1c5e5caed52cf36e9bed47cb21b37721779828c130e6b3fd9793c1b
   md5: 496c6c9411a6284addf55c898d6ed8d7
@@ -19603,21 +18782,6 @@ packages:
   purls: []
   size: 28912
   timestamp: 1775508892545
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda
-  sha256: c5594497f0646e9079705b3199dbb2d5b13c48173cf110000fa1c8818e2b3e0c
-  md5: 7892f39a39ed39591a89a28eba03e987
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libglib >=2.86.4,<3.0a0
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  - liblzma >=5.8.2,<6.0a0
-  - libpng >=1.6.56,<1.7.0a0
-  - libtiff >=4.7.1,<4.8.0a0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 577414
-  timestamp: 1774985848058
 - conda: https://prefix.dev/conda-forge/linux-64/gdk-pixbuf-2.44.4-h2b0a6b4_0.conda
   sha256: f47222f58839bcc77c15f11a8814c1d8cb8080c5ca6ba83398a12b640fd3c85c
   md5: c379d67c686fb83475c1a6ed41cc41ff
@@ -19727,19 +18891,6 @@ packages:
   purls: []
   size: 106638
   timestamp: 1726599967617
-- conda: https://conda.anaconda.org/conda-forge/noarch/gguf-0.17.1-pyhc364b38_1.conda
-  sha256: db9153390627023f88c83e8fca87825a67bde3080dca91554be83b8db369e75e
-  md5: 99d5d8bfe8def56f3514c82bfe840315
-  depends:
-  - python >=3.8
-  - numpy >=1.17
-  - tqdm >=4.27
-  - pyyaml >=5.1
-  - python
-  license: MIT
-  license_family: MIT
-  size: 92302
-  timestamp: 1770223049607
 - conda: https://prefix.dev/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
   sha256: aac402a8298f0c0cc528664249170372ef6b37ac39fdc92b40601a6aed1e32ff
   md5: 3bf7b9fd5a7136126e0234db4b87c8b6
@@ -19920,18 +19071,6 @@ packages:
   purls: []
   size: 145811
   timestamp: 1718284208668
-- conda: https://conda.anaconda.org/conda-forge/linux-64/glslang-16.2.0-h96af755_1.conda
-  sha256: 88a5ad3571948bde22957d08ab01328b8a7eb04fdee66268b3125cc322dbde8b
-  md5: ba5b655d827f263090ad2dc514810328
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - spirv-tools >=2026,<2027.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1353008
-  timestamp: 1770195199411
 - conda: https://prefix.dev/conda-forge/linux-64/glslang-16.2.0-h96af755_1.conda
   sha256: 88a5ad3571948bde22957d08ab01328b8a7eb04fdee66268b3125cc322dbde8b
   md5: ba5b655d827f263090ad2dc514810328
@@ -19970,15 +19109,6 @@ packages:
   purls: []
   size: 1348415
   timestamp: 1770195275881
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
-  sha256: 309cf4f04fec0c31b6771a5809a1909b4b3154a2208f52351e1ada006f4c750c
-  md5: c94a5994ef49749880a8139cf9afcbe1
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: GPL-2.0-or-later OR LGPL-3.0-or-later
-  size: 460055
-  timestamp: 1718980856608
 - conda: https://prefix.dev/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
   sha256: 309cf4f04fec0c31b6771a5809a1909b4b3154a2208f52351e1ada006f4c750c
   md5: c94a5994ef49749880a8139cf9afcbe1
@@ -20067,17 +19197,6 @@ packages:
   - pkg:pypi/gmpy2?source=compressed-mapping
   size: 243515
   timestamp: 1773245145964
-- conda: https://conda.anaconda.org/conda-forge/noarch/googleapis-common-protos-1.74.0-pyhcf101f3_0.conda
-  sha256: 0c7454493ae6965b5351ecfb056fb8a36385c565a09642f49714dab0a164991e
-  md5: 4c8212089cf56e73b7d64c1c6440bc00
-  depends:
-  - python >=3.10
-  - protobuf >=4.25.8,<8.0.0
-  - python
-  license: Apache-2.0
-  license_family: APACHE
-  size: 149863
-  timestamp: 1775210699986
 - pypi: https://files.pythonhosted.org/packages/38/3c/1568ee82f0e4308612aaf964168e93b7f2adb64c3e77b7877fd397e773bf/gradio-6.8.0-py3-none-any.whl
   name: gradio
   version: 6.8.0
@@ -20141,17 +19260,6 @@ packages:
   - opencv-python>=4.10.0 ; extra == 'dev'
   - twine ; extra == 'dev'
   requires_python: '>=3.10'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
-  sha256: 25ba37da5c39697a77fce2c9a15e48cf0a84f1464ad2aafbe53d8357a9f6cc8c
-  md5: 2cd94587f3a401ae05e03a6caf09539d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 99596
-  timestamp: 1755102025473
 - conda: https://prefix.dev/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
   sha256: 25ba37da5c39697a77fce2c9a15e48cf0a84f1464ad2aafbe53d8357a9f6cc8c
   md5: 2cd94587f3a401ae05e03a6caf09539d
@@ -20183,24 +19291,6 @@ packages:
   - pytest ; extra == 'dev'
   - ruff==0.9.3 ; extra == 'dev'
   requires_python: '>3.9'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.80.0-py311h3aa0767_0.conda
-  sha256: 0ba36e4cf64270bcd2508a82e7f0ad7a4b3a4905a0ea27a4ed19ccbc245e0e82
-  md5: de4bd498e64e82c582bd10f144a566e3
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.1,<20260108.0a0
-  - libgcc >=14
-  - libgrpc 1.80.0 h1d1128b_0
-  - libstdcxx >=14
-  - libzlib >=1.3.2,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - typing-extensions >=4.12,<5
-  license: Apache-2.0
-  license_family: APACHE
-  size: 904625
-  timestamp: 1775544165668
 - pypi: git+https://github.com/nerfstudio-project/gsplat.git?rev=970dd84803ecf8570651f8e121e328bfef567fb9#970dd84803ecf8570651f8e121e328bfef567fb9
   name: gsplat
   version: 1.5.3
@@ -20382,17 +19472,6 @@ packages:
   purls: []
   size: 27503
   timestamp: 1770908213813
-- conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
-  sha256: 96cac6573fd35ae151f4d6979bab6fbc90cb6b1fb99054ba19eb075da9822fcb
-  md5: b8993c19b0c32a2f7b66cbb58ca27069
-  depends:
-  - python >=3.10
-  - typing_extensions
-  - python
-  license: MIT
-  license_family: MIT
-  size: 39069
-  timestamp: 1767729720872
 - conda: https://prefix.dev/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
   sha256: 96cac6573fd35ae151f4d6979bab6fbc90cb6b1fb99054ba19eb075da9822fcb
   md5: b8993c19b0c32a2f7b66cbb58ca27069
@@ -20406,18 +19485,6 @@ packages:
   - pkg:pypi/h11?source=compressed-mapping
   size: 39069
   timestamp: 1767729720872
-- conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-  sha256: 84c64443368f84b600bfecc529a1194a3b14c3656ee2e832d15a20e0329b6da3
-  md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
-  depends:
-  - python >=3.10
-  - hyperframe >=6.1,<7
-  - hpack >=4.1,<5
-  - python
-  license: MIT
-  license_family: MIT
-  size: 95967
-  timestamp: 1756364871835
 - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
   sha256: 84c64443368f84b600bfecc529a1194a3b14c3656ee2e832d15a20e0329b6da3
   md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
@@ -20449,25 +19516,6 @@ packages:
   - pkg:pypi/h5py?source=hash-mapping
   size: 1290741
   timestamp: 1764016665782
-- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.1.0-h6083320_0.conda
-  sha256: 22c4f6df7eb4684a4b60e62de84211e7d80a0df2d7cfdbbd093a73650e3f2d45
-  md5: ca8a94b613db5d805c3d2498a7c30997
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cairo >=1.18.4,<2.0a0
-  - graphite2 >=1.3.14,<2.0a0
-  - icu >=78.3,<79.0a0
-  - libexpat >=2.7.5,<3.0a0
-  - libfreetype >=2.14.3
-  - libfreetype6 >=2.14.3
-  - libgcc >=14
-  - libglib >=2.86.4,<3.0a0
-  - libstdcxx >=14
-  - libzlib >=1.3.2,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 2338203
-  timestamp: 1775569314754
 - conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-12.2.0-h15599e2_0.conda
   sha256: 6bd8b22beb7d40562b2889dc68232c589ff0d11a5ad3addd41a8570d11f039d9
   md5: b8690f53007e9b5ee2c2178dd4ac778c
@@ -20770,20 +19818,6 @@ packages:
   purls: []
   size: 3924367
   timestamp: 1774414695892
-- conda: https://conda.anaconda.org/conda-forge/linux-64/hf-transfer-0.1.9-py311he4d9500_2.conda
-  sha256: da2150643021bcf156f007b457d750eebf89da251ac70f189c6b604c7c42cac3
-  md5: 849d8b7040094c423de3440def16eded
-  depends:
-  - python
-  - __glibc >=2.17,<3.0.a0
-  - openssl >=3.5.2,<4.0a0
-  - python_abi 3.11.* *_cp311
-  constrains:
-  - __glibc >=2.17
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1304149
-  timestamp: 1756624831937
 - conda: https://prefix.dev/conda-forge/linux-64/hf-transfer-0.1.9-py310h3a8baf8_2.conda
   sha256: 3c5acbfc48a8a78cd2df03f5a5cb0f80d1af249d8a7bb342a8479a9bc260215b
   md5: 144df7777cb368ec71c9573e42e9e81a
@@ -20864,23 +19898,6 @@ packages:
   - pkg:pypi/hf-transfer?source=hash-mapping
   size: 1328708
   timestamp: 1756624872246
-- conda: https://conda.anaconda.org/conda-forge/linux-64/hf-xet-1.4.3-py310hb823017_0.conda
-  noarch: python
-  sha256: 561e79c25acdbc68d79585564c69b8a268e870c49229a496550da212a8fc95ae
-  md5: 3b07fdd2e38ac0de55f997d912b1592d
-  depends:
-  - python
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - openssl >=3.5.5,<4.0a0
-  - _python_abi3_support 1.*
-  - cpython >=3.10
-  constrains:
-  - __glibc >=2.17
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3373679
-  timestamp: 1775006270278
 - conda: https://prefix.dev/conda-forge/linux-64/hf-xet-1.2.1-py310hb823017_0.conda
   noarch: python
   sha256: 11b840645c4d321d2b33c0e4cf8a1132bd01d1ccd8e019135c01fab7d4b96ca3
@@ -21049,15 +20066,6 @@ packages:
   - pkg:pypi/hf-xet?source=hash-mapping
   size: 3284933
   timestamp: 1775006265539
-- conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
-  sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
-  md5: 0a802cb9888dd14eeefc611f05c40b6e
-  depends:
-  - python >=3.9
-  license: MIT
-  license_family: MIT
-  size: 30731
-  timestamp: 1737618390337
 - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
   sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
   md5: 0a802cb9888dd14eeefc611f05c40b6e
@@ -21069,21 +20077,6 @@ packages:
   - pkg:pypi/hpack?source=hash-mapping
   size: 30731
   timestamp: 1737618390337
-- conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
-  sha256: 04d49cb3c42714ce533a8553986e1642d0549a05dc5cc48e0d43ff5be6679a5b
-  md5: 4f14640d58e2cc0aa0819d9d8ba125bb
-  depends:
-  - python >=3.9
-  - h11 >=0.16
-  - h2 >=3,<5
-  - sniffio 1.*
-  - anyio >=4.0,<5.0
-  - certifi
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 49483
-  timestamp: 1745602916758
 - conda: https://prefix.dev/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
   sha256: 04d49cb3c42714ce533a8553986e1642d0549a05dc5cc48e0d43ff5be6679a5b
   md5: 4f14640d58e2cc0aa0819d9d8ba125bb
@@ -21106,31 +20099,6 @@ packages:
   version: 0.7.1
   sha256: 2c15f37ef679ab9ecc06bfc4e6e8628c32a8e4b305459de7cf6785acd57e4d03
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/httptools-0.7.1-py311h49ec1c0_1.conda
-  sha256: 18f42d651525ecf9e53603a42b0a2c72cecf5e2adfdafc0e0187cb0149c27f6b
-  md5: b275c72b72e92f01de93e2eed8f0c821
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: MIT
-  license_family: MIT
-  size: 98273
-  timestamp: 1762504031887
-- conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
-  sha256: cd0f1de3697b252df95f98383e9edb1d00386bfdd03fdf607fa42fe5fcb09950
-  md5: d6989ead454181f4f9bc987d3dc4e285
-  depends:
-  - anyio
-  - certifi
-  - httpcore 1.*
-  - idna
-  - python >=3.9
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 63082
-  timestamp: 1733663449209
 - conda: https://prefix.dev/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
   sha256: cd0f1de3697b252df95f98383e9edb1d00386bfdd03fdf607fa42fe5fcb09950
   md5: d6989ead454181f4f9bc987d3dc4e285
@@ -21146,26 +20114,6 @@ packages:
   - pkg:pypi/httpx?source=hash-mapping
   size: 63082
   timestamp: 1733663449209
-- conda: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-1.9.2-pyhd8ed1ab_0.conda
-  sha256: 9a1da097e83b6bc44cb9babc113ddbbd36c380f90f507a092b2b14e686671223
-  md5: 6e83ba78f643ddc0d7f43246338f11a7
-  depends:
-  - filelock >=3.10.0
-  - fsspec >=2023.5.0
-  - hf-xet >=1.4.3,<2.0.0
-  - httpx >=0.23.0,<1
-  - packaging >=20.9
-  - python >=3.10
-  - pyyaml >=5.1
-  - requests
-  - tqdm >=4.42.1
-  - typer
-  - typing-extensions >=3.7.4.3
-  - typing_extensions >=4.1.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 400637
-  timestamp: 1775661557832
 - conda: https://prefix.dev/conda-forge/noarch/huggingface_hub-1.5.0-pyhd8ed1ab_0.conda
   sha256: 08547802885bc678c3e3218280f556a35c9d1d0f5979065f02fb5b33056721a9
   md5: e56074c80e1f7ff45e73161ca0508b25
@@ -21289,15 +20237,6 @@ packages:
   - pyreadline ; python_full_version < '3.8' and sys_platform == 'win32'
   - pyreadline3 ; python_full_version >= '3.8' and sys_platform == 'win32'
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*'
-- conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-  sha256: 77af6f5fe8b62ca07d09ac60127a30d9069fdc3c68d6b256754d0ffb1f7779f8
-  md5: 8e6923fc12f1fe8f8c4e5c9f343256ac
-  depends:
-  - python >=3.9
-  license: MIT
-  license_family: MIT
-  size: 17397
-  timestamp: 1737618427549
 - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
   sha256: 77af6f5fe8b62ca07d09ac60127a30d9069fdc3c68d6b256754d0ffb1f7779f8
   md5: 8e6923fc12f1fe8f8c4e5c9f343256ac
@@ -21390,17 +20329,6 @@ packages:
   - pkg:pypi/icecream?source=hash-mapping
   size: 16230
   timestamp: 1769177278583
-- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
-  sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
-  md5: c80d8a3b84358cb967fa81e7075fbc8a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 12723451
-  timestamp: 1773822285671
 - conda: https://prefix.dev/conda-forge/linux-64/icu-75.1-he02047a_0.conda
   sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
   md5: 8b189310083baabfb622af68fd9d3ae3
@@ -21477,15 +20405,6 @@ packages:
   - pretend ; extra == 'test'
   - coverage[toml] ; extra == 'test'
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
-  sha256: ae89d0299ada2a3162c2614a9d26557a92aa6a77120ce142f8e0109bbf0342b0
-  md5: 53abe63df7e10a6ba605dc5f9f961d36
-  depends:
-  - python >=3.10
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 50721
-  timestamp: 1760286526795
 - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
   sha256: ae89d0299ada2a3162c2614a9d26557a92aa6a77120ce142f8e0109bbf0342b0
   md5: 53abe63df7e10a6ba605dc5f9f961d36
@@ -21586,17 +20505,6 @@ packages:
   - pytest-mypy>=1.0.1 ; extra == 'type'
   - mypy<1.19 ; platform_python_implementation == 'PyPy' and extra == 'type'
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
-  sha256: c18ab120a0613ada4391b15981d86ff777b5690ca461ea7e9e49531e8f374745
-  md5: 63ccfdc3a3ce25b027b8767eb722fca8
-  depends:
-  - python >=3.9
-  - zipp >=3.20
-  - python
-  license: Apache-2.0
-  license_family: APACHE
-  size: 34641
-  timestamp: 1747934053147
 - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
   sha256: c18ab120a0613ada4391b15981d86ff777b5690ca461ea7e9e49531e8f374745
   md5: 63ccfdc3a3ce25b027b8767eb722fca8
@@ -21634,17 +20542,6 @@ packages:
   - pkg:pypi/iniconfig?source=compressed-mapping
   size: 13387
   timestamp: 1760831448842
-- conda: https://conda.anaconda.org/conda-forge/linux-64/intel-gmmlib-22.10.0-hb700be7_0.conda
-  sha256: bc231d69eb6663db0e09738fb916c5e5507147cf1ac60f364f964004e0b29bab
-  md5: 10909406c1b0e4b57f9f4f0eb0999af8
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 1013714
-  timestamp: 1774422680665
 - conda: https://prefix.dev/conda-forge/linux-64/intel-gmmlib-22.10.0-hb700be7_0.conda
   sha256: bc231d69eb6663db0e09738fb916c5e5507147cf1ac60f364f964004e0b29bab
   md5: 10909406c1b0e4b57f9f4f0eb0999af8
@@ -21669,19 +20566,6 @@ packages:
   purls: []
   size: 1009795
   timestamp: 1765886047465
-- conda: https://conda.anaconda.org/conda-forge/linux-64/intel-media-driver-26.1.5-hecca717_0.conda
-  sha256: 11392c7e965a68548754f17b0e358f54590c233da6cbcdac1096c2a39ff0f6da
-  md5: 6124ffce32e909624a446aa5c419faec
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - intel-gmmlib >=22.9.0,<23.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libva >=2.23.0,<3.0a0
-  license: MIT
-  license_family: MIT
-  size: 8786646
-  timestamp: 1774266925285
 - conda: https://prefix.dev/conda-forge/linux-64/intel-media-driver-25.3.4-hecca717_0.conda
   sha256: 286679d4c175e8db2d047be766d1629f1ea5828bff9fe7e6aac2e6f0fad2b427
   md5: 7ae2034a0e2e24eb07468f1a50cdf0bb
@@ -22022,17 +20906,6 @@ packages:
   - async-timeout ; python_full_version < '3.11' and extra == 'test'
   - trio ; extra == 'trio'
   requires_python: '>=3.7'
-- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
-  sha256: fc9ca7348a4f25fed2079f2153ecdcf5f9cf2a0bc36c4172420ca09e1849df7b
-  md5: 04558c96691bed63104678757beb4f8d
-  depends:
-  - markupsafe >=2.0
-  - python >=3.10
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 120685
-  timestamp: 1764517220861
 - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
   sha256: fc9ca7348a4f25fed2079f2153ecdcf5f9cf2a0bc36c4172420ca09e1849df7b
   md5: 04558c96691bed63104678757beb4f8d
@@ -22159,21 +21032,6 @@ packages:
   - pkg:pypi/jupyter-lsp?source=hash-mapping
   size: 60377
   timestamp: 1756388269267
-- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
-  sha256: 19d8bd5bb2fde910ec59e081eeb59529491995ce0d653a5209366611023a0b3a
-  md5: 4ebae00eae9705b0c3d6d1018a81d047
-  depends:
-  - importlib-metadata >=4.8.3
-  - jupyter_core >=4.12,!=5.0.*
-  - python >=3.9
-  - python-dateutil >=2.8.2
-  - pyzmq >=23.0
-  - tornado >=6.2
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 106342
-  timestamp: 1733441040958
 - conda: https://prefix.dev/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
   sha256: 19d8bd5bb2fde910ec59e081eeb59529491995ce0d653a5209366611023a0b3a
   md5: 4ebae00eae9705b0c3d6d1018a81d047
@@ -22208,22 +21066,6 @@ packages:
   - pkg:pypi/jupyter-client?source=compressed-mapping
   size: 112785
   timestamp: 1767954655912
-- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
-  sha256: 1d34b80e5bfcd5323f104dbf99a2aafc0e5d823019d626d0dce5d3d356a2a52a
-  md5: b38fe4e78ee75def7e599843ef4c1ab0
-  depends:
-  - __unix
-  - python
-  - platformdirs >=2.5
-  - python >=3.10
-  - traitlets >=5.3
-  - python
-  constrains:
-  - pywin32 >=300
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 65503
-  timestamp: 1760643864586
 - conda: https://prefix.dev/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
   sha256: 1d34b80e5bfcd5323f104dbf99a2aafc0e5d823019d626d0dce5d3d356a2a52a
   md5: b38fe4e78ee75def7e599843ef4c1ab0
@@ -22440,15 +21282,6 @@ packages:
   - types-pywin32 ; extra == 'type'
   - shtab>=1.1.0 ; extra == 'completion'
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
-  sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
-  md5: b38117a3c920364aff79f870c984b4a3
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: LGPL-2.1-or-later
-  size: 134088
-  timestamp: 1754905959823
 - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
   sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
   md5: b38117a3c920364aff79f870c984b4a3
@@ -22538,21 +21371,6 @@ packages:
   - pkg:pypi/kiwisolver?source=compressed-mapping
   size: 77120
   timestamp: 1773067050308
-- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
-  sha256: 3e307628ca3527448dd1cb14ad7bb9d04d1d28c7d4c5f97ba196ae984571dd25
-  md5: fb53fb07ce46a575c5d004bbc96032c2
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - keyutils >=1.6.3,<2.0a0
-  - libedit >=3.1.20250104,<3.2.0a0
-  - libedit >=3.1.20250104,<4.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - openssl >=3.5.5,<4.0a0
-  license: MIT
-  license_family: MIT
-  size: 1386730
-  timestamp: 1769769569681
 - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
   sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
   md5: 3f43953b7d3fb3aaa1d0d0723d91e368
@@ -22599,15 +21417,6 @@ packages:
   purls: []
   size: 1517436
   timestamp: 1769773395215
-- conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
-  sha256: aad2a703b9d7b038c0f745b853c6bb5f122988fe1a7a096e0e606d9cbec4eaab
-  md5: a8832b479f93521a9e7b5b743803be51
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.0-only
-  license_family: LGPL
-  size: 508258
-  timestamp: 1664996250081
 - conda: https://prefix.dev/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
   sha256: aad2a703b9d7b038c0f745b853c6bb5f122988fe1a7a096e0e606d9cbec4eaab
   md5: a8832b479f93521a9e7b5b743803be51
@@ -22651,18 +21460,6 @@ packages:
   - pytest>=7.4 ; extra == 'test'
   - pytest-cov>=4.1 ; extra == 'test'
   requires_python: '>=3.7'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.18-h0c24ade_0.conda
-  sha256: 836ec4b895352110335b9fdcfa83a8dcdbe6c5fb7c06c4929130600caea91c0a
-  md5: 6f2e2c8f58160147c4d1c6f4c14cbac4
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  - libtiff >=4.7.1,<4.8.0a0
-  license: MIT
-  license_family: MIT
-  size: 249959
-  timestamp: 1768184673131
 - conda: https://prefix.dev/conda-forge/linux-64/lcms2-2.18-h0c24ade_0.conda
   sha256: 836ec4b895352110335b9fdcfa83a8dcdbe6c5fb7c06c4929130600caea91c0a
   md5: 6f2e2c8f58160147c4d1c6f4c14cbac4
@@ -22688,18 +21485,6 @@ packages:
   purls: []
   size: 293039
   timestamp: 1768184778398
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
-  sha256: 3d584956604909ff5df353767f3a2a2f60e07d070b328d109f30ac40cd62df6c
-  md5: 18335a698559cdbcd86150a48bf54ba6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - zstd >=1.5.7,<1.6.0a0
-  constrains:
-  - binutils_impl_linux-64 2.45.1
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 728002
-  timestamp: 1774197446916
 - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
   sha256: 565941ac1f8b0d2f2e8f02827cbca648f4d18cd461afc31f15604cd291b5c5f3
   md5: 12bd9a3f089ee6c9266a37dab82afabd
@@ -22750,17 +21535,6 @@ packages:
   purls: []
   size: 875596
   timestamp: 1774197520746
-- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
-  sha256: f84cb54782f7e9cea95e810ea8fef186e0652d0fa73d3009914fa2c1262594e1
-  md5: a752488c68f2e7c456bcbd8f16eec275
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: Apache-2.0
-  license_family: Apache
-  size: 261513
-  timestamp: 1773113328888
 - conda: https://prefix.dev/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
   sha256: 412381a43d5ff9bbed82cd52a0bbca5b90623f62e41007c9c42d3870c60945ff
   md5: 9344155d33912347b37f0ae6c410a835
@@ -22796,17 +21570,6 @@ packages:
   purls: []
   size: 240444
   timestamp: 1773114901155
-- conda: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.28.2-hb700be7_0.conda
-  sha256: 5384380213daffbd7fe4d568b2cf2ab9f2476f7a5f228a3d70280e98333eaf0f
-  md5: 4323e07abff8366503b97a0f17924b76
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 858387
-  timestamp: 1772045965844
 - conda: https://prefix.dev/conda-forge/linux-64/level-zero-1.28.2-hb700be7_0.conda
   sha256: 5384380213daffbd7fe4d568b2cf2ab9f2476f7a5f228a3d70280e98333eaf0f
   md5: 4323e07abff8366503b97a0f17924b76
@@ -22819,20 +21582,6 @@ packages:
   purls: []
   size: 858387
   timestamp: 1772045965844
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
-  sha256: a7a4481a4d217a3eadea0ec489826a69070fcc3153f00443aa491ed21527d239
-  md5: 6f7b4302263347698fd24565fbf11310
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - libabseil-static =20260107.1=cxx17*
-  - abseil-cpp =20260107.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 1384817
-  timestamp: 1770863194876
 - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20250512.1-cxx17_hba17884_0.conda
   sha256: dcd1429a1782864c452057a6c5bc1860f2b637dc20a2b7e6eacd57395bbceff8
   md5: 83b160d4da3e1e847bf044997621ed63
@@ -23101,23 +21850,6 @@ packages:
   purls: []
   size: 53582
   timestamp: 1753342901341
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.4-h96ad9f0_0.conda
-  sha256: 035eb8b54e03e72e42ef707420f9979c7427776ea99e0f1e3c969f92eb573f19
-  md5: d3be7b2870bf7aff45b12ea53165babd
-  depends:
-  - libgcc >=13
-  - __glibc >=2.17,<3.0.a0
-  - libzlib >=1.3.1,<2.0a0
-  - libfreetype >=2.13.3
-  - libfreetype6 >=2.13.3
-  - fribidi >=1.0.10,<2.0a0
-  - libiconv >=1.18,<2.0a0
-  - fontconfig >=2.15.0,<3.0a0
-  - fonts-conda-ecosystem
-  - harfbuzz >=11.0.1
-  license: ISC
-  size: 152179
-  timestamp: 1749328931930
 - conda: https://prefix.dev/conda-forge/linux-64/libass-0.17.4-h96ad9f0_0.conda
   sha256: 035eb8b54e03e72e42ef707420f9979c7427776ea99e0f1e3c969f92eb573f19
   md5: d3be7b2870bf7aff45b12ea53165babd
@@ -23237,23 +21969,6 @@ packages:
   purls: []
   size: 147953
   timestamp: 1774042696884
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-6_h4a7cf45_openblas.conda
-  build_number: 6
-  sha256: 7bfe936dbb5db04820cf300a9cc1f5ee8d5302fc896c2d66e30f1ee2f20fbfd6
-  md5: 6d6d225559bfa6e2f3c90ee9c03d4e2e
-  depends:
-  - libopenblas >=0.3.32,<0.3.33.0a0
-  - libopenblas >=0.3.32,<1.0a0
-  constrains:
-  - blas 2.306   openblas
-  - liblapack  3.11.0   6*_openblas
-  - liblapacke 3.11.0   6*_openblas
-  - libcblas   3.11.0   6*_openblas
-  - mkl <2026
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 18621
-  timestamp: 1774503034895
 - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-5_h4a7cf45_openblas.conda
   build_number: 5
   sha256: 18c72545080b86739352482ba14ba2c4815e19e26a7417ca21a95b76ec8da24c
@@ -23400,16 +22115,6 @@ packages:
   purls: []
   size: 2978265
   timestamp: 1763017293494
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
-  sha256: 318f36bd49ca8ad85e6478bd8506c88d82454cc008c1ac1c6bf00a3c42fa610e
-  md5: 72c8fd1af66bd67bf580645b426513ed
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 79965
-  timestamp: 1764017188531
 - conda: https://prefix.dev/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
   sha256: 318f36bd49ca8ad85e6478bd8506c88d82454cc008c1ac1c6bf00a3c42fa610e
   md5: 72c8fd1af66bd67bf580645b426513ed
@@ -23431,17 +22136,6 @@ packages:
   purls: []
   size: 80030
   timestamp: 1764017273715
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
-  sha256: 12fff21d38f98bc446d82baa890e01fd82e3b750378fedc720ff93522ffb752b
-  md5: 366b40a69f0ad6072561c1d09301c886
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libbrotlicommon 1.2.0 hb03c661_1
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 34632
-  timestamp: 1764017199083
 - conda: https://prefix.dev/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
   sha256: 12fff21d38f98bc446d82baa890e01fd82e3b750378fedc720ff93522ffb752b
   md5: 366b40a69f0ad6072561c1d09301c886
@@ -23465,17 +22159,6 @@ packages:
   purls: []
   size: 33166
   timestamp: 1764017282936
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
-  sha256: a0c15c79997820bbd3fbc8ecf146f4fe0eca36cc60b62b63ac6cf78857f1dd0d
-  md5: 4ffbb341c8b616aa2494b6afb26a0c5f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libbrotlicommon 1.2.0 hb03c661_1
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 298378
-  timestamp: 1764017210931
 - conda: https://prefix.dev/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
   sha256: a0c15c79997820bbd3fbc8ecf146f4fe0eca36cc60b62b63ac6cf78857f1dd0d
   md5: 4ffbb341c8b616aa2494b6afb26a0c5f
@@ -23522,16 +22205,6 @@ packages:
   purls: []
   size: 44119
   timestamp: 1741963824815
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-hd0affe5_1.conda
-  sha256: 37c41b1024d0c75da76822e3c079aabaf121618a32fe05e53a897b35a88008fc
-  md5: 499cd8e2d4358986dbe3b30e8fe1bf6a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 124432
-  timestamp: 1774333989027
 - conda: https://prefix.dev/conda-forge/linux-64/libcap-2.77-h3ff7636_0.conda
   sha256: 9517cce5193144af0fcbf19b7bd67db0a329c2cc2618f28ffecaa921a1cbe9d3
   md5: 09c264d40c67b82b49a3f3b89037bd2e
@@ -23576,20 +22249,6 @@ packages:
   purls: []
   size: 109458
   timestamp: 1774335293336
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-6_h0358290_openblas.conda
-  build_number: 6
-  sha256: 57edafa7796f6fa3ebbd5367692dd4c7f552be42109c2dd1a7c89b55089bf374
-  md5: 36ae340a916635b97ac8a0655ace2a35
-  depends:
-  - libblas 3.11.0 6_h4a7cf45_openblas
-  constrains:
-  - blas 2.306   openblas
-  - liblapack  3.11.0   6*_openblas
-  - liblapacke 3.11.0   6*_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 18622
-  timestamp: 1774503050205
 - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-5_h0358290_openblas.conda
   build_number: 5
   sha256: 0cbdcc67901e02dc17f1d19e1f9170610bd828100dc207de4d5b6b8ad1ae7ad8
@@ -24244,16 +22903,6 @@ packages:
   purls: []
   size: 411814
   timestamp: 1703088639063
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
-  sha256: aa8e8c4be9a2e81610ddf574e05b64ee131fab5e0e3693210c9d6d2fba32c680
-  md5: 6c77a605a7a689d17d4819c0f8ac9a00
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 73490
-  timestamp: 1761979956660
 - conda: https://prefix.dev/conda-forge/linux-64/libdeflate-1.24-h86f0d12_0.conda
   sha256: 8420748ea1cc5f18ecc5068b4f24c7a023cc9b20971c99c824ba10641fb95ddf
   md5: 64f0c503da58ec25ebd359e4d990afa8
@@ -24286,17 +22935,6 @@ packages:
   purls: []
   size: 71117
   timestamp: 1761979776756
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
-  sha256: c076a213bd3676cc1ef22eeff91588826273513ccc6040d9bea68bccdc849501
-  md5: 9314bc5a1fe7d1044dc9dfd3ef400535
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libpciaccess >=0.18,<0.19.0a0
-  license: MIT
-  license_family: MIT
-  size: 310785
-  timestamp: 1757212153962
 - conda: https://prefix.dev/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
   sha256: c076a213bd3676cc1ef22eeff91588826273513ccc6040d9bea68bccdc849501
   md5: 9314bc5a1fe7d1044dc9dfd3ef400535
@@ -24320,18 +22958,6 @@ packages:
   purls: []
   size: 344548
   timestamp: 1757212128414
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
-  sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
-  md5: c277e0a4d549b03ac1e9d6cbbe3d017b
-  depends:
-  - ncurses
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - ncurses >=6.5,<7.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 134676
-  timestamp: 1738479519902
 - conda: https://prefix.dev/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
   sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
   md5: c277e0a4d549b03ac1e9d6cbbe3d017b
@@ -24357,15 +22983,6 @@ packages:
   purls: []
   size: 148125
   timestamp: 1738479808948
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
-  sha256: 7fd5408d359d05a969133e47af580183fbf38e2235b562193d427bb9dad79723
-  md5: c151d5eb730e9b7480e6d48c0fc44048
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libglvnd 1.7.0 ha4b6fd6_2
-  license: LicenseRef-libglvnd
-  size: 44840
-  timestamp: 1731330973553
 - conda: https://prefix.dev/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
   sha256: 7fd5408d359d05a969133e47af580183fbf38e2235b562193d427bb9dad79723
   md5: c151d5eb730e9b7480e6d48c0fc44048
@@ -24427,18 +23044,6 @@ packages:
   purls: []
   size: 438992
   timestamp: 1685726046519
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
-  sha256: e8c2b57f6aacabdf2f1b0924bd4831ce5071ba080baa4a9e8c0d720588b6794c
-  md5: 49f570f3bc4c874a06ea69b7225753af
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - expat 2.7.5.*
-  license: MIT
-  license_family: MIT
-  size: 76624
-  timestamp: 1774719175983
 - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
   sha256: d78f1d3bea8c031d2f032b760f36676d87929b18146351c4464c66b0869df3f5
   md5: e7f7ce06ec24cfcfb9e36d28cf82ba57
@@ -24535,16 +23140,6 @@ packages:
   purls: []
   size: 74649641
   timestamp: 1734672887808
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
-  sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
-  md5: a360c33a5abe61c07959e449fa1453eb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 58592
-  timestamp: 1769456073053
 - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
   sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
   md5: a360c33a5abe61c07959e449fa1453eb
@@ -24566,19 +23161,6 @@ packages:
   purls: []
   size: 55952
   timestamp: 1769456078358
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
-  sha256: e755e234236bdda3d265ae82e5b0581d259a9279e3e5b31d745dc43251ad64fb
-  md5: 47595b9d53054907a00d95e4d47af1d6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - libogg >=1.3.5,<1.4.0a0
-  - libstdcxx >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 424563
-  timestamp: 1764526740626
 - conda: https://prefix.dev/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
   sha256: e755e234236bdda3d265ae82e5b0581d259a9279e3e5b31d745dc43251ad64fb
   md5: 47595b9d53054907a00d95e4d47af1d6
@@ -24606,14 +23188,6 @@ packages:
   purls: []
   size: 397272
   timestamp: 1764526699497
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
-  sha256: 38f014a7129e644636e46064ecd6b1945e729c2140e21d75bb476af39e692db2
-  md5: e289f3d17880e44b633ba911d57a321b
-  depends:
-  - libfreetype6 >=2.14.3
-  license: GPL-2.0-only OR FTL
-  size: 8049
-  timestamp: 1774298163029
 - conda: https://prefix.dev/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
   sha256: 4641d37faeb97cf8a121efafd6afd040904d4bca8c46798122f417c31d5dfbec
   md5: f4084e4e6577797150f9b04a4560ceb0
@@ -24659,19 +23233,6 @@ packages:
   purls: []
   size: 8125
   timestamp: 1774301094057
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
-  sha256: 16f020f96da79db1863fcdd8f2b8f4f7d52f177dd4c58601e38e9182e91adf1d
-  md5: fb16b4b69e3f1dcfe79d80db8fd0c55d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libpng >=1.6.55,<1.7.0a0
-  - libzlib >=1.3.2,<2.0a0
-  constrains:
-  - freetype >=2.14.3
-  license: GPL-2.0-only OR FTL
-  size: 384575
-  timestamp: 1774298162622
 - conda: https://prefix.dev/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda
   sha256: 4a7af818a3179fafb6c91111752954e29d3a2a950259c14a2fc7ba40a8b03652
   md5: 8e7251989bca326a28f4a5ffbd74557a
@@ -24740,19 +23301,6 @@ packages:
   purls: []
   size: 422941
   timestamp: 1774301093473
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
-  sha256: faf7d2017b4d718951e3a59d081eb09759152f93038479b768e3d612688f83f5
-  md5: 0aa00f03f9e39fb9876085dee11a85d4
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - _openmp_mutex >=4.5
-  constrains:
-  - libgcc-ng ==15.2.0=*_18
-  - libgomp 15.2.0 he0feb66_18
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 1041788
-  timestamp: 1771378212382
 - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
   sha256: faf7d2017b4d718951e3a59d081eb09759152f93038479b768e3d612688f83f5
   md5: 0aa00f03f9e39fb9876085dee11a85d4
@@ -24800,15 +23348,6 @@ packages:
   purls: []
   size: 2335839
   timestamp: 1771377646960
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
-  sha256: e318a711400f536c81123e753d4c797a821021fb38970cebfb3f454126016893
-  md5: d5e96b1ed75ca01906b3d2469b4ce493
-  depends:
-  - libgcc 15.2.0 he0feb66_18
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 27526
-  timestamp: 1771378224552
 - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
   sha256: e318a711400f536c81123e753d4c797a821021fb38970cebfb3f454126016893
   md5: d5e96b1ed75ca01906b3d2469b4ce493
@@ -24841,17 +23380,6 @@ packages:
   purls: []
   size: 188293
   timestamp: 1753342911214
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_18.conda
-  sha256: d2c9fad338fd85e4487424865da8e74006ab2e2475bd788f624d7a39b2a72aee
-  md5: 9063115da5bc35fdc3e1002e69b9ef6e
-  depends:
-  - libgfortran5 15.2.0 h68bc16d_18
-  constrains:
-  - libgfortran-ng ==15.2.0=*_18
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 27523
-  timestamp: 1771378269450
 - conda: https://prefix.dev/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_18.conda
   sha256: d2c9fad338fd85e4487424865da8e74006ab2e2475bd788f624d7a39b2a72aee
   md5: 9063115da5bc35fdc3e1002e69b9ef6e
@@ -24876,18 +23404,6 @@ packages:
   purls: []
   size: 27587
   timestamp: 1771378169244
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_18.conda
-  sha256: 539b57cf50ec85509a94ba9949b7e30717839e4d694bc94f30d41c9d34de2d12
-  md5: 646855f357199a12f02a87382d429b75
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=15.2.0
-  constrains:
-  - libgfortran 15.2.0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 2482475
-  timestamp: 1771378241063
 - conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_18.conda
   sha256: 539b57cf50ec85509a94ba9949b7e30717839e4d694bc94f30d41c9d34de2d12
   md5: 646855f357199a12f02a87382d429b75
@@ -24913,16 +23429,6 @@ packages:
   purls: []
   size: 1486341
   timestamp: 1771378148102
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
-  sha256: dc2752241fa3d9e40ce552c1942d0a4b5eeb93740c9723873f6fcf8d39ef8d2d
-  md5: 928b8be80851f5d8ffb016f9c81dae7a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libglvnd 1.7.0 ha4b6fd6_2
-  - libglx 1.7.0 ha4b6fd6_2
-  license: LicenseRef-libglvnd
-  size: 134712
-  timestamp: 1731330998354
 - conda: https://prefix.dev/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
   sha256: dc2752241fa3d9e40ce552c1942d0a4b5eeb93740c9723873f6fcf8d39ef8d2d
   md5: 928b8be80851f5d8ffb016f9c81dae7a
@@ -24944,21 +23450,6 @@ packages:
   purls: []
   size: 145442
   timestamp: 1731331005019
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.4-h6548e54_1.conda
-  sha256: a27e44168a1240b15659888ce0d9b938ed4bdb49e9ea68a7c1ff27bcea8b55ce
-  md5: bb26456332b07f68bf3b7622ed71c0da
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libffi >=3.5.2,<3.6.0a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  constrains:
-  - glib 2.86.4 *_1
-  license: LGPL-2.1-or-later
-  size: 4398701
-  timestamp: 1771863239578
 - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.86.2-h32235b2_0.conda
   sha256: 918306d6ed211ab483e4e19368e5748b265d24e75c88a1c66a61f72b9fa30b29
   md5: 0cb0612bc9cb30c62baf41f9d600611b
@@ -25029,14 +23520,6 @@ packages:
   purls: []
   size: 310655
   timestamp: 1748692200349
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
-  sha256: 1175f8a7a0c68b7f81962699751bb6574e6f07db4c9f72825f978e3016f46850
-  md5: 434ca7e50e40f4918ab701e3facd59a0
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  license: LicenseRef-libglvnd
-  size: 132463
-  timestamp: 1731330968309
 - conda: https://prefix.dev/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
   sha256: 1175f8a7a0c68b7f81962699751bb6574e6f07db4c9f72825f978e3016f46850
   md5: 434ca7e50e40f4918ab701e3facd59a0
@@ -25053,16 +23536,6 @@ packages:
   purls: []
   size: 152135
   timestamp: 1731330986070
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
-  sha256: 2d35a679624a93ce5b3e9dd301fff92343db609b79f0363e6d0ceb3a6478bfa7
-  md5: c8013e438185f33b13814c5c488acd5c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libglvnd 1.7.0 ha4b6fd6_2
-  - xorg-libx11 >=1.8.10,<2.0a0
-  license: LicenseRef-libglvnd
-  size: 75504
-  timestamp: 1731330988898
 - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
   sha256: 2d35a679624a93ce5b3e9dd301fff92343db609b79f0363e6d0ceb3a6478bfa7
   md5: c8013e438185f33b13814c5c488acd5c
@@ -25084,15 +23557,6 @@ packages:
   purls: []
   size: 77736
   timestamp: 1731330998960
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
-  sha256: 21337ab58e5e0649d869ab168d4e609b033509de22521de1bfed0c031bfc5110
-  md5: 239c5e9546c38a1e884d69effcf4c882
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 603262
-  timestamp: 1771378117851
 - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
   sha256: 21337ab58e5e0649d869ab168d4e609b033509de22521de1bfed0c031bfc5110
   md5: 239c5e9546c38a1e884d69effcf4c882
@@ -25185,27 +23649,6 @@ packages:
   purls: []
   size: 750245
   timestamp: 1770462239980
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.80.0-h1d1128b_0.conda
-  sha256: 6391a098496b68dc80dfd721293505782ab00bdce21cf6677587b925bcbafeca
-  md5: 4362f717c7656e8a08ecb50315c775c1
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - c-ares >=1.34.6,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.1,<20260108.0a0
-  - libgcc >=14
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libre2-11 >=2025.11.5
-  - libstdcxx >=14
-  - libzlib >=1.3.2,<2.0a0
-  - openssl >=3.5.5,<4.0a0
-  - re2
-  constrains:
-  - grpc-cpp =1.80.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 7092989
-  timestamp: 1775543962358
 - conda: https://prefix.dev/conda-forge/linux-64/libgrpc-1.78.0-h1d1128b_1.conda
   sha256: f6861217d6c4bf96283738ba8d55782fccb577513a6cd346abc60cf88d1795df
   md5: 66055700c90b50c0405a4e515bb4fe3c
@@ -25266,19 +23709,6 @@ packages:
   purls: []
   size: 596714
   timestamp: 1741306859216
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
-  sha256: 2cf160794dda62cf93539adf16d26cfd31092829f2a2757dbdd562984c1b110a
-  md5: 0ed3aa3e3e6bc85050d38881673a692f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libxml2
-  - libxml2-16 >=2.14.6
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2449916
-  timestamp: 1765103845133
 - conda: https://prefix.dev/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
   sha256: 2cf160794dda62cf93539adf16d26cfd31092829f2a2757dbdd562984c1b110a
   md5: 0ed3aa3e3e6bc85050d38881673a692f
@@ -25306,16 +23736,6 @@ packages:
   purls: []
   size: 2467105
   timestamp: 1765103804193
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwy-1.3.0-h4c17acf_1.conda
-  sha256: 2bdd1cdd677b119abc5e83069bec2e28fe6bfb21ebaea3cd07acee67f38ea274
-  md5: c2a0c1d0120520e979685034e0b79859
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: Apache-2.0 OR BSD-3-Clause
-  size: 1448617
-  timestamp: 1758894401402
 - conda: https://prefix.dev/conda-forge/linux-64/libhwy-1.3.0-h4c17acf_1.conda
   sha256: 2bdd1cdd677b119abc5e83069bec2e28fe6bfb21ebaea3cd07acee67f38ea274
   md5: c2a0c1d0120520e979685034e0b79859
@@ -25337,15 +23757,6 @@ packages:
   purls: []
   size: 1180000
   timestamp: 1758894754411
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
-  sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
-  md5: 915f5995e94f60e9a4826e0b0920ee88
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: LGPL-2.1-only
-  size: 790176
-  timestamp: 1754908768807
 - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
   sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
   md5: 915f5995e94f60e9a4826e0b0920ee88
@@ -25365,17 +23776,6 @@ packages:
   purls: []
   size: 791226
   timestamp: 1754910975665
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
-  sha256: cc9aba923eea0af8e30e0f94f2ad7156e2984d80d1e8e7fe6be5a1f257f0eb32
-  md5: 8397539e3a0bbd1695584fb4f927485a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - jpeg <0.0.0a
-  license: IJG AND BSD-3-Clause AND Zlib
-  size: 633710
-  timestamp: 1762094827865
 - conda: https://prefix.dev/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
   sha256: cc9aba923eea0af8e30e0f94f2ad7156e2984d80d1e8e7fe6be5a1f257f0eb32
   md5: 8397539e3a0bbd1695584fb4f927485a
@@ -25399,20 +23799,6 @@ packages:
   purls: []
   size: 691818
   timestamp: 1762094728337
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.2-ha09017c_0.conda
-  sha256: 0c2399cef02953b719afe6591223fb11d287d5a108ef8bb9a02dd509a0f738d7
-  md5: 1df8c1b1d6665642107883685db6cf37
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libhwy >=1.3.0,<1.4.0a0
-  - libbrotlienc >=1.2.0,<1.3.0a0
-  - libbrotlidec >=1.2.0,<1.3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1883476
-  timestamp: 1770801977654
 - conda: https://prefix.dev/conda-forge/linux-64/libjxl-0.11.2-ha09017c_0.conda
   sha256: 0c2399cef02953b719afe6591223fb11d287d5a108ef8bb9a02dd509a0f738d7
   md5: 1df8c1b1d6665642107883685db6cf37
@@ -25464,20 +23850,6 @@ packages:
   purls: []
   size: 131775
   timestamp: 1741963824816
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-6_h47877c9_openblas.conda
-  build_number: 6
-  sha256: 371f517eb7010b21c6cc882c7606daccebb943307cb9a3bf2c70456a5c024f7d
-  md5: 881d801569b201c2e753f03c84b85e15
-  depends:
-  - libblas 3.11.0 6_h4a7cf45_openblas
-  constrains:
-  - blas 2.306   openblas
-  - liblapacke 3.11.0   6*_openblas
-  - libcblas   3.11.0   6*_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 18624
-  timestamp: 1774503065378
 - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-5_h47877c9_openblas.conda
   build_number: 5
   sha256: c723b6599fcd4c6c75dee728359ef418307280fa3e2ee376e14e85e5bbdda053
@@ -25814,17 +24186,6 @@ packages:
   purls: []
   size: 18687
   timestamp: 1728095215498
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
-  sha256: 755c55ebab181d678c12e49cced893598f2bab22d582fbbf4d8b83c18be207eb
-  md5: c7c83eecbb72d88b940c249af56c8b17
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - xz 5.8.2.*
-  license: 0BSD
-  size: 113207
-  timestamp: 1768752626120
 - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
   sha256: 755c55ebab181d678c12e49cced893598f2bab22d582fbbf4d8b83c18be207eb
   md5: c7c83eecbb72d88b940c249af56c8b17
@@ -26047,16 +24408,6 @@ packages:
   purls: []
   size: 175579371
   timestamp: 1761098886446
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
-  sha256: 927fe72b054277cde6cb82597d0fcf6baf127dcbce2e0a9d8925a68f1265eef5
-  md5: d864d34357c3b65a4b731f78c0801dc4
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: LGPL-2.1-only
-  license_family: GPL
-  size: 33731
-  timestamp: 1750274110928
 - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
   sha256: 927fe72b054277cde6cb82597d0fcf6baf127dcbce2e0a9d8925a68f1265eef5
   md5: d864d34357c3b65a4b731f78c0801dc4
@@ -26152,16 +24503,6 @@ packages:
   purls: []
   size: 14422867
   timestamp: 1753975387297
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
-  sha256: ffb066ddf2e76953f92e06677021c73c85536098f1c21fcd15360dbc859e22e4
-  md5: 68e52064ed3897463c0e958ab5c8f91b
-  depends:
-  - libgcc >=13
-  - __glibc >=2.17,<3.0.a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 218500
-  timestamp: 1745825989535
 - conda: https://prefix.dev/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
   sha256: ffb066ddf2e76953f92e06677021c73c85536098f1c21fcd15360dbc859e22e4
   md5: 68e52064ed3897463c0e958ab5c8f91b
@@ -26183,20 +24524,6 @@ packages:
   purls: []
   size: 220653
   timestamp: 1745826021156
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.32-pthreads_h94d23a6_0.conda
-  sha256: 6dc30b28f32737a1c52dada10c8f3a41bc9e021854215efca04a7f00487d09d9
-  md5: 89d61bc91d3f39fda0ca10fcd3c68594
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libgfortran
-  - libgfortran5 >=14.3.0
-  constrains:
-  - openblas >=0.3.32,<0.3.33.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 5928890
-  timestamp: 1774471724897
 - conda: https://prefix.dev/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_4.conda
   sha256: 199d79c237afb0d4780ccd2fbf829cea80743df60df4705202558675e07dd2c5
   md5: be43915efc66345cccb3c310b6ed0374
@@ -26883,19 +25210,6 @@ packages:
   purls: []
   size: 363154
   timestamp: 1770452333803
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2026.0.0-hb56ce9e_1.conda
-  sha256: a396a2d1aa267f21c98717ac097138b32e41e4c40ae501729bded3801476eeb5
-  md5: 9f0596e995efe372c470ff45c93131cb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - pugixml >=1.15,<1.16.0a0
-  - tbb >=2022.3.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 6582302
-  timestamp: 1772727204779
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-2025.2.0-hb617929_1.conda
   sha256: 235e7d474c90ad9d8955401b8a91dbe373aa1dc65db3c8232a5e22e4eaf41976
   md5: 1da20cc4ff32dc74424dec68ec087dba
@@ -26973,19 +25287,6 @@ packages:
   purls: []
   size: 10237615
   timestamp: 1772721303162
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2026.0.0-hd85de46_1.conda
-  sha256: 286de85805dc69ce0bd25367ae2a20c8096ddef35eb2483474eb246dacd5387e
-  md5: ee41df976413676f794af2785b291b0c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libstdcxx >=14
-  - tbb >=2022.3.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 114431
-  timestamp: 1772727230331
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-batch-plugin-2025.2.0-hed573e4_1.conda
   sha256: 193f760e828b0dd5168dd1d28580d4bf429c5f14a4eee5e0c02ff4c6d4cf8093
   md5: 94f9d17be1d658213b66b22f63cc6578
@@ -27049,19 +25350,6 @@ packages:
   purls: []
   size: 111064
   timestamp: 1772721336786
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2026.0.0-hd85de46_1.conda
-  sha256: 9988ed6339a5eb044ae8d079e2b22f5a310c41e49a0cf716057f30b21ef9cec2
-  md5: ca025fa5c42ba94453636a2ae333de6b
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libstdcxx >=14
-  - tbb >=2022.3.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 249056
-  timestamp: 1772727247597
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-plugin-2025.2.0-hed573e4_1.conda
   sha256: a6f9f996e64e6d2f295f017a833eda7018ff58b6894503272d72f0002dfd6f33
   md5: 071b3a82342715a411f216d379ab6205
@@ -27125,19 +25413,6 @@ packages:
   purls: []
   size: 236010
   timestamp: 1772721351244
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2026.0.0-hd41364c_1.conda
-  sha256: c7db498aeda5b0f36b347f4211b93b66ba108faaf54157a08bae8fa3c3af5f81
-  md5: 07a23e96db38f63d9763f666b2db66aa
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libstdcxx >=14
-  - pugixml >=1.15,<1.16.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 211582
-  timestamp: 1772727264950
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-hetero-plugin-2025.2.0-hd41364c_1.conda
   sha256: f43f9049338ef9735b6815bac3f483d1e3adddecbfdeb13be365bc3f601fe156
   md5: 77c0c7028a8110076d40314dc7b1fa98
@@ -27201,20 +25476,6 @@ packages:
   purls: []
   size: 202574
   timestamp: 1772721365749
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2026.0.0-hb56ce9e_1.conda
-  sha256: 01a28c0bd1f205b3800e7759e30bc8e8a75836e0d5a73a745b4da42837bbb174
-  md5: b43b96578573ddbcc8d084ae6e44c964
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libstdcxx >=14
-  - pugixml >=1.15,<1.16.0a0
-  - tbb >=2022.3.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 13173323
-  timestamp: 1772727282718
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2025.2.0-hb617929_1.conda
   sha256: a4a1cd320fa010a45d01f438dc3431b7a60271ee19188a901f884399fe744268
   md5: e4cc6db5bdc8b554c06bf569de57f85f
@@ -27269,21 +25530,6 @@ packages:
   purls: []
   size: 13173323
   timestamp: 1772727282718
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2026.0.0-hb56ce9e_1.conda
-  sha256: 720b87e1d5f1a10c577e040d4bf425072a978e925c6dfab8b1551bc848007c94
-  md5: 26e8e92c90d1a22af6eac8e9507d9b8f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libstdcxx >=14
-  - ocl-icd >=2.3.3,<3.0a0
-  - pugixml >=1.15,<1.16.0a0
-  - tbb >=2022.3.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 11402462
-  timestamp: 1772727323957
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2025.2.0-hb617929_1.conda
   sha256: 03ebf700586775144ca5913f401393a386b9a1d7a7cfcba4494830063ca5eb92
   md5: b846fe6c158ca417e246122172d68d3a
@@ -27342,21 +25588,6 @@ packages:
   purls: []
   size: 11402462
   timestamp: 1772727323957
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2026.0.0-hb56ce9e_1.conda
-  sha256: df7eb2b23a1af38f2cd2281353309f2e2a04da1374ecedc7c6745c2a67ba617c
-  md5: 01ba8b179ac45b2b37fe2d4225dddcc7
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - level-zero >=1.28.2,<2.0a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libstdcxx >=14
-  - pugixml >=1.15,<1.16.0a0
-  - tbb >=2022.3.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1994640
-  timestamp: 1772727360780
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-npu-plugin-2025.2.0-hb617929_1.conda
   sha256: b6dbc342293d6ce0c7b37c9f29f734b3e1856cff9405a02fb33cedd1b36528e6
   md5: 86fd4c25f6accaf646c86adf0f1382d3
@@ -27415,19 +25646,6 @@ packages:
   purls: []
   size: 1994640
   timestamp: 1772727360780
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2026.0.0-hd41364c_1.conda
-  sha256: 8e7356b0b80b3f180615e264694d6811d388b210155d419553ff64e42f78ffa0
-  md5: aa002c4d343b01cdcc458c95cd071d1b
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libstdcxx >=14
-  - pugixml >=1.15,<1.16.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 192778
-  timestamp: 1772727380069
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-ir-frontend-2025.2.0-hd41364c_1.conda
   sha256: 334733396d4c9a9b2b2d7d7d850e8ee8deca1f9becd0368d106010076ceb20ca
   md5: 75e595d9f2019a60f6dcb500266da615
@@ -27491,21 +25709,6 @@ packages:
   purls: []
   size: 185648
   timestamp: 1772721380070
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2026.0.0-h7a07914_1.conda
-  sha256: 35a68214201e807bd9a31f94e618cb6a5385198e89eef46dde6c122cff77da58
-  md5: 218084544c2e7e78e4b8877ec37b8cdb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.1,<20260108.0a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libstdcxx >=14
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1860687
-  timestamp: 1772727397981
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-onnx-frontend-2025.2.0-h1862bb8_1.conda
   sha256: 3937b028e7192ed3805581ac0ea171725843056c8544537754fad45a1791e864
   md5: 68f5ad9d8e3979362bb9dfc9388980aa
@@ -27579,21 +25782,6 @@ packages:
   purls: []
   size: 1665115
   timestamp: 1772721394860
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2026.0.0-h7a07914_1.conda
-  sha256: cb37b717480207a66443a93d4342cf88210a74c0820fc0edd70e4fc791a64779
-  md5: 74915e5e271ef76a89f711eff5959a75
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.1,<20260108.0a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libstdcxx >=14
-  license: Apache-2.0
-  license_family: APACHE
-  size: 684224
-  timestamp: 1772727417276
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-paddle-frontend-2025.2.0-h1862bb8_1.conda
   sha256: c7ac3d4187323ab37ef62ec0896a41c8ca7da426c7f587494c72fe74852269e5
   md5: a032d03468dee9fb5b8eaf635b4571c2
@@ -27667,18 +25855,6 @@ packages:
   purls: []
   size: 631754
   timestamp: 1772721411589
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2026.0.0-hecca717_1.conda
-  sha256: 086469e5cd8bfde48975fe8641a7d6924e3da00d75dd06c99e03a78df03a0568
-  md5: 559ef86008749861a53025f669004f18
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libstdcxx >=14
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1185558
-  timestamp: 1772727435039
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-pytorch-frontend-2025.2.0-hecca717_1.conda
   sha256: 2d4a680a16509b8dd06ccd7a236655e46cc7c242bb5b6e88b83a834b891658db
   md5: cd40cf2d10a3279654c9769f3bc8caf5
@@ -27737,22 +25913,6 @@ packages:
   purls: []
   size: 1091266
   timestamp: 1772721428223
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2026.0.0-h78e8023_1.conda
-  sha256: 3a9a404bc9fd39e7395d49f4bd8facb58a01a31aeceabe8723a9d4f8eb5cc381
-  md5: fb20f4234bc0e29af1baa13d35e36785
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.1,<20260108.0a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libstdcxx >=14
-  - snappy >=1.2.2,<1.3.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1257870
-  timestamp: 1772727453738
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.2.0-h0767aad_1.conda
   sha256: 311ec1118448a28e76f0359c4393c7f7f5e64761c48ac7b169bf928a391eae77
   md5: f71c6b4e342b560cc40687063ef62c50
@@ -27831,18 +25991,6 @@ packages:
   purls: []
   size: 1184078
   timestamp: 1772721443833
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2026.0.0-hecca717_1.conda
-  sha256: e7cee37c92ed0b62c0458c13937b6ad66319f1879f236a31c3a67391a999f429
-  md5: 0f0281435478b981f672a44d0029018c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libstdcxx >=14
-  license: Apache-2.0
-  license_family: APACHE
-  size: 456585
-  timestamp: 1772727473378
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2025.2.0-hecca717_1.conda
   sha256: 581f4951e645e820c4a6ffe40fb0174b56d6e31fb1fefd2d64913fea01f8f69e
   md5: fd9dacd7101f80ff1110ea6b76adb95d
@@ -27901,16 +26049,6 @@ packages:
   purls: []
   size: 428895
   timestamp: 1772721459028
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
-  sha256: f1061a26213b9653bbb8372bfa3f291787ca091a9a3060a10df4d5297aad74fd
-  md5: 2446ac1fe030c2aa6141386c1f5a6aed
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 324993
-  timestamp: 1768497114401
 - conda: https://prefix.dev/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
   sha256: f1061a26213b9653bbb8372bfa3f291787ca091a9a3060a10df4d5297aad74fd
   md5: 2446ac1fe030c2aa6141386c1f5a6aed
@@ -27980,16 +26118,6 @@ packages:
   purls: []
   size: 89738
   timestamp: 1741963824815
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
-  sha256: 0bd91de9b447a2991e666f284ae8c722ffb1d84acb594dbd0c031bd656fa32b2
-  md5: 70e3400cbbfa03e96dcde7fc13e38c7b
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 28424
-  timestamp: 1749901812541
 - conda: https://prefix.dev/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
   sha256: 0bd91de9b447a2991e666f284ae8c722ffb1d84acb594dbd0c031bd656fa32b2
   md5: 70e3400cbbfa03e96dcde7fc13e38c7b
@@ -28011,16 +26139,6 @@ packages:
   purls: []
   size: 29512
   timestamp: 1749901899881
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.57-h421ea60_0.conda
-  sha256: 06323fb0a831440f0b72a53013182e1d4bb219e3ea958bb37af98b25dc0cf518
-  md5: 06f225e6d8c549ad6c0201679828a882
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libzlib >=1.3.2,<2.0a0
-  license: zlib-acknowledgement
-  size: 317779
-  timestamp: 1775692841709
 - conda: https://prefix.dev/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
   sha256: 36ade759122cdf0f16e2a2562a19746d96cf9c863ffaa812f2f5071ebbe9c03c
   md5: 5f13ffc7d30ffec87864e678df9957b4
@@ -28129,20 +26247,6 @@ packages:
   purls: []
   size: 2854221
   timestamp: 1772136342536
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.33.5-h2b00c02_0.conda
-  sha256: afbf195443269ae10a940372c1d37cda749355d2bd96ef9587a962abd87f2429
-  md5: 11ac478fa72cf12c214199b8a96523f4
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3638698
-  timestamp: 1769749419271
 - conda: https://prefix.dev/conda-forge/linux-64/libprotobuf-6.31.1-h49aed37_4.conda
   sha256: 0ef142ac31e6fd59b4af89ac800acb6deb3fbd9cc4ccf070c03cc2c784dc7296
   md5: 07479fc04ba3ddd5d9f760ef1635cfa7
@@ -28215,21 +26319,6 @@ packages:
   purls: []
   size: 46633
   timestamp: 1741963824815
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h0dc7533_1.conda
-  sha256: 138fc85321a8c0731c1715688b38e2be4fb71db349c9ab25f685315095ae70ff
-  md5: ced7f10b6cfb4389385556f47c0ad949
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - re2 2025.11.05.*
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 213122
-  timestamp: 1768190028309
 - conda: https://prefix.dev/conda-forge/linux-64/libre2-11-2025.11.05-h0dc7533_1.conda
   sha256: 138fc85321a8c0731c1715688b38e2be4fb71db349c9ab25f685315095ae70ff
   md5: ced7f10b6cfb4389385556f47c0ad949
@@ -28261,25 +26350,6 @@ packages:
   purls: []
   size: 206469
   timestamp: 1768189988250
-- conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.1-h4c96295_0.conda
-  sha256: dc4698b32b2ca3fc0715d7d307476a71622bee0f2f708f9dadec8af21e1047c8
-  md5: a4b87f1fbcdbb8ad32e99c2611120f2e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cairo >=1.18.4,<2.0a0
-  - fontconfig >=2.17.1,<3.0a0
-  - fonts-conda-ecosystem
-  - gdk-pixbuf >=2.44.5,<3.0a0
-  - harfbuzz >=13.1.1
-  - libgcc >=14
-  - libglib >=2.86.4,<3.0a0
-  - libxml2-16 >=2.14.6
-  - pango >=1.56.4,<2.0a0
-  constrains:
-  - __glibc >=2.17
-  license: LGPL-2.1-or-later
-  size: 3474421
-  timestamp: 1773814909137
 - conda: https://prefix.dev/conda-forge/linux-64/librsvg-2.60.0-h61e6d4b_0.conda
   sha256: 960b137673b2b8293e2a12d194add72967b3bf12fcdf691e7ad8bd5c8318cec3
   md5: 91e6d4d684e237fba31b9815c4b40edf
@@ -28415,37 +26485,6 @@ packages:
   purls: []
   size: 7526147
   timestamp: 1771377792671
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsentencepiece-0.2.1-h432359f_3.conda
-  sha256: 5a40fb6a8190a57c704f8dc7c23fbcee0eca400a70e1bcf8774aeae708575f4a
-  md5: ba0d4bf618ee90dd0d88780b0a925923
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libstdcxx >=14
-  license: Apache-2.0
-  license_family: Apache
-  size: 859187
-  timestamp: 1770167820403
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
-  sha256: 57cb5f92110324c04498b96563211a1bca6a74b2918b1e8df578bfed03cc32e4
-  md5: 067590f061c9f6ea7e61e3b2112ed6b3
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - lame >=3.100,<3.101.0a0
-  - libflac >=1.5.0,<1.6.0a0
-  - libgcc >=14
-  - libogg >=1.3.5,<1.4.0a0
-  - libopus >=1.5.2,<2.0a0
-  - libstdcxx >=14
-  - libvorbis >=1.3.7,<1.4.0a0
-  - mpg123 >=1.32.9,<1.33.0a0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 355619
-  timestamp: 1765181778282
 - conda: https://prefix.dev/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
   sha256: 57cb5f92110324c04498b96563211a1bca6a74b2918b1e8df578bfed03cc32e4
   md5: 067590f061c9f6ea7e61e3b2112ed6b3
@@ -28481,15 +26520,6 @@ packages:
   purls: []
   size: 406978
   timestamp: 1765181892661
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.21-h280c20c_3.conda
-  sha256: 64e5c80cbce4680a2d25179949739a6def695d72c40ca28f010711764e372d97
-  md5: 7af961ef4aa2c1136e11dd43ded245ab
-  depends:
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  license: ISC
-  size: 277661
-  timestamp: 1772479381288
 - conda: https://prefix.dev/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
   sha256: 0105bd108f19ea8e6a78d2d994a6d4a8db16d19a41212070d2d1d48a63c34161
   md5: a587892d3c13b6621a6091be690dbca2
@@ -28543,17 +26573,6 @@ packages:
   purls: []
   size: 203419
   timestamp: 1741963824816
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
-  sha256: d716847b7deca293d2e49ed1c8ab9e4b9e04b9d780aea49a97c26925b28a7993
-  md5: fd893f6a3002a635b5e50ceb9dd2c0f4
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - icu >=78.2,<79.0a0
-  - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
-  license: blessing
-  size: 951405
-  timestamp: 1772818874251
 - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.51.2-hf4e2dac_0.conda
   sha256: 04596fcee262a870e4b7c9807224680ff48d4d0cc0dac076a602503d3dc6d217
   md5: da5be73701eecd0e8454423fd6ffcf30
@@ -28625,18 +26644,6 @@ packages:
   purls: []
   size: 311396
   timestamp: 1745609845915
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
-  sha256: 78668020064fdaa27e9ab65cd2997e2c837b564ab26ce3bf0e58a2ce1a525c6e
-  md5: 1b08cd684f34175e4514474793d44bcb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc 15.2.0 he0feb66_18
-  constrains:
-  - libstdcxx-ng ==15.2.0=*_18
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 5852330
-  timestamp: 1771378262446
 - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
   sha256: 78668020064fdaa27e9ab65cd2997e2c837b564ab26ce3bf0e58a2ce1a525c6e
   md5: 1b08cd684f34175e4514474793d44bcb
@@ -28682,15 +26689,6 @@ packages:
   purls: []
   size: 17565700
   timestamp: 1771377672552
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
-  sha256: 3c902ffd673cb3c6ddde624cdb80f870b6c835f8bf28384b0016e7d444dd0145
-  md5: 6235adb93d064ecdf3d44faee6f468de
-  depends:
-  - libstdcxx 15.2.0 h934c35e_18
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 27575
-  timestamp: 1771378314494
 - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
   sha256: 3c902ffd673cb3c6ddde624cdb80f870b6c835f8bf28384b0016e7d444dd0145
   md5: 6235adb93d064ecdf3d44faee6f468de
@@ -28726,16 +26724,6 @@ packages:
   purls: []
   size: 42708
   timestamp: 1741963824815
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.13-hd0affe5_0.conda
-  sha256: c5008b602cb5c819f7b52d418b3ed17e1818cbbf6705b189e7ab36bb70cce3d8
-  md5: 8ee3cb7f64be0e8c4787f3a4dbe024e6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libcap >=2.77,<2.78.0a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  size: 492799
-  timestamp: 1773797095649
 - conda: https://prefix.dev/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_4.conda
   sha256: f0356bb344a684e7616fc84675cfca6401140320594e8686be30e8ac7547aed2
   md5: 1d4c18d75c51ed9d00092a891a547a7d
@@ -28821,23 +26809,6 @@ packages:
   purls: []
   size: 415854
   timestamp: 1753277171370
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-  sha256: e5f8c38625aa6d567809733ae04bb71c161a42e44a9fa8227abe61fa5c60ebe0
-  md5: cd5a90476766d53e901500df9215e927
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - lerc >=4.0.0,<5.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libgcc >=14
-  - libjpeg-turbo >=3.1.0,<4.0a0
-  - liblzma >=5.8.1,<6.0a0
-  - libstdcxx >=14
-  - libwebp-base >=1.6.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: HPND
-  size: 435273
-  timestamp: 1762022005702
 - conda: https://prefix.dev/conda-forge/linux-64/libtiff-4.7.1-h8261f1e_0.conda
   sha256: ddda0d7ee67e71e904a452010c73e32da416806f5cb9145fb62c322f97e717fb
   md5: 72b531694ebe4e8aa6f5745d1015c1b4
@@ -29098,16 +27069,6 @@ packages:
   purls: []
   size: 45127007
   timestamp: 1772259207112
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.13-hd0affe5_0.conda
-  sha256: 1a1e367c04d66030aa93b4d33905f7f6fbb59cfc292e816fe3e9c1e8b3f4d1e2
-  md5: 2c2270f93d6f9073cbf72d821dfc7d72
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libcap >=2.77,<2.78.0a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  size: 145087
-  timestamp: 1773797108513
 - conda: https://prefix.dev/conda-forge/linux-64/libudev1-257.10-hd0affe5_4.conda
   sha256: ed4d2c01fbeb1330f112f7e399408634db277d3dfb2dec1d0395f56feaa24351
   md5: 6c74fba677b61a0842cbf0f63eee683b
@@ -29165,17 +27126,6 @@ packages:
   purls: []
   size: 404065
   timestamp: 1741963824815
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
-  sha256: 71c8b9d5c72473752a0bb6e91b01dd209a03916cb71f36cc6a564e3a2a132d7a
-  md5: e179a69edd30d75c0144d7a380b88f28
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 75995
-  timestamp: 1757032240102
 - conda: https://prefix.dev/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
   sha256: 71c8b9d5c72473752a0bb6e91b01dd209a03916cb71f36cc6a564e3a2a132d7a
   md5: e179a69edd30d75c0144d7a380b88f28
@@ -29199,17 +27149,6 @@ packages:
   purls: []
   size: 94555
   timestamp: 1757032278900
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liburing-2.14-hb700be7_0.conda
-  sha256: 3d17b7aa90610afc65356e9e6149aeac0b2df19deda73a51f0a09cf04fd89286
-  md5: 56f65185b520e016d29d01657ac02c0d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 154203
-  timestamp: 1770566529700
 - conda: https://prefix.dev/conda-forge/linux-64/liburing-2.14-hb700be7_0.conda
   sha256: 3d17b7aa90610afc65356e9e6149aeac0b2df19deda73a51f0a09cf04fd89286
   md5: 56f65185b520e016d29d01657ac02c0d
@@ -29233,16 +27172,6 @@ packages:
   purls: []
   size: 155011
   timestamp: 1770567701524
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
-  sha256: 89c84f5b26028a9d0f5c4014330703e7dff73ba0c98f90103e9cef6b43a5323c
-  md5: d17e3fb595a9f24fa9e149239a33475d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libudev1 >=257.4
-  license: LGPL-2.1-or-later
-  size: 89551
-  timestamp: 1748856210075
 - conda: https://prefix.dev/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
   sha256: 89c84f5b26028a9d0f5c4014330703e7dff73ba0c98f90103e9cef6b43a5323c
   md5: d17e3fb595a9f24fa9e149239a33475d
@@ -29285,16 +27214,6 @@ packages:
   purls: []
   size: 86509
   timestamp: 1768735090367
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
-  sha256: bc1b08c92626c91500fd9f26f2c797f3eb153b627d53e9c13cd167f1e12b2829
-  md5: 38ffe67b78c9d4de527be8315e5ada2c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 40297
-  timestamp: 1775052476770
 - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
   sha256: 1a7539cfa7df00714e8943e18de0b06cceef6778e420a5ee3a2a145773758aee
   md5: db409b7c1720428638e7c0d509d3e1b5
@@ -29337,16 +27256,6 @@ packages:
   purls: []
   size: 43567
   timestamp: 1775052485727
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
-  sha256: c180f4124a889ac343fc59d15558e93667d894a966ec6fdb61da1604481be26b
-  md5: 0f03292cc56bf91a077a134ea8747118
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 895108
-  timestamp: 1753948278280
 - conda: https://prefix.dev/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
   sha256: c180f4124a889ac343fc59d15558e93667d894a966ec6fdb61da1604481be26b
   md5: 0f03292cc56bf91a077a134ea8747118
@@ -29368,26 +27277,6 @@ packages:
   purls: []
   size: 629238
   timestamp: 1753948296190
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.23.0-he1eb515_0.conda
-  sha256: 255c7d00b54e26f19fad9340db080716bced1d8539606e2b8396c57abd40007c
-  md5: 25813fe38b3e541fc40007592f12bae5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libdrm >=2.4.125,<2.5.0a0
-  - libegl >=1.7.0,<2.0a0
-  - libgcc >=14
-  - libgl >=1.7.0,<2.0a0
-  - libglx >=1.7.0,<2.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - wayland >=1.24.0,<2.0a0
-  - wayland-protocols
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxfixes >=6.0.2,<7.0a0
-  license: MIT
-  license_family: MIT
-  size: 221308
-  timestamp: 1765652453244
 - conda: https://prefix.dev/conda-forge/linux-64/libva-2.23.0-he1eb515_0.conda
   sha256: 255c7d00b54e26f19fad9340db080716bced1d8539606e2b8396c57abd40007c
   md5: 25813fe38b3e541fc40007592f12bae5
@@ -29409,20 +27298,6 @@ packages:
   purls: []
   size: 221308
   timestamp: 1765652453244
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
-  sha256: ca494c99c7e5ecc1b4cd2f72b5584cef3d4ce631d23511184411abcbb90a21a5
-  md5: b4ecbefe517ed0157c37f8182768271c
-  depends:
-  - libogg
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - libogg >=1.3.5,<1.4.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 285894
-  timestamp: 1753879378005
 - conda: https://prefix.dev/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
   sha256: ca494c99c7e5ecc1b4cd2f72b5584cef3d4ce631d23511184411abcbb90a21a5
   md5: b4ecbefe517ed0157c37f8182768271c
@@ -29451,19 +27326,6 @@ packages:
   purls: []
   size: 289391
   timestamp: 1753879417231
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libvpl-2.16.0-h54a6638_0.conda
-  sha256: 38850657dd6835613ef16b34895a54bea98bc7639db6a649c886b331635714fc
-  md5: 9f6b0090c3902b2c763a16f7dace7b6e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - intel-media-driver >=26.1.2,<26.2.0a0
-  - libva >=2.23.0,<3.0a0
-  license: MIT
-  license_family: MIT
-  size: 287992
-  timestamp: 1772980546550
 - conda: https://prefix.dev/conda-forge/linux-64/libvpl-2.15.0-h54a6638_1.conda
   sha256: bf0010d93f5b154c59bd9d3cc32168698c1d24f2904729f4693917cce5b27a9f
   md5: a41a299c157cc6d0eff05e5fc298cc45
@@ -29493,17 +27355,6 @@ packages:
   purls: []
   size: 287992
   timestamp: 1772980546550
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.15.2-hecca717_0.conda
-  sha256: 8e1119977f235b488ab32d540c018d3fd1eccefc3dd3859921a0ff555d8c10d2
-  md5: 10f5008f1c89a40b09711b5a9cdbd229
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1070048
-  timestamp: 1762010217363
 - conda: https://prefix.dev/conda-forge/linux-64/libvpx-1.14.1-hac33072_0.conda
   sha256: e7d2daf409c807be48310fcc8924e481b62988143f582eb3a58c5523a6763b13
   md5: cde393f461e0c169d9ffb2fc70f81c33
@@ -29538,21 +27389,6 @@ packages:
   purls: []
   size: 1296382
   timestamp: 1762012332100
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.341.0-h5279c79_0.conda
-  sha256: a68280d57dfd29e3d53400409a39d67c4b9515097eba733aa6fe00c880620e2b
-  md5: 31ad065eda3c2d88f8215b1289df9c89
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxrandr >=1.5.5,<2.0a0
-  constrains:
-  - libvulkan-headers 1.4.341.0.*
-  license: Apache-2.0
-  license_family: APACHE
-  size: 199795
-  timestamp: 1770077125520
 - conda: https://prefix.dev/conda-forge/linux-64/libvulkan-loader-1.4.341.0-h5279c79_0.conda
   sha256: a68280d57dfd29e3d53400409a39d67c4b9515097eba733aa6fe00c880620e2b
   md5: 31ad065eda3c2d88f8215b1289df9c89
@@ -29584,18 +27420,6 @@ packages:
   purls: []
   size: 217655
   timestamp: 1770077141862
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
-  sha256: 3aed21ab28eddffdaf7f804f49be7a7d701e8f0e46c856d801270b470820a37b
-  md5: aea31d2e5b1091feca96fcfe945c3cf9
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - libwebp 1.6.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 429011
-  timestamp: 1752159441324
 - conda: https://prefix.dev/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
   sha256: 3aed21ab28eddffdaf7f804f49be7a7d701e8f0e46c856d801270b470820a37b
   md5: aea31d2e5b1091feca96fcfe945c3cf9
@@ -29621,19 +27445,6 @@ packages:
   purls: []
   size: 359496
   timestamp: 1752160685488
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
-  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
-  md5: 92ed62436b625154323d40d5f2f11dd7
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - pthread-stubs
-  - xorg-libxau >=1.0.11,<2.0a0
-  - xorg-libxdmcp
-  license: MIT
-  license_family: MIT
-  size: 395888
-  timestamp: 1727278577118
 - conda: https://prefix.dev/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
   sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
   md5: 92ed62436b625154323d40d5f2f11dd7
@@ -29661,14 +27472,6 @@ packages:
   purls: []
   size: 397493
   timestamp: 1727280745441
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
-  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
-  md5: 5aa797f8787fe7a17d1b0821485b5adc
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1-or-later
-  size: 100393
-  timestamp: 1702724383534
 - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
   sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
   md5: 5aa797f8787fe7a17d1b0821485b5adc
@@ -29687,22 +27490,6 @@ packages:
   purls: []
   size: 114269
   timestamp: 1702724369203
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.1-hca5e8e5_0.conda
-  sha256: d2195b5fbcb0af1ff7b345efdf89290c279b8d1d74f325ae0ac98148c375863c
-  md5: 2bca1fbb221d9c3c8e3a155784bbc2e9
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libxcb >=1.17.0,<2.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - xkeyboard-config
-  - xorg-libxau >=1.0.12,<2.0a0
-  license: MIT/X11 Derivative
-  license_family: MIT
-  size: 837922
-  timestamp: 1764794163823
 - conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.13.1-hca5e8e5_0.conda
   sha256: d2195b5fbcb0af1ff7b345efdf89290c279b8d1d74f325ae0ac98148c375863c
   md5: 2bca1fbb221d9c3c8e3a155784bbc2e9
@@ -29736,21 +27523,6 @@ packages:
   purls: []
   size: 863646
   timestamp: 1764794352540
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.2-he237659_0.conda
-  sha256: 275c324f87bda1a3b67d2f4fcc3555eeff9e228a37655aa001284a7ceb6b0392
-  md5: e49238a1609f9a4a844b09d9926f2c3d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - icu >=78.2,<79.0a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.2,<6.0a0
-  - libxml2-16 2.15.2 hca6bf5a_0
-  - libzlib >=1.3.1,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 45968
-  timestamp: 1772704614539
 - conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.15.1-h26afc86_0.conda
   sha256: ec0735ae56c3549149eebd7dc22c0bed91fd50c02eaa77ff418613ddda190aa8
   md5: e512be7dc1f84966d50959e900ca121f
@@ -29798,22 +27570,6 @@ packages:
   purls: []
   size: 47837
   timestamp: 1772704681112
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.2-hca6bf5a_0.conda
-  sha256: 08d2b34b49bec9613784f868209bb7c3bb8840d6cf835ff692e036b09745188c
-  md5: f3bc152cb4f86babe30f3a4bf0dbef69
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - icu >=78.2,<79.0a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.2,<6.0a0
-  - libzlib >=1.3.1,<2.0a0
-  constrains:
-  - libxml2 2.15.2
-  license: MIT
-  license_family: MIT
-  size: 557492
-  timestamp: 1772704601644
 - conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.1-ha9997c6_0.conda
   sha256: 71436e72a286ef8b57d6f4287626ff91991eb03c7bdbe835280521791efd1434
   md5: e7733bc6785ec009e47a224a71917e84
@@ -29891,17 +27647,6 @@ packages:
   purls: []
   size: 109043
   timestamp: 1730442108429
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-  sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
-  md5: d87ff7921124eccd67248aa483c23fec
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  constrains:
-  - zlib 1.3.2 *_2
-  license: Zlib
-  license_family: Other
-  size: 63629
-  timestamp: 1774072609062
 - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
   sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
   md5: edb0dca6bc32e4f4789199455a1dbeb8
@@ -29989,22 +27734,6 @@ packages:
   - pkg:pypi/lightning-utilities?source=hash-mapping
   size: 32379
   timestamp: 1772138325789
-- conda: https://conda.anaconda.org/conda-forge/linux-64/llguidance-1.7.0-py310hc9716df_0.conda
-  noarch: python
-  sha256: 542f802478f65cd9fb6796e5ed8d93250f1c7b7fa9c141b61e56246379ca9ad6
-  md5: 28f3e8825c7a4daf72ecde2ec3f7bd3d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - _python_abi3_support 1.*
-  - cpython >=3.10
-  - libgcc >=14
-  - python
-  constrains:
-  - __glibc >=2.17
-  license: MIT
-  license_family: MIT
-  size: 2166297
-  timestamp: 1773873138695
 - conda: https://prefix.dev/conda-forge/linux-64/llvm-openmp-22.1.0-h4922eb0_0.conda
   sha256: 543c9f17cf6ee6d7b635823fb9009df421d510c36739534df6ae43eadaf6ff4e
   md5: 5e7da5333653c631d27732893b934351
@@ -30180,16 +27909,6 @@ packages:
   purls: []
   size: 184953
   timestamp: 1733740984533
-- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
-  sha256: 7b1da4b5c40385791dbc3cc85ceea9fad5da680a27d5d3cb8bfaa185e304a89e
-  md5: 5b5203189eb668f042ac2b0826244964
-  depends:
-  - mdurl >=0.1,<1
-  - python >=3.10
-  license: MIT
-  license_family: MIT
-  size: 64736
-  timestamp: 1754951288511
 - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
   sha256: 7b1da4b5c40385791dbc3cc85ceea9fad5da680a27d5d3cb8bfaa185e304a89e
   md5: 5b5203189eb668f042ac2b0826244964
@@ -30202,20 +27921,6 @@ packages:
   - pkg:pypi/markdown-it-py?source=hash-mapping
   size: 64736
   timestamp: 1754951288511
-- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py311h3778330_1.conda
-  sha256: 710e207b2e91308a34bcfe547c60ad86c1fa294827266ba18548c1fe1a9d8333
-  md5: f9efdf9b0f3d0cc309d56af6edf2a6b0
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  constrains:
-  - jinja2 >=3.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 26756
-  timestamp: 1772445078834
 - conda: https://prefix.dev/conda-forge/linux-64/markupsafe-3.0.3-py310h3406613_1.conda
   sha256: 9f3c34f8a7a8dcfed64221a2e19bbe0094ab2c6df7c029b7df713e52c9c9f229
   md5: 671afe636d2a97759804723f5afc22e0
@@ -30516,77 +28221,6 @@ packages:
   - pkg:pypi/matplotlib-inline?source=hash-mapping
   size: 15175
   timestamp: 1761214578417
-- conda: https://conda.modular.com/max-nightly/linux-64/max-26.3.0.dev2026040905-3.11release.conda
-  sha256: 4c324adb2adbf5d39b1334ba1e02c61b8dbe797183108a1c8a09833bbc8ada91
-  md5: 98664988a814ffaf4a6e5f06ed86c92d
-  depends:
-  - numpy >=1.18
-  - typing-extensions >=4.12.2
-  - pyyaml >=6.0.1
-  - rich >=13.0.1
-  - python 3.11.*
-  - python-gil
-  - max-core ==26.3.0.dev2026040905
-  license: LicenseRef-Modular-Proprietary
-  size: 6744298
-  timestamp: 1775713845712
-- conda: https://conda.modular.com/max-nightly/linux-64/max-core-26.3.0.dev2026040905-release.conda
-  sha256: 0929044d859f8b4d79bac9595b8e82f047a40c4ae0ef3147ed40f4c0babd45b8
-  md5: 0ac12cc4d8f69f678865195f12e00f6b
-  depends:
-  - mojo-compiler ==0.26.3.0.dev2026040905
-  license: LicenseRef-Modular-Proprietary
-  size: 149853601
-  timestamp: 1775713881397
-- conda: https://conda.modular.com/max-nightly/noarch/max-pipelines-26.3.0.dev2026040905-release.conda
-  noarch: python
-  sha256: a22be5f8946e13adb95f7ab5b50694f9c2a799480313bb9bf49474f93080b26e
-  md5: a3ba60e54c63e9c1d0276238651eb081
-  depends:
-  - av >=14.0.0
-  - click >=8.0.0
-  - exceptiongroup >=0.2.2
-  - gguf >=0.17.1
-  - hf-transfer >=0.1.9
-  - huggingface_hub >=0.28.0
-  - llguidance >=0.7.30
-  - jinja2 >=3.1.0
-  - pillow >=11.0.0
-  - psutil >=6.1.1
-  - pydantic-settings >=2.7.1
-  - pydantic
-  - pydantic-core
-  - requests >=2.32.3
-  - sentencepiece >=0.2.0
-  - taskgroup >=0.2.2
-  - tiktoken >=0.5.0
-  - tqdm >=4.67.1
-  - transformers >=5.0.0,<5.3.0
-  - uvicorn >=0.34.0
-  - uvloop >=0.21.0
-  - aiofiles >=24.1.0
-  - asgiref >=3.8.1
-  - fastapi >=0.115.3
-  - grpcio >=1.68.0
-  - httpx >=0.28.1,<0.29
-  - msgspec >=0.19.0
-  - opentelemetry-api >=1.29.0
-  - opentelemetry-exporter-otlp-proto-http >=1.27.0
-  - opentelemetry-exporter-prometheus >=0.50b0
-  - opentelemetry-sdk >=1.29.0,<1.36.0
-  - prometheus_client >=0.21.0
-  - protobuf >=6.33.5,<6.34.0
-  - pyinstrument >=5.0.1
-  - python-json-logger >=2.0.7
-  - pyzmq >=26.3.0
-  - regex >=2024.11.6
-  - scipy >=1.13.0
-  - sse-starlette >=2.1.2
-  - starlette >=0.47.2
-  - max ==26.3.0.dev2026040905
-  license: LicenseRef-Modular-Proprietary
-  size: 16986
-  timestamp: 1775713531758
 - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.3.0.dev2026040905-release.conda
   noarch: python
   sha256: 6eda5e41e1a41337cdb5160c998821dcdb73c86392155657d7e45ca3bf995f44
@@ -30602,15 +28236,6 @@ packages:
   license: LicenseRef-Modular-Proprietary
   size: 134441
   timestamp: 1775713531590
-- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-  sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
-  md5: 592132998493b3ff25fd7479396e8351
-  depends:
-  - python >=3.9
-  license: MIT
-  license_family: MIT
-  size: 14465
-  timestamp: 1733255681319
 - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
   sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
   md5: 592132998493b3ff25fd7479396e8351
@@ -30733,16 +28358,6 @@ packages:
   - glcontext>=3.0.0
   - glcontext>=3.0.0 ; extra == 'headless'
   requires_python: '>=3.7'
-- conda: https://conda.modular.com/max-nightly/noarch/modular-26.3.0.dev2026040905-release.conda
-  noarch: python
-  sha256: f3b341ac1969ec4bb5a5e0015a72ee769023e78e570c1c6243f92312bca24a11
-  md5: 76a0321384353b13b6861f6799e188eb
-  depends:
-  - max-pipelines ==26.3.0.dev2026040905
-  - mojo ==0.26.3.0.dev2026040905
-  license: LicenseRef-Modular-Proprietary
-  size: 16482
-  timestamp: 1775713531348
 - pypi: git+https://github.com/microsoft/MoGe.git#07444410f1e33f402353b99d6ccd26bd31e469e8
   name: moge
   version: 2.0.0
@@ -30799,7 +28414,7 @@ packages:
   - pytorch-lightning>=2.5.1,<3
   - diffusers[torch]>=0.32.2
   - timm>=1.0.15,<2
-  - sam3-rerun @ file:///var/tmp/vibe-kanban/worktrees/4658-mast3r-slam-mojo/examples-monorepo/packages/sam3-rerun
+  - sam3-rerun @ file:///var/tmp/vibe-kanban/worktrees/0c88-mast3r-slam-fix/examples-monorepo/packages/sam3-rerun
   requires_python: '>=3.11.0'
 - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
   name: more-itertools
@@ -30884,17 +28499,6 @@ packages:
   purls: []
   size: 1933306
   timestamp: 1773413839223
-- conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
-  sha256: 39c4700fb3fbe403a77d8cc27352fa72ba744db487559d5d44bf8411bb4ea200
-  md5: c7f302fd11eeb0987a6a5e1f3aed6a21
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  license: LGPL-2.1-only
-  license_family: LGPL
-  size: 491140
-  timestamp: 1730581373280
 - conda: https://prefix.dev/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
   sha256: 39c4700fb3fbe403a77d8cc27352fa72ba744db487559d5d44bf8411bb4ea200
   md5: c7f302fd11eeb0987a6a5e1f3aed6a21
@@ -30983,18 +28587,6 @@ packages:
   - pkg:pypi/msgpack?source=hash-mapping
   size: 102525
   timestamp: 1762504116832
-- conda: https://conda.anaconda.org/conda-forge/linux-64/msgspec-0.21.0-py311h49ec1c0_0.conda
-  sha256: 73c48ad38b8962ef5381c77d85e03006700b3f330f1f86426ab0ea988f1f77b2
-  md5: e1f6dec51f6147d0fb411ba5fd6c059d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 217814
-  timestamp: 1775696162645
 - pypi: https://files.pythonhosted.org/packages/4b/ac/b605473de2bb404e742f2cc3583d12aedb2352a70e49ae8fce455b50c5aa/multidict-6.7.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: multidict
   version: 6.7.1
@@ -31076,15 +28668,6 @@ packages:
   - pkg:pypi/munkres?source=hash-mapping
   size: 15851
   timestamp: 1749895533014
-- conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-  sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
-  md5: e9c622e0d00fa24a6292279af3ab6d06
-  depends:
-  - python >=3.9
-  license: MIT
-  license_family: MIT
-  size: 11766
-  timestamp: 1745776666688
 - conda: https://prefix.dev/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
   sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
   md5: e9c622e0d00fa24a6292279af3ab6d06
@@ -31236,15 +28819,6 @@ packages:
   purls: []
   size: 292847927
   timestamp: 1770781403687
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
-  sha256: 3fde293232fa3fca98635e1167de6b7c7fda83caf24b9d6c91ec9eefb4f4d586
-  md5: 47e340acb35de30501a76c7c799c41d7
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: X11 AND BSD-3-Clause
-  size: 891641
-  timestamp: 1738195959188
 - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
   sha256: 3fde293232fa3fca98635e1167de6b7c7fda83caf24b9d6c91ec9eefb4f4d586
   md5: 47e340acb35de30501a76c7c799c41d7
@@ -31418,24 +28992,6 @@ packages:
   requires_dist:
   - numpy>=1.23.0
   requires_python: '>=3.10'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py311h2e04523_0.conda
-  sha256: ea4e92bb68b58ce92c0d4152c308eecfee94f131d5ef247395fbe70b7697074d
-  md5: cfc8f864dea571677095ebae8e6f0c07
-  depends:
-  - python
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libcblas >=3.9.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - python_abi 3.11.* *_cp311
-  - libblas >=3.9.0,<4.0a0
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 9384747
-  timestamp: 1773839224422
 - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.2.6-py310hefbff90_0.conda
   sha256: 0ba94a61f91d67413e60fa8daa85627a8f299b5054b0eff8f93d26da83ec755e
   md5: b0cea2c364bf65cd19e023040eeab05d
@@ -31556,17 +29112,6 @@ packages:
   - pkg:pypi/numpy?source=compressed-mapping
   size: 7841597
   timestamp: 1773839274579
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
-  sha256: 2254dae821b286fb57c61895f2b40e3571a070910fdab79a948ff703e1ea807b
-  md5: 56f8947aa9d5cf37b0b3d43b83f34192
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - opencl-headers >=2024.10.24
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 106742
-  timestamp: 1743700382939
 - conda: https://prefix.dev/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
   sha256: 2254dae821b286fb57c61895f2b40e3571a070910fdab79a948ff703e1ea807b
   md5: 56f8947aa9d5cf37b0b3d43b83f34192
@@ -31783,17 +29328,6 @@ packages:
   - pkg:pypi/open3d-cpu?source=hash-mapping
   size: 10452037
   timestamp: 1772689732042
-- conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-hecca717_0.conda
-  sha256: 8de2f0cd8a659b01abf86e7fbb8cea4f28ada62fd288429a2bbc040db1b98dd0
-  md5: c930c8052d780caa41216af7de472226
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: Apache-2.0
-  license_family: APACHE
-  size: 55754
-  timestamp: 1773844383536
 - conda: https://prefix.dev/conda-forge/linux-64/opencl-headers-2025.06.13-h5888daf_0.conda
   sha256: 2b6ce54174ec19110e1b3c37455f7cd138d0e228a75727a9bba443427da30a36
   md5: 45c3d2c224002d6d0d7769142b29f986
@@ -31942,17 +29476,6 @@ packages:
   purls: []
   size: 1176418
   timestamp: 1774561011034
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
-  sha256: 3f231f2747a37a58471c82a9a8a80d92b7fece9f3fce10901a5ac888ce00b747
-  md5: b28cf020fd2dead0ca6d113608683842
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 731471
-  timestamp: 1739400677213
 - conda: https://prefix.dev/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
   sha256: 3f231f2747a37a58471c82a9a8a80d92b7fece9f3fce10901a5ac888ce00b747
   md5: b28cf020fd2dead0ca6d113608683842
@@ -32007,20 +29530,6 @@ packages:
   purls: []
   size: 4118591
   timestamp: 1756560466627
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
-  sha256: 3900f9f2dbbf4129cf3ad6acf4e4b6f7101390b53843591c53b00f034343bc4d
-  md5: 11b3379b191f63139e29c0d19dee24cd
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libpng >=1.6.50,<1.7.0a0
-  - libstdcxx >=14
-  - libtiff >=4.7.1,<4.8.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 355400
-  timestamp: 1758489294972
 - conda: https://prefix.dev/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
   sha256: 3900f9f2dbbf4129cf3ad6acf4e4b6f7101390b53843591c53b00f034343bc4d
   md5: 11b3379b191f63139e29c0d19dee24cd
@@ -32134,17 +29643,6 @@ packages:
   purls: []
   size: 907905
   timestamp: 1771970279050
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
-  sha256: c0ef482280e38c71a08ad6d71448194b719630345b0c9c60744a2010e8a8e0cb
-  md5: da1b85b6a87e141f5140bb9924cecab0
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - ca-certificates
-  - libgcc >=14
-  license: Apache-2.0
-  license_family: Apache
-  size: 3167099
-  timestamp: 1775587756857
 - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
   sha256: 44c877f8af015332a5d12f5ff0fb20ca32f896526a7d0cdb30c769df1144fb5c
   md5: f61eb8cd60ff9057122a3d338b99c00f
@@ -32180,94 +29678,6 @@ packages:
   purls: []
   size: 3692030
   timestamp: 1769557678657
-- conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-api-1.35.0-pyhd8ed1ab_0.conda
-  sha256: 6228c870ad994ea843b78505c3df818dada38a6e9a8c658a02552898c8ddb218
-  md5: 241b102f0e44e7992f58c2419b84cf2e
-  depends:
-  - deprecated >=1.2.6
-  - importlib-metadata <8.8.0,>=6.0
-  - python >=3.9
-  - typing_extensions >=4.5.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 45773
-  timestamp: 1752286891826
-- conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-exporter-otlp-proto-common-1.35.0-pyhd8ed1ab_0.conda
-  sha256: ff2776168c26365290ab480ac14f8f27392d4286c6f8fabd9c33884bd9fff094
-  md5: d98d06fedf338be8773b6c9bb023952d
-  depends:
-  - backoff >=1.10.0,<3.0.0
-  - opentelemetry-proto 1.35.0
-  - python >=3.9
-  license: Apache-2.0
-  license_family: APACHE
-  size: 19234
-  timestamp: 1752327590965
-- conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-exporter-otlp-proto-http-1.35.0-pyhd8ed1ab_0.conda
-  sha256: 41c96d6d309eedfd9c2ef49784e79ab0e228351fb9ef6ccbdb3839ac110fcb7c
-  md5: 2582574aa069164d1127c0b84e31bf47
-  depends:
-  - deprecated >=1.2.6
-  - googleapis-common-protos >=1.52,<2.dev0
-  - opentelemetry-api >=1.15,<2.dev0
-  - opentelemetry-exporter-otlp-proto-common 1.35.0
-  - opentelemetry-proto 1.35.0
-  - opentelemetry-sdk >=1.35.0,<1.36.dev0
-  - python >=3.9
-  - requests >=2.7,<3.dev0
-  - typing_extensions >=4.5.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 18011
-  timestamp: 1752362461602
-- conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-exporter-prometheus-0.56b0-pyhe01879c_1.conda
-  sha256: 145d87a756d2f6db6963d9105c26f09c04f79a24278b631f672d13adbb469c70
-  md5: 372d2c49b89dbb827ec2e85998a75095
-  depends:
-  - python >=3.9
-  - opentelemetry-api >=1.12,<2.dev0
-  - opentelemetry-sdk >=1.35.0,<1.36.dev0
-  - prometheus_client >=0.5.0,<1.0.0
-  - python
-  license: Apache-2.0
-  license_family: APACHE
-  size: 22901
-  timestamp: 1754090360044
-- conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-proto-1.35.0-pyhd8ed1ab_0.conda
-  sha256: 53f20256a65df56031b8d285dd76c5181fe987682efe8286dd02f5fee31e3ce9
-  md5: 67e3d4dd1e0ced032ef8fa99340e50c5
-  depends:
-  - protobuf <7.0,>=5.0
-  - python >=3.9
-  license: Apache-2.0
-  license_family: APACHE
-  size: 45741
-  timestamp: 1752308297180
-- conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-sdk-1.35.0-pyhd8ed1ab_0.conda
-  sha256: f091363a1a0dd8d1c9b889f9ee433f28efb122edbc4222b8468790689fd106b1
-  md5: 226ec4d220a74e1fcc8c658f365bd3ef
-  depends:
-  - opentelemetry-api 1.35.0
-  - opentelemetry-semantic-conventions 0.56b0
-  - python >=3.9
-  - typing-extensions >=3.7.4
-  - typing_extensions >=4.5.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 78751
-  timestamp: 1752299653515
-- conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-semantic-conventions-0.56b0-pyh3cfb1c2_0.conda
-  sha256: 9d439ad39d33f3ea61553b5a48b4250fd06d8a4ad99ccb3bac6d8d1a273339ba
-  md5: 251c0dfb684e8f43a71d579091191580
-  depends:
-  - deprecated >=1.2.6
-  - opentelemetry-api 1.35.0
-  - python >=3.9
-  - typing_extensions >=4.5.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 107441
-  timestamp: 1752290820962
 - conda: https://prefix.dev/conda-forge/linux-64/optree-0.19.0-py311hdf67eae_0.conda
   sha256: 9f72b0082149ddc825b2df028a150c54636536e3eb42364eb84b40ec9d5af2b5
   md5: 31ba7cdcaa7cf05056a297898f855497
@@ -32400,16 +29810,6 @@ packages:
   - pkg:pypi/overrides?source=hash-mapping
   size: 30139
   timestamp: 1734587755455
-- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
-  sha256: c1fc0f953048f743385d31c468b4a678b3ad20caffdeaa94bed85ba63049fd58
-  md5: b76541e68fea4d511b1ac46a28dcd2c6
-  depends:
-  - python >=3.8
-  - python
-  license: Apache-2.0
-  license_family: APACHE
-  size: 72010
-  timestamp: 1769093650580
 - conda: https://prefix.dev/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
   sha256: c1fc0f953048f743385d31c468b4a678b3ad20caffdeaa94bed85ba63049fd58
   md5: b76541e68fea4d511b1ac46a28dcd2c6
@@ -33117,26 +30517,6 @@ packages:
   - pkg:pypi/pandocfilters?source=hash-mapping
   size: 11627
   timestamp: 1631603397334
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
-  sha256: 315b52bfa6d1a820f4806f6490d472581438a28e21df175290477caec18972b0
-  md5: d53ffc0edc8eabf4253508008493c5bc
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cairo >=1.18.4,<2.0a0
-  - fontconfig >=2.17.1,<3.0a0
-  - fonts-conda-ecosystem
-  - fribidi >=1.0.16,<2.0a0
-  - harfbuzz >=13.2.1
-  - libexpat >=2.7.4,<3.0a0
-  - libfreetype >=2.14.2
-  - libfreetype6 >=2.14.2
-  - libgcc >=14
-  - libglib >=2.86.4,<3.0a0
-  - libpng >=1.6.55,<1.7.0a0
-  - libzlib >=1.3.2,<2.0a0
-  license: LGPL-2.1-or-later
-  size: 458036
-  timestamp: 1774281947855
 - conda: https://prefix.dev/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
   sha256: 3613774ad27e48503a3a6a9d72017087ea70f1426f6e5541dbdb59a3b626eaaf
   md5: 79f71230c069a287efe3a8614069ddf1
@@ -33236,15 +30616,6 @@ packages:
   version: 0.5.2
   sha256: 4c9d94cf1b23af417ce7c0417b43333b06a106c01000b286c99de230d95eefbb
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
-  sha256: 29ea20d0faf20374fcd61c25f6d32fb8e9a2c786a7f1473a0c3ead359470fbe1
-  md5: 2908273ac396d2cd210a8127f5f1c0d6
-  depends:
-  - python >=3.10
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 53739
-  timestamp: 1769677743677
 - conda: https://prefix.dev/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
   sha256: 29ea20d0faf20374fcd61c25f6d32fb8e9a2c786a7f1473a0c3ead359470fbe1
   md5: 2908273ac396d2cd210a8127f5f1c0d6
@@ -33256,18 +30627,6 @@ packages:
   - pkg:pypi/pathspec?source=hash-mapping
   size: 53739
   timestamp: 1769677743677
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
-  sha256: 5e6f7d161356fefd981948bea5139c5aa0436767751a6930cb1ca801ebb113ff
-  md5: 7a3bff861a6583f1889021facefc08b1
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1222481
-  timestamp: 1763655398280
 - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.46-h1321c63_0.conda
   sha256: 5c7380c8fd3ad5fc0f8039069a45586aa452cf165264bc5a437ad80397b32934
   md5: 7fa07cb0fb1b625a089ccc01218ee5b1
@@ -33357,27 +30716,6 @@ packages:
   - pkg:pypi/pexpect?source=hash-mapping
   size: 53561
   timestamp: 1733302019362
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.2.0-py311hf88fc01_0.conda
-  sha256: 5b182a7588874e497514b52e2ef278b66fa4089e94379d249897df28b917a659
-  md5: b4e4b0fc807b68aa1706457f2e31279d
-  depends:
-  - python
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - lcms2 >=2.18,<3.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - python_abi 3.11.* *_cp311
-  - tk >=8.6.13,<8.7.0a0
-  - zlib-ng >=2.3.3,<2.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libtiff >=4.7.1,<4.8.0a0
-  - openjpeg >=2.5.4,<3.0a0
-  - libfreetype >=2.14.3
-  - libfreetype6 >=2.14.3
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  license: HPND
-  size: 1056849
-  timestamp: 1775060059882
 - conda: https://prefix.dev/conda-forge/linux-64/pillow-11.3.0-py310h6557065_3.conda
   sha256: 7fe27fd1c5a3d85ea355a609d050e50469382223bbf5a07ca750e30b6aebdc25
   md5: e169733dc0c743687a852f1c6e989140
@@ -33579,18 +30917,6 @@ packages:
   name: pipeline
   version: 1.0.0
   requires_python: '>=3.8'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
-  sha256: 43d37bc9ca3b257c5dd7bf76a8426addbdec381f6786ff441dc90b1a49143b6a
-  md5: c01af13bdc553d1a8fbfff6e8db075f0
-  depends:
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  license: MIT
-  license_family: MIT
-  size: 450960
-  timestamp: 1754665235234
 - conda: https://prefix.dev/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
   sha256: 43d37bc9ca3b257c5dd7bf76a8426addbdec381f6786ff441dc90b1a49143b6a
   md5: c01af13bdc553d1a8fbfff6e8db075f0
@@ -33643,15 +30969,6 @@ packages:
   version: 4.9.4
   sha256: 68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868
   requires_python: '>=3.10'
-- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
-  sha256: 8f29915c172f1f7f4f7c9391cd5dac3ebf5d13745c8b7c8006032615246345a5
-  md5: 89c0b6d1793601a2a3a3f7d2d3d8b937
-  depends:
-  - python >=3.10
-  - python
-  license: MIT
-  size: 25862
-  timestamp: 1775741140609
 - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
   sha256: 7f263219cecf0ba6d74c751efa60c4676ce823157ca90aa43ebba5ac615ca0fa
   md5: 4fefefb892ce9cc1539405bec2f1a6cd
@@ -33830,15 +31147,6 @@ packages:
   purls: []
   size: 211335
   timestamp: 1730769181127
-- conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.24.1-pyhd8ed1ab_0.conda
-  sha256: 75b2589159d04b3fb92db16d9970b396b9124652c784ab05b66f584edc97f283
-  md5: 7526d20621b53440b0aae45d4797847e
-  depends:
-  - python >=3.10
-  license: Apache-2.0
-  license_family: Apache
-  size: 56634
-  timestamp: 1768476602855
 - conda: https://prefix.dev/conda-forge/noarch/prometheus_client-0.24.1-pyhd8ed1ab_0.conda
   sha256: 75b2589159d04b3fb92db16d9970b396b9124652c784ab05b66f584edc97f283
   md5: 7526d20621b53440b0aae45d4797847e
@@ -33932,24 +31240,6 @@ packages:
   version: 7.34.1
   sha256: 5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b
   requires_python: '>=3.10'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-6.33.5-py311h3f0a9aa_2.conda
-  sha256: f6184d8b4c2c39ef107b579f3712a38947ad52d5bd1c9415c919057ea8aed785
-  md5: 3b8a5188f2b1365af1105c40a7ec32e9
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.1,<20260108.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  constrains:
-  - libprotobuf 6.33.5
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 488615
-  timestamp: 1773265956304
 - conda: https://prefix.dev/conda-forge/linux-64/protobuf-6.33.5-py312ha7b3241_1.conda
   sha256: 9095e1f9a58ff85278c2e0a5a2f2090e4b01b9f1293c593ce4c673fa6741efcd
   md5: 471bddc987c96beb8603b43ecd53cc02
@@ -34025,18 +31315,6 @@ packages:
   - wheel ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'test'
   - wmi ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'test'
   requires_python: '>=3.6'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py311haee01d2_0.conda
-  sha256: 8d9325af538a8f56013e42bbb91a4dc6935aece34476e20bafacf6007b571e86
-  md5: 2ed8f6fe8b51d8e19f7621941f7bb95f
-  depends:
-  - python
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python_abi 3.11.* *_cp311
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 231786
-  timestamp: 1769678156460
 - conda: https://prefix.dev/conda-forge/linux-64/psutil-7.2.2-py312h5253ce2_0.conda
   sha256: d834fd656133c9e4eaf63ffe9a117c7d0917d86d89f7d64073f4e3a0020bd8a7
   md5: dd94c506b119130aef5a9382aed648e7
@@ -34051,16 +31329,6 @@ packages:
   - pkg:pypi/psutil?source=compressed-mapping
   size: 225545
   timestamp: 1769678155334
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
-  sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
-  md5: b3c17d95b5a10c6e64a21fa17573e70e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 8252
-  timestamp: 1726802366959
 - conda: https://prefix.dev/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
   sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
   md5: b3c17d95b5a10c6e64a21fa17573e70e
@@ -34092,17 +31360,6 @@ packages:
   - pkg:pypi/ptyprocess?source=hash-mapping
   size: 19457
   timestamp: 1733302371990
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
-  sha256: 23c98a5000356e173568dc5c5770b53393879f946f3ace716bbdefac2a8b23d2
-  md5: b11a4c6bf6f6f44e5e143f759ffa2087
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  license: MIT
-  license_family: MIT
-  size: 118488
-  timestamp: 1736601364156
 - conda: https://prefix.dev/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
   sha256: 23c98a5000356e173568dc5c5770b53393879f946f3ace716bbdefac2a8b23d2
   md5: b11a4c6bf6f6f44e5e143f759ffa2087
@@ -34126,24 +31383,6 @@ packages:
   purls: []
   size: 113424
   timestamp: 1737355438448
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
-  sha256: 0a0858c59805d627d02bdceee965dd84fde0aceab03a2f984325eec08d822096
-  md5: b8ea447fdf62e3597cb8d2fae4eb1a90
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - dbus >=1.16.2,<2.0a0
-  - libgcc >=14
-  - libglib >=2.86.1,<3.0a0
-  - libiconv >=1.18,<2.0a0
-  - libsndfile >=1.2.2,<1.3.0a0
-  - libsystemd0 >=257.10
-  - libxcb >=1.17.0,<2.0a0
-  constrains:
-  - pulseaudio 17.0 *_3
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 750785
-  timestamp: 1763148198088
 - conda: https://prefix.dev/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
   sha256: 0a0858c59805d627d02bdceee965dd84fde0aceab03a2f984325eec08d822096
   md5: b8ea447fdf62e3597cb8d2fae4eb1a90
@@ -34606,21 +31845,6 @@ packages:
   - email-validator>=2.0.0 ; extra == 'email'
   - tzdata ; python_full_version >= '3.9' and sys_platform == 'win32' and extra == 'timezone'
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
-  sha256: 868569d9505b7fe246c880c11e2c44924d7613a8cdcc1f6ef85d5375e892f13d
-  md5: c3946ed24acdb28db1b5d63321dbca7d
-  depends:
-  - typing-inspection >=0.4.2
-  - typing_extensions >=4.14.1
-  - python >=3.10
-  - typing-extensions >=4.6.1
-  - annotated-types >=0.6.0
-  - pydantic-core ==2.41.5
-  - python
-  license: MIT
-  license_family: MIT
-  size: 340482
-  timestamp: 1764434463101
 - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.11.10-pyh3cfb1c2_0.conda
   sha256: 26779821ba83b896f319837d7c5301cc244dee41b311d2bd57cbd693ed9e43ef
   md5: 918d9adfc81cb14ab4cced31d22c7711
@@ -34672,21 +31896,6 @@ packages:
   requires_dist:
   - typing-extensions>=4.6.0,!=4.7.0
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py311h902ca64_1.conda
-  sha256: da6e2060a91de065031214f9ca56e24906785ea412cd274d1f32128992dc0d43
-  md5: 08d407f0331ff8e871db23bec7eef83c
-  depends:
-  - python
-  - typing-extensions >=4.6.0,!=4.7.0
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.11.* *_cp311
-  constrains:
-  - __glibc >=2.17
-  license: MIT
-  license_family: MIT
-  size: 1938184
-  timestamp: 1762988992467
 - conda: https://prefix.dev/conda-forge/linux-64/pydantic-core-2.33.2-py312h680f630_0.conda
   sha256: 4d14d7634c8f351ff1e63d733f6bb15cba9a0ec77e468b0de9102014a4ddc103
   md5: cfbd96e5a0182dfb4110fc42dda63e57
@@ -34704,37 +31913,6 @@ packages:
   - pkg:pypi/pydantic-core?source=hash-mapping
   size: 1890081
   timestamp: 1746625309715
-- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.2-pyhcf101f3_0.conda
-  sha256: 0e86d31f300abe09d958d8a02c164e742b4cfe7403955a24ca02b498d50251c7
-  md5: f9acfec2bcfcf6f43594674389da835e
-  depends:
-  - python >=3.10
-  - pydantic >=2.5.2
-  - python
-  constrains:
-  - phonenumbers >=8,<9
-  - pycountry >=23
-  - semver >=3.0.2,<4
-  - python-ulid >=1,<4
-  - pendulum >=3.0.0,<4.0.0
-  - pytz >=2024.1
-  - tzdata >=2024a
-  license: MIT
-  license_family: MIT
-  size: 73947
-  timestamp: 1775429718410
-- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.13.1-pyhd8ed1ab_0.conda
-  sha256: 343988d65c08477a87268d4fbeba59d0295514143965d2755ac4519b73155479
-  md5: cc0da73801948100ae97383b8da12993
-  depends:
-  - pydantic >=2.7.0
-  - python >=3.10
-  - python-dotenv >=0.21.0
-  - typing-inspection >=0.4.0
-  license: MIT
-  license_family: MIT
-  size: 49319
-  timestamp: 1771527313149
 - pypi: https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl
   name: pydub
   version: 0.25.1
@@ -34768,15 +31946,6 @@ packages:
   - pkg:pypi/pyglet?source=hash-mapping
   size: 725938
   timestamp: 1770169149613
-- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-  sha256: cf70b2f5ad9ae472b71235e5c8a736c9316df3705746de419b59d442e8348e86
-  md5: 16c18772b340887160c79a6acc022db0
-  depends:
-  - python >=3.10
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 893031
-  timestamp: 1774796815820
 - conda: https://prefix.dev/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
   sha256: 5577623b9f6685ece2697c6eb7511b4c9ac5fb607c9babc2646c811b428fd46a
   md5: 6b6ece66ebcae2d5f326c77ef2c5a066
@@ -34799,18 +31968,6 @@ packages:
   - pkg:pypi/pygments?source=compressed-mapping
   size: 893031
   timestamp: 1774796815820
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyinstrument-5.1.2-py311h49ec1c0_0.conda
-  sha256: 37293d78effcfd7958d7e467bf961e0abb017ddd49eb75fa3cbdefe489d04b2f
-  md5: 9ec77f7ef80f25bc19d8eeb8ba12f142
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 191363
-  timestamp: 1767565475544
 - pypi: https://files.pythonhosted.org/packages/46/aa/ad48cc40d15c6c12d64d06768db96bde01e8f72dbfbbcebf391bcc1682fb/pykdtree-1.4.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: pykdtree
   version: 1.4.3
@@ -35084,16 +32241,6 @@ packages:
   - pkg:pypi/shiboken6?source=hash-mapping
   size: 13113402
   timestamp: 1775062816827
-- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-  sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
-  md5: 461219d1a5bd61342293efa2c0c90eac
-  depends:
-  - __unix
-  - python >=3.9
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 21085
-  timestamp: 1733217331982
 - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
   sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
   md5: 461219d1a5bd61342293efa2c0c90eac
@@ -35127,32 +32274,6 @@ packages:
   - pkg:pypi/pytest?source=hash-mapping
   size: 294852
   timestamp: 1762354779909
-- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.15-hd63d673_0_cpython.conda
-  sha256: bf6a32c69889d38482436a786bea32276756cedf0e9805cc856ffd088e8d00f0
-  md5: a5ebcefec0c12a333bcd6d7bf3bddc1f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-64 >=2.36.1
-  - libexpat >=2.7.4,<3.0a0
-  - libffi >=3.5.2,<3.6.0a0
-  - libgcc >=14
-  - liblzma >=5.8.2,<6.0a0
-  - libnsl >=2.0.1,<2.1.0a0
-  - libsqlite >=3.51.2,<4.0a0
-  - libuuid >=2.41.3,<3.0a0
-  - libxcrypt >=4.4.36
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - openssl >=3.5.5,<4.0a0
-  - readline >=8.3,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  constrains:
-  - python_abi 3.11.* *_cp311
-  license: Python-2.0
-  size: 30949404
-  timestamp: 1772730362552
 - conda: https://prefix.dev/conda-forge/linux-64/python-3.10.20-h3c07f61_0_cpython.conda
   sha256: 8ff2ce308faf2588b69c65b120293f59a8f2577b772b34df4e817d220b09e081
   md5: 5d4e2b00d99feacd026859b7fa239dc0
@@ -35293,17 +32414,6 @@ packages:
   requires_dist:
   - six>=1.5
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*'
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-  sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
-  md5: 5b8d21249ff20967101ffa321cab24e8
-  depends:
-  - python >=3.9
-  - six >=1.5
-  - python
-  license: Apache-2.0
-  license_family: APACHE
-  size: 233310
-  timestamp: 1751104122689
 - conda: https://prefix.dev/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
   sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
   md5: 5b8d21249ff20967101ffa321cab24e8
@@ -35324,15 +32434,6 @@ packages:
   requires_dist:
   - click>=5.0 ; extra == 'cli'
   requires_python: '>=3.10'
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
-  sha256: 74e417a768f59f02a242c25e7db0aa796627b5bc8c818863b57786072aeb85e5
-  md5: 130584ad9f3a513cdd71b1fdc1244e9c
-  depends:
-  - python >=3.10
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 27848
-  timestamp: 1772388605021
 - conda: https://prefix.dev/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
   sha256: df9aa74e9e28e8d1309274648aac08ec447a92512c33f61a8de0afa9ce32ebe8
   md5: 23029aae904a2ba587daba708208012f
@@ -35345,15 +32446,6 @@ packages:
   - pkg:pypi/fastjsonschema?source=hash-mapping
   size: 244628
   timestamp: 1755304154927
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.11.15-hd8ed1ab_0.conda
-  sha256: d4431c088320de51f61df0c0aa5aa85921037fdcfcff528b9d7e614ed5d7c6b4
-  md5: 8793751936480e56ce4047b4f54b997f
-  depends:
-  - cpython 3.11.15.*
-  - python_abi * *_cp311
-  license: Python-2.0
-  size: 47985
-  timestamp: 1772730345561
 - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.10.20-hd8ed1ab_0.conda
   sha256: 091050470b40e33ba730455f5be1a0780f62070d254ad9378a3778936aacfae8
   md5: f1bbb89516401b50c98046ec41ece796
@@ -35384,15 +32476,6 @@ packages:
   purls: []
   size: 46449
   timestamp: 1772728979370
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
-  sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
-  md5: a61bf9ec79426938ff785eb69dbb1960
-  depends:
-  - python >=3.6
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 13383
-  timestamp: 1677079727691
 - conda: https://prefix.dev/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
   sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
   md5: a61bf9ec79426938ff785eb69dbb1960
@@ -35414,16 +32497,6 @@ packages:
   version: 0.0.24
   sha256: 9b110a98db707df01a53c194f0af075e736a770dc5058089650d70b4a182f950
   requires_python: '>=3.10'
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.24-pyhcf101f3_0.conda
-  sha256: fabe7fa67ae117b2908fde1af3a15a3cf3e28fcfb0ea6e327712a21260b41406
-  md5: f319dd7ebed160df398fda1141fa263d
-  depends:
-  - python >=3.10
-  - python
-  license: Apache-2.0
-  license_family: APACHE
-  size: 30108
-  timestamp: 1775462580903
 - conda: https://prefix.dev/conda-forge/noarch/python-tzdata-2025.3-pyhd8ed1ab_0.conda
   sha256: 467134ef39f0af2dbb57d78cb3e4821f01003488d331a8dd7119334f4f47bfbd
   md5: 7ead57407430ba33f681738905278d03
@@ -35435,16 +32508,6 @@ packages:
   - pkg:pypi/tzdata?source=hash-mapping
   size: 143542
   timestamp: 1765719982349
-- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
-  build_number: 8
-  sha256: fddf123692aa4b1fc48f0471e346400d9852d96eeed77dbfdd746fa50a8ff894
-  md5: 8fcb6b0e2161850556231336dae58358
-  constrains:
-  - python 3.11.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 7003
-  timestamp: 1752805919375
 - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.10-8_cp310.conda
   build_number: 8
   sha256: 7ad76fa396e4bde336872350124c0819032a9e8a0a40590744ff9527b54351c1
@@ -35918,19 +32981,6 @@ packages:
   version: 0.1.0
   sha256: d4135e44a60bcdda18583c60dee92a790daa42561237c70525a35134072c1edc
   requires_python: '>=3.12'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py311h3778330_1.conda
-  sha256: c9a6cd2c290d7c3d2b30ea34a0ccda30f770e8ddb2937871f2c404faf60d0050
-  md5: a24add9a3bababee946f3bc1c829acfe
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  size: 206190
-  timestamp: 1770223702917
 - conda: https://prefix.dev/conda-forge/linux-64/pyyaml-6.0.3-py310h3406613_1.conda
   sha256: f23de6cc72541c6081d3d27482dbc9fc5dd03be93126d9155f06d0cf15d6e90e
   md5: 2160894f57a40d2d629a34ee8497795f
@@ -36006,20 +33056,6 @@ packages:
   - pkg:pypi/pyyaml?source=hash-mapping
   size: 192182
   timestamp: 1770223431156
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py311h57d2397_2.conda
-  sha256: 4137226663b353919396f8cf239971cfa54107cd077cf3b65e979ba3e1f8a037
-  md5: 759edfe34f07c5c4565b6c5ec0c7fb17
-  depends:
-  - python
-  - libgcc >=14
-  - libstdcxx >=14
-  - __glibc >=2.17,<3.0.a0
-  - zeromq >=4.3.5,<4.4.0a0
-  - python_abi 3.11.* *_cp311
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 383627
-  timestamp: 1771716979818
 - conda: https://prefix.dev/conda-forge/linux-64/pyzmq-27.1.0-py311h57d2397_2.conda
   sha256: 4137226663b353919396f8cf239971cfa54107cd077cf3b65e979ba3e1f8a037
   md5: 759edfe34f07c5c4565b6c5ec0c7fb17
@@ -36646,15 +33682,6 @@ packages:
   purls: []
   size: 1268666
   timestamp: 1769154883613
-- conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h5301d42_1.conda
-  sha256: 3fc684b81631348540e9a42f6768b871dfeab532d3f47d5c341f1f83e2a2b2b2
-  md5: 66a715bc01c77d43aca1f9fcb13dde3c
-  depends:
-  - libre2-11 2025.11.05 h0dc7533_1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 27469
-  timestamp: 1768190052132
 - conda: https://prefix.dev/conda-forge/linux-64/re2-2025.11.05-h5301d42_1.conda
   sha256: 3fc684b81631348540e9a42f6768b871dfeab532d3f47d5c341f1f83e2a2b2b2
   md5: 66a715bc01c77d43aca1f9fcb13dde3c
@@ -36675,17 +33702,6 @@ packages:
   purls: []
   size: 27491
   timestamp: 1768190008421
-- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
-  sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
-  md5: d7d95fc8287ea7bf33e0e7116d2b95ec
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 345073
-  timestamp: 1765813471974
 - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
   sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
   md5: d7d95fc8287ea7bf33e0e7116d2b95ec
@@ -36734,18 +33750,6 @@ packages:
   - pkg:pypi/referencing?source=hash-mapping
   size: 51788
   timestamp: 1760379115194
-- conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2026.4.4-py311h49ec1c0_0.conda
-  sha256: 39d02ad3d3cf40001354e9fd4f9ea68d25394d7a19dd471699ddb88a497ccec2
-  md5: eea925134b3b1aad18dd1f3ca0e5b072
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: Apache-2.0 AND CNRI-Python
-  license_family: PSF
-  size: 417911
-  timestamp: 1775259328064
 - conda: https://prefix.dev/conda-forge/linux-64/regex-2026.2.28-py310h7c4b9e2_0.conda
   sha256: e7ed845d42cf13c4b90e7a2da344d49329ebe9f5785598e95c798433872061d2
   md5: 738db83155dbc6ef5f4277822d470fb4
@@ -36844,22 +33848,6 @@ packages:
   - pkg:pypi/regex?source=hash-mapping
   size: 407091
   timestamp: 1774742178070
-- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
-  sha256: c0249bc4bf4c0e8e06d0e7b4d117a5d593cc4ab2144d5006d6d47c83cb0af18e
-  md5: 10afbb4dbf06ff959ad25a92ccee6e59
-  depends:
-  - python >=3.10
-  - certifi >=2023.5.7
-  - charset-normalizer >=2,<4
-  - idna >=2.5,<4
-  - urllib3 >=1.26,<3
-  - python
-  constrains:
-  - chardet >=3.0.2,<6
-  license: Apache-2.0
-  license_family: APACHE
-  size: 63712
-  timestamp: 1774894783063
 - conda: https://prefix.dev/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
   sha256: 7813c38b79ae549504b2c57b3f33394cea4f2ad083f0994d2045c2e24cb538c5
   md5: c65df89a0b2e321045a9e01d1337b182
@@ -36908,7 +33896,7 @@ packages:
   version: 0.1.0
   sha256: 6010c475dca8016b74cdbd14fec5a399b674644eb3797dd861ad6c4670702b67
   requires_dist:
-  - monopriors @ file:///var/tmp/vibe-kanban/worktrees/4658-mast3r-slam-mojo/examples-monorepo/packages/monoprior
+  - monopriors @ file:///var/tmp/vibe-kanban/worktrees/0c88-mast3r-slam-fix/examples-monorepo/packages/monoprior
   requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/72/15/4e9929e536bda99ac1fe8b106e54c5f83846130b812350f76537f4806b19/rerun_sdk-0.31.1-cp310-abi3-manylinux_2_28_aarch64.whl
   name: rerun-sdk
@@ -37044,19 +34032,6 @@ packages:
   purls: []
   size: 207475
   timestamp: 1748644952027
-- conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
-  sha256: b06ce84d6a10c266811a7d3adbfa1c11f13393b91cc6f8a5b468277d90be9590
-  md5: 7a6289c50631d620652f5045a63eb573
-  depends:
-  - markdown-it-py >=2.2.0
-  - pygments >=2.13.0,<3.0.0
-  - python >=3.10
-  - typing_extensions >=4.0.0,<5.0.0
-  - python
-  license: MIT
-  license_family: MIT
-  size: 208472
-  timestamp: 1771572730357
 - conda: https://prefix.dev/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
   sha256: b06ce84d6a10c266811a7d3adbfa1c11f13393b91cc6f8a5b468277d90be9590
   md5: 7a6289c50631d620652f5045a63eb573
@@ -37072,19 +34047,6 @@ packages:
   - pkg:pypi/rich?source=compressed-mapping
   size: 208472
   timestamp: 1771572730357
-- conda: https://conda.anaconda.org/conda-forge/noarch/rich-toolkit-0.19.7-pyhcf101f3_0.conda
-  sha256: 9cf3b9a083ebdee70ef5a48fbe409d91d2a8c4eed3c581a7b33b4d5ca7c813be
-  md5: 8b1a4d854f9a4ea1e4abc93ccab0ded9
-  depends:
-  - python >=3.10
-  - rich >=13.7.1
-  - click >=8.1.7
-  - typing_extensions >=4.12.2
-  - python
-  license: MIT
-  license_family: MIT
-  size: 32484
-  timestamp: 1771977622605
 - pypi: ./packages/robocap-slam
   name: robocap-slam
   version: 0.1.0
@@ -37364,20 +34326,6 @@ packages:
   - httpx
   - pytest ; extra == 'dev'
   requires_python: '>3.9'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/safetensors-0.7.0-py311hc8fb587_0.conda
-  sha256: d79784414777e165fd30ea61a01c45861409b88db1150d870c7db3c7eb2a0e95
-  md5: a281fa38e4112cf59a694c52b2d674c1
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  constrains:
-  - __glibc >=2.17
-  license: Apache-2.0
-  license_family: APACHE
-  size: 451514
-  timestamp: 1763569677024
 - conda: https://prefix.dev/conda-forge/linux-64/safetensors-0.7.0-py310hdfeec95_0.conda
   sha256: a8a95e662dff8b3d864bf126e569a021bbb56472f1de596e7cd041ac97dc90d5
   md5: 2b88b39db90a04bef04db640ca693b14
@@ -37483,8 +34431,8 @@ packages:
   - omegaconf>=2.3.0,<3
   - termcolor>=3.2.0,<4
   - spaces>=0.43.0
-  - monopriors @ file:///var/tmp/vibe-kanban/worktrees/4658-mast3r-slam-mojo/examples-monorepo/packages/monoprior
-  - sam3-rerun @ file:///var/tmp/vibe-kanban/worktrees/4658-mast3r-slam-mojo/examples-monorepo/packages/sam3-rerun
+  - monopriors @ file:///var/tmp/vibe-kanban/worktrees/0c88-mast3r-slam-fix/examples-monorepo/packages/monoprior
+  - sam3-rerun @ file:///var/tmp/vibe-kanban/worktrees/0c88-mast3r-slam-fix/examples-monorepo/packages/sam3-rerun
   requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/f4/a2/70401a107d6d7466d64b466927e6b96fcefa99d57494b972608e2f8be50f/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
   name: scikit-image
@@ -37681,27 +34629,6 @@ packages:
   - ruff>=0.12.0 ; extra == 'dev'
   - cython-lint>=0.12.2 ; extra == 'dev'
   requires_python: '>=3.11'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py311hbe70eeb_0.conda
-  sha256: 0063a75e9406357ef8ecc2fb38808a2442b269bfc5a854cf2bcd368060d9a2d7
-  md5: 5ae6d73ab0bebbc892c2d46dc51e90a5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libgcc >=14
-  - libgfortran
-  - libgfortran5 >=14.3.0
-  - liblapack >=3.9.0,<4.0a0
-  - libstdcxx >=14
-  - numpy <2.7
-  - numpy >=1.23,<3
-  - numpy >=1.25.2
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 17099824
-  timestamp: 1771880736635
 - conda: https://prefix.dev/conda-forge/linux-64/scipy-1.15.2-py310h1d65ade_0.conda
   sha256: 4cb98641f870666d365594013701d5691205a0fe81ac3ba7778a23b1cc2caa8e
   md5: 8c29cd33b64b2eb78597fa28b5595c8d
@@ -37817,19 +34744,6 @@ packages:
   - pkg:pypi/scipy?source=hash-mapping
   size: 16675045
   timestamp: 1771881005471
-- conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
-  sha256: 987ad072939fdd51c92ea8d3544b286bb240aefda329f9b03a51d9b7e777f9de
-  md5: cdd138897d94dc07d99afe7113a07bec
-  depends:
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgl >=1.7.0,<2.0a0
-  - sdl3 >=3.2.22,<4.0a0
-  - libegl >=1.7.0,<2.0a0
-  license: Zlib
-  size: 589145
-  timestamp: 1757842881
 - conda: https://prefix.dev/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
   sha256: 987ad072939fdd51c92ea8d3544b286bb240aefda329f9b03a51d9b7e777f9de
   md5: cdd138897d94dc07d99afe7113a07bec
@@ -37857,35 +34771,6 @@ packages:
   purls: []
   size: 597756
   timestamp: 1757842928996
-- conda: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.4.4-hdeec2a5_0.conda
-  sha256: 4acc06278e14ea9394d50debd0d47006b6daf135749471e2d0f1f30cc602bdd8
-  md5: 78f56b31513ee775c3e72a744bd26a7e
-  depends:
-  - libgcc >=14
-  - libstdcxx >=14
-  - __glibc >=2.17,<3.0.a0
-  - xorg-libxcursor >=1.2.3,<2.0a0
-  - wayland >=1.25.0,<2.0a0
-  - xorg-libxi >=1.8.2,<2.0a0
-  - xorg-libxscrnsaver >=1.2.4,<2.0a0
-  - libudev1 >=257.13
-  - xorg-libxtst >=1.2.5,<2.0a0
-  - libxkbcommon >=1.13.1,<2.0a0
-  - pulseaudio-client >=17.0,<17.1.0a0
-  - libdrm >=2.4.125,<2.5.0a0
-  - libgl >=1.7.0,<2.0a0
-  - xorg-libxfixes >=6.0.2,<7.0a0
-  - liburing >=2.14,<2.15.0a0
-  - libvulkan-loader >=1.4.341.0,<2.0a0
-  - libusb >=1.0.29,<2.0a0
-  - libunwind >=1.8.3,<1.9.0a0
-  - dbus >=1.16.2,<2.0a0
-  - xorg-libxext >=1.3.7,<2.0a0
-  - xorg-libx11 >=1.8.13,<2.0a0
-  - libegl >=1.7.0,<2.0a0
-  license: Zlib
-  size: 2143141
-  timestamp: 1775266679380
 - conda: https://prefix.dev/conda-forge/linux-64/sdl3-3.4.2-hdeec2a5_0.conda
   sha256: 64b982664550e01c25f8f09333c0ee54d4764a80fe8636b8aaf881fe6e8a0dbe
   md5: 88a69db027a8ff59dab972a09d69a1ab
@@ -38042,48 +34927,6 @@ packages:
   - pkg:pypi/send2trash?source=hash-mapping
   size: 24108
   timestamp: 1770937597662
-- conda: https://conda.anaconda.org/conda-forge/linux-64/sentencepiece-0.2.1-ha8de79c_3.conda
-  sha256: 39fb08075d08e26063002f78c44a0d82127baf041c33dce50f86ab29e28adc41
-  md5: eba48a4ca18ee91949c60aed71fa421f
-  depends:
-  - libsentencepiece 0.2.1 h432359f_3
-  - python_abi 3.11.* *_cp311
-  - sentencepiece-python 0.2.1 py311he27d5e9_3
-  - sentencepiece-spm 0.2.1 h432359f_3
-  license: Apache-2.0
-  license_family: Apache
-  size: 19962
-  timestamp: 1770168276862
-- conda: https://conda.anaconda.org/conda-forge/linux-64/sentencepiece-python-0.2.1-py311he27d5e9_3.conda
-  sha256: d0c9a2f4d6586d66e7e5b6e72fd89679baa50a30d6ad123d9621676d8f1fde40
-  md5: b17dcc8ef522482ba4568ac836053c3b
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libsentencepiece 0.2.1 h432359f_3
-  - libstdcxx >=14
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: Apache-2.0
-  license_family: Apache
-  size: 3216094
-  timestamp: 1770167963060
-- conda: https://conda.anaconda.org/conda-forge/linux-64/sentencepiece-spm-0.2.1-h432359f_3.conda
-  sha256: f6cec76b6bf9d2e6d35706be91aaf4072557e351fff40f7d1aea421c0777accb
-  md5: d6c303d1238b187b6d1e47d473a5cd87
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libsentencepiece 0.2.1 h432359f_3
-  - libstdcxx >=14
-  license: Apache-2.0
-  license_family: Apache
-  size: 87674
-  timestamp: 1770168237369
 - conda: https://prefix.dev/conda-forge/noarch/sentry-sdk-2.54.0-pyhd8ed1ab_0.conda
   sha256: 0ebc591b2b8fafe3b9a49d0048395fd9a300494a5fceb0c24b53c562acfc4609
   md5: c2cb59203cd085fe11850178e09b9c01
@@ -38133,19 +34976,6 @@ packages:
   - pkg:pypi/setuptools?source=compressed-mapping
   size: 639697
   timestamp: 1773074868565
-- conda: https://conda.anaconda.org/conda-forge/linux-64/shaderc-2025.5-h718be3e_1.conda
-  sha256: 0c2d6f24ee2b614ee1da4d7d99cc9944ea1ace65455a47d48d8c1f726317168a
-  md5: 8dc8dda113c4c568256bdd486b6e842e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - glslang >=16,<17.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - spirv-tools >=2026,<2027.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 113513
-  timestamp: 1770208767759
 - conda: https://prefix.dev/conda-forge/linux-64/shaderc-2025.5-h3e344bc_0.conda
   sha256: fd4d20f8b74c473e3579f181c40687697777be7ac617ee62866a2fe3199745d9
   md5: 6455b7f6e2c8caeb87b83cab7163bcb8
@@ -38187,15 +35017,6 @@ packages:
   purls: []
   size: 115498
   timestamp: 1770208786806
-- conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
-  sha256: 1d6534df8e7924d9087bd388fbac5bd868c5bf8971c36885f9f016da0657d22b
-  md5: 83ea3a2ddb7a75c1b09cea582aa4f106
-  depends:
-  - python >=3.10
-  license: MIT
-  license_family: MIT
-  size: 15018
-  timestamp: 1762858315311
 - conda: https://prefix.dev/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
   sha256: 1d6534df8e7924d9087bd388fbac5bd868c5bf8971c36885f9f016da0657d22b
   md5: 83ea3a2ddb7a75c1b09cea582aa4f106
@@ -38272,16 +35093,6 @@ packages:
   version: 1.17.0
   sha256: 4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*'
-- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-  sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
-  md5: 3339e3b65d58accf4ca4fb8748ab16b3
-  depends:
-  - python >=3.9
-  - python
-  license: MIT
-  license_family: MIT
-  size: 18455
-  timestamp: 1753199211006
 - conda: https://prefix.dev/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
   md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -38328,18 +35139,6 @@ packages:
   - pkg:pypi/smmap?source=hash-mapping
   size: 26051
   timestamp: 1739781801801
-- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
-  sha256: 48f3f6a76c34b2cfe80de9ce7f2283ecb55d5ed47367ba91e8bb8104e12b8f11
-  md5: 98b6c9dc80eb87b2519b97bcf7e578dd
-  depends:
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 45829
-  timestamp: 1762948049098
 - conda: https://prefix.dev/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
   sha256: 48f3f6a76c34b2cfe80de9ce7f2283ecb55d5ed47367ba91e8bb8104e12b8f11
   md5: 98b6c9dc80eb87b2519b97bcf7e578dd
@@ -38365,15 +35164,6 @@ packages:
   purls: []
   size: 47096
   timestamp: 1762948094646
-- conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
-  sha256: dce518f45e24cd03f401cb0616917773159a210c19d601c5f2d4e0e5879d30ad
-  md5: 03fe290994c5e4ec17293cfb6bdce520
-  depends:
-  - python >=3.10
-  license: Apache-2.0
-  license_family: Apache
-  size: 15698
-  timestamp: 1762941572482
 - conda: https://prefix.dev/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
   sha256: dce518f45e24cd03f401cb0616917773159a210c19d601c5f2d4e0e5879d30ad
   md5: 03fe290994c5e4ec17293cfb6bdce520
@@ -38420,19 +35210,6 @@ packages:
   - requests>=2.19,<3.0
   - typing-extensions>=4,<5
   requires_python: '>=3.10,<3.15'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/spirv-tools-2026.1-hb700be7_0.conda
-  sha256: 003180b3a2e0c6490b1f3461cf9e0ed740b1bbf88ee4b73ee177b94bea0dc95d
-  md5: 8809e0bd5ec279bfe4bb6651c3ed2730
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - spirv-headers >=1.4.341.0,<1.4.341.1.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 2296977
-  timestamp: 1770089626195
 - conda: https://prefix.dev/conda-forge/linux-64/spirv-tools-2025.5-hb700be7_0.conda
   sha256: 7547142ab1352132adf98d555ed955badd96c9f277cbd054ae52f7edd6cf6cb8
   md5: 058d5f16eaa3018be91aa3508df00d7c
@@ -38514,17 +35291,6 @@ packages:
   purls: []
   size: 203641
   timestamp: 1772818888368
-- conda: https://conda.anaconda.org/conda-forge/noarch/sse-starlette-3.3.4-pyhd8ed1ab_0.conda
-  sha256: c9b13c7ac3950b16b3ad91c0d87582ec069241820cb5fc0ea357a79c5d1b9441
-  md5: b5dc4c97ce89045e3b71dabb991bffa1
-  depends:
-  - anyio >=4.7.0
-  - python >=3.10
-  - starlette >=0.49.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 20040
-  timestamp: 1774778744164
 - conda: https://prefix.dev/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
   sha256: 570da295d421661af487f1595045760526964f41471021056e993e73089e9c41
   md5: b1b505328da7a6b246787df4b5a49fbc
@@ -38552,18 +35318,6 @@ packages:
   - python-multipart>=0.0.18 ; extra == 'full'
   - pyyaml ; extra == 'full'
   requires_python: '>=3.10'
-- conda: https://conda.anaconda.org/conda-forge/noarch/starlette-1.0.0-pyhcf101f3_0.conda
-  sha256: 1a1dc376e95491f4b2003f4428e6f7caf4a3de0ef9869248b29dcc9704c34b39
-  md5: 8fbd5b6879350f1b5303c1a652d4b781
-  depends:
-  - anyio >=3.6.2,<5
-  - python >=3.10
-  - typing_extensions >=4.10.0
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 63717
-  timestamp: 1774215956101
 - conda: https://prefix.dev/conda-forge/linux-64/suitesparse-7.10.1-h5b2951e_7100101.conda
   sha256: 7c1c5bd2ba8385202ac3cb4c9c7f9bb87a2e677e977afd72c910314c014b28be
   md5: e927e0f248a498050443dab8bb1203a9
@@ -38587,17 +35341,6 @@ packages:
   purls: []
   size: 12135
   timestamp: 1741963824816
-- conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-4.0.1-hecca717_0.conda
-  sha256: 4a1d2005153b9454fc21c9bad1b539df189905be49e851ec62a6212c2e045381
-  md5: 2a2170a3e5c9a354d09e4be718c43235
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 2619743
-  timestamp: 1769664536467
 - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-3.1.2-hecca717_0.conda
   sha256: 34e2e9c505cd25dba0a9311eb332381b15147cf599d972322a7c197aedfc8ce2
   md5: 9859766c658e78fec9afa4a54891d920
@@ -38681,29 +35424,6 @@ packages:
   purls: []
   size: 23644746
   timestamp: 1765578629426
-- conda: https://conda.anaconda.org/conda-forge/noarch/taskgroup-0.2.2-pyhd8ed1ab_0.conda
-  sha256: 6f8db6da8de445930de55b708e6a5d3ab5f076bc14a39578db0190b2a9b8e437
-  md5: 9fa69537fb68a095fbac139210575bad
-  depends:
-  - exceptiongroup
-  - python >=3.9
-  - typing_extensions >=4.12.2,<5
-  license: MIT
-  license_family: MIT
-  size: 17330
-  timestamp: 1736003478648
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
-  sha256: 975710e4b7f1b13c3c30b7fbf21e22f50abe0463b6b47a231582fdedcc45c961
-  md5: 8f7278ca5f7456a974992a8b34284737
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libhwloc >=2.12.2,<2.12.3.0a0
-  - libstdcxx >=14
-  license: Apache-2.0
-  license_family: APACHE
-  size: 181329
-  timestamp: 1767886632911
 - conda: https://prefix.dev/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
   sha256: 975710e4b7f1b13c3c30b7fbf21e22f50abe0463b6b47a231582fdedcc45c961
   md5: 8f7278ca5f7456a974992a8b34284737
@@ -38801,23 +35521,6 @@ packages:
   - xarray ; extra == 'test'
   - zarr>=3.1.5 ; extra == 'test'
   requires_python: '>=3.11'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tiktoken-0.12.0-py311h9a14573_3.conda
-  sha256: 42ce58a177c5245b22a2f84316e99d55e03a1eedfe28229887ef3342dc9dd84e
-  md5: 372be24f38799dd9a4ad97765a07ea0f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - regex >=2022.1.18
-  - requests >=2.26.0
-  constrains:
-  - __glibc >=2.17
-  license: MIT
-  license_family: MIT
-  size: 937826
-  timestamp: 1764028384900
 - pypi: https://files.pythonhosted.org/packages/ef/50/de09f69a74278a16f08f1d562047a2d6713783765ee3c6971881a2b21a3f/timm-1.0.25-py3-none-any.whl
   name: timm
   version: 1.0.25
@@ -38875,19 +35578,6 @@ packages:
   purls: []
   size: 71746
   timestamp: 1704450371417
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
-  sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
-  md5: cffd3bdd58090148f4cfcd831f4b26ab
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
-  constrains:
-  - xorg-libx11 >=1.8.12,<2.0a0
-  license: TCL
-  license_family: BSD
-  size: 3301196
-  timestamp: 1769460227866
 - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
   sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
   md5: cffd3bdd58090148f4cfcd831f4b26ab
@@ -38915,23 +35605,6 @@ packages:
   purls: []
   size: 3368666
   timestamp: 1769464148928
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tokenizers-0.22.2-py311ha21528d_0.conda
-  sha256: 66de58af9de8b3f543194053aac6775f1864054590fe8a0884791dec5ddd8272
-  md5: d732f4fb6e6deddfa98106af4e26110e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - huggingface_hub >=0.16.4,<2.0
-  - libgcc >=14
-  - libstdcxx >=14
-  - openssl >=3.5.4,<4.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  constrains:
-  - __glibc >=2.17
-  license: Apache-2.0
-  license_family: APACHE
-  size: 2466409
-  timestamp: 1764695037875
 - conda: https://prefix.dev/conda-forge/linux-64/tokenizers-0.22.2-py310h4551fc8_0.conda
   sha256: 21aa4a00198ecf8eeb1ca8342c29f4569b47fd53c245368b122a8180a5e1a11e
   md5: 534df67f91381ffa5ccc2c614029860d
@@ -39039,16 +35712,6 @@ packages:
   - pkg:pypi/toml?source=hash-mapping
   size: 24017
   timestamp: 1764486833072
-- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-  sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
-  md5: b5325cf06a000c5b14970462ff5e4d58
-  depends:
-  - python >=3.10
-  - python
-  license: MIT
-  license_family: MIT
-  size: 21561
-  timestamp: 1774492402955
 - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
   sha256: 62940c563de45790ba0f076b9f2085a842a65662268b02dd136a8e9b1eaf47a8
   md5: 72e780e9aa2d0a3295f59b1874e3768b
@@ -39692,18 +36355,6 @@ packages:
   - pkg:pypi/torchvision-extra-decoders?source=hash-mapping
   size: 65356
   timestamp: 1759392542188
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.5-py311h49ec1c0_0.conda
-  sha256: cd8bc08ca661291cfbb05581b79f7e6a6971a072a54a335abcea5460c1230880
-  md5: 73b44a114241e564deb5846e7394bf19
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: Apache-2.0
-  license_family: Apache
-  size: 876817
-  timestamp: 1774358035290
 - conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.3-py312h4c3975b_0.conda
   sha256: bed440cad040f0fe76266f9a527feecbaf00385b68a96532aa69614fe5153f8e
   md5: e03a4bf52d2170d64c816b2a52972097
@@ -39732,16 +36383,6 @@ packages:
   - pkg:pypi/tornado?source=compressed-mapping
   size: 876817
   timestamp: 1774358035290
-- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
-  sha256: 9ef8e47cf00e4d6dcc114eb32a1504cc18206300572ef14d76634ba29dfe1eb6
-  md5: e5ce43272193b38c2e9037446c1d9206
-  depends:
-  - python >=3.10
-  - __unix
-  - python
-  license: MPL-2.0 and MIT
-  size: 94132
-  timestamp: 1770153424136
 - conda: https://prefix.dev/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
   sha256: 9ef8e47cf00e4d6dcc114eb32a1504cc18206300572ef14d76634ba29dfe1eb6
   md5: e5ce43272193b38c2e9037446c1d9206
@@ -39754,15 +36395,6 @@ packages:
   - pkg:pypi/tqdm?source=compressed-mapping
   size: 94132
   timestamp: 1770153424136
-- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
-  sha256: f39a5620c6e8e9e98357507262a7869de2ae8cc07da8b7f84e517c9fd6c2b959
-  md5: 019a7385be9af33791c989871317e1ed
-  depends:
-  - python >=3.9
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 110051
-  timestamp: 1733367480074
 - conda: https://prefix.dev/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
   sha256: f39a5620c6e8e9e98357507262a7869de2ae8cc07da8b7f84e517c9fd6c2b959
   md5: 019a7385be9af33791c989871317e1ed
@@ -39778,25 +36410,6 @@ packages:
   name: trampoline
   version: 0.1.2
   sha256: 36cc9a4ff9811843d177fc0e0740efbd7da39eadfe6e50c9e2937cbc06d899d9
-- conda: https://conda.anaconda.org/conda-forge/noarch/transformers-5.2.0-pyhd8ed1ab_0.conda
-  sha256: 93d6abf1fecc02bccb3e106bbc8f71203c7dd3a8ecdf9843926e8389d875c4f1
-  md5: 3078c0ebf41540f403698098e68f164d
-  depends:
-  - filelock
-  - huggingface_hub >=1.3.0,<2.0
-  - numpy >=1.17
-  - packaging >=20.0
-  - python >=3.10
-  - pyyaml >=5.1
-  - regex !=2019.12.17
-  - requests
-  - safetensors >=0.4.1
-  - tokenizers >=0.22,<=0.23
-  - tqdm >=4.27
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3777900
-  timestamp: 1771289451738
 - conda: https://prefix.dev/conda-forge/noarch/transformers-5.3.0-pyhd8ed1ab_0.conda
   sha256: d1958f0f5bad819bd9bd2bf796b5cafc74ad21582f858cc4a556a47315d798a9
   md5: cb150519cebd510ec5eecc1e950ae003
@@ -40172,20 +36785,6 @@ packages:
   - pkg:pypi/typeguard?source=hash-mapping
   size: 19655
   timestamp: 1658932205516
-- conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.24.1-pyhcf101f3_0.conda
-  sha256: 859aec3457a4d6dd6e4a68d9f4ad4216ce05e1a1a94d244f10629848de77739b
-  md5: 0bb9dfbe0806165f4960331a0ac05ab5
-  depends:
-  - annotated-doc >=0.0.2
-  - click >=8.2.1
-  - python >=3.10
-  - rich >=12.3.0
-  - shellingham >=1.3.0
-  - python
-  license: MIT
-  license_family: MIT
-  size: 116134
-  timestamp: 1775138098187
 - conda: https://prefix.dev/conda-forge/noarch/typer-0.24.0-pyhcf101f3_0.conda
   sha256: e1116d08e6a55b2b42a090130c268f75211ad8e6a8e7749e977924de3864d487
   md5: 10870929f587540c5802cd9b071cba5c
@@ -40288,15 +36887,6 @@ packages:
   purls: []
   size: 9502
   timestamp: 1733927569850
-- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
-  sha256: 7c2df5721c742c2a47b2c8f960e718c930031663ac1174da67c1ed5999f7938c
-  md5: edd329d7d3a4ab45dcf905899a7a6115
-  depends:
-  - typing_extensions ==4.15.0 pyhcf101f3_0
-  license: PSF-2.0
-  license_family: PSF
-  size: 91383
-  timestamp: 1756220668932
 - conda: https://prefix.dev/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
   noarch: python
   sha256: c8e9c1c467b5f960b627d7adc1c65fece8e929a3de89967e91ef0f726422fd32
@@ -40315,16 +36905,6 @@ packages:
   requires_dist:
   - typing-extensions>=4.12.0
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
-  sha256: 70db27de58a97aeb7ba7448366c9853f91b21137492e0b4430251a1870aa8ff4
-  md5: a0a4a3035667fc34f29bfbd5c190baa6
-  depends:
-  - python >=3.10
-  - typing_extensions >=4.12.0
-  license: MIT
-  license_family: MIT
-  size: 18923
-  timestamp: 1764158430324
 - conda: https://prefix.dev/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
   sha256: 70db27de58a97aeb7ba7448366c9853f91b21137492e0b4430251a1870aa8ff4
   md5: a0a4a3035667fc34f29bfbd5c190baa6
@@ -40337,16 +36917,6 @@ packages:
   - pkg:pypi/typing-inspection?source=hash-mapping
   size: 18923
   timestamp: 1764158430324
-- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-  sha256: 032271135bca55aeb156cee361c81350c6f3fb203f57d024d7e5a1fc9ef18731
-  md5: 0caa1af407ecff61170c9437a808404d
-  depends:
-  - python >=3.10
-  - python
-  license: PSF-2.0
-  license_family: PSF
-  size: 51692
-  timestamp: 1756220668932
 - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
   sha256: 337be7af5af8b2817f115b3b68870208b30c31d3439bec07bfb2d8f4823e3568
   md5: d17f13df8b65464ca316cbc000a3cb64
@@ -40435,12 +37005,6 @@ packages:
   version: '2025.3'
   sha256: 06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1
   requires_python: '>=2'
-- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-  sha256: 1d30098909076af33a35017eed6f2953af1c769e273a0626a04722ac4acaba3c
-  md5: ad659d0a2b3e47e38d829aa8cad2d610
-  license: LicenseRef-Public-Domain
-  size: 119135
-  timestamp: 1767016325805
 - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
   sha256: 1d30098909076af33a35017eed6f2953af1c769e273a0626a04722ac4acaba3c
   md5: ad659d0a2b3e47e38d829aa8cad2d610
@@ -40582,19 +37146,6 @@ packages:
   - pkg:pypi/uri-template?source=hash-mapping
   size: 23990
   timestamp: 1733323714454
-- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
-  sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
-  md5: 9272daa869e03efe68833e3dc7a02130
-  depends:
-  - backports.zstd >=1.0.0
-  - brotli-python >=1.2.0
-  - h2 >=4,<5
-  - pysocks >=1.5.6,<2.0,!=1.5.7
-  - python >=3.10
-  license: MIT
-  license_family: MIT
-  size: 103172
-  timestamp: 1767817860341
 - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
   sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
   md5: 9272daa869e03efe68833e3dc7a02130
@@ -40674,36 +37225,6 @@ packages:
   - watchfiles>=0.20 ; extra == 'standard'
   - websockets>=10.4 ; extra == 'standard'
   requires_python: '>=3.10'
-- conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.44.0-pyhc90fa1f_0.conda
-  sha256: a1db6280c2bee294e625bd3026f0b0792e8f21454d105baa530a28effd8d8d09
-  md5: 83d36e00ae3614c8c3bb0e55e24c7f50
-  depends:
-  - __unix
-  - click >=7.0
-  - h11 >=0.8
-  - python >=3.10
-  - typing_extensions >=4.0
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 55522
-  timestamp: 1775475773715
-- conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.44.0-h4457471_0.conda
-  sha256: dd5c71e2539b9f05e629ff275185d1a0022c998aaf75d6c019919b01e4adb57b
-  md5: ab23bf4012a60c25855e0bb4c0145af0
-  depends:
-  - __unix
-  - uvicorn ==0.44.0 pyhc90fa1f_0
-  - websockets >=10.4
-  - httptools >=0.6.3
-  - watchfiles >=0.20
-  - python-dotenv >=0.13
-  - pyyaml >=5.1
-  - uvloop >=0.15.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 4145
-  timestamp: 1775475773715
 - pypi: https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: uvloop
   version: 0.22.1
@@ -40721,18 +37242,6 @@ packages:
   - sphinxcontrib-asyncio~=0.3.0 ; extra == 'docs'
   - sphinx-rtd-theme~=0.5.2 ; extra == 'docs'
   requires_python: '>=3.8.1'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/uvloop-0.22.1-py311h49ec1c0_1.conda
-  sha256: e81c2216560697d8d59769f4ffc8e77c1103c1d7c9b00935002a1ef33dd6f2d3
-  md5: 28d7b3a71c298c5d051a4c40d9bad128
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libuv >=1.51.0,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: MIT OR Apache-2.0
-  size: 582925
-  timestamp: 1762472823020
 - pypi: git+https://github.com/pablovela5620/vggt.git?rev=5ed6ec88a951f27959f73bc72eb4b6dc7a028b0c#5ed6ec88a951f27959f73bc72eb4b6dc7a028b0c
   name: vggt
   version: 0.0.1
@@ -40821,7 +37330,7 @@ packages:
   sha256: 040445160e2ce50aa6695f139ee7258a27456ec50ee1fbcc9351b9e46aa686b5
   requires_dist:
   - einops>=0.8.1,<0.9
-  - monopriors @ file:///var/tmp/vibe-kanban/worktrees/4658-mast3r-slam-mojo/examples-monorepo/packages/monoprior
+  - monopriors @ file:///var/tmp/vibe-kanban/worktrees/0c88-mast3r-slam-fix/examples-monorepo/packages/monoprior
   requires_python: '>=3.11'
 - conda: https://prefix.dev/conda-forge/linux-64/vlfeat-0.9.21-hd590300_1.conda
   sha256: f3fca24ef6a327072378dd654eba37c6a6da15499ca212eb20b0af422c1ad4c5
@@ -41113,34 +37622,6 @@ packages:
   requires_dist:
   - anyio>=3.0.0
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-1.1.1-py311hc8fb587_0.conda
-  sha256: f4f7adf15412ed355e04a753a755df48c283edb8c240fd91441cb36ac2d068c6
-  md5: 428c04e02589d97bfe18f60d41d9732b
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - anyio >=3.0.0
-  - libgcc >=14
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  constrains:
-  - __glibc >=2.17
-  license: MIT
-  license_family: MIT
-  size: 420458
-  timestamp: 1760456756154
-- conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
-  sha256: ea374d57a8fcda281a0a89af0ee49a2c2e99cc4ac97cf2e2db7064e74e764bdb
-  md5: 996583ea9c796e5b915f7d7580b51ea6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libexpat >=2.7.4,<3.0a0
-  - libffi >=3.5.2,<3.6.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 334139
-  timestamp: 1773959575393
 - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.24.0-hd6090a7_1.conda
   sha256: 3aa04ae8e9521d9b56b562376d944c3e52b69f9d2a0667f77b8953464822e125
   md5: 035da2e4f5770f036ff704fa17aace24
@@ -41195,13 +37676,6 @@ packages:
   purls: []
   size: 335260
   timestamp: 1773959583826
-- conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
-  sha256: 9ab2c12053ea8984228dd573114ffc6d63df42c501d59fda3bf3aeb1eaa1d23e
-  md5: 7da1571f560d4ba3343f7f4c48a79c76
-  license: MIT
-  license_family: MIT
-  size: 140476
-  timestamp: 1765821981856
 - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
   sha256: 9ab2c12053ea8984228dd573114ffc6d63df42c501d59fda3bf3aeb1eaa1d23e
   md5: 7da1571f560d4ba3343f7f4c48a79c76
@@ -41277,18 +37751,6 @@ packages:
   version: '16.0'
   sha256: 9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c
   requires_python: '>=3.10'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/websockets-16.0-py311haee01d2_1.conda
-  sha256: e6e5c186b536a33746685fcadb7dd79157719605b5399fc0b0e266907cc20e93
-  md5: defede84505024487007ba30c59412a3
-  depends:
-  - python
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.11.* *_cp311
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 357003
-  timestamp: 1768087394959
 - conda: https://prefix.dev/conda-forge/noarch/werkzeug-3.1.6-pyhcf101f3_0.conda
   sha256: 06e3d5bec9d2730a23ecf023b7cba329c0772c51f2704714c17b3080b0385113
   md5: 2d9bfc6055e55ff58b2c359323a753d2
@@ -41391,18 +37853,6 @@ packages:
   - pytest ; extra == 'dev'
   - setuptools ; extra == 'dev'
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.1.2-py311h49ec1c0_0.conda
-  sha256: d537a3b65e9314ddb44ad9d3c4a09c9049dd628051c29a2ed14146c660e48854
-  md5: 223070bed75e3d053feebff09f54ea36
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 89341
-  timestamp: 1772794806958
 - conda: https://prefix.dev/conda-forge/noarch/wslink-2.5.5-pyhd8ed1ab_0.conda
   sha256: a30083522306002ab179327eb1fd4e5f2686335cca789cc97aaad914bee2feb1
   md5: 755b2c36ab87bbb590a8637ebb29e488
@@ -41428,15 +37878,6 @@ packages:
   - pkg:pypi/wslink?source=compressed-mapping
   size: 36729
   timestamp: 1773305846931
-- conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
-  sha256: 175315eb3d6ea1f64a6ce470be00fa2ee59980108f246d3072ab8b977cb048a5
-  md5: 6c99772d483f566d59e25037fea2c4b1
-  depends:
-  - libgcc-ng >=12
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 897548
-  timestamp: 1660323080555
 - conda: https://prefix.dev/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
   sha256: 175315eb3d6ea1f64a6ce470be00fa2ee59980108f246d3072ab8b977cb048a5
   md5: 6c99772d483f566d59e25037fea2c4b1
@@ -41457,16 +37898,6 @@ packages:
   purls: []
   size: 1000661
   timestamp: 1660324722559
-- conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
-  sha256: 76c7405bcf2af639971150f342550484efac18219c0203c5ee2e38b8956fe2a0
-  md5: e7f6ed84d4623d52ee581325c1587a6b
-  depends:
-  - libgcc-ng >=10.3.0
-  - libstdcxx-ng >=10.3.0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 3357188
-  timestamp: 1646609687141
 - conda: https://prefix.dev/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
   sha256: 76c7405bcf2af639971150f342550484efac18219c0203c5ee2e38b8956fe2a0
   md5: e7f6ed84d4623d52ee581325c1587a6b
@@ -41631,17 +38062,6 @@ packages:
   purls: []
   size: 50772
   timestamp: 1718845072660
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.47-hb03c661_0.conda
-  sha256: 19c2bb14bec84b0e995b56b752369775c75f1589314b43733948bb5f471a6915
-  md5: b56e0c8432b56decafae7e78c5f29ba5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - xorg-libx11 >=1.8.13,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 399291
-  timestamp: 1772021302485
 - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.47-hb03c661_0.conda
   sha256: 19c2bb14bec84b0e995b56b752369775c75f1589314b43733948bb5f471a6915
   md5: b56e0c8432b56decafae7e78c5f29ba5
@@ -41665,16 +38085,6 @@ packages:
   purls: []
   size: 399629
   timestamp: 1772021320967
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
-  sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
-  md5: fb901ff28063514abb6046c9ec2c4a45
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 58628
-  timestamp: 1734227592886
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
   sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
   md5: fb901ff28063514abb6046c9ec2c4a45
@@ -41696,18 +38106,6 @@ packages:
   purls: []
   size: 60433
   timestamp: 1734229908988
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
-  sha256: 277841c43a39f738927145930ff963c5ce4c4dacf66637a3d95d802a64173250
-  md5: 1c74ff8c35dcadf952a16f752ca5aa49
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libuuid >=2.38.1,<3.0a0
-  - xorg-libice >=1.1.2,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 27590
-  timestamp: 1741896361728
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
   sha256: 277841c43a39f738927145930ff963c5ce4c4dacf66637a3d95d802a64173250
   md5: 1c74ff8c35dcadf952a16f752ca5aa49
@@ -41733,17 +38131,6 @@ packages:
   purls: []
   size: 28701
   timestamp: 1741897678254
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
-  sha256: 516d4060139dbb4de49a4dcdc6317a9353fb39ebd47789c14e6fe52de0deee42
-  md5: 861fb6ccbc677bb9a9fb2468430b9c6a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libxcb >=1.17.0,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 839652
-  timestamp: 1770819209719
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
   sha256: 516d4060139dbb4de49a4dcdc6317a9353fb39ebd47789c14e6fe52de0deee42
   md5: 861fb6ccbc677bb9a9fb2468430b9c6a
@@ -41767,16 +38154,6 @@ packages:
   purls: []
   size: 869058
   timestamp: 1770819244991
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
-  sha256: 6bc6ab7a90a5d8ac94c7e300cc10beb0500eeba4b99822768ca2f2ef356f731b
-  md5: b2895afaf55bf96a8c8282a2e47a5de0
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 15321
-  timestamp: 1762976464266
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
   sha256: 6bc6ab7a90a5d8ac94c7e300cc10beb0500eeba4b99822768ca2f2ef356f731b
   md5: b2895afaf55bf96a8c8282a2e47a5de0
@@ -41823,19 +38200,6 @@ packages:
   purls: []
   size: 14915
   timestamp: 1770044415607
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
-  sha256: 832f538ade441b1eee863c8c91af9e69b356cd3e9e1350fff4fe36cc573fc91a
-  md5: 2ccd714aa2242315acaf0a67faea780b
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - xorg-libx11 >=1.8.10,<2.0a0
-  - xorg-libxfixes >=6.0.1,<7.0a0
-  - xorg-libxrender >=0.9.11,<0.10.0a0
-  license: MIT
-  license_family: MIT
-  size: 32533
-  timestamp: 1730908305254
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
   sha256: 832f538ade441b1eee863c8c91af9e69b356cd3e9e1350fff4fe36cc573fc91a
   md5: 2ccd714aa2242315acaf0a67faea780b
@@ -41890,16 +38254,6 @@ packages:
   purls: []
   size: 13794
   timestamp: 1727891406431
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
-  sha256: 25d255fb2eef929d21ff660a0c687d38a6d2ccfbcbf0cc6aa738b12af6e9d142
-  md5: 1dafce8548e38671bea82e3f5c6ce22f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 20591
-  timestamp: 1762976546182
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
   sha256: 25d255fb2eef929d21ff660a0c687d38a6d2ccfbcbf0cc6aa738b12af6e9d142
   md5: 1dafce8548e38671bea82e3f5c6ce22f
@@ -41921,17 +38275,6 @@ packages:
   purls: []
   size: 21039
   timestamp: 1762979038025
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
-  sha256: 79c60fc6acfd3d713d6340d3b4e296836a0f8c51602327b32794625826bd052f
-  md5: 34e54f03dfea3e7a2dcf1453a85f1085
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - xorg-libx11 >=1.8.12,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 50326
-  timestamp: 1769445253162
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
   sha256: 79c60fc6acfd3d713d6340d3b4e296836a0f8c51602327b32794625826bd052f
   md5: 34e54f03dfea3e7a2dcf1453a85f1085
@@ -41955,17 +38298,6 @@ packages:
   purls: []
   size: 52409
   timestamp: 1769446753771
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
-  sha256: 83c4c99d60b8784a611351220452a0a85b080668188dce5dfa394b723d7b64f4
-  md5: ba231da7fccf9ea1e768caf5c7099b84
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - xorg-libx11 >=1.8.12,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 20071
-  timestamp: 1759282564045
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
   sha256: 83c4c99d60b8784a611351220452a0a85b080668188dce5dfa394b723d7b64f4
   md5: ba231da7fccf9ea1e768caf5c7099b84
@@ -41989,19 +38321,6 @@ packages:
   purls: []
   size: 20704
   timestamp: 1759284028146
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
-  sha256: 1a724b47d98d7880f26da40e45f01728e7638e6ec69f35a3e11f92acd05f9e7a
-  md5: 17dcc85db3c7886650b8908b183d6876
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - xorg-libx11 >=1.8.10,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxfixes >=6.0.1,<7.0a0
-  license: MIT
-  license_family: MIT
-  size: 47179
-  timestamp: 1727799254088
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
   sha256: 1a724b47d98d7880f26da40e45f01728e7638e6ec69f35a3e11f92acd05f9e7a
   md5: 17dcc85db3c7886650b8908b183d6876
@@ -42043,19 +38362,6 @@ packages:
   purls: []
   size: 14818
   timestamp: 1769432261050
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
-  sha256: 80ed047a5cb30632c3dc5804c7716131d767089f65877813d4ae855ee5c9d343
-  md5: e192019153591938acf7322b6459d36e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxrender >=0.9.12,<0.10.0a0
-  license: MIT
-  license_family: MIT
-  size: 30456
-  timestamp: 1769445263457
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
   sha256: 80ed047a5cb30632c3dc5804c7716131d767089f65877813d4ae855ee5c9d343
   md5: e192019153591938acf7322b6459d36e
@@ -42083,17 +38389,6 @@ packages:
   purls: []
   size: 31122
   timestamp: 1769445286951
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
-  sha256: 044c7b3153c224c6cedd4484dd91b389d2d7fd9c776ad0f4a34f099b3389f4a1
-  md5: 96d57aba173e878a2089d5638016dc5e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - xorg-libx11 >=1.8.10,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 33005
-  timestamp: 1734229037766
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
   sha256: 044c7b3153c224c6cedd4484dd91b389d2d7fd9c776ad0f4a34f099b3389f4a1
   md5: 96d57aba173e878a2089d5638016dc5e
@@ -42117,18 +38412,6 @@ packages:
   purls: []
   size: 33649
   timestamp: 1734229123157
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
-  sha256: 58e8fc1687534124832d22e102f098b5401173212ac69eb9fd96b16a3e2c8cb2
-  md5: 303f7a0e9e0cd7d250bb6b952cecda90
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - xorg-libx11 >=1.8.10,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 14412
-  timestamp: 1727899730073
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
   sha256: 58e8fc1687534124832d22e102f098b5401173212ac69eb9fd96b16a3e2c8cb2
   md5: 303f7a0e9e0cd7d250bb6b952cecda90
@@ -42165,19 +38448,6 @@ packages:
   purls: []
   size: 12302
   timestamp: 1734168591429
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
-  sha256: 752fdaac5d58ed863bbf685bb6f98092fe1a488ea8ebb7ed7b606ccfce08637a
-  md5: 7bbe9a0cc0df0ac5f5a8ad6d6a11af2f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - xorg-libx11 >=1.8.10,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxi >=1.7.10,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 32808
-  timestamp: 1727964811275
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
   sha256: 752fdaac5d58ed863bbf685bb6f98092fe1a488ea8ebb7ed7b606ccfce08637a
   md5: 7bbe9a0cc0df0ac5f5a8ad6d6a11af2f
@@ -42251,16 +38521,6 @@ packages:
   sha256: 99f893e30497a4b66842821bac316386f7bd5c4f47ad35c9073ef089aa33af32
   requires_dist:
   - pyyaml
-- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
-  sha256: 6d9ea2f731e284e9316d95fa61869fe7bbba33df7929f82693c121022810f4ad
-  md5: a77f85f77be52ff59391544bfe73390a
-  depends:
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  license: MIT
-  license_family: MIT
-  size: 85189
-  timestamp: 1753484064210
 - conda: https://prefix.dev/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
   sha256: 6d9ea2f731e284e9316d95fa61869fe7bbba33df7929f82693c121022810f4ad
   md5: a77f85f77be52ff59391544bfe73390a
@@ -42352,19 +38612,6 @@ packages:
   - pkg:pypi/yarl?source=compressed-mapping
   size: 147028
   timestamp: 1772409590700
-- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h41580af_10.conda
-  sha256: 325d370b28e2b9cc1f765c5b4cdb394c91a5d958fbd15da1a14607a28fee09f6
-  md5: 755b096086851e1193f3b10347415d7c
-  depends:
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - krb5 >=1.22.2,<1.23.0a0
-  - libsodium >=1.0.21,<1.0.22.0a0
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 311150
-  timestamp: 1772476812121
 - conda: https://prefix.dev/conda-forge/linux-64/zeromq-4.3.5-h387f397_9.conda
   sha256: 47cfe31255b91b4a6fa0e9dbaf26baa60ac97e033402dbc8b90ba5fee5ffe184
   md5: 8035e5b54c08429354d5d64027041cad
@@ -42431,16 +38678,6 @@ packages:
   - pytest-enabler>=2.2 ; extra == 'enabler'
   - pytest-mypy ; extra == 'type'
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
-  sha256: b4533f7d9efc976511a73ef7d4a2473406d7f4c750884be8e8620b0ce70f4dae
-  md5: 30cd29cb87d819caead4d55184c1d115
-  depends:
-  - python >=3.10
-  - python
-  license: MIT
-  license_family: MIT
-  size: 24194
-  timestamp: 1764460141901
 - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
   sha256: b4533f7d9efc976511a73ef7d4a2473406d7f4c750884be8e8620b0ce70f4dae
   md5: 30cd29cb87d819caead4d55184c1d115
@@ -42487,17 +38724,6 @@ packages:
   purls: []
   size: 95582
   timestamp: 1727963203597
-- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
-  sha256: ea4e50c465d70236408cb0bfe0115609fd14db1adcd8bd30d8918e0291f8a75f
-  md5: 2aadb0d17215603a82a2a6b0afd9a4cb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: Zlib
-  license_family: Other
-  size: 122618
-  timestamp: 1770167931827
 - conda: https://prefix.dev/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
   sha256: ea4e50c465d70236408cb0bfe0115609fd14db1adcd8bd30d8918e0291f8a75f
   md5: 2aadb0d17215603a82a2a6b0afd9a4cb
@@ -42529,16 +38755,6 @@ packages:
   - cffi~=1.17 ; python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'cffi'
   - cffi>=2.0.0b0 ; python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and extra == 'cffi'
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-  sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
-  md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 601375
-  timestamp: 1764777111296
 - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
   sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
   md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829

--- a/pixi.lock
+++ b/pixi.lock
@@ -257,6 +257,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/vulture-2.16-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
@@ -590,6 +591,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/vulture-2.16-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/wayland-1.25.0-h4f8a99f_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/x264-1!164.3095-h4e544f5_2.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-aarch64/x265-3.5-hdd96247_3.tar.bz2
@@ -1672,6 +1674,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/tyro-0.9.1-pyhff2d567_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/vulture-2.16-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
@@ -2009,6 +2012,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/tyro-0.9.1-pyhff2d567_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/vulture-2.16-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/wayland-1.25.0-h4f8a99f_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/x264-1!164.3095-h4e544f5_2.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-aarch64/x265-3.5-hdd96247_3.tar.bz2
@@ -3033,6 +3037,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/utfcpp-4.09-ha770c72_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/viskores-1.1.0-cuda12.9_h14fae2a_.conda
       - conda: https://prefix.dev/conda-forge/linux-64/vtk-base-9.6.0-py311h53b44c0_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/vulture-2.16-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/werkzeug-3.1.8-pyhcf101f3_0.conda
@@ -4283,6 +4288,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/utfcpp-4.09-ha770c72_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/viskores-1.1.0-cpu_h6262cab_.conda
       - conda: https://prefix.dev/conda-forge/linux-64/vtk-base-9.6.0-py312hfe0e207_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/vulture-2.16-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wandb-0.19.11-py312h7545c40_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.24.0-hd6090a7_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
@@ -5308,6 +5314,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/utfcpp-4.09-ha770c72_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/viskores-1.1.0-cpu_hc82bd48_.conda
       - conda: https://prefix.dev/conda-forge/linux-64/vtk-base-9.6.0-py312hcf65a95_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/vulture-2.16-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.24.0-hd6090a7_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/werkzeug-3.1.6-pyhcf101f3_0.conda
@@ -6313,6 +6320,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/vlfeat-0.9.21-hd590300_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/vulture-2.16-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
@@ -7362,6 +7370,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/tyro-0.9.1-pyhff2d567_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/vulture-2.16-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
@@ -7702,6 +7711,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/tyro-0.9.1-pyhff2d567_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/vulture-2.16-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/wayland-1.25.0-h4f8a99f_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/x264-1!164.3095-h4e544f5_2.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-aarch64/x265-3.5-hdd96247_3.tar.bz2
@@ -8896,6 +8906,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/vulture-2.16-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.24.0-hd6090a7_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/wheel-0.46.3-pyhd8ed1ab_0.conda
@@ -9291,6 +9302,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/vulture-2.16-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/wayland-1.24.0-h4f8a99f_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/wheel-0.46.3-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/x264-1!164.3095-h4e544f5_2.tar.bz2
@@ -10195,6 +10207,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/vulture-2.16-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.24.0-hd6090a7_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
@@ -11251,6 +11264,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/utfcpp-4.09-ha770c72_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/viskores-1.1.0-cpu_hc82bd48_.conda
       - conda: https://prefix.dev/conda-forge/linux-64/vtk-base-9.6.0-py312hcf65a95_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/vulture-2.16-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.24.0-hd6090a7_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/werkzeug-3.1.6-pyhcf101f3_0.conda
@@ -12332,6 +12346,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/utfcpp-4.09-ha770c72_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/viskores-1.1.0-cuda12.9_h14fae2a_.conda
       - conda: https://prefix.dev/conda-forge/linux-64/vtk-base-9.6.0-py312h64f160b_4.conda
+      - conda: https://prefix.dev/conda-forge/noarch/vulture-2.16-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/werkzeug-3.1.7-pyhcf101f3_0.conda
@@ -13286,6 +13301,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/vulture-2.16-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.24.0-hd6090a7_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
@@ -19321,7 +19337,7 @@ packages:
 - pypi: ./packages/gsplat-rust-renderer
   name: gsplat-rust-renderer
   version: 0.1.0
-  sha256: d9f3fa0bb5684ae7cff60500f829a3d0429d12478a929668aacc2fe791a01a79
+  sha256: 8c6924feb68896b950157c5a64873e650b1d250f4003aeff667f56d964cf75d7
   requires_python: '>=3.12'
 - conda: https://prefix.dev/conda-forge/linux-64/gst-plugins-base-1.24.11-h651a532_0.conda
   sha256: a497d2ba34fdfa4bead423cba5261b7e619df3ac491fb0b6231d91da45bd05fc
@@ -28012,7 +28028,7 @@ packages:
 - pypi: ./packages/mast3r-slam
   name: mast3r-slam
   version: 0.0.1
-  sha256: efdddc33ec20e7ea3bb369fef6f7969d973fd7ddfac25ba41c95671c172ff90e
+  sha256: 0b4aee916e8c2d2ec59834b954b865bab6ed3ddfd96e6b98de4f430965955f93
   requires_dist:
   - einops
   - natsort
@@ -28407,7 +28423,7 @@ packages:
 - pypi: ./packages/monoprior
   name: monopriors
   version: 0.3.2
-  sha256: 6c4bafc8fddd27a076923a72bbba443bd01e6bc5eec292776f8adeee06e3a50f
+  sha256: b9650205147a4a3586a725f8707c7e9f99eb229fc1228b1c8d465fa4c4d9cc6d
   requires_dist:
   - geffnet>=1.0.2
   - omnidata-tools>=0.0.23
@@ -32213,7 +32229,7 @@ packages:
 - pypi: ./packages/pysfm
   name: pysfm
   version: 0.1.0
-  sha256: a004089a859a27da0bd4abd3acd7bd60e12ebd7fc10749868d2c19bac6601035
+  sha256: 8d4a0847adbfa1ded34638ef72f214c2f80395b6ade07b65abd8299086a05db1
   requires_python: '>=3.11'
 - conda: https://prefix.dev/conda-forge/linux-64/pyside6-6.10.2-py311hf27b23e_2.conda
   sha256: 04fb70ae66672361aeb85f7706b12792b34194a601216eab6c2131fd5e98763b
@@ -32979,7 +32995,7 @@ packages:
 - pypi: ./packages/pyvrs-viewer
   name: pyvrs-viewer
   version: 0.1.0
-  sha256: d4135e44a60bcdda18583c60dee92a790daa42561237c70525a35134072c1edc
+  sha256: ee174c4adc55abebc7d7cdcd0b388e63a823723a813fab5d3b3d2a60ed1a405d
   requires_python: '>=3.12'
 - conda: https://prefix.dev/conda-forge/linux-64/pyyaml-6.0.3-py310h3406613_1.conda
   sha256: f23de6cc72541c6081d3d27482dbc9fc5dd03be93126d9155f06d0cf15d6e90e
@@ -33894,7 +33910,7 @@ packages:
 - pypi: ./packages/prompt-da
   name: rerun-prompt-da
   version: 0.1.0
-  sha256: 6010c475dca8016b74cdbd14fec5a399b674644eb3797dd861ad6c4670702b67
+  sha256: 745a5f6282ad01b5a906b256f8f803725a4eddb4f4e5f3561bb4465a0abdc24c
   requires_dist:
   - monopriors @ file:///var/tmp/vibe-kanban/worktrees/0c88-mast3r-slam-fix/examples-monorepo/packages/monoprior
   requires_python: '>=3.12'
@@ -34050,7 +34066,7 @@ packages:
 - pypi: ./packages/robocap-slam
   name: robocap-slam
   version: 0.1.0
-  sha256: e5e9b7afe3b28560960a5d77ca4c98e67b6da0f8bcd0229946da73c5e72817a1
+  sha256: 5cabb0e90bf8c6f1d23bf4ad3c7734a0a420f5d91ff3925f7c13b200b19090fc
   requires_dist:
   - pyyaml
   - pyarrow
@@ -34409,7 +34425,7 @@ packages:
 - pypi: ./packages/sam3-rerun
   name: sam3-rerun
   version: 0.1.0
-  sha256: d03756d33ea02d8b6452906fb2a966b57b5a7f37e4d9ead61aa104ecc844244b
+  sha256: 314786c153a414d7be1e2251eab0e5cb6db2f48d426407bddfe283c66bc46176
   requires_dist:
   - einops>=0.8.0
   - tyro>=0.9.1
@@ -34417,7 +34433,7 @@ packages:
 - pypi: ./packages/sam3d-body-rerun
   name: sam3d-body
   version: 0.1.0
-  sha256: a70099f7d594445eb44234f400c15f387145990769ac190ce489e96333eb682d
+  sha256: fafc5560ccaaa82432b7c4990084a15100631dda31f973ab22bb81ad38261c83
   requires_dist:
   - einops>=0.8.0
   - icecream>=2.1.3
@@ -37327,7 +37343,7 @@ packages:
 - pypi: ./packages/vistadream
   name: vistadream
   version: 0.1.0
-  sha256: 040445160e2ce50aa6695f139ee7258a27456ec50ee1fbcc9351b9e46aa686b5
+  sha256: a73114f7930cefc5fd61f7116a507c1ed218d5c909a24af0c113608ed440e827
   requires_dist:
   - einops>=0.8.1,<0.9
   - monopriors @ file:///var/tmp/vibe-kanban/worktrees/0c88-mast3r-slam-fix/examples-monorepo/packages/monoprior
@@ -37581,6 +37597,18 @@ packages:
   - pkg:pypi/vtk?source=hash-mapping
   size: 85574429
   timestamp: 1772669146387
+- conda: https://prefix.dev/conda-forge/noarch/vulture-2.16-pyhd8ed1ab_0.conda
+  sha256: 8110ce046263dfaf60b79f81e6b58189352ce0332dc9410e3e0f5dd05a6c17f0
+  md5: 07eb801541c33aef793e6ce25de33eab
+  depends:
+  - python >=3.10
+  - tomli >=1.1.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/vulture?source=hash-mapping
+  size: 29832
+  timestamp: 1774490312775
 - conda: https://prefix.dev/conda-forge/linux-64/wandb-0.19.11-py312h7545c40_0.conda
   sha256: 34a2a7c1012a552ae89042fa2bc1a00a8d6cdd86fa9514ea70b55ceec4b757e3
   md5: f3ca0e2bab1df90f0cb456cea802b562
@@ -37804,7 +37832,7 @@ packages:
 - pypi: ./packages/wilor-nano
   name: wilor-nano
   version: 0.1.0
-  sha256: 90226910a61ac83b85d7db6fd03b7193f2169c91c433419b38d9d707742a317a
+  sha256: 4d9695a52af9cd93bcc16bca50eb34cd53ab2fe92e04164fd30ccf2e5065ccfd
   requires_dist:
   - timm
   - einops

--- a/pixi.toml
+++ b/pixi.toml
@@ -88,6 +88,7 @@ pytest = ">=8.0.0,<9"
 beartype = ">=0.22.9"
 pyrefly = "*"
 hypothesis = "*"
+vulture = "*"
 
 [feature.dev.pypi-dependencies]
 types-tqdm = "*"
@@ -102,6 +103,10 @@ description = "Lint the package"
 [feature.dev.tasks.typecheck]
 cmd = "cd $PACKAGE_DIR && pyrefly check -c ../../pyrefly.toml ."
 description = "Typecheck the package"
+
+[feature.dev.tasks.deadcode]
+cmd = "cd $PACKAGE_DIR && vulture --config pyproject.toml"
+description = "Find dead code in the package"
 
 [feature.dev.tasks.tests]
 cmd = "cd $PACKAGE_DIR && pytest -q"

--- a/pixi.toml
+++ b/pixi.toml
@@ -813,7 +813,6 @@ description = "Run MASt3R-SLAM inference (base config, 512px)"
 [feature.mast3r-slam.tasks.mast3r-slam-app]
 cmd = "python tools/gradio-app.py"
 depends-on = [
-    "_build-cuda-kernels",
     "_build-mojo-kernels",
     "_download-checkpoints",
     "_download-example-data",


### PR DESCRIPTION
## Summary
This PR fixes MASt3R-SLAM backend keyframe camera updates after the move from synchronous to async logging, keeps the lighter backend pose-refresh path that survived benchmarking, and cleans up the package so Ruff, Pyrefly, and Vulture pass for `mast3r-slam`.

## What Changed
- mark backend-updated keyframes as dirty when shared camera poses are rewritten
- propagate dirty keyframe updates through the inference/logging pipeline so backend pose refinement reaches the viewer
- refresh backend-updated keyframes with lightweight pose-update events instead of replaying full dirty-keyframe snapshots
- cache keyframe intrinsics on first log so backend pose refreshes can rebuild the camera update from cached intrinsics plus new extrinsics
- add a regression test for dirty keyframe tracking
- add Vulture to the shared dev tooling and package-local Vulture config across the repo’s package `pyproject.toml` files
- clean up `mast3r-slam` dead code, benchmark/test typing, and legacy unused state so Ruff, Pyrefly, and Vulture are clean

## Why
When logging moved from the synchronous path to the async logger, backend pose refinement stopped fully updating keyframe camera entities in Rerun. The result was that keyframes stayed on the stale frontend odometry path, which degraded the reconstructed point cloud, especially on `example-fast`.

The branch originally explored broader logging optimizations, but some of those changes increased `.rrd` size and were intentionally rolled back. The final version keeps the backend-camera correctness fix plus the narrower lightweight pose-refresh change, then adds tooling and code cleanup so the package checks pass cleanly.

## Important Implementation Details
- `SharedKeyframes.update_world_sim3_cams()` marks rewritten keyframes dirty so backend pose changes are visible to the logger.
- The frontend emits backend pose updates as `(kf_idx, world_sim3_cam_data)` events rather than resnapshotting full keyframes.
- The async logger stores static keyframe pinhole metadata at first log and uses it to replay backend camera updates with the refined pose.
- The branch intentionally does **not** keep the later buffer-only image logging and related logging-overhead optimizations that were benchmarked, because they increased `.rrd` size.
- `mast3r-slam` now passes Ruff, Pyrefly, and Vulture; remaining Pyrefly output is limited to repo-level environment warnings from the shared `pyrefly.toml`, not package type errors.

## Validation
- `pixi run -e mast3r-slam-dev pytest -q packages/mast3r-slam/tests` → `27 passed, 8 skipped`
- `pixi run -e mast3r-slam --frozen example-fast` → exited `0`
- `pixi run -e mast3r-slam-dev ruff check packages/mast3r-slam` → passed
- `pixi run -e mast3r-slam-dev pyrefly check -c pyrefly.toml packages/mast3r-slam` → `0` package errors
- `pixi run -e mast3r-slam-dev deadcode` → clean for `mast3r-slam`

This PR was written using [Vibe Kanban](https://vibekanban.com)