### PR TITLE
Torchcodec singleview tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,17 @@ packages/<name>/
 
 **pyrefly** config is monorepo-wide in root `pyrefly.toml`. Do not add `[tool.pyrefly]` to per-package `pyproject.toml`.
 
+## Rerun Tools
+
+When adding or updating Tyro-facing Rerun CLIs, prefer the shared `RerunTyroConfig`
+from `simplecv.rerun_log_utils` instead of hand-rolling viewer/save/connect
+flags or creating a local `rr.RecordingStream`. Add it as a nested dataclass
+field such as `rr_config: RerunTyroConfig`, let its `__post_init__` configure
+spawn/connect/save/serve/headless behavior, and then use the normal global
+`rr.*` logging calls unless a test or library boundary specifically requires an
+explicit recording stream. This preserves the flexible viewer and save behavior
+expected across SimpleCV tools.
+
 ## Gotchas
 
 - **Never use pip** — all dependency management goes through Pixi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,13 @@ packages/<name>/
   tests/
 ```
 
+## Code Style
+
+Prefer straightforward inline code over tiny one-off helpers. Only extract a
+function when it has meaningful reuse, hides real complexity, names a domain
+concept, or improves testability. Thin wrappers that only pass through
+arguments or hide a single call should usually be inlined at the call site.
+
 **Ruff** — line length 150, rules: E, F, UP, B, SIM, I. Ignored: E501, F722/F821 (jaxtyping), UP037/UP040, SIM901.
 
 **pyrefly** config is monorepo-wide in root `pyrefly.toml`. Do not add `[tool.pyrefly]` to per-package `pyproject.toml`.

--- a/packages/simplecv/simplecv/_benchmark_utils.py
+++ b/packages/simplecv/simplecv/_benchmark_utils.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from io import StringIO
+from pathlib import Path
+
+import torch
+from rich import box
+from rich.console import Console
+from rich.table import Table
+
+from simplecv.video_io import required_torchcodec_int
+
+CONSOLE_WIDTH: int = 140
+CONSOLE: Console = Console(width=CONSOLE_WIDTH)
+
+
+@dataclass(frozen=True, slots=True)
+class TorchCodecVideoMetadata:
+    """TorchCodec video metadata needed by decode benchmarks."""
+
+    frame_count: int
+    """Number of frames in the benchmarked sequence."""
+    height: int
+    """Frame height in pixels."""
+    width: int
+    """Frame width in pixels."""
+
+
+@dataclass(frozen=True, slots=True)
+class TimingResult:
+    """Decode benchmark timing."""
+
+    label: str
+    """Reader label."""
+    elapsed_seconds: float
+    """Wall-clock seconds for the timed decode path."""
+    frames: int
+    """Total decoded frames, or camera-frames for multiview benchmarks."""
+    detail: str
+    """Short detail string for the output table."""
+
+
+def validate_chunk_size(chunk_size: int) -> None:
+    """Validate a chunk size before constructing benchmark readers."""
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be positive")
+
+
+def maybe_synchronize(device: str) -> None:
+    """Synchronize CUDA work when the selected device is CUDA."""
+    if device.startswith("cuda") and torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+def read_torchcodec_video_metadata(video_paths: Sequence[Path]) -> TorchCodecVideoMetadata:
+    """Read min frame count, height, and width with TorchCodec metadata."""
+    if not video_paths:
+        raise ValueError("video_paths must contain at least one video")
+
+    from torchcodec.decoders import VideoDecoder
+
+    frame_counts: list[int] = []
+    heights: list[int] = []
+    widths: list[int] = []
+    for video_path in video_paths:
+        decoder: VideoDecoder = VideoDecoder(video_path, device="cpu", dimension_order="NCHW", num_ffmpeg_threads=0)
+        frame_counts.append(required_torchcodec_int(decoder.metadata.num_frames, "num_frames"))
+        heights.append(required_torchcodec_int(decoder.metadata.height, "height"))
+        widths.append(required_torchcodec_int(decoder.metadata.width, "width"))
+    metadata: TorchCodecVideoMetadata = TorchCodecVideoMetadata(
+        frame_count=min(frame_counts),
+        height=heights[0],
+        width=widths[0],
+    )
+    return metadata
+
+
+def read_torchcodec_fallback_statuses(video_paths: Sequence[Path], device: str) -> list[str]:
+    """Return TorchCodec CPU fallback status strings for each video."""
+    from torchcodec.decoders import VideoDecoder
+
+    statuses: list[str] = []
+    for video_path in video_paths:
+        decoder: VideoDecoder = VideoDecoder(video_path, device=device, dimension_order="NCHW", num_ffmpeg_threads=0)
+        statuses.append(str(getattr(decoder, "cpu_fallback", "unavailable")))
+    return statuses
+
+
+def build_timing_table(results: list[TimingResult], throughput_header: str = "FPS") -> Table:
+    """Build the Rich timing results table."""
+    if not results:
+        raise ValueError("results must contain at least one timing result")
+
+    baseline_result: TimingResult = results[0]
+    baseline_fps: float = baseline_result.frames / baseline_result.elapsed_seconds
+    table: Table = Table(
+        title=f"Results (baseline: {baseline_result.label})",
+        box=box.SIMPLE_HEAVY,
+        border_style="bright_black",
+        header_style="bold white",
+        title_style="bold cyan",
+        row_styles=["", "dim"],
+        show_lines=False,
+    )
+    table.add_column("Reader", no_wrap=True, style="cyan")
+    table.add_column("Time", justify="right", no_wrap=True, style="magenta")
+    table.add_column(throughput_header, justify="right", no_wrap=True, style="green")
+    table.add_column("Relative", justify="right", no_wrap=True, style="yellow")
+    table.add_column("Details", style="white")
+    for result in results:
+        fps: float = result.frames / result.elapsed_seconds
+        relative: float = fps / baseline_fps
+        table.add_row(
+            result.label,
+            f"{result.elapsed_seconds:,.3f}s",
+            f"{fps:,.1f}",
+            f"{relative:.2f}x",
+            result.detail,
+        )
+    return table
+
+
+def format_timing_table(results: list[TimingResult], throughput_header: str = "FPS") -> str:
+    """Format timing results as a readable comparison table."""
+    console_buffer: StringIO = StringIO()
+    console: Console = Console(file=console_buffer, width=CONSOLE_WIDTH, force_terminal=False, color_system=None)
+    if not results:
+        console.print("Results")
+        console.print("No benchmark paths ran.")
+        return console_buffer.getvalue().rstrip()
+
+    console.print(build_timing_table(results, throughput_header=throughput_header))
+    return console_buffer.getvalue().rstrip()
+
+
+def print_timing_results(results: list[TimingResult], throughput_header: str = "FPS") -> None:
+    """Print benchmark timing results with consistent empty-result handling."""
+    CONSOLE.print()
+    if results:
+        CONSOLE.print(build_timing_table(results, throughput_header=throughput_header))
+    else:
+        CONSOLE.print(format_timing_table(results, throughput_header=throughput_header))

--- a/packages/simplecv/simplecv/_torchcodec_view_utils.py
+++ b/packages/simplecv/simplecv/_torchcodec_view_utils.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import numpy as np
+import rerun as rr
+import rerun.blueprint as rrb
+from einops import rearrange
+from jaxtyping import Int, UInt8
+from numpy import ndarray
+from torch import Tensor
+from tqdm import tqdm
+
+TIMELINE: str = "video_time"
+PREVIEW_SECONDS: float = 1.0
+
+
+def build_blueprint(video_names: list[str]) -> rrb.Blueprint:
+    """Build a compact video-stream vs decoded-image comparison blueprint."""
+    rows: list[rrb.Horizontal] = []
+    for video_name in video_names:
+        video_root: str = f"/videos/{video_name}"
+        row: rrb.Horizontal = rrb.Horizontal(
+            rrb.Spatial2DView(origin=f"{video_root}/video", name=f"{video_name} video"),
+            rrb.Spatial2DView(origin=f"{video_root}/decoded", name=f"{video_name} decoded"),
+            column_shares=[1, 1],
+        )
+        rows.append(row)
+
+    preview_start_time: rr.datatypes.TimeInt = rr.datatypes.TimeInt(seconds=0.0)
+    preview_end_time: rr.datatypes.TimeInt = rr.datatypes.TimeInt(seconds=PREVIEW_SECONDS)
+    preview_time_selection: rrb.components.AbsoluteTimeRange = rrb.components.AbsoluteTimeRange(
+        min=preview_start_time,
+        max=preview_end_time,
+    )
+    time_panel: rrb.TimePanel = rrb.TimePanel(
+        timeline=TIMELINE,
+        play_state="playing",
+        loop_mode="selection",
+        time_selection=preview_time_selection,
+    )
+    return rrb.Blueprint(rrb.Tabs(contents=rows), time_panel, collapse_panels=True)
+
+
+def log_torchcodec_decoded_chunks(
+    *,
+    chunked_videos: Iterable[list[UInt8[Tensor, "b 3 h w"]]],
+    video_names: list[str],
+    frame_timestamps_by_video: list[Int[ndarray, "num_frames"]],
+    total_frames: int,
+    chunk_size: int,
+) -> None:
+    """Log TorchCodec RGB chunks as decoded-image streams next to native videos."""
+    total_chunks: int = (total_frames + chunk_size - 1) // chunk_size
+    for chunk_idx, videos in enumerate(
+        tqdm(
+            chunked_videos,
+            total=total_chunks,
+            desc="TorchCodec images",
+            unit="chunk",
+        )
+    ):
+        start_frame_idx: int = chunk_idx * chunk_size
+        for video_idx, video in enumerate(
+            tqdm(
+                videos,
+                desc="Videos in chunk",
+                leave=False,
+            )
+        ):
+            video_name: str = video_names[video_idx]
+            frame_timestamps_ns: Int[ndarray, "num_frames"] = frame_timestamps_by_video[video_idx]
+            bgr_nchw: UInt8[Tensor, "b 3 h w"] = video.detach().flip(dims=(1,))
+            bgr_nhwc_tensor: UInt8[Tensor, "b h w 3"] = rearrange(bgr_nchw, "b c h w -> b h w c")
+            bgr_nhwc: UInt8[ndarray, "b h w 3"] = np.ascontiguousarray(bgr_nhwc_tensor.cpu().numpy(), dtype=np.uint8)
+            for local_frame_idx in range(video.shape[0]):
+                frame_idx: int = start_frame_idx + local_frame_idx
+                if frame_idx >= len(frame_timestamps_ns):
+                    continue
+                bgr_hwc: UInt8[ndarray, "h w 3"] = bgr_nhwc[local_frame_idx]
+                rr.set_time(TIMELINE, duration=float(frame_timestamps_ns[frame_idx]) * 1e-9)
+                rr.set_time("frame", sequence=frame_idx)
+                rr.log(
+                    f"/videos/{video_name}/decoded",
+                    rr.Image(bgr_hwc, color_model=rr.ColorModel.BGR).compress(jpeg_quality=80),
+                )

--- a/packages/simplecv/simplecv/_torchcodec_view_utils.py
+++ b/packages/simplecv/simplecv/_torchcodec_view_utils.py
@@ -51,6 +51,9 @@ def log_torchcodec_decoded_chunks(
     chunk_size: int,
 ) -> None:
     """Log TorchCodec RGB chunks as decoded-image streams next to native videos."""
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be positive")
+
     total_chunks: int = (total_frames + chunk_size - 1) // chunk_size
     for chunk_idx, videos in enumerate(
         tqdm(

--- a/packages/simplecv/simplecv/apis/benchmark_torchcodec_cuda_multiview.py
+++ b/packages/simplecv/simplecv/apis/benchmark_torchcodec_cuda_multiview.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
+from itertools import islice
 from pathlib import Path
 from typing import Literal
 
@@ -9,7 +10,23 @@ import torch
 from jaxtyping import Int64, UInt8
 from tqdm import tqdm
 
-from simplecv.video_io import MultiVideoReader, TorchCodecMultiVideoReader
+from simplecv._benchmark_utils import (
+    CONSOLE,
+    TimingResult,
+    TorchCodecVideoMetadata,
+    maybe_synchronize,
+    print_timing_results,
+    read_torchcodec_fallback_statuses,
+    read_torchcodec_video_metadata,
+    validate_chunk_size,
+)
+from simplecv.image_types import BGRList, ImageBGR
+from simplecv.print_utils import format_bytes
+from simplecv.video_io import (
+    MultiVideoReader,
+    TorchCodecMultiVideoReader,
+    bgr_hwc_frames_to_rgb_nchw_tensor,
+)
 
 RGB_LOW_VIDEO_GLOB: str = "*_rgb_low.mp4"
 DEFAULT_VIDEO_GLOB: str = "*.mp4"
@@ -38,23 +55,9 @@ class BenchmarkConfig:
     skip_torchcodec: bool = False
     """Skip the TorchCodec CUDA benchmark."""
     skip_existing: bool = False
-    """Skip the existing MultiVideoReader benchmark."""
+    """Skip the OpenCV-backed MultiVideoReader benchmarks."""
     dry_run: bool = False
     """Print discovered video metadata without decoding frames."""
-
-
-@dataclass(frozen=True, slots=True)
-class TimingResult:
-    """Decode benchmark timing."""
-
-    label: str
-    """Reader label."""
-    elapsed_seconds: float
-    """Wall-clock seconds for the timed decode path."""
-    camera_frames: int
-    """Total decoded camera frames across all videos."""
-    detail: str
-    """Short detail string for the output table."""
 
 
 def find_video_paths(video_dir: Path) -> list[Path]:
@@ -72,55 +75,6 @@ def find_video_paths(video_dir: Path) -> list[Path]:
     return video_paths
 
 
-def format_bytes(num_bytes: int) -> str:
-    """Format a byte count."""
-    value: float = float(num_bytes)
-    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
-        if value < 1024.0:
-            return f"{value:.1f} {unit}"
-        value /= 1024.0
-    return f"{value:.1f} PiB"
-
-
-def required_int(value: int | None, name: str) -> int:
-    """Return a required TorchCodec metadata integer."""
-    if value is None:
-        raise ValueError(f"TorchCodec metadata field {name} is missing")
-    return int(value)
-
-
-def torchcodec_frame_count(video_paths: list[Path]) -> tuple[int, int, int]:
-    """Read min frame count, height, and width with TorchCodec metadata."""
-    from torchcodec.decoders import VideoDecoder
-
-    frame_counts: list[int] = []
-    heights: list[int] = []
-    widths: list[int] = []
-    for video_path in video_paths:
-        decoder = VideoDecoder(video_path, device="cpu", dimension_order="NCHW", num_ffmpeg_threads=0)
-        frame_counts.append(required_int(decoder.metadata.num_frames, "num_frames"))
-        heights.append(required_int(decoder.metadata.height, "height"))
-        widths.append(required_int(decoder.metadata.width, "width"))
-    return min(frame_counts), heights[0], widths[0]
-
-
-def torchcodec_fallback_status(video_paths: list[Path], device: str) -> list[str]:
-    """Return TorchCodec CPU fallback status strings for each video."""
-    from torchcodec.decoders import VideoDecoder
-
-    statuses: list[str] = []
-    for video_path in video_paths:
-        decoder = VideoDecoder(video_path, device=device, dimension_order="NCHW", num_ffmpeg_threads=0)
-        statuses.append(str(getattr(decoder, "cpu_fallback", "unavailable")))
-    return statuses
-
-
-def maybe_synchronize(device: str) -> None:
-    """Synchronize CUDA work when the selected device is CUDA."""
-    if device.startswith("cuda") and torch.cuda.is_available():
-        torch.cuda.synchronize()
-
-
 def benchmark_torchcodec_chunked(
     video_paths: list[Path],
     device: str,
@@ -131,6 +85,7 @@ def benchmark_torchcodec_chunked(
     seek_mode: Literal["exact", "approximate"],
 ) -> TimingResult:
     """Decode the multiview sequence in GPU-resident chunks."""
+    validate_chunk_size(chunk_size)
     maybe_synchronize(device)
     start: float = time.perf_counter()
     video_sources: list[Path | bytes] = list(video_paths)
@@ -142,28 +97,32 @@ def benchmark_torchcodec_chunked(
         seek_mode=seek_mode,
     )
     frame_count: int = len(reader) if max_frames is None else min(max_frames, len(reader))
-    total_chunks: int = (frame_count + chunk_size - 1) // chunk_size
+    total_camera_frames: int = frame_count * len(video_paths)
     camera_frames: int = 0
     checksum_tensor: Int64[torch.Tensor, ""] | None = None
-    for chunk in tqdm(
-        reader.iter_chunks(chunk_size=chunk_size, max_frames=max_frames),
-        total=total_chunks,
-        desc="TorchCodec chunks",
-        unit="chunk",
+    with tqdm(
+        total=total_camera_frames,
+        desc=f"TorchCodec chunks ({chunk_size} frames/chunk x {len(video_paths)} cameras)",
+        unit=" camera-frames",
         mininterval=5.0,
-    ):
-        videos: list[UInt8[torch.Tensor, "b 3 h w"]] = chunk
-        for video in videos:
-            camera_frames += int(video.shape[0])
-            partial_checksum: Int64[torch.Tensor, ""] = video[:, 0, 0, 0].sum(dtype=torch.int64)
-            checksum_tensor = partial_checksum if checksum_tensor is None else checksum_tensor + partial_checksum
+    ) as progress_bar:
+        for chunk in reader.iter_chunks(chunk_size=chunk_size, max_frames=max_frames):
+            videos: list[UInt8[torch.Tensor, "b 3 h w"]] = chunk
+            chunk_camera_frames: int = 0
+            for video in videos:
+                decoded_frames: int = video.shape[0]
+                camera_frames += decoded_frames
+                chunk_camera_frames += decoded_frames
+                partial_checksum: Int64[torch.Tensor, ""] = video[:, 0, 0, 0].sum(dtype=torch.int64)
+                checksum_tensor = partial_checksum if checksum_tensor is None else checksum_tensor + partial_checksum
+            progress_bar.update(chunk_camera_frames)
     maybe_synchronize(device)
     elapsed_seconds: float = time.perf_counter() - start
     checksum: int = int(checksum_tensor.item()) if checksum_tensor is not None else 0
     return TimingResult(
         label=f"TorchCodec {device}",
         elapsed_seconds=elapsed_seconds,
-        camera_frames=camera_frames,
+        frames=camera_frames,
         detail=f"chunk_size={chunk_size}, workers={num_workers}, seek={seek_mode}, checksum={checksum}",
     )
 
@@ -173,62 +132,131 @@ def benchmark_existing(video_paths: list[Path], max_frames: int | None) -> Timin
     start: float = time.perf_counter()
     reader: MultiVideoReader = MultiVideoReader(video_paths)
     frame_count: int = len(reader) if max_frames is None else min(max_frames, len(reader))
+    total_camera_frames: int = frame_count * len(video_paths)
     camera_frames: int = 0
     checksum: int = 0
-    for frame_idx, bgr_list in enumerate(
-        tqdm(reader, total=frame_count, desc="MultiVideoReader", unit="frame", mininterval=5.0)
-    ):
-        if bgr_list is None:
-            break
-        if max_frames is not None and frame_idx >= max_frames:
-            break
-        for bgr in bgr_list:
-            camera_frames += 1
-            checksum += int(bgr[0, 0, 0])
+    with tqdm(
+        total=total_camera_frames,
+        desc=f"MultiVideoReader ({len(video_paths)} cameras)",
+        unit=" camera-frames",
+        mininterval=5.0,
+    ) as progress_bar:
+        for bgr_list in islice(reader, frame_count):
+            if bgr_list is None:
+                break
+            bgr_frames: BGRList = bgr_list
+            decoded_camera_frames: int = len(bgr_frames)
+            for bgr in bgr_frames:
+                checksum += int(bgr[0, 0, 0])
+            camera_frames += decoded_camera_frames
+            progress_bar.update(decoded_camera_frames)
     elapsed_seconds: float = time.perf_counter() - start
     return TimingResult(
         label="MultiVideoReader",
         elapsed_seconds=elapsed_seconds,
-        camera_frames=camera_frames,
+        frames=camera_frames,
         detail=f"streamed BGR numpy frames, checksum={checksum}",
     )
 
 
-def print_timing(result: TimingResult) -> None:
-    """Print one timing row."""
-    fps: float = result.camera_frames / result.elapsed_seconds
-    print(f"{result.label:20s} {result.elapsed_seconds:9.3f}s  {fps:9.1f} camera-fps  {result.detail}", flush=True)
+def benchmark_existing_tensor(
+    video_paths: list[Path],
+    max_frames: int | None,
+    device: str,
+    chunk_size: int,
+) -> TimingResult:
+    """Decode with MultiVideoReader and convert chunks to RGB ``NCHW`` uint8 tensors."""
+    validate_chunk_size(chunk_size)
+    maybe_synchronize(device)
+    start: float = time.perf_counter()
+    reader: MultiVideoReader = MultiVideoReader(video_paths)
+    frame_count: int = len(reader) if max_frames is None else min(max_frames, len(reader))
+    total_camera_frames: int = frame_count * len(video_paths)
+    camera_frames: int = 0
+    checksum_tensor: Int64[torch.Tensor, ""] | None = None
+    bgr_chunks_by_camera: list[list[ImageBGR]] = [[] for _ in video_paths]
+    with tqdm(
+        total=total_camera_frames,
+        desc=f"MultiVideoReader -> {device} ({chunk_size} frames/chunk x {len(video_paths)} cameras)",
+        unit=" camera-frames",
+        mininterval=5.0,
+    ) as progress_bar:
+        for bgr_list in islice(reader, frame_count):
+            if bgr_list is None:
+                break
+            bgr_frames: BGRList = bgr_list
+            for camera_idx, bgr in enumerate(bgr_frames):
+                bgr_chunks_by_camera[camera_idx].append(bgr)
+            if all(len(bgr_chunk) == chunk_size for bgr_chunk in bgr_chunks_by_camera):
+                chunk_camera_frames: int = 0
+                for bgr_chunk in bgr_chunks_by_camera:
+                    video: UInt8[torch.Tensor, "b 3 h w"] = bgr_hwc_frames_to_rgb_nchw_tensor(bgr_chunk, device=device)
+                    decoded_frames: int = video.shape[0]
+                    camera_frames += decoded_frames
+                    chunk_camera_frames += decoded_frames
+                    partial_checksum: Int64[torch.Tensor, ""] = video[:, 0, 0, 0].sum(dtype=torch.int64)
+                    checksum_tensor = partial_checksum if checksum_tensor is None else checksum_tensor + partial_checksum
+                bgr_chunks_by_camera = [[] for _ in video_paths]
+                progress_bar.update(chunk_camera_frames)
+        if any(bgr_chunks_by_camera):
+            final_camera_frames: int = 0
+            for bgr_chunk in bgr_chunks_by_camera:
+                if not bgr_chunk:
+                    continue
+                final_video: UInt8[torch.Tensor, "b 3 h w"] = bgr_hwc_frames_to_rgb_nchw_tensor(bgr_chunk, device=device)
+                final_frame_count: int = final_video.shape[0]
+                camera_frames += final_frame_count
+                final_camera_frames += final_frame_count
+                final_checksum: Int64[torch.Tensor, ""] = final_video[:, 0, 0, 0].sum(dtype=torch.int64)
+                checksum_tensor = final_checksum if checksum_tensor is None else checksum_tensor + final_checksum
+            progress_bar.update(final_camera_frames)
+    maybe_synchronize(device)
+    elapsed_seconds: float = time.perf_counter() - start
+    checksum: int = int(checksum_tensor.item()) if checksum_tensor is not None else 0
+    return TimingResult(
+        label=f"MultiVideoReader -> {device}",
+        elapsed_seconds=elapsed_seconds,
+        frames=camera_frames,
+        detail=f"RGB NCHW uint8 tensors, chunk_size={chunk_size}, checksum={checksum}",
+    )
 
 
 def main(config: BenchmarkConfig) -> None:
     """Run the TorchCodec CUDA multiview benchmark."""
-    if config.chunk_size <= 0:
-        raise ValueError("chunk_size must be positive")
+    validate_chunk_size(config.chunk_size)
 
     video_paths: list[Path] = find_video_paths(config.video_dir)
-    full_frame_count, height, width = torchcodec_frame_count(video_paths)
+    metadata: TorchCodecVideoMetadata = read_torchcodec_video_metadata(video_paths)
+    full_frame_count: int = metadata.frame_count
+    height: int = metadata.height
+    width: int = metadata.width
     max_frames: int | None = None if config.max_frames < 0 else config.max_frames
     decode_frame_count: int = full_frame_count if max_frames is None else min(max_frames, full_frame_count)
     required_bytes: int = len(video_paths) * decode_frame_count * 3 * height * width
 
-    print(f"Video dir: {config.video_dir}", flush=True)
-    print(f"Videos: {len(video_paths)} x {width}x{height}, {full_frame_count} frames/video", flush=True)
-    print(f"Full sequence tensor footprint: {format_bytes(required_bytes)}", flush=True)
+    CONSOLE.print(f"Video dir: {config.video_dir}", markup=False)
+    CONSOLE.print(f"Videos: {len(video_paths)} x {width}x{height}, {full_frame_count} frames/video", markup=False)
+    CONSOLE.print(f"Full sequence tensor footprint: {format_bytes(required_bytes)}")
     chunk_frame_count: int = min(config.chunk_size, decode_frame_count)
     chunk_bytes: int = len(video_paths) * chunk_frame_count * 3 * height * width
-    print(f"Chunked TorchCodec tensor bytes: {format_bytes(chunk_bytes)} per chunk", flush=True)
+    CONSOLE.print(f"Chunked TorchCodec tensor bytes: {format_bytes(chunk_bytes)} per chunk")
     if config.device.startswith("cuda") and torch.cuda.is_available():
-        free_bytes, total_bytes = torch.cuda.mem_get_info()
-        print(f"CUDA memory: {format_bytes(free_bytes)} free / {format_bytes(total_bytes)} total", flush=True)
+        cuda_memory_result: tuple[int, int] = torch.cuda.mem_get_info()
+        free_bytes: int = cuda_memory_result[0]
+        total_bytes: int = cuda_memory_result[1]
+        CONSOLE.print(f"CUDA memory: {format_bytes(free_bytes)} free / {format_bytes(total_bytes)} total")
     if config.dry_run:
         return
     if config.device.startswith("cuda") and not torch.cuda.is_available():
-        raise SystemExit("CUDA was requested, but torch.cuda.is_available() is false. Use --device cpu for a CPU smoke run.")
+        raise SystemExit(
+            "CUDA was requested, but torch.cuda.is_available() is false. Use --device cpu for a CPU smoke run."
+        )
     if config.check_fallback:
-        fallback_statuses: list[str] = torchcodec_fallback_status(video_paths, config.device)
+        fallback_statuses: list[str] = read_torchcodec_fallback_statuses(video_paths, config.device)
         unique_statuses: str = " | ".join(sorted(set(fallback_statuses)))
-        print(f"TorchCodec fallback status: {unique_statuses}", flush=True)
+        CONSOLE.print(f"TorchCodec fallback status: {unique_statuses}", markup=False)
 
+    timing_results: list[TimingResult] = []
     if not config.skip_torchcodec:
         torchcodec_result: TimingResult = benchmark_torchcodec_chunked(
             video_paths,
@@ -239,9 +267,18 @@ def main(config: BenchmarkConfig) -> None:
             config.ffmpeg_threads,
             config.seek_mode,
         )
-        print(flush=True)
-        print_timing(torchcodec_result)
+        timing_results.append(torchcodec_result)
 
     if not config.skip_existing:
+        existing_tensor_result: TimingResult = benchmark_existing_tensor(
+            video_paths,
+            max_frames,
+            config.device,
+            config.chunk_size,
+        )
+        timing_results.append(existing_tensor_result)
+
         existing_result: TimingResult = benchmark_existing(video_paths, max_frames)
-        print_timing(existing_result)
+        timing_results.append(existing_result)
+
+    print_timing_results(timing_results, throughput_header="Camera FPS")

--- a/packages/simplecv/simplecv/apis/benchmark_torchcodec_cuda_singleview.py
+++ b/packages/simplecv/simplecv/apis/benchmark_torchcodec_cuda_singleview.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from itertools import islice
+from pathlib import Path
+from typing import Literal
+
+import torch
+from jaxtyping import Int64, UInt8
+from tqdm import tqdm
+
+from simplecv._benchmark_utils import (
+    CONSOLE,
+    TimingResult,
+    TorchCodecVideoMetadata,
+    maybe_synchronize,
+    print_timing_results,
+    read_torchcodec_fallback_statuses,
+    read_torchcodec_video_metadata,
+    validate_chunk_size,
+)
+from simplecv.image_types import ImageBGR
+from simplecv.print_utils import format_bytes
+from simplecv.video_io import (
+    TorchCodecVideoReader,
+    VideoReader,
+    bgr_hwc_frames_to_rgb_nchw_tensor,
+    validate_video_file_path,
+)
+
+
+@dataclass
+class BenchmarkConfig:
+    """TorchCodec CUDA singleview benchmark config."""
+
+    video_path: Path
+    """Path to the mp4 video."""
+    device: str = "cuda"
+    """Torch device passed to TorchCodec."""
+    max_frames: int = 120
+    """Frames to decode. Use -1 for all frames."""
+    chunk_size: int = 32
+    """Frames per TorchCodec chunk."""
+    ffmpeg_threads: int = 0
+    """FFmpeg thread count passed to TorchCodec."""
+    seek_mode: Literal["exact", "approximate"] = "approximate"
+    """TorchCodec seek mode."""
+    check_fallback: bool = False
+    """Print TorchCodec CPU fallback status before benchmarking."""
+    skip_torchcodec: bool = False
+    """Skip the TorchCodec CUDA benchmark."""
+    skip_existing: bool = False
+    """Skip the OpenCV-backed VideoReader benchmarks."""
+    dry_run: bool = False
+    """Print discovered video metadata without decoding frames."""
+
+
+def benchmark_torchcodec_chunked(
+    video_path: Path,
+    device: str,
+    max_frames: int | None,
+    chunk_size: int,
+    num_ffmpeg_threads: int,
+    seek_mode: Literal["exact", "approximate"],
+) -> TimingResult:
+    """Decode one video in GPU-resident chunks."""
+    validate_chunk_size(chunk_size)
+    maybe_synchronize(device)
+    start_time: float = time.perf_counter()
+    reader: TorchCodecVideoReader = TorchCodecVideoReader(
+        video_path,
+        device=device,
+        num_ffmpeg_threads=num_ffmpeg_threads,
+        seek_mode=seek_mode,
+    )
+    frame_count: int = len(reader) if max_frames is None else min(max_frames, len(reader))
+    frames: int = 0
+    checksum_tensor: Int64[torch.Tensor, ""] | None = None
+    with tqdm(
+        total=frame_count,
+        desc=f"TorchCodec chunks ({chunk_size} frames/chunk)",
+        unit=" frames",
+        mininterval=5.0,
+    ) as progress_bar:
+        for video in reader.iter_chunks(chunk_size=chunk_size, max_frames=max_frames):
+            decoded_frames: int = video.shape[0]
+            frames += decoded_frames
+            partial_checksum: Int64[torch.Tensor, ""] = video[:, 0, 0, 0].sum(dtype=torch.int64)
+            checksum_tensor = partial_checksum if checksum_tensor is None else checksum_tensor + partial_checksum
+            progress_bar.update(decoded_frames)
+    maybe_synchronize(device)
+    elapsed_seconds: float = time.perf_counter() - start_time
+    checksum: int = int(checksum_tensor.item()) if checksum_tensor is not None else 0
+    return TimingResult(
+        label=f"TorchCodec {device}",
+        elapsed_seconds=elapsed_seconds,
+        frames=frames,
+        detail=f"chunk_size={chunk_size}, seek={seek_mode}, checksum={checksum}",
+    )
+
+
+def benchmark_existing(video_path: Path, max_frames: int | None) -> TimingResult:
+    """Decode with the existing OpenCV-backed VideoReader."""
+    start_time: float = time.perf_counter()
+    reader: VideoReader = VideoReader(video_path)
+    frame_count: int = len(reader) if max_frames is None else min(max_frames, len(reader))
+    frames: int = 0
+    checksum: int = 0
+    for bgr_frame in tqdm(islice(reader, frame_count), total=frame_count, desc="VideoReader", unit=" frames", mininterval=5.0):
+        bgr: ImageBGR = bgr_frame
+        frames += 1
+        checksum += int(bgr[0, 0, 0])
+    elapsed_seconds: float = time.perf_counter() - start_time
+    return TimingResult(
+        label="VideoReader",
+        elapsed_seconds=elapsed_seconds,
+        frames=frames,
+        detail=f"streamed BGR numpy frames, checksum={checksum}",
+    )
+
+
+def benchmark_existing_tensor(
+    video_path: Path,
+    max_frames: int | None,
+    device: str,
+    chunk_size: int,
+) -> TimingResult:
+    """Decode with VideoReader and convert chunks to RGB ``NCHW`` uint8 tensors."""
+    validate_chunk_size(chunk_size)
+    maybe_synchronize(device)
+    start_time: float = time.perf_counter()
+    reader: VideoReader = VideoReader(video_path)
+    frame_count: int = len(reader) if max_frames is None else min(max_frames, len(reader))
+    frames: int = 0
+    checksum_tensor: Int64[torch.Tensor, ""] | None = None
+    bgr_chunk: list[ImageBGR] = []
+    with tqdm(
+        total=frame_count,
+        desc=f"VideoReader -> {device} ({chunk_size} frames/chunk)",
+        unit=" frames",
+        mininterval=5.0,
+    ) as progress_bar:
+        for bgr_frame in islice(reader, frame_count):
+            bgr: ImageBGR = bgr_frame
+            bgr_chunk.append(bgr)
+            if len(bgr_chunk) == chunk_size:
+                video: UInt8[torch.Tensor, "b 3 h w"] = bgr_hwc_frames_to_rgb_nchw_tensor(bgr_chunk, device=device)
+                decoded_frames: int = video.shape[0]
+                frames += decoded_frames
+                partial_checksum: Int64[torch.Tensor, ""] = video[:, 0, 0, 0].sum(dtype=torch.int64)
+                checksum_tensor = partial_checksum if checksum_tensor is None else checksum_tensor + partial_checksum
+                bgr_chunk = []
+                progress_bar.update(decoded_frames)
+        if bgr_chunk:
+            final_video: UInt8[torch.Tensor, "b 3 h w"] = bgr_hwc_frames_to_rgb_nchw_tensor(bgr_chunk, device=device)
+            final_frame_count: int = final_video.shape[0]
+            frames += final_frame_count
+            final_checksum: Int64[torch.Tensor, ""] = final_video[:, 0, 0, 0].sum(dtype=torch.int64)
+            checksum_tensor = final_checksum if checksum_tensor is None else checksum_tensor + final_checksum
+            progress_bar.update(final_frame_count)
+    maybe_synchronize(device)
+    elapsed_seconds: float = time.perf_counter() - start_time
+    checksum: int = int(checksum_tensor.item()) if checksum_tensor is not None else 0
+    return TimingResult(
+        label=f"VideoReader -> {device}",
+        elapsed_seconds=elapsed_seconds,
+        frames=frames,
+        detail=f"RGB NCHW uint8 tensor, chunk_size={chunk_size}, checksum={checksum}",
+    )
+
+
+def main(config: BenchmarkConfig) -> None:
+    """Run the TorchCodec CUDA singleview benchmark."""
+    validate_chunk_size(config.chunk_size)
+
+    video_path: Path = validate_video_file_path(config.video_path)
+    metadata: TorchCodecVideoMetadata = read_torchcodec_video_metadata([video_path])
+    full_frame_count: int = metadata.frame_count
+    height: int = metadata.height
+    width: int = metadata.width
+    max_frames: int | None = None if config.max_frames < 0 else config.max_frames
+    decode_frame_count: int = full_frame_count if max_frames is None else min(max_frames, full_frame_count)
+    required_bytes: int = decode_frame_count * 3 * height * width
+
+    CONSOLE.print(f"Video: {video_path}", markup=False)
+    CONSOLE.print(f"Resolution: {width}x{height}, {full_frame_count} frames", markup=False)
+    CONSOLE.print(f"Full tensor footprint: {format_bytes(required_bytes)}")
+    chunk_frame_count: int = min(config.chunk_size, decode_frame_count)
+    chunk_bytes: int = chunk_frame_count * 3 * height * width
+    CONSOLE.print(f"Chunked TorchCodec tensor bytes: {format_bytes(chunk_bytes)} per chunk")
+    if config.device.startswith("cuda") and torch.cuda.is_available():
+        cuda_memory_result: tuple[int, int] = torch.cuda.mem_get_info()
+        free_bytes: int = cuda_memory_result[0]
+        total_bytes: int = cuda_memory_result[1]
+        CONSOLE.print(f"CUDA memory: {format_bytes(free_bytes)} free / {format_bytes(total_bytes)} total")
+    if config.dry_run:
+        return
+    if config.device.startswith("cuda") and not torch.cuda.is_available():
+        raise SystemExit(
+            "CUDA was requested, but torch.cuda.is_available() is false. Use --device cpu for a CPU smoke run."
+        )
+    if config.check_fallback:
+        fallback_statuses: list[str] = read_torchcodec_fallback_statuses([video_path], config.device)
+        fallback_status: str = fallback_statuses[0]
+        CONSOLE.print(f"TorchCodec fallback status: {fallback_status}", markup=False)
+
+    timing_results: list[TimingResult] = []
+    if not config.skip_torchcodec:
+        torchcodec_result: TimingResult = benchmark_torchcodec_chunked(
+            video_path,
+            config.device,
+            max_frames,
+            config.chunk_size,
+            config.ffmpeg_threads,
+            config.seek_mode,
+        )
+        timing_results.append(torchcodec_result)
+
+    if not config.skip_existing:
+        existing_tensor_result: TimingResult = benchmark_existing_tensor(
+            video_path,
+            max_frames,
+            config.device,
+            config.chunk_size,
+        )
+        timing_results.append(existing_tensor_result)
+
+        existing_result: TimingResult = benchmark_existing(video_path, max_frames)
+        timing_results.append(existing_result)
+
+    print_timing_results(timing_results)

--- a/packages/simplecv/simplecv/apis/view_torchcodec_multiview.py
+++ b/packages/simplecv/simplecv/apis/view_torchcodec_multiview.py
@@ -9,9 +9,10 @@ import torch
 from einops import rearrange
 from jaxtyping import Int, UInt8
 from numpy import ndarray
+from torch import Tensor
 from tqdm import tqdm
 
-from simplecv.rerun_log_utils import log_video
+from simplecv.rerun_log_utils import RerunTyroConfig, log_video
 from simplecv.video_io import TorchCodecMultiVideoReader
 
 DEFAULT_SAVE_PATH: Path = Path("/tmp/torchcodec_multiview.rrd")
@@ -23,10 +24,9 @@ PREVIEW_SECONDS: float = 1.0
 class TorchCodecMultiviewConfig:
     """TorchCodec multiview Rerun viewer config."""
 
+    rr_config: RerunTyroConfig
     video_dir: Path
     """Directory containing one or more ``.mp4`` videos."""
-    save_path: Path = DEFAULT_SAVE_PATH
-    """Path to save the generated Rerun recording."""
     max_videos: int = 0
     """Maximum videos to log for the side-by-side check. Use ``0`` for all videos."""
     max_frames: int = 32
@@ -73,22 +73,18 @@ def build_blueprint(video_names: list[str]) -> rrb.Blueprint:
             column_shares=[1, 1],
         )
         rows.append(row)
-    preview_time_selection: rrb.components.AbsoluteTimeRange = rrb.components.AbsoluteTimeRange(
-        min=rr.datatypes.TimeInt(seconds=0.0),
-        max=rr.datatypes.TimeInt(seconds=PREVIEW_SECONDS),
-    )
+
     time_panel: rrb.TimePanel = rrb.TimePanel(
         timeline=TIMELINE,
         play_state="playing",
         loop_mode="selection",
-        time_selection=preview_time_selection,
     )
-    return rrb.Blueprint(rrb.Vertical(contents=rows), time_panel, collapse_panels=True)
+    return rrb.Blueprint(rrb.Tabs(contents=rows), time_panel, collapse_panels=True)
 
 
-def rgb_chw_to_rgb_hwc_numpy(rgb_chw: UInt8[torch.Tensor, "3 h w"]) -> UInt8[ndarray, "h w 3"]:
+def rgb_chw_to_rgb_hwc_numpy(rgb_chw: UInt8[Tensor, "3 h w"]) -> UInt8[ndarray, "h w 3"]:
     """Move one RGB CHW torch tensor to a contiguous RGB HWC numpy image."""
-    rgb_hwc: UInt8[torch.Tensor, "h w 3"] = rearrange(rgb_chw, "c h w -> h w c")
+    rgb_hwc: UInt8[Tensor, "h w 3"] = rearrange(rgb_chw, "c h w -> h w c")
     rgb_np: UInt8[ndarray, "h w 3"] = rgb_hwc.cpu().contiguous().numpy()
     return rgb_np
 
@@ -100,7 +96,6 @@ def log_torchcodec_decoded_images(
     frame_timestamps_by_video: list[Int[ndarray, "num_frames"]],
     max_frames: int,
     chunk_size: int,
-    recording: rr.RecordingStream,
 ) -> None:
     """Decode multiview chunks with TorchCodec and log RGB images next to video streams."""
     total_frames: int = min(max_frames, len(reader))
@@ -113,39 +108,40 @@ def log_torchcodec_decoded_images(
         )
     ):
         start_frame_idx: int = chunk_start * chunk_size
-        for video_idx, video in enumerate(videos):
+        for video_idx, video in enumerate(
+            tqdm(
+                videos,
+                desc="Videos in chunk",
+                leave=False,
+            )
+        ):
             video_name: str = video_names[video_idx]
             frame_timestamps_ns: Int[ndarray, "num_frames"] = frame_timestamps_by_video[video_idx]
-            for local_frame_idx in range(int(video.shape[0])):
+            for local_frame_idx in range(video.shape[0]):
                 frame_idx: int = start_frame_idx + local_frame_idx
                 if frame_idx >= len(frame_timestamps_ns):
                     continue
-                rgb_chw: UInt8[torch.Tensor, "3 h w"] = video[local_frame_idx]
+                rgb_chw: UInt8[Tensor, "3 h w"] = video[local_frame_idx]
                 rgb_hwc: UInt8[ndarray, "h w 3"] = rgb_chw_to_rgb_hwc_numpy(rgb_chw)
-                rr.set_time(TIMELINE, duration=float(frame_timestamps_ns[frame_idx]) * 1e-9, recording=recording)
-                rr.set_time("frame", sequence=frame_idx, recording=recording)
+                rr.set_time(TIMELINE, duration=float(frame_timestamps_ns[frame_idx]) * 1e-9)
+                rr.set_time("frame", sequence=frame_idx)
                 rr.log(
                     f"/videos/{video_name}/decoded",
                     rr.Image(rgb_hwc, color_model=rr.ColorModel.RGB).compress(jpeg_quality=80),
-                    recording=recording,
                 )
 
 
 def main(config: TorchCodecMultiviewConfig) -> None:
     """Log native video streams and TorchCodec decoded image frames to Rerun."""
     if config.device.startswith("cuda") and not torch.cuda.is_available():
-        raise SystemExit("CUDA was requested, but torch.cuda.is_available() is false. Use --device cpu for a smoke run.")
+        raise SystemExit(
+            "CUDA was requested, but torch.cuda.is_available() is false. Use --device cpu for a smoke run."
+        )
 
     video_paths: list[Path] = discover_video_paths(config.video_dir, max_videos=config.max_videos)
     video_names: list[str] = video_entity_names(config.video_dir, video_paths)
 
-    config.save_path.parent.mkdir(parents=True, exist_ok=True)
-    recording: rr.RecordingStream = rr.RecordingStream(
-        application_id="torchcodec_multiview",
-        recording_id=f"torchcodec_multiview_{config.video_dir.name}",
-    )
-    recording.save(str(config.save_path))
-    rr.send_blueprint(build_blueprint(video_names), recording=recording)
+    rr.send_blueprint(build_blueprint(video_names))
 
     frame_timestamps_by_video: list[Int[ndarray, "num_frames"]] = []
     for video_name, video_path in zip(video_names, video_paths, strict=True):
@@ -153,7 +149,6 @@ def main(config: TorchCodecMultiviewConfig) -> None:
             video_path,
             video_log_path=Path(f"/videos/{video_name}/video"),
             timeline=TIMELINE,
-            recording=recording,
         )
         frame_timestamps_by_video.append(frame_timestamps_ns)
 
@@ -169,7 +164,4 @@ def main(config: TorchCodecMultiviewConfig) -> None:
         frame_timestamps_by_video=frame_timestamps_by_video,
         max_frames=config.max_frames,
         chunk_size=config.chunk_size,
-        recording=recording,
     )
-    recording.flush(timeout_sec=30.0)
-    print(f"Saved {config.save_path}")

--- a/packages/simplecv/simplecv/apis/view_torchcodec_multiview.py
+++ b/packages/simplecv/simplecv/apis/view_torchcodec_multiview.py
@@ -4,20 +4,13 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import rerun as rr
-import rerun.blueprint as rrb
 import torch
-from einops import rearrange
-from jaxtyping import Int, UInt8
+from jaxtyping import Int
 from numpy import ndarray
-from torch import Tensor
-from tqdm import tqdm
 
+from simplecv._torchcodec_view_utils import TIMELINE, build_blueprint, log_torchcodec_decoded_chunks
 from simplecv.rerun_log_utils import RerunTyroConfig, log_video
 from simplecv.video_io import TorchCodecMultiVideoReader
-
-DEFAULT_SAVE_PATH: Path = Path("/tmp/torchcodec_multiview.rrd")
-TIMELINE: str = "video_time"
-PREVIEW_SECONDS: float = 1.0
 
 
 @dataclass
@@ -29,7 +22,7 @@ class TorchCodecMultiviewConfig:
     """Directory containing one or more ``.mp4`` videos."""
     max_videos: int = 0
     """Maximum videos to log for the side-by-side check. Use ``0`` for all videos."""
-    max_frames: int = 32
+    max_frames: int = 32 * 10
     """Maximum decoded frames per video to log as ``rr.Image``."""
     chunk_size: int = 32
     """TorchCodec decode chunk size."""
@@ -62,75 +55,6 @@ def video_entity_names(video_dir: Path, video_paths: list[Path]) -> list[str]:
     return entity_names
 
 
-def build_blueprint(video_names: list[str]) -> rrb.Blueprint:
-    """Build a compact video-stream vs decoded-image comparison blueprint."""
-    rows: list[rrb.Horizontal] = []
-    for video_name in video_names:
-        video_root: str = f"/videos/{video_name}"
-        row: rrb.Horizontal = rrb.Horizontal(
-            rrb.Spatial2DView(origin=f"{video_root}/video", name=f"{video_name} video"),
-            rrb.Spatial2DView(origin=f"{video_root}/decoded", name=f"{video_name} decoded"),
-            column_shares=[1, 1],
-        )
-        rows.append(row)
-
-    time_panel: rrb.TimePanel = rrb.TimePanel(
-        timeline=TIMELINE,
-        play_state="playing",
-        loop_mode="selection",
-    )
-    return rrb.Blueprint(rrb.Tabs(contents=rows), time_panel, collapse_panels=True)
-
-
-def rgb_chw_to_rgb_hwc_numpy(rgb_chw: UInt8[Tensor, "3 h w"]) -> UInt8[ndarray, "h w 3"]:
-    """Move one RGB CHW torch tensor to a contiguous RGB HWC numpy image."""
-    rgb_hwc: UInt8[Tensor, "h w 3"] = rearrange(rgb_chw, "c h w -> h w c")
-    rgb_np: UInt8[ndarray, "h w 3"] = rgb_hwc.cpu().contiguous().numpy()
-    return rgb_np
-
-
-def log_torchcodec_decoded_images(
-    *,
-    reader: TorchCodecMultiVideoReader,
-    video_names: list[str],
-    frame_timestamps_by_video: list[Int[ndarray, "num_frames"]],
-    max_frames: int,
-    chunk_size: int,
-) -> None:
-    """Decode multiview chunks with TorchCodec and log RGB images next to video streams."""
-    total_frames: int = min(max_frames, len(reader))
-    for chunk_start, videos in enumerate(
-        tqdm(
-            reader.iter_chunks(chunk_size=chunk_size, max_frames=total_frames),
-            total=(total_frames + chunk_size - 1) // chunk_size,
-            desc="TorchCodec images",
-            unit="chunk",
-        )
-    ):
-        start_frame_idx: int = chunk_start * chunk_size
-        for video_idx, video in enumerate(
-            tqdm(
-                videos,
-                desc="Videos in chunk",
-                leave=False,
-            )
-        ):
-            video_name: str = video_names[video_idx]
-            frame_timestamps_ns: Int[ndarray, "num_frames"] = frame_timestamps_by_video[video_idx]
-            for local_frame_idx in range(video.shape[0]):
-                frame_idx: int = start_frame_idx + local_frame_idx
-                if frame_idx >= len(frame_timestamps_ns):
-                    continue
-                rgb_chw: UInt8[Tensor, "3 h w"] = video[local_frame_idx]
-                rgb_hwc: UInt8[ndarray, "h w 3"] = rgb_chw_to_rgb_hwc_numpy(rgb_chw)
-                rr.set_time(TIMELINE, duration=float(frame_timestamps_ns[frame_idx]) * 1e-9)
-                rr.set_time("frame", sequence=frame_idx)
-                rr.log(
-                    f"/videos/{video_name}/decoded",
-                    rr.Image(rgb_hwc, color_model=rr.ColorModel.RGB).compress(jpeg_quality=80),
-                )
-
-
 def main(config: TorchCodecMultiviewConfig) -> None:
     """Log native video streams and TorchCodec decoded image frames to Rerun."""
     if config.device.startswith("cuda") and not torch.cuda.is_available():
@@ -158,10 +82,11 @@ def main(config: TorchCodecMultiviewConfig) -> None:
         device=config.device,
         seek_mode="approximate",
     )
-    log_torchcodec_decoded_images(
-        reader=reader,
+    total_frames: int = min(config.max_frames, len(reader))
+    log_torchcodec_decoded_chunks(
+        chunked_videos=reader.iter_chunks(chunk_size=config.chunk_size, max_frames=total_frames),
         video_names=video_names,
         frame_timestamps_by_video=frame_timestamps_by_video,
-        max_frames=config.max_frames,
+        total_frames=total_frames,
         chunk_size=config.chunk_size,
     )

--- a/packages/simplecv/simplecv/apis/view_torchcodec_singleview.py
+++ b/packages/simplecv/simplecv/apis/view_torchcodec_singleview.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import rerun as rr
+import torch
+from jaxtyping import Int
+from numpy import ndarray
+
+from simplecv._torchcodec_view_utils import TIMELINE, build_blueprint, log_torchcodec_decoded_chunks
+from simplecv.rerun_log_utils import RerunTyroConfig, log_video
+from simplecv.video_io import TorchCodecVideoReader, validate_video_file_path
+
+
+@dataclass
+class TorchCodecSingleviewConfig:
+    """TorchCodec singleview Rerun viewer config."""
+
+    rr_config: RerunTyroConfig
+    video_path: Path
+    """Path to an ``.mp4`` video."""
+    max_frames: int = 32 * 10
+    """Maximum decoded frames to log as ``rr.Image``."""
+    chunk_size: int = 32
+    """TorchCodec decode chunk size."""
+    device: str = "cuda"
+    """TorchCodec decode device."""
+
+
+def main(config: TorchCodecSingleviewConfig) -> None:
+    """Log native video streams and TorchCodec decoded image frames to Rerun."""
+    if config.device.startswith("cuda") and not torch.cuda.is_available():
+        raise SystemExit(
+            "CUDA was requested, but torch.cuda.is_available() is false. Use --device cpu for a smoke run."
+        )
+
+    video_path: Path = validate_video_file_path(config.video_path)
+    video_name: str = video_path.stem
+    rr.send_blueprint(build_blueprint([video_name]))
+
+    frame_timestamps_ns: Int[ndarray, "num_frames"] = log_video(
+        video_path,
+        video_log_path=Path(f"/videos/{video_name}/video"),
+        timeline=TIMELINE,
+    )
+
+    video_source: Path = config.video_path
+    torch_reader: TorchCodecVideoReader = TorchCodecVideoReader(
+        video_source,
+        device=config.device,
+        seek_mode="approximate",
+    )
+    total_frames: int = min(config.max_frames, len(torch_reader))
+    log_torchcodec_decoded_chunks(
+        chunked_videos=([video] for video in torch_reader.iter_chunks(chunk_size=config.chunk_size, max_frames=total_frames)),
+        video_names=[video_name],
+        frame_timestamps_by_video=[frame_timestamps_ns],
+        total_frames=total_frames,
+        chunk_size=config.chunk_size,
+    )

--- a/packages/simplecv/simplecv/apis/view_torchcodec_singleview.py
+++ b/packages/simplecv/simplecv/apis/view_torchcodec_singleview.py
@@ -45,7 +45,7 @@ def main(config: TorchCodecSingleviewConfig) -> None:
         timeline=TIMELINE,
     )
 
-    video_source: Path = config.video_path
+    video_source: Path = video_path
     torch_reader: TorchCodecVideoReader = TorchCodecVideoReader(
         video_source,
         device=config.device,

--- a/packages/simplecv/simplecv/print_utils.py
+++ b/packages/simplecv/simplecv/print_utils.py
@@ -5,6 +5,16 @@ import numpy as np
 from lovely_numpy import lo
 
 
+def format_bytes(num_bytes: int) -> str:
+    """Format a byte count with binary units."""
+    value: float = float(num_bytes)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if value < 1024.0:
+            return f"{value:.1f} {unit}"
+        value /= 1024.0
+    return f"{value:.1f} PiB"
+
+
 def debug_numpy(tensor: np.ndarray | Any) -> Callable:
     """
     Convert a tensor to a numpy array if it is not already one.

--- a/packages/simplecv/simplecv/rerun_log_utils.py
+++ b/packages/simplecv/simplecv/rerun_log_utils.py
@@ -302,7 +302,9 @@ def _log_asset_video(
     recording: rr.RecordingStream | None,
 ) -> Int[ndarray, "num_frames"]:
     """Embed the MP4 as an ``rr.AssetVideo`` and emit ``VideoFrameReference`` rows."""
-    video_asset = rr.AssetVideo(contents=video_source) if isinstance(video_source, bytes) else rr.AssetVideo(path=video_source)
+    video_asset = (
+        rr.AssetVideo(contents=video_source) if isinstance(video_source, bytes) else rr.AssetVideo(path=video_source)
+    )
 
     rr.log(str(video_log_path), video_asset, static=True, recording=recording)
 
@@ -370,7 +372,7 @@ def _log_video_stream(
     is_keyframes: list[bool] = []
     try:
         in_stream: av.video.stream.VideoStream = container.streams.video[0]
-        codec_id: int = int(in_stream.codec_context.codec.id)
+        codec_id: int = in_stream.codec_context.codec.id
         codec_name: str = in_stream.codec_context.name
         codec: rr.VideoCodec | None = _CODEC_ID_MAP.get(codec_id)
         if codec is None:
@@ -381,7 +383,9 @@ def _log_video_stream(
             )
 
         bsf_name: str | None = _BSF_FOR_CODEC_ID.get(codec_id)
-        bsf: av.BitStreamFilterContext | None = av.BitStreamFilterContext(bsf_name, in_stream) if bsf_name is not None else None
+        bsf: av.BitStreamFilterContext | None = (
+            av.BitStreamFilterContext(bsf_name, in_stream) if bsf_name is not None else None
+        )
 
         rr.log(
             str(video_log_path),
@@ -440,7 +444,9 @@ def _log_video_stream(
     return frame_timestamps_ns
 
 
-def read_video_stream_from_rrd(rrd_path: str, video_entity: str, timeline: str) -> tuple[rr.VideoCodec, ChunkedArray, ChunkedArray]:
+def read_video_stream_from_rrd(
+    rrd_path: str, video_entity: str, timeline: str
+) -> tuple[rr.VideoCodec, ChunkedArray, ChunkedArray]:
     """Read a ``rr.VideoStream`` entity back from an ``.rrd`` recording.
 
     Args:

--- a/packages/simplecv/simplecv/video_io.py
+++ b/packages/simplecv/simplecv/video_io.py
@@ -23,6 +23,29 @@ from jaxtyping import UInt8
 from simplecv.image_types import BGRList, ImageBGR
 
 
+def validate_video_file_path(video_path: Path) -> Path:
+    """Return a valid local video file path."""
+    if not video_path.exists():
+        raise FileNotFoundError(f"Video file does not exist: {video_path}")
+    if not video_path.is_file():
+        raise ValueError(f"Video path must be a file: {video_path}")
+    return video_path
+
+
+def required_torchcodec_int(value: int | None, name: str) -> int:
+    """Return a required TorchCodec metadata integer."""
+    if value is None:
+        raise ValueError(f"TorchCodec metadata field {name} is missing")
+    return int(value)
+
+
+def required_torchcodec_float(value: float | None, name: str) -> float:
+    """Return a required TorchCodec metadata float."""
+    if value is None:
+        raise ValueError(f"TorchCodec metadata field {name} is missing")
+    return float(value)
+
+
 def rgb_chw_tensor_to_bgr_hwc(rgb_chw: UInt8[torch.Tensor, "3 h w"]) -> ImageBGR:
     """Convert an RGB ``CHW`` uint8 tensor to a BGR ``HWC`` numpy image."""
     if rgb_chw.ndim != 3 or rgb_chw.shape[0] != 3:
@@ -32,6 +55,22 @@ def rgb_chw_tensor_to_bgr_hwc(rgb_chw: UInt8[torch.Tensor, "3 h w"]) -> ImageBGR
     bgr_hwc_tensor: UInt8[torch.Tensor, "h w 3"] = rearrange(bgr_chw, "c h w -> h w c")
     bgr_hwc: ImageBGR = np.ascontiguousarray(bgr_hwc_tensor.cpu().numpy(), dtype=np.uint8)
     return bgr_hwc
+
+
+def bgr_hwc_frames_to_rgb_nchw_tensor(
+    bgr_frames: list[ImageBGR],
+    device: str | torch.device,
+) -> UInt8[torch.Tensor, "b 3 h w"]:
+    """Convert BGR ``HWC`` numpy frames to a contiguous RGB ``NCHW`` tensor."""
+    if not bgr_frames:
+        raise ValueError("bgr_frames must contain at least one frame")
+
+    bgr_nhwc: UInt8[np.ndarray, "b h w 3"] = np.stack(bgr_frames, axis=0)
+    bgr_nhwc_cpu: UInt8[torch.Tensor, "b h w 3"] = torch.from_numpy(bgr_nhwc)
+    bgr_nhwc_tensor: UInt8[torch.Tensor, "b h w 3"] = bgr_nhwc_cpu.to(device=device)
+    bgr_nchw: UInt8[torch.Tensor, "b 3 h w"] = rearrange(bgr_nhwc_tensor, "b h w c -> b c h w")
+    rgb_nchw: UInt8[torch.Tensor, "b 3 h w"] = torch.flip(bgr_nchw, dims=(1,)).contiguous()
+    return rgb_nchw
 
 
 class Cache:
@@ -333,27 +372,15 @@ class TorchCodecVideoReader:
         )
 
         metadata = self._decoder.metadata
-        self._width: int = self._required_int(metadata.width, "width")
-        self._height: int = self._required_int(metadata.height, "height")
-        self._fps: float = self._required_float(metadata.average_fps, "average_fps")
-        self._frame_cnt: int = self._required_int(metadata.num_frames, "num_frames")
+        self._width: int = required_torchcodec_int(metadata.width, "width")
+        self._height: int = required_torchcodec_int(metadata.height, "height")
+        self._fps: float = required_torchcodec_float(metadata.average_fps, "average_fps")
+        self._frame_cnt: int = required_torchcodec_int(metadata.num_frames, "num_frames")
         self._position: int = 0
         self._read_chunk_size: int = 32
         self._read_buffer: UInt8[torch.Tensor, "b 3 h w"] | None = None
         self._read_buffer_start: int = 0
         self._read_buffer_stop: int = 0
-
-    @staticmethod
-    def _required_int(value: int | None, name: str) -> int:
-        if value is None:
-            raise ValueError(f"TorchCodec metadata field {name} is missing")
-        return int(value)
-
-    @staticmethod
-    def _required_float(value: float | None, name: str) -> float:
-        if value is None:
-            raise ValueError(f"TorchCodec metadata field {name} is missing")
-        return float(value)
 
     @property
     def width(self) -> int:
@@ -442,6 +469,21 @@ class TorchCodecVideoReader:
             return empty
         video: UInt8[torch.Tensor, "b 3 h w"] = self._decoder.get_frames_in_range(start, clamped_stop).data
         return video
+
+    def iter_chunks(
+        self,
+        chunk_size: int = 32,
+        max_frames: int | None = None,
+    ) -> Generator[UInt8[torch.Tensor, "b 3 h w"], None, None]:
+        """Decode the video in bounded RGB ``NCHW`` chunks."""
+        if chunk_size <= 0:
+            raise ValueError("chunk_size must be positive")
+
+        frame_count: int = len(self) if max_frames is None else min(max_frames, len(self))
+        for start in range(0, frame_count, chunk_size):
+            stop: int = min(start + chunk_size, frame_count)
+            video: UInt8[torch.Tensor, "b 3 h w"] = self.get_frames_in_range(start, stop)
+            yield video
 
     def __len__(self) -> int:
         return self._frame_cnt

--- a/packages/simplecv/tests/test_benchmark_torchcodec_cuda_multiview.py
+++ b/packages/simplecv/tests/test_benchmark_torchcodec_cuda_multiview.py
@@ -1,64 +1,204 @@
 from __future__ import annotations
 
-import importlib.util
-import sys
+import runpy
+from collections.abc import Iterable, Iterator
 from pathlib import Path
-from types import ModuleType
 
+import numpy as np
+import pytest
+from jaxtyping import UInt8
 
-def _load_benchmark_module() -> ModuleType:
-    module_path: Path = Path(__file__).parent.parent / "simplecv" / "apis" / "benchmark_torchcodec_cuda_multiview.py"
-    spec = importlib.util.spec_from_file_location("simplecv.apis.benchmark_torchcodec_cuda_multiview", module_path)
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return module
+import simplecv.apis.benchmark_torchcodec_cuda_multiview as benchmark_module
 
 
 def test_find_video_paths_searches_directory_in_sorted_order(tmp_path: Path) -> None:
     """Benchmark inputs are discovered as sorted mp4s from a directory."""
-    module: ModuleType = _load_benchmark_module()
     video_dir: Path = tmp_path / "videos"
     video_dir.mkdir()
     (video_dir / "cam_b.mp4").touch()
     (video_dir / "notes.txt").touch()
     (video_dir / "cam_a.mp4").touch()
 
-    video_paths: list[Path] = module.find_video_paths(video_dir)
+    video_paths: list[Path] = benchmark_module.find_video_paths(video_dir)
 
     assert [path.name for path in video_paths] == ["cam_a.mp4", "cam_b.mp4"]
 
 
 def test_find_video_paths_prefers_rgb_low_videos(tmp_path: Path) -> None:
     """Assembly101-style RGB exo videos are selected when mixed mp4s exist."""
-    module: ModuleType = _load_benchmark_module()
     video_dir: Path = tmp_path / "videos"
     video_dir.mkdir()
     (video_dir / "C10095_rgb_low.mp4").touch()
     (video_dir / "C10115_rgb_low.mp4").touch()
     (video_dir / "HMC_84346135_mono10bit_low.mp4").touch()
 
-    video_paths: list[Path] = module.find_video_paths(video_dir)
+    video_paths: list[Path] = benchmark_module.find_video_paths(video_dir)
 
     assert [path.name for path in video_paths] == ["C10095_rgb_low.mp4", "C10115_rgb_low.mp4"]
 
 
 def test_benchmark_config_defaults_to_chunked_approximate_decode(tmp_path: Path) -> None:
     """The benchmark defaults to the chosen simple chunked CUDA path."""
-    module: ModuleType = _load_benchmark_module()
-
-    config = module.BenchmarkConfig(video_dir=tmp_path)
+    config = benchmark_module.BenchmarkConfig(video_dir=tmp_path)
 
     assert config.chunk_size == 32
     assert config.seek_mode == "approximate"
 
 
-def test_tool_is_minimal_tyro_wrapper() -> None:
-    """The CLI tool should delegate parsing to tyro and implementation to the API."""
-    tool_path: Path = Path(__file__).parent.parent / "tools" / "benchmark_torchcodec_cuda_multiview.py"
-    tool_text: str = tool_path.read_text()
+def test_existing_tensor_benchmark_reports_gpu_ready_rgb_nchw_baseline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The OpenCV multiview tensor baseline reports GPU-ready RGB NCHW uint8 batches."""
+    cam0_frame0: UInt8[np.ndarray, "h w 3"] = np.array([[[1, 2, 3]]], dtype=np.uint8)
+    cam1_frame0: UInt8[np.ndarray, "h w 3"] = np.array([[[4, 5, 6]]], dtype=np.uint8)
+    cam0_frame1: UInt8[np.ndarray, "h w 3"] = np.array([[[7, 8, 9]]], dtype=np.uint8)
+    cam1_frame1: UInt8[np.ndarray, "h w 3"] = np.array([[[10, 11, 12]]], dtype=np.uint8)
 
-    assert "tyro.cli(BenchmarkConfig" in tool_text
-    assert "from simplecv.apis.benchmark_torchcodec_cuda_multiview import BenchmarkConfig, main" in tool_text
+    class FakeMultiVideoReader:
+        instances: list["FakeMultiVideoReader"] = []
+
+        def __init__(self, _video_paths: list[Path]) -> None:
+            self.frames: list[list[UInt8[np.ndarray, "h w 3"]]] = [
+                [cam0_frame0, cam1_frame0],
+                [cam0_frame1, cam1_frame1],
+            ]
+            self.next_calls: int = 0
+            self.instances.append(self)
+
+        def __len__(self) -> int:
+            return len(self.frames)
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self.next_calls >= len(self.frames):
+                raise StopIteration
+            frames: list[UInt8[np.ndarray, "h w 3"]] = self.frames[self.next_calls]
+            self.next_calls += 1
+            return frames
+
+    monkeypatch.setattr(benchmark_module, "MultiVideoReader", FakeMultiVideoReader)
+
+    result = benchmark_module.benchmark_existing_tensor(
+        [Path("cam0.mp4"), Path("cam1.mp4")],
+        max_frames=1,
+        device="cpu",
+        chunk_size=1,
+    )
+
+    assert result.label == "MultiVideoReader -> cpu"
+    assert result.frames == 2
+    assert "RGB NCHW uint8 tensors" in result.detail
+    assert "checksum=9" in result.detail
+    assert FakeMultiVideoReader.instances[0].next_calls == 1
+
+
+def test_chunked_benchmark_helpers_validate_chunk_size_before_decoding() -> None:
+    """Chunked benchmark helpers reject invalid chunks before opening decoders."""
+    with pytest.raises(ValueError, match="chunk_size must be positive"):
+        benchmark_module.benchmark_torchcodec_chunked(
+            [Path("cam0.mp4"), Path("cam1.mp4")],
+            device="cpu",
+            max_frames=None,
+            num_workers=None,
+            chunk_size=0,
+            num_ffmpeg_threads=0,
+            seek_mode="approximate",
+        )
+
+    with pytest.raises(ValueError, match="chunk_size must be positive"):
+        benchmark_module.benchmark_existing_tensor(
+            [Path("cam0.mp4"), Path("cam1.mp4")],
+            max_frames=None,
+            device="cpu",
+            chunk_size=0,
+        )
+
+
+def test_multiview_tensor_progress_reports_camera_frame_rate_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Chunked multiview progress reports camera-frames and shows the chunk shape."""
+    cam0_frame0: UInt8[np.ndarray, "h w 3"] = np.array([[[1, 2, 3]]], dtype=np.uint8)
+    cam1_frame0: UInt8[np.ndarray, "h w 3"] = np.array([[[4, 5, 6]]], dtype=np.uint8)
+    cam0_frame1: UInt8[np.ndarray, "h w 3"] = np.array([[[7, 8, 9]]], dtype=np.uint8)
+    cam1_frame1: UInt8[np.ndarray, "h w 3"] = np.array([[[10, 11, 12]]], dtype=np.uint8)
+
+    class FakeTqdm:
+        instances: list["FakeTqdm"] = []
+
+        def __init__(self, iterable: Iterable[object] | None = None, **kwargs: object) -> None:
+            self.iterable: Iterable[object] | None = iterable
+            self.kwargs: dict[str, object] = kwargs
+            self.updates: list[int] = []
+            self.instances.append(self)
+
+        def __iter__(self) -> Iterator[object]:
+            assert self.iterable is not None
+            return iter(self.iterable)
+
+        def __enter__(self) -> "FakeTqdm":
+            return self
+
+        def __exit__(self, _exc_type: object, _exc_value: object, _traceback: object) -> None:
+            return None
+
+        def update(self, n: int) -> None:
+            self.updates.append(n)
+
+    class FakeMultiVideoReader:
+        def __init__(self, _video_paths: list[Path]) -> None:
+            self.frames: list[list[UInt8[np.ndarray, "h w 3"]]] = [
+                [cam0_frame0, cam1_frame0],
+                [cam0_frame1, cam1_frame1],
+            ]
+            self.next_calls: int = 0
+
+        def __len__(self) -> int:
+            return len(self.frames)
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self.next_calls >= len(self.frames):
+                raise StopIteration
+            frames: list[UInt8[np.ndarray, "h w 3"]] = self.frames[self.next_calls]
+            self.next_calls += 1
+            return frames
+
+    monkeypatch.setattr(benchmark_module, "tqdm", FakeTqdm)
+    monkeypatch.setattr(benchmark_module, "MultiVideoReader", FakeMultiVideoReader)
+
+    result = benchmark_module.benchmark_existing_tensor(
+        [Path("cam0.mp4"), Path("cam1.mp4")],
+        max_frames=None,
+        device="cpu",
+        chunk_size=2,
+    )
+
+    progress_bar: FakeTqdm = FakeTqdm.instances[0]
+    assert result.frames == 4
+    assert progress_bar.kwargs["total"] == 4
+    assert progress_bar.kwargs["desc"] == "MultiVideoReader -> cpu (2 frames/chunk x 2 cameras)"
+    assert progress_bar.kwargs["unit"] == " camera-frames"
+    assert progress_bar.updates == [4]
+
+
+def test_tool_is_minimal_tyro_wrapper(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CLI tool delegates parsing to tyro and execution to the API main."""
+    tool_path: Path = Path(__file__).parent.parent / "tools" / "benchmark_torchcodec_cuda_multiview.py"
+    config: object = object()
+    main_calls: list[object] = []
+
+    def fake_cli(config_cls: type, description: str) -> object:
+        assert config_cls is benchmark_module.BenchmarkConfig
+        assert "multiview" in description
+        return config
+
+    def fake_main(parsed_config: object) -> None:
+        main_calls.append(parsed_config)
+
+    monkeypatch.setattr("tyro.cli", fake_cli)
+    monkeypatch.setattr(benchmark_module, "main", fake_main)
+
+    runpy.run_path(str(tool_path), run_name="__main__")
+
+    assert main_calls == [config]

--- a/packages/simplecv/tests/test_benchmark_torchcodec_cuda_singleview.py
+++ b/packages/simplecv/tests/test_benchmark_torchcodec_cuda_singleview.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import runpy
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from jaxtyping import UInt8
+
+import simplecv.apis.benchmark_torchcodec_cuda_singleview as benchmark_module
+
+
+def test_benchmark_config_defaults_to_chunked_approximate_decode(tmp_path: Path) -> None:
+    """The singleview benchmark defaults to the simple chunked CUDA path."""
+    config = benchmark_module.BenchmarkConfig(video_path=tmp_path / "sample.mp4")
+
+    assert config.chunk_size == 32
+    assert config.seek_mode == "approximate"
+
+
+def test_existing_tensor_benchmark_reports_gpu_ready_rgb_nchw_baseline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The OpenCV tensor baseline reports GPU-ready RGB NCHW uint8 batches."""
+    first_bgr: UInt8[np.ndarray, "h w 3"] = np.array([[[1, 2, 3]]], dtype=np.uint8)
+    second_bgr: UInt8[np.ndarray, "h w 3"] = np.array([[[4, 5, 6]]], dtype=np.uint8)
+
+    class FakeVideoReader:
+        instances: list["FakeVideoReader"] = []
+
+        def __init__(self, _video_path: Path) -> None:
+            self.frames: list[UInt8[np.ndarray, "h w 3"]] = [first_bgr, second_bgr]
+            self.next_calls: int = 0
+            self.instances.append(self)
+
+        def __len__(self) -> int:
+            return len(self.frames)
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self.next_calls >= len(self.frames):
+                raise StopIteration
+            frame: UInt8[np.ndarray, "h w 3"] = self.frames[self.next_calls]
+            self.next_calls += 1
+            return frame
+
+    monkeypatch.setattr(benchmark_module, "VideoReader", FakeVideoReader)
+
+    result = benchmark_module.benchmark_existing_tensor(
+        Path("sample.mp4"),
+        max_frames=1,
+        device="cpu",
+        chunk_size=1,
+    )
+
+    assert result.label == "VideoReader -> cpu"
+    assert result.frames == 1
+    assert "RGB NCHW uint8 tensor" in result.detail
+    assert "checksum=3" in result.detail
+    assert FakeVideoReader.instances[0].next_calls == 1
+
+
+def test_chunked_benchmark_helpers_validate_chunk_size_before_decoding() -> None:
+    """Chunked benchmark helpers reject invalid chunks before opening decoders."""
+    with pytest.raises(ValueError, match="chunk_size must be positive"):
+        benchmark_module.benchmark_torchcodec_chunked(
+            Path("missing.mp4"),
+            device="cpu",
+            max_frames=None,
+            chunk_size=0,
+            num_ffmpeg_threads=0,
+            seek_mode="approximate",
+        )
+
+    with pytest.raises(ValueError, match="chunk_size must be positive"):
+        benchmark_module.benchmark_existing_tensor(
+            Path("missing.mp4"),
+            max_frames=None,
+            device="cpu",
+            chunk_size=0,
+        )
+
+
+def test_torchcodec_chunk_progress_reports_frame_rate_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Chunked singleview progress reports frames, while still showing chunk size."""
+    class FakeTqdm:
+        instances: list["FakeTqdm"] = []
+
+        def __init__(self, iterable: Iterable[int] | None = None, **kwargs: object) -> None:
+            self.iterable: Iterable[int] | None = iterable
+            self.kwargs: dict[str, object] = kwargs
+            self.updates: list[int] = []
+            self.instances.append(self)
+
+        def __iter__(self) -> Iterator[int]:
+            assert self.iterable is not None
+            return iter(self.iterable)
+
+        def __enter__(self) -> "FakeTqdm":
+            return self
+
+        def __exit__(self, _exc_type: object, _exc_value: object, _traceback: object) -> None:
+            return None
+
+        def update(self, n: int) -> None:
+            self.updates.append(n)
+
+    class FakeTorchCodecVideoReader:
+        def __init__(self, _video_path: Path, *, device: str, num_ffmpeg_threads: int, seek_mode: str) -> None:
+            self.frame_count: int = 3
+
+        def __len__(self) -> int:
+            return self.frame_count
+
+        def iter_chunks(
+            self,
+            chunk_size: int,
+            max_frames: int | None = None,
+        ) -> Iterator[UInt8[torch.Tensor, "b 3 h w"]]:
+            frame_count: int = self.frame_count if max_frames is None else min(max_frames, self.frame_count)
+            for start in range(0, frame_count, chunk_size):
+                stop: int = min(start + chunk_size, frame_count)
+                yield self.get_frames_in_range(start, stop)
+
+        def get_frames_in_range(self, start: int, stop: int) -> UInt8[torch.Tensor, "b 3 h w"]:
+            frame_count: int = stop - start
+            video: UInt8[torch.Tensor, "b 3 h w"] = torch.ones((frame_count, 3, 1, 1), dtype=torch.uint8)
+            return video
+
+    monkeypatch.setattr(benchmark_module, "tqdm", FakeTqdm)
+    monkeypatch.setattr(benchmark_module, "TorchCodecVideoReader", FakeTorchCodecVideoReader)
+
+    result = benchmark_module.benchmark_torchcodec_chunked(
+        Path("sample.mp4"),
+        device="cpu",
+        max_frames=None,
+        chunk_size=2,
+        num_ffmpeg_threads=0,
+        seek_mode="approximate",
+    )
+
+    progress_bar: FakeTqdm = FakeTqdm.instances[0]
+    assert result.frames == 3
+    assert progress_bar.kwargs["total"] == 3
+    assert progress_bar.kwargs["desc"] == "TorchCodec chunks (2 frames/chunk)"
+    assert progress_bar.kwargs["unit"] == " frames"
+    assert progress_bar.updates == [2, 1]
+
+
+def test_tool_is_minimal_tyro_wrapper(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CLI tool delegates parsing to tyro and execution to the API main."""
+    tool_path: Path = Path(__file__).parent.parent / "tools" / "benchmark_torchcodec_cuda_singleview.py"
+    config: object = object()
+    main_calls: list[object] = []
+
+    def fake_cli(config_cls: type, description: str) -> object:
+        assert config_cls is benchmark_module.BenchmarkConfig
+        assert "singleview" in description
+        return config
+
+    def fake_main(parsed_config: object) -> None:
+        main_calls.append(parsed_config)
+
+    monkeypatch.setattr("tyro.cli", fake_cli)
+    monkeypatch.setattr(benchmark_module, "main", fake_main)
+
+    runpy.run_path(str(tool_path), run_name="__main__")
+
+    assert main_calls == [config]

--- a/packages/simplecv/tests/test_benchmark_utils.py
+++ b/packages/simplecv/tests/test_benchmark_utils.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from simplecv._benchmark_utils import TimingResult, build_timing_table, format_timing_table
+
+
+def test_timing_table_prints_readable_relative_summary() -> None:
+    """Timing rows are rendered as one readable comparison table."""
+    torchcodec_result: TimingResult = TimingResult(
+        label="TorchCodec cuda",
+        elapsed_seconds=1.0,
+        frames=800,
+        detail="chunk_size=32, checksum=1",
+    )
+    existing_result: TimingResult = TimingResult(
+        label="MultiVideoReader -> cuda",
+        elapsed_seconds=8.0,
+        frames=800,
+        detail="RGB NCHW uint8 tensors, checksum=2",
+    )
+
+    table_text: str = format_timing_table(
+        [torchcodec_result, existing_result],
+        throughput_header="Camera FPS",
+    )
+    rich_table = build_timing_table(
+        [torchcodec_result, existing_result],
+        throughput_header="Camera FPS",
+    )
+
+    assert "Results" in table_text
+    assert "Camera FPS" in table_text
+    assert "TorchCodec cuda" in table_text
+    assert "MultiVideoReader -> cuda" in table_text
+    assert "0.12x" in table_text
+    assert "RGB NCHW uint8 tensors" in table_text
+    assert rich_table.title_style == "bold cyan"
+    assert rich_table.header_style == "bold white"
+    assert rich_table.columns[0].style == "cyan"
+    assert rich_table.columns[2].style == "green"

--- a/packages/simplecv/tests/test_print_utils.py
+++ b/packages/simplecv/tests/test_print_utils.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from simplecv.print_utils import format_bytes
+
+
+def test_format_bytes_uses_binary_units() -> None:
+    """Byte counts are formatted with binary units for benchmark output."""
+    assert format_bytes(0) == "0.0 B"
+    assert format_bytes(1023) == "1023.0 B"
+    assert format_bytes(1024) == "1.0 KiB"
+    assert format_bytes(1024 * 1024) == "1.0 MiB"

--- a/packages/simplecv/tests/test_torchcodec_video_io.py
+++ b/packages/simplecv/tests/test_torchcodec_video_io.py
@@ -16,7 +16,11 @@ from simplecv.video_io import (
     TorchCodecMultiVideoReader,
     TorchCodecVideoReader,
     VideoReader,
+    bgr_hwc_frames_to_rgb_nchw_tensor,
+    required_torchcodec_float,
+    required_torchcodec_int,
     rgb_chw_tensor_to_bgr_hwc,
+    validate_video_file_path,
 )
 
 # Test data directory
@@ -39,6 +43,58 @@ def test_rgb_chw_tensor_to_bgr_hwc_converts_layout_and_channels() -> None:
 
     assert bgr_hwc.flags.c_contiguous
     assert np.array_equal(bgr_hwc, expected_bgr_hwc)
+
+
+def test_bgr_hwc_frames_to_rgb_nchw_tensor_converts_batch_layout_and_channels() -> None:
+    """Convert BGR HWC numpy frames to RGB NCHW tensor batches for model input."""
+    first_bgr: UInt8[np.ndarray, "h w 3"] = np.array([[[1, 2, 3], [4, 5, 6]]], dtype=np.uint8)
+    second_bgr: UInt8[np.ndarray, "h w 3"] = np.array([[[7, 8, 9], [10, 11, 12]]], dtype=np.uint8)
+
+    rgb_nchw: UInt8[torch.Tensor, "b 3 h w"] = bgr_hwc_frames_to_rgb_nchw_tensor(
+        [first_bgr, second_bgr],
+        device="cpu",
+    )
+
+    expected_rgb_nchw: UInt8[torch.Tensor, "b 3 h w"] = torch.tensor(
+        [
+            [[[3, 6]], [[2, 5]], [[1, 4]]],
+            [[[9, 12]], [[8, 11]], [[7, 10]]],
+        ],
+        dtype=torch.uint8,
+    )
+    assert rgb_nchw.device.type == "cpu"
+    assert rgb_nchw.dtype == torch.uint8
+    assert rgb_nchw.is_contiguous()
+    assert torch.equal(rgb_nchw, expected_rgb_nchw)
+
+
+def test_required_torchcodec_metadata_helpers_cast_values() -> None:
+    """TorchCodec metadata helpers reject missing fields and cast present values."""
+    frame_count: int = required_torchcodec_int(12, "num_frames")
+    average_fps: float = required_torchcodec_float(29.0, "average_fps")
+
+    assert frame_count == 12
+    assert average_fps == 29.0
+
+    with pytest.raises(ValueError, match="TorchCodec metadata field height is missing"):
+        required_torchcodec_int(None, "height")
+
+    with pytest.raises(ValueError, match="TorchCodec metadata field average_fps is missing"):
+        required_torchcodec_float(None, "average_fps")
+
+
+def test_validate_video_file_path_requires_existing_file(tmp_path: Path) -> None:
+    """Video path validation accepts files and rejects missing paths or directories."""
+    video_path: Path = tmp_path / "sample.mp4"
+    video_path.touch()
+    directory_path: Path = tmp_path / "videos"
+    directory_path.mkdir()
+
+    assert validate_video_file_path(video_path) == video_path
+    with pytest.raises(FileNotFoundError, match="Video file does not exist"):
+        validate_video_file_path(tmp_path / "missing.mp4")
+    with pytest.raises(ValueError, match="Video path must be a file"):
+        validate_video_file_path(directory_path)
 
 
 @pytest.fixture

--- a/packages/simplecv/tests/test_torchcodec_view_utils.py
+++ b/packages/simplecv/tests/test_torchcodec_view_utils.py
@@ -88,3 +88,17 @@ def test_log_torchcodec_decoded_chunks_logs_bgr_images_with_video_time(monkeypat
     assert logged_images[0].image[0, 0].tolist() == [3, 2, 1]
     assert logged_images[0].color_model == "BGR"
     assert logged_images[0].jpeg_quality == 80
+
+
+def test_log_torchcodec_decoded_chunks_rejects_nonpositive_chunk_size() -> None:
+    """Chunk logging fails clearly before deriving progress totals."""
+    frame_timestamps: Int[np.ndarray, "num_frames"] = np.array([10], dtype=np.int64)
+
+    with pytest.raises(ValueError, match="chunk_size must be positive"):
+        view_utils.log_torchcodec_decoded_chunks(
+            chunked_videos=[],
+            video_names=["cam"],
+            frame_timestamps_by_video=[frame_timestamps],
+            total_frames=1,
+            chunk_size=0,
+        )

--- a/packages/simplecv/tests/test_torchcodec_view_utils.py
+++ b/packages/simplecv/tests/test_torchcodec_view_utils.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import pytest
+import torch
+from jaxtyping import Int, UInt8
+
+import simplecv._torchcodec_view_utils as view_utils
+
+
+def test_build_blueprint_creates_video_and_decoded_views() -> None:
+    """The Rerun layout places native video and decoded images side by side."""
+    blueprint: Any = view_utils.build_blueprint(["cam_a/output"])
+    time_selection: Any = blueprint.time_panel.time_selection
+
+    assert blueprint is not None
+    assert blueprint.time_panel.timeline == "video_time"
+    assert blueprint.time_panel.loop_mode == "selection"
+    assert time_selection is not None
+    assert time_selection.min.value == 0
+
+
+def test_log_torchcodec_decoded_chunks_logs_bgr_images_with_video_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Decoded TorchCodec chunks are logged beside the native video stream."""
+    timeline_events: list[tuple[str, float | None, int | None]] = []
+    log_paths: list[str] = []
+    logged_images: list["FakeImage"] = []
+
+    class FakeImage:
+        def __init__(self, image: UInt8[np.ndarray, "h w 3"], color_model: object) -> None:
+            self.image: UInt8[np.ndarray, "h w 3"] = image
+            self.color_model: object = color_model
+            self.jpeg_quality: int | None = None
+
+        def compress(self, jpeg_quality: int) -> "FakeImage":
+            self.jpeg_quality = jpeg_quality
+            return self
+
+    def fake_set_time(timeline: str, *, duration: float | None = None, sequence: int | None = None) -> None:
+        timeline_events.append((timeline, duration, sequence))
+
+    def fake_log(path: str, image: FakeImage) -> None:
+        log_paths.append(path)
+        logged_images.append(image)
+
+    monkeypatch.setattr(view_utils.rr, "set_time", fake_set_time)
+    monkeypatch.setattr(view_utils.rr, "log", fake_log)
+    monkeypatch.setattr(view_utils.rr, "Image", FakeImage)
+    monkeypatch.setattr(view_utils.rr, "ColorModel", SimpleNamespace(BGR="BGR"))
+
+    first_chunk: UInt8[torch.Tensor, "b 3 h w"] = torch.tensor(
+        [
+            [[[1]], [[2]], [[3]]],
+            [[[4]], [[5]], [[6]]],
+        ],
+        dtype=torch.uint8,
+    )
+    second_chunk: UInt8[torch.Tensor, "b 3 h w"] = torch.tensor(
+        [
+            [[[7]], [[8]], [[9]]],
+        ],
+        dtype=torch.uint8,
+    )
+    frame_timestamps: Int[np.ndarray, "num_frames"] = np.array([10, 20, 30], dtype=np.int64)
+
+    view_utils.log_torchcodec_decoded_chunks(
+        chunked_videos=[[first_chunk], [second_chunk]],
+        video_names=["cam"],
+        frame_timestamps_by_video=[frame_timestamps],
+        total_frames=3,
+        chunk_size=2,
+    )
+
+    assert log_paths == ["/videos/cam/decoded", "/videos/cam/decoded", "/videos/cam/decoded"]
+    video_time_events: list[tuple[str, float | None, int | None]] = [
+        event for event in timeline_events if event[0] == "video_time"
+    ]
+    assert [event[1] for event in video_time_events] == pytest.approx([10e-9, 20e-9, 30e-9])
+    assert [event[2] for event in video_time_events] == [None, None, None]
+    assert [event for event in timeline_events if event[0] == "frame"] == [
+        ("frame", None, 0),
+        ("frame", None, 1),
+        ("frame", None, 2),
+    ]
+    assert logged_images[0].image[0, 0].tolist() == [3, 2, 1]
+    assert logged_images[0].color_model == "BGR"
+    assert logged_images[0].jpeg_quality == 80

--- a/packages/simplecv/tests/test_view_torchcodec_multiview.py
+++ b/packages/simplecv/tests/test_view_torchcodec_multiview.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
-from simplecv.apis.view_torchcodec_multiview import build_blueprint, discover_video_paths, video_entity_names
+from simplecv.apis.view_torchcodec_multiview import discover_video_paths, video_entity_names
 
 
 def test_discover_video_paths_returns_sorted_mp4s_recursively(tmp_path: Path) -> None:
@@ -25,15 +24,3 @@ def test_discover_video_paths_returns_sorted_mp4s_recursively(tmp_path: Path) ->
 
     assert video_paths == [first_video_path, second_video_path, third_video_path]
     assert entity_names == ["cam_a/output", "cam_b/output", "root"]
-
-
-def test_build_blueprint_creates_video_and_decoded_views() -> None:
-    """The Rerun layout places native video and decoded images side by side."""
-    blueprint: Any = build_blueprint(["cam_a/output"])
-    time_selection: Any = blueprint.time_panel.time_selection
-
-    assert blueprint is not None
-    assert blueprint.time_panel.timeline == "video_time"
-    assert blueprint.time_panel.loop_mode == "selection"
-    assert time_selection is not None
-    assert time_selection.min.value == 0

--- a/packages/simplecv/tests/test_view_torchcodec_singleview.py
+++ b/packages/simplecv/tests/test_view_torchcodec_singleview.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+import pytest
+import torch
+from jaxtyping import Int, UInt8
+
+import simplecv.apis.view_torchcodec_singleview as singleview
+from simplecv.rerun_log_utils import RerunTyroConfig
+
+
+def test_singleview_main_logs_video_stream_and_decoded_chunks(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Singleview logs the native video stream and matching TorchCodec decoded chunks."""
+    video_path: Path = tmp_path / "sample.mp4"
+    video_path.touch()
+    sent_blueprints: list[Any] = []
+    logged_videos: list[tuple[Path, Path, str]] = []
+    decoded_calls: list[dict[str, Any]] = []
+
+    class FakeTorchCodecVideoReader(singleview.TorchCodecVideoReader):
+        instances: list["FakeTorchCodecVideoReader"] = []
+
+        def __init__(self, source: Path, *, device: str, seek_mode: Literal["exact", "approximate"]) -> None:
+            self.received_source: Path = source
+            self.device: str = device
+            self.seek_mode: Literal["exact", "approximate"] = seek_mode
+            self.frame_count: int = 5
+            self.ranges: list[tuple[int, int]] = []
+            self.instances.append(self)
+
+        def __len__(self) -> int:
+            return self.frame_count
+
+        def get_frames_in_range(self, start: int, stop: int) -> UInt8[torch.Tensor, "b 3 h w"]:
+            self.ranges.append((start, stop))
+            frame_count: int = stop - start
+            video: UInt8[torch.Tensor, "b 3 h w"] = torch.zeros((frame_count, 3, 1, 1), dtype=torch.uint8)
+            return video
+
+    def fake_send_blueprint(blueprint: Any) -> None:
+        sent_blueprints.append(blueprint)
+
+    def fake_log_video(video_path_arg: Path, video_log_path: Path, timeline: str) -> Int[np.ndarray, "num_frames"]:
+        logged_videos.append((video_path_arg, video_log_path, timeline))
+        timestamps: Int[np.ndarray, "num_frames"] = np.arange(5, dtype=np.int64)
+        return timestamps
+
+    def fake_log_torchcodec_decoded_chunks(**kwargs: Any) -> None:
+        chunks: list[list[UInt8[torch.Tensor, "b 3 h w"]]] = list(kwargs["chunked_videos"])
+        kwargs["chunked_videos"] = chunks
+        decoded_calls.append(kwargs)
+
+    monkeypatch.setattr(singleview.rr, "send_blueprint", fake_send_blueprint)
+    monkeypatch.setattr(singleview, "log_video", fake_log_video)
+    monkeypatch.setattr(singleview, "TorchCodecVideoReader", FakeTorchCodecVideoReader)
+    monkeypatch.setattr(singleview, "log_torchcodec_decoded_chunks", fake_log_torchcodec_decoded_chunks)
+
+    rr_config: RerunTyroConfig = RerunTyroConfig(headless=True)
+    config: singleview.TorchCodecSingleviewConfig = singleview.TorchCodecSingleviewConfig(
+        rr_config=rr_config,
+        video_path=video_path,
+        max_frames=3,
+        chunk_size=2,
+        device="cpu",
+    )
+
+    singleview.main(config)
+
+    assert len(sent_blueprints) == 1
+    assert logged_videos == [(video_path, Path("/videos/sample/video"), "video_time")]
+    assert FakeTorchCodecVideoReader.instances[0].received_source == video_path
+    assert FakeTorchCodecVideoReader.instances[0].device == "cpu"
+    assert FakeTorchCodecVideoReader.instances[0].seek_mode == "approximate"
+    assert FakeTorchCodecVideoReader.instances[0].ranges == [(0, 2), (2, 3)]
+    assert decoded_calls[0]["video_names"] == ["sample"]
+    assert decoded_calls[0]["total_frames"] == 3
+    assert decoded_calls[0]["chunk_size"] == 2
+    assert [chunk[0].shape[0] for chunk in decoded_calls[0]["chunked_videos"]] == [2, 1]

--- a/packages/simplecv/tests/test_view_torchcodec_singleview.py
+++ b/packages/simplecv/tests/test_view_torchcodec_singleview.py
@@ -14,11 +14,13 @@ from simplecv.rerun_log_utils import RerunTyroConfig
 
 def test_singleview_main_logs_video_stream_and_decoded_chunks(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Singleview logs the native video stream and matching TorchCodec decoded chunks."""
-    video_path: Path = tmp_path / "sample.mp4"
-    video_path.touch()
+    config_video_path: Path = tmp_path / "raw.mp4"
+    validated_video_path: Path = tmp_path / "sample.mp4"
+    validated_video_path.touch()
     sent_blueprints: list[Any] = []
     logged_videos: list[tuple[Path, Path, str]] = []
     decoded_calls: list[dict[str, Any]] = []
+    validated_paths: list[Path] = []
 
     class FakeTorchCodecVideoReader(singleview.TorchCodecVideoReader):
         instances: list["FakeTorchCodecVideoReader"] = []
@@ -53,15 +55,20 @@ def test_singleview_main_logs_video_stream_and_decoded_chunks(monkeypatch: pytes
         kwargs["chunked_videos"] = chunks
         decoded_calls.append(kwargs)
 
+    def fake_validate_video_file_path(video_path_arg: Path) -> Path:
+        validated_paths.append(video_path_arg)
+        return validated_video_path
+
     monkeypatch.setattr(singleview.rr, "send_blueprint", fake_send_blueprint)
     monkeypatch.setattr(singleview, "log_video", fake_log_video)
     monkeypatch.setattr(singleview, "TorchCodecVideoReader", FakeTorchCodecVideoReader)
     monkeypatch.setattr(singleview, "log_torchcodec_decoded_chunks", fake_log_torchcodec_decoded_chunks)
+    monkeypatch.setattr(singleview, "validate_video_file_path", fake_validate_video_file_path)
 
     rr_config: RerunTyroConfig = RerunTyroConfig(headless=True)
     config: singleview.TorchCodecSingleviewConfig = singleview.TorchCodecSingleviewConfig(
         rr_config=rr_config,
-        video_path=video_path,
+        video_path=config_video_path,
         max_frames=3,
         chunk_size=2,
         device="cpu",
@@ -70,8 +77,9 @@ def test_singleview_main_logs_video_stream_and_decoded_chunks(monkeypatch: pytes
     singleview.main(config)
 
     assert len(sent_blueprints) == 1
-    assert logged_videos == [(video_path, Path("/videos/sample/video"), "video_time")]
-    assert FakeTorchCodecVideoReader.instances[0].received_source == video_path
+    assert validated_paths == [config_video_path]
+    assert logged_videos == [(validated_video_path, Path("/videos/sample/video"), "video_time")]
+    assert FakeTorchCodecVideoReader.instances[0].received_source == validated_video_path
     assert FakeTorchCodecVideoReader.instances[0].device == "cpu"
     assert FakeTorchCodecVideoReader.instances[0].seek_mode == "approximate"
     assert FakeTorchCodecVideoReader.instances[0].ranges == [(0, 2), (2, 3)]

--- a/packages/simplecv/tools/benchmark_torchcodec_cuda_singleview.py
+++ b/packages/simplecv/tools/benchmark_torchcodec_cuda_singleview.py
@@ -1,0 +1,6 @@
+import tyro
+
+from simplecv.apis.benchmark_torchcodec_cuda_singleview import BenchmarkConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(BenchmarkConfig, description="Benchmark TorchCodec CUDA singleview video decoding."))

--- a/packages/simplecv/tools/view_torchcodec_singleview.py
+++ b/packages/simplecv/tools/view_torchcodec_singleview.py
@@ -1,0 +1,6 @@
+import tyro
+
+from simplecv.apis.view_torchcodec_singleview import TorchCodecSingleviewConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(TorchCodecSingleviewConfig, description="Log video and TorchCodec CUDA decoded frames to Rerun."))

--- a/pixi.lock
+++ b/pixi.lock
@@ -1351,6 +1351,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/websocket-client-1.9.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - conda_source: dpretrieval[71ac0d5b] @ packages/dpretrieval
       - pypi: https://aiinfra.pkgs.visualstudio.com/2692857e-05ef-43b4-ba9c-ccf1c22c437c/_packaging/22685817-9e91-4967-bafe-94c9843c26a9/pypi/download/onnxruntime-gpu/1.26/onnxruntime_gpu-1.26.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl
@@ -1956,6 +1957,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/websocket-client-1.9.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - conda_source: dpretrieval[71ac0d5b] @ packages/dpretrieval
       - pypi: https://aiinfra.pkgs.visualstudio.com/2692857e-05ef-43b4-ba9c-ccf1c22c437c/_packaging/22685817-9e91-4967-bafe-94c9843c26a9/pypi/download/onnxruntime-gpu/1.26/onnxruntime_gpu-1.26.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl
@@ -5235,6 +5237,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/werkzeug-3.1.8-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/wslink-2.5.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - conda_source: asmk[e04de9ec] @ packages/asmk
+      - conda_source: mast3r[979b4dac] @ packages/mast3r
       - pypi: https://aiinfra.pkgs.visualstudio.com/2692857e-05ef-43b4-ba9c-ccf1c22c437c/_packaging/22685817-9e91-4967-bafe-94c9843c26a9/pypi/download/onnxruntime-gpu/1.26/onnxruntime_gpu-1.26.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl
@@ -5837,6 +5841,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/werkzeug-3.1.8-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/wslink-2.5.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - conda_source: asmk[e04de9ec] @ packages/asmk
+      - conda_source: mast3r[979b4dac] @ packages/mast3r
       - pypi: https://aiinfra.pkgs.visualstudio.com/2692857e-05ef-43b4-ba9c-ccf1c22c437c/_packaging/22685817-9e91-4967-bafe-94c9843c26a9/pypi/download/onnxruntime-gpu/1.26/onnxruntime_gpu-1.26.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl
@@ -24912,6 +24918,33 @@ packages:
     - alsa-lib >=1.2.15.3,<1.3.0a0
   size: 584660
   timestamp: 1768327524772
+- conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16-hb03c661_0.conda
+  sha256: 64484cb7e7cf65d9c7188498d595125a6e0751604dd7fb483e1bb327eec0f738
+  md5: 18d273b22e96c97c2017813f099faa82
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  license_family: GPL
+  run_exports:
+    weak:
+    - alsa-lib >=1.2.16,<1.3.0a0
+  size: 591046
+  timestamp: 1780398678742
+- conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
+  sha256: b1d972a9b949a88babee681437535550b3ca5dbca6a23a40dffeb7900fec19fd
+  md5: 5a78a69eb3b50f24b379e9d2a93163ae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - aom >=3.14.1,<3.15.0a0
+  size: 3103347
+  timestamp: 1780752473089
 - conda: https://prefix.dev/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
   sha256: b08ef033817b5f9f76ce62dfcac7694e7b6b4006420372de22494503decac855
   md5: 346722a0be40f6edc53f12640d301338
@@ -25107,6 +25140,24 @@ packages:
     - aws-c-auth >=0.10.3,<0.10.4.0a0
   size: 134414
   timestamp: 1779877481302
+- conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.3-hea842a7_2.conda
+  sha256: 5b9c20a38fe084b4ffd1f2c64b3797ec6ef9a99e83cc0c1f84e016c9801e3a5c
+  md5: c463d2dbfb12a208c943165d2a568db4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-auth >=0.10.3,<0.10.4.0a0
+  size: 134385
+  timestamp: 1780598328124
 - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.13-h2c9d079_1.conda
   sha256: f21d648349a318f4ae457ea5403d542ba6c0e0343b8642038523dd612b2a5064
   md5: 3c3d02681058c3d206b562b2e3bc337f
@@ -25123,6 +25174,21 @@ packages:
     - aws-c-cal >=0.9.13,<0.9.14.0a0
   size: 56230
   timestamp: 1764593147526
+- conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.14-h78948cc_2.conda
+  sha256: 06a0e2af439b21c94adff8fac5dd66dbda5f182fc80ac635c4903959ea306cbb
+  md5: fe81235aae00f32df8584267b4f2daf8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - libgcc >=14
+  - openssl >=3.5.6,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - aws-c-cal >=0.9.14,<0.9.15.0a0
+  size: 57011
+  timestamp: 1780566647051
 - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.14-h8e43964_1.conda
   sha256: 574b5ff4e848e5a03cb4a627ff185b759d26f4cfd8d95db0dc13021c8d5abe34
   md5: eb6e8fb306b4025bf9c68b6c16db4e19
@@ -25167,6 +25233,19 @@ packages:
     - aws-c-common >=0.13.1,<0.13.2.0a0
   size: 242317
   timestamp: 1779302509297
+- conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.14.0-hb03c661_0.conda
+  sha256: 6d2b33965bf6daeffd3ad336f41410053ff06ed6f2b2ce62c1ec27c0a39b4e7e
+  md5: f1c005b2e3b618706112ddd7f3af4521
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - aws-c-common >=0.14.0,<0.14.1.0a0
+  size: 242497
+  timestamp: 1780160843944
 - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-h16e98cb_1.conda
   sha256: e0b936833991cea92044b37186de156790b3e945b2b6aefebc49c13423b919fb
   md5: 673828462eb87b76c178b582b6e19824
@@ -25197,6 +25276,20 @@ packages:
     - aws-c-compression >=0.3.2,<0.3.3.0a0
   size: 22278
   timestamp: 1767790836624
+- conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-haa0cbde_2.conda
+  sha256: 0e4952f9be8de7f281ca7d734a3a8f05ad0db856c6ef1e0897798c4afbcd9a54
+  md5: 595911421e25551e36fde7027bf33f38
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-compression >=0.3.2,<0.3.3.0a0
+  size: 22007
+  timestamp: 1780566239465
 - conda: https://prefix.dev/conda-forge/linux-64/aws-c-event-stream-0.6.0-h9b893ba_1.conda
   sha256: 4a1a060ab40cb4fa39d24418758ca9faa1f51df6918f05143118e79bb11b4350
   md5: cd4946050ecfcb3c6fd09106ae6a261e
@@ -25286,6 +25379,23 @@ packages:
     - aws-c-http >=0.10.13,<0.10.14.0a0
   size: 225826
   timestamp: 1774488399486
+- conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.11.0-h6488f85_2.conda
+  sha256: d2b844db1a4dfbc20b5129b7df4a656c1459c5fb16745101bbd802813ba8d411
+  md5: da0be1e8cb4a43c876f26d9d812dea06
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - aws-c-compression >=0.3.2,<0.3.3.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-http >=0.11.0,<0.11.1.0a0
+  size: 230293
+  timestamp: 1780586764553
 - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.11.0-hcbcd92d_1.conda
   sha256: abe70bc1b0de021c442631cfb69f321701be8618e7a24d25f718f39253cc6f65
   md5: 333fa38d6dfe23cd68c67e20cb1726c9
@@ -25303,6 +25413,22 @@ packages:
     - aws-c-http >=0.11.0,<0.11.1.0a0
   size: 230314
   timestamp: 1779870958760
+- conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.26.3-h5b668fc_4.conda
+  sha256: c27b972325342f062da00b7aa2d5abf6f3ce55668a05703a175be958745cc226
+  md5: 555400dce62f2d989ff77761c010d166
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - s2n >=1.7.3,<1.7.4.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-io >=0.26.3,<0.26.4.0a0
+  size: 181627
+  timestamp: 1780575920109
 - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.26.3-h955231c_3.conda
   sha256: 54815f1c64d5cf1e4616f457c8866424e6a0d4069a00736da241f1abc269c717
   md5: a3581835895ca9b7782beb5a49746db7
@@ -25448,6 +25574,26 @@ packages:
     - aws-c-s3 >=0.12.3,<0.12.4.0a0
   size: 152972
   timestamp: 1779885126536
+- conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.12.5-hb916526_1.conda
+  sha256: 8f193173f1dccb25ff86a95543db27f0c762cccfe93157b02cf20bd5b4c11a92
+  md5: 70bc8e5e8cefd19407423733e7ebf540
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - aws-checksums >=0.2.10,<0.2.11.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - openssl >=3.5.6,<4.0a0
+  - aws-c-auth >=0.10.3,<0.10.4.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-s3 >=0.12.5,<0.12.6.0a0
+  size: 153453
+  timestamp: 1780609553521
 - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-h16e98cb_5.conda
   sha256: 315eab8c5b10512b1c4643dd3433c254e6f5bac96043744e900ea5a332b32b4b
   md5: a81045d3ce07a74751541de2bad6fa49
@@ -25478,6 +25624,20 @@ packages:
     - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
   size: 59383
   timestamp: 1764610113765
+- conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-haa0cbde_6.conda
+  sha256: 123c4325b16f1f6db95846d51e5e4201399ee29c0325f8b5a8db2e7d732b9151
+  md5: 4b66ac29a7e917a629b790c3d239d110
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  size: 59085
+  timestamp: 1780568538653
 - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-h16e98cb_1.conda
   sha256: 2200ba495513559be733d877096e678ecdff41ea015bcaf68be297981cfe31f9
   md5: 8d963dc4805936cc294348743201d68e
@@ -25508,6 +25668,20 @@ packages:
     - aws-checksums >=0.2.10,<0.2.11.0a0
   size: 101435
   timestamp: 1771063496927
+- conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-haa0cbde_2.conda
+  sha256: ad49333d96a5f9bcce02752a6515cbb077d7513e358a8fb1a832f4e772d54bac
+  md5: 5c05a63452bf73c50aa272a6f961c4fc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-checksums >=0.2.10,<0.2.11.0a0
+  size: 101627
+  timestamp: 1780568539000
 - conda: https://prefix.dev/conda-forge/linux-64/aws-crt-cpp-0.37.4-h4c8aef7_3.conda
   sha256: b82d0bc6d4b716347e1aefb0acc6e4bff04b3f807537ada9b458a7e467beb2a0
   md5: 798a499cf76e530a992365d557ba5827
@@ -26190,6 +26364,27 @@ packages:
   run_exports: {}
   size: 23076535
   timestamp: 1776799558143
+- conda: https://prefix.dev/conda-forge/linux-64/cmake-4.3.3-hc85cc9f_0.conda
+  sha256: 796276f96ea27acaba1f25755977f6c12dfbc886fd1db713263c795184168f59
+  md5: 30a266b5d91bc45fccbcc45588b2db79
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libgcc >=14
+  - liblzma >=5.8.3,<6.0a0
+  - libstdcxx >=14
+  - libuv >=1.51.0,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - rhash >=1.4.6,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 23085721
+  timestamp: 1779398000620
 - conda: https://prefix.dev/conda-forge/linux-64/colmap-4.0.4-cuda_129hdbc9e7e_0.conda
   sha256: 5bf16c9c3e5240ac6a967e288d6b4827f532848f45fb06bc7792c451afbf4de6
   md5: 3aa57b5d46097ac53efcc5b893cdf09c
@@ -26754,6 +26949,20 @@ packages:
     - cyrus-sasl >=2.1.28,<3.0a0
   size: 209774
   timestamp: 1750239039316
+- conda: https://prefix.dev/conda-forge/linux-64/cython-3.2.5-py311h0daaf2c_0.conda
+  sha256: 2b5194ade96aad8ed3e35ca03e4b6455e61ab43de294040bd200f4647fa9fe47
+  md5: 285d32d8160e800cb853a2ac0f64d970
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 3743364
+  timestamp: 1779724018272
 - conda: https://prefix.dev/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
   sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
   md5: 418c6ca5929a611cbd69204907a83995
@@ -27000,6 +27209,73 @@ packages:
     - ffmpeg >=7.1.1,<8.0a0
   size: 10533973
   timestamp: 1758924873115
+- conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-8.1.1-gpl_h6d6c1bd_904.conda
+  sha256: d9064d5f8575e4f7b6a2c73718f4d4b8986808d8a92eabc5f6b50d5a2fbb18ec
+  md5: 5acc906a0f5f8f56d28665ac6b840f8e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.16,<1.3.0a0
+  - aom >=3.14.1,<3.15.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.18.1,<3.0a0
+  - fonts-conda-ecosystem
+  - gmp >=6.3.0,<7.0a0
+  - harfbuzz >=14.2.1
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.4,<0.17.5.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libopenvino >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-auto-batch-plugin >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-auto-plugin >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-hetero-plugin >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-intel-cpu-plugin >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-intel-gpu-plugin >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-intel-npu-plugin >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-ir-frontend >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-onnx-frontend >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-paddle-frontend >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-pytorch-frontend >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-tensorflow-frontend >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2026.2.0,<2026.2.1.0a0
+  - libopus >=1.6.1,<2.0a0
+  - libplacebo >=7.360.1,<7.361.0a0
+  - librsvg >=2.62.3,<3.0a0
+  - libstdcxx >=14
+  - libva >=2.23.0,<3.0a0
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libvpl >=2.16.0,<2.17.0a0
+  - libvpx >=1.15.2,<1.16.0a0
+  - libvulkan-loader >=1.4.341.0,<2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzlib >=1.3.2,<2.0a0
+  - openh264 >=2.6.0,<2.6.1.0a0
+  - openssl >=3.5.6,<4.0a0
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - sdl2 >=2.32.56,<3.0a0
+  - shaderc >=2026.2,<2026.3.0a0
+  - svt-av1 >=4.0.1,<4.0.2.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  constrains:
+  - __cuda  >=12.8
+  license: GPL-2.0-or-later
+  license_family: GPL
+  run_exports:
+    weak:
+    - ffmpeg >=8.1.1,<9.0a0
+  size: 12996053
+  timestamp: 1780667981113
 - conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-8.1.1-gpl_hee00b0e_901.conda
   sha256: 6af3f45857478c28fa134e23a8ab7a81ce63cdd29aa2d899232eb7d9410b26e7
   md5: 57b938a79ebb6b996505ea79394bd0c9
@@ -27156,6 +27432,25 @@ packages:
     - fonts-conda-ecosystem
   size: 280882
   timestamp: 1779421631622
+- conda: https://prefix.dev/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
+  sha256: 2e50bdcebdf70a865b81f2456bbc586386451ec601c60f2b6cd22b8c40a2d384
+  md5: e0e050cfa9fa85fe39632ab11cb7f3e0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libexpat >=2.8.1,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libuuid >=2.42.1,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - fontconfig >=2.18.1,<3.0a0
+    - fonts-conda-ecosystem
+  size: 281880
+  timestamp: 1780450077431
 - conda: https://prefix.dev/conda-forge/linux-64/fonttools-4.63.0-py311h3778330_0.conda
   sha256: ce5004df66a6bf4e3d634850ab43471b98700291065281eb1982eb54b7bf7d85
   md5: 498ede447c05b203be980ae1dceb06f3
@@ -27377,6 +27672,23 @@ packages:
   run_exports: {}
   size: 81043749
   timestamp: 1778860073982
+- conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-he0086c7_19.conda
+  sha256: a48400ec4b73369c1c59babe4ad35821b63a88bba0ec40a80cea5f8c53a26b83
+  md5: e3be72048d3c4a78b8e27ec48ba06252
+  depends:
+  - binutils_impl_linux-64 >=2.45
+  - libgcc >=15.2.0
+  - libgcc-devel_linux-64 15.2.0 hcc6f6b0_119
+  - libgomp >=15.2.0
+  - libsanitizer 15.2.0 h90f66d4_19
+  - libstdcxx >=15.2.0
+  - libstdcxx-devel_linux-64 15.2.0 hd446a21_119
+  - sysroot_linux-64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 81180457
+  timestamp: 1778269124617
 - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-14.3.0-h50e9bb6_24.conda
   sha256: 5f73bc0ce1729466f99d072678fb1bc13d5424d03a34cb2e69fbafbfd5e27ab2
   md5: 91b0f19212d79a1a4dca034aac729e4f
@@ -27407,6 +27719,20 @@ packages:
     - libgcc >=14
   size: 29191
   timestamp: 1779371710532
+- conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_25.conda
+  sha256: 3fbe01ebb16418d9f1971a283f969dc0f0e1071119f24164f4293057c79dc58c
+  md5: 46ca2358101b2477cb098c4248795d12
+  depends:
+  - gcc_impl_linux-64 15.2.0.*
+  - binutils_linux-64
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    strong:
+    - libgcc >=15
+  size: 29190
+  timestamp: 1779371750402
 - conda: https://prefix.dev/conda-forge/linux-64/gdk-pixbuf-2.44.4-h2b0a6b4_0.conda
   sha256: f47222f58839bcc77c15f11a8814c1d8cb8080c5ca6ba83398a12b640fd3c85c
   md5: c379d67c686fb83475c1a6ed41cc41ff
@@ -27473,6 +27799,23 @@ packages:
     - giflib >=5.2.2,<5.3.0a0
   size: 77248
   timestamp: 1712692454246
+- conda: https://prefix.dev/conda-forge/linux-64/git-2.54.0-pl5321h6d3cee1_1.conda
+  sha256: bc98305103a2754f1b143bc525db9f2c2b0aee6ca278e909ee9eba28c1558c10
+  md5: ef4ced80193d2a6d4cd92e4b46636b07
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libcurl >=8.20.0,<9.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - perl 5.*
+  license: GPL-2.0-or-later and LGPL-2.1-or-later
+  run_exports: {}
+  size: 11507059
+  timestamp: 1780737102525
 - conda: https://prefix.dev/conda-forge/linux-64/gl2ps-1.4.2-h36e74d4_2.conda
   sha256: e28a214c71590a09f75f1aaccf5795bbcfb99b00c2d6ef55d34320b4f47485bd
   md5: 787c780ff43f9f79d78d01e476b81a7c
@@ -27680,6 +28023,20 @@ packages:
     - graphite2 >=1.3.14,<2.0a0
   size: 99596
   timestamp: 1755102025473
+- conda: https://prefix.dev/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
+  sha256: 885fa7d1d7e2ad9ed0a700ee0d81ceb49de278253082d517959b22d6336eecce
+  md5: cf09e9fc938518e91d0706572cadf17a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  run_exports:
+    weak:
+    - graphite2 >=1.3.15,<2.0a0
+  size: 100054
+  timestamp: 1780454302233
 - conda: https://prefix.dev/conda-forge/linux-64/gst-plugins-base-1.24.11-h651a532_0.conda
   sha256: a497d2ba34fdfa4bead423cba5261b7e619df3ac491fb0b6231d91da45bd05fc
   md5: d8d8894f8ced2c9be76dc9ad1ae531ce
@@ -27835,6 +28192,19 @@ packages:
   run_exports: {}
   size: 15235650
   timestamp: 1778268773535
+- conda: https://prefix.dev/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-hda75c37_19.conda
+  sha256: 3f5288346b9fe233352443b3c2e31f1fde845e39d3e96475fc05ec2e782af158
+  md5: 9d41f3899b512199af0a4bb939b83e21
+  depends:
+  - gcc_impl_linux-64 15.2.0 he0086c7_19
+  - libstdcxx-devel_linux-64 15.2.0 hd446a21_119
+  - sysroot_linux-64
+  - tzdata
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 16356816
+  timestamp: 1778269332159
 - conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-14.3.0-h72ca5df_25.conda
   sha256: 369abc77d74a8275c734f9ca2375892b86d3163a541b1f5a2de946083a9e3ab0
   md5: 4718c7fefd927621bad46a8bcc6387d6
@@ -27869,6 +28239,22 @@ packages:
     - libgcc >=14
   size: 27606
   timestamp: 1777144725126
+- conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-15.2.0-h1b0a0b8_25.conda
+  sha256: 24bc169bc881759107d5ad8c4e3c4ce259ea8542ae97f2e79ebc3a7214d34b1d
+  md5: 77a6c6a8ad55a302e7f407d37b4c451a
+  depends:
+  - gxx_impl_linux-64 15.2.0.*
+  - gcc_linux-64 ==15.2.0 h7be306e_25
+  - binutils_linux-64
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    strong:
+    - libstdcxx >=15
+    - libgcc >=15
+  size: 27702
+  timestamp: 1779371750402
 - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha4f8f14_102.conda
   sha256: de9ec9b1b01b90f2da2d896a5835a2fd8049859aff0c6331ca4594327ec79a8b
   md5: b270340809d19ae40ff9913f277b803a
@@ -27933,6 +28319,28 @@ packages:
     - harfbuzz >=14.2.0
   size: 2333599
   timestamp: 1776778392713
+- conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda
+  sha256: da9901aa1e20cbc2369fda212039b294dd02bce95f005539bab840b7310bf7d0
+  md5: 21ee4640b7c2d94e584349fa12b29b9a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - graphite2 >=1.3.14,<2.0a0
+  - icu >=78.3,<79.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libglib >=2.88.1,<3.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - harfbuzz >=14.2.1
+  size: 2362258
+  timestamp: 1780450503234
 - conda: https://prefix.dev/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
   sha256: 0d09b6dc1ce5c4005ae1c6a19dc10767932ef9a5e9c755cfdbb5189ac8fb0684
   md5: bd77f8da987968ec3927990495dc22e4
@@ -27991,6 +28399,32 @@ packages:
     - hdf5 >=1.14.6,<1.14.7.0a0
   size: 3719822
   timestamp: 1777518369641
+- conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_h735b18d_107.conda
+  sha256: ff8336394dcfaccf49e56d1dd66091cf767df0d3d33f3fa440c980e0445b34cc
+  md5: b1b444bca8da3ff6cc4afad1fa7f7d61
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-auth >=0.10.3,<0.10.4.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-s3 >=0.12.5,<0.12.6.0a0
+  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - libaec >=1.1.5,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - hdf5 >=2.1.0,<3.0a0
+  size: 4610890
+  timestamp: 1780923415022
 - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_h87a9417_105.conda
   sha256: beb8a2fb18924ca7b5b82cfb50f008f882f577daef2c00ed88022abea35fec76
   md5: 0d0595612fa229dddb5fc565c260a11f
@@ -28414,6 +28848,21 @@ packages:
     - lcms2 >=2.19.1,<3.0a0
   size: 251086
   timestamp: 1778079286384
+- conda: https://prefix.dev/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_1.conda
+  sha256: 112b5b9462572d970f4abd2912f76a25ee7db158b1e7260163d91dd8a630db84
+  md5: 8b3ce45e929cd8e8e5f4d18586b56d8b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - lcms2 >=2.19.1,<3.0a0
+  size: 251971
+  timestamp: 1780211695895
 - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
   sha256: 3d584956604909ff5df353767f3a2a2f60e07d070b328d109f30ac40cd62df6c
   md5: 18335a698559cdbcd86150a48bf54ba6
@@ -28456,6 +28905,18 @@ packages:
   run_exports: {}
   size: 858263
   timestamp: 1777157859593
+- conda: https://prefix.dev/conda-forge/linux-64/level-zero-1.29.0-hb700be7_0.conda
+  sha256: d87cfc5eaa08eefff97d891ecb49faa958fcfc32a425767796269c4100d4e516
+  md5: f3c3bc77c96af553f761af0e78bc8d9d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 875773
+  timestamp: 1780142086148
 - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20250512.1-cxx17_hba17884_0.conda
   sha256: dcd1429a1782864c452057a6c5bc1860f2b637dc20a2b7e6eacd57395bbceff8
   md5: 83b160d4da3e1e847bf044997621ed63
@@ -28959,6 +29420,23 @@ packages:
     - libavif16 >=1.4.2,<2.0a0
   size: 149510
   timestamp: 1779847073231
+- conda: https://prefix.dev/conda-forge/linux-64/libavif16-1.4.2-hf998032_1.conda
+  sha256: b831161d7c86f7dfeb58d7189176c3314d7c2ccb38b4e1c8b376557ae4238f0b
+  md5: 57845550bac29aeb754615c41b518f74
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aom >=3.14.1,<3.15.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - libgcc >=14
+  - rav1e >=0.8.1,<0.9.0a0
+  - svt-av1 >=4.0.1,<4.0.2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libavif16 >=1.4.2,<2.0a0
+  size: 149787
+  timestamp: 1780665914755
 - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-6_h5875eb1_mkl.conda
   build_number: 6
   sha256: a73ec64c0f60a7733f82a679342bdad88e0230ba8243b12ece13a23aded431f4
@@ -29024,6 +29502,26 @@ packages:
     - libblas >=3.11.0,<4.0a0
   size: 19112
   timestamp: 1778489855165
+- conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+  build_number: 8
+  sha256: b2da6bfd72a1c9cb143ccf64bf5b28790cb4eb58bd1cb978f6537b2322f7d48b
+  md5: 00fc660ab1b2f5ca07e92b4900d10c79
+  depends:
+  - libopenblas >=0.3.33,<0.3.34.0a0
+  - libopenblas >=0.3.33,<1.0a0
+  constrains:
+  - blas 2.308   openblas
+  - mkl <2027
+  - libcblas   3.11.0   8*_openblas
+  - liblapack  3.11.0   8*_openblas
+  - liblapacke 3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libblas >=3.11.0,<4.0a0
+  size: 18804
+  timestamp: 1779859100675
 - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-8_h5875eb1_mkl.conda
   build_number: 8
   sha256: e30f7fa2a2fb6985f9ac6604575cb318b9ae44e263f6cacc282daee9dbd6127d
@@ -29151,6 +29649,19 @@ packages:
     - libcap >=2.77,<2.78.0a0
   size: 124432
   timestamp: 1774333989027
+- conda: https://prefix.dev/conda-forge/linux-64/libcap-2.78-hd0affe5_0.conda
+  sha256: cc8c9fc6ddf0fbd3d1275b558ae9abad6cda23bced268732e2da21a87bb358cd
+  md5: f9f17eab7f3df1c6fd4b1a548a2f683a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libcap >=2.78,<2.79.0a0
+  size: 124335
+  timestamp: 1775488792584
 - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-6_hfef963f_mkl.conda
   build_number: 6
   sha256: d98a39a8e61af301bf67bf3fb946baff9686864886560cdd48d5259c080c58a5
@@ -29209,6 +29720,23 @@ packages:
     - libcblas >=3.11.0,<4.0a0
   size: 18751
   timestamp: 1778489862494
+- conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+  build_number: 8
+  sha256: 1a2bc77bb26520255904a3d9b1f40e6bf0bf9d8d3405c7709dd162282820915a
+  md5: 33a413f1095f8325e5c30fde3b0d2445
+  depends:
+  - libblas 3.11.0 8_h4a7cf45_openblas
+  constrains:
+  - blas 2.308   openblas
+  - liblapacke 3.11.0   8*_openblas
+  - liblapack  3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libcblas >=3.11.0,<4.0a0
+  size: 18778
+  timestamp: 1779859107964
 - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-8_hfef963f_mkl.conda
   build_number: 8
   sha256: a3ea22126a74321ddf754a0efaf998486ffb8b9ec69fc735b3f0eacb6ffc8a4e
@@ -30616,6 +31144,23 @@ packages:
     - liblapack >=3.11.0,<3.12.0a0
   size: 18762
   timestamp: 1778489869820
+- conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+  build_number: 8
+  sha256: 168e327d737059553e15cc6ec36d76b9bbb3931c2a7721555fd68b4c9348b247
+  md5: 809be8ba8712c77bc7d44c2d99390dc4
+  depends:
+  - libblas 3.11.0 8_h4a7cf45_openblas
+  constrains:
+  - blas 2.308   openblas
+  - libcblas   3.11.0   8*_openblas
+  - liblapacke 3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - liblapack >=3.11.0,<3.12.0a0
+  size: 18790
+  timestamp: 1779859115086
 - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-8_h5e43f62_mkl.conda
   build_number: 8
   sha256: 0cb26d433dfa15a392eaeeb8a96ac468f4d007d7e7e37ef7bf46856aaf9a9785
@@ -30693,6 +31238,23 @@ packages:
     - liblapacke >=3.11.0,<3.12.0a0
   size: 18789
   timestamp: 1778489877166
+- conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-8_h6ae95b6_openblas.conda
+  build_number: 8
+  sha256: 0b982865888a73fe7c2e7d8e8ee3738ac378b83012a7da1a12264a473cb2382b
+  md5: da17457f689df5c0f246d2f0b3798fd2
+  depends:
+  - libblas 3.11.0 8_h4a7cf45_openblas
+  - libcblas 3.11.0 8_h0358290_openblas
+  - liblapack 3.11.0 8_h47877c9_openblas
+  constrains:
+  - blas 2.308   openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - liblapacke >=3.11.0,<3.12.0a0
+  size: 18824
+  timestamp: 1779859122364
 - conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-8_hdba1596_mkl.conda
   build_number: 8
   sha256: a3a3ec318b551073248e24b486879ffd9b85b84ed56ccbb2d6e0d6f24c08a273
@@ -31318,6 +31880,59 @@ packages:
     - libopencv >=4.13.0,<4.13.1.0a0
   size: 33427078
   timestamp: 1777749424531
+- conda: https://prefix.dev/conda-forge/linux-64/libopencv-4.13.0-qt6_py313h4b3fa3f_610.conda
+  sha256: 6537fcd52eb0eb75663e88a0cf46b1ab9931e1ab118bc4c27a3fe183bf62ac0a
+  md5: f110933ed76eee0febfc62902bcbf614
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - ffmpeg >=8.1.1,<9.0a0
+  - harfbuzz >=14.2.1
+  - hdf5 >=2.1.0,<3.0a0
+  - imath >=3.2.2,<3.2.3.0a0
+  - libavif16 >=1.4.2,<2.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libgl >=1.7.0,<2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-auto-batch-plugin >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-auto-plugin >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-hetero-plugin >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-intel-cpu-plugin >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-intel-gpu-plugin >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-intel-npu-plugin >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-ir-frontend >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-onnx-frontend >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-paddle-frontend >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-pytorch-frontend >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-tensorflow-frontend >=2026.2.0,<2026.2.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2026.2.0,<2026.2.1.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libstdcxx >=14
+  - libtiff >=4.7.1,<4.8.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - numpy >=1.23,<3
+  - openexr >=3.4.12,<3.5.0a0
+  - openjpeg >=2.5.4,<3.0a0
+  - qt6-main >=6.11.1,<6.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - libopencv >=4.13.0,<4.13.1.0a0
+  size: 33406732
+  timestamp: 1780563556232
 - conda: https://prefix.dev/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
   sha256: 215086c108d80349e96051ad14131b751d17af3ed2cb5a34edd62fa89bfe8ead
   md5: 7df50d44d4a14d6c31a2c54f2cd92157
@@ -31417,6 +32032,22 @@ packages:
     - libopenvino >=2026.0.0,<2026.0.1.0a0
   size: 6582302
   timestamp: 1772727204779
+- conda: https://prefix.dev/conda-forge/linux-64/libopenvino-2026.2.0-hb56ce9e_0.conda
+  sha256: 1f2d5f0236eaf872c6c11891e59d9f4166913f3ab3b342352d12280b02b58185
+  md5: db1296fbbd6fe992484e37f5ba9a6f27
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - pugixml >=1.15,<1.16.0a0
+  - tbb >=2022.3.0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - libopenvino >=2026.2.0,<2026.2.1.0a0
+  size: 6813018
+  timestamp: 1780395324902
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-batch-plugin-2025.2.0-hed573e4_1.conda
   sha256: 193f760e828b0dd5168dd1d28580d4bf429c5f14a4eee5e0c02ff4c6d4cf8093
   md5: 94f9d17be1d658213b66b22f63cc6578
@@ -31445,6 +32076,20 @@ packages:
   run_exports: {}
   size: 114431
   timestamp: 1772727230331
+- conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-batch-plugin-2026.2.0-hd85de46_0.conda
+  sha256: b926fd97763e5c8fc2f4f53eaa657818eca85eab6f7d3992d3ceef5bd86349ca
+  md5: 17ccdfee138a9369103983a5b8e30675
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2026.2.0 hb56ce9e_0
+  - libstdcxx >=14
+  - tbb >=2022.3.0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 115526
+  timestamp: 1780395345452
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-plugin-2025.2.0-hed573e4_1.conda
   sha256: a6f9f996e64e6d2f295f017a833eda7018ff58b6894503272d72f0002dfd6f33
   md5: 071b3a82342715a411f216d379ab6205
@@ -31473,6 +32118,20 @@ packages:
   run_exports: {}
   size: 249056
   timestamp: 1772727247597
+- conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-plugin-2026.2.0-hd85de46_0.conda
+  sha256: 0f386b1f58fbe63bd599855a08bd9d738615730cba86d9e64f2bba8d3872d24e
+  md5: 0453294b5631705c297c822fe963e7fc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2026.2.0 hb56ce9e_0
+  - libstdcxx >=14
+  - tbb >=2022.3.0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 250550
+  timestamp: 1780395355986
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-hetero-plugin-2025.2.0-hd41364c_1.conda
   sha256: f43f9049338ef9735b6815bac3f483d1e3adddecbfdeb13be365bc3f601fe156
   md5: 77c0c7028a8110076d40314dc7b1fa98
@@ -31501,6 +32160,20 @@ packages:
   run_exports: {}
   size: 211582
   timestamp: 1772727264950
+- conda: https://prefix.dev/conda-forge/linux-64/libopenvino-hetero-plugin-2026.2.0-hd41364c_0.conda
+  sha256: dbb54fe5cbb27d9528797826c9aa80b0f742bc07e44652c09de2c79750719a5d
+  md5: 5542641915bccd4e95b15658062eb8f0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2026.2.0 hb56ce9e_0
+  - libstdcxx >=14
+  - pugixml >=1.15,<1.16.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 216023
+  timestamp: 1780395366723
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2025.2.0-hb617929_1.conda
   sha256: a4a1cd320fa010a45d01f438dc3431b7a60271ee19188a901f884399fe744268
   md5: e4cc6db5bdc8b554c06bf569de57f85f
@@ -31531,6 +32204,21 @@ packages:
   run_exports: {}
   size: 13173323
   timestamp: 1772727282718
+- conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2026.2.0-hb56ce9e_0.conda
+  sha256: 87aa0a430b462c275a5f7b7ffb5f490d37d8ce97ccdc3d6e93b8bccb3d66f19f
+  md5: 930ac67c3e49a2ec1b45bcc2c2f701fd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2026.2.0 hb56ce9e_0
+  - libstdcxx >=14
+  - pugixml >=1.15,<1.16.0a0
+  - tbb >=2022.3.0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 13586589
+  timestamp: 1780395378959
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2025.2.0-hb617929_1.conda
   sha256: 03ebf700586775144ca5913f401393a386b9a1d7a7cfcba4494830063ca5eb92
   md5: b846fe6c158ca417e246122172d68d3a
@@ -31563,6 +32251,22 @@ packages:
   run_exports: {}
   size: 11402462
   timestamp: 1772727323957
+- conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2026.2.0-hb56ce9e_0.conda
+  sha256: 1efa48f137a3720a83276ee0b50201d540e1d41a92efe323118c43410ccf697b
+  md5: bc71ff82983c3d233928d3d89c141f82
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2026.2.0 hb56ce9e_0
+  - libstdcxx >=14
+  - ocl-icd >=2.3.4,<3.0a0
+  - pugixml >=1.15,<1.16.0a0
+  - tbb >=2022.3.0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 12325490
+  timestamp: 1780395417543
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-npu-plugin-2025.2.0-hb617929_1.conda
   sha256: b6dbc342293d6ce0c7b37c9f29f734b3e1856cff9405a02fb33cedd1b36528e6
   md5: 86fd4c25f6accaf646c86adf0f1382d3
@@ -31595,6 +32299,22 @@ packages:
   run_exports: {}
   size: 1994640
   timestamp: 1772727360780
+- conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-npu-plugin-2026.2.0-hb56ce9e_0.conda
+  sha256: c300e263c51208457a320c98f94f1b18e713451577ed81ab425793e52e483d03
+  md5: 30b2cabfd4d3e08af17e324260a0fb65
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - level-zero >=1.29.0,<2.0a0
+  - libgcc >=14
+  - libopenvino 2026.2.0 hb56ce9e_0
+  - libstdcxx >=14
+  - pugixml >=1.15,<1.16.0a0
+  - tbb >=2022.3.0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 2619772
+  timestamp: 1780395452811
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-ir-frontend-2025.2.0-hd41364c_1.conda
   sha256: 334733396d4c9a9b2b2d7d7d850e8ee8deca1f9becd0368d106010076ceb20ca
   md5: 75e595d9f2019a60f6dcb500266da615
@@ -31627,6 +32347,22 @@ packages:
     - libopenvino-ir-frontend >=2026.0.0,<2026.0.1.0a0
   size: 192778
   timestamp: 1772727380069
+- conda: https://prefix.dev/conda-forge/linux-64/libopenvino-ir-frontend-2026.2.0-hd41364c_0.conda
+  sha256: 4e8e2c111820120d563d58e0863d239e0ff155f5bcbf5cf88fa3084b52fa0829
+  md5: e63fab556e1ffa1ae56a6b4dace8b98c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2026.2.0 hb56ce9e_0
+  - libstdcxx >=14
+  - pugixml >=1.15,<1.16.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - libopenvino-ir-frontend >=2026.2.0,<2026.2.1.0a0
+  size: 201661
+  timestamp: 1780395466300
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-onnx-frontend-2025.2.0-h1862bb8_1.conda
   sha256: 3937b028e7192ed3805581ac0ea171725843056c8544537754fad45a1791e864
   md5: 68f5ad9d8e3979362bb9dfc9388980aa
@@ -31663,6 +32399,24 @@ packages:
     - libopenvino-onnx-frontend >=2026.0.0,<2026.0.1.0a0
   size: 1860687
   timestamp: 1772727397981
+- conda: https://prefix.dev/conda-forge/linux-64/libopenvino-onnx-frontend-2026.2.0-h7a07914_0.conda
+  sha256: d34154e5dfdb43fce02ba15277d52e9b0a524d789826e6b1ea8289fd76a8ad75
+  md5: 1fffc68405e92be38303bfdad42a25a6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libgcc >=14
+  - libopenvino 2026.2.0 hb56ce9e_0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libstdcxx >=14
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - libopenvino-onnx-frontend >=2026.2.0,<2026.2.1.0a0
+  size: 1936193
+  timestamp: 1780395477218
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-paddle-frontend-2025.2.0-h1862bb8_1.conda
   sha256: c7ac3d4187323ab37ef62ec0896a41c8ca7da426c7f587494c72fe74852269e5
   md5: a032d03468dee9fb5b8eaf635b4571c2
@@ -31699,6 +32453,24 @@ packages:
     - libopenvino-paddle-frontend >=2026.0.0,<2026.0.1.0a0
   size: 684224
   timestamp: 1772727417276
+- conda: https://prefix.dev/conda-forge/linux-64/libopenvino-paddle-frontend-2026.2.0-h7a07914_0.conda
+  sha256: e0d2e852c4cf581efc6e5065b5ae48ab782bc4430d5dde358387c777eaaa9e95
+  md5: 25841468f7fa47d4358f962b8b60b19a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libgcc >=14
+  - libopenvino 2026.2.0 hb56ce9e_0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libstdcxx >=14
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - libopenvino-paddle-frontend >=2026.2.0,<2026.2.1.0a0
+  size: 689792
+  timestamp: 1780395490135
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-pytorch-frontend-2025.2.0-hecca717_1.conda
   sha256: 2d4a680a16509b8dd06ccd7a236655e46cc7c242bb5b6e88b83a834b891658db
   md5: cd40cf2d10a3279654c9769f3bc8caf5
@@ -31729,6 +32501,21 @@ packages:
     - libopenvino-pytorch-frontend >=2026.0.0,<2026.0.1.0a0
   size: 1185558
   timestamp: 1772727435039
+- conda: https://prefix.dev/conda-forge/linux-64/libopenvino-pytorch-frontend-2026.2.0-hecca717_0.conda
+  sha256: 712a3ca68db324a503cfe13223b992fbb90fced5e53d561941b4186c4714bb08
+  md5: 4abf4fe404eabad43831c6d496d97747
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2026.2.0 hb56ce9e_0
+  - libstdcxx >=14
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - libopenvino-pytorch-frontend >=2026.2.0,<2026.2.1.0a0
+  size: 1223721
+  timestamp: 1780395502677
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.2.0-h0767aad_1.conda
   sha256: 311ec1118448a28e76f0359c4393c7f7f5e64761c48ac7b169bf928a391eae77
   md5: f71c6b4e342b560cc40687063ef62c50
@@ -31767,6 +32554,25 @@ packages:
     - libopenvino-tensorflow-frontend >=2026.0.0,<2026.0.1.0a0
   size: 1257870
   timestamp: 1772727453738
+- conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-frontend-2026.2.0-h78e8023_0.conda
+  sha256: 7df7413374e2e4e2c77960c0e4265d4a5871668f2766545253b91585c9bf50b7
+  md5: cded5d117c53c5963fbab737a5333a33
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libgcc >=14
+  - libopenvino 2026.2.0 hb56ce9e_0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libstdcxx >=14
+  - snappy >=1.2.2,<1.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - libopenvino-tensorflow-frontend >=2026.2.0,<2026.2.1.0a0
+  size: 1281126
+  timestamp: 1780395514787
 - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2025.2.0-hecca717_1.conda
   sha256: 581f4951e645e820c4a6ffe40fb0174b56d6e31fb1fefd2d64913fea01f8f69e
   md5: fd9dacd7101f80ff1110ea6b76adb95d
@@ -31797,6 +32603,21 @@ packages:
     - libopenvino-tensorflow-lite-frontend >=2026.0.0,<2026.0.1.0a0
   size: 456585
   timestamp: 1772727473378
+- conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2026.2.0-hecca717_0.conda
+  sha256: 72474e82f180fb15d8cf207b2ded6c12041871ebf9cae02c81c3a5c381b3f4c9
+  md5: 37a1e17203f653196077d666365632fc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2026.2.0 hb56ce9e_0
+  - libstdcxx >=14
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - libopenvino-tensorflow-lite-frontend >=2026.2.0,<2026.2.1.0a0
+  size: 500837
+  timestamp: 1780395526579
 - conda: https://prefix.dev/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
   sha256: f1061a26213b9653bbb8372bfa3f291787ca091a9a3060a10df4d5297aad74fd
   md5: 2446ac1fe030c2aa6141386c1f5a6aed
@@ -32004,6 +32825,23 @@ packages:
     - libprotobuf >=6.33.5,<6.33.6.0a0
   size: 3638698
   timestamp: 1769749419271
+- conda: https://prefix.dev/conda-forge/linux-64/libprotobuf-6.33.5-h6eeba95_1.conda
+  sha256: a59aa3f076d5710c618ca8fd12d9cd8211d8b738f6b0e0c98517c0162f23a5de
+  md5: 7a4b11f3dd7374f1991a4088390d07c1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libprotobuf >=6.33.5,<6.33.6.0a0
+  size: 3675765
+  timestamp: 1780003831209
 - conda: https://prefix.dev/conda-forge/linux-64/libraw-0.21.5-h074291d_0.conda
   sha256: 7b11ab45e471ba77eab1a21872be3dce8cc81edc2500cd782a6ff49816bce6d4
   md5: c307c91b10217c31fc9d8e18cd58dc64
@@ -32123,6 +32961,28 @@ packages:
     - librsvg >=2.62.2,<3.0a0
   size: 3507905
   timestamp: 1779414238375
+- conda: https://prefix.dev/conda-forge/linux-64/librsvg-2.62.3-h4c96295_0.conda
+  sha256: 5571bd8239d71961d4e3ce972f865b3ea95a91ce0b53d5749fe2dd24254ddbda
+  md5: 492c8d9b1c564c2e948b6cb4ba0f8261
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - fontconfig >=2.18.0,<3.0a0
+  - fonts-conda-ecosystem
+  - gdk-pixbuf >=2.44.6,<3.0a0
+  - harfbuzz >=14.2.0
+  - libgcc >=14
+  - libglib >=2.88.1,<3.0a0
+  - libxml2-16 >=2.14.6
+  - pango >=1.56.4,<2.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - librsvg >=2.62.3,<3.0a0
+  size: 3476570
+  timestamp: 1780450632624
 - conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_19.conda
   sha256: 8766de5423b0a510e2b1bdd1963d0554bdad2119f3e31d8fbd4189af434235ca
   md5: 007796e5a595bbc7df4a5e1580d72e1a
@@ -32253,6 +33113,19 @@ packages:
     - libsqlite >=3.53.1,<4.0a0
   size: 954962
   timestamp: 1777986471789
+- conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.2-h0c1763c_0.conda
+  sha256: 1ab603b6ec93933e76027e1f23b21b22b858ba1b56f1e1695ef6fe5e80cb7358
+  md5: 062b0ac602fb0adf250e3dfa86f221c4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  run_exports:
+    weak:
+    - libsqlite >=3.53.2,<4.0a0
+  size: 957849
+  timestamp: 1780574429573
 - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
   sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
   md5: eecce068c7e4eddeb169591baac20ac4
@@ -32314,6 +33187,17 @@ packages:
     - libsuitesparseconfig >=7.10.1,<8.0a0
   size: 42708
   timestamp: 1741963824815
+- conda: https://prefix.dev/conda-forge/linux-64/libsystemd0-257.13-h084b8d7_1.conda
+  sha256: 2293884d59cf0436c37fc0a4bad71011a8de2a6913610d1c701a7703377c1f75
+  md5: ea0da9c20bbb221b530810c3c68bbe62
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcap >=2.78,<2.79.0a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  run_exports: {}
+  size: 493022
+  timestamp: 1780084748140
 - conda: https://prefix.dev/conda-forge/linux-64/libsystemd0-257.13-hd0affe5_0.conda
   sha256: c5008b602cb5c819f7b52d418b3ed17e1818cbbf6705b189e7ab36bb70cce3d8
   md5: 8ee3cb7f64be0e8c4787f3a4dbe024e6
@@ -32525,6 +33409,17 @@ packages:
     - libtorch >=2.8.0,<2.9.0a0
   size: 876816719
   timestamp: 1762140104716
+- conda: https://prefix.dev/conda-forge/linux-64/libudev1-257.13-h084b8d7_1.conda
+  sha256: 287d05680e49eea51b8145fbf34bc213c0618b04f32e450e9da5d715e5134e38
+  md5: 89e5671a076d99516a6acd72a35b1640
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcap >=2.78,<2.79.0a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  run_exports: {}
+  size: 145969
+  timestamp: 1780084753104
 - conda: https://prefix.dev/conda-forge/linux-64/libudev1-257.13-hd0affe5_0.conda
   sha256: 1a1e367c04d66030aa93b4d33905f7f6fbb59cfc292e816fe3e9c1e8b3f4d1e2
   md5: 2c2270f93d6f9073cbf72d821dfc7d72
@@ -32845,6 +33740,25 @@ packages:
     - libxkbcommon >=1.13.1,<2.0a0
   size: 837922
   timestamp: 1764794163823
+- conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.13.2-hca5e8e5_0.conda
+  sha256: 046f2ff4acebd8729fac03e99c8c307dfb48b6a32894ba8c11576e78f6e76e43
+  md5: dc8b067e22b414172bedd8e3f03f3c95
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxcb >=1.17.0,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - xkeyboard-config
+  - xorg-libxau >=1.0.12,<2.0a0
+  license: MIT/X11 Derivative
+  license_family: MIT
+  run_exports:
+    weak:
+    - libxkbcommon >=1.13.2,<2.0a0
+  size: 851166
+  timestamp: 1780213397575
 - conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.1-ha9997c6_0.conda
   sha256: 71436e72a286ef8b57d6f4287626ff91991eb03c7bdbe835280521791efd1434
   md5: e7733bc6785ec009e47a224a71917e84
@@ -33685,6 +34599,20 @@ packages:
     - ocl-icd >=2.3.3,<3.0a0
   size: 106742
   timestamp: 1743700382939
+- conda: https://prefix.dev/conda-forge/linux-64/ocl-icd-2.3.4-hb03c661_1.conda
+  sha256: 75f3bf733523a338f73d6c276c4a26634877cd970edb558f2769d9fa52b100a9
+  md5: c2871ba95727fd1382c05db66048b64c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - opencl-headers >=2025.6.13
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - ocl-icd >=2.3.4,<3.0a0
+  size: 109598
+  timestamp: 1780362789611
 - conda: https://prefix.dev/conda-forge/linux-64/onemkl-license-2025.3.1-hf2ce2f3_12.conda
   sha256: bdc5e2eec18512a21ab330d5b2b3dd8b285410f4076efc5379a2ef193d81b832
   md5: 95321ce2d03500a23a6e80034cbd4804
@@ -33978,6 +34906,21 @@ packages:
     - openjph >=0.27.3,<0.28.0a0
   size: 283239
   timestamp: 1778775149306
+- conda: https://prefix.dev/conda-forge/linux-64/openjph-0.27.4-h8d634f6_0.conda
+  sha256: b4be74b706500c2f9471135b9a59a0d4325b999d992acf69ad0c598cfc5f9938
+  md5: 6fb2763a192402111e655f420f1d88d7
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libtiff >=4.7.1,<4.8.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - openjph >=0.27.4,<0.28.0a0
+  size: 283312
+  timestamp: 1780596792557
 - conda: https://prefix.dev/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
   sha256: cb0b07db15e303e6f0a19646807715d28f1264c6350309a559702f4f34f37892
   md5: 2e5bf4f1da39c0b32778561c3c4e5878
@@ -34245,6 +35188,17 @@ packages:
     - pango >=1.56.4,<2.0a0
   size: 458036
   timestamp: 1774281947855
+- conda: https://prefix.dev/conda-forge/linux-64/patch-2.8-hb03c661_1002.conda
+  sha256: 61d3a3ef79952014bf536ffd84828d3558fc58b332adb89ed198b77fb301c2c5
+  md5: eaa73c6e5aff5b28675147abc350d49a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: GPL-3.0-or-later
+  license_family: GPL
+  run_exports: {}
+  size: 117222
+  timestamp: 1757600683480
 - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.46-h1321c63_0.conda
   sha256: 5c7380c8fd3ad5fc0f8039069a45586aa452cf165264bc5a437ad80397b32934
   md5: 7fa07cb0fb1b625a089ccc01218ee5b1
@@ -34277,6 +35231,21 @@ packages:
     - pcre2 >=10.47,<10.48.0a0
   size: 1222481
   timestamp: 1763655398280
+- conda: https://prefix.dev/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
+  build_number: 7
+  sha256: 9ec32b6936b0e37bcb0ed34f22ec3116e75b3c0964f9f50ecea5f58734ed6ce9
+  md5: f2cfec9406850991f4e3d960cc9e3321
+  depends:
+  - libgcc-ng >=12
+  - libxcrypt >=4.4.36
+  license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  run_exports:
+    weak:
+    - perl >=5.32.1,<5.33.0a0 *_perl5
+    noarch:
+    - perl >=5.32.1,<6.0a0 *_perl5
+  size: 13344463
+  timestamp: 1703310653947
 - conda: https://prefix.dev/conda-forge/linux-64/pillow-12.2.0-py311hf88fc01_0.conda
   sha256: 5b182a7588874e497514b52e2ef278b66fa4089e94379d249897df28b917a659
   md5: b4e4b0fc807b68aa1706457f2e31279d
@@ -35670,6 +36639,81 @@ packages:
     - qt6-main >=6.11.1,<6.12.0a0
   size: 60185269
   timestamp: 1778597122245
+- conda: https://prefix.dev/conda-forge/linux-64/qt6-main-6.11.1-pl5321h16c4a6b_1.conda
+  sha256: aefbc43bde188ff4027d480da99c7fa9e8e6341e9762e065190239cb9b99bb1c
+  md5: 331d660aef48fec733a878dd1f8f4206
+  depends:
+  - libxcb
+  - xcb-util
+  - xcb-util-wm
+  - xcb-util-keysyms
+  - xcb-util-image
+  - xcb-util-renderutil
+  - xcb-util-cursor
+  - libgl-devel
+  - libegl-devel
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - fontconfig >=2.18.1,<3.0a0
+  - fonts-conda-ecosystem
+  - xorg-libxxf86vm >=1.1.7,<2.0a0
+  - xorg-libxrandr >=1.5.5,<2.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libpq >=18.4,<19.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - wayland >=1.25.0,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libvulkan-loader >=1.4.341.0,<2.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - harfbuzz >=14.2.1
+  - xcb-util-cursor >=0.1.6,<0.2.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - libcups >=2.3.3,<2.4.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libdrm >=2.4.127,<2.5.0a0
+  - xorg-libxcomposite >=0.4.7,<1.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - icu >=78.3,<79.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - alsa-lib >=1.2.16,<1.3.0a0
+  - openssl >=3.5.6,<4.0a0
+  - libglib >=2.88.1,<3.0a0
+  - libgl >=1.7.0,<2.0a0
+  - libxkbcommon >=1.13.2,<2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - double-conversion >=3.4.0,<3.5.0a0
+  - dbus >=1.16.2,<2.0a0
+  - xorg-libxtst >=1.2.5,<2.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  constrains:
+  - qt ==6.11.1
+  license: LGPL-3.0-only
+  license_family: LGPL
+  run_exports:
+    weak:
+    - qt6-main >=6.11.1,<7.0a0
+  size: 60185421
+  timestamp: 1780593127053
 - conda: https://prefix.dev/conda-forge/linux-64/qt6-main-6.9.3-h5c1c036_1.conda
   sha256: 51537408ce1493d267b375b33ec02a060d77c4e00c7bef5e2e1c6724e08a23e3
   md5: 762af6d08fdfa7a45346b1466740bacd
@@ -36162,6 +37206,38 @@ packages:
     - sdl2 >=2.32.56,<3.0a0
   size: 589145
   timestamp: 1757842881000
+- conda: https://prefix.dev/conda-forge/linux-64/sdl3-3.4.10-hdeec2a5_0.conda
+  sha256: 04fa7dab2b8f688e3fc4b7ae4522fd3935fb0601e3329cda8b40d63c60d6cc05
+  md5: 845c0b154836c034f361668bec2a4f20
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - libusb >=1.0.29,<2.0a0
+  - libxkbcommon >=1.13.2,<2.0a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - xorg-libxi >=1.8.3,<2.0a0
+  - liburing >=2.14,<2.15.0a0
+  - libunwind >=1.8.3,<1.9.0a0
+  - xorg-libxtst >=1.2.5,<2.0a0
+  - wayland >=1.25.0,<2.0a0
+  - dbus >=1.16.2,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libxscrnsaver >=1.2.4,<2.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - libdrm >=2.4.127,<2.5.0a0
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - libvulkan-loader >=1.4.341.0,<2.0a0
+  - libegl >=1.7.0,<2.0a0
+  - xorg-libxfixes >=6.0.2,<7.0a0
+  - libudev1 >=257.13
+  license: Zlib
+  run_exports:
+    weak:
+    - sdl3 >=3.4.10,<4.0a0
+  size: 2148830
+  timestamp: 1780262823658
 - conda: https://prefix.dev/conda-forge/linux-64/sdl3-3.4.8-hdeec2a5_0.conda
   sha256: bec327fffc08369afe4c1384a5b50cac9b38e7af42ebdf5f89628633bd980dbd
   md5: 508bad511e617479f0ad60cc49fba903
@@ -36319,6 +37395,22 @@ packages:
     - spirv-tools >=2026,<2027.0a0
   size: 2296977
   timestamp: 1770089626195
+- conda: https://prefix.dev/conda-forge/linux-64/spirv-tools-2026.2-hb700be7_0.conda
+  sha256: 309d1a3317e91a03611bc960fc807cf2c0c5baacbfddea0f5636438a76c52256
+  md5: 0c2b1d811632f1f4aa923450a002ff4f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - spirv-headers >=1.4.350.0,<1.4.350.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - spirv-tools >=2026,<2027.0a0
+  size: 2392190
+  timestamp: 1780139567779
 - conda: https://prefix.dev/conda-forge/linux-64/sqlite-3.53.1-hbc0de68_0.conda
   sha256: d167fa92781bcdcd3b9aaa6bb1cd50c5b108f6190c170098a118b5cf5df2f881
   md5: 8e0b8654ead18e50af552e54b5a08a61
@@ -45244,6 +46336,18 @@ packages:
   - pkg:pypi/pickleshare?source=hash-mapping
   size: 11748
   timestamp: 1733327448200
+- conda: https://prefix.dev/conda-forge/noarch/pip-26.1.2-pyh8b19718_0.conda
+  sha256: 29b7d75bf81ad11645a8e320b369abdc90a92b93f2a9178e853d9dddf82e5106
+  md5: 511fbc2c63d2c73650ad1755e4d357ba
+  depends:
+  - python >=3.10,<3.13.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 1203173
+  timestamp: 1780262795392
 - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
   sha256: 8f29915c172f1f7f4f7c9391cd5dac3ebf5d13745c8b7c8006032615246345a5
   md5: 89c0b6d1793601a2a3a3f7d2d3d8b937
@@ -45403,6 +46507,20 @@ packages:
   run_exports: {}
   size: 232875
   timestamp: 1755953378112
+- conda: https://prefix.dev/conda-forge/noarch/pybind11-3.0.3-pyhfe8187e_0.conda
+  sha256: 71a9524f44d6ac6304feae71e2bbe8d8ce0816f0be7a0271c15681ad1040965d
+  md5: e0f4549ccb507d4af8ed5c5345210673
+  depends:
+  - python >=3.8
+  - pybind11-global ==3.0.3 *_0
+  - python
+  constrains:
+  - pybind11-abi ==11
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 247963
+  timestamp: 1775004608640
 - conda: https://prefix.dev/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
   sha256: 9e7fe12f727acd2787fb5816b2049cef4604b7a00ad3e408c5e709c298ce8bf1
   md5: f0599959a2447c1e544e216bddf393fa
@@ -45456,6 +46574,20 @@ packages:
   run_exports: {}
   size: 228871
   timestamp: 1755953338243
+- conda: https://prefix.dev/conda-forge/noarch/pybind11-global-3.0.3-pyh648e204_0.conda
+  sha256: 97a0fbd2a81d95e90d714e5c628fe860b29a3caad53abcfb90add1965ad85bef
+  md5: 7fdc3e18c14b862ae5f064c1ea8e2636
+  depends:
+  - python >=3.8
+  - __unix
+  - python
+  constrains:
+  - pybind11-abi ==11
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 243898
+  timestamp: 1775004520432
 - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
   sha256: 79db7928d13fab2d892592223d7570f5061c192f27b9febd1a418427b719acc6
   md5: 12c566707c80111f9799308d9e265aef
@@ -46602,6 +47734,17 @@ packages:
   run_exports: {}
   size: 258232
   timestamp: 1775160081069
+- conda: https://prefix.dev/conda-forge/noarch/wheel-0.47.0-pyhd8ed1ab_0.conda
+  sha256: 9e156ffaefb8463437144326ada4b85d1de17961b9997ac5f1cbbaf747bd8bed
+  md5: d0e3b2f0030cf4fca58bde71d246e94c
+  depends:
+  - packaging >=24.0
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 33491
+  timestamp: 1776878563806
 - conda: https://prefix.dev/conda-forge/noarch/wslink-2.5.7-pyhd8ed1ab_0.conda
   sha256: 894762dc1a6520888de7cbe8d6f59999a94005aad11951fddcfdbef85d726a2d
   md5: 410dee7cbee308f33b01645f16f11efc
@@ -49477,6 +50620,378 @@ packages:
     - zstd >=1.5.7,<1.6.0a0
   size: 433413
   timestamp: 1764777166076
+- conda_source: asmk[e04de9ec] @ packages/asmk
+  variants:
+    target_platform: linux-64
+  depends:
+  - python 3.11.*
+  - libgcc >=15
+  - python_abi 3.11.* *_cp311
+  build_packages:
+  - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_102.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-ha6850e4_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_25.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-15.2.0-h90f66d4_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  - conda: https://prefix.dev/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+  - conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_119.conda
+  - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_119.conda
+  - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  host_packages:
+  - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/cython-3.2.5-py311h0daaf2c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.2-h0c1763c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/python-3.11.15-hd63d673_0_cpython.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pip-26.1.2-pyh8b19718_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.11-8_cp311.conda
+  - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/wheel-0.47.0-pyhd8ed1ab_0.conda
+- conda_source: dpretrieval[71ac0d5b] @ packages/dpretrieval
+  variants:
+    target_platform: linux-64
+  depends:
+  - python 3.11.*
+  - libopencv
+  - libopencv >=4.13.0,<4.13.1.0a0
+  - libstdcxx >=15
+  - libgcc >=15
+  - python_abi 3.11.* *_cp311
+  build_packages:
+  - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_102.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/cmake-4.3.3-hc85cc9f_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-he0086c7_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_25.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/git-2.54.0-pl5321h6d3cee1_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-hda75c37_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-15.2.0-h1b0a0b8_25.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-15.2.0-h90f66d4_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libuv-1.52.1-h280c20c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/ninja-1.13.2-h171cf75_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/rhash-1.4.6-hb9d3cd8_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+  - conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_119.conda
+  - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_119.conda
+  - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  host_packages:
+  - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.3-hea842a7_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.14-h78948cc_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.14.0-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-haa0cbde_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.11.0-h6488f85_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.26.3-h5b668fc_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.12.5-hb916526_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-haa0cbde_6.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-haa0cbde_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-8.1.1-gpl_h6d6c1bd_904.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/glslang-16.3.0-h96af755_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_h735b18d_107.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/imath-3.2.2-hde8ca8f_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/intel-gmmlib-22.10.0-hb700be7_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/intel-media-driver-26.1.6-hecca717_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+  - conda: https://prefix.dev/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/level-zero-1.29.0-hb700be7_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libass-0.17.4-h96ad9f0_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libavif16-1.4.2-hf998032_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libcap-2.78-hd0affe5_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libdovi-3.3.2-ha23c83e_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libdrm-2.4.127-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libhwloc-2.13.0-default_he001693_1000.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libhwy-1.4.0-h10be129_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libjxl-0.11.2-h174a0a3_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-8_h6ae95b6_openblas.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libopencv-4.13.0-qt6_py313h4b3fa3f_610.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-2026.2.0-hb56ce9e_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-batch-plugin-2026.2.0-hd85de46_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-plugin-2026.2.0-hd85de46_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-hetero-plugin-2026.2.0-hd41364c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2026.2.0-hb56ce9e_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2026.2.0-hb56ce9e_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-npu-plugin-2026.2.0-hb56ce9e_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-ir-frontend-2026.2.0-hd41364c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-onnx-frontend-2026.2.0-h7a07914_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-paddle-frontend-2026.2.0-h7a07914_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-pytorch-frontend-2026.2.0-hecca717_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-frontend-2026.2.0-h78e8023_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2026.2.0-hecca717_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libpciaccess-0.19-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libplacebo-7.360.1-h9eeb4b2_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libpq-18.4-hd5a49e9_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libprotobuf-6.33.5-h6eeba95_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/librsvg-2.62.3-h4c96295_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.2-h0c1763c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libsystemd0-257.13-h084b8d7_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libudev1-257.13-h084b8d7_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/liburing-2.14-hb700be7_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libva-2.23.0-he1eb515_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libvpl-2.16.0-h54a6638_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libvpx-1.15.2-hecca717_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libvulkan-loader-1.4.341.0-h5279c79_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.13.2-hca5e8e5_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.4.6-py311h2e04523_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/ocl-icd-2.3.4-hb03c661_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/opencl-headers-2025.06.13-hecca717_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/openexr-3.4.12-h9f1635d_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/openjph-0.27.4-h8d634f6_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/python-3.11.15-hd63d673_0_cpython.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/qt6-main-6.11.1-pl5321h16c4a6b_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/rav1e-0.8.1-h1fbca29_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.3-hc5a330e_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/sdl3-3.4.10-hdeec2a5_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/shaderc-2026.2-h718be3e_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/spirv-tools-2026.2-hb700be7_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-4.0.1-hecca717_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+  - conda: https://prefix.dev/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+  - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.47-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxi-1.8.3-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-xorgproto-2025.1-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+  - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pybind11-3.0.3-pyhfe8187e_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pybind11-global-3.0.3-pyh648e204_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.11-8_cp311.conda
+  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
+- conda_source: mast3r[979b4dac] @ packages/mast3r
+  variants:
+    target_platform: noarch
+  depends:
+  - python >=3.11
+  - python *
+  build_packages:
+  - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/git-2.54.0-pl5321h6d3cee1_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/patch-2.8-hb03c661_1002.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+  host_packages:
+  - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.2-h0c1763c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/python-3.11.15-hd63d673_0_cpython.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pip-26.1.2-pyh8b19718_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/wheel-0.47.0-pyhd8ed1ab_0.conda
 - pypi: /home/pablo/0Dev/personal/daggr
   name: daggr
   requires_dist:


### PR DESCRIPTION
This pull request introduces significant refactoring and new utilities to improve benchmarking and visualization for TorchCodec-based multiview video decoding in the `simplecv` package. The main changes include extracting benchmarking helpers into a new module for reuse, adding new utilities for Rerun visualization, and updating the main benchmarking script to use these abstractions. This streamlines code, reduces duplication, and improves maintainability.

**Benchmarking utilities refactor:**
- Extracted common benchmarking helpers (such as `TimingResult`, metadata reading, chunk size validation, timing table formatting, and CUDA synchronization) from `benchmark_torchcodec_cuda_multiview.py` into a new module `simplecv/_benchmark_utils.py` for reuse and cleaner code organization. [[1]](diffhunk://#diff-7fe715d70e8e4ea431ed7835ce6393722ccf91cb4f978233f41913188dd15124R1-R144) [[2]](diffhunk://#diff-1cbe9e5924258fd83df8b1b5310c1cc3f350aa143fbd0af73b94fc5b8b76771bL41-L59) [[3]](diffhunk://#diff-1cbe9e5924258fd83df8b1b5310c1cc3f350aa143fbd0af73b94fc5b8b76771bL75-L123) [[4]](diffhunk://#diff-1cbe9e5924258fd83df8b1b5310c1cc3f350aa143fbd0af73b94fc5b8b76771bR88) [[5]](diffhunk://#diff-1cbe9e5924258fd83df8b1b5310c1cc3f350aa143fbd0af73b94fc5b8b76771bL145-R125)
- Updated `benchmark_torchcodec_cuda_multiview.py` to use the new benchmarking utilities, removing duplicated code and simplifying the main benchmarking logic.

**Visualization and Rerun integration:**
- Added a new utility module `simplecv/_torchcodec_view_utils.py` for building Rerun blueprints and logging decoded video chunks, enabling side-by-side comparisons of original and decoded video streams.

**Documentation and code style:**
- Updated the `AGENTS.md` documentation to clarify code style guidelines (favoring inlining over thin wrappers) and added instructions for using shared Rerun configuration utilities when adding Tyro-facing CLIs.