### PR TITLE
[codex] Add Sapiens COCO-133 pose package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ packages/dpvo/data/
 packages/*/outputs/
 packages/*/checkpoints/
 packages/*/_checkpoints/
+packages/*/pretrained_models/
 
 packages/vistadream/ckpt/
 
@@ -119,7 +120,6 @@ packages/gsplat-rust-renderer/target/
 packages/gsplat-rust-renderer/examples/*.ply
 
 # Package-specific ignores
-packages/wilor-nano/pretrained_models/
 packages/wilor-nano/onnx_models/
 packages/wilor-nano/demo/
 packages/wilor-nano/results/

--- a/packages/sapiens-coco133-pose/README.md
+++ b/packages/sapiens-coco133-pose/README.md
@@ -1,0 +1,124 @@
+# Sapiens / RTMLib COCO-133 Pose
+
+Human pose package that pairs MV-API's RTMLib YOLOX HumanArt detector with a switchable COCO WholeBody 133 pose backend:
+
+- `sapiens`: Sapiens2 0.4B pose, projected from native 308 keypoints to COCO-133.
+- `rtmlib`: MV-API's RTMLib RTMW wholebody pose path, which already emits COCO-133.
+
+The non-batched iterable path writes the golden `.rrd` artifact. The TensorRT video path uses the standard `RerunTyroConfig`, so it opens the viewer by default and can save an `.rrd` with `--rr-config.save`. Source video is logged once at `video`, and pose overlays are logged on stable `video/person_*` entities over the `video_time` timeline. It keeps decode, detector preprocessing, detector inference, pose crops, pose inference, and pose decode on the GPU until final Rerun logging.
+
+```mermaid
+flowchart TD
+  A["Video"] --> B["Iterable golden path"]
+  B --> C["TorchCodec CPU decode"]
+  C --> D["RTMLib YOLOX detector"]
+  D --> E{"pose backend"}
+  E -->|sapiens| F["Sapiens2 PyTorch pose"]
+  F --> G["Project 308 -> COCO-133"]
+  E -->|rtmlib| H["RTMLib RTMW pose"]
+  H --> I["COCO-133 keypoints"]
+  G --> J["Golden RRD"]
+  I --> J
+
+  A --> K["Batched TensorRT path"]
+  K --> L["TorchCodec CUDA decode"]
+  L --> M["YOLOX GPU preprocess"]
+  M --> N["YOLOX TensorRT"]
+  N --> O["GPU NMS"]
+  O --> P{"pose backend"}
+  P -->|sapiens| Q["Sapiens GPU crops"]
+  Q --> R["Sapiens TensorRT FP16"]
+  R --> S["GPU heatmap decode + COCO-133 projection"]
+  P -->|rtmlib| T["RTMW GPU affine crops"]
+  T --> U["RTMW TensorRT FP16"]
+  U --> V["GPU SimCC decode"]
+  S --> W["Rerun viewer or candidate RRD"]
+  V --> W
+  J --> X["RRD parity check"]
+  W --> X
+```
+
+| Stage | Iterable golden | Batched TensorRT |
+| --- | --- | --- |
+| Video decode | CPU | GPU |
+| YOLOX preprocessing | CPU/OpenCV inside RTMLib | GPU Torch |
+| YOLOX inference | ONNX Runtime/OpenCV via RTMLib | TensorRT |
+| Detector NMS | RTMLib backend | GPU TorchVision NMS |
+| Sapiens pose crop | PyTorch runtime path | GPU Torch |
+| Sapiens pose inference | PyTorch | TensorRT FP16 |
+| RTMLib pose crop | RTMLib OpenCV affine | GPU Torch affine |
+| RTMLib pose inference | ONNX Runtime/OpenCV via RTMLib | TensorRT FP16 |
+| Pose decode | Backend runtime | GPU Torch, then CPU arrays for Rerun logging |
+| Artifact write | CPU Rerun SDK | CPU Rerun SDK |
+
+Typical video flows:
+
+```bash
+pixi run -e sapiens-coco133-pose --frozen iterable-video \
+  --video-path /path/to/video.mp4
+
+pixi run -e sapiens-coco133-pose --frozen iterable-video \
+  --video-path /path/to/video.mp4 \
+  --pose-backend rtmlib
+
+pixi run -e sapiens-coco133-pose --frozen video-trt \
+  --video-path /path/to/video.mp4
+
+pixi run -e sapiens-coco133-pose --frozen video-trt \
+  --video-path /path/to/video.mp4 \
+  rtmlib
+
+pixi run -e sapiens-coco133-pose --frozen video-trt \
+  --video-path /path/to/video.mp4 \
+  --rr-config.save /tmp/sapiens_coco133/batched_tensorrt.rrd \
+  --rr-config.headless
+
+pixi run -e sapiens-coco133-pose --frozen export-pose-onnx \
+  --config.checkpoint-path /path/to/sapiens2_0.4b_pose.safetensors \
+  --config.onnx-path /tmp/sapiens_coco133/sapiens2_0.4b_b8_fp16.onnx \
+  --config.batch-size 8
+```
+
+Typical RTMLib RTMW TensorRT build and benchmark:
+
+```bash
+pixi run -e sapiens-coco133-pose --frozen build-trt \
+  --config.target rtmlib-pose \
+  --config.onnx-path ~/.cache/rtmlib/hub/checkpoints/rtmw-dw-x-l_simcc-cocktail14_270e-256x192_20231122.onnx \
+  --config.engine-path /tmp/sapiens_coco133/rtmw_256x192_b32_fp16.trt \
+  --config.input-name input \
+  --config.output-names simcc_x simcc_y \
+  --config.input-shape 3 256 192 \
+  --config.batch-size 32
+
+pixi run -e sapiens-coco133-pose --frozen benchmark \
+  --config.video-path /path/to/video.mp4 \
+  --config.detector.engine-path /tmp/sapiens_coco133/yolox_humanart_head_b8_fp16.trt \
+  --config.output-dir /tmp/sapiens_coco133/rtmlib_benchmark \
+  --config.max-frames 480 \
+  --config.runtime.detector-batch-size 8 \
+  --config.runtime.pose-batch-size 32 \
+  rtmlib \
+  --engine-path /tmp/sapiens_coco133/rtmw_256x192_b32_fp16.trt
+```
+
+The benchmark writes `rtmlib_iterable_golden.rrd` and `rtmlib_batched_tensorrt.rrd`, compares those RRDs directly, and reports inference speed. On the 480-frame validation clip, the RTMLib TensorRT no-logging path measures about 750-760 FPS end-to-end; small RRD comparison runs stay above the 10x speedup target.
+
+The short `video-trt` command assumes the default Sapiens preset:
+
+- detector engine: `pretrained_models/tensorrt/yolox_humanart_head_b8_fp16.trt`
+- pose engine: `pretrained_models/tensorrt/sapiens2_0.4b_b8_fp16.trt`
+- Rerun output: viewer by default, or RRD via `--rr-config.save`
+- tqdm progress: enabled by default
+- detector static/input metadata: fixed internally for the shipped engine
+- detector runtime batch: `8`
+- pose runtime batch: selected pose engine static batch unless `--runtime.pose-batch-size` is set
+
+The short `iterable-video` command writes `/tmp/sapiens_coco133/iterable_golden.rrd` by default and enables tqdm progress by default. Override with `--rrd-path`.
+
+For `video-trt`, the RTMLib preset switches to:
+
+- pose engine: `pretrained_models/tensorrt/rtmw_256x192_b32_fp16.trt`
+- pose static/input metadata: fixed internally for the shipped engine
+- pose runtime batch: `32`
+- pose input/output binding names are fixed internally as `input`, `simcc_x`, and `simcc_y`

--- a/packages/sapiens-coco133-pose/pyproject.toml
+++ b/packages/sapiens-coco133-pose/pyproject.toml
@@ -1,0 +1,35 @@
+[project]
+authors = [{ name = "pablo vela", email = "pablovela5620@gmail.com" }]
+dependencies = [
+    # common: numpy, scipy, jaxtyping, rerun-sdk, huggingface_hub, tqdm,
+    #         pyserde, av, opencv, transformers, simplecv
+    # cuda: pytorch-gpu, torchvision
+    "sapiens2-pose",
+    "mv-api",
+    "rtmlib",
+    "tyro>=0.9.1",
+]
+description = "RTMLib YOLOX human detection plus Sapiens2 COCO-133 pose estimation with iterable and batched TensorRT video paths"
+name = "sapiens-coco133-pose"
+requires-python = ">= 3.12"
+version = "0.1.0"
+
+[build-system]
+build-backend = "hatchling.build"
+requires = ["hatchling"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/sapiens_coco133_pose"]
+
+[tool.ruff]
+line-length = 150
+
+[tool.ruff.lint]
+select = ["E", "F", "UP", "B", "SIM", "I"]
+ignore = ["E501", "F722", "F821", "UP037", "UP040"]
+
+[tool.vulture]
+paths = ["src/sapiens_coco133_pose", "tests", "tools"]
+exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modules/*"]
+sort_by_size = true
+min_confidence = 60

--- a/packages/sapiens-coco133-pose/src/sapiens_coco133_pose/__init__.py
+++ b/packages/sapiens-coco133-pose/src/sapiens_coco133_pose/__init__.py
@@ -1,0 +1,10 @@
+"""COCO-133 human pose estimation with RTMLib YOLOX and Sapiens2."""
+
+from __future__ import annotations
+
+import os
+
+if os.environ.get("PIXI_DEV_MODE") == "1":
+    from beartype.claw import beartype_this_package
+
+    beartype_this_package()

--- a/packages/sapiens-coco133-pose/src/sapiens_coco133_pose/api/__init__.py
+++ b/packages/sapiens-coco133-pose/src/sapiens_coco133_pose/api/__init__.py
@@ -1,0 +1,5 @@
+"""Public APIs for Sapiens COCO-133 pose pipelines."""
+
+from sapiens_coco133_pose.api.artifact import Coco133PoseFrame, Coco133VideoPoseArtifact
+
+__all__ = ["Coco133PoseFrame", "Coco133VideoPoseArtifact"]

--- a/packages/sapiens-coco133-pose/src/sapiens_coco133_pose/api/artifact.py
+++ b/packages/sapiens-coco133-pose/src/sapiens_coco133_pose/api/artifact.py
@@ -1,0 +1,313 @@
+"""COCO-133 video pose artifacts and Rerun logging helpers."""
+# ruff: noqa: I001
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, NamedTuple
+
+import numpy as np
+import rerun as rr
+import rerun.blueprint as rrb
+from jaxtyping import Bool, Float32, Int, UInt8
+from numpy import ndarray
+from sapiens2_pose.api.metadata import get_pose_schema, log_annotation_context
+from sapiens2_pose.api.pose_artifact import PoseArtifactComparisonConfig, PoseArtifactComparisonMetrics, PosePredictionArtifact, compare_pose_prediction_artifacts
+from sapiens2_pose.api.rerun_pose_artifact import _load_one_recording_chunks
+from simplecv.rerun_custom_types import Points2DWithConfidence, confidence_scores_to_rgb
+from simplecv.rerun_log_utils import log_video
+
+_LEGACY_POSE_ENTITY_PATTERN = re.compile(r"^/?video/frame_(?P<frame>\d+)/person_(?P<person>\d+)/(?P<kind>bbox|keypoints)$")
+_STABLE_POSE_ENTITY_PATTERN = re.compile(r"^/?video/person_(?P<person>\d+)/(?P<kind>bbox|keypoints)$")
+_BOX_CENTERS_COMPONENT = "Boxes2D:centers"
+_BOX_HALF_SIZES_COMPONENT = "Boxes2D:half_sizes"
+_POINTS_POSITION_COMPONENT = "Points2D:positions"
+POINTS_CONFIDENCE_COMPONENT = "simplecv.KeypointConfidence2D:confidences"
+POINTS_AVERAGE_CONFIDENCE_COMPONENT = "simplecv.KeypointConfidence2D:average_confidence"
+_FRAME_INDEX_COLUMN = "frame"
+_VIDEO_TIME_COLUMN = "video_time"
+_VIDEO_TIMELINE = "video_time"
+_FRAME_TIMELINE = "frame"
+
+
+@dataclass(frozen=True, slots=True)
+class Coco133PoseFrame:
+    """Pose predictions for one video frame in COCO WholeBody order."""
+
+    frame_index: int
+    """Zero-based video frame index."""
+    timestamp_ns: int
+    """Frame timestamp in nanoseconds on the video timeline."""
+    image_rgb: UInt8[ndarray, "h w 3"] | None
+    """Optional RGB image for image-frame logging when video media is not logged separately."""
+    bboxes: Float32[ndarray, "n 4"]
+    """Person bounding boxes in image-space ``xyxy`` order."""
+    keypoints: Float32[ndarray, "n 133 2"]
+    """COCO-133 keypoint coordinates in image-space ``xy`` order."""
+    scores: Float32[ndarray, "n 133"]
+    """Per-keypoint confidence scores aligned with ``keypoints``."""
+
+
+class Coco133VideoPoseArtifact(NamedTuple):
+    """Flat, frame-aware COCO-133 pose artifact loaded from an RRD."""
+
+    frame_indices: Int[ndarray, "n_frames"]
+    """Frame ids present in the artifact."""
+    timestamps_ns: Int[ndarray, "n_frames"]
+    """Frame timestamps in nanoseconds."""
+    person_frame_indices: Int[ndarray, "n_persons"]
+    """Frame id for each person row."""
+    bboxes: Float32[ndarray, "n_persons 4"]
+    """Person boxes in ``xyxy`` order."""
+    keypoints: Float32[ndarray, "n_persons 133 2"]
+    """COCO-133 keypoints in image coordinates."""
+    scores: Float32[ndarray, "n_persons 133"]
+    """COCO-133 per-keypoint confidence scores."""
+
+
+def _empty_rows() -> tuple[Float32[ndarray, "0 4"], Float32[ndarray, "0 133 2"], Float32[ndarray, "0 133"]]:
+    return np.empty((0, 4), np.float32), np.empty((0, 133, 2), np.float32), np.empty((0, 133), np.float32)
+
+
+def compare_video_pose_artifacts(baseline: Coco133VideoPoseArtifact, candidate: Coco133VideoPoseArtifact, config: PoseArtifactComparisonConfig) -> PoseArtifactComparisonMetrics:
+    """Compare two COCO-133 video artifacts.
+
+    Args:
+        baseline: Reference video pose artifact.
+        candidate: Candidate video pose artifact to compare against ``baseline``.
+        config: Numeric tolerances and keypoint visibility thresholds.
+
+    Returns:
+        Aggregate comparison metrics over matching bbox and keypoint rows.
+
+    Raises:
+        AssertionError: If frame or person row identities differ before value comparison.
+    """
+    if not np.array_equal(baseline.frame_indices, candidate.frame_indices):
+        raise AssertionError("Video artifact frame_indices differ.")
+    if not np.array_equal(baseline.person_frame_indices, candidate.person_frame_indices):
+        raise AssertionError("Video artifact person_frame_indices differ.")
+    return compare_pose_prediction_artifacts(PosePredictionArtifact(np.asarray(baseline.bboxes, np.float32), np.asarray(baseline.keypoints, np.float32), np.asarray(baseline.scores, np.float32)), PosePredictionArtifact(np.asarray(candidate.bboxes, np.float32), np.asarray(candidate.keypoints, np.float32), np.asarray(candidate.scores, np.float32)), config)
+
+
+def _frame_timestamp_ns(frame: Coco133PoseFrame, video_timestamps_ns: Int[ndarray, "num_video_frames"] | None) -> int:
+    """Return the timestamp used for overlaying a predicted frame on the video timeline."""
+    if video_timestamps_ns is None or frame.frame_index < 0 or frame.frame_index >= int(video_timestamps_ns.shape[0]):
+        return int(frame.timestamp_ns)
+    return int(video_timestamps_ns[int(frame.frame_index)])
+
+
+def coco133_points2d_with_confidence(
+    keypoints: Float32[ndarray, "133 2"],
+    scores: Float32[ndarray, "133"],
+    *,
+    keypoint_threshold: float,
+    keypoint_ids: list[int],
+    class_id: int = 0,
+) -> Points2DWithConfidence:
+    """Build the package-wide COCO-133 Rerun keypoint archetype.
+
+    Args:
+        keypoints: Image-space COCO-133 keypoint coordinates.
+        scores: Per-keypoint confidence scores.
+        keypoint_threshold: Minimum confidence for visible keypoints. Lower-confidence points are logged as ``NaN``.
+        keypoint_ids: COCO-133 keypoint ids used by Rerun annotation context.
+        class_id: Rerun class id for the person instance.
+
+    Returns:
+        ``Points2DWithConfidence`` containing positions, confidence values, keypoint ids, class ids, and confidence colors.
+    """
+    keypoints_f32: Float32[ndarray, "133 2"] = np.asarray(keypoints, dtype=np.float32).reshape(133, 2).copy()
+    scores_f32: Float32[ndarray, "133"] = np.asarray(scores, dtype=np.float32).reshape(133).copy()
+    visible_mask: Bool[ndarray, "133"] = np.asarray(scores_f32 >= np.float32(keypoint_threshold), dtype=np.bool_)
+    keypoints_f32[~visible_mask] = np.nan
+    confidence_rgb: UInt8[ndarray, "133 3"] = confidence_scores_to_rgb(scores_f32[np.newaxis, :, np.newaxis])[0]
+    return Points2DWithConfidence(positions=keypoints_f32, confidences=scores_f32, class_ids=class_id, keypoint_ids=keypoint_ids, colors=confidence_rgb, show_labels=False)
+
+
+def log_video_pose_frames(frames: list[Coco133PoseFrame], *, keypoint_threshold: float, recording: rr.RecordingStream, video_path: Path | None = None, video_log_path: Path = Path("video")) -> rr.RecordingStream:
+    """Log frame-major COCO-133 pose predictions into an existing Rerun recording.
+
+    Args:
+        frames: Frame-major pose predictions to log.
+        keypoint_threshold: Minimum confidence for visible keypoints.
+        recording: Rerun recording stream that receives video, boxes, and keypoints.
+        video_path: Optional encoded video path to log once as media.
+        video_log_path: Rerun entity path for the video and pose overlays.
+
+    Returns:
+        The same recording stream after logging.
+    """
+    schema = get_pose_schema("coco133")
+    video_entity: str = str(video_log_path)
+    video_timestamps_ns: Int[ndarray, "num_video_frames"] | None = None
+    rr.send_blueprint(rrb.Blueprint(rrb.Spatial2DView(name="COCO-133 Pose", origin=f"/{video_entity}"), collapse_panels=True), recording=recording)
+    log_annotation_context(schema, recording=recording)
+    if video_path is not None:
+        video_timestamps_ns = log_video(video_path, video_log_path=video_log_path, timeline=_VIDEO_TIMELINE, recording=recording)
+    previous_person_count: int = 0
+    for frame in frames:
+        timestamp_ns: int = _frame_timestamp_ns(frame, video_timestamps_ns)
+        rr.set_time(_FRAME_TIMELINE, sequence=int(frame.frame_index), recording=recording)
+        rr.set_time(_VIDEO_TIMELINE, duration=float(timestamp_ns) * 1e-9, recording=recording)
+        if video_path is None and frame.image_rgb is not None:
+            rr.log(f"{video_entity}/image", rr.Image(np.asarray(frame.image_rgb, dtype=np.uint8), color_model=rr.ColorModel.RGB), recording=recording)
+        person_count: int = min(int(frame.bboxes.shape[0]), int(frame.keypoints.shape[0]), int(frame.scores.shape[0]))
+        for person_idx, bbox in enumerate(np.asarray(frame.bboxes[:person_count], dtype=np.float32).reshape(-1, 4)):
+            rr.log(f"{video_entity}/person_{person_idx}/bbox", rr.Boxes2D(array=bbox.reshape(1, 4), array_format=rr.Box2DFormat.XYXY, class_ids=0, labels=f"person_{person_idx}", colors=(0, 255, 0)), recording=recording)
+            rr.log(f"{video_entity}/person_{person_idx}/keypoints", coco133_points2d_with_confidence(frame.keypoints[person_idx], frame.scores[person_idx], keypoint_threshold=keypoint_threshold, keypoint_ids=schema.keypoint_ids), recording=recording)
+        for stale_person_idx in range(person_count, previous_person_count):
+            rr.log(f"{video_entity}/person_{stale_person_idx}", rr.Clear(recursive=True), recording=recording)
+        previous_person_count = person_count
+    return recording
+
+
+def write_video_pose_rrd(frames: list[Coco133PoseFrame], *, rrd_path: Path, keypoint_threshold: float, application_id: str = "sapiens_coco133_pose", video_path: Path | None = None) -> Path:
+    """Write frame-major COCO-133 pose predictions to an RRD file.
+
+    Args:
+        frames: Frame-major pose predictions to serialize.
+        rrd_path: Output RRD path.
+        keypoint_threshold: Minimum confidence for visible keypoints.
+        application_id: Rerun application id stored in the recording.
+        video_path: Optional encoded video path to log once as media.
+
+    Returns:
+        The written RRD path.
+    """
+    recording = rr.RecordingStream(application_id=application_id)
+    rrd_path.parent.mkdir(parents=True, exist_ok=True)
+    with recording:
+        log_video_pose_frames(frames, keypoint_threshold=keypoint_threshold, recording=recording, video_path=video_path)
+    recording.save(str(rrd_path))
+    return rrd_path
+
+
+def _parse_pose_chunk_path(entity_path: str) -> tuple[int | None, int, str] | None:
+    legacy_match: re.Match[str] | None = _LEGACY_POSE_ENTITY_PATTERN.fullmatch(entity_path)
+    if legacy_match is not None:
+        return int(legacy_match.group("frame")), int(legacy_match.group("person")), legacy_match.group("kind")
+    stable_match: re.Match[str] | None = _STABLE_POSE_ENTITY_PATTERN.fullmatch(entity_path)
+    if stable_match is None:
+        return None
+    return None, int(stable_match.group("person")), stable_match.group("kind")
+
+
+def _duration_ns(value: Any) -> int:
+    if hasattr(value, "value"):
+        return int(value.value)
+    if isinstance(value, np.timedelta64):
+        return int(value.astype("timedelta64[ns]").astype(np.int64))
+    if isinstance(value, int | np.integer):
+        return int(value)
+    return int(float(value) * 1_000_000_000)
+
+
+def _component_rows(batch_data: dict[str, list[Any]], component_name: str, entity_path: str) -> list[Any]:
+    if component_name not in batch_data:
+        raise ValueError(f"Missing Rerun component {component_name!r} on entity {entity_path!r}.")
+    return batch_data[component_name]
+
+
+def _row_frame_indices(batch_data: dict[str, list[Any]], path_frame: int | None, row_count: int, entity_path: str) -> list[int]:
+    if path_frame is not None:
+        return [path_frame] * row_count
+    if _FRAME_INDEX_COLUMN not in batch_data:
+        raise ValueError(f"Missing Rerun frame timeline on stable video pose entity {entity_path!r}.")
+    return [int(frame_idx) for frame_idx in batch_data[_FRAME_INDEX_COLUMN][:row_count]]
+
+
+def _row_timestamps_ns(batch_data: dict[str, list[Any]], row_count: int) -> list[int | None]:
+    if _VIDEO_TIME_COLUMN not in batch_data:
+        return [None] * row_count
+    return [_duration_ns(value) for value in batch_data[_VIDEO_TIME_COLUMN][:row_count]]
+
+
+def _load_bbox_row(batch_data: dict[str, list[Any]], row_idx: int, entity_path: str) -> Float32[ndarray, "4"]:
+    centers: Float32[ndarray, "boxes 2"] = np.asarray(_component_rows(batch_data, _BOX_CENTERS_COMPONENT, entity_path)[row_idx], dtype=np.float32).reshape(-1, 2)
+    half_sizes: Float32[ndarray, "boxes 2"] = np.asarray(_component_rows(batch_data, _BOX_HALF_SIZES_COMPONENT, entity_path)[row_idx], dtype=np.float32).reshape(-1, 2)
+    if centers.shape != half_sizes.shape:
+        raise ValueError(f"Rerun bbox centers/half-sizes shapes differ on {entity_path!r}: {centers.shape} != {half_sizes.shape}.")
+    if centers.shape[0] != 1:
+        raise ValueError(f"Expected one box on entity {entity_path!r}, found {centers.shape[0]}.")
+    return np.concatenate([centers[0] - half_sizes[0], centers[0] + half_sizes[0]], axis=0).astype(np.float32, copy=False)
+
+
+def _load_keypoints_row(batch_data: dict[str, list[Any]], row_idx: int, entity_path: str) -> Float32[ndarray, "133 2"]:
+    return np.asarray(_component_rows(batch_data, _POINTS_POSITION_COMPONENT, entity_path)[row_idx], dtype=np.float32).reshape(133, 2)
+
+
+def _load_scores_row(batch_data: dict[str, list[Any]], row_idx: int, entity_path: str, keypoints: Float32[ndarray, "133 2"]) -> Float32[ndarray, "133"]:
+    if POINTS_CONFIDENCE_COMPONENT not in batch_data:
+        return np.asarray(np.isfinite(keypoints).all(axis=-1), dtype=np.float32)
+    scores: Float32[ndarray, "n"] = np.asarray(batch_data[POINTS_CONFIDENCE_COMPONENT][row_idx], dtype=np.float32).reshape(-1)
+    if scores.shape[0] != 133:
+        raise ValueError(f"Expected 133 keypoint confidence values on entity {entity_path!r}, found {scores.shape[0]}.")
+    return scores.astype(np.float32, copy=False)
+
+
+def load_rerun_video_pose_artifact(rrd_path: Path) -> Coco133VideoPoseArtifact:
+    """Load bbox and keypoint rows from a COCO-133 video pose RRD.
+
+    Args:
+        rrd_path: Rerun recording containing COCO-133 video pose entities.
+
+    Returns:
+        A row-major artifact with frame ids, timestamps, person frame ids, bboxes, keypoints, and scores.
+
+    Raises:
+        ValueError: If bbox and keypoint rows do not line up by frame and person id.
+    """
+    frame_indices: set[int] = set()
+    timestamps_by_frame: dict[int, int] = {}
+    bboxes: dict[tuple[int, int], Float32[ndarray, "4"]] = {}
+    keypoints: dict[tuple[int, int], Float32[ndarray, "133 2"]] = {}
+    scores: dict[tuple[int, int], Float32[ndarray, "133"]] = {}
+    for chunk in _load_one_recording_chunks(rrd_path):
+        entity_path: str = str(chunk.entity_path)
+        parsed_path: tuple[int | None, int, str] | None = _parse_pose_chunk_path(entity_path)
+        if parsed_path is None:
+            continue
+        path_frame, person_idx, kind = parsed_path
+        batch_data: dict[str, list[Any]] = chunk.to_record_batch().to_pydict()
+        component_name: str = _BOX_CENTERS_COMPONENT if kind == "bbox" else _POINTS_POSITION_COMPONENT
+        row_count: int = len(_component_rows(batch_data, component_name, entity_path))
+        frame_rows: list[int] = _row_frame_indices(batch_data, path_frame, row_count, entity_path)
+        timestamp_rows: list[int | None] = _row_timestamps_ns(batch_data, row_count)
+        for row_idx, frame_idx in enumerate(frame_rows):
+            key = (int(frame_idx), int(person_idx))
+            frame_indices.add(key[0])
+            timestamp_ns: int | None = timestamp_rows[row_idx]
+            if timestamp_ns is not None:
+                timestamps_by_frame[key[0]] = int(timestamp_ns)
+            if kind == "bbox":
+                bboxes[key] = _load_bbox_row(batch_data, row_idx, entity_path)
+            else:
+                keypoint_row: Float32[ndarray, "133 2"] = _load_keypoints_row(batch_data, row_idx, entity_path)
+                keypoints[key] = keypoint_row
+                scores[key] = _load_scores_row(batch_data, row_idx, entity_path, keypoint_row)
+    rows = sorted(bboxes)
+    if rows != sorted(keypoints):
+        raise ValueError(f"Rerun bbox/keypoint row sets differ in {rrd_path}: bboxes={rows}, keypoints={sorted(keypoints)}.")
+    sorted_frame_indices: Int[ndarray, "n_frames"] = np.asarray(sorted(frame_indices), np.int64)
+    timestamps_ns: Int[ndarray, "n_frames"] = np.asarray([timestamps_by_frame.get(int(frame_idx), 0) for frame_idx in sorted_frame_indices], np.int64)
+    if not rows:
+        empty_bboxes, empty_keypoints, empty_scores = _empty_rows()
+        return Coco133VideoPoseArtifact(sorted_frame_indices, timestamps_ns, np.empty((0,), np.int64), empty_bboxes, empty_keypoints, empty_scores)
+    stacked_keypoints = np.stack([keypoints[row] for row in rows], axis=0).astype(np.float32, copy=False)
+    stacked_scores: Float32[ndarray, "n_persons 133"] = np.stack([scores[row] for row in rows], axis=0).astype(np.float32, copy=False)
+    return Coco133VideoPoseArtifact(sorted_frame_indices, timestamps_ns, np.asarray([frame for frame, _ in rows], np.int64), np.stack([bboxes[row] for row in rows], axis=0).astype(np.float32, copy=False), stacked_keypoints, stacked_scores)
+
+
+def compare_video_pose_rrds(baseline_rrd_path: Path, candidate_rrd_path: Path, config: PoseArtifactComparisonConfig) -> PoseArtifactComparisonMetrics:
+    """Compare two COCO-133 video pose RRDs.
+
+    Args:
+        baseline_rrd_path: Reference RRD path.
+        candidate_rrd_path: Candidate RRD path.
+        config: Numeric tolerances and keypoint visibility thresholds.
+
+    Returns:
+        Aggregate comparison metrics from the loaded RRD artifacts.
+    """
+    return compare_video_pose_artifacts(load_rerun_video_pose_artifact(baseline_rrd_path), load_rerun_video_pose_artifact(candidate_rrd_path), config)

--- a/packages/sapiens-coco133-pose/src/sapiens_coco133_pose/api/batched_tensorrt.py
+++ b/packages/sapiens-coco133-pose/src/sapiens_coco133_pose/api/batched_tensorrt.py
@@ -1,0 +1,765 @@
+"""Batched GPU/TensorRT Sapiens COCO-133 video pipeline."""
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal, NamedTuple, Protocol, SupportsFloat, SupportsInt, runtime_checkable
+
+import numpy as np
+import torch
+import tyro
+from jaxtyping import Float, Float32, Int, UInt8
+from numpy import ndarray
+from sapiens2_pose.api.coco133_gpu import (
+    RTMLIB_POSE_INPUT_SIZE,
+    RtmlibPoseInputBatch,
+    SapiensPoseInputBatch,
+    TensorRtRtmlibPoseRunner,
+    TensorRtSapiensPoseRunner,
+    TensorRtYoloxDetectorRunner,
+    YoloxDetectorOutput,
+    decode_rtmlib_simcc_to_coco133_torch,
+    decode_sapiens_heatmaps_to_coco133_torch,
+    postprocess_yolox_outputs_torch,
+    prepare_rtmlib_pose_inputs_torch,
+    prepare_sapiens_pose_inputs_torch,
+    preprocess_yolox_detector_torch,
+)
+from sapiens2_pose.api.runtime import DEFAULT_MODEL_SIZE, ModelSize
+from simplecv.rerun_log_utils import RerunTyroConfig
+from torch import Tensor
+
+from sapiens_coco133_pose.api.artifact import Coco133PoseFrame, log_video_pose_frames
+
+TORCH_UINT8 = torch.__dict__["uint8"]
+PoseBackend = Literal["sapiens", "rtmlib"]
+DetectorRunner = Callable[[Float[Tensor, "batch 3 det_h det_w"]], YoloxDetectorOutput]
+PoseRunner = Callable[[Float[Tensor, "batch 3 h w"]], tuple[Tensor, ...]]
+
+DEFAULT_TRT_DIR = Path(__file__).resolve().parents[3] / "pretrained_models" / "tensorrt"
+DEFAULT_DETECTOR_ENGINE_PATH = DEFAULT_TRT_DIR / "yolox_humanart_head_b8_fp16.trt"
+DEFAULT_SAPIENS_POSE_ENGINE_PATH = DEFAULT_TRT_DIR / "sapiens2_0.4b_b8_fp16.trt"
+DEFAULT_RTMLIB_POSE_ENGINE_PATH = DEFAULT_TRT_DIR / "rtmw_256x192_b32_fp16.trt"
+DETECTOR_DEFAULT_BATCH_SIZE = 8
+POSE_DEFAULT_BATCH_SIZE = 8
+RTMLIB_POSE_DEFAULT_BATCH_SIZE = 32
+YOLOX_DEFAULT_MAX_DETECTIONS = 1024
+DETECTOR_INPUT_SIZE = (640, 640)
+DETECTOR_DEFAULT_SCORE_THR = 0.7
+DETECTOR_DEFAULT_NMS_THR = 0.45
+
+DETECTOR_INPUT_NAME = "input"
+DETECTOR_OUTPUT_NAME = "1436"
+DETECTOR_SCORE_OUTPUT_NAME = "1438"
+SAPIENS_POSE_INPUT_NAME = "inputs"
+SAPIENS_POSE_OUTPUT_NAME = "heatmaps"
+RTMLIB_POSE_INPUT_NAME = "input"
+RTMLIB_POSE_SIMCC_X_OUTPUT_NAME = "simcc_x"
+RTMLIB_POSE_SIMCC_Y_OUTPUT_NAME = "simcc_y"
+
+__all__ = (
+    "AnnotatedPoseTensorRtConfig",
+    "BatchedTensorRtCoco133Pipeline",
+    "BatchedTensorRtPoseConfig",
+    "BatchedTensorRtVideoConfig",
+    "BatchedTensorRtVideoFramePredictor",
+    "BatchedTensorRtVideoSummary",
+    "RtmlibTensorRtPoseConfig",
+    "SapiensTensorRtPoseConfig",
+    "TensorRtDetectorConfig",
+    "TensorRtRuntimeConfig",
+    "create_batched_tensorrt_video_frame_predictor",
+    "run_batched_tensorrt_video_coco133",
+)
+
+
+@runtime_checkable
+class VideoDecoderMetadata(Protocol):
+    """Metadata exposed by TorchCodec's CUDA video decoder."""
+
+    @property
+    def num_frames(self) -> SupportsInt | None:
+        """Number of frames in the decoded video."""
+
+    @property
+    def average_fps(self) -> SupportsFloat | None:
+        """Average video frame rate."""
+
+
+@runtime_checkable
+class VideoFrameBatch(Protocol):
+    """Frame batch returned by TorchCodec video range reads."""
+
+    @property
+    def data(self) -> UInt8[Tensor, "batch h w 3"]:
+        """CUDA uint8 RGB frames in NHWC order."""
+
+
+@runtime_checkable
+class CudaVideoDecoder(Protocol):
+    """Protocol for the TorchCodec CUDA decoder used by the video path."""
+
+    @property
+    def metadata(self) -> VideoDecoderMetadata:
+        """Video metadata read by TorchCodec."""
+
+    def get_frames_in_range(self, start: int, stop: int) -> VideoFrameBatch:
+        """Return decoded CUDA frames in ``[start, stop)``.
+
+        Args:
+            start: Inclusive start frame index.
+            stop: Exclusive stop frame index.
+
+        Returns:
+            CUDA RGB frame batch in NHWC order.
+        """
+
+
+@dataclass(frozen=True, slots=True)
+class TensorRtDetectorConfig:
+    """TensorRT YOLOX HumanArt detector configuration."""
+
+    engine_path: Path = DEFAULT_DETECTOR_ENGINE_PATH
+    """Path to the YOLOX TensorRT engine."""
+
+    @property
+    def static_batch_size(self) -> int:
+        """Static batch size baked into the shipped detector engine."""
+        return DETECTOR_DEFAULT_BATCH_SIZE
+
+    @property
+    def input_size(self) -> tuple[int, int]:
+        """Detector input size as ``(height, width)`` for the shipped engine."""
+        return DETECTOR_INPUT_SIZE
+
+    @property
+    def max_detections(self) -> int:
+        """Maximum decoded detections kept by the detector runner."""
+        return YOLOX_DEFAULT_MAX_DETECTIONS
+
+    @property
+    def input_name(self) -> str:
+        """Fixed detector input binding name for the exported engine."""
+        return DETECTOR_INPUT_NAME
+
+    @property
+    def output_name(self) -> str:
+        """Fixed decoded-box output binding name for the exported engine."""
+        return DETECTOR_OUTPUT_NAME
+
+    @property
+    def score_output_name(self) -> str:
+        """Fixed decoded-score output binding name for the exported engine."""
+        return DETECTOR_SCORE_OUTPUT_NAME
+
+    @property
+    def extra_output_names(self) -> tuple[str, ...]:
+        """Extra detector outputs requested from TensorRT."""
+        return ()
+
+
+@dataclass(frozen=True, slots=True)
+class SapiensTensorRtPoseConfig:
+    """TensorRT Sapiens2 COCO-133 pose backend configuration."""
+
+    engine_path: Path = DEFAULT_SAPIENS_POSE_ENGINE_PATH
+    """Path to the Sapiens2 TensorRT pose engine."""
+
+    @property
+    def static_batch_size(self) -> int:
+        """Static batch size baked into the shipped Sapiens pose engine."""
+        return POSE_DEFAULT_BATCH_SIZE
+
+    @property
+    def model_size(self) -> ModelSize:
+        """Sapiens model size used to decode the shipped engine heatmaps."""
+        return DEFAULT_MODEL_SIZE
+
+    @property
+    def backend(self) -> Literal["sapiens"]:
+        """Pose backend identifier."""
+        return "sapiens"
+
+    @property
+    def input_name(self) -> str:
+        """Fixed Sapiens pose input binding name."""
+        return SAPIENS_POSE_INPUT_NAME
+
+    @property
+    def output_name(self) -> str:
+        """Fixed Sapiens heatmap output binding name."""
+        return SAPIENS_POSE_OUTPUT_NAME
+
+
+@dataclass(frozen=True, slots=True)
+class RtmlibTensorRtPoseConfig:
+    """TensorRT RTMLib RTMW COCO-133 pose backend configuration."""
+
+    engine_path: Path = DEFAULT_RTMLIB_POSE_ENGINE_PATH
+    """Path to the RTMW TensorRT pose engine."""
+
+    @property
+    def static_batch_size(self) -> int:
+        """Static batch size baked into the shipped RTMW pose engine."""
+        return RTMLIB_POSE_DEFAULT_BATCH_SIZE
+
+    @property
+    def input_size(self) -> tuple[int, int]:
+        """RTMW pose crop size as ``(width, height)`` for the shipped engine."""
+        return RTMLIB_POSE_INPUT_SIZE
+
+    @property
+    def backend(self) -> Literal["rtmlib"]:
+        """Pose backend identifier."""
+        return "rtmlib"
+
+    @property
+    def input_name(self) -> str:
+        """Fixed RTMW pose input binding name."""
+        return RTMLIB_POSE_INPUT_NAME
+
+    @property
+    def simcc_x_output_name(self) -> str:
+        """Fixed RTMW SimCC-x output binding name."""
+        return RTMLIB_POSE_SIMCC_X_OUTPUT_NAME
+
+    @property
+    def simcc_y_output_name(self) -> str:
+        """Fixed RTMW SimCC-y output binding name."""
+        return RTMLIB_POSE_SIMCC_Y_OUTPUT_NAME
+
+
+if TYPE_CHECKING:
+    PoseTensorRtConfig = SapiensTensorRtPoseConfig | RtmlibTensorRtPoseConfig
+else:
+    pose_tensor_rt_defaults = {
+        "sapiens": SapiensTensorRtPoseConfig(),
+        "rtmlib": RtmlibTensorRtPoseConfig(),
+    }
+    PoseTensorRtConfig = tyro.extras.subcommand_type_from_defaults(pose_tensor_rt_defaults, prefix_names=False)
+
+AnnotatedPoseTensorRtConfig = tyro.conf.OmitSubcommandPrefixes[PoseTensorRtConfig]
+
+
+@dataclass(frozen=True, slots=True)
+class TensorRtRuntimeConfig:
+    """Runtime batching and detector postprocessing configuration."""
+
+    detector_batch_size: int = DETECTOR_DEFAULT_BATCH_SIZE
+    """Detector frames processed per TensorRT call."""
+    pose_batch_size: int | None = None
+    """Pose crops processed per TensorRT call. If unset, uses the selected pose engine static batch."""
+    detector_score_thr: float = DETECTOR_DEFAULT_SCORE_THR
+    """YOLOX person score threshold."""
+    detector_nms_thr: float = DETECTOR_DEFAULT_NMS_THR
+    """YOLOX person NMS threshold."""
+
+    def effective_pose_batch_size(self, pose: PoseTensorRtConfig) -> int:
+        """Return the runtime pose batch after applying the backend default.
+
+        Args:
+            pose: Selected TensorRT pose backend config.
+
+        Returns:
+            Explicit runtime pose batch size or the selected pose engine static batch.
+        """
+        return pose.static_batch_size if self.pose_batch_size is None else self.pose_batch_size
+
+    def validate(self, *, detector_static_batch_size: int, pose_static_batch_size: int) -> None:
+        """Validate runtime batches against static TensorRT engine batches.
+
+        Args:
+            detector_static_batch_size: Static batch size baked into the detector engine.
+            pose_static_batch_size: Static batch size baked into the selected pose engine.
+
+        Raises:
+            ValueError: If runtime batch sizes are non-positive or exceed the static engine batches.
+        """
+        pose_batch_size: int = pose_static_batch_size if self.pose_batch_size is None else self.pose_batch_size
+        if (
+            min(self.detector_batch_size, pose_batch_size, detector_static_batch_size, pose_static_batch_size) <= 0
+            or self.detector_batch_size > detector_static_batch_size
+            or pose_batch_size > pose_static_batch_size
+        ):
+            raise ValueError("Runtime batch sizes must be positive and cannot exceed static TensorRT batches.")
+
+
+@dataclass(frozen=True, slots=True)
+class BatchedTensorRtPoseConfig:
+    """TensorRT detector plus pose backend configuration."""
+
+    detector: TensorRtDetectorConfig = field(default_factory=TensorRtDetectorConfig)
+    """Detector engine and preprocessing configuration."""
+    pose: AnnotatedPoseTensorRtConfig = field(default_factory=SapiensTensorRtPoseConfig)
+    """Pose backend configuration selected by the ``sapiens`` or ``rtmlib`` subcommand."""
+    execution_device: Literal["cuda"] = field(default="cuda", init=False)
+    """TensorRT execution device type."""
+    dtype: torch.dtype = field(default=torch.float16, init=False)
+    """TensorRT pose input dtype."""
+
+    def __post_init__(self) -> None:
+        if (
+            self.detector.static_batch_size <= 0
+            or self.pose.static_batch_size <= 0
+            or self.execution_device != "cuda"
+            or self.dtype != torch.float16
+        ):
+            raise ValueError("The batched TensorRT path requires positive static CUDA FP16 batches.")
+
+    @property
+    def device(self) -> torch.device:
+        """Backward-compatible alias for the TensorRT execution device."""
+        return torch.device(self.execution_device)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class BatchedTensorRtVideoConfig:
+    """Configuration for running batched TensorRT pose over a video."""
+
+    rr_config: RerunTyroConfig = field(default_factory=RerunTyroConfig)
+    """Rerun logging configuration."""
+    video_path: Path
+    """Input video path."""
+    detector: TensorRtDetectorConfig = field(default_factory=TensorRtDetectorConfig)
+    """Detector engine and preprocessing configuration."""
+    pose: AnnotatedPoseTensorRtConfig = field(default_factory=SapiensTensorRtPoseConfig)
+    """Pose backend configuration selected by the ``sapiens`` or ``rtmlib`` subcommand."""
+    runtime: TensorRtRuntimeConfig = field(default_factory=TensorRtRuntimeConfig)
+    """Runtime batch sizes and detector postprocessing thresholds."""
+    max_frames: int | None = None
+    """Maximum number of frames to process. If None, process the full video."""
+    keypoint_threshold: float = 0.3
+    """Confidence threshold used only for Rerun keypoint visibility."""
+    include_images: bool = False
+    """Whether returned frame artifacts should include CPU RGB images."""
+    log_video_media: bool = True
+    """Whether to log the source video media once into Rerun."""
+    show_progress: bool = True
+    """Whether to show tqdm progress over TensorRT batches."""
+
+    def __post_init__(self) -> None:
+        self.runtime.validate(
+            detector_static_batch_size=self.detector.static_batch_size,
+            pose_static_batch_size=self.pose.static_batch_size,
+        )
+
+    def to_pipeline_config(self) -> BatchedTensorRtPoseConfig:
+        """Return the detector plus pose config used to initialize TensorRT runners.
+
+        Returns:
+            TensorRT detector and pose configuration without video/logging options.
+        """
+        return BatchedTensorRtPoseConfig(detector=self.detector, pose=self.pose)
+
+
+class BatchedTensorRtVideoSummary(NamedTuple):
+    """Summary returned after running batched TensorRT video pose."""
+
+    output_path: Path | None
+    """RRD output path when the Rerun config saved one."""
+    frame_count: int
+    """Number of processed frames."""
+    person_count: int
+    """Number of detected person instances."""
+
+
+@dataclass(frozen=True, slots=True)
+class BatchedTensorRtVideoFramePredictor:
+    """Initialized CUDA decoder and TensorRT pipeline for video-frame inference."""
+
+    config: BatchedTensorRtVideoConfig
+    """Video inference configuration."""
+    decoder: CudaVideoDecoder
+    """CUDA video decoder."""
+    fps: float
+    """Video frame rate."""
+    frame_count: int
+    """Number of frames that will be processed."""
+    pipeline: "BatchedTensorRtCoco133Pipeline"
+    """Initialized batched TensorRT detector plus pose pipeline."""
+
+    def predict_frames(self) -> list[Coco133PoseFrame]:
+        """Run batched TensorRT inference over the configured video.
+
+        Returns:
+            Frame-major COCO-133 pose predictions for the configured frame range.
+        """
+        pose_batch_size: int = self.config.runtime.effective_pose_batch_size(self.config.pose)
+        batch_stride: int = max(self.config.runtime.detector_batch_size, pose_batch_size)
+        starts: Iterable[int] = range(0, self.frame_count, batch_stride)
+        if self.config.show_progress:
+            from tqdm.auto import tqdm
+
+            starts = tqdm(starts, desc=f"{self.config.pose.backend} coco133 TRT batches")
+        frames: list[Coco133PoseFrame] = []
+        for start in starts:
+            stop: int = min(start + batch_stride, self.frame_count)
+            frames_rgb: UInt8[Tensor, "batch h w 3"] = self.decoder.get_frames_in_range(start, stop).data.contiguous()
+            if frames_rgb.dtype != TORCH_UINT8:
+                raise TypeError(f"Expected TorchCodec uint8 frames, got {frames_rgb.dtype}.")
+            timestamps_ns: Int[ndarray, "batch"] = (
+                np.arange(start, stop, dtype=np.float64) / self.fps * 1_000_000_000
+            ).astype(np.int64)
+            frames.extend(
+                self.pipeline.predict_batch_rgb_tensor(
+                    frames_rgb,
+                    frame_start_index=start,
+                    timestamps_ns=timestamps_ns,
+                    detector_batch_size=self.config.runtime.detector_batch_size,
+                    pose_batch_size=pose_batch_size,
+                    score_thr=self.config.runtime.detector_score_thr,
+                    nms_thr=self.config.runtime.detector_nms_thr,
+                    include_images=self.config.include_images,
+                )
+            )
+        return frames
+
+
+class BatchedTensorRtCoco133Pipeline:
+    """Batched CUDA/TensorRT person detection plus switchable COCO-133 pose."""
+
+    def __init__(
+        self,
+        config: BatchedTensorRtPoseConfig,
+        *,
+        detector_runner_factory: Callable[..., DetectorRunner] | None = None,
+        pose_runner_factory: Callable[..., PoseRunner] | None = None,
+    ) -> None:
+        """Initialize detector and pose TensorRT runners.
+
+        Args:
+            config: TensorRT detector and pose backend configuration.
+            detector_runner_factory: Optional detector runner factory used by tests.
+            pose_runner_factory: Optional pose runner factory used by tests.
+        """
+        self.config: BatchedTensorRtPoseConfig = config
+        detector_config: TensorRtDetectorConfig = config.detector
+        detector_factory: Callable[..., DetectorRunner] = detector_runner_factory or TensorRtYoloxDetectorRunner
+        self.detector: DetectorRunner = detector_factory(
+            detector_config.engine_path,
+            input_name=detector_config.input_name,
+            output_name=detector_config.output_name,
+            score_output_name=detector_config.score_output_name,
+            extra_output_names=detector_config.extra_output_names,
+            max_detections=detector_config.max_detections,
+            model_input_size=detector_config.input_size,
+            static_batch_size=detector_config.static_batch_size,
+        )
+        pose_factory: Callable[..., PoseRunner]
+        if isinstance(config.pose, RtmlibTensorRtPoseConfig):
+            pose_config: RtmlibTensorRtPoseConfig = config.pose
+            pose_factory = pose_runner_factory or TensorRtRtmlibPoseRunner
+            self.pose: PoseRunner = pose_factory(
+                pose_config.engine_path,
+                input_name=pose_config.input_name,
+                simcc_x_output_name=pose_config.simcc_x_output_name,
+                simcc_y_output_name=pose_config.simcc_y_output_name,
+                model_input_size=pose_config.input_size,
+                static_batch_size=pose_config.static_batch_size,
+            )
+        else:
+            sapiens_pose_config: SapiensTensorRtPoseConfig = config.pose
+            pose_factory = pose_runner_factory or TensorRtSapiensPoseRunner
+            self.pose = pose_factory(
+                sapiens_pose_config.engine_path,
+                input_name=sapiens_pose_config.input_name,
+                output_name=sapiens_pose_config.output_name,
+                static_batch_size=sapiens_pose_config.static_batch_size,
+            )
+
+    @torch.no_grad()
+    def predict_batch_rgb_tensor(
+        self,
+        frames_rgb: UInt8[Tensor, "batch h w 3"],
+        *,
+        frame_start_index: int = 0,
+        timestamps_ns: Int[ndarray, "batch"] | None = None,
+        detector_batch_size: int | None = None,
+        pose_batch_size: int | None = None,
+        score_thr: float = DETECTOR_DEFAULT_SCORE_THR,
+        nms_thr: float = DETECTOR_DEFAULT_NMS_THR,
+        include_images: bool = False,
+    ) -> list[Coco133PoseFrame]:
+        """Run batched person detection and pose estimation on CUDA RGB frames.
+
+        Args:
+            frames_rgb: CUDA uint8 RGB frames with shape ``(batch, height, width, 3)``.
+            frame_start_index: Global frame index for ``frames_rgb[0]``.
+            timestamps_ns: Optional per-frame timestamps in nanoseconds.
+            detector_batch_size: Optional detector runtime batch size.
+            pose_batch_size: Optional pose runtime batch size.
+            score_thr: YOLOX person score threshold.
+            nms_thr: YOLOX person NMS threshold.
+            include_images: Whether output frame records should include CPU RGB images.
+
+        Returns:
+            Frame-major COCO-133 pose predictions.
+
+        Raises:
+            ValueError: If inputs are not CUDA uint8 RGB frames or runtime batches exceed static engine batches.
+        """
+        if frames_rgb.device.type != self.config.execution_device or frames_rgb.dtype != TORCH_UINT8:
+            raise ValueError("Batched TensorRT pipeline expects CUDA uint8 RGB frames.")
+        det_bs: int = detector_batch_size or self.config.detector.static_batch_size
+        pose_bs: int = pose_batch_size or self.config.pose.static_batch_size
+        num_frames: int = int(frames_rgb.shape[0])
+        if (
+            det_bs <= 0
+            or pose_bs <= 0
+            or det_bs > self.config.detector.static_batch_size
+            or pose_bs > self.config.pose.static_batch_size
+        ):
+            raise ValueError("Runtime batch sizes must be positive and cannot exceed static batches.")
+
+        per_frame_boxes: list[Float[Tensor, "n 4"]] = []
+        for start in range(0, num_frames, det_bs):
+            stop: int = min(start + det_bs, num_frames)
+            inputs, ratios = preprocess_yolox_detector_torch(
+                frames_rgb[start:stop],
+                model_input_size=self.config.detector.input_size,
+            )
+            per_frame_boxes.extend(
+                postprocess_yolox_outputs_torch(
+                    self.detector(inputs),
+                    resize_ratios=ratios,
+                    model_input_size=self.config.detector.input_size,
+                    score_thr=score_thr,
+                    nms_thr=nms_thr,
+                )
+            )
+
+        person_counts: list[int] = []
+        frame_rows: list[Int[Tensor, "n"]] = []
+        bbox_rows: list[Float[Tensor, "n 4"]] = []
+        for idx, boxes in enumerate(per_frame_boxes):
+            count: int = int(boxes.shape[0])
+            person_counts.append(count)
+            if count:
+                frame_rows.append(torch.full((count,), idx, dtype=torch.long, device=frames_rgb.device))
+                bbox_rows.append(boxes.to(device=frames_rgb.device, dtype=torch.float32))
+        if not bbox_rows:
+            return [
+                _empty_pose_frame(
+                    frames_rgb,
+                    local_frame_idx=idx,
+                    global_frame_idx=frame_start_index + idx,
+                    timestamps_ns=timestamps_ns,
+                    include_images=include_images,
+                )
+                for idx in range(num_frames)
+            ]
+
+        frame_indices: Int[Tensor, "n_persons"] = torch.cat(frame_rows).long()
+        bboxes: Float[Tensor, "n_persons 4"] = torch.cat(bbox_rows).float()
+        if isinstance(self.config.pose, RtmlibTensorRtPoseConfig):
+            keypoints, scores = self._predict_rtmlib_pose(
+                frames_rgb,
+                frame_indices=frame_indices,
+                bboxes=bboxes,
+                pose_batch_size=pose_bs,
+            )
+        else:
+            keypoints, scores = self._predict_sapiens_pose(
+                frames_rgb,
+                frame_indices=frame_indices,
+                bboxes=bboxes,
+                pose_batch_size=pose_bs,
+                pose_config=self.config.pose,
+            )
+        return _ordered_pose_rows_to_frames(
+            frames_rgb,
+            frame_start_index=frame_start_index,
+            timestamps_ns=timestamps_ns,
+            person_counts=person_counts,
+            bboxes=bboxes.detach().cpu().numpy().astype(np.float32, copy=False),
+            keypoints=keypoints,
+            scores=scores,
+            include_images=include_images,
+        )
+
+    def _predict_rtmlib_pose(
+        self,
+        frames_rgb: UInt8[Tensor, "batch h w 3"],
+        *,
+        frame_indices: Int[Tensor, "n_persons"],
+        bboxes: Float[Tensor, "n_persons 4"],
+        pose_batch_size: int,
+    ) -> tuple[Float32[ndarray, "n_persons 133 2"], Float32[ndarray, "n_persons 133"]]:
+        """Run RTMLib TensorRT pose inference for detected people.
+
+        Args:
+            frames_rgb: CUDA uint8 RGB frames with shape ``(batch, height, width, 3)``.
+            frame_indices: Source frame index for each detected person.
+            bboxes: Person boxes in image-space ``xyxy`` order.
+            pose_batch_size: Runtime pose batch size.
+
+        Returns:
+            Image-space COCO-133 keypoints and confidence scores.
+
+        Raises:
+            TypeError: If the pipeline was not configured with the RTMLib backend.
+        """
+        if not isinstance(self.config.pose, RtmlibTensorRtPoseConfig):
+            raise TypeError("RTMLib pose prediction requires an RTMLib pose config.")
+        pose_config: RtmlibTensorRtPoseConfig = self.config.pose
+        rtmlib_pose_batch: RtmlibPoseInputBatch = prepare_rtmlib_pose_inputs_torch(
+            frames_rgb,
+            frame_indices=frame_indices,
+            bboxes_xyxy=bboxes,
+            input_size=pose_config.input_size,
+            dtype=self.config.dtype,
+        )
+        simcc_x_rows: list[Tensor] = []
+        simcc_y_rows: list[Tensor] = []
+        for start in range(0, int(rtmlib_pose_batch.inputs.shape[0]), pose_batch_size):
+            stop: int = min(start + pose_batch_size, int(rtmlib_pose_batch.inputs.shape[0]))
+            simcc_outputs: tuple[Tensor, ...] = self.pose(rtmlib_pose_batch.inputs[start:stop])
+            simcc_x_rows.append(simcc_outputs[0])
+            simcc_y_rows.append(simcc_outputs[1])
+        return decode_rtmlib_simcc_to_coco133_torch(
+            torch.cat(simcc_x_rows, dim=0),
+            torch.cat(simcc_y_rows, dim=0),
+            rtmlib_pose_batch,
+        )
+
+    def _predict_sapiens_pose(
+        self,
+        frames_rgb: UInt8[Tensor, "batch h w 3"],
+        *,
+        frame_indices: Int[Tensor, "n_persons"],
+        bboxes: Float[Tensor, "n_persons 4"],
+        pose_batch_size: int,
+        pose_config: SapiensTensorRtPoseConfig,
+    ) -> tuple[Float32[ndarray, "n_persons 133 2"], Float32[ndarray, "n_persons 133"]]:
+        """Run Sapiens TensorRT pose inference for detected people.
+
+        Args:
+            frames_rgb: CUDA uint8 RGB frames with shape ``(batch, height, width, 3)``.
+            frame_indices: Source frame index for each detected person.
+            bboxes: Person boxes in image-space ``xyxy`` order.
+            pose_batch_size: Runtime pose batch size.
+            pose_config: Sapiens TensorRT pose backend configuration.
+
+        Returns:
+            Image-space COCO-133 keypoints and confidence scores.
+        """
+        pose_batch: SapiensPoseInputBatch = prepare_sapiens_pose_inputs_torch(
+            frames_rgb,
+            frame_indices=frame_indices,
+            bboxes_xyxy=bboxes,
+            dtype=self.config.dtype,
+        )
+        heatmaps: Tensor = torch.cat(
+            [
+                self.pose(pose_batch.inputs[start : min(start + pose_batch_size, int(pose_batch.inputs.shape[0]))])[0]
+                for start in range(0, int(pose_batch.inputs.shape[0]), pose_batch_size)
+            ],
+            dim=0,
+        )
+        return decode_sapiens_heatmaps_to_coco133_torch(heatmaps, pose_batch, model_size=pose_config.model_size)
+
+
+def create_batched_tensorrt_video_frame_predictor(
+    config: BatchedTensorRtVideoConfig,
+) -> BatchedTensorRtVideoFramePredictor:
+    """Initialize CUDA decoder and TensorRT engines outside timed inference loops.
+
+    Args:
+        config: Batched TensorRT video configuration.
+
+    Returns:
+        Initialized predictor with CUDA decoder, video metadata, and TensorRT pipeline.
+
+    Raises:
+        ValueError: If valid frame count or FPS metadata cannot be read from the video.
+    """
+    from torchcodec.decoders import VideoDecoder
+
+    decoder: CudaVideoDecoder = VideoDecoder(config.video_path, dimension_order="NHWC", device="cuda")
+    frame_count_raw: SupportsInt | None = decoder.metadata.num_frames
+    fps_raw: SupportsFloat | None = decoder.metadata.average_fps
+    if frame_count_raw is None or fps_raw is None or float(fps_raw) <= 0.0 or int(frame_count_raw) < 0:
+        raise ValueError(f"Could not read valid video metadata from {config.video_path}.")
+    return BatchedTensorRtVideoFramePredictor(
+        config,
+        decoder,
+        float(fps_raw),
+        int(frame_count_raw) if config.max_frames is None else min(int(frame_count_raw), int(config.max_frames)),
+        BatchedTensorRtCoco133Pipeline(config.to_pipeline_config()),
+    )
+
+
+def run_batched_tensorrt_video_coco133(config: BatchedTensorRtVideoConfig) -> BatchedTensorRtVideoSummary:
+    """Run the optimized CUDA/TensorRT video path and log through ``RerunTyroConfig``.
+
+    Args:
+        config: Batched TensorRT video configuration.
+
+    Returns:
+        Output RRD path, processed frame count, and detected person count.
+    """
+    frames: list[Coco133PoseFrame] = create_batched_tensorrt_video_frame_predictor(config).predict_frames()
+    log_video_pose_frames(
+        frames,
+        keypoint_threshold=config.keypoint_threshold,
+        recording=config.rr_config.rec_stream,
+        video_path=config.video_path if config.log_video_media else None,
+    )
+    return BatchedTensorRtVideoSummary(
+        config.rr_config.save,
+        len(frames),
+        sum(int(frame.bboxes.shape[0]) for frame in frames),
+    )
+
+
+def _ordered_pose_rows_to_frames(
+    frames_rgb: UInt8[Tensor, "batch h w 3"],
+    *,
+    frame_start_index: int,
+    timestamps_ns: Int[ndarray, "batch"] | None,
+    person_counts: list[int],
+    bboxes: Float32[ndarray, "n_persons 4"],
+    keypoints: Float32[ndarray, "n_persons 133 2"],
+    scores: Float32[ndarray, "n_persons 133"],
+    include_images: bool,
+) -> list[Coco133PoseFrame]:
+    frames: list[Coco133PoseFrame] = []
+    row_start: int = 0
+    for local_idx, count in enumerate(person_counts):
+        row_stop: int = row_start + int(count)
+        image: UInt8[ndarray, "h w 3"] | None = (
+            frames_rgb[local_idx].detach().cpu().numpy().astype(np.uint8, copy=False) if include_images else None
+        )
+        frames.append(
+            Coco133PoseFrame(
+                frame_start_index + local_idx,
+                0 if timestamps_ns is None else int(timestamps_ns[local_idx]),
+                image,
+                bboxes[row_start:row_stop].astype(np.float32, copy=False).reshape(-1, 4),
+                keypoints[row_start:row_stop].astype(np.float32, copy=False).reshape(-1, 133, 2),
+                scores[row_start:row_stop].astype(np.float32, copy=False).reshape(-1, 133),
+            )
+        )
+        row_start = row_stop
+    return frames
+
+
+def _empty_pose_frame(
+    frames_rgb: UInt8[Tensor, "batch h w 3"],
+    *,
+    local_frame_idx: int,
+    global_frame_idx: int,
+    timestamps_ns: Int[ndarray, "batch"] | None,
+    include_images: bool,
+) -> Coco133PoseFrame:
+    image: UInt8[ndarray, "h w 3"] | None = (
+        frames_rgb[local_frame_idx].detach().cpu().numpy().astype(np.uint8, copy=False) if include_images else None
+    )
+    return Coco133PoseFrame(
+        global_frame_idx,
+        0 if timestamps_ns is None else int(timestamps_ns[local_frame_idx]),
+        image,
+        np.empty((0, 4), np.float32),
+        np.empty((0, 133, 2), np.float32),
+        np.empty((0, 133), np.float32),
+    )

--- a/packages/sapiens-coco133-pose/src/sapiens_coco133_pose/api/benchmark.py
+++ b/packages/sapiens-coco133-pose/src/sapiens_coco133_pose/api/benchmark.py
@@ -1,0 +1,188 @@
+"""Benchmark iterable PyTorch and batched TensorRT COCO-133 pose pipelines."""
+# ruff: noqa: I001
+
+import gc
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import NamedTuple
+
+import torch
+from sapiens2_pose.api.pose_artifact import PoseArtifactComparisonConfig, PoseArtifactComparisonMetrics
+from simplecv.rerun_log_utils import RerunTyroConfig
+
+from sapiens_coco133_pose.api.artifact import Coco133PoseFrame, compare_video_pose_rrds, write_video_pose_rrd
+from sapiens_coco133_pose.api.batched_tensorrt import (
+    AnnotatedPoseTensorRtConfig,
+    BatchedTensorRtVideoConfig,
+    BatchedTensorRtVideoSummary,
+    SapiensTensorRtPoseConfig,
+    TensorRtDetectorConfig,
+    TensorRtRuntimeConfig,
+    create_batched_tensorrt_video_frame_predictor,
+)
+from sapiens_coco133_pose.api.iterable import IterableVideoPoseConfig, IterableVideoPoseSummary, iter_video_pose_coco133
+
+
+@dataclass(frozen=True, slots=True)
+class PoseBenchmarkConfig:
+    """Configuration for benchmarking iterable versus batched TensorRT pose."""
+
+    video_path: Path
+    """Input video path."""
+    detector: TensorRtDetectorConfig = field(default_factory=TensorRtDetectorConfig)
+    """TensorRT detector engine configuration."""
+    pose: AnnotatedPoseTensorRtConfig = field(default_factory=SapiensTensorRtPoseConfig)
+    """TensorRT pose backend configuration selected by Tyro subcommand."""
+    runtime: TensorRtRuntimeConfig = field(default_factory=TensorRtRuntimeConfig)
+    """Runtime batch sizes and detector postprocessing thresholds."""
+    output_dir: Path = Path("/tmp/sapiens-coco133-benchmark")
+    """Directory where iterable and batched RRD artifacts are written."""
+    max_frames: int | None = 100
+    """Maximum number of frames to benchmark. If None, benchmark the full video."""
+    keypoint_threshold: float = 0.3
+    """Confidence threshold used for visible keypoints during RRD comparison."""
+    required_speedup: float = 10.0
+    """Minimum required batched TensorRT speedup over the iterable path."""
+    max_relative_difference: float = 10.0
+    """Maximum allowed relative numeric difference for RRD comparison."""
+    max_keypoint_bbox_fraction: float = 0.06
+    """Maximum allowed keypoint difference as a fraction of bbox size."""
+
+
+class PoseBenchmarkSummary(NamedTuple):
+    """Summary returned after benchmarking iterable and batched TensorRT pose paths."""
+
+    iterable_summary: IterableVideoPoseSummary
+    """Iterable path artifact summary."""
+    batched_summary: BatchedTensorRtVideoSummary
+    """Batched TensorRT path artifact summary."""
+    iterable_seconds: float
+    """Timed iterable inference seconds."""
+    batched_seconds: float
+    """Timed batched TensorRT inference seconds."""
+    iterable_fps: float
+    """Iterable inference frames per second."""
+    batched_fps: float
+    """Batched TensorRT inference frames per second."""
+    speedup: float
+    """Batched FPS divided by iterable FPS."""
+    passes_speed_target: bool
+    """Whether ``speedup`` met ``required_speedup``."""
+    comparison_metrics: PoseArtifactComparisonMetrics
+    """RRD comparison metrics between iterable and batched artifacts."""
+
+
+class BenchmarkArtifactCounts(NamedTuple):
+    """Counts returned after writing an RRD benchmark artifact."""
+
+    frame_count: int
+    """Number of frames written to the artifact."""
+    person_count: int
+    """Number of person rows written to the artifact."""
+
+
+def run_pose_benchmark(config: PoseBenchmarkConfig) -> PoseBenchmarkSummary:
+    """Benchmark iterable and batched TensorRT COCO-133 pose inference.
+
+    Args:
+        config: Benchmark input video, TensorRT configs, runtime settings, and accuracy/speed thresholds.
+
+    Returns:
+        Inference timings, FPS values, speedup status, artifact summaries, and RRD comparison metrics.
+    """
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    artifact_prefix = "" if config.pose.backend == "sapiens" else f"{config.pose.backend}_"
+    iterable_rrd_path = config.output_dir / f"{artifact_prefix}iterable_golden.rrd"
+    batched_rrd_path = config.output_dir / f"{artifact_prefix}batched_tensorrt.rrd"
+    iterable_config = IterableVideoPoseConfig(
+        video_path=config.video_path,
+        rrd_path=iterable_rrd_path,
+        max_frames=config.max_frames,
+        pose_backend=config.pose.backend,
+        keypoint_threshold=config.keypoint_threshold,
+        log_images=False,
+    )
+    batched_config = BatchedTensorRtVideoConfig(
+        rr_config=RerunTyroConfig(application_id="sapiens_coco133_pose_benchmark", headless=True),
+        video_path=config.video_path,
+        detector=config.detector,
+        pose=config.pose,
+        runtime=config.runtime,
+        max_frames=config.max_frames,
+        keypoint_threshold=config.keypoint_threshold,
+    )
+    _synchronize_cuda()
+    start = time.perf_counter()
+    iterable_frames = list(iter_video_pose_coco133(iterable_config))
+    _synchronize_cuda()
+    iterable_seconds = time.perf_counter() - start
+    if not iterable_frames:
+        raise ValueError("Iterable benchmark produced no frames; cannot compute FPS or compare artifacts.")
+    iterable_counts = _write_benchmark_artifacts(iterable_frames, rrd_path=iterable_rrd_path, keypoint_threshold=config.keypoint_threshold)
+    iterable_summary = IterableVideoPoseSummary(iterable_rrd_path, iterable_counts.frame_count, iterable_counts.person_count)
+    _release_iterable_gpu_caches()
+    predictor = create_batched_tensorrt_video_frame_predictor(batched_config)
+    _synchronize_cuda()
+    start = time.perf_counter()
+    batched_frames = predictor.predict_frames()
+    _synchronize_cuda()
+    batched_seconds = time.perf_counter() - start
+    if not batched_frames:
+        raise ValueError("Batched TensorRT benchmark produced no frames; cannot compute FPS or compare artifacts.")
+    batched_counts = _write_benchmark_artifacts(batched_frames, rrd_path=batched_rrd_path, keypoint_threshold=config.keypoint_threshold)
+    batched_summary = BatchedTensorRtVideoSummary(batched_rrd_path, batched_counts.frame_count, batched_counts.person_count)
+    comparison = compare_video_pose_rrds(
+        iterable_rrd_path,
+        batched_rrd_path,
+        PoseArtifactComparisonConfig(
+            config.max_relative_difference,
+            keypoint_score_threshold=config.keypoint_threshold,
+            max_keypoint_bbox_fraction=config.max_keypoint_bbox_fraction,
+        ),
+    )
+    frame_count = iterable_summary.frame_count
+    iterable_fps, batched_fps = frame_count / max(iterable_seconds, 1e-9), frame_count / max(batched_seconds, 1e-9)
+    speedup = batched_fps / max(iterable_fps, 1e-9)
+    return PoseBenchmarkSummary(
+        iterable_summary,
+        batched_summary,
+        iterable_seconds,
+        batched_seconds,
+        iterable_fps,
+        batched_fps,
+        speedup,
+        speedup >= config.required_speedup,
+        comparison,
+    )
+
+
+def _write_benchmark_artifacts(frames: list[Coco133PoseFrame], *, rrd_path: Path, keypoint_threshold: float) -> BenchmarkArtifactCounts:
+    """Write benchmark RRD outside timed inference.
+
+    Args:
+        frames: Pose frames to serialize.
+        rrd_path: Destination RRD path.
+        keypoint_threshold: Confidence threshold used for visible keypoints.
+
+    Returns:
+        Frame and person counts written to the RRD.
+    """
+    write_video_pose_rrd(frames, rrd_path=rrd_path, keypoint_threshold=keypoint_threshold)
+    return BenchmarkArtifactCounts(len(frames), sum(int(frame.bboxes.shape[0]) for frame in frames))
+
+
+def _synchronize_cuda() -> None:
+    """Synchronize CUDA if available so timing includes queued GPU work."""
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+def _release_iterable_gpu_caches() -> None:
+    """Release cached PyTorch baseline models before constructing TensorRT engines."""
+    import sapiens2_pose.api.runtime as sapiens_runtime
+
+    sapiens_runtime.clear_pose_model_cache()
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()

--- a/packages/sapiens-coco133-pose/src/sapiens_coco133_pose/api/iterable.py
+++ b/packages/sapiens-coco133-pose/src/sapiens_coco133_pose/api/iterable.py
@@ -1,0 +1,405 @@
+"""Iterable PyTorch Sapiens COCO-133 pose pipeline."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Iterator
+from dataclasses import dataclass
+from functools import cache
+from pathlib import Path
+from typing import Literal, NamedTuple, Protocol, runtime_checkable
+
+import numpy as np
+from jaxtyping import Float32, UInt8
+from numpy import ndarray
+from sapiens2_pose.api.metadata import project_instances_to_schema
+from sapiens2_pose.api.runtime import (
+    DEFAULT_MODEL_SIZE,
+    DeviceChoice,
+    ModelSize,
+    PoseEstimation,
+    estimate_frame_pose_from_bboxes,
+)
+
+from sapiens_coco133_pose.api.artifact import Coco133PoseFrame, write_video_pose_rrd
+
+TrackerMode = Literal["lightweight", "balanced", "performance", "wholebody"]
+PoseBackend = Literal["sapiens", "rtmlib"]
+RtmlibBackend = Literal["onnxruntime", "opencv"]
+RtmlibDevice = Literal["cpu", "cuda"]
+DEFAULT_ITERABLE_RRD_PATH = Path("/tmp/sapiens_coco133/iterable_golden.rrd")
+DetectPersonsFn = Callable[[UInt8[ndarray, "h w 3"]], Float32[ndarray, "n 4"]]
+
+
+@runtime_checkable
+class NativePoseEstimatorFn(Protocol):
+    """Callable interface for native Sapiens pose estimation from precomputed boxes."""
+
+    def __call__(
+        self,
+        image_rgb: UInt8[ndarray, "h w 3"],
+        bboxes: Float32[ndarray, "n 4"],
+        *,
+        model_size: ModelSize = DEFAULT_MODEL_SIZE,
+        device: DeviceChoice = "cuda",
+    ) -> PoseEstimation:
+        """Estimate native Sapiens keypoints for one RGB image and its person boxes."""
+
+
+@runtime_checkable
+class RtmlibPoseEstimatorFn(Protocol):
+    """Callable interface for RTMLib COCO-133 pose estimation from precomputed boxes."""
+
+    def __call__(
+        self,
+        image_rgb: UInt8[ndarray, "h w 3"],
+        bboxes: Float32[ndarray, "n 4"],
+    ) -> tuple[Float32[ndarray, "n 133 2"], Float32[ndarray, "n 133"]]:
+        """Estimate COCO-133 keypoints for one RGB image and its person boxes."""
+
+
+@dataclass(frozen=True, slots=True)
+class RtmlibYoloxDetectorConfig:
+    """Configuration for the RTMLib YOLOX person detector used by MV-API."""
+
+    mode: TrackerMode = "wholebody"
+    """MV-API detector preset name."""
+    backend: RtmlibBackend = "onnxruntime"
+    """RTMLib inference backend."""
+    device: RtmlibDevice = "cuda"
+    """Device used by the detector backend."""
+    nms_thr: float = 0.45
+    """YOLOX non-maximum suppression threshold."""
+    score_thr: float = 0.7
+    """Minimum YOLOX person confidence score."""
+
+
+@dataclass(frozen=True, slots=True)
+class RtmlibPoseEstimatorConfig:
+    """Configuration for MV-API's RTMLib COCO-133 pose estimator."""
+
+    mode: TrackerMode = "wholebody"
+    """MV-API pose preset name."""
+    backend: RtmlibBackend = "onnxruntime"
+    """RTMLib inference backend."""
+    device: RtmlibDevice = "cuda"
+    """Device used by the pose backend."""
+
+
+@dataclass(frozen=True, slots=True)
+class IterableVideoPoseConfig:
+    """Configuration for the non-batched golden-artifact video path."""
+
+    video_path: Path
+    """Input video path."""
+    rrd_path: Path = DEFAULT_ITERABLE_RRD_PATH
+    """Output RRD path for the golden artifact."""
+    max_frames: int | None = None
+    """Maximum number of frames to process. If None, process the full video."""
+    model_size: ModelSize = DEFAULT_MODEL_SIZE
+    """Sapiens pose model size used by the native Sapiens backend."""
+    detector_mode: TrackerMode = "wholebody"
+    """MV-API detector preset used for person boxes."""
+    detector_backend: RtmlibBackend = "onnxruntime"
+    """RTMLib backend used by the detector."""
+    detector_device: RtmlibDevice = "cuda"
+    """Device used by RTMLib detector inference."""
+    rtmlib_pose_mode: TrackerMode = "wholebody"
+    """MV-API pose preset used when ``pose_backend`` is ``"rtmlib"``."""
+    rtmlib_pose_backend: RtmlibBackend = "onnxruntime"
+    """RTMLib backend used when ``pose_backend`` is ``"rtmlib"``."""
+    rtmlib_pose_device: RtmlibDevice = "cuda"
+    """Device used when ``pose_backend`` is ``"rtmlib"``."""
+    pose_device: DeviceChoice = "cuda"
+    """Device used by the native Sapiens pose estimator."""
+    pose_backend: PoseBackend = "sapiens"
+    """Pose backend run after person detection."""
+    keypoint_threshold: float = 0.3
+    """Confidence threshold used only for Rerun keypoint visibility."""
+    log_images: bool = True
+    """Whether to log RGB images into the output RRD."""
+    show_progress: bool = True
+    """Whether to show tqdm progress over video frames."""
+
+
+class IterableVideoPoseSummary(NamedTuple):
+    """Summary returned after running the iterable video pose path."""
+
+    rrd_path: Path
+    """Written RRD path."""
+    frame_count: int
+    """Number of processed video frames."""
+    person_count: int
+    """Number of detected person instances."""
+
+
+class RtmlibYoloxPersonDetector:
+    """Callable RGB person detector backed by MV-API's RTMLib YOLOX assets."""
+
+    def __init__(self, config: RtmlibYoloxDetectorConfig) -> None:
+        """Initialize the RTMLib YOLOX detector.
+
+        Args:
+            config: RTMLib detector backend, device, preset, and thresholds.
+        """
+        from mv_api.multiview_pose_estimator import MODE
+        from rtmlib import YOLOX
+
+        assets = MODE[config.mode]
+        self._model = YOLOX(
+            assets.det,
+            model_input_size=assets.det_input_size,
+            nms_thr=config.nms_thr,
+            score_thr=config.score_thr,
+            backend=config.backend,
+            device=config.device,
+        )
+
+    def __call__(self, image_rgb: UInt8[ndarray, "h w 3"]) -> Float32[ndarray, "n 4"]:
+        """Detect person boxes in one RGB image.
+
+        Args:
+            image_rgb: RGB image with shape ``(height, width, 3)``.
+
+        Returns:
+            Person bounding boxes in image-space ``xyxy`` order.
+        """
+        det_output = self._model(np.ascontiguousarray(image_rgb[..., ::-1], dtype=np.uint8))
+        raw = np.asarray(det_output[0] if isinstance(det_output, tuple) else det_output, dtype=np.float32)
+        return (
+            np.empty((0, 4), dtype=np.float32)
+            if raw.size == 0
+            else np.ascontiguousarray(raw.reshape(-1, raw.shape[-1])[:, :4], dtype=np.float32)
+        )
+
+
+class RtmlibCoco133PoseEstimator:
+    """Callable RGB pose estimator backed by MV-API's RTMLib wholebody assets."""
+
+    def __init__(self, config: RtmlibPoseEstimatorConfig) -> None:
+        """Initialize the RTMLib COCO-133 pose estimator.
+
+        Args:
+            config: RTMLib pose backend, device, and preset.
+        """
+        from mv_api.multiview_pose_estimator import MODE
+        from rtmlib import RTMPose
+
+        assets = MODE[config.mode]
+        self._model = RTMPose(
+            assets.pose,
+            model_input_size=assets.pose_input_size,
+            to_openpose=False,
+            backend=config.backend,
+            device=config.device,
+        )
+
+    def __call__(
+        self, image_rgb: UInt8[ndarray, "h w 3"], bboxes: Float32[ndarray, "n 4"]
+    ) -> tuple[Float32[ndarray, "n 133 2"], Float32[ndarray, "n 133"]]:
+        """Estimate COCO-133 keypoints for detected people.
+
+        Args:
+            image_rgb: RGB image with shape ``(height, width, 3)``.
+            bboxes: Person bounding boxes in image-space ``xyxy`` order.
+
+        Returns:
+            A tuple containing image-space keypoints with shape ``(n, 133, 2)`` and confidence scores with shape
+            ``(n, 133)``.
+        """
+        bboxes_np: Float32[ndarray, "n 4"] = np.asarray(bboxes, dtype=np.float32).reshape(-1, 4)
+        if bboxes_np.shape[0] == 0:
+            return np.empty((0, 133, 2), dtype=np.float32), np.empty((0, 133), dtype=np.float32)
+        keypoints, scores = self._model(
+            np.ascontiguousarray(image_rgb[..., ::-1], dtype=np.uint8), bboxes=bboxes_np.tolist()
+        )
+        return np.asarray(keypoints, dtype=np.float32).reshape(-1, 133, 2), np.asarray(
+            scores, dtype=np.float32
+        ).reshape(-1, 133)
+
+
+@cache
+def _cached_rtmlib_detector(config: RtmlibYoloxDetectorConfig) -> RtmlibYoloxPersonDetector:
+    """Return a cached default RTMLib detector for direct frame-level calls."""
+    return RtmlibYoloxPersonDetector(config)
+
+
+@cache
+def _cached_rtmlib_pose_estimator(config: RtmlibPoseEstimatorConfig) -> RtmlibCoco133PoseEstimator:
+    """Return a cached default RTMLib pose estimator for direct frame-level calls."""
+    return RtmlibCoco133PoseEstimator(config)
+
+
+def estimate_frame_pose_coco133(
+    image_rgb: UInt8[ndarray, "h w 3"],
+    *,
+    frame_index: int,
+    timestamp_ns: int,
+    detector: DetectPersonsFn | None = None,
+    native_pose_estimator: NativePoseEstimatorFn | None = None,
+    rtmlib_pose_estimator: RtmlibPoseEstimatorFn | None = None,
+    pose_backend: PoseBackend = "sapiens",
+    rtmlib_pose_config: RtmlibPoseEstimatorConfig | None = None,
+    model_size: ModelSize = DEFAULT_MODEL_SIZE,
+    device: DeviceChoice = "cuda",
+) -> Coco133PoseFrame:
+    """Run person detection and one pose backend for one RGB frame.
+
+    Args:
+        image_rgb: RGB image with shape ``(height, width, 3)``.
+        frame_index: Zero-based source video frame index.
+        timestamp_ns: Frame timestamp in nanoseconds.
+        detector: Optional person detector override used by tests and alternate integrations.
+        native_pose_estimator: Optional native Sapiens pose estimator override.
+        rtmlib_pose_estimator: Optional RTMLib pose estimator override.
+        pose_backend: Pose backend to run after person detection.
+        rtmlib_pose_config: RTMLib pose config used when ``pose_backend`` is ``"rtmlib"``.
+        model_size: Sapiens model size used when ``pose_backend`` is ``"sapiens"``.
+        device: Sapiens inference device used when ``pose_backend`` is ``"sapiens"``.
+
+    Returns:
+        COCO-133 pose predictions for the frame.
+    """
+    effective_detector: DetectPersonsFn = detector or _cached_rtmlib_detector(RtmlibYoloxDetectorConfig())
+    bboxes = np.asarray(
+        effective_detector(image_rgb), dtype=np.float32
+    ).reshape(-1, 4)
+    if bboxes.shape[0] == 0:
+        return Coco133PoseFrame(
+            frame_index,
+            timestamp_ns,
+            image_rgb,
+            bboxes,
+            np.empty((0, 133, 2), np.float32),
+            np.empty((0, 133), np.float32),
+        )
+    if pose_backend == "rtmlib":
+        effective_rtmlib_pose_estimator: RtmlibPoseEstimatorFn = (
+            rtmlib_pose_estimator
+            or _cached_rtmlib_pose_estimator(rtmlib_pose_config or RtmlibPoseEstimatorConfig())
+        )
+        keypoints, scores = effective_rtmlib_pose_estimator(image_rgb, bboxes)
+        return Coco133PoseFrame(
+            frame_index,
+            timestamp_ns,
+            image_rgb,
+            bboxes,
+            np.asarray(keypoints, dtype=np.float32).reshape(-1, 133, 2),
+            np.asarray(scores, dtype=np.float32).reshape(-1, 133),
+        )
+    effective_native_pose_estimator: NativePoseEstimatorFn = native_pose_estimator or estimate_frame_pose_from_bboxes
+    native = effective_native_pose_estimator(image_rgb, bboxes, model_size=model_size, device=device)
+    keypoints, scores = project_instances_to_schema(native.keypoints, native.scores, "coco133")
+    return Coco133PoseFrame(
+        frame_index,
+        timestamp_ns,
+        image_rgb,
+        np.asarray(native.bboxes, dtype=np.float32).reshape(-1, 4),
+        np.stack(keypoints).astype(np.float32, copy=False),
+        np.stack(scores).astype(np.float32, copy=False),
+    )
+
+
+def iter_video_pose_coco133(
+    config: IterableVideoPoseConfig,
+    *,
+    detector: DetectPersonsFn | None = None,
+    native_pose_estimator: NativePoseEstimatorFn | None = None,
+    rtmlib_pose_estimator: RtmlibPoseEstimatorFn | None = None,
+) -> Iterator[Coco133PoseFrame]:
+    """Yield non-batched COCO-133 pose predictions for a video.
+
+    Args:
+        config: Video path, output controls, detector settings, and pose backend settings.
+        detector: Optional person detector override.
+        native_pose_estimator: Optional native Sapiens pose estimator override.
+        rtmlib_pose_estimator: Optional RTMLib pose estimator override.
+
+    Yields:
+        Per-frame COCO-133 pose predictions.
+
+    Raises:
+        ValueError: If valid frame count or FPS metadata cannot be read from the video.
+    """
+    from torchcodec.decoders import VideoDecoder
+
+    effective_detector = detector or RtmlibYoloxPersonDetector(
+        RtmlibYoloxDetectorConfig(config.detector_mode, config.detector_backend, config.detector_device)
+    )
+    effective_rtmlib_pose_estimator: RtmlibPoseEstimatorFn | None = rtmlib_pose_estimator
+    rtmlib_pose_config = RtmlibPoseEstimatorConfig(
+        config.rtmlib_pose_mode,
+        config.rtmlib_pose_backend,
+        config.rtmlib_pose_device,
+    )
+    if effective_rtmlib_pose_estimator is None and config.pose_backend == "rtmlib":
+        effective_rtmlib_pose_estimator = RtmlibCoco133PoseEstimator(
+            rtmlib_pose_config
+        )
+    decoder = VideoDecoder(config.video_path, dimension_order="NHWC", device="cpu")
+    frame_count_raw, fps_raw = decoder.metadata.num_frames, decoder.metadata.average_fps
+    if frame_count_raw is None or fps_raw is None or fps_raw <= 0.0 or frame_count_raw < 0:
+        raise ValueError(f"Could not read valid video metadata from {config.video_path}.")
+    frame_count: int = frame_count_raw if config.max_frames is None else min(frame_count_raw, config.max_frames)
+    frame_indices: Iterable[int] = range(frame_count)
+    if config.show_progress:
+        from tqdm.auto import tqdm
+
+        frame_indices = tqdm(frame_indices, total=frame_count, desc=f"{config.pose_backend} coco133 iterable frames")
+    for frame_index in frame_indices:
+        image_rgb = np.asarray(
+            decoder.get_frames_in_range(frame_index, frame_index + 1).data[0].cpu().numpy(), dtype=np.uint8
+        )
+        frame = estimate_frame_pose_coco133(
+            image_rgb,
+            frame_index=frame_index,
+            timestamp_ns=round(frame_index / fps_raw * 1_000_000_000),
+            detector=effective_detector,
+            native_pose_estimator=native_pose_estimator,
+            rtmlib_pose_estimator=effective_rtmlib_pose_estimator,
+            pose_backend=config.pose_backend,
+            rtmlib_pose_config=rtmlib_pose_config,
+            model_size=config.model_size,
+            device=config.pose_device,
+        )
+        yield (
+            frame
+            if config.log_images
+            else Coco133PoseFrame(
+                frame.frame_index, frame.timestamp_ns, None, frame.bboxes, frame.keypoints, frame.scores
+            )
+        )
+
+
+def run_iterable_video_pose_coco133(
+    config: IterableVideoPoseConfig,
+    *,
+    detector: DetectPersonsFn | None = None,
+    native_pose_estimator: NativePoseEstimatorFn | None = None,
+    rtmlib_pose_estimator: RtmlibPoseEstimatorFn | None = None,
+) -> IterableVideoPoseSummary:
+    """Run the non-batched path and write a Rerun artifact.
+
+    Args:
+        config: Iterable video pose configuration.
+        detector: Optional person detector override.
+        native_pose_estimator: Optional native Sapiens pose estimator override.
+        rtmlib_pose_estimator: Optional RTMLib pose estimator override.
+
+    Returns:
+        Output RRD path and processed frame/person counts.
+    """
+    frames = list(
+        iter_video_pose_coco133(
+            config,
+            detector=detector,
+            native_pose_estimator=native_pose_estimator,
+            rtmlib_pose_estimator=rtmlib_pose_estimator,
+        )
+    )
+    write_video_pose_rrd(
+        frames,
+        rrd_path=config.rrd_path,
+        keypoint_threshold=config.keypoint_threshold,
+        video_path=config.video_path if config.log_images else None,
+    )
+    return IterableVideoPoseSummary(config.rrd_path, len(frames), sum(int(frame.bboxes.shape[0]) for frame in frames))

--- a/packages/sapiens-coco133-pose/tests/test_batched_tensorrt_preprocess.py
+++ b/packages/sapiens-coco133-pose/tests/test_batched_tensorrt_preprocess.py
@@ -1,0 +1,478 @@
+# ruff: noqa: I001
+
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import rerun as rr
+import rerun_bindings as rb
+import torch
+import tyro
+from sapiens2_pose.api.coco133_gpu import (
+    DecodedYoloxHeadOutput,
+    RtmlibPoseInputBatch,
+    SapiensPoseInputBatch,
+    _gaussian_blur_heatmaps_torch,
+    decode_rtmlib_simcc_to_coco133_torch,
+    decode_sapiens_heatmaps_to_coco133_torch,
+    postprocess_yolox_outputs_torch,
+    prepare_rtmlib_pose_inputs_torch,
+    prepare_sapiens_pose_inputs_torch,
+    preprocess_yolox_detector_torch,
+)
+from sapiens2_pose.api.metadata import get_sapiens_metainfo
+from simplecv.rerun_log_utils import RerunTyroConfig
+
+from sapiens_coco133_pose.api import batched_tensorrt as batched_module
+from sapiens_coco133_pose.api.artifact import POINTS_CONFIDENCE_COMPONENT, Coco133PoseFrame
+from sapiens_coco133_pose.api.batched_tensorrt import (
+    BatchedTensorRtCoco133Pipeline,
+    BatchedTensorRtPoseConfig,
+    BatchedTensorRtVideoConfig,
+    RtmlibTensorRtPoseConfig,
+    SapiensTensorRtPoseConfig,
+    TensorRtDetectorConfig,
+    run_batched_tensorrt_video_coco133,
+)
+
+
+def _headless_rr_config() -> RerunTyroConfig:
+    return RerunTyroConfig(application_id="sapiens_coco133_pose_test", headless=True)
+
+
+def test_preprocess_yolox_detector_torch_matches_rtmlib_top_left_bgr_letterbox() -> None:
+    frames_rgb: torch.Tensor = torch.zeros((1, 2, 4, 3), dtype=torch.uint8)
+    frames_rgb[0, 0, 0] = torch.tensor([1, 2, 3], dtype=torch.uint8)
+
+    detector_inputs, resize_ratios = preprocess_yolox_detector_torch(frames_rgb, model_input_size=(4, 4))
+
+    assert tuple(detector_inputs.shape) == (1, 3, 4, 4)
+    assert detector_inputs.dtype == torch.float32
+    assert resize_ratios.tolist() == [1.0]
+    torch.testing.assert_close(detector_inputs[0, :, 0, 0], torch.tensor([3.0, 2.0, 1.0]))
+    torch.testing.assert_close(detector_inputs[0, :, 3, 0], torch.tensor([114.0, 114.0, 114.0]))
+
+
+def test_prepare_sapiens_pose_inputs_torch_uses_udp_bbox_scale_and_normalizes_rgb() -> None:
+    frames_rgb: torch.Tensor = torch.zeros((1, 20, 10, 3), dtype=torch.uint8)
+    bboxes: torch.Tensor = torch.tensor([[0.0, 0.0, 9.0, 19.0]], dtype=torch.float32)
+    frame_indices: torch.Tensor = torch.tensor([0], dtype=torch.long)
+
+    batch = prepare_sapiens_pose_inputs_torch(
+        frames_rgb,
+        frame_indices=frame_indices,
+        bboxes_xyxy=bboxes,
+        dtype=torch.float32,
+    )
+
+    assert tuple(batch.inputs.shape) == (1, 3, 1024, 768)
+    assert batch.inputs.dtype == torch.float32
+    np.testing.assert_allclose(batch.bbox_centers.cpu().numpy(), np.asarray([[4.5, 9.5]], dtype=np.float32))
+    np.testing.assert_allclose(batch.bbox_scales.cpu().numpy(), np.asarray([[17.8125, 23.75]], dtype=np.float32))
+    torch.testing.assert_close(batch.inputs[0, :, 512, 384], torch.tensor([-2.1179, -2.0357, -1.8044]), rtol=1e-4, atol=1e-4)
+
+
+def test_prepare_rtmlib_pose_inputs_torch_matches_rtmlib_affine_bgr_normalization() -> None:
+    from rtmlib.tools.pose_estimation.pre_processings import bbox_xyxy2cs, top_down_affine
+
+    frames_rgb: torch.Tensor = torch.arange(1 * 12 * 10 * 3, dtype=torch.uint8).reshape(1, 12, 10, 3)
+    bboxes: torch.Tensor = torch.tensor([[1.0, 2.0, 8.0, 10.0]], dtype=torch.float32)
+    frame_indices: torch.Tensor = torch.tensor([0], dtype=torch.long)
+
+    batch = prepare_rtmlib_pose_inputs_torch(
+        frames_rgb,
+        frame_indices=frame_indices,
+        bboxes_xyxy=bboxes,
+        dtype=torch.float32,
+    )
+
+    image_bgr: np.ndarray = frames_rgb[0].numpy()[..., ::-1].copy()
+    expected_center, expected_scale = bbox_xyxy2cs(bboxes[0].numpy(), padding=1.25)
+    top_down_affine_any: Any = top_down_affine
+    expected_crop, expected_scale = top_down_affine_any((192, 256), expected_scale, expected_center, image_bgr)
+    expected_input: np.ndarray = ((expected_crop - np.asarray([123.675, 116.28, 103.53], dtype=np.float32)) / np.asarray([58.395, 57.12, 57.375], dtype=np.float32)).transpose(2, 0, 1)
+
+    assert tuple(batch.inputs.shape) == (1, 3, 256, 192)
+    np.testing.assert_allclose(batch.bbox_centers.cpu().numpy(), expected_center.reshape(1, 2), rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(batch.bbox_scales.cpu().numpy(), expected_scale.reshape(1, 2), rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(batch.inputs.cpu().numpy()[0, :, 64:192:64, 48:144:48], expected_input[:, 64:192:64, 48:144:48], rtol=2e-2, atol=2e-2)
+
+
+def test_postprocess_yolox_outputs_torch_accepts_decoded_head_boxes_and_scores() -> None:
+    boxes: torch.Tensor = torch.tensor(
+        [
+            [
+                [10.0, 20.0, 50.0, 80.0],
+                [12.0, 22.0, 52.0, 82.0],
+                [100.0, 120.0, 140.0, 160.0],
+            ]
+        ],
+        dtype=torch.float32,
+    )
+    scores: torch.Tensor = torch.zeros((1, 3, 80), dtype=torch.float32)
+    scores[0, 0, 0] = 0.95
+    scores[0, 1, 0] = 0.90
+    scores[0, 2, 0] = 0.05
+    outputs = DecodedYoloxHeadOutput(boxes=boxes, scores=scores)
+
+    frame_boxes = postprocess_yolox_outputs_torch(
+        outputs,
+        resize_ratios=torch.tensor([0.5], dtype=torch.float32),
+        model_input_size=(640, 640),
+        score_thr=0.3,
+        nms_thr=0.45,
+    )
+
+    assert len(frame_boxes) == 1
+    torch.testing.assert_close(frame_boxes[0], torch.tensor([[20.0, 40.0, 100.0, 160.0]], dtype=torch.float32))
+
+
+def test_batched_video_config_drops_default_label_output_for_decoded_head(tmp_path: Path) -> None:
+    config = BatchedTensorRtVideoConfig(
+        rr_config=_headless_rr_config(),
+        video_path=tmp_path / "input.mp4",
+        detector=TensorRtDetectorConfig(engine_path=tmp_path / "detector.trt"),
+        pose=SapiensTensorRtPoseConfig(engine_path=tmp_path / "pose.trt"),
+    )
+
+    assert config.detector.extra_output_names == ()
+    assert config.to_pipeline_config().detector.extra_output_names == ()
+    assert config.show_progress is True
+
+
+def test_batched_video_config_defaults_to_minimal_sapiens_trt_preset(tmp_path: Path) -> None:
+    config = BatchedTensorRtVideoConfig(rr_config=_headless_rr_config(), video_path=tmp_path / "input.mp4")
+
+    assert config.detector.engine_path.name == "yolox_humanart_head_b8_fp16.trt"
+    assert config.pose.engine_path.name == "sapiens2_0.4b_b8_fp16.trt"
+    assert config.runtime.detector_batch_size == 8
+    assert config.detector.static_batch_size == 8
+    assert config.runtime.effective_pose_batch_size(config.pose) == 8
+    assert config.pose.static_batch_size == 8
+    assert config.detector.output_name == "1436"
+    assert config.detector.score_output_name == "1438"
+    assert config.detector.extra_output_names == ()
+    assert isinstance(config.pose, SapiensTensorRtPoseConfig)
+    assert config.pose.input_name == "inputs"
+    assert config.pose.output_name == "heatmaps"
+    assert config.pose.backend == "sapiens"
+    assert config.show_progress is True
+
+
+def test_batched_video_config_defaults_to_minimal_rtmlib_trt_preset(tmp_path: Path) -> None:
+    config = BatchedTensorRtVideoConfig(
+        rr_config=_headless_rr_config(),
+        video_path=tmp_path / "input.mp4",
+        pose=RtmlibTensorRtPoseConfig(),
+    )
+
+    assert config.detector.engine_path.name == "yolox_humanart_head_b8_fp16.trt"
+    assert isinstance(config.pose, RtmlibTensorRtPoseConfig)
+    assert config.pose.engine_path.name == "rtmw_256x192_b32_fp16.trt"
+    assert config.pose.input_name == "input"
+    assert config.pose.simcc_x_output_name == "simcc_x"
+    assert config.pose.simcc_y_output_name == "simcc_y"
+    assert config.runtime.effective_pose_batch_size(config.pose) == 32
+    assert config.pose.static_batch_size == 32
+    assert config.pose.backend == "rtmlib"
+    assert config.show_progress is True
+
+
+def test_static_tensorrt_engine_metadata_is_not_user_config() -> None:
+    assert tuple(TensorRtDetectorConfig.__dataclass_fields__) == ("engine_path",)
+    assert "input_name" not in TensorRtDetectorConfig.__dataclass_fields__
+    assert "output_name" not in TensorRtDetectorConfig.__dataclass_fields__
+    assert "static_batch_size" not in TensorRtDetectorConfig.__dataclass_fields__
+    assert "input_size" not in TensorRtDetectorConfig.__dataclass_fields__
+    assert "max_detections" not in TensorRtDetectorConfig.__dataclass_fields__
+    assert tuple(SapiensTensorRtPoseConfig.__dataclass_fields__) == ("engine_path",)
+    assert "static_batch_size" not in SapiensTensorRtPoseConfig.__dataclass_fields__
+    assert "model_size" not in SapiensTensorRtPoseConfig.__dataclass_fields__
+    assert tuple(RtmlibTensorRtPoseConfig.__dataclass_fields__) == ("engine_path",)
+    assert "static_batch_size" not in RtmlibTensorRtPoseConfig.__dataclass_fields__
+    assert "input_size" not in RtmlibTensorRtPoseConfig.__dataclass_fields__
+    assert "simcc_x_output_name" not in RtmlibTensorRtPoseConfig.__dataclass_fields__
+    assert "simcc_y_output_name" not in RtmlibTensorRtPoseConfig.__dataclass_fields__
+
+
+def test_batched_tensorrt_public_exports_hide_low_level_gpu_helpers() -> None:
+    public_names: set[str] = set(batched_module.__all__)
+
+    assert {
+        "BatchedTensorRtVideoConfig",
+        "BatchedTensorRtCoco133Pipeline",
+        "TensorRtDetectorConfig",
+        "SapiensTensorRtPoseConfig",
+        "RtmlibTensorRtPoseConfig",
+        "TensorRtRuntimeConfig",
+        "run_batched_tensorrt_video_coco133",
+    } <= public_names
+    assert "preprocess_yolox_detector_torch" not in public_names
+    assert "prepare_sapiens_pose_inputs_torch" not in public_names
+    assert "TensorRtYoloxDetectorRunner" not in public_names
+    assert "_gaussian_blur_heatmaps_torch" not in public_names
+
+
+def test_batched_video_cli_hides_static_tensorrt_engine_metadata(capsys: Any) -> None:
+    with suppress(SystemExit):
+        tyro.cli(BatchedTensorRtVideoConfig, args=["--help"])
+
+    help_text = capsys.readouterr().out
+
+    assert "--detector.engine-path" in help_text
+    assert "--runtime.detector-batch-size" in help_text
+    assert "--runtime.pose-batch-size" in help_text
+    assert "--detector.static-batch-size" not in help_text
+    assert "--detector.input-size" not in help_text
+    assert "--detector.max-detections" not in help_text
+    assert "--static-batch-size" not in help_text
+    assert "--input-size" not in help_text
+
+
+def test_batched_video_cli_accepts_minimal_sapiens_trt_command(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.setattr(rr, "spawn", lambda **_kwargs: None)
+
+    config = tyro.cli(BatchedTensorRtVideoConfig, args=["--video-path", str(tmp_path / "input.mp4")])
+
+    assert config.video_path == tmp_path / "input.mp4"
+    assert config.rr_config.headless is False
+    assert isinstance(config.pose, SapiensTensorRtPoseConfig)
+    assert config.to_pipeline_config().dtype is torch.float16
+    assert config.to_pipeline_config().execution_device == "cuda"
+    assert config.to_pipeline_config().device == torch.device("cuda")
+
+
+def test_batched_video_cli_accepts_rtmlib_pose_subcommand(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.setattr(rr, "spawn", lambda **_kwargs: None)
+
+    config = tyro.cli(BatchedTensorRtVideoConfig, args=["--video-path", str(tmp_path / "input.mp4"), "rtmlib"])
+
+    assert config.video_path == tmp_path / "input.mp4"
+    assert isinstance(config.pose, RtmlibTensorRtPoseConfig)
+    assert config.runtime.effective_pose_batch_size(config.pose) == 32
+
+
+def test_run_batched_video_logs_to_rr_config_recording_without_writing_rrd(monkeypatch: Any, tmp_path: Path) -> None:
+    frame = Coco133PoseFrame(0, 0, None, np.empty((0, 4), np.float32), np.empty((0, 133, 2), np.float32), np.empty((0, 133), np.float32))
+    events: list[str] = []
+
+    class FakePredictor:
+        def predict_frames(self) -> list[Coco133PoseFrame]:
+            events.append("predict")
+            return [frame]
+
+    def fake_create_predictor(_config: BatchedTensorRtVideoConfig) -> FakePredictor:
+        return FakePredictor()
+
+    def fake_log_video_pose_frames(frames: list[Coco133PoseFrame], *, keypoint_threshold: float, recording: rr.RecordingStream, video_path: Path | None) -> rr.RecordingStream:
+        assert frames == [frame]
+        assert keypoint_threshold == 0.3
+        assert video_path == tmp_path / "input.mp4"
+        events.append("log-viewer")
+        return recording
+
+    monkeypatch.setattr(batched_module, "create_batched_tensorrt_video_frame_predictor", fake_create_predictor)
+    monkeypatch.setattr(batched_module, "log_video_pose_frames", fake_log_video_pose_frames)
+
+    summary = run_batched_tensorrt_video_coco133(BatchedTensorRtVideoConfig(rr_config=_headless_rr_config(), video_path=tmp_path / "input.mp4"))
+
+    assert events == ["predict", "log-viewer"]
+    assert summary.output_path is None
+    assert summary.frame_count == 1
+    assert summary.person_count == 0
+
+
+def test_run_batched_video_rrd_contains_keypoint_confidence_components(monkeypatch: Any, tmp_path: Path) -> None:
+    bboxes: np.ndarray = np.asarray([[1.0, 2.0, 10.0, 14.0]], dtype=np.float32)
+    keypoints: np.ndarray = np.full((1, 133, 2), np.nan, dtype=np.float32)
+    scores: np.ndarray = np.zeros((1, 133), dtype=np.float32)
+    keypoints[0, 0] = np.asarray([3.0, 4.0], dtype=np.float32)
+    scores[0, 0] = 0.91
+    frame = Coco133PoseFrame(0, 0, None, bboxes, keypoints, scores)
+    rrd_path = tmp_path / "video_trt.rrd"
+
+    class FakePredictor:
+        def predict_frames(self) -> list[Coco133PoseFrame]:
+            return [frame]
+
+    monkeypatch.setattr(batched_module, "create_batched_tensorrt_video_frame_predictor", lambda _config: FakePredictor())
+
+    summary = run_batched_tensorrt_video_coco133(
+        BatchedTensorRtVideoConfig(
+            rr_config=RerunTyroConfig(application_id="sapiens_coco133_pose_trt_confidence_test", save=rrd_path, headless=True),
+            video_path=tmp_path / "input.mp4",
+            log_video_media=False,
+        )
+    )
+
+    assert summary.output_path == rrd_path
+    recordings: list[Any] = list(rb.load_archive(str(rrd_path)).all_recordings())
+    keypoint_rows: list[dict[str, list[Any]]] = [
+        chunk.to_record_batch().to_pydict()
+        for chunk in recordings[0].chunks()
+        if str(chunk.entity_path) == "/video/person_0/keypoints"
+    ]
+    assert keypoint_rows
+    np.testing.assert_allclose(np.asarray(keypoint_rows[0][POINTS_CONFIDENCE_COMPONENT][0], dtype=np.float32)[:1], scores[0, :1])
+
+
+def test_decode_sapiens_heatmaps_to_coco133_torch_matches_numpy_udp_decoder() -> None:
+    from sapiens2_pose.api.runtime import DEFAULT_MODEL_SIZE
+    from sapiens2_pose.sapiens_lite.pose import MODEL_SPECS, UDPHeatmap
+
+    meta: dict[str, Any] = get_sapiens_metainfo()
+    mapping: dict[int, int] = {int(k): int(v) for k, v in meta["coco_wholebody_to_goliath_mapping"].items()}
+    coco_idx: int = min(mapping)
+    sapiens_idx: int = mapping[coco_idx]
+    heatmaps_np: np.ndarray = np.zeros((1, 308, 256, 192), dtype=np.float32)
+    heatmaps_np[0, sapiens_idx, 80, 64] = 10.0
+    heatmaps: torch.Tensor = torch.from_numpy(heatmaps_np)
+    batch = SapiensPoseInputBatch(
+        inputs=torch.empty((1, 3, 1024, 768), dtype=torch.float32),
+        frame_indices=torch.tensor([0], dtype=torch.long),
+        bboxes_xyxy=torch.tensor([[0.0, 0.0, 768.0, 1024.0]], dtype=torch.float32),
+        bbox_centers=torch.tensor([[384.0, 512.0]], dtype=torch.float32),
+        bbox_scales=torch.tensor([[768.0, 1024.0]], dtype=torch.float32),
+        input_size=(768, 1024),
+    )
+
+    keypoints_torch, scores_torch = decode_sapiens_heatmaps_to_coco133_torch(heatmaps, batch)
+
+    spec = MODEL_SPECS[DEFAULT_MODEL_SIZE]
+    expected_input_keypoints, expected_scores = UDPHeatmap(input_size=spec.input_size, heatmap_size=spec.heatmap_size, sigma=spec.sigma).decode(heatmaps_np[0, sapiens_idx : sapiens_idx + 1])
+    expected_image_keypoint: np.ndarray = expected_input_keypoints[0, 0] / np.asarray(batch.input_size, dtype=np.float32) * batch.bbox_scales.numpy()[0] + batch.bbox_centers.numpy()[0] - 0.5 * batch.bbox_scales.numpy()[0]
+
+    assert keypoints_torch.shape == (1, 133, 2)
+    assert scores_torch.shape == (1, 133)
+    np.testing.assert_allclose(keypoints_torch[0, coco_idx], expected_image_keypoint, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(scores_torch[0, coco_idx], expected_scores[0, 0], rtol=1e-6, atol=1e-6)
+
+
+def test_decode_rtmlib_simcc_to_coco133_torch_maps_simcc_peaks_to_image_space() -> None:
+    simcc_x: torch.Tensor = torch.zeros((1, 133, 384), dtype=torch.float32)
+    simcc_y: torch.Tensor = torch.zeros((1, 133, 512), dtype=torch.float32)
+    simcc_x[0, 5, 40] = 0.8
+    simcc_y[0, 5, 80] = 0.6
+    batch = RtmlibPoseInputBatch(
+        inputs=torch.empty((1, 3, 256, 192), dtype=torch.float32),
+        frame_indices=torch.tensor([0], dtype=torch.long),
+        bboxes_xyxy=torch.tensor([[0.0, 0.0, 96.0, 128.0]], dtype=torch.float32),
+        bbox_centers=torch.tensor([[48.0, 64.0]], dtype=torch.float32),
+        bbox_scales=torch.tensor([[96.0, 128.0]], dtype=torch.float32),
+        input_size=(192, 256),
+    )
+
+    keypoints, scores = decode_rtmlib_simcc_to_coco133_torch(simcc_x, simcc_y, batch)
+
+    expected_keypoint: np.ndarray = np.asarray([10.0, 20.0], dtype=np.float32)
+    np.testing.assert_allclose(keypoints[0, 5], expected_keypoint, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(scores[0, 5], np.float32(0.7), rtol=1e-6, atol=1e-6)
+
+
+def test_gaussian_blur_heatmaps_torch_matches_full_2d_convolution() -> None:
+    heatmaps: torch.Tensor = torch.arange(2 * 3 * 7 * 9, dtype=torch.float32).reshape(2, 3, 7, 9)
+    kernel_size: int = 5
+    border: int = (kernel_size - 1) // 2
+    kernel_1d: torch.Tensor = torch.as_tensor(__import__("cv2").getGaussianKernel(kernel_size, 0).reshape(kernel_size), dtype=torch.float32)
+    kernel_2d: torch.Tensor = (kernel_1d[:, None] * kernel_1d[None, :]).reshape(1, 1, kernel_size, kernel_size)
+    flat_heatmaps: torch.Tensor = heatmaps.reshape(6, 1, 7, 9)
+    zero_padded: torch.Tensor = torch.nn.functional.pad(flat_heatmaps, (border, border, border, border), mode="constant", value=0.0)
+    blurred_padded: torch.Tensor = torch.nn.functional.conv2d(zero_padded, kernel_2d, padding=border)
+    expected: torch.Tensor = blurred_padded[:, :, border:-border, border:-border].reshape_as(heatmaps)
+
+    actual = _gaussian_blur_heatmaps_torch(heatmaps, kernel_size)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_batched_pipeline_preserves_empty_frames_and_person_rows_with_fake_rtmlib_runners() -> None:
+    config = BatchedTensorRtPoseConfig(
+        detector=TensorRtDetectorConfig(engine_path=Path("detector.trt")),
+        pose=RtmlibTensorRtPoseConfig(engine_path=Path("pose.trt")),
+    )
+    object.__setattr__(config, "execution_device", "cpu")
+    object.__setattr__(config, "dtype", torch.float32)
+
+    class FakeDetectorRunner:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            self.frame_cursor: int = 0
+
+        def __call__(self, inputs: torch.Tensor) -> DecodedYoloxHeadOutput:
+            batch_size: int = int(inputs.shape[0])
+            boxes: torch.Tensor = torch.zeros((batch_size, 2, 4), dtype=torch.float32)
+            scores: torch.Tensor = torch.zeros((batch_size, 2, 80), dtype=torch.float32)
+            detections: dict[int, list[list[float]]] = {
+                0: [[0.0, 0.0, 2.0, 2.0]],
+                1: [],
+                2: [[0.0, 0.0, 1.0, 1.0], [2.0, 2.0, 3.5, 3.5]],
+            }
+            for local_idx in range(batch_size):
+                for anchor_idx, box in enumerate(detections[self.frame_cursor + local_idx]):
+                    boxes[local_idx, anchor_idx] = torch.tensor(box, dtype=torch.float32)
+                    scores[local_idx, anchor_idx, 0] = 0.9 - 0.1 * anchor_idx
+            self.frame_cursor += batch_size
+            return DecodedYoloxHeadOutput(boxes, scores)
+
+    class FakeRtmlibPoseRunner:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def __call__(self, inputs: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+            simcc_x: torch.Tensor = torch.zeros((int(inputs.shape[0]), 133, 384), dtype=torch.float32)
+            simcc_y: torch.Tensor = torch.zeros((int(inputs.shape[0]), 133, 512), dtype=torch.float32)
+            simcc_x[:, 5, 40] = 0.8
+            simcc_y[:, 5, 80] = 0.6
+            return simcc_x, simcc_y
+
+    pipeline = BatchedTensorRtCoco133Pipeline(config, detector_runner_factory=FakeDetectorRunner, pose_runner_factory=FakeRtmlibPoseRunner)
+    frames = pipeline.predict_batch_rgb_tensor(torch.zeros((3, 640, 640, 3), dtype=torch.uint8), frame_start_index=100, timestamps_ns=np.asarray([10, 20, 30], dtype=np.int64), detector_batch_size=2, pose_batch_size=2)
+
+    assert [frame.frame_index for frame in frames] == [100, 101, 102]
+    assert [frame.timestamp_ns for frame in frames] == [10, 20, 30]
+    assert [int(frame.bboxes.shape[0]) for frame in frames] == [1, 0, 2]
+    np.testing.assert_allclose(frames[0].bboxes, np.asarray([[0.0, 0.0, 2.0, 2.0]], dtype=np.float32))
+    np.testing.assert_allclose(frames[1].keypoints, np.empty((0, 133, 2), dtype=np.float32))
+    np.testing.assert_allclose(frames[2].bboxes, np.asarray([[0.0, 0.0, 1.0, 1.0], [2.0, 2.0, 3.5, 3.5]], dtype=np.float32))
+    np.testing.assert_allclose(frames[2].scores[:, 5], np.asarray([0.7, 0.7], dtype=np.float32), rtol=1e-6, atol=1e-6)
+
+
+def test_batched_pipeline_direct_call_uses_runtime_detector_score_threshold_default() -> None:
+    config = BatchedTensorRtPoseConfig(
+        detector=TensorRtDetectorConfig(engine_path=Path("detector.trt")),
+        pose=RtmlibTensorRtPoseConfig(engine_path=Path("pose.trt")),
+    )
+    object.__setattr__(config, "execution_device", "cpu")
+    object.__setattr__(config, "dtype", torch.float32)
+
+    class FakeDetectorRunner:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def __call__(self, inputs: torch.Tensor) -> DecodedYoloxHeadOutput:
+            boxes: torch.Tensor = torch.zeros((int(inputs.shape[0]), 1, 4), dtype=torch.float32)
+            scores: torch.Tensor = torch.zeros((int(inputs.shape[0]), 1, 80), dtype=torch.float32)
+            boxes[:, 0] = torch.tensor([0.0, 0.0, 2.0, 2.0], dtype=torch.float32)
+            scores[:, 0, 0] = 0.5
+            return DecodedYoloxHeadOutput(boxes, scores)
+
+    class FakeRtmlibPoseRunner:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def __call__(self, _inputs: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+            raise AssertionError("Pose should not run when the direct-call detector default threshold rejects the box.")
+
+    pipeline = BatchedTensorRtCoco133Pipeline(
+        config,
+        detector_runner_factory=FakeDetectorRunner,
+        pose_runner_factory=FakeRtmlibPoseRunner,
+    )
+    frames = pipeline.predict_batch_rgb_tensor(
+        torch.zeros((1, 640, 640, 3), dtype=torch.uint8),
+        detector_batch_size=1,
+        pose_batch_size=1,
+    )
+
+    assert len(frames) == 1
+    assert frames[0].bboxes.shape == (0, 4)

--- a/packages/sapiens-coco133-pose/tests/test_benchmark.py
+++ b/packages/sapiens-coco133-pose/tests/test_benchmark.py
@@ -1,0 +1,137 @@
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+import tyro
+from sapiens2_pose.api.pose_artifact import PoseArtifactComparisonMetrics
+
+from sapiens_coco133_pose.api import benchmark as benchmark_module
+from sapiens_coco133_pose.api.artifact import Coco133PoseFrame
+from sapiens_coco133_pose.api.batched_tensorrt import SapiensTensorRtPoseConfig, TensorRtDetectorConfig
+from sapiens_coco133_pose.api.benchmark import PoseBenchmarkConfig, run_pose_benchmark
+
+
+def test_pose_benchmark_cli_hides_static_tensorrt_engine_metadata(capsys: Any) -> None:
+    with suppress(SystemExit):
+        tyro.cli(run_pose_benchmark, args=["--help"])
+
+    help_text = capsys.readouterr().out
+
+    assert "--config.detector.engine-path" in help_text
+    assert "--config.runtime.detector-batch-size" in help_text
+    assert "--config.runtime.pose-batch-size" in help_text
+    assert "--config.detector.static-batch-size" not in help_text
+    assert "--config.detector.input-size" not in help_text
+    assert "--config.detector.max-detections" not in help_text
+    assert "--static-batch-size" not in help_text
+    assert "--input-size" not in help_text
+
+
+def test_run_pose_benchmark_times_inference_before_artifact_writes(monkeypatch: Any, tmp_path: Path) -> None:
+    frame = Coco133PoseFrame(
+        frame_index=0,
+        timestamp_ns=0,
+        image_rgb=None,
+        bboxes=np.empty((0, 4), dtype=np.float32),
+        keypoints=np.empty((0, 133, 2), dtype=np.float32),
+        scores=np.empty((0, 133), dtype=np.float32),
+    )
+    events: list[str] = []
+
+    def fake_iter_video_pose_coco133(_config: object) -> list[Coco133PoseFrame]:
+        events.append("iterable_inference")
+        return [frame]
+
+    class FakeBatchedPredictor:
+        """Fake initialized predictor used to verify benchmark timing boundaries."""
+
+        def predict_frames(self) -> list[Coco133PoseFrame]:
+            events.append("batched_inference")
+            return [frame]
+
+    def fake_create_batched_tensorrt_video_frame_predictor(_config: object) -> FakeBatchedPredictor:
+        events.append("batched_init")
+        return FakeBatchedPredictor()
+
+    def fake_write_video_pose_rrd(_frames: list[Coco133PoseFrame], *, rrd_path: Path, keypoint_threshold: float) -> None:
+        del keypoint_threshold
+        events.append(f"rrd:{rrd_path.name}")
+
+    def fake_compare_video_pose_rrds(baseline_rrd_path: Path, candidate_rrd_path: Path, _config: object) -> PoseArtifactComparisonMetrics:
+        events.append(f"compare-rrd:{baseline_rrd_path.name}:{candidate_rrd_path.name}")
+        return PoseArtifactComparisonMetrics(
+            max_relative_difference=0.0,
+            mean_relative_difference=0.0,
+            max_absolute_difference=0.0,
+            mean_absolute_difference=0.0,
+            compared_values=0,
+            max_keypoint_bbox_fraction=0.0,
+            mean_keypoint_bbox_fraction=0.0,
+            compared_keypoints=0,
+        )
+
+    monkeypatch.setattr(benchmark_module, "iter_video_pose_coco133", fake_iter_video_pose_coco133)
+    monkeypatch.setattr(benchmark_module, "create_batched_tensorrt_video_frame_predictor", fake_create_batched_tensorrt_video_frame_predictor)
+    monkeypatch.setattr(benchmark_module, "write_video_pose_rrd", fake_write_video_pose_rrd)
+    monkeypatch.setattr(benchmark_module, "compare_video_pose_rrds", fake_compare_video_pose_rrds)
+    monkeypatch.setattr(benchmark_module, "_synchronize_cuda", lambda: None)
+    monkeypatch.setattr(benchmark_module, "_release_iterable_gpu_caches", lambda: None)
+
+    output_dir = tmp_path / "outputs"
+    run_pose_benchmark(
+        PoseBenchmarkConfig(
+            video_path=tmp_path / "video.mp4",
+            detector=TensorRtDetectorConfig(engine_path=tmp_path / "detector.trt"),
+            pose=SapiensTensorRtPoseConfig(engine_path=tmp_path / "pose.trt"),
+            output_dir=output_dir,
+            max_frames=1,
+        )
+    )
+
+    assert events[:2] == ["iterable_inference", "rrd:iterable_golden.rrd"]
+    assert "batched_init" in events
+    assert "batched_inference" in events
+    assert events.index("batched_init") < events.index("batched_inference")
+    assert events.index("batched_inference") < events.index("rrd:batched_tensorrt.rrd")
+    assert all(not event.startswith("save:") for event in events)
+    assert list(output_dir.glob("*.npz")) == []
+    assert events.index("rrd:iterable_golden.rrd") < events.index("compare-rrd:iterable_golden.rrd:batched_tensorrt.rrd")
+    assert events.index("rrd:batched_tensorrt.rrd") < events.index("compare-rrd:iterable_golden.rrd:batched_tensorrt.rrd")
+
+
+def test_release_iterable_gpu_caches_uses_public_sapiens_runtime_api(monkeypatch: Any) -> None:
+    import sapiens2_pose.api.runtime as sapiens_runtime
+
+    events: list[str] = []
+
+    monkeypatch.setattr(sapiens_runtime, "clear_pose_model_cache", lambda: events.append("clear-sapiens-cache"))
+    monkeypatch.setattr(benchmark_module.gc, "collect", lambda: events.append("gc"))
+    monkeypatch.setattr(benchmark_module.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(benchmark_module.torch.cuda, "empty_cache", lambda: events.append("empty-cuda-cache"))
+
+    benchmark_module._release_iterable_gpu_caches()
+
+    assert events == ["clear-sapiens-cache", "gc", "empty-cuda-cache"]
+
+
+def test_run_pose_benchmark_rejects_empty_iterable_runs(monkeypatch: Any, tmp_path: Path) -> None:
+    events: list[str] = []
+
+    def fake_iter_video_pose_coco133(_config: object) -> list[Coco133PoseFrame]:
+        events.append("iterable_inference")
+        return []
+
+    def fake_create_batched_tensorrt_video_frame_predictor(_config: object) -> object:
+        events.append("batched_init")
+        raise AssertionError("Batched path should not run after an empty iterable benchmark.")
+
+    monkeypatch.setattr(benchmark_module, "iter_video_pose_coco133", fake_iter_video_pose_coco133)
+    monkeypatch.setattr(benchmark_module, "create_batched_tensorrt_video_frame_predictor", fake_create_batched_tensorrt_video_frame_predictor)
+    monkeypatch.setattr(benchmark_module, "_synchronize_cuda", lambda: None)
+
+    with pytest.raises(ValueError, match="Iterable benchmark produced no frames"):
+        run_pose_benchmark(PoseBenchmarkConfig(video_path=tmp_path / "video.mp4", output_dir=tmp_path / "outputs"))
+
+    assert events == ["iterable_inference"]

--- a/packages/sapiens-coco133-pose/tests/test_iterable_pipeline.py
+++ b/packages/sapiens-coco133-pose/tests/test_iterable_pipeline.py
@@ -1,0 +1,198 @@
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import torch
+from jaxtyping import Float32, UInt8
+from numpy import ndarray
+from sapiens2_pose.api.metadata import get_sapiens_metainfo
+from sapiens2_pose.api.runtime import PoseEstimation
+
+from sapiens_coco133_pose.api import iterable as iterable_module
+from sapiens_coco133_pose.api.iterable import DEFAULT_ITERABLE_RRD_PATH, IterableVideoPoseConfig, estimate_frame_pose_coco133, iter_video_pose_coco133
+
+
+def test_estimate_frame_pose_coco133_detects_boxes_and_projects_sapiens_keypoints() -> None:
+    expected_image_rgb: UInt8[ndarray, "h w 3"] = np.zeros((24, 32, 3), dtype=np.uint8)
+    expected_bboxes: Float32[ndarray, "n 4"] = np.asarray([[2.0, 3.0, 20.0, 22.0]], dtype=np.float32)
+    meta: dict[str, Any] = get_sapiens_metainfo()
+    mapping: dict[int, int] = {int(k): int(v) for k, v in meta["coco_wholebody_to_goliath_mapping"].items()}
+    coco_idx: int = min(mapping)
+    sapiens_idx: int = mapping[coco_idx]
+    native_keypoints: Float32[ndarray, "sapiens_k 2"] = np.zeros((308, 2), dtype=np.float32)
+    native_scores: Float32[ndarray, "sapiens_k"] = np.zeros((308,), dtype=np.float32)
+    native_keypoints[sapiens_idx] = np.asarray([9.0, 10.0], dtype=np.float32)
+    native_scores[sapiens_idx] = 0.75
+    detector_calls: list[UInt8[ndarray, "h w 3"]] = []
+
+    def fake_detector(input_image: UInt8[ndarray, "h w 3"]) -> Float32[ndarray, "n 4"]:
+        detector_calls.append(input_image)
+        return expected_bboxes
+
+    def fake_pose_estimator(
+        image_rgb: UInt8[ndarray, "h w 3"],
+        bboxes: Float32[ndarray, "n 4"],
+        **_kwargs: object,
+    ) -> PoseEstimation:
+        assert image_rgb is expected_image_rgb
+        np.testing.assert_allclose(bboxes, expected_bboxes)
+        return PoseEstimation(bboxes=bboxes, keypoints=[native_keypoints], scores=[native_scores])
+
+    frame = estimate_frame_pose_coco133(
+        expected_image_rgb,
+        frame_index=7,
+        timestamp_ns=1234,
+        detector=fake_detector,
+        native_pose_estimator=fake_pose_estimator,
+        device="cpu",
+    )
+
+    assert detector_calls == [expected_image_rgb]
+    assert frame.frame_index == 7
+    assert frame.timestamp_ns == 1234
+    np.testing.assert_allclose(frame.bboxes, expected_bboxes)
+    assert frame.keypoints.shape == (1, 133, 2)
+    assert frame.scores.shape == (1, 133)
+    np.testing.assert_allclose(frame.keypoints[0, coco_idx], np.asarray([9.0, 10.0], dtype=np.float32))
+    assert frame.scores[0, coco_idx] == np.float32(0.75)
+
+
+def test_estimate_frame_pose_coco133_can_use_rtmlib_direct_coco133_keypoints() -> None:
+    expected_image_rgb: UInt8[ndarray, "h w 3"] = np.zeros((24, 32, 3), dtype=np.uint8)
+    expected_bboxes: Float32[ndarray, "n 4"] = np.asarray([[2.0, 3.0, 20.0, 22.0]], dtype=np.float32)
+    expected_keypoints: Float32[ndarray, "n coco_k 2"] = np.zeros((1, 133, 2), dtype=np.float32)
+    expected_scores: Float32[ndarray, "n coco_k"] = np.zeros((1, 133), dtype=np.float32)
+    expected_keypoints[0, 17] = np.asarray([12.0, 14.0], dtype=np.float32)
+    expected_scores[0, 17] = 0.91
+
+    def fake_detector(_input_image: UInt8[ndarray, "h w 3"]) -> Float32[ndarray, "n 4"]:
+        return expected_bboxes
+
+    def fake_rtmlib_pose_estimator(
+        image_rgb: UInt8[ndarray, "h w 3"],
+        bboxes: Float32[ndarray, "n 4"],
+    ) -> tuple[Float32[ndarray, "n coco_k 2"], Float32[ndarray, "n coco_k"]]:
+        assert image_rgb is expected_image_rgb
+        np.testing.assert_allclose(bboxes, expected_bboxes)
+        return expected_keypoints, expected_scores
+
+    frame = estimate_frame_pose_coco133(
+        expected_image_rgb,
+        frame_index=9,
+        timestamp_ns=5678,
+        detector=fake_detector,
+        rtmlib_pose_estimator=fake_rtmlib_pose_estimator,
+        pose_backend="rtmlib",
+        device="cpu",
+    )
+
+    assert frame.frame_index == 9
+    assert frame.timestamp_ns == 5678
+    np.testing.assert_allclose(frame.bboxes, expected_bboxes)
+    np.testing.assert_allclose(frame.keypoints, expected_keypoints)
+    np.testing.assert_allclose(frame.scores, expected_scores)
+
+
+def test_iter_video_pose_coco133_uses_rtmlib_progress_defaults(monkeypatch: Any, tmp_path: Path) -> None:
+    import tqdm.auto as tqdm_auto
+    from torchcodec import decoders as torchcodec_decoders
+
+    progress_calls: list[tuple[int | None, str | None]] = []
+
+    class FakeVideoDecoder:
+        """Small TorchCodec-compatible decoder used to keep the iterable API test in-process."""
+
+        metadata: SimpleNamespace = SimpleNamespace(num_frames=3, average_fps=30.0)
+
+        def __init__(self, video_path: Path, *, dimension_order: str, device: str) -> None:
+            assert video_path == tmp_path / "input.mp4"
+            assert dimension_order == "NHWC"
+            assert device == "cpu"
+
+        def get_frames_in_range(self, start: int, stop: int) -> SimpleNamespace:
+            del stop
+            frame_rgb: UInt8[torch.Tensor, "1 h w 3"] = torch.full((1, 8, 10, 3), start, dtype=torch.uint8)
+            return SimpleNamespace(data=frame_rgb)
+
+    def fake_tqdm(iterable: Any, *, total: int | None = None, desc: str | None = None) -> Any:
+        progress_calls.append((total, desc))
+        return iterable
+
+    def fake_detector(_image_rgb: UInt8[ndarray, "h w 3"]) -> Float32[ndarray, "n 4"]:
+        return np.empty((0, 4), dtype=np.float32)
+
+    def fake_rtmlib_pose_estimator(
+        image_rgb: UInt8[ndarray, "h w 3"],
+        bboxes: Float32[ndarray, "n 4"],
+    ) -> tuple[Float32[ndarray, "n coco_k 2"], Float32[ndarray, "n coco_k"]]:
+        del image_rgb, bboxes
+        raise AssertionError("Pose estimator should not run when the detector returns no boxes.")
+
+    monkeypatch.setattr(torchcodec_decoders, "VideoDecoder", FakeVideoDecoder)
+    monkeypatch.setattr(tqdm_auto, "tqdm", fake_tqdm)
+
+    config = IterableVideoPoseConfig(video_path=tmp_path / "input.mp4", max_frames=2, pose_backend="rtmlib")
+    frames: list[Any] = list(iter_video_pose_coco133(config, detector=fake_detector, rtmlib_pose_estimator=fake_rtmlib_pose_estimator))
+
+    assert config.rrd_path == DEFAULT_ITERABLE_RRD_PATH
+    assert config.show_progress is True
+    assert [frame.frame_index for frame in frames] == [0, 1]
+    assert progress_calls == [(2, "rtmlib coco133 iterable frames")]
+
+
+def test_iter_video_pose_coco133_allows_independent_rtmlib_pose_runtime_config(monkeypatch: Any, tmp_path: Path) -> None:
+    from torchcodec import decoders as torchcodec_decoders
+
+    constructed_pose_configs: list[Any] = []
+
+    class FakeVideoDecoder:
+        """Small TorchCodec-compatible decoder for config plumbing tests."""
+
+        metadata: SimpleNamespace = SimpleNamespace(num_frames=1, average_fps=30.0)
+
+        def __init__(self, video_path: Path, *, dimension_order: str, device: str) -> None:
+            assert video_path == tmp_path / "input.mp4"
+            assert dimension_order == "NHWC"
+            assert device == "cpu"
+
+        def get_frames_in_range(self, start: int, stop: int) -> SimpleNamespace:
+            del start, stop
+            frame_rgb: UInt8[torch.Tensor, "1 h w 3"] = torch.zeros((1, 8, 10, 3), dtype=torch.uint8)
+            return SimpleNamespace(data=frame_rgb)
+
+    class FakeRtmlibPoseEstimator:
+        """Records the RTMLib pose config without constructing real ONNX sessions."""
+
+        def __init__(self, config: object) -> None:
+            constructed_pose_configs.append(config)
+
+        def __call__(
+            self,
+            _image_rgb: UInt8[ndarray, "h w 3"],
+            _bboxes: Float32[ndarray, "n 4"],
+        ) -> tuple[Float32[ndarray, "n coco_k 2"], Float32[ndarray, "n coco_k"]]:
+            return np.empty((0, 133, 2), dtype=np.float32), np.empty((0, 133), dtype=np.float32)
+
+    def fake_detector(_image_rgb: UInt8[ndarray, "h w 3"]) -> Float32[ndarray, "n 4"]:
+        return np.empty((0, 4), dtype=np.float32)
+
+    monkeypatch.setattr(torchcodec_decoders, "VideoDecoder", FakeVideoDecoder)
+    monkeypatch.setattr(iterable_module, "RtmlibCoco133PoseEstimator", FakeRtmlibPoseEstimator)
+
+    config = IterableVideoPoseConfig(
+        video_path=tmp_path / "input.mp4",
+        max_frames=1,
+        pose_backend="rtmlib",
+        detector_backend="onnxruntime",
+        detector_device="cuda",
+        rtmlib_pose_backend="opencv",
+        rtmlib_pose_device="cpu",
+        show_progress=False,
+    )
+    frames: list[Any] = list(iter_video_pose_coco133(config, detector=fake_detector))
+
+    assert [frame.frame_index for frame in frames] == [0]
+    assert len(constructed_pose_configs) == 1
+    assert constructed_pose_configs[0].backend == "opencv"
+    assert constructed_pose_configs[0].device == "cpu"

--- a/packages/sapiens-coco133-pose/tests/test_rerun_video_artifact.py
+++ b/packages/sapiens-coco133-pose/tests/test_rerun_video_artifact.py
@@ -1,0 +1,105 @@
+import os
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+import rerun_bindings as rb
+from jaxtyping import Float32, UInt8
+from numpy import ndarray
+from sapiens2_pose.api.pose_artifact import PoseArtifactComparisonConfig
+
+from sapiens_coco133_pose.api.artifact import (
+    POINTS_AVERAGE_CONFIDENCE_COMPONENT,
+    POINTS_CONFIDENCE_COMPONENT,
+    Coco133PoseFrame,
+    compare_video_pose_rrds,
+    load_rerun_video_pose_artifact,
+    write_video_pose_rrd,
+)
+
+
+def test_write_video_pose_rrd_round_trips_bbox_and_coco133_keypoints(tmp_path: Path) -> None:
+    image_rgb: UInt8[ndarray, "h w 3"] = np.zeros((16, 20, 3), dtype=np.uint8)
+    bboxes: Float32[ndarray, "n 4"] = np.asarray([[1.0, 2.0, 10.0, 14.0]], dtype=np.float32)
+    keypoints: Float32[ndarray, "n 133 2"] = np.full((1, 133, 2), np.nan, dtype=np.float32)
+    scores: Float32[ndarray, "n 133"] = np.zeros((1, 133), dtype=np.float32)
+    keypoints[0, 0] = np.asarray([3.0, 4.0], dtype=np.float32)
+    keypoints[0, 1] = np.asarray([5.0, 6.0], dtype=np.float32)
+    keypoints[0, 2] = np.asarray([7.0, 8.0], dtype=np.float32)
+    scores[0, 0] = 0.9
+    scores[0, 1] = 0.8
+    scores[0, 2] = 0.25
+    frame: Coco133PoseFrame = Coco133PoseFrame(
+        frame_index=0,
+        timestamp_ns=123,
+        image_rgb=image_rgb,
+        bboxes=bboxes,
+        keypoints=keypoints,
+        scores=scores,
+    )
+    rrd_path: Path = tmp_path / "golden.rrd"
+
+    write_video_pose_rrd([frame], rrd_path=rrd_path, keypoint_threshold=0.5)
+    artifact = load_rerun_video_pose_artifact(rrd_path)
+
+    assert artifact.frame_indices.tolist() == [0]
+    assert artifact.person_frame_indices.tolist() == [0]
+    np.testing.assert_allclose(artifact.bboxes, bboxes)
+    assert artifact.keypoints.shape == (1, 133, 2)
+    np.testing.assert_allclose(artifact.keypoints[0, :2], keypoints[0, :2])
+    assert np.isnan(artifact.keypoints[0, 2, :]).all()
+    assert np.isnan(artifact.keypoints[0, 3:, :]).all()
+    np.testing.assert_allclose(artifact.scores[0, :3], scores[0, :3])
+
+    archive = rb.load_archive(str(rrd_path))
+    recordings: list[Any] = list(archive.all_recordings())
+    keypoint_batches: list[dict[str, list[Any]]] = [
+        chunk.to_record_batch().to_pydict()
+        for chunk in recordings[0].chunks()
+        if str(chunk.entity_path) == "/video/person_0/keypoints"
+    ]
+    assert keypoint_batches
+    assert POINTS_CONFIDENCE_COMPONENT in keypoint_batches[0]
+    assert POINTS_AVERAGE_CONFIDENCE_COMPONENT in keypoint_batches[0]
+
+
+def test_video_pose_rrd_uses_one_stable_video_entity_for_frame_overlays(tmp_path: Path) -> None:
+    image_rgb: UInt8[ndarray, "h w 3"] = np.zeros((16, 20, 3), dtype=np.uint8)
+    bboxes: Float32[ndarray, "n 4"] = np.asarray([[1.0, 2.0, 10.0, 14.0]], dtype=np.float32)
+    keypoints: Float32[ndarray, "n 133 2"] = np.full((1, 133, 2), np.nan, dtype=np.float32)
+    scores: Float32[ndarray, "n 133"] = np.zeros((1, 133), dtype=np.float32)
+    keypoints[0, 0] = np.asarray([3.0, 4.0], dtype=np.float32)
+    scores[0, 0] = 0.9
+    frames: list[Coco133PoseFrame] = [
+        Coco133PoseFrame(frame_index=0, timestamp_ns=0, image_rgb=image_rgb, bboxes=bboxes, keypoints=keypoints, scores=scores),
+        Coco133PoseFrame(frame_index=1, timestamp_ns=33_000_000, image_rgb=image_rgb, bboxes=bboxes + 1.0, keypoints=keypoints + 1.0, scores=scores),
+    ]
+    rrd_path: Path = tmp_path / "stable_video.rrd"
+
+    write_video_pose_rrd(frames, rrd_path=rrd_path, keypoint_threshold=0.5)
+
+    archive = rb.load_archive(str(rrd_path))
+    recordings: list[Any] = list(archive.all_recordings())
+    entity_paths: set[str] = {str(chunk.entity_path) for chunk in recordings[0].chunks()}
+    assert "/video/image" in entity_paths
+    assert "/video/person_0/bbox" in entity_paths
+    assert "/video/person_0/keypoints" in entity_paths
+    assert all("/video/frame_" not in entity_path for entity_path in entity_paths)
+
+    artifact = load_rerun_video_pose_artifact(rrd_path)
+    assert artifact.frame_indices.tolist() == [0, 1]
+    assert artifact.person_frame_indices.tolist() == [0, 1]
+    np.testing.assert_allclose(artifact.bboxes, np.stack([bboxes[0], bboxes[0] + 1.0], axis=0))
+
+
+def test_rrd_candidate_matches_baseline_when_paths_are_provided() -> None:
+    baseline_rrd = os.environ.get("SAPIENS_COCO133_BASELINE_RRD")
+    candidate_rrd = os.environ.get("SAPIENS_COCO133_CANDIDATE_RRD")
+    if baseline_rrd is None or candidate_rrd is None:
+        pytest.skip("Set SAPIENS_COCO133_BASELINE_RRD and SAPIENS_COCO133_CANDIDATE_RRD to run RRD parity.")
+
+    metrics = compare_video_pose_rrds(Path(baseline_rrd), Path(candidate_rrd), PoseArtifactComparisonConfig(0.0, keypoint_score_threshold=0.3, max_keypoint_bbox_fraction=0.0))
+
+    assert metrics.max_absolute_difference == 0.0
+    assert metrics.max_keypoint_bbox_fraction == 0.0

--- a/packages/sapiens-coco133-pose/tests/test_tensorrt_conversion.py
+++ b/packages/sapiens-coco133-pose/tests/test_tensorrt_conversion.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+from typing import Any
+
+import torch
+from sapiens2_pose.api.coco133_tensorrt_conversion import (
+    SapiensCoco133PoseOnnxExportConfig,
+    TensorRtEngineBuildConfig,
+    export_sapiens_coco133_pose_onnx,
+)
+
+
+def test_export_sapiens_coco133_pose_onnx_uses_static_fp16_batch(tmp_path: Path) -> None:
+    checkpoint_path: Path = tmp_path / "sapiens.safetensors"
+    onnx_path: Path = tmp_path / "sapiens_b8_fp16.onnx"
+    checkpoint_path.write_bytes(b"checkpoint")
+    calls: list[dict[str, Any]] = []
+
+    def fake_loader(size: str, checkpoint: str | Path, device: str = "cuda") -> torch.nn.Module:
+        assert size == "0.4B"
+        assert Path(checkpoint) == checkpoint_path
+        assert device == "cpu"
+        return torch.nn.Identity()
+
+    def fake_export(_model: torch.nn.Module, args: tuple[torch.Tensor], f: str | Path, **kwargs: Any) -> None:
+        calls.append({"inputs": args[0], "path": Path(f), **kwargs})
+        Path(f).write_bytes(b"onnx")
+
+    summary = export_sapiens_coco133_pose_onnx(
+        SapiensCoco133PoseOnnxExportConfig(
+            checkpoint_path=checkpoint_path,
+            onnx_path=onnx_path,
+            batch_size=8,
+            device="cpu",
+        ),
+        model_loader=fake_loader,
+        export_fn=fake_export,
+    )
+
+    assert summary.onnx_path == onnx_path
+    assert summary.input_shape == (8, 3, 1024, 768)
+    assert summary.output_shape == (8, 308, 256, 192)
+    assert calls[0]["inputs"].dtype == torch.float16
+    assert calls[0]["input_names"] == ["inputs"]
+    assert calls[0]["output_names"] == ["heatmaps"]
+
+
+def test_tensorrt_engine_build_manifest_records_static_batch_and_fp16(tmp_path: Path) -> None:
+    onnx_path: Path = tmp_path / "model.onnx"
+    engine_path: Path = tmp_path / "model.trt"
+    onnx_path.write_bytes(b"onnx bytes")
+
+    manifest = TensorRtEngineBuildConfig(
+        target="pose",
+        onnx_path=onnx_path,
+        engine_path=engine_path,
+        input_name="inputs",
+        output_names=("heatmaps",),
+        input_shape=(3, 1024, 768),
+        batch_size=8,
+    ).to_manifest(tensorrt_version="10.13.3.9", cuda_device_name="NVIDIA")
+
+    assert manifest["target"] == "pose"
+    assert manifest["precision"] == "fp16"
+    assert manifest["batch_profile"] == {"min": 8, "optimal": 8, "max": 8}
+    assert manifest["model_io"] == {
+        "input_name": "inputs",
+        "input_shape": [8, 3, 1024, 768],
+        "output_names": ["heatmaps"],
+    }

--- a/packages/sapiens-coco133-pose/tools/conversion/build_tensorrt_engine.py
+++ b/packages/sapiens-coco133-pose/tools/conversion/build_tensorrt_engine.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import tyro
+from sapiens2_pose.api.coco133_tensorrt_conversion import build_tensorrt_engine
+
+
+def main() -> None:
+    """Run the TensorRT engine build CLI."""
+    print(tyro.cli(build_tensorrt_engine))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/sapiens-coco133-pose/tools/conversion/export_sapiens_pose_onnx.py
+++ b/packages/sapiens-coco133-pose/tools/conversion/export_sapiens_pose_onnx.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import tyro
+from sapiens2_pose.api.coco133_tensorrt_conversion import export_sapiens_coco133_pose_onnx
+
+
+def main() -> None:
+    """Run the Sapiens COCO-133 ONNX export CLI."""
+    print(tyro.cli(export_sapiens_coco133_pose_onnx))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/sapiens-coco133-pose/tools/demos/batched_tensorrt_video_pose.py
+++ b/packages/sapiens-coco133-pose/tools/demos/batched_tensorrt_video_pose.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import tyro
+
+from sapiens_coco133_pose.api.batched_tensorrt import BatchedTensorRtVideoConfig, run_batched_tensorrt_video_coco133
+
+
+def main() -> None:
+    """Run the batched TensorRT video pose demo."""
+    print(run_batched_tensorrt_video_coco133(tyro.cli(BatchedTensorRtVideoConfig)))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/sapiens-coco133-pose/tools/demos/iterable_video_pose.py
+++ b/packages/sapiens-coco133-pose/tools/demos/iterable_video_pose.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import tyro
+
+from sapiens_coco133_pose.api.iterable import IterableVideoPoseConfig, run_iterable_video_pose_coco133
+
+
+def main() -> None:
+    """Run the iterable video pose demo."""
+    print(run_iterable_video_pose_coco133(tyro.cli(IterableVideoPoseConfig)))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/sapiens-coco133-pose/tools/eval/benchmark.py
+++ b/packages/sapiens-coco133-pose/tools/eval/benchmark.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import tyro
+
+from sapiens_coco133_pose.api.benchmark import run_pose_benchmark
+
+
+def main() -> None:
+    """Run the COCO-133 pose benchmark CLI."""
+    print(tyro.cli(run_pose_benchmark))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/sapiens2-pose/src/sapiens2_pose/api/coco133_gpu.py
+++ b/packages/sapiens2-pose/src/sapiens2_pose/api/coco133_gpu.py
@@ -1,0 +1,450 @@
+"""Torch helpers for batched COCO-133 pose preprocessing and decode."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from jaxtyping import Float, Float32, Int, UInt8
+from numpy import ndarray
+from torch import Tensor
+
+from sapiens2_pose.api.metadata import get_sapiens_metainfo
+from sapiens2_pose.api.runtime import DEFAULT_MODEL_SIZE, ModelSize
+from sapiens2_pose.sapiens_lite.pose import MODEL_SPECS
+
+TORCH_UINT8 = torch.__dict__["uint8"]
+YoloxRawOutput = Float[Tensor, "batch anchors fields"]
+POSE_INPUT_SHAPE = (3, 1024, 768)
+RTMLIB_POSE_INPUT_SIZE = (192, 256)
+YOLOX_DEFAULT_MAX_DETECTIONS = 1024
+
+
+@dataclass(frozen=True, slots=True)
+class DecodedYoloxHeadOutput:
+    """Decoded YOLOX head outputs before score thresholding and NMS."""
+
+    boxes: Float[Tensor, "batch anchors 4"]
+    """Decoded image-space boxes in detector-input coordinates."""
+    scores: Float[Tensor, "batch anchors classes"]
+    """Class confidence scores aligned with ``boxes``."""
+
+
+YoloxDetectorOutput = YoloxRawOutput | DecodedYoloxHeadOutput
+
+
+@dataclass(frozen=True, slots=True)
+class PoseInputBatch:
+    """Batched pose inputs and bbox decode metadata."""
+
+    inputs: Float[Tensor, "n 3 h w"]
+    """Normalized pose crops ready for the selected pose model."""
+    frame_indices: Int[Tensor, "n"]
+    """Source frame index for each pose crop."""
+    bboxes_xyxy: Float[Tensor, "n 4"]
+    """Source person boxes in image-space ``xyxy`` order."""
+    bbox_centers: Float[Tensor, "n 2"]
+    """Image-space bbox centers used to map model outputs back to the source image."""
+    bbox_scales: Float[Tensor, "n 2"]
+    """Width and height of the padded crop in source-image pixels."""
+    input_size: tuple[int, int]
+    """Pose model crop size as ``(width, height)``."""
+
+
+SapiensPoseInputBatch = PoseInputBatch
+RtmlibPoseInputBatch = PoseInputBatch
+
+
+def preprocess_yolox_detector_torch(frames_rgb: UInt8[Tensor, "batch h w 3"], *, model_input_size: tuple[int, int]) -> tuple[Float[Tensor, "batch 3 det_h det_w"], Float[Tensor, "batch"]]:
+    """Preprocess RGB frames for the RTMLib YOLOX detector.
+
+    The operation stays in torch so CUDA video frames can flow directly into the TensorRT detector. It matches RTMLib's
+    preprocessing convention: RGB to BGR, top-left letterbox padding with value 114, and no mean/std normalization.
+
+    Args:
+        frames_rgb: RGB video frames with shape ``(batch, height, width, 3)``.
+        model_input_size: Detector input size as ``(height, width)``.
+
+    Returns:
+        A tuple of detector inputs with shape ``(batch, 3, det_h, det_w)`` and per-frame resize ratios.
+
+    Raises:
+        ValueError: If ``frames_rgb`` is not a uint8 NHWC RGB tensor.
+    """
+    if frames_rgb.dtype != TORCH_UINT8 or frames_rgb.ndim != 4 or int(frames_rgb.shape[-1]) != 3:
+        raise ValueError("YOLOX preprocessing expects uint8 RGB frames with shape (batch, height, width, 3).")
+    in_h, in_w, out_h, out_w = int(frames_rgb.shape[1]), int(frames_rgb.shape[2]), int(model_input_size[0]), int(model_input_size[1])
+    ratio = min(out_h / in_h, out_w / in_w)
+    resized_h, resized_w = int(in_h * ratio), int(in_w * ratio)
+    resized = F.interpolate(frames_rgb.flip((-1,)).permute(0, 3, 1, 2).float(), size=(resized_h, resized_w), mode="bilinear", align_corners=False)
+    detector_inputs = torch.full((int(frames_rgb.shape[0]), 3, out_h, out_w), 114.0, dtype=torch.float32, device=frames_rgb.device)
+    detector_inputs[:, :, :resized_h, :resized_w] = resized
+    return detector_inputs.contiguous(), torch.full((int(frames_rgb.shape[0]),), ratio, dtype=torch.float32, device=frames_rgb.device)
+
+
+def prepare_sapiens_pose_inputs_torch(frames_rgb: UInt8[Tensor, "batch h w 3"], *, frame_indices: Int[Tensor, "n"], bboxes_xyxy: Float[Tensor, "n 4"], input_size: tuple[int, int] = (768, 1024), padding: float = 1.25, dtype: torch.dtype = torch.float16) -> SapiensPoseInputBatch:
+    """Generate batched Sapiens pose crops from GPU frames and person boxes.
+
+    Args:
+        frames_rgb: RGB video frames with shape ``(batch, height, width, 3)``.
+        frame_indices: Source frame index for each person crop.
+        bboxes_xyxy: Person boxes in image-space ``xyxy`` order.
+        input_size: Sapiens crop size as ``(width, height)``.
+        padding: Bbox padding multiplier used before cropping.
+        dtype: Output tensor dtype for TensorRT/PyTorch pose inference.
+
+    Returns:
+        Pose input batch with normalized crops and decode metadata.
+    """
+    return _prepare_pose_inputs_torch(frames_rgb, frame_indices=frame_indices, bboxes_xyxy=bboxes_xyxy, input_size=input_size, padding=padding, dtype=dtype, batch_type=SapiensPoseInputBatch, cv2_affine=False, bgr_input=False)
+
+
+def prepare_rtmlib_pose_inputs_torch(frames_rgb: UInt8[Tensor, "batch h w 3"], *, frame_indices: Int[Tensor, "n"], bboxes_xyxy: Float[Tensor, "n 4"], input_size: tuple[int, int] = RTMLIB_POSE_INPUT_SIZE, padding: float = 1.25, dtype: torch.dtype = torch.float16) -> RtmlibPoseInputBatch:
+    """Generate batched RTMLib pose crops from GPU RGB frames.
+
+    Args:
+        frames_rgb: RGB video frames with shape ``(batch, height, width, 3)``.
+        frame_indices: Source frame index for each person crop.
+        bboxes_xyxy: Person boxes in image-space ``xyxy`` order.
+        input_size: RTMLib crop size as ``(width, height)``.
+        padding: Bbox padding multiplier used before cropping.
+        dtype: Output tensor dtype for TensorRT/PyTorch pose inference.
+
+    Returns:
+        Pose input batch with BGR-normalized crops and decode metadata.
+    """
+    return _prepare_pose_inputs_torch(frames_rgb, frame_indices=frame_indices, bboxes_xyxy=bboxes_xyxy, input_size=input_size, padding=padding, dtype=dtype, batch_type=RtmlibPoseInputBatch, cv2_affine=True, bgr_input=True)
+
+
+def _prepare_pose_inputs_torch(frames_rgb: UInt8[Tensor, "batch h w 3"], *, frame_indices: Int[Tensor, "n"], bboxes_xyxy: Float[Tensor, "n 4"], input_size: tuple[int, int], padding: float, dtype: torch.dtype, batch_type: type[PoseInputBatch], cv2_affine: bool, bgr_input: bool) -> PoseInputBatch:
+    if frames_rgb.dtype != TORCH_UINT8 or frames_rgb.ndim != 4 or int(frames_rgb.shape[-1]) != 3:
+        raise ValueError("Pose crop preprocessing expects uint8 RGB frames with shape (batch, height, width, 3).")
+    frame_indices = frame_indices.to(device=frames_rgb.device, dtype=torch.long).reshape(-1)
+    bboxes = bboxes_xyxy.to(device=frames_rgb.device, dtype=torch.float32).reshape(-1, 4)
+    out_w, out_h = int(input_size[0]), int(input_size[1])
+    if int(bboxes.shape[0]) == 0:
+        return batch_type(torch.empty((0, 3, out_h, out_w), dtype=dtype, device=frames_rgb.device), frame_indices, bboxes, torch.empty((0, 2), dtype=torch.float32, device=frames_rgb.device), torch.empty((0, 2), dtype=torch.float32, device=frames_rgb.device), input_size)
+    centers, scales = _bbox_xyxy_to_sapiens_center_scale_torch(bboxes, input_size=input_size, padding=padding)
+    yy, xx = _sapiens_crop_meshgrid_torch(out_h, out_w, centers.device, centers.dtype)
+    src_x = (xx[None] - float(out_w) * 0.5) * scales[:, 0, None, None] / float(out_w) + centers[:, 0, None, None] if cv2_affine else xx[None] * scales[:, 0, None, None] / float(out_w - 1) + centers[:, 0, None, None] - 0.5 * scales[:, 0, None, None]
+    src_y = (yy[None] - float(out_h) * 0.5) * scales[:, 1, None, None] / float(out_h) + centers[:, 1, None, None] if cv2_affine else yy[None] * scales[:, 1, None, None] / float(out_h - 1) + centers[:, 1, None, None] - 0.5 * scales[:, 1, None, None]
+    grid = torch.stack([src_x / float(int(frames_rgb.shape[2]) - 1) * 2.0 - 1.0, src_y / float(int(frames_rgb.shape[1]) - 1) * 2.0 - 1.0], dim=-1).contiguous()
+    with torch.backends.cudnn.flags(enabled=False):
+        crops = F.grid_sample((frames_rgb[frame_indices].flip((-1,)) if bgr_input else frames_rgb[frame_indices]).permute(0, 3, 1, 2).contiguous().float(), grid, mode="bilinear", padding_mode="zeros", align_corners=True)
+    mean, std = _sapiens_normalization_tensors_torch(frames_rgb.device)
+    return batch_type(((crops - mean) / std).to(dtype=dtype).contiguous(), frame_indices, bboxes, centers, scales, input_size)
+
+
+def _bbox_xyxy_to_sapiens_center_scale_torch(bboxes_xyxy: Float[Tensor, "n 4"], *, input_size: tuple[int, int], padding: float) -> tuple[Float[Tensor, "n 2"], Float[Tensor, "n 2"]]:
+    centers = (bboxes_xyxy[:, 0:2] + bboxes_xyxy[:, 2:4]) * 0.5
+    scales = (bboxes_xyxy[:, 2:4] - bboxes_xyxy[:, 0:2]) * float(padding)
+    aspect, widths, heights = float(input_size[0]) / float(input_size[1]), scales[:, 0], scales[:, 1]
+    return centers.contiguous(), torch.where((widths > heights * aspect)[:, None], torch.stack([widths, widths / aspect], dim=1), torch.stack([heights * aspect, heights], dim=1)).contiguous()
+
+
+@lru_cache(maxsize=8)
+def _sapiens_normalization_tensors_torch(device: torch.device) -> tuple[Float[Tensor, "1 3 1 1"], Float[Tensor, "1 3 1 1"]]:
+    return torch.tensor([123.675, 116.28, 103.53], dtype=torch.float32, device=device).view(1, 3, 1, 1), torch.tensor([58.395, 57.12, 57.375], dtype=torch.float32, device=device).view(1, 3, 1, 1)
+
+
+@lru_cache(maxsize=8)
+def _sapiens_crop_meshgrid_torch(output_height: int, output_width: int, device: torch.device, dtype: torch.dtype) -> tuple[Float[Tensor, "out_h out_w"], Float[Tensor, "out_h out_w"]]:
+    grid_y: Float[Tensor, "out_h out_w"]
+    grid_x: Float[Tensor, "out_h out_w"]
+    grid_y, grid_x = torch.meshgrid(torch.linspace(0.0, float(output_height - 1), output_height, dtype=dtype, device=device), torch.linspace(0.0, float(output_width - 1), output_width, dtype=dtype, device=device), indexing="ij")
+    return grid_y, grid_x
+
+
+def decode_sapiens_heatmaps_to_coco133_torch(heatmaps: Tensor, batch: SapiensPoseInputBatch, *, model_size: ModelSize = DEFAULT_MODEL_SIZE) -> tuple[Float32[ndarray, "n 133 2"], Float32[ndarray, "n 133"]]:
+    """Decode Sapiens heatmaps into image-space COCO-133 keypoints.
+
+    Args:
+        heatmaps: Sapiens heatmaps with shape ``(n, 308, heatmap_h, heatmap_w)``.
+        batch: Sapiens pose input batch containing crop centers and scales.
+        model_size: Sapiens model size used to select heatmap/input metadata.
+
+    Returns:
+        A tuple containing image-space COCO-133 keypoints with shape ``(n, 133, 2)`` and confidence scores with shape
+        ``(n, 133)``.
+
+    Raises:
+        ValueError: If ``heatmaps`` does not have the expected Sapiens channel layout.
+    """
+    if heatmaps.ndim != 4 or int(heatmaps.shape[1]) != 308:
+        raise ValueError(f"Expected Sapiens heatmaps with shape (n, 308, h, w), got {tuple(heatmaps.shape)}.")
+    spec, device, num_instances = MODEL_SPECS[model_size], heatmaps.device, int(heatmaps.shape[0])
+    coco_indices, sapiens_indices = _coco133_projection_index_tensors(device)
+    keypoints_input, mapped_scores = _decode_udp_heatmaps_torch(heatmaps[:, sapiens_indices].float(), input_size=(int(spec.input_size[0]), int(spec.input_size[1])), heatmap_size=(int(spec.heatmap_size[0]), int(spec.heatmap_size[1])), blur_kernel_size=11)
+    centers, scales = batch.bbox_centers.to(device=device, dtype=torch.float32), batch.bbox_scales.to(device=device, dtype=torch.float32)
+    keypoints_image = keypoints_input / _float32_vector_torch(batch.input_size, device) * scales[:, None, :] + centers[:, None, :] - 0.5 * scales[:, None, :]
+    keypoints_coco = torch.full((num_instances, 133, 2), float("nan"), dtype=torch.float32, device=device)
+    scores_coco = torch.zeros((num_instances, 133), dtype=torch.float32, device=device)
+    keypoints_coco[:, coco_indices], scores_coco[:, coco_indices] = keypoints_image, mapped_scores
+    return keypoints_coco.cpu().numpy().astype(np.float32, copy=False), scores_coco.cpu().numpy().astype(np.float32, copy=False)
+
+
+def decode_rtmlib_simcc_to_coco133_torch(simcc_x: Tensor, simcc_y: Tensor, batch: RtmlibPoseInputBatch) -> tuple[Float32[ndarray, "n 133 2"], Float32[ndarray, "n 133"]]:
+    """Decode RTMLib RTMW SimCC outputs into image-space COCO-133 keypoints.
+
+    Args:
+        simcc_x: RTMW x-axis SimCC logits with shape ``(n, 133, bins_x)``.
+        simcc_y: RTMW y-axis SimCC logits with shape ``(n, 133, bins_y)``.
+        batch: RTMLib pose input batch containing crop centers and scales.
+
+    Returns:
+        A tuple containing image-space COCO-133 keypoints with shape ``(n, 133, 2)`` and confidence scores with shape
+        ``(n, 133)``.
+
+    Raises:
+        ValueError: If either SimCC tensor does not have the expected COCO-133 layout.
+    """
+    if simcc_x.ndim != 3 or simcc_y.ndim != 3 or int(simcc_x.shape[1]) != 133 or int(simcc_y.shape[1]) != 133:
+        raise ValueError(f"Expected RTMLib SimCC outputs with shape (n, 133, bins), got {tuple(simcc_x.shape)} and {tuple(simcc_y.shape)}.")
+    x_scores, x_locs = simcc_x.float().max(dim=-1)
+    y_scores, y_locs = simcc_y.float().max(dim=-1)
+    scores = 0.5 * (x_scores + y_scores)
+    locs = torch.where((scores > 0.0)[:, :, None], torch.stack([x_locs.float(), y_locs.float()], dim=-1), torch.full((*scores.shape, 2), -1.0, dtype=torch.float32, device=simcc_x.device))
+    centers, scales = batch.bbox_centers.to(device=simcc_x.device, dtype=torch.float32), batch.bbox_scales.to(device=simcc_x.device, dtype=torch.float32)
+    keypoints_image = (locs / 2.0) / _float32_vector_torch(batch.input_size, simcc_x.device) * scales[:, None, :] + centers[:, None, :] - 0.5 * scales[:, None, :]
+    return keypoints_image.cpu().numpy().astype(np.float32, copy=False), scores.cpu().numpy().astype(np.float32, copy=False)
+
+
+def _decode_udp_heatmaps_torch(heatmaps: Float[Tensor, "n k h w"], *, input_size: tuple[int, int], heatmap_size: tuple[int, int], blur_kernel_size: int) -> tuple[Float[Tensor, "n k 2"], Float[Tensor, "n k"]]:
+    num_instances, num_keypoints, heatmap_height, heatmap_width = int(heatmaps.shape[0]), int(heatmaps.shape[1]), int(heatmaps.shape[2]), int(heatmaps.shape[3])
+    scores, flat_indices = heatmaps.reshape(num_instances, num_keypoints, -1).max(dim=-1)
+    keypoints = torch.stack([(flat_indices % heatmap_width).float(), torch.div(flat_indices, heatmap_width, rounding_mode="floor").float()], dim=-1)
+    keypoints = torch.where((scores > 0.0)[:, :, None], keypoints, torch.full_like(keypoints, -1.0))
+    original_max = heatmaps.reshape(num_instances * num_keypoints, -1).amax(dim=1).clamp_min(1e-12)
+    blurred = _gaussian_blur_heatmaps_torch(heatmaps, blur_kernel_size)
+    blurred = blurred * (original_max / blurred.reshape(num_instances * num_keypoints, -1).amax(dim=1).clamp_min(1e-12)).reshape(num_instances, num_keypoints, 1, 1)
+    padded = F.pad(blurred.clamp(1e-3, 50.0).log().reshape(num_instances * num_keypoints, 1, heatmap_height, heatmap_width), (1, 1, 1, 1), mode="replicate").reshape(num_instances, num_keypoints, heatmap_height + 2, heatmap_width + 2)
+    x_idx, y_idx = keypoints[..., 0].round().long().clamp(0, heatmap_width - 1) + 1, keypoints[..., 1].round().long().clamp(0, heatmap_height - 1) + 1
+    instance_idx, keypoint_idx = _long_arange_torch(num_instances, heatmaps.device)[:, None], _long_arange_torch(num_keypoints, heatmaps.device)[None, :]
+    center, ix1, iy1 = padded[instance_idx, keypoint_idx, y_idx, x_idx], padded[instance_idx, keypoint_idx, y_idx, x_idx + 1], padded[instance_idx, keypoint_idx, y_idx + 1, x_idx]
+    ix1y1, ix1_y1_, ix1_, iy1_ = padded[instance_idx, keypoint_idx, y_idx + 1, x_idx + 1], padded[instance_idx, keypoint_idx, y_idx - 1, x_idx - 1], padded[instance_idx, keypoint_idx, y_idx, x_idx - 1], padded[instance_idx, keypoint_idx, y_idx - 1, x_idx]
+    derivative = torch.stack([0.5 * (ix1 - ix1_), 0.5 * (iy1 - iy1_)], dim=-1).unsqueeze(-1)
+    dxy = 0.5 * (ix1y1 - ix1 - iy1 + center + center - ix1_ - iy1_ + ix1_y1_)
+    hessian = torch.stack([ix1 - 2.0 * center + ix1_, dxy, dxy, iy1 - 2.0 * center + iy1_], dim=-1).reshape(num_instances, num_keypoints, 2, 2)
+    offsets = torch.linalg.solve(hessian + torch.finfo(torch.float32).eps * _eye2_torch(heatmaps.device), derivative).squeeze(-1)
+    refined = torch.where(torch.isfinite(offsets).all(dim=-1, keepdim=True), keypoints - offsets, keypoints)
+    return refined * _float32_vector_torch((float(input_size[0]) / float(heatmap_size[0] - 1), float(input_size[1]) / float(heatmap_size[1] - 1)), heatmaps.device), scores
+
+
+def _gaussian_blur_heatmaps_torch(heatmaps: Float[Tensor, "n k h w"], kernel_size: int) -> Float[Tensor, "n k h w"]:
+    border, n, k, h, w = (kernel_size - 1) // 2, int(heatmaps.shape[0]), int(heatmaps.shape[1]), int(heatmaps.shape[2]), int(heatmaps.shape[3])
+    kernel = _gaussian_kernel1d_torch(kernel_size, device=heatmaps.device)
+    padded = F.pad(heatmaps.reshape(n * k, 1, h, w), (border, border, border, border), mode="constant", value=0.0)
+    return F.conv2d(F.conv2d(padded, kernel.reshape(1, 1, 1, kernel_size), padding=(0, border)), kernel.reshape(1, 1, kernel_size, 1), padding=(border, 0))[:, :, border:-border, border:-border].reshape(n, k, h, w)
+
+
+@lru_cache(maxsize=8)
+def _gaussian_kernel1d_np(kernel_size: int) -> Float32[ndarray, "kernel"]:
+    import cv2
+
+    return cv2.getGaussianKernel(kernel_size, 0).astype(np.float32).reshape(kernel_size)
+
+
+@lru_cache(maxsize=16)
+def _gaussian_kernel1d_torch(kernel_size: int, *, device: torch.device) -> Float[Tensor, "kernel"]:
+    return torch.as_tensor(_gaussian_kernel1d_np(kernel_size), dtype=torch.float32, device=device)
+
+
+@lru_cache(maxsize=1)
+def _coco133_projection_indices_np() -> tuple[Int[ndarray, "mapped"], Int[ndarray, "mapped"]]:
+    mapping = {int(k): int(v) for k, v in get_sapiens_metainfo()["coco_wholebody_to_goliath_mapping"].items()}
+    pairs = sorted((coco_idx, sapiens_idx) for coco_idx, sapiens_idx in mapping.items() if 0 <= coco_idx < 133)
+    return np.asarray([p[0] for p in pairs], dtype=np.int64), np.asarray([p[1] for p in pairs], dtype=np.int64)
+
+
+@lru_cache(maxsize=8)
+def _coco133_projection_index_tensors(device: torch.device) -> tuple[Tensor, Tensor]:
+    coco_indices, sapiens_indices = _coco133_projection_indices_np()
+    return torch.as_tensor(coco_indices, dtype=torch.long, device=device), torch.as_tensor(sapiens_indices, dtype=torch.long, device=device)
+
+
+@lru_cache(maxsize=16)
+def _float32_vector_torch(values: tuple[float, ...] | tuple[int, ...], device: torch.device) -> Float[Tensor, "n"]:
+    return torch.tensor(tuple(float(v) for v in values), dtype=torch.float32, device=device)
+
+
+@lru_cache(maxsize=16)
+def _long_arange_torch(length: int, device: torch.device) -> Tensor:
+    return torch.arange(length, dtype=torch.long, device=device)
+
+
+@lru_cache(maxsize=8)
+def _eye2_torch(device: torch.device) -> Float[Tensor, "1 1 2 2"]:
+    return torch.eye(2, dtype=torch.float32, device=device).reshape(1, 1, 2, 2)
+
+
+class TensorRtYoloxDetectorRunner:
+    """Callable wrapper for a static-batch RTMLib YOLOX TensorRT engine."""
+
+    def __init__(self, engine_path: Path, *, input_name: str, output_name: str, score_output_name: str | None = None, extra_output_names: tuple[str, ...] = (), max_detections: int = YOLOX_DEFAULT_MAX_DETECTIONS, model_input_size: tuple[int, int], static_batch_size: int) -> None:
+        """Initialize a static-batch YOLOX TensorRT runner.
+
+        Args:
+            engine_path: Path to the TensorRT detector engine.
+            input_name: TensorRT input tensor name.
+            output_name: TensorRT decoded-box or raw-output tensor name.
+            score_output_name: Optional decoded-score tensor name.
+            extra_output_names: Additional output tensor names to bind.
+            max_detections: Maximum decoded detections expected from the engine. Kept for API symmetry.
+            model_input_size: Detector input size as ``(height, width)``.
+            static_batch_size: Static batch size baked into the engine.
+        """
+        from wilor_nano.api.tensorrt_runtime import _StaticTensorRtRunner
+
+        del max_detections
+        self._runner = _StaticTensorRtRunner(engine_path, input_name=input_name, output_names=(output_name, *(() if score_output_name is None else (score_output_name,)), *extra_output_names), static_input_shape=(3, int(model_input_size[0]), int(model_input_size[1])), static_batch_size=static_batch_size)
+        self._output_name, self._score_output_name = output_name, score_output_name
+
+    def __call__(self, inputs: Float[Tensor, "batch 3 det_h det_w"]) -> YoloxDetectorOutput:
+        """Run YOLOX TensorRT inference.
+
+        Args:
+            inputs: CUDA float32 detector inputs with shape ``(batch, 3, det_h, det_w)``.
+
+        Returns:
+            Raw YOLOX output or decoded boxes and scores, depending on the engine outputs.
+
+        Raises:
+            ValueError: If ``inputs`` is not CUDA float32.
+        """
+        if inputs.device.type != "cuda" or inputs.dtype != torch.float32:
+            raise ValueError("YOLOX TensorRT expects CUDA float32 NCHW inputs.")
+        batch_size, outputs = self._runner.run(inputs)
+        return DecodedYoloxHeadOutput(outputs[self._output_name][:batch_size], outputs[self._score_output_name][:batch_size]) if self._score_output_name is not None else outputs[self._output_name][:batch_size]
+
+
+class TensorRtPoseRunner:
+    """Callable wrapper for a static-batch pose TensorRT engine."""
+
+    def __init__(self, engine_path: Path, *, input_name: str, output_names: tuple[str, ...], static_input_shape: tuple[int, int, int], static_batch_size: int, convert_input_dtype: bool) -> None:
+        """Initialize a static-batch pose TensorRT runner.
+
+        Args:
+            engine_path: Path to the TensorRT pose engine.
+            input_name: TensorRT input tensor name.
+            output_names: TensorRT output tensor names.
+            static_input_shape: Static input shape without batch as ``(channels, height, width)``.
+            static_batch_size: Static batch size baked into the engine.
+            convert_input_dtype: Whether to cast incoming tensors to the engine input dtype.
+        """
+        from wilor_nano.api.tensorrt_runtime import _StaticTensorRtRunner
+
+        self._runner = _StaticTensorRtRunner(engine_path, input_name=input_name, output_names=output_names, static_input_shape=static_input_shape, static_batch_size=static_batch_size)
+        self._output_names, self._convert_input_dtype = output_names, convert_input_dtype
+        input_dtype: Any = self._runner._engine.get_tensor_dtype(self._runner._input_name)
+        self._input_dtype: torch.dtype = torch.float16 if input_dtype == self._runner._trt.DataType.HALF else torch.float32
+
+    def __call__(self, inputs: Float[Tensor, "batch 3 h w"]) -> tuple[Tensor, ...]:
+        """Run pose TensorRT inference.
+
+        Args:
+            inputs: CUDA NCHW pose inputs.
+
+        Returns:
+            Output tensors sliced back to the unpadded runtime batch size.
+
+        Raises:
+            ValueError: If device or dtype does not match the engine requirements.
+        """
+        if inputs.device.type != "cuda" or inputs.dtype not in (torch.float16, torch.float32):
+            raise ValueError("Pose TensorRT expects CUDA float16 or float32 NCHW inputs.")
+        if inputs.dtype != self._input_dtype and self._convert_input_dtype:
+            inputs = inputs.to(dtype=self._input_dtype)
+        elif inputs.dtype != self._input_dtype:
+            raise ValueError(f"Pose TensorRT expects {self._input_dtype} inputs.")
+        batch_size, outputs = self._runner.run(inputs)
+        return tuple(outputs[name][:batch_size] for name in self._output_names)
+
+
+def TensorRtSapiensPoseRunner(engine_path: Path, *, input_name: str, output_name: str, static_batch_size: int) -> TensorRtPoseRunner:
+    """Create a Sapiens heatmap TensorRT runner.
+
+    Args:
+        engine_path: Path to the Sapiens TensorRT engine.
+        input_name: TensorRT input tensor name.
+        output_name: TensorRT heatmap output tensor name.
+        static_batch_size: Static batch size baked into the engine.
+
+    Returns:
+        Configured static-batch pose runner.
+    """
+    return TensorRtPoseRunner(engine_path, input_name=input_name, output_names=(output_name,), static_input_shape=POSE_INPUT_SHAPE, static_batch_size=static_batch_size, convert_input_dtype=False)
+
+
+def TensorRtRtmlibPoseRunner(engine_path: Path, *, input_name: str, simcc_x_output_name: str, simcc_y_output_name: str, model_input_size: tuple[int, int], static_batch_size: int) -> TensorRtPoseRunner:
+    """Create an RTMLib RTMW SimCC TensorRT runner.
+
+    Args:
+        engine_path: Path to the RTMW TensorRT engine.
+        input_name: TensorRT input tensor name.
+        simcc_x_output_name: TensorRT SimCC-x output tensor name.
+        simcc_y_output_name: TensorRT SimCC-y output tensor name.
+        model_input_size: RTMW pose input size as ``(width, height)``.
+        static_batch_size: Static batch size baked into the engine.
+
+    Returns:
+        Configured static-batch pose runner.
+    """
+    return TensorRtPoseRunner(engine_path, input_name=input_name, output_names=(simcc_x_output_name, simcc_y_output_name), static_input_shape=(3, int(model_input_size[1]), int(model_input_size[0])), static_batch_size=static_batch_size, convert_input_dtype=True)
+
+
+def postprocess_yolox_outputs_torch(outputs: YoloxDetectorOutput, *, resize_ratios: Float[Tensor, "batch"], model_input_size: tuple[int, int], score_thr: float = 0.3, nms_thr: float = 0.45) -> list[Float[Tensor, "n 4"]]:
+    """Postprocess batched YOLOX outputs into per-frame person boxes.
+
+    Args:
+        outputs: Raw or decoded YOLOX TensorRT outputs.
+        resize_ratios: Per-frame letterbox resize ratios returned by preprocessing.
+        model_input_size: Detector input size as ``(height, width)``.
+        score_thr: Minimum person score.
+        nms_thr: Non-maximum suppression threshold.
+
+    Returns:
+        One image-space ``xyxy`` box tensor per input frame.
+    """
+    from torchvision.ops import nms
+
+    boxes_xyxy, person_scores = _yolox_boxes_and_scores(outputs, model_input_size=model_input_size)
+    frame_boxes = []
+    for idx in range(int(boxes_xyxy.shape[0])):
+        boxes, scores = boxes_xyxy[idx] / resize_ratios[idx], person_scores[idx]
+        mask = scores > float(score_thr)
+        boxes, scores = boxes[mask], scores[mask]
+        frame_boxes.append(torch.empty((0, 4), dtype=torch.float32, device=boxes_xyxy.device) if int(boxes.shape[0]) == 0 else boxes[nms(boxes, scores, float(nms_thr))].contiguous())
+    return frame_boxes
+
+
+def _yolox_boxes_and_scores(outputs: YoloxDetectorOutput, *, model_input_size: tuple[int, int]) -> tuple[Tensor, Tensor]:
+    if isinstance(outputs, DecodedYoloxHeadOutput):
+        if outputs.boxes.ndim != 3 or outputs.scores.ndim != 3 or int(outputs.boxes.shape[-1]) != 4 or int(outputs.scores.shape[-1]) < 1:
+            raise ValueError(f"Expected decoded YOLOX boxes (batch, anchors, 4) and scores (batch, anchors, classes), got {tuple(outputs.boxes.shape)} and {tuple(outputs.scores.shape)}.")
+        return outputs.boxes.float(), outputs.scores[..., 0].float()
+    if outputs.ndim != 3 or int(outputs.shape[-1]) < 5:
+        raise ValueError(f"Expected YOLOX output shape (batch, anchors, fields>=5), got {tuple(outputs.shape)}.")
+    if int(outputs.shape[-1]) == 5:
+        return outputs[..., :4].float(), outputs[..., 4].float()
+    grid, stride = _yolox_grid_stride(int(model_input_size[0]), int(model_input_size[1]), outputs.device)
+    pred = outputs.float().clone()
+    pred[..., :2], pred[..., 2:4] = (pred[..., :2] + grid) * stride, torch.exp(pred[..., 2:4]) * stride
+    boxes = torch.empty_like(pred[..., :4])
+    boxes[..., 0:2], boxes[..., 2:4] = pred[..., :2] - pred[..., 2:4] * 0.5, pred[..., :2] + pred[..., 2:4] * 0.5
+    return boxes, (pred[..., 4:5] * pred[..., 5:])[..., 0]
+
+
+@lru_cache(maxsize=8)
+def _yolox_grid_stride(height: int, width: int, device: torch.device) -> tuple[Tensor, Tensor]:
+    grids, strides = [], []
+    for stride in (8, 16, 32):
+        yy, xx = torch.meshgrid(torch.arange(height // stride, dtype=torch.float32, device=device), torch.arange(width // stride, dtype=torch.float32, device=device), indexing="ij")
+        grid = torch.stack((xx, yy), dim=2).reshape(1, -1, 2)
+        grids.append(grid)
+        strides.append(torch.full((*grid.shape[:2], 1), float(stride), dtype=torch.float32, device=device))
+    return torch.cat(grids, dim=1), torch.cat(strides, dim=1)

--- a/packages/sapiens2-pose/src/sapiens2_pose/api/coco133_tensorrt_conversion.py
+++ b/packages/sapiens2-pose/src/sapiens2_pose/api/coco133_tensorrt_conversion.py
@@ -1,0 +1,229 @@
+"""ONNX export and TensorRT build helpers for Sapiens COCO-133 deployment."""
+
+import hashlib
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, NamedTuple
+
+import torch
+from jaxtyping import Float
+from torch import Tensor
+
+from sapiens2_pose.api.runtime import DEFAULT_MODEL_SIZE, DeviceChoice, ModelSize, resolve_device
+from sapiens2_pose.api.tensorrt_pose import make_sapiens_pose_onnx_exportable
+from sapiens2_pose.sapiens_lite.pose import MODEL_SPECS, init_pose_model
+
+TensorRtTarget = Literal["detector", "pose", "rtmlib-pose"]
+TensorRtPrecision = Literal["fp16"]
+ModelLoader = Callable[[str, str | Path, str], torch.nn.Module]
+ExportFn = Callable[..., object]
+
+
+@dataclass(frozen=True, slots=True)
+class SapiensCoco133PoseOnnxExportConfig:
+    """Configuration for exporting batched Sapiens2 pose ONNX."""
+
+    checkpoint_path: Path
+    """Input Sapiens checkpoint path."""
+    onnx_path: Path
+    """Output ONNX path."""
+    model_size: ModelSize = DEFAULT_MODEL_SIZE
+    """Sapiens model size to export."""
+    batch_size: int = 4
+    """Static batch size baked into the exported ONNX graph."""
+    device: DeviceChoice = "cuda"
+    """Device used while exporting the ONNX graph."""
+    opset_version: int = 17
+    """ONNX opset version passed to ``torch.onnx.export``."""
+    dynamo: bool = True
+    """Whether to use the torch.export-based ONNX exporter."""
+
+    @property
+    def dtype(self) -> torch.dtype:
+        """Tensor dtype used by the exported pose graph.
+
+        Returns:
+            The fixed FP16 export dtype.
+        """
+        return torch.float16
+
+
+class SapiensCoco133PoseOnnxExportSummary(NamedTuple):
+    """Summary returned after exporting Sapiens COCO-133 pose ONNX."""
+
+    checkpoint_path: Path
+    """Input Sapiens checkpoint path."""
+    onnx_path: Path
+    """Written ONNX path."""
+    model_size: ModelSize
+    """Exported Sapiens model size."""
+    batch_size: int
+    """Static batch size baked into the ONNX graph."""
+    input_shape: tuple[int, int, int, int]
+    """Exported input tensor shape."""
+    output_shape: tuple[int, int, int, int]
+    """Exported output tensor shape."""
+    opset_version: int
+    """ONNX opset version."""
+    dynamo: bool
+    """Whether the torch.export-based ONNX exporter was used."""
+
+
+@dataclass(frozen=True, slots=True)
+class TensorRtEngineBuildConfig:
+    """Configuration for building one static-batch TensorRT engine."""
+
+    target: TensorRtTarget
+    """Deployment target represented by the ONNX graph."""
+    onnx_path: Path
+    """Input ONNX model path."""
+    engine_path: Path
+    """Output TensorRT engine path."""
+    input_name: str
+    """TensorRT network input tensor name."""
+    output_names: tuple[str, ...]
+    """TensorRT network output tensor names."""
+    input_shape: tuple[int, ...]
+    """Static input shape without the batch dimension."""
+    batch_size: int
+    """Static batch size for the TensorRT optimization profile."""
+    workspace_gib: float = 24.0
+    """TensorRT builder workspace size in GiB."""
+    builder_optimization_level: int = 3
+    """TensorRT builder optimization level from 0 to 5."""
+
+    @property
+    def precision(self) -> TensorRtPrecision:
+        """TensorRT precision preset.
+
+        Returns:
+            The fixed FP16 precision string.
+        """
+        return "fp16"
+
+    def validate(self) -> None:
+        """Validate TensorRT build settings.
+
+        Raises:
+            ValueError: If batch size, workspace, or optimization level is invalid.
+        """
+        if self.batch_size <= 0 or self.workspace_gib <= 0.0 or not (0 <= self.builder_optimization_level <= 5):
+            raise ValueError("Invalid TensorRT build settings.")
+
+    def to_manifest(self, *, tensorrt_version: str, cuda_device_name: str) -> dict[str, object]:
+        """Build reproducibility metadata for a machine-local TensorRT engine.
+
+        Args:
+            tensorrt_version: TensorRT package version used for the build.
+            cuda_device_name: CUDA device name used for the build.
+
+        Returns:
+            JSON-serializable manifest content.
+        """
+        self.validate()
+        return {"target": self.target, "precision": self.precision, "onnx_path": str(self.onnx_path), "onnx_sha256": _sha256_file(self.onnx_path), "engine_path": str(self.engine_path), "portable_engine": False, "rebuild_from_onnx_on_target_machine": True, "batch_profile_preset": f"static-b{self.batch_size}", "batch_profile": {"min": self.batch_size, "optimal": self.batch_size, "max": self.batch_size}, "workspace_gib": self.workspace_gib, "builder_optimization_level": self.builder_optimization_level, "runtime_recommendation": "static_batch_padding", "tensorrt_version": tensorrt_version, "cuda_device_name": cuda_device_name, "model_io": {"input_name": self.input_name, "input_shape": [self.batch_size, *self.input_shape], "output_names": list(self.output_names)}}
+
+
+class TensorRtEngineBuildSummary(NamedTuple):
+    """Summary returned after building a TensorRT engine."""
+
+    engine_path: Path
+    """Written TensorRT engine path."""
+    manifest_path: Path
+    """Written engine reproducibility manifest path."""
+    target: TensorRtTarget
+    """Engine target type."""
+    precision: TensorRtPrecision
+    """TensorRT precision preset."""
+    static_batch_size: int
+    """Static batch size baked into the engine optimization profile."""
+
+
+def export_sapiens_coco133_pose_onnx(config: SapiensCoco133PoseOnnxExportConfig, *, model_loader: ModelLoader = init_pose_model, export_fn: ExportFn = torch.onnx.export) -> SapiensCoco133PoseOnnxExportSummary:
+    """Export a static-batch FP16 Sapiens2 pose network to ONNX.
+
+    Args:
+        config: Sapiens checkpoint, output path, model size, batch, device, and exporter settings.
+        model_loader: Model loader override used by tests.
+        export_fn: ONNX export function override used by tests.
+
+    Returns:
+        Export summary containing paths, model size, batch size, input/output shapes, and exporter settings.
+
+    Raises:
+        ValueError: If ``batch_size`` is not positive.
+    """
+    if config.batch_size <= 0:
+        raise ValueError("batch_size must be positive.")
+    device = resolve_device(config.device)
+    spec = MODEL_SPECS[config.model_size]
+    input_shape = (config.batch_size, 3, int(spec.image_size[0]), int(spec.image_size[1]))
+    output_shape = (config.batch_size, int(spec.num_keypoints), int(spec.heatmap_size[1]), int(spec.heatmap_size[0]))
+    model = make_sapiens_pose_onnx_exportable(model_loader(config.model_size, config.checkpoint_path, device)).to(device=device, dtype=config.dtype).eval()
+    dummy_inputs: Float[Tensor, "batch 3 1024 768"] = torch.zeros(input_shape, dtype=config.dtype, device=device)
+    config.onnx_path.parent.mkdir(parents=True, exist_ok=True)
+    with torch.no_grad():
+        export_fn(model, (dummy_inputs,), config.onnx_path, export_params=True, opset_version=config.opset_version, do_constant_folding=True, input_names=["inputs"], output_names=["heatmaps"], dynamic_axes=None, dynamo=config.dynamo)
+    return SapiensCoco133PoseOnnxExportSummary(config.checkpoint_path, config.onnx_path, config.model_size, config.batch_size, input_shape, output_shape, config.opset_version, config.dynamo)
+
+
+def build_tensorrt_engine(config: TensorRtEngineBuildConfig) -> TensorRtEngineBuildSummary:
+    """Build a static-batch FP16 TensorRT engine from ONNX and write a manifest.
+
+    Args:
+        config: TensorRT target, ONNX path, output engine path, IO names, shape, and builder settings.
+
+    Returns:
+        Engine path, manifest path, target, precision, and static batch size.
+
+    Raises:
+        RuntimeError: If TensorRT cannot parse the ONNX graph or returns no serialized engine.
+    """
+    config.validate()
+    trt = _import_tensorrt()
+    logger = trt.Logger(trt.Logger.INFO)
+    builder = trt.Builder(logger)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
+    parser = trt.OnnxParser(network, logger)
+    if not bool(parser.parse_from_file(str(config.onnx_path))):
+        raise RuntimeError("TensorRT failed to parse ONNX graph:\n" + "\n".join(str(parser.get_error(idx)) for idx in range(parser.num_errors)))
+    if config.target in ("pose", "rtmlib-pose"):
+        network.get_input(0).dtype = trt.float16
+        for output_idx in range(int(network.num_outputs)):
+            network.get_output(output_idx).dtype = trt.float16
+    builder_config = builder.create_builder_config()
+    builder_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, int(config.workspace_gib * 1024**3))
+    if hasattr(builder_config, "builder_optimization_level"):
+        builder_config.builder_optimization_level = config.builder_optimization_level
+    if hasattr(trt.BuilderFlag, "TF32"):
+        builder_config.clear_flag(trt.BuilderFlag.TF32)
+    builder_config.set_flag(trt.BuilderFlag.FP16)
+    profile = builder.create_optimization_profile()
+    profile.set_shape(str(network.get_input(0).name), (config.batch_size, *config.input_shape), (config.batch_size, *config.input_shape), (config.batch_size, *config.input_shape))
+    builder_config.add_optimization_profile(profile)
+    serialized_engine = builder.build_serialized_network(network, builder_config)
+    if serialized_engine is None:
+        raise RuntimeError("TensorRT returned no serialized engine.")
+    config.engine_path.parent.mkdir(parents=True, exist_ok=True)
+    config.engine_path.write_bytes(bytes(serialized_engine))
+    manifest_path = config.engine_path.with_suffix(config.engine_path.suffix + ".json")
+    manifest_path.write_text(json.dumps(config.to_manifest(tensorrt_version=str(trt.__version__), cuda_device_name=torch.cuda.get_device_name(0) if torch.cuda.is_available() else "unknown"), indent=2, sort_keys=True) + "\n")
+    return TensorRtEngineBuildSummary(config.engine_path, manifest_path, config.target, config.precision, config.batch_size)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return str(digest.hexdigest())
+
+
+def _import_tensorrt() -> Any:
+    try:
+        import tensorrt as trt
+    except ImportError as exc:
+        raise RuntimeError("TensorRT Python bindings are not installed in this Pixi environment.") from exc
+    return trt

--- a/packages/sapiens2-pose/src/sapiens2_pose/api/runtime.py
+++ b/packages/sapiens2-pose/src/sapiens2_pose/api/runtime.py
@@ -60,6 +60,11 @@ _pose_model_cache: dict[tuple[ModelSize, str], Any] = {}
 _detector_cache: dict[str, tuple[Any, Any]] = {}
 
 
+def clear_pose_model_cache() -> None:
+    """Clear cached Sapiens pose models held by this runtime module."""
+    _pose_model_cache.clear()
+
+
 def resolve_device(device: DeviceChoice = "auto") -> str:
     """Resolve a user device choice into a concrete torch device string."""
     if device == "auto":

--- a/pixi.lock
+++ b/pixi.lock
@@ -18024,6 +18024,1124 @@ environments:
       - pypi: packages/monoprior
       - pypi: packages/sam3-rerun
       - pypi: packages/sam3d-body-rerun
+  sapiens-coco133-pose:
+    channels:
+    - url: https://prefix.dev/ai-demos/
+    - url: https://prefix.dev/conda-forge/
+    indexes:
+    - https://pypi.org/simple
+    packages:
+      linux-64:
+      - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/argon2-cffi-bindings-25.1.0-py312h4c3975b_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/av-17.0.1-py312h46547aa_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.1-ha62d5e7_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.13-h2c9d079_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-h8b1a151_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.10.13-h4bacb7b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.26.3-hb18f61d_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.12.2-he6ee468_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-h8b1a151_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-h8b1a151_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/backports.zstd-1.5.0-py312h90b7ffd_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils-2.45.1-default_h4852527_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/brotli-python-1.2.0-py312hdb49522_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-compiler-1.11.0-h4d9bdce_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-crt-12.9.86-h69a702a_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-crt-tools-12.9.86-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-12.9.79-h5888daf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-dev-12.9.79-h5888daf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-static-12.9.79-h5888daf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cuobjdump-12.9.82-hffce074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cupti-12.9.79-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cuxxfilt-12.9.82-hffce074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-driver-dev-12.9.79-h5888daf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-12.9.86-hcdd1206_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-impl-12.9.86-h85509e4_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-tools-12.9.86-he02047a_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc_linux-64-12.9.86-he0b4e1d_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvdisasm-12.9.88-hffce074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvml-dev-12.9.79-hffce074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvprune-12.9.82-hffce074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvrtc-12.9.86-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvrtc-dev-12.9.86-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvtx-12.9.79-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvtx-dev-12.9.79-ha770c72_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvvm-impl-12.9.86-h4bc722e_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvvm-tools-12.9.86-h4bc722e_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-profiler-api-12.9.79-h7938cbb_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cudnn-9.10.2.21-hbcb9cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cusparselt-0.8.1.1-h58dd1b1_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cxx-compiler-1.11.0-hfcd1e18_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/debugpy-1.8.20-py312h8285ef7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-8.1.1-gpl_hee00b0e_901.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fmt-12.1.0-hff5e90c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fontconfig-2.18.0-h27c8c51_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/frozendict-2.4.7-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc-14.3.0-h0dff253_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-h235f0fe_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-14.3.0-h50e9bb6_25.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/glslang-16.3.0-h96af755_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gmpy2-2.3.0-py312hcaba1f9_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx-14.3.0-he448592_7.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-h2185e75_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-14.3.0-h72ca5df_25.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-14.2.0-h6083320_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_h87a9417_105.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hf-transfer-0.1.9-py312h914ccca_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hf-xet-1.5.0-py310hb823017_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/imath-3.2.2-hde8ca8f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/intel-gmmlib-22.10.0-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/intel-media-driver-26.1.6-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/level-zero-1.28.4-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libass-0.17.4-h96ad9f0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libavif16-1.4.2-hcfa2d63_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-7_h5875eb1_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcap-2.77-hd0affe5_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-7_hfef963f_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcublas-12.9.2.10-h676940d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcublas-dev-12.9.2.10-h676940d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudnn-9.10.2.21-hf7e9902_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudnn-dev-9.10.2.21-h58dd1b1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudss-0.7.1.4-h58dd1b1_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudss-dev-0.7.1.4-hee47b17_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufft-11.4.1.4-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufft-dev-11.4.1.4-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufile-1.14.1.1-hbc026e6_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufile-dev-1.14.1.1-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurand-10.3.10.19-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurand-dev-10.3.10.19-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusolver-11.7.5.82-h676940d_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusolver-dev-11.7.5.82-h676940d_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusparse-12.5.10.65-hecca717_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusparse-dev-12.5.10.65-hecca717_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdovi-3.3.2-ha23c83e_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdrm-2.4.127-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhwloc-2.13.0-default_he001693_1000.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhwy-1.4.0-h10be129_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libjxl-0.11.2-h174a0a3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-7_h5e43f62_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-7_hdba1596_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmagma-2.9.0-ha7672b3_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmagma_sparse-2.9.0-h9918c94_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnpp-12.4.1.87-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvjitlink-12.9.86-hecca717_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvjpeg-12.4.0.76-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvptxcompiler-dev-12.9.86-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopencv-4.13.0-qt6_py312h63cde4a_608.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-2026.0.0-hb56ce9e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-batch-plugin-2026.0.0-hd85de46_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-plugin-2026.0.0-hd85de46_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-hetero-plugin-2026.0.0-hd41364c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2026.0.0-hb56ce9e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2026.0.0-hb56ce9e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-npu-plugin-2026.0.0-hb56ce9e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-ir-frontend-2026.0.0-hd41364c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-onnx-frontend-2026.0.0-h7a07914_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-paddle-frontend-2026.0.0-h7a07914_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-pytorch-frontend-2026.0.0-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-frontend-2026.0.0-h78e8023_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2026.0.0-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpciaccess-0.19-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libplacebo-7.360.1-h9eeb4b2_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpq-18.4-hd5a49e9_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libprotobuf-6.33.5-h2b00c02_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/librsvg-2.62.2-h4c96295_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsodium-1.0.22-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsystemd0-257.13-hd0affe5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libtorch-2.10.0-cuda129_mkl_hd98981c_304.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libudev1-257.13-hd0affe5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liburing-2.14-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libuv-1.52.1-h280c20c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libva-2.23.0-he1eb515_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvpl-2.16.0-h54a6638_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvpx-1.15.2-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvulkan-loader-1.4.341.0-h5279c79_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.13.1-hca5e8e5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/llvm-openmp-22.1.6-h4922eb0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mkl-2026.0.0-h0e700b2_915.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/nccl-2.30.4.1-h4d09622_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.4.6-py312h33ff503_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/onemkl-license-2026.0.0-hf2ce2f3_915.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/opencl-headers-2025.06.13-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openexr-3.4.12-h9f1635d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openjph-0.27.3-h8d634f6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/optree-0.19.1-py312hd9148b4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pillow-12.2.0-py312h50c33e8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/psutil-7.2.2-py312h5253ce2_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/py-opencv-4.13.0-qt6_py312h0610cdf_608.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pytorch-2.10.0-cuda129_mkl_py312_he03aca0_304.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pytorch-gpu-2.10.0-cuda129_mkl_h0d04637_304.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/qt6-main-6.11.1-pl5321h16c4a6b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/rav1e-0.8.1-h1fbca29_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/rdma-core-63.0-h192683f_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/regex-2026.5.9-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/rpds-py-0.30.0-py312h868fb18_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.3-hc5a330e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/safetensors-0.7.0-py312h0ccc70a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sdl3-3.4.8-hdeec2a5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/shaderc-2026.2-h718be3e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/spirv-tools-2026.1-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-4.0.1-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tokenizers-0.22.2-py312hf875000_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/torchcodec-0.10.0-cuda129_py312_h88a133a_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/torchvision-0.26.0-cuda129_py312_h69a17e1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.5-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/triton-3.6.0-cuda129py312h811769c_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.47-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxi-1.8.3-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-xorgproto-2025.1-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zeromq-4.3.5-h09e67af_11.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/arrow-1.4.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/asttokens-3.0.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/async-lru-2.3.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/beartype-0.22.9-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/bleach-6.3.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/bleach-with-css-6.3.0-hbca2aae_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/casefy-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.5.20-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/click-8.4.0-pyhc90fa1f_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cccl_linux-64-12.9.27-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-compiler-12.9.2-hbad6d8a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-crt-dev_linux-64-12.9.86-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart-dev_linux-64-12.9.79-h3f2d84a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart-static_linux-64-12.9.79-h3f2d84a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart_linux-64-12.9.79-h3f2d84a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-driver-dev_linux-64-12.9.79-h3f2d84a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-nvcc-dev_linux-64-12.9.86-he91c749_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-nvvm-dev_linux-64-12.9.86-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-version-12.9-h4f385c5_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/docstring_parser-0.18.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/eval_type_backport-0.3.1-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/huggingface_hub-1.16.4-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ipykernel-7.2.0-pyha191276_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ipython-9.13.0-pyh53cf698_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jaxtyping-0.2.36-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/json5-0.14.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jsonschema-with-format-nongpl-4.26.0-hcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter-lsp-2.3.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter_client-8.8.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter_events-0.12.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter_server-2.18.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter_server_terminals-0.5.4-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyterlab-4.5.7-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_119.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libnvptxcompiler-dev_linux-64-12.9.86-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_119.conda
+      - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mistune-3.2.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/nbclient-0.10.4-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/plum-dispatch-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/prometheus_client-0.25.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-global-3.0.1-pyhc7ab6ef_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pyserde-0.29.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.12.13-hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-json-logger-3.2.1-pyh332efcf_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-tzdata-2026.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://prefix.dev/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/send2trash-2.1.0-pyha191276_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/shtab-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/soupsieve-2.8.4-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+      - conda: https://prefix.dev/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/transformers-5.9.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typeguard-2.13.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/typer-0.25.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tyro-0.9.1-pyhff2d567_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wcwidth-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/webcolors-25.10.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/websocket-client-1.9.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - pypi: git+https://github.com/pablovela5620/rtmlib.git?rev=98bca2193c39b349034b280803b54c9ee58f7c68#98bca2193c39b349034b280803b54c9ee58f7c68
+      - pypi: git+https://github.com/pablovela5620/simplecv.git?rev=f7b66c6e3874cec0c009e464b212afe1f393352e#f7b66c6e3874cec0c009e464b212afe1f393352e
+      - pypi: https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0e/a4/82b7a2fe5d8a67a59ed831b24d59a3d46ea7d207b66e1602d376541d94a6/orjson-3.11.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/11/c8/26f2e4aae92f11522a96043892ba39a90eac610d5242523aa863212bc1c7/cuda_pathfinder-1.5.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/16/99/f5376b53e095d8fd4572cb05e75d7549a5a0b0861fbb01831fd94958d803/ultralytics-8.4.52-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/93/fb357cc7847c58a8ae790be718903afa81a28d23e642c843dc4129e8a0b2/wrapt-2.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/1b/0e/bf298920729f216adcb002acf7ea01b90842603d2e4e2ce9b900d9ee8fab/nh3-0.3.5-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/1f/2e/26bab7686ff4aed48f8f5f6c23e2aa37b7a37ddd9effe3aa61e908fd518f/timm-1.0.27-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1f/6e/7d8850ff112f8f80d394ca45e89b975a3a43559d47af3137b767669b3294/tifffile-2026.5.15-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1f/92/f899f7bbb5617bb65ec52a6eac1e9a1447a86b916c4194f8a5001b8cde0c/cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/28/27/3d6dcadc8a3214d8522c1e7f6a19554e33659be44546d44a2f7572ac7d2a/groovy-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/a3/0f0b7d78e2f1eb9e8e1afbff1d2bff8d60144aee17aca51c065b516743dd/safehttpx-0.1.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/30/2d/afff2ee87e75d8eb85c92bb8cf0e15b05c23c2ebd8fd8dec781d8601ed7f/hf_gradio-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/32/91/d024616abdba99e83120e07a20658976f6a343646710760c4a51df126029/matplotlib-3.10.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/37/ee/478689c69b3cb1ccabb2d52feac0c181f6cdf20b51a81df35344b1dab9a6/datafusion-52.3.0-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3f/95/0ad40fb92ba3e6fe36182f722f81d69842a1e93cab1d9c6171256ef55418/gradio-6.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4a/da/b4dbe129f941afe1c24a09ba53521b78875626763d96414798a74763282f/cuda_python-13.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/53/18/5a04b06b773047cbf43912ab802eef3c1d50ef7e66d51a41b16726f9bc62/polars_runtime_32-1.41.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/55/bd/dd56edc2680df7658c7bdeeb58270ab35dfcdc0e2670899ce9771604b436/roma-1.5.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/57/d8/8d44036d7eb7b6a8ec4c5494ea0c8c8b94fbc0ed3991c1a7adf230df03bf/aiohttp-3.13.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/58/cc/8eddae7c3b0bd6d51290624c59f05b51ec3ded917b3689f1975f8dcfc601/tensorrt_cu12_bindings-10.13.3.9-cp312-none-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/a4/9d1ea10ebc9e028a289a72fec84da170689549a8102c8aacfcad26bc5035/s3fs-2026.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5f/fc/a7bf5b6e4e617b45f90f2d9d2a68519c249c81dd4fc2658c7a2a61c4f4b7/aiohappyeyeballs-2.6.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/65/b6/09b01cdbc15224e2850365192d17b7bdebb8bdbd8780ed221fcdf0d9a515/pandas-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/74/af3e40919305f16968ea3ab88d84b511d710dd281eb5dafaf4897579dd22/ultralytics_thop-2.0.19-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/70/5b/6baf9008817964454055ff3fe65f1de0b5f1e26c80c82f7fb108b7cd4ea3/protobuf-7.35.0-cp310-abi3-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/70/bd/cb98519aa658b488710aef0d5bac1435e7b95756b7e28c8c97ca394f5260/lovely_numpy-0.2.24-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/77/c7/2342da9830e3e9d4870305ca5d2091d2a83284f2953079b7bdd3b5e029d8/fonttools-4.63.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/78/81/0a861b8e1ff42960139c6cd4c7dd591292fa09ea1ae2d87677441cba4c00/gradio_client-2.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/82/9707c7b0336bca53b75f52fc350956a93da66eb6be632b370bc933216fb4/icecream-2.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/da/323a01c349bd5fb01bb6652e314d9bb218cee630a736bdb810ad50e4013f/yarl-1.24.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/aa/f7a53321c60b9ad9ee184b6018292ed6b5389947592a2c8c09c736bb7f9e/onnx_ir-0.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/90/5f/85535dfb3cfd6442d66d1df1694062c5d6df02f895329e7e120b2a3d2b8b/aiobotocore-3.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/94/fd/59bee7cffaa435da44fefdeb63e29c61de4dbfa4b279852f59cd02c042ae/onnxruntime_gpu-1.26.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/7e/86bf0708c6c61e6bd08cb30d57b6b6f3ea74d9e561d599eabdeb913a0e2a/spaces-0.50.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a7/00/4823f06357892d1e60d6f34e7299d2ba4ed2108c487cc394f7ce85a3ff14/onnx-1.21.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/29/c028a0731e202035f0e2e0bfbf1a3e46ad6c628cbb17f6f1cc9eea5d9ff1/pathlib_abc-0.5.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/93/1d0d28d7f87a4b17fbb097b333c9ff4a1259570042e99a37737ff5bc939d/gradio_rerun-0.32.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/97/30a3a3775ead580134088dfc116a410e2ae490c044ec357109eeb11503ec/monopriors-0.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b9/ce/2ed92575cc3be4ea1db5f38f16f20765f9b20b69b14d6c1d9972658a8ee9/onnxscript-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/46/a92db19b8309581092a3add7e6fceb4c301a3fd233969856a8cbf042cd3c/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/1f/73c53fcbfb0b5a78f91176df41945ca466e71e9d9d836e5c522abda39ee7/pydantic-2.11.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/4b/afc1fef8a43bafb139f57f73bbd70df82807af5934321e8112ae50668827/botocore-1.43.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c3/c8/5807714256c5f3de08593113df17f14f99417a451cb2d91530ad94785003/polars-1.41.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/13/680c54afe3e65767bed7ec1a15571e1a2f1257128733851ade24abcefbcc/kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c7/41/2c368f804bb9bd918da3b61324207fc4b410d0f32352c372c0680fc1f670/fastcore-1.13.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/cc/cf/0e8a7687f9c8554f9ba9c7497e40fe5bf1fc0e6e11ad7d8cef55d11439fb/rerun_sdk-0.32.2-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dd/1a/5d9a402b39ec892d856bbdd9db502ff73ce28cdf4aff72eb1ce1d6843506/universal_pathlib-0.3.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/d3/82b9a603cac94975dbb25d33c7ffb1dba6851980f2dc630f2bf9caf0bffb/tensorrt_cu12_libs-10.13.3.9.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f4/a2/70401a107d6d7466d64b466927e6b96fcefa99d57494b972608e2f8be50f/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
+      - pypi: https://pypi.nvidia.com/tensorrt-cu12/tensorrt_cu12-10.13.3.9.tar.gz
+      - pypi: packages/mv-api
+      - pypi: packages/sapiens-coco133-pose
+      - pypi: packages/sapiens2-pose
+      - pypi: packages/wilor-nano
+  sapiens-coco133-pose-dev:
+    channels:
+    - url: https://prefix.dev/ai-demos/
+    - url: https://prefix.dev/conda-forge/
+    indexes:
+    - https://pypi.org/simple
+    packages:
+      linux-64:
+      - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/argon2-cffi-bindings-25.1.0-py312h4c3975b_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/av-17.0.1-py312h46547aa_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.1-ha62d5e7_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.13-h2c9d079_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-h8b1a151_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.10.13-h4bacb7b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.26.3-hb18f61d_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.12.2-he6ee468_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-h8b1a151_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-h8b1a151_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/backports.zstd-1.5.0-py312h90b7ffd_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils-2.45.1-default_h4852527_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/brotli-python-1.2.0-py312hdb49522_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-compiler-1.11.0-h4d9bdce_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-crt-12.9.86-h69a702a_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-crt-tools-12.9.86-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-12.9.79-h5888daf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-dev-12.9.79-h5888daf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-static-12.9.79-h5888daf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cuobjdump-12.9.82-hffce074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cupti-12.9.79-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cuxxfilt-12.9.82-hffce074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-driver-dev-12.9.79-h5888daf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-12.9.86-hcdd1206_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-impl-12.9.86-h85509e4_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-tools-12.9.86-he02047a_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc_linux-64-12.9.86-he0b4e1d_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvdisasm-12.9.88-hffce074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvml-dev-12.9.79-hffce074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvprune-12.9.82-hffce074_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvrtc-12.9.86-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvrtc-dev-12.9.86-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvtx-12.9.79-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvtx-dev-12.9.79-ha770c72_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvvm-impl-12.9.86-h4bc722e_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvvm-tools-12.9.86-h4bc722e_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-profiler-api-12.9.79-h7938cbb_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cudnn-9.10.2.21-hbcb9cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cusparselt-0.8.1.1-h58dd1b1_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cxx-compiler-1.11.0-hfcd1e18_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/debugpy-1.8.20-py312h8285ef7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-8.1.1-gpl_hee00b0e_901.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fmt-12.1.0-hff5e90c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fontconfig-2.18.0-h27c8c51_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/frozendict-2.4.7-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc-14.3.0-h0dff253_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-h235f0fe_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-14.3.0-h50e9bb6_25.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/glslang-16.3.0-h96af755_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gmpy2-2.3.0-py312hcaba1f9_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx-14.3.0-he448592_7.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-h2185e75_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-14.3.0-h72ca5df_25.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-14.2.0-h6083320_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_h87a9417_105.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hf-transfer-0.1.9-py312h914ccca_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hf-xet-1.5.0-py310hb823017_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/imath-3.2.2-hde8ca8f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/intel-gmmlib-22.10.0-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/intel-media-driver-26.1.6-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/level-zero-1.28.4-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libass-0.17.4-h96ad9f0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libavif16-1.4.2-hcfa2d63_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-7_h5875eb1_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcap-2.77-hd0affe5_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-7_hfef963f_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcublas-12.9.2.10-h676940d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcublas-dev-12.9.2.10-h676940d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudnn-9.10.2.21-hf7e9902_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudnn-dev-9.10.2.21-h58dd1b1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudss-0.7.1.4-h58dd1b1_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudss-dev-0.7.1.4-hee47b17_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufft-11.4.1.4-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufft-dev-11.4.1.4-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufile-1.14.1.1-hbc026e6_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufile-dev-1.14.1.1-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurand-10.3.10.19-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurand-dev-10.3.10.19-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusolver-11.7.5.82-h676940d_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusolver-dev-11.7.5.82-h676940d_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusparse-12.5.10.65-hecca717_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusparse-dev-12.5.10.65-hecca717_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdovi-3.3.2-ha23c83e_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdrm-2.4.127-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhwloc-2.13.0-default_he001693_1000.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhwy-1.4.0-h10be129_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libjxl-0.11.2-h174a0a3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-7_h5e43f62_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-7_hdba1596_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmagma-2.9.0-ha7672b3_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmagma_sparse-2.9.0-h9918c94_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnpp-12.4.1.87-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvjitlink-12.9.86-hecca717_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvjpeg-12.4.0.76-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvptxcompiler-dev-12.9.86-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopencv-4.13.0-qt6_py312h63cde4a_608.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-2026.0.0-hb56ce9e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-batch-plugin-2026.0.0-hd85de46_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-plugin-2026.0.0-hd85de46_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-hetero-plugin-2026.0.0-hd41364c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2026.0.0-hb56ce9e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2026.0.0-hb56ce9e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-npu-plugin-2026.0.0-hb56ce9e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-ir-frontend-2026.0.0-hd41364c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-onnx-frontend-2026.0.0-h7a07914_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-paddle-frontend-2026.0.0-h7a07914_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-pytorch-frontend-2026.0.0-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-frontend-2026.0.0-h78e8023_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2026.0.0-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpciaccess-0.19-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libplacebo-7.360.1-h9eeb4b2_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpq-18.4-hd5a49e9_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libprotobuf-6.33.5-h2b00c02_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/librsvg-2.62.2-h4c96295_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsodium-1.0.22-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsystemd0-257.13-hd0affe5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libtorch-2.10.0-cuda129_mkl_hd98981c_304.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libudev1-257.13-hd0affe5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liburing-2.14-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libuv-1.52.1-h280c20c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libva-2.23.0-he1eb515_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvpl-2.16.0-h54a6638_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvpx-1.15.2-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvulkan-loader-1.4.341.0-h5279c79_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.13.1-hca5e8e5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/llvm-openmp-22.1.6-h4922eb0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mkl-2026.0.0-h0e700b2_915.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/nccl-2.30.4.1-h4d09622_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.4.6-py312h33ff503_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/onemkl-license-2026.0.0-hf2ce2f3_915.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/opencl-headers-2025.06.13-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openexr-3.4.12-h9f1635d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openjph-0.27.3-h8d634f6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/optree-0.19.1-py312hd9148b4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pillow-12.2.0-py312h50c33e8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/psutil-7.2.2-py312h5253ce2_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/py-opencv-4.13.0-qt6_py312h0610cdf_608.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyrefly-1.0.0-h2b88eb6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pytorch-2.10.0-cuda129_mkl_py312_he03aca0_304.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pytorch-gpu-2.10.0-cuda129_mkl_h0d04637_304.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/qt6-main-6.11.1-pl5321h16c4a6b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/rav1e-0.8.1-h1fbca29_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/rdma-core-63.0-h192683f_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/regex-2026.5.9-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/rpds-py-0.30.0-py312h868fb18_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ruff-0.15.14-h994f30f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.3-hc5a330e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/safetensors-0.7.0-py312h0ccc70a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sdl3-3.4.8-hdeec2a5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/shaderc-2026.2-h718be3e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/spirv-tools-2026.1-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-4.0.1-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tokenizers-0.22.2-py312hf875000_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/torchcodec-0.10.0-cuda129_py312_h88a133a_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/torchvision-0.26.0-cuda129_py312_h69a17e1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.5-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/triton-3.6.0-cuda129py312h811769c_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.47-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxi-1.8.3-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-xorgproto-2025.1-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zeromq-4.3.5-h09e67af_11.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/arrow-1.4.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/asttokens-3.0.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/async-lru-2.3.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/beartype-0.22.9-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/bleach-6.3.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/bleach-with-css-6.3.0-hbca2aae_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/casefy-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.5.20-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/click-8.4.0-pyhc90fa1f_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cccl_linux-64-12.9.27-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-compiler-12.9.2-hbad6d8a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-crt-dev_linux-64-12.9.86-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart-dev_linux-64-12.9.79-h3f2d84a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart-static_linux-64-12.9.79-h3f2d84a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart_linux-64-12.9.79-h3f2d84a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-driver-dev_linux-64-12.9.79-h3f2d84a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-nvcc-dev_linux-64-12.9.86-he91c749_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-nvvm-dev_linux-64-12.9.86-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-version-12.9-h4f385c5_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/docstring_parser-0.18.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/eval_type_backport-0.3.1-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/huggingface_hub-1.16.4-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.153.0-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ipykernel-7.2.0-pyha191276_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ipython-9.13.0-pyh53cf698_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jaxtyping-0.2.36-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/json5-0.14.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jsonschema-with-format-nongpl-4.26.0-hcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter-lsp-2.3.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter_client-8.8.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter_events-0.12.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter_server-2.18.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter_server_terminals-0.5.4-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyterlab-4.5.7-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_119.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libnvptxcompiler-dev_linux-64-12.9.86-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_119.conda
+      - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mistune-3.2.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/nbclient-0.10.4-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/plum-dispatch-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/prometheus_client-0.25.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-global-3.0.1-pyhc7ab6ef_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pyserde-0.29.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.12.13-hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-json-logger-3.2.1-pyh332efcf_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-tzdata-2026.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://prefix.dev/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/send2trash-2.1.0-pyha191276_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/shtab-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/soupsieve-2.8.4-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+      - conda: https://prefix.dev/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/transformers-5.9.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typeguard-2.13.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/typer-0.25.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tyro-0.9.1-pyhff2d567_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/vulture-2.16-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wcwidth-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/webcolors-25.10.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/websocket-client-1.9.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - pypi: git+https://github.com/pablovela5620/rtmlib.git?rev=98bca2193c39b349034b280803b54c9ee58f7c68#98bca2193c39b349034b280803b54c9ee58f7c68
+      - pypi: git+https://github.com/pablovela5620/simplecv.git?rev=f7b66c6e3874cec0c009e464b212afe1f393352e#f7b66c6e3874cec0c009e464b212afe1f393352e
+      - pypi: https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0e/a4/82b7a2fe5d8a67a59ed831b24d59a3d46ea7d207b66e1602d376541d94a6/orjson-3.11.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/11/c8/26f2e4aae92f11522a96043892ba39a90eac610d5242523aa863212bc1c7/cuda_pathfinder-1.5.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/16/99/f5376b53e095d8fd4572cb05e75d7549a5a0b0861fbb01831fd94958d803/ultralytics-8.4.52-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/93/fb357cc7847c58a8ae790be718903afa81a28d23e642c843dc4129e8a0b2/wrapt-2.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/1b/0e/bf298920729f216adcb002acf7ea01b90842603d2e4e2ce9b900d9ee8fab/nh3-0.3.5-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1f/2e/26bab7686ff4aed48f8f5f6c23e2aa37b7a37ddd9effe3aa61e908fd518f/timm-1.0.27-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1f/6e/7d8850ff112f8f80d394ca45e89b975a3a43559d47af3137b767669b3294/tifffile-2026.5.15-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1f/92/f899f7bbb5617bb65ec52a6eac1e9a1447a86b916c4194f8a5001b8cde0c/cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/28/27/3d6dcadc8a3214d8522c1e7f6a19554e33659be44546d44a2f7572ac7d2a/groovy-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/a3/0f0b7d78e2f1eb9e8e1afbff1d2bff8d60144aee17aca51c065b516743dd/safehttpx-0.1.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/30/2d/afff2ee87e75d8eb85c92bb8cf0e15b05c23c2ebd8fd8dec781d8601ed7f/hf_gradio-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/32/91/d024616abdba99e83120e07a20658976f6a343646710760c4a51df126029/matplotlib-3.10.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/37/ee/478689c69b3cb1ccabb2d52feac0c181f6cdf20b51a81df35344b1dab9a6/datafusion-52.3.0-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3f/95/0ad40fb92ba3e6fe36182f722f81d69842a1e93cab1d9c6171256ef55418/gradio-6.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4a/da/b4dbe129f941afe1c24a09ba53521b78875626763d96414798a74763282f/cuda_python-13.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/53/18/5a04b06b773047cbf43912ab802eef3c1d50ef7e66d51a41b16726f9bc62/polars_runtime_32-1.41.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/55/bd/dd56edc2680df7658c7bdeeb58270ab35dfcdc0e2670899ce9771604b436/roma-1.5.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/56/59/dbe84f71186645b821cf63f71fc746e1455fbce074594a86f486bee8dc89/types_tqdm-4.67.3.20260518-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/57/d8/8d44036d7eb7b6a8ec4c5494ea0c8c8b94fbc0ed3991c1a7adf230df03bf/aiohttp-3.13.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/58/cc/8eddae7c3b0bd6d51290624c59f05b51ec3ded917b3689f1975f8dcfc601/tensorrt_cu12_bindings-10.13.3.9-cp312-none-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/a4/9d1ea10ebc9e028a289a72fec84da170689549a8102c8aacfcad26bc5035/s3fs-2026.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5f/fc/a7bf5b6e4e617b45f90f2d9d2a68519c249c81dd4fc2658c7a2a61c4f4b7/aiohappyeyeballs-2.6.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/65/b6/09b01cdbc15224e2850365192d17b7bdebb8bdbd8780ed221fcdf0d9a515/pandas-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/74/af3e40919305f16968ea3ab88d84b511d710dd281eb5dafaf4897579dd22/ultralytics_thop-2.0.19-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/70/5b/6baf9008817964454055ff3fe65f1de0b5f1e26c80c82f7fb108b7cd4ea3/protobuf-7.35.0-cp310-abi3-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/70/bd/cb98519aa658b488710aef0d5bac1435e7b95756b7e28c8c97ca394f5260/lovely_numpy-0.2.24-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/77/c7/2342da9830e3e9d4870305ca5d2091d2a83284f2953079b7bdd3b5e029d8/fonttools-4.63.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/78/81/0a861b8e1ff42960139c6cd4c7dd591292fa09ea1ae2d87677441cba4c00/gradio_client-2.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/82/9707c7b0336bca53b75f52fc350956a93da66eb6be632b370bc933216fb4/icecream-2.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/da/323a01c349bd5fb01bb6652e314d9bb218cee630a736bdb810ad50e4013f/yarl-1.24.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/aa/f7a53321c60b9ad9ee184b6018292ed6b5389947592a2c8c09c736bb7f9e/onnx_ir-0.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/90/5f/85535dfb3cfd6442d66d1df1694062c5d6df02f895329e7e120b2a3d2b8b/aiobotocore-3.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/94/fd/59bee7cffaa435da44fefdeb63e29c61de4dbfa4b279852f59cd02c042ae/onnxruntime_gpu-1.26.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/7e/86bf0708c6c61e6bd08cb30d57b6b6f3ea74d9e561d599eabdeb913a0e2a/spaces-0.50.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a7/00/4823f06357892d1e60d6f34e7299d2ba4ed2108c487cc394f7ce85a3ff14/onnx-1.21.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/29/c028a0731e202035f0e2e0bfbf1a3e46ad6c628cbb17f6f1cc9eea5d9ff1/pathlib_abc-0.5.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/93/1d0d28d7f87a4b17fbb097b333c9ff4a1259570042e99a37737ff5bc939d/gradio_rerun-0.32.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/97/30a3a3775ead580134088dfc116a410e2ae490c044ec357109eeb11503ec/monopriors-0.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b9/ce/2ed92575cc3be4ea1db5f38f16f20765f9b20b69b14d6c1d9972658a8ee9/onnxscript-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/46/a92db19b8309581092a3add7e6fceb4c301a3fd233969856a8cbf042cd3c/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/1f/73c53fcbfb0b5a78f91176df41945ca466e71e9d9d836e5c522abda39ee7/pydantic-2.11.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/4b/afc1fef8a43bafb139f57f73bbd70df82807af5934321e8112ae50668827/botocore-1.43.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c3/c8/5807714256c5f3de08593113df17f14f99417a451cb2d91530ad94785003/polars-1.41.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/13/680c54afe3e65767bed7ec1a15571e1a2f1257128733851ade24abcefbcc/kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c7/41/2c368f804bb9bd918da3b61324207fc4b410d0f32352c372c0680fc1f670/fastcore-1.13.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/cc/cf/0e8a7687f9c8554f9ba9c7497e40fe5bf1fc0e6e11ad7d8cef55d11439fb/rerun_sdk-0.32.2-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dd/1a/5d9a402b39ec892d856bbdd9db502ff73ce28cdf4aff72eb1ce1d6843506/universal_pathlib-0.3.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/d3/82b9a603cac94975dbb25d33c7ffb1dba6851980f2dc630f2bf9caf0bffb/tensorrt_cu12_libs-10.13.3.9.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f4/a2/70401a107d6d7466d64b466927e6b96fcefa99d57494b972608e2f8be50f/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
+      - pypi: https://pypi.nvidia.com/tensorrt-cu12/tensorrt_cu12-10.13.3.9.tar.gz
+      - pypi: packages/mv-api
+      - pypi: packages/sapiens-coco133-pose
+      - pypi: packages/sapiens2-pose
+      - pypi: packages/wilor-nano
   sapiens2-pose:
     channels:
     - url: https://prefix.dev/ai-demos/
@@ -24668,6 +25786,26 @@ packages:
     - fonts-conda-ecosystem
   size: 270705
   timestamp: 1771382710863
+- conda: https://prefix.dev/conda-forge/linux-64/fontconfig-2.18.0-h27c8c51_0.conda
+  sha256: e798086d8a65d55dc4c51f5746705639c9a5f2eeb0b8fc50e6152cfc0d69a4e8
+  md5: 06965b2f9854d0b15e0443ee81fe83dc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libexpat >=2.8.1,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libuuid >=2.42.1,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - fontconfig >=2.18.0,<3.0a0
+    - fonts-conda-ecosystem
+  size: 280882
+  timestamp: 1779421631622
 - conda: https://prefix.dev/conda-forge/linux-64/fonttools-4.63.0-py311h3778330_0.conda
   sha256: ce5004df66a6bf4e3d634850ab43471b98700291065281eb1982eb54b7bf7d85
   md5: 498ede447c05b203be980ae1dceb06f3
@@ -24921,6 +26059,21 @@ packages:
     - libgcc >=14
   size: 29073
   timestamp: 1777144725126
+- conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-14.3.0-h50e9bb6_25.conda
+  sha256: 95d22db25f0b8875febe63073f809c0c64f4026cc9e6aa0cca7130de51e4d044
+  md5: 0a9089d9eeeeb23313a9ce670fb89052
+  depends:
+  - gcc_impl_linux-64 14.3.0.*
+  - binutils_linux-64
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    strong:
+    - libgcc >=14
+  size: 29191
+  timestamp: 1779371710532
 - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_24.conda
   sha256: 7e1a77123819f9e6c15439df9a987c66235c53e4c6d12a9ab3cea883258214df
   md5: 81f96ca8673107e2da4a6b9e3807cf74
@@ -25393,6 +26546,23 @@ packages:
   run_exports: {}
   size: 16356816
   timestamp: 1778269332159
+- conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-14.3.0-h72ca5df_25.conda
+  sha256: 369abc77d74a8275c734f9ca2375892b86d3163a541b1f5a2de946083a9e3ab0
+  md5: 4718c7fefd927621bad46a8bcc6387d6
+  depends:
+  - gxx_impl_linux-64 14.3.0.*
+  - gcc_linux-64 ==14.3.0 h50e9bb6_25
+  - binutils_linux-64
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    strong:
+    - libstdcxx >=14
+    - libgcc >=14
+  size: 27696
+  timestamp: 1779371710532
 - conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-14.3.0-h8a413ad_24.conda
   sha256: 66e357fad69998624d24ed52d7e1550f8159dc78418fff044377790f29e0fee3
   md5: ea3921760f33250a1c12926fce1660eb
@@ -26394,6 +27564,24 @@ packages:
     - libavif16 >=1.4.1,<2.0a0
   size: 148710
   timestamp: 1774042709303
+- conda: https://prefix.dev/conda-forge/linux-64/libavif16-1.4.2-hcfa2d63_0.conda
+  sha256: 10c362ae43bce56f7ff88b51f8bd3a867d081585ce0fd1d7cb6271a28143a5f9
+  md5: 12f487a194816b619d5da0c53680c92e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aom >=3.9.1,<3.10.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - libgcc >=14
+  - rav1e >=0.8.1,<0.9.0a0
+  - svt-av1 >=4.0.1,<4.0.2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libavif16 >=1.4.2,<2.0a0
+  size: 149510
+  timestamp: 1779847073231
 - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-6_h5875eb1_mkl.conda
   build_number: 6
   sha256: a73ec64c0f60a7733f82a679342bdad88e0230ba8243b12ece13a23aded431f4
@@ -27192,6 +28380,17 @@ packages:
   run_exports: {}
   size: 44840
   timestamp: 1731330973553
+- conda: https://prefix.dev/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_3.conda
+  sha256: 9a25ea93e8272785405a21d30f84e620befb1d545f6dfaae18f06103b5df0443
+  md5: 75e9f795be506c96dd43cb09c7c8d557
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_3
+  license: LicenseRef-libglvnd
+  purls: []
+  run_exports: {}
+  size: 46500
+  timestamp: 1779728188901
 - conda: https://prefix.dev/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_2.conda
   sha256: f6e7095260305dc05238062142fb8db4b940346329b5b54894a90610afa6749f
   md5: b513eb83b3137eca1192c34bf4f013a7
@@ -27207,6 +28406,21 @@ packages:
     - libegl >=1.7.0,<2.0a0
   size: 30380
   timestamp: 1731331017249
+- conda: https://prefix.dev/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_3.conda
+  sha256: e4b46919c9bb65930bce238bd2736110ed7b8c30e5cd5394e4e1edb48de54843
+  md5: 5bc6d55503483aabe8a90c5e7f49a2a4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libegl 1.7.0 ha4b6fd6_3
+  - libgl-devel 1.7.0 ha4b6fd6_3
+  - xorg-libx11
+  license: LicenseRef-libglvnd
+  purls: []
+  run_exports:
+    weak:
+    - libegl >=1.7.0,<2.0a0
+  size: 31718
+  timestamp: 1779728222280
 - conda: https://prefix.dev/conda-forge/linux-64/libev-4.33-hd590300_2.conda
   sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
   md5: 172bf1cd1ff8629f2b1179945ed45055
@@ -27248,6 +28462,20 @@ packages:
   run_exports: {}
   size: 77241
   timestamp: 1777846112704
+- conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_0.conda
+  sha256: 363018b25fdb5534c79783d912bd4b685a3547f4fc5996357ad548899b0ee8e7
+  md5: 93764a5ca80616e9c10106cdaec92f74
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 77294
+  timestamp: 1779278686680
 - conda: https://prefix.dev/conda-forge/linux-64/libfaiss-1.10.0-cuda129_mkl_h5f1db2f_300.conda
   sha256: d39cf5f0cb72b9dcfcbf7eb1ad1d17592097f2e0747038d068a186f901baf5a6
   md5: 518f4eb7323e7792280208b43a6327b9
@@ -27440,6 +28668,18 @@ packages:
   run_exports: {}
   size: 134712
   timestamp: 1731330998354
+- conda: https://prefix.dev/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_3.conda
+  sha256: ec353b3076ed8e357ed961d0e9ff6997491cade0e603de5bd18a2e301ac78ebd
+  md5: f25206d7322c0e9648e8b83694d143ab
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_3
+  - libglx 1.7.0 ha4b6fd6_3
+  license: LicenseRef-libglvnd
+  purls: []
+  run_exports: {}
+  size: 133469
+  timestamp: 1779728207669
 - conda: https://prefix.dev/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_2.conda
   sha256: e281356c0975751f478c53e14f3efea6cd1e23c3069406d10708d6c409525260
   md5: 53e7cbb2beb03d69a478631e23e340e9
@@ -27454,6 +28694,20 @@ packages:
     - libgl >=1.7.0,<2.0a0
   size: 113911
   timestamp: 1731331012126
+- conda: https://prefix.dev/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_3.conda
+  sha256: 41d7d864ad1f199bdb06ff6cc3931455c8af62f1d2071a08c6fa08affbcb678f
+  md5: 63e43d278ee5084813fe3c2edf4834ce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgl 1.7.0 ha4b6fd6_3
+  - libglx-devel 1.7.0 ha4b6fd6_3
+  license: LicenseRef-libglvnd
+  purls: []
+  run_exports:
+    weak:
+    - libgl >=1.7.0,<2.0a0
+  size: 115664
+  timestamp: 1779728218325
 - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.86.2-h32235b2_0.conda
   sha256: 918306d6ed211ab483e4e19368e5748b265d24e75c88a1c66a61f72b9fa30b29
   md5: 0cb0612bc9cb30c62baf41f9d600611b
@@ -27517,6 +28771,16 @@ packages:
   run_exports: {}
   size: 132463
   timestamp: 1731330968309
+- conda: https://prefix.dev/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_3.conda
+  sha256: e019ebe4e3f5cdf23e2f5e58ddf7ade27988c53820115b17b98f218ebcc87748
+  md5: eb83f3f8cecc3e9bff9e250817fc69b6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: LicenseRef-libglvnd
+  purls: []
+  run_exports: {}
+  size: 133586
+  timestamp: 1779728183422
 - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
   sha256: 2d35a679624a93ce5b3e9dd301fff92343db609b79f0363e6d0ceb3a6478bfa7
   md5: c8013e438185f33b13814c5c488acd5c
@@ -27529,6 +28793,18 @@ packages:
   run_exports: {}
   size: 75504
   timestamp: 1731330988898
+- conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda
+  sha256: 2f74713c9ca408ea84e88a30a9028153e7b553e8bb42e06139eac9a753c27da9
+  md5: ec3c4350aa0261bf7f87b8ca15c8e80e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_3
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: LicenseRef-libglvnd
+  purls: []
+  run_exports: {}
+  size: 76586
+  timestamp: 1779728199059
 - conda: https://prefix.dev/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_2.conda
   sha256: 0a930e0148ab6e61089bbcdba25a2e17ee383e7de82e7af10cc5c12c82c580f3
   md5: 27ac5ae872a21375d980bd4a6f99edf3
@@ -27544,6 +28820,21 @@ packages:
     - libglx >=1.7.0,<2.0a0
   size: 26388
   timestamp: 1731331003255
+- conda: https://prefix.dev/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda
+  sha256: a17ae2d4cb2de04a20882ae14ec3cc1958e868a4dec81e3d7eca30115ee50e94
+  md5: 16b6330783ce0d1ae8d22782173b32c9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglx 1.7.0 ha4b6fd6_3
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - xorg-xorgproto
+  license: LicenseRef-libglvnd
+  purls: []
+  run_exports:
+    weak:
+    - libglx >=1.7.0,<2.0a0
+  size: 27363
+  timestamp: 1779728211402
 - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
   sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
   md5: faac990cb7aedc7f3a2224f2c9b0c26c
@@ -29247,6 +30538,29 @@ packages:
     - librsvg >=2.62.1,<3.0a0
   size: 3474421
   timestamp: 1773814909137
+- conda: https://prefix.dev/conda-forge/linux-64/librsvg-2.62.2-h4c96295_0.conda
+  sha256: 864d93b0385778c7495c369d9df408e2b436ef136c8f7de645e25fd461acc553
+  md5: e318357f3d948cc16936d9f3b36cc7d9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - fontconfig >=2.17.1,<3.0a0
+  - fonts-conda-ecosystem
+  - gdk-pixbuf >=2.44.6,<3.0a0
+  - harfbuzz >=14.2.0
+  - libgcc >=14
+  - libglib >=2.88.1,<3.0a0
+  - libxml2-16 >=2.14.6
+  - pango >=1.56.4,<2.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LGPL-2.1-or-later
+  purls: []
+  run_exports:
+    weak:
+    - librsvg >=2.62.2,<3.0a0
+  size: 3507905
+  timestamp: 1779414238375
 - conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_19.conda
   sha256: 8766de5423b0a510e2b1bdd1963d0554bdad2119f3e31d8fbd4189af434235ca
   md5: 007796e5a595bbc7df4a5e1580d72e1a
@@ -29765,6 +31079,20 @@ packages:
     - libuv >=1.51.0,<2.0a0
   size: 895108
   timestamp: 1753948278280
+- conda: https://prefix.dev/conda-forge/linux-64/libuv-1.52.1-h280c20c_0.conda
+  sha256: e28e4519223f78b3163599ca89c3f2d80bfb53e907e7fc74e806e60d1efa578b
+  md5: 4e33d49bf4fc853855a3b00643aa5484
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libuv >=1.52.1,<2.0a0
+  size: 419935
+  timestamp: 1779396012261
 - conda: https://prefix.dev/conda-forge/linux-64/libva-2.23.0-he1eb515_0.conda
   sha256: 255c7d00b54e26f19fad9340db080716bced1d8539606e2b8396c57abd40007c
   md5: 25813fe38b3e541fc40007592f12bae5
@@ -30111,6 +31439,24 @@ packages:
     - _openmp_mutex * *_llvm
   size: 6128130
   timestamp: 1778447746870
+- conda: https://prefix.dev/conda-forge/linux-64/llvm-openmp-22.1.6-h4922eb0_0.conda
+  sha256: e74dbafd2b420687cc913f5587050270c8f57042405b6b0d66c3a8013dc104ab
+  md5: a7f80a18bc21daad0f4d5c3fbad1e8c1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - openmp 22.1.6|22.1.6.*
+  - intel-openmp <0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  purls: []
+  run_exports:
+    strong:
+    - llvm-openmp >=22.1.6
+    - _openmp_mutex >=4.5
+    - _openmp_mutex * *_llvm
+  size: 6121374
+  timestamp: 1779340573879
 - conda: https://prefix.dev/conda-forge/linux-64/llvmlite-0.47.0-py311h41a00d4_1.conda
   sha256: 689cc23dc0f80c008094931aaa54ec229dd9dbabd169e825e13ea262d5e6dade
   md5: 62d9d69ab00067a2b3cdf60407f4c491
@@ -30434,6 +31780,24 @@ packages:
   run_exports: {}
   size: 143144285
   timestamp: 1779170127132
+- conda: https://prefix.dev/conda-forge/linux-64/mkl-2026.0.0-h0e700b2_915.conda
+  sha256: b23dc574c681cfa9708378b781d206fa790f1944cfb7b4c20177824b96938544
+  md5: 44208bd851118db1e20923441f1bb3bb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex * *_llvm
+  - _openmp_mutex >=4.5
+  - libgcc >=14
+  - libstdcxx >=14
+  - llvm-openmp >=22.1.5
+  - onemkl-license 2026.0.0 hf2ce2f3_915
+  - tbb >=2023.0.0
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  purls: []
+  run_exports: {}
+  size: 143064527
+  timestamp: 1779292528964
 - conda: https://prefix.dev/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
   sha256: c1fdeebc9f8e4f51df265efca4ea20c7a13911193cc255db73cccb6e422ae486
   md5: 770d00bf57b5599c4544d61b61d8c6c6
@@ -30801,6 +32165,15 @@ packages:
   run_exports: {}
   size: 39971
   timestamp: 1779170020804
+- conda: https://prefix.dev/conda-forge/linux-64/onemkl-license-2026.0.0-hf2ce2f3_915.conda
+  sha256: fd53c7f3e874b6fd2add63103028ed707b728cc275597d12951886cfcda46e7d
+  md5: f9a902d29c0980c672f77eff7be1794c
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  purls: []
+  run_exports: {}
+  size: 39987
+  timestamp: 1779292418348
 - conda: https://prefix.dev/conda-forge/linux-64/onnxruntime-cpp-1.24.2-he83aaa8_200_cuda129.conda
   build_number: 200
   sha256: ec964c0519d2d74111a704ca8578a282a2f99c584620429b29914787df78608b
@@ -30966,6 +32339,24 @@ packages:
     - openexr >=3.4.11,<3.5.0a0
   size: 1218919
   timestamp: 1777531700890
+- conda: https://prefix.dev/conda-forge/linux-64/openexr-3.4.12-h9f1635d_0.conda
+  sha256: 9d75e4982065fb8a79b0f908f63d8a884db6d0f44abcecbbdb28eca35b01aa80
+  md5: 705c195cdfe5c3b67e6e9b091fe7b602
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - imath >=3.2.2,<3.2.3.0a0
+  - openjph >=0.27.3,<0.28.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  license: BSD-3-Clause
+  purls: []
+  run_exports:
+    weak:
+    - openexr >=3.4.12,<3.5.0a0
+  size: 1220558
+  timestamp: 1779680416588
 - conda: https://prefix.dev/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
   sha256: 3f231f2747a37a58471c82a9a8a80d92b7fece9f3fce10901a5ac888ce00b747
   md5: b28cf020fd2dead0ca6d113608683842
@@ -32577,6 +33968,25 @@ packages:
   run_exports: {}
   size: 211567
   timestamp: 1771716961404
+- conda: https://prefix.dev/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_3.conda
+  noarch: python
+  sha256: 970b2a1d12983d8d1cc05d914ad88a0b6ef1fa14038c9649aa834dd6ebee65d7
+  md5: acd216255e1370e9aeab5351b831f07c
+  depends:
+  - python
+  - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - _python_abi3_support 1.*
+  - cpython >=3.12
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pyzmq?source=hash-mapping
+  run_exports: {}
+  size: 210896
+  timestamp: 1779483879367
 - conda: https://prefix.dev/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
   sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
   md5: 353823361b1d27eb3960efb076dfcaf6
@@ -33143,6 +34553,23 @@ packages:
   run_exports: {}
   size: 9317508
   timestamp: 1778780215313
+- conda: https://prefix.dev/conda-forge/linux-64/ruff-0.15.14-h994f30f_0.conda
+  noarch: python
+  sha256: 787f6608c4d23abe735875cfcfe316790e06ba43654ff269a43b920e83482bbe
+  md5: 605e065354fc2525ae245adbe189eb84
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ruff?source=compressed-mapping
+  run_exports: {}
+  size: 9340598
+  timestamp: 1779388159173
 - conda: https://prefix.dev/conda-forge/linux-64/rust-1.93.1-h53717f1_0.conda
   sha256: 21e067aabf5863eee02fc5681a6d56de888abea6eaa521abf756b707c0dbcd39
   md5: f05b79be5b5f13fecc79af60892bb1c4
@@ -34091,6 +35518,31 @@ packages:
   run_exports: {}
   size: 236000420
   timestamp: 1771627574109
+- conda: https://prefix.dev/conda-forge/linux-64/triton-3.6.0-cuda129py312h811769c_2.conda
+  sha256: c05760ebac92d1ea2acb028b34f3a7ac699cd26f5fbc43f48273e6c31d6c775b
+  md5: e9ab7c66d31b8b37398d41915f755b21
+  depends:
+  - python
+  - setuptools
+  - cuda-nvcc-tools
+  - cuda-cuobjdump
+  - cuda-cudart
+  - cuda-cupti
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - cuda-version >=12.9,<13
+  - python_abi 3.12.* *_cp312
+  - cuda-cupti >=12.9.79,<13.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/triton?source=hash-mapping
+  run_exports: {}
+  size: 236040035
+  timestamp: 1779452450814
 - conda: https://prefix.dev/conda-forge/linux-64/unicodedata2-17.0.1-py311h49ec1c0_0.conda
   sha256: 2bd8ee058dc98e614003591eb221a8b08449768b13aebe76dad8528bf0f5f88b
   md5: 2889f0c0b6a6d7a37bd64ec60f4cc210
@@ -40316,6 +41768,16 @@ packages:
   run_exports: {}
   size: 131039
   timestamp: 1776865545798
+- conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+  sha256: 9812a303a1395e1dafbd92e5bc8a1ff6013bcbba0a09c7f03a8d23e43560aa9b
+  md5: 489b8e97e666c93f68fdb35c3c9b957f
+  depends:
+  - __unix
+  license: ISC
+  purls: []
+  run_exports: {}
+  size: 129868
+  timestamp: 1779289852439
 - conda: https://prefix.dev/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
   noarch: python
   sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
@@ -40363,6 +41825,17 @@ packages:
   run_exports: {}
   size: 135656
   timestamp: 1776866680878
+- conda: https://prefix.dev/conda-forge/noarch/certifi-2026.5.20-pyhd8ed1ab_0.conda
+  sha256: 645655a3510e38e625da136595f3f16f2130c3263630cc3bc8f60f619ddbe490
+  md5: 9fefff2f745ea1cc2ef15211a20c054a
+  depends:
+  - python >=3.10
+  license: ISC
+  purls:
+  - pkg:pypi/certifi?source=compressed-mapping
+  run_exports: {}
+  size: 134201
+  timestamp: 1779285131141
 - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
   sha256: 3f9483d62ce24ecd063f8a5a714448445dc8d9e201147c46699fc0033e824457
   md5: a9167b9571f3baa9d448faa2139d1089
@@ -41079,6 +42552,29 @@ packages:
   run_exports: {}
   size: 418023
   timestamp: 1778854456651
+- conda: https://prefix.dev/conda-forge/noarch/huggingface_hub-1.16.4-pyhd8ed1ab_0.conda
+  sha256: d9b8685e43a67810a292400032185045e144ed2c8d4b5b17301b898638d1ed9f
+  md5: 73e4fb253dadeedf4b28c5904b087e36
+  depends:
+  - click >=8.4.0
+  - filelock >=3.10.0
+  - fsspec >=2023.5.0
+  - hf-xet >=1.4.3,<2.0.0
+  - httpx >=0.23.0,<1
+  - packaging >=20.9
+  - python >=3.10
+  - pyyaml >=5.1
+  - requests
+  - tqdm >=4.42.1
+  - typer >=0.20.0,<0.26.0
+  - typing-extensions >=3.7.4.3
+  - typing_extensions >=4.1.0
+  license: Apache-2.0
+  purls:
+  - pkg:pypi/huggingface-hub?source=hash-mapping
+  run_exports: {}
+  size: 420678
+  timestamp: 1779844921712
 - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
   sha256: 77af6f5fe8b62ca07d09ac60127a30d9069fdc3c68d6b256754d0ffb1f7779f8
   md5: 8e6923fc12f1fe8f8c4e5c9f343256ac
@@ -41108,6 +42604,22 @@ packages:
   run_exports: {}
   size: 384701
   timestamp: 1779217479559
+- conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.153.0-pyha770c72_0.conda
+  sha256: 9a546efa4a3d346748f0eedf0489fad3aa3f25a070db85763e8e743b8a2b2e0a
+  md5: 02e729e141ce7af6261e15ba9f8ee5d2
+  depends:
+  - attrs >=22.2.0
+  - click >=7.0
+  - exceptiongroup >=1.0.0
+  - python >=3.10
+  - setuptools
+  - sortedcontainers >=2.1.0,<3.0.0
+  license: MPL-2.0
+  purls:
+  - pkg:pypi/hypothesis?source=hash-mapping
+  run_exports: {}
+  size: 386259
+  timestamp: 1779779246364
 - conda: https://prefix.dev/conda-forge/noarch/icecream-2.1.10-pyhd8ed1ab_0.conda
   sha256: fc98472faeb6303928a51293120f0a10ce54a83f02a98c9d7d13ba664f0c2edf
   md5: 8f13926864eefc16b0bbe2a51652507e
@@ -41153,6 +42665,19 @@ packages:
   run_exports: {}
   size: 59038
   timestamp: 1776947141407
+- conda: https://prefix.dev/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+  sha256: 3d25f9f6f7ab3e1ce6429fc8c8aae0335cf446692e715068488536d220cc43de
+  md5: 1b9083b7f00609605d1483dbc6071a81
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/idna?source=compressed-mapping
+  run_exports: {}
+  size: 62642
+  timestamp: 1779294335905
 - conda: https://prefix.dev/conda-forge/noarch/imageio-2.37.0-pyhfb79c49_0.conda
   sha256: 8ef69fa00c68fad34a3b7b260ea774fda9bd9274fd706d3baffb9519fd0063fe
   md5: b5577bc2212219566578fd5af9993af6
@@ -41193,6 +42718,19 @@ packages:
   run_exports: {}
   size: 34387
   timestamp: 1773931568510
+- conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+  sha256: 43e2a5497cad1598ff88a3e69f69bc88b7b8f141fa63c60eab5db296317318b8
+  md5: ffc17e785d64e12fc311af9184221839
+  depends:
+  - python >=3.10
+  - zipp >=3.20
+  - python
+  license: Apache-2.0
+  purls:
+  - pkg:pypi/importlib-metadata?source=compressed-mapping
+  run_exports: {}
+  size: 34766
+  timestamp: 1779714582554
 - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
   sha256: e1a9e3b1c8fe62dc3932a616c284b5d8cbe3124bbfbedcf4ce5c828cb166ee19
   md5: 9614359868482abba1bd15ce465e3c42
@@ -42458,6 +43996,19 @@ packages:
   run_exports: {}
   size: 110100
   timestamp: 1733195786147
+- conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
+  sha256: e27e0473fc6723311a0bd48b89b616fa1b996a2f7a2b555338cbbcfb9c640568
+  md5: 9c5491066224083c41b6d5635ed7107b
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pycparser?source=compressed-mapping
+  run_exports: {}
+  size: 55886
+  timestamp: 1779293633166
 - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.11.10-pyh3cfb1c2_0.conda
   sha256: 26779821ba83b896f319837d7c5301cc244dee41b311d2bd57cbd693ed9e43ef
   md5: 918d9adfc81cb14ab4cced31d22c7711
@@ -43020,6 +44571,17 @@ packages:
   run_exports: {}
   size: 38187
   timestamp: 1769034509657
+- conda: https://prefix.dev/conda-forge/noarch/soupsieve-2.8.4-pyhd8ed1ab_0.conda
+  sha256: 2afa5fe9331c09b4c4689ddf6ace8fc16c837eae547c57dab325b844072fdd77
+  md5: 9e21f087f087f805debe877d88e00a14
+  depends:
+  - python >=3.10
+  license: MIT
+  purls:
+  - pkg:pypi/soupsieve?source=compressed-mapping
+  run_exports: {}
+  size: 38802
+  timestamp: 1779635534390
 - conda: https://prefix.dev/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
   sha256: 570da295d421661af487f1595045760526964f41471021056e993e73089e9c41
   md5: b1b505328da7a6b246787df4b5a49fbc
@@ -43242,6 +44804,28 @@ packages:
   run_exports: {}
   size: 3962753
   timestamp: 1778645573996
+- conda: https://prefix.dev/conda-forge/noarch/transformers-5.9.0-pyhd8ed1ab_0.conda
+  sha256: 33bfd2055cc492cfdd149bce3e158c1d9a297c8aea57d65b65dcdea59ac2f8cd
+  md5: dbb07430fe646f873f3e5673472e1dd2
+  depends:
+  - filelock
+  - huggingface_hub >=1.3.0,<2.0
+  - numpy >=1.17
+  - packaging >=20.0
+  - python >=3.10
+  - pyyaml >=5.1
+  - regex !=2019.12.17
+  - requests
+  - safetensors >=0.4.1
+  - tokenizers >=0.22,<=0.23
+  - tqdm >=4.27
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/transformers?source=compressed-mapping
+  run_exports: {}
+  size: 4074128
+  timestamp: 1779300388504
 - conda: https://prefix.dev/conda-forge/noarch/trimesh-4.12.2-pyh7b2049a_0.conda
   sha256: ec8151a7211e7225f7d378f36a50b7f8336f114bd79935527e49bbd36e013c08
   md5: 1cc13d0d9f4f21cbcbf99b68f2f2a130
@@ -47087,6 +48671,22 @@ packages:
   - ruff>=0.12.0 ; extra == 'dev'
   - cython-lint>=0.12.2 ; extra == 'dev'
   requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl
+  name: uvicorn
+  version: 0.48.0
+  sha256: 48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad
+  requires_dist:
+  - click>=7.0
+  - h11>=0.8
+  - typing-extensions>=4.0 ; python_full_version < '3.11'
+  - colorama>=0.4 ; sys_platform == 'win32' and extra == 'standard'
+  - httptools>=0.6.3 ; extra == 'standard'
+  - python-dotenv>=0.13 ; extra == 'standard'
+  - pyyaml>=5.1 ; extra == 'standard'
+  - uvloop>=0.15.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32' and extra == 'standard'
+  - watchfiles>=0.20 ; extra == 'standard'
+  - websockets>=10.4 ; extra == 'standard'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
   name: docutils
   version: 0.22.4
@@ -47435,6 +49035,11 @@ packages:
   version: 1.8.0
   sha256: 2552f44204b744fba866e573be4c1f9048d6a324dfe14475103fd51613eb1d1f
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/11/c8/26f2e4aae92f11522a96043892ba39a90eac610d5242523aa863212bc1c7/cuda_pathfinder-1.5.5-py3-none-any.whl
+  name: cuda-pathfinder
+  version: 1.5.5
+  sha256: 0228c023f95d1480f143ef5c8922d27a2ab052087a942e81dc289c9eb8f91689
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/11/d0/c177e29701cf1d3008d7d2b16b5fc626592ce13bd535f8795c5f57187e0e/cuda_pathfinder-1.5.4-py3-none-any.whl
   name: cuda-pathfinder
   version: 1.5.4
@@ -47561,6 +49166,14 @@ packages:
   - types-requests ; extra == 'typing'
   - types-shapely ; extra == 'typing'
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/17/93/fb357cc7847c58a8ae790be718903afa81a28d23e642c843dc4129e8a0b2/wrapt-2.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+  name: wrapt
+  version: 2.2.1
+  sha256: 61acce4257a9883669703c525447c5b4c392edf0f987ae77ec32668440158f0e
+  requires_dist:
+  - pytest ; extra == 'dev'
+  - setuptools ; extra == 'dev'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
   name: websockets
   version: '16.0'
@@ -48950,6 +50563,11 @@ packages:
   - sphinxcontrib-asyncio~=0.3.0 ; extra == 'docs'
   - sphinx-rtd-theme~=0.5.2 ; extra == 'docs'
   requires_python: '>=3.8.1'
+- pypi: https://files.pythonhosted.org/packages/5f/fc/a7bf5b6e4e617b45f90f2d9d2a68519c249c81dd4fc2658c7a2a61c4f4b7/aiohappyeyeballs-2.6.2-py3-none-any.whl
+  name: aiohappyeyeballs
+  version: 2.6.2
+  sha256: 4708045e2d7a6c6bdf8aafa8ed39649eaf926a4543b54560659129e3365953c4
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/61/94/5961070353b97647917166b00cccf98773370e65b8716dedd14d99cf14dd/aiobotocore-3.0.0-py3-none-any.whl
   name: aiobotocore
   version: 3.0.0
@@ -50166,6 +51784,19 @@ packages:
   - numpy>=1.22 ; extra == 'express'
   - kaleido>=1.1.0 ; extra == 'kaleido'
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl
+  name: starlette
+  version: 1.1.0
+  sha256: 7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382
+  requires_dist:
+  - anyio>=3.6.2,<5
+  - typing-extensions>=4.10.0 ; python_full_version < '3.13'
+  - httpx>=0.27.0,<0.29.0 ; extra == 'full'
+  - itsdangerous ; extra == 'full'
+  - jinja2 ; extra == 'full'
+  - python-multipart>=0.0.18 ; extra == 'full'
+  - pyyaml ; extra == 'full'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl
   name: werkzeug
   version: 3.1.8
@@ -50655,6 +52286,11 @@ packages:
   - cryptography>=2.0
   - jeepney>=0.6
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/b7/97/30a3a3775ead580134088dfc116a410e2ae490c044ec357109eeb11503ec/monopriors-0.1.0-py3-none-any.whl
+  name: monopriors
+  version: 0.1.0
+  sha256: 5198d2d6a7e2f78caad9a4755bf383bb973996579a493709def1179dcad125bc
+  requires_python: '>=3.10.0'
 - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
   name: six
   version: 1.17.0
@@ -51387,6 +53023,44 @@ packages:
   name: pyperclip
   version: 1.11.0
   sha256: 299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273
+- pypi: https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl
+  name: fastapi
+  version: 0.136.3
+  sha256: 3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620
+  requires_dist:
+  - starlette>=0.46.0
+  - pydantic>=2.9.0
+  - typing-extensions>=4.8.0
+  - typing-inspection>=0.4.2
+  - annotated-doc>=0.0.2
+  - fastapi-cli[standard]>=0.0.8 ; extra == 'standard'
+  - fastar>=0.9.0 ; extra == 'standard'
+  - httpx>=0.23.0,<1.0.0 ; extra == 'standard'
+  - jinja2>=3.1.5 ; extra == 'standard'
+  - python-multipart>=0.0.18 ; extra == 'standard'
+  - email-validator>=2.0.0 ; extra == 'standard'
+  - uvicorn[standard]>=0.12.0 ; extra == 'standard'
+  - pydantic-settings>=2.0.0 ; extra == 'standard'
+  - pydantic-extra-types>=2.0.0 ; extra == 'standard'
+  - fastapi-cli[standard-no-fastapi-cloud-cli]>=0.0.8 ; extra == 'standard-no-fastapi-cloud-cli'
+  - httpx>=0.23.0,<1.0.0 ; extra == 'standard-no-fastapi-cloud-cli'
+  - jinja2>=3.1.5 ; extra == 'standard-no-fastapi-cloud-cli'
+  - python-multipart>=0.0.18 ; extra == 'standard-no-fastapi-cloud-cli'
+  - email-validator>=2.0.0 ; extra == 'standard-no-fastapi-cloud-cli'
+  - uvicorn[standard]>=0.12.0 ; extra == 'standard-no-fastapi-cloud-cli'
+  - pydantic-settings>=2.0.0 ; extra == 'standard-no-fastapi-cloud-cli'
+  - pydantic-extra-types>=2.0.0 ; extra == 'standard-no-fastapi-cloud-cli'
+  - fastapi-cli[standard]>=0.0.8 ; extra == 'all'
+  - httpx>=0.23.0,<1.0.0 ; extra == 'all'
+  - jinja2>=3.1.5 ; extra == 'all'
+  - python-multipart>=0.0.18 ; extra == 'all'
+  - itsdangerous>=1.1.0 ; extra == 'all'
+  - pyyaml>=5.3.1 ; extra == 'all'
+  - email-validator>=2.0.0 ; extra == 'all'
+  - uvicorn[standard]>=0.12.0 ; extra == 'all'
+  - pydantic-settings>=2.0.0 ; extra == 'all'
+  - pydantic-extra-types>=2.0.0 ; extra == 'all'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl
   name: readme-renderer
   version: '44.0'
@@ -51475,6 +53149,11 @@ packages:
   name: flatbuffers
   version: 25.12.19
   sha256: 7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4
+- pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
+  name: more-itertools
+  version: 11.1.0
+  sha256: 4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/e8/b6/f54d676ed93cc2dd2234c3b172ea9c8c3d7d29361e66b1b23dec57a67465/peft-0.19.1-py3-none-any.whl
   name: peft
   version: 0.19.1
@@ -51886,6 +53565,14 @@ packages:
   - spaces>=0.43.0
   - monopriors>=0.3.2
   - sam3-rerun>=0.1.0
+  requires_python: '>=3.12'
+- pypi: packages/sapiens-coco133-pose
+  name: sapiens-coco133-pose
+  requires_dist:
+  - sapiens2-pose
+  - mv-api
+  - rtmlib
+  - tyro>=0.9.1
   requires_python: '>=3.12'
 - pypi: packages/sapiens2-pose
   name: sapiens2-pose

--- a/pixi.toml
+++ b/pixi.toml
@@ -730,6 +730,60 @@ cwd = "packages/sapiens2-pose"
 description = "Launch the Sapiens2 video pose Gradio app in dev mode"
 
 # ═══════════════════════════════════════════════════════════════════════════
+# sapiens-coco133-pose
+# ═══════════════════════════════════════════════════════════════════════════
+[feature.sapiens-coco133-pose]
+platforms = ["linux-64"]
+
+[feature.sapiens-coco133-pose.dependencies]
+python = "3.12.*"
+torchcodec = ">=0.10.0,<0.11"
+tyro = ">=0.9.1,<0.10"
+
+[feature.sapiens-coco133-pose.pypi-dependencies]
+sapiens-coco133-pose = { path = "packages/sapiens-coco133-pose", editable = true }
+sapiens2-pose = { path = "packages/sapiens2-pose", editable = true }
+mv-api = { path = "packages/mv-api", editable = true }
+wilor_nano = { path = "packages/wilor-nano", editable = true }
+rtmlib = { git = "https://github.com/pablovela5620/rtmlib.git", rev = "98bca2193c39b349034b280803b54c9ee58f7c68" }
+onnx = "*"
+onnxscript = "*"
+
+[feature.sapiens-coco133-pose.target.linux-64.pypi-dependencies]
+# TensorRT engines are machine-local artifacts; keep ONNX portable and rebuild engines per target GPU.
+tensorrt-cu12 = { version = "==10.13.3.9", index = "https://pypi.nvidia.com" }
+cuda-python = "*"
+
+[feature.sapiens-coco133-pose.activation.env]
+PACKAGE_DIR = "packages/sapiens-coco133-pose"
+SAPIENS_PRELOAD_MODELS = "0"
+
+[feature.sapiens-coco133-pose.tasks.iterable-video]
+cmd = "python tools/demos/iterable_video_pose.py"
+cwd = "packages/sapiens-coco133-pose"
+description = "Run non-batched RTMLib YOLOX + Sapiens COCO-133 video pose and write the golden RRD/artifact"
+
+[feature.sapiens-coco133-pose.tasks.video-trt]
+cmd = "python tools/demos/batched_tensorrt_video_pose.py"
+cwd = "packages/sapiens-coco133-pose"
+description = "Run batched CUDA/TensorRT COCO-133 video pose"
+
+[feature.sapiens-coco133-pose.tasks.export-pose-onnx]
+cmd = "python tools/conversion/export_sapiens_pose_onnx.py"
+cwd = "packages/sapiens-coco133-pose"
+description = "Export static-batch FP16 Sapiens2 pose ONNX"
+
+[feature.sapiens-coco133-pose.tasks.build-trt]
+cmd = "python tools/conversion/build_tensorrt_engine.py"
+cwd = "packages/sapiens-coco133-pose"
+description = "Build a static-batch FP16 TensorRT engine from ONNX"
+
+[feature.sapiens-coco133-pose.tasks.benchmark]
+cmd = "python tools/eval/benchmark.py"
+cwd = "packages/sapiens-coco133-pose"
+description = "Benchmark iterable golden path against batched TensorRT path"
+
+# ═══════════════════════════════════════════════════════════════════════════
 # robocap-slam
 # ═══════════════════════════════════════════════════════════════════════════
 [feature.robocap.dependencies]
@@ -1548,6 +1602,17 @@ sapiens2-pose-dev = { features = [
     "sapiens2-pose",
     "dev",
 ], solve-group = "sapiens2-pose", no-default-feature = true }
+sapiens-coco133-pose = { features = [
+    "common",
+    "cuda",
+    "sapiens-coco133-pose",
+], solve-group = "sapiens-coco133-pose", no-default-feature = true }
+sapiens-coco133-pose-dev = { features = [
+    "common",
+    "cuda",
+    "sapiens-coco133-pose",
+    "dev",
+], solve-group = "sapiens-coco133-pose", no-default-feature = true }
 robocap = { features = [
     "common",
     "robocap",

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -16,6 +16,7 @@ project-includes = [
     "packages/dpvo/dpvo/**/*",
     "packages/slam-evals/slam_evals/**/*",
     "packages/sapiens2-pose/src/**/*",
+    "packages/sapiens-coco133-pose/src/**/*",
     "packages/egoexo-forge/src/**/*",
 ]
 project-excludes = ["**/node_modules", "**/__pycache__", "**/*venv/**/*"]
@@ -47,6 +48,7 @@ search-path = [
     "packages/slam-evals",
     "packages/sapiens2-pose",
     "packages/sapiens2-pose/src",
+    "packages/sapiens-coco133-pose/src",
     "packages/egoexo-forge/src",
 ]
 
@@ -77,6 +79,8 @@ site-package-path = [
     ".pixi/envs/slam-evals-dev/lib/python3.10/site-packages",
     ".pixi/envs/sapiens2-pose-dev/lib/python3.12/site-packages",
     ".pixi/envs/sapiens2-pose-dev/lib/python3.12/site-packages/rerun_sdk",
+    ".pixi/envs/sapiens-coco133-pose-dev/lib/python3.12/site-packages",
+    ".pixi/envs/sapiens-coco133-pose-dev/lib/python3.12/site-packages/rerun_sdk",
     ".pixi/envs/egoexo-forge-dev/lib/python3.12/site-packages",
     ".pixi/envs/egoexo-forge-dev/lib/python3.12/site-packages/rerun_sdk",
 ]


### PR DESCRIPTION
## Summary

- Add `sapiens-coco133-pose`, a COCO-133 human pose package with an iterable golden path, batched CUDA/TensorRT video path, RTMLib/Sapiens backends, Rerun RRD logging/comparison, and demo/conversion/benchmark CLIs.
- Add Sapiens2 COCO-133 GPU preprocessing/decoding and TensorRT export/build helpers.
- Address review cleanup: ignore local TRT model dirs, expose public Sapiens cache cleanup, split typed estimator config, keep direct-call detector defaults aligned, guard benchmark zero-frame cases, and remove import/tool shims.

## Validation

- `env CONDA_OVERRIDE_CUDA=12.0 pixi run -e sapiens-coco133-pose-dev --frozen ruff check packages/sapiens-coco133-pose packages/sapiens2-pose/src/sapiens2_pose/api/runtime.py packages/sapiens2-pose/src/sapiens2_pose/api/coco133_tensorrt_conversion.py`
- `env CONDA_OVERRIDE_CUDA=12.0 pixi run -e sapiens-coco133-pose-dev --frozen pyrefly check packages/sapiens-coco133-pose packages/sapiens2-pose/src/sapiens2_pose/api/runtime.py packages/sapiens2-pose/src/sapiens2_pose/api/coco133_tensorrt_conversion.py`
- `env CONDA_OVERRIDE_CUDA=12.0 pixi run -e sapiens-coco133-pose-dev --frozen vulture packages/sapiens-coco133-pose/src packages/sapiens-coco133-pose/tests packages/sapiens2-pose/src/sapiens2_pose/api/runtime.py packages/sapiens2-pose/src/sapiens2_pose/api/coco133_tensorrt_conversion.py --min-confidence 80`
- `env CONDA_OVERRIDE_CUDA=12.0 pixi run -e sapiens-coco133-pose-dev --frozen pytest packages/sapiens-coco133-pose/tests -q`
- RTMLib no-logging speed sanity: ~758 FPS default / ~760 FPS beta over 480 frames.
- RTMLib RRD comparison: 30 frames, 15.26x speedup, `max_keypoint_bbox_fraction=0.0533` under the 0.06 accuracy guard.

Notes: pyrefly reported 0 errors with existing repo warnings for missing optional environment/search paths; pytest passed with existing PEP585 beartype warnings from `sapiens_lite`.
