### PR TITLE
live-rerun: adopt generic SLAM-ready rig schema (system-agnostic naming)

### DIFF
--- a/packages/live-rerun/README.md
+++ b/packages/live-rerun/README.md
@@ -31,10 +31,33 @@ streams share one resolution; RGB 720p is the 1080p sensor ISP-downscaled by 2/3
 
 ## What it logs
 
-- Three encoded streams — RGB (`CAM_A`), left (`CAM_B`), right (`CAM_C`) — each as
-  a `VideoStream` under `world/oak/<cam>/pinhole/video`.
+A generic, system-agnostic **rig** schema (COLMAP-style), so a different
+multicam system maps onto the same layout and opens identically. Entity paths
+use `rig_*` / `cam_*` (no `oak`); the OAK specifics stay in `sources/`. The
+contract is documented in [`docs/rig_schema.md`](docs/rig_schema.md).
+
+```
+/world                       ViewCoordinates.RDF (static)
+  /rig_00                    schema metadata (static); no transform = implicit
+                             identity now — a SLAM pass logs world_T_rig here
+    /cam_00                  left  — reference sensor, identity, frustum tinted green
+      /pinhole/video         VideoStream (encoded H.265/H.264 samples)
+    /cam_01                  rgb
+    /cam_02                  right
+```
+
+(Entity ids are zero-padded to two digits — `cam_00`, `rig_00` — so they sort
+lexicographically; see [`docs/rig_schema.md`](docs/rig_schema.md).)
+
+- Three encoded streams — left (`CAM_B`) → `cam_00`, RGB (`CAM_A`) → `cam_01`,
+  right (`CAM_C`) → `cam_02` — each a `VideoStream` under `…/cam_<NN>/pinhole/video`.
+- The **left** camera is the rig **reference sensor** (identity pose, the rig
+  origin); rgb/right are expressed relative to it. SLAM is run around the left
+  camera, so the rig moves rigidly with it.
 - Camera **intrinsics + extrinsics** as static Rerun pinholes (the rig is assumed
   stationary), so the three cameras appear as frusta in a 3D view.
+- Per-sensor metadata as static `rr.AnyValues` (`name`, `kind`); a schema block
+  (`schema_version`, `reference`, `num_cameras`) on `/world/rig_00`.
 - A blueprint with the 3D rig above the three video panels.
 
 Keyframe flags come from the device (`EncodedFrame.getFrameType()`), so scrubbing

--- a/packages/live-rerun/docs/rig_schema.md
+++ b/packages/live-rerun/docs/rig_schema.md
@@ -1,0 +1,119 @@
+# live-rerun rig schema
+
+`live-rerun` logs a multi-sensor **rig** into Rerun using a generic,
+system-agnostic entity layout. The schema is deliberately the same shape as the
+monorepo's SLAM-oriented [`slam-evals`](../../slam-evals/docs/schema.md) package
+(COLMAP rig/sensor model) so a recording made here drops into the same mental
+model and could be ingested by the same tooling later. This is the *entity
+schema* only — `live-rerun` does **not** implement SLAM; it just logs a layout a
+future SLAM pass can drive.
+
+Nothing in the logging core (`rerun_video_logger.py`, `blueprint.py`,
+`rig.py`) knows the word "oak". Vendor specifics live under `sources/` and in
+`calibration.py`, which translate a device's calibration into the generic
+[`RigCalibration`](../src/live_rerun/rig.py) the core consumes.
+
+## Transform notation
+
+Right-to-left composition, matching `slam-evals` and the project-wide rule:
+
+```
+cam_points     = cam_T_world @ world_points        # world  → camera
+world_points   = world_T_cam @ cam_points          # camera → world
+world_T_cam    = world_T_rig @ rig_T_cam           # composes along the entity tree
+```
+
+A `Transform3D` logged at `/a/b` is the parent-to-child step Rerun multiplies
+when walking the entity path. `simplecv.rerun_log_utils.log_pinhole` logs the
+camera extrinsic as `Transform3D(..., from_parent=True)`, so the value stored at
+`/world/rig_00/cam_<NN>` is `rig_T_cam` (here the rig frame *is* the reference
+camera's frame, see below).
+
+## Entity tree
+
+```
+/world                          ViewCoordinates.RDF (static)
+  /rig_00                       AnyValues{schema_version, reference, num_cameras}
+                                NO transform -> implicit identity now; a future
+                                SLAM pass logs world_T_rig here over the timeline
+    /cam_00                     Transform3D = rig_T_cam_00 (static)
+                                AnyValues{name, kind}
+      /pinhole                  Pinhole / PinholeWithDistortion (static)
+        /video                  VideoStream (encoded H.265/H.264 samples,
+                                device_time timeline)
+    /cam_01
+      /pinhole/video
+    /cam_02
+      /pinhole/video
+    /imu_<NN>                   (reserved — see "Reserved sensors")
+```
+
+Entity ids are **zero-padded to two digits** (`cam_00`, `rig_00`, `imu_00`) so
+they sort lexicographically in numeric order — `cam_02` sorts before `cam_10`,
+whereas a single digit would put `cam_10` first. (This is the one deliberate
+divergence from `slam-evals`, which uses single-digit `rig_0`/`cam_0`.)
+
+- The rig is stationary today, so the per-sensor `Transform3D` and `Pinhole` are
+  logged once as **static**, and the rig node itself carries **no transform**
+  (implicit identity). The per-frame `VideoStream` samples are the only
+  time-varying data, on a shared `device_time` timeline. A future SLAM pass logs
+  `world_T_rig` **temporally** on `/world/rig_00`, moving every sensor rigidly —
+  logging a *static* identity there would shadow that temporal pose and trip
+  Rerun's "static + temporal" conflict, so we deliberately omit it.
+- All entities use metres and the OpenCV `RDF` (Right-Down-Forward) camera
+  convention, logged as `ViewCoordinates.RDF` at `/world`.
+
+## Naming conventions
+
+- **`rig_<NN>`** — zero-padded rig root. A single device is `rig_00`; the index
+  anticipates multi-rig setups (matches `slam-evals`, modulo the padding).
+- **`cam_<NN>`** — zero-padded sensors, peers under the rig. The path index is
+  system-agnostic; the human role (`left`/`rgb`/`right`) rides in metadata, not
+  the path, so any multicam system maps onto the same tree.
+- **Reference sensor = `cam_00`** — the sensor whose `rig_T_cam` is identity (the
+  rig origin). Its frustum is tinted green in the viewer. For the OAK backend the
+  reference is the **left** camera (CAM_B): SLAM is run around the left camera, so
+  the whole rig moves rigidly with it. `rgb`/`right` are expressed relative to it.
+
+### OAK backend mapping
+
+| entity   | OAK socket   | `name`  | `kind`      | role               |
+|----------|--------------|---------|-------------|--------------------|
+| `cam_00` | CAM_B (mono) | `left`  | `grayscale` | reference (origin) |
+| `cam_01` | CAM_A (color)| `rgb`   | `rgb`       | —                  |
+| `cam_02` | CAM_C (mono) | `right` | `grayscale` | —                  |
+
+## Metadata
+
+Metadata is logged as **static `rr.AnyValues`** on the relevant entity (no
+recording-property plumbing required), so it is discoverable by selecting the
+entity in the viewer:
+
+- per sensor, on `/world/rig_00/cam_<NN>`: `name` (role label) and `kind` (one of
+  the reserved sensor kinds below).
+- once, on `/world/rig_00`: `schema_version` (`"live-rerun-rig:v1"`),
+  `reference` (e.g. `"cam_00"`), and `num_cameras`.
+
+A loader can read `schema_version` to validate the layout and `reference` to
+find the rig origin.
+
+## Reserved sensors
+
+`live_rerun.rig.SensorKind` reserves `depth` and `imu` alongside the emitted
+`rgb`/`grayscale`. They are **not logged today**:
+
+- **IMU** would land at `/world/rig_00/imu_00` as a peer of the cameras (a static
+  `rig_T_imu` transform plus `gyro`/`accel` scalars), exactly as in
+  `slam-evals`. There is **no IMU backend**: on the target OAK-D-W unit even a
+  minimal IMU stream crashes the device (`INTERNAL_ERROR_CORE` / `IMUHalTask`,
+  see the README). Do not enable it without deliberately testing that failure.
+- **depth** would hang off a camera's pinhole (`…/cam_<NN>/pinhole/depth`).
+
+Adding either is mechanical (a new peer entity + `kind`) and needs no change to
+the existing schema.
+
+## References
+
+- COLMAP rig/sensor model: <https://colmap.github.io/concepts.html#rigs>
+- slam-evals schema (the SLAM-side counterpart): [`../../slam-evals/docs/schema.md`](../../slam-evals/docs/schema.md)
+- simplecv exo/ego schema (related, many-cams-as-many-rigs): [`../../simplecv/docs/exoego_schema.md`](../../simplecv/docs/exoego_schema.md)

--- a/packages/live-rerun/src/live_rerun/apis/oak_live_rerun.py
+++ b/packages/live-rerun/src/live_rerun/apis/oak_live_rerun.py
@@ -19,7 +19,7 @@ import rerun as rr
 from simplecv.rerun_log_utils import RerunTyroConfig
 
 from live_rerun.blueprint import create_blueprint
-from live_rerun.calibration import oak_calibration_to_pinholes
+from live_rerun.calibration import oak_calibration_to_rig
 from live_rerun.rerun_video_logger import RerunVideoLogger
 from live_rerun.sources.depthai import DepthAiConfig, OakSource
 
@@ -47,9 +47,9 @@ def main(config: OakLiveRerunConfig) -> None:
         print("device:", source.device.getDeviceInfo(), flush=True)
         print("usb_speed:", source.device.getUsbSpeed(), flush=True)
 
-        pinholes = oak_calibration_to_pinholes(source.calibrations)
-        logger = RerunVideoLogger(pinholes, config.source.codec, image_plane_distance=config.image_plane_distance)
-        rr.send_blueprint(create_blueprint(logger.video_paths), make_active=True)
+        rig = oak_calibration_to_rig(source.calibrations)
+        logger = RerunVideoLogger(rig, config.source.codec, image_plane_distance=config.image_plane_distance)
+        rr.send_blueprint(create_blueprint(logger.pinhole_paths), make_active=True)
         logger.log_static()
 
         deadline: float | None = None if config.seconds is None else time.monotonic() + config.seconds

--- a/packages/live-rerun/src/live_rerun/blueprint.py
+++ b/packages/live-rerun/src/live_rerun/blueprint.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 import rerun.blueprint as rrb
 
 
-def create_blueprint(video_paths: dict[str, str], *, world_path: str = "world") -> rrb.Blueprint:
+def create_blueprint(panels: dict[str, str], *, world_path: str = "world") -> rrb.Blueprint:
     """Build the default layout: 3D rig frusta on top, video streams side by side below.
 
-    ``video_paths`` maps each camera label to its ``.../pinhole/video`` entity path
-    (as produced by :class:`live_rerun.rerun_video_logger.RerunVideoLogger`).
+    ``panels`` maps each panel's display name to the entity it shows. Use the
+    canonical ``cam_<NN>`` ids as keys (e.g. :attr:`RerunVideoLogger.pinhole_paths`)
+    so the 2D panel titles match the 3D entity tree; the human role label
+    (``left``/``rgb``/``right``) is available as per-sensor metadata.
     """
-    video_views: list[rrb.Spatial2DView] = [rrb.Spatial2DView(name=label, origin=path) for label, path in video_paths.items()]
+    video_views: list[rrb.Spatial2DView] = [rrb.Spatial2DView(name=name, origin=origin) for name, origin in panels.items()]
     return rrb.Blueprint(
         rrb.Vertical(
             rrb.Spatial3DView(name="rig", origin=world_path),

--- a/packages/live-rerun/src/live_rerun/calibration.py
+++ b/packages/live-rerun/src/live_rerun/calibration.py
@@ -1,12 +1,19 @@
-"""Device-free conversion of an OAK/DepthAI calibration into simplecv pinholes.
+"""Device-free conversion of an OAK/DepthAI calibration into a generic rig.
 
 The DepthAI-touching extraction lives in :mod:`live_rerun.sources.depthai`; this
 module takes the already-extracted raw values (a 3x3 K matrix at the *encoded*
-resolution, the Brown-Conrady distortion coefficients, and the 4x4 transform from
-the reference camera, with translation in **centimetres** as DepthAI reports it)
-and builds :class:`simplecv.camera_parameters.PinholeParameters`. Keeping it pure
-makes the unit-prone bits (cm->m, K at encoded resolution, extrinsics direction)
-testable without a camera attached.
+resolution, the Brown-Conrady distortion coefficients, and the 4x4 transform
+relative to the **reference** camera, with translation in **centimetres** as
+DepthAI reports it) and builds the system-agnostic :class:`live_rerun.rig`
+descriptors (:class:`~live_rerun.rig.CameraSensor` /
+:class:`~live_rerun.rig.RigCalibration`) the core logger consumes. Keeping it
+pure makes the unit-prone bits (cm->m, K at encoded resolution, extrinsics
+direction, reference identity) testable without a camera attached.
+
+The reference sensor is the OAK's **left** mono camera (CAM_B): it gets the
+identity ``rig_T_cam`` pose (the rig origin), and ``rgb``/``right`` are expressed
+relative to it. SLAM is run around the left camera, so the rig moves rigidly
+with it.
 """
 
 from __future__ import annotations
@@ -23,6 +30,8 @@ from simplecv.camera_parameters import (
     PinholeParameters,
 )
 
+from live_rerun.rig import CameraSensor, RigCalibration, SensorKind, entity_id
+
 # DepthAI reports extrinsic translations in centimetres; simplecv / Rerun log in
 # metres. See getCameraExtrinsics docs and the calibration_reader example.
 _CM_TO_M: float = 0.01
@@ -35,9 +44,10 @@ class OakCameraCalib:
     ``k_matrix`` must already be scaled to ``(width, height)`` of the encoded
     stream (``getCameraIntrinsics(socket, width, height)`` does this). ``distortion``
     is the DepthAI coefficient list, whose order matches
-    :class:`~simplecv.camera_parameters.BrownConradyDistortion`. ``ref_T_cam_cm`` is
-    the 4x4 world->camera transform from the reference camera with translation in
-    centimetres, or ``None`` for the reference camera itself (identity pose).
+    :class:`~simplecv.camera_parameters.BrownConradyDistortion`. ``kind`` is the
+    image content (``"rgb"`` / ``"grayscale"``). ``ref_T_cam_cm`` is the 4x4
+    reference->camera transform with translation in centimetres, or ``None`` for
+    the reference camera itself (identity pose, the rig origin).
     """
 
     label: str
@@ -45,17 +55,19 @@ class OakCameraCalib:
     height: int
     k_matrix: Float[ndarray, "3 3"]
     distortion: list[float]
+    kind: SensorKind
     ref_T_cam_cm: Float[ndarray, "4 4"] | None = None
 
 
 def _extrinsics_from_ref(ref_T_cam_cm: Float[ndarray, "4 4"] | None) -> Extrinsics:
-    """Build world->camera extrinsics, converting the translation from cm to m.
+    """Build rig->camera extrinsics, converting the translation from cm to m.
 
-    The reference camera (``None``) is the world origin (identity pose). For the
+    The reference camera (``None``) is the rig origin (identity pose). For the
     others, DepthAI's ``getCameraExtrinsics(reference, socket)`` returns the 4x4
-    that maps a point from the reference frame into ``socket``'s frame, i.e. the
-    world->camera transform, so the rotation/translation map straight onto
-    ``world_R_cam`` / ``world_t_cam``.
+    that maps a point from the reference frame into ``socket``'s frame. Because
+    the reference camera *is* the rig frame, that rotation/translation map
+    straight onto ``world_R_cam`` / ``world_t_cam`` (here "world" == rig frame),
+    i.e. ``rig_T_cam``.
     """
     if ref_T_cam_cm is None:
         return Extrinsics(world_R_cam=np.eye(3), world_t_cam=np.zeros(3))
@@ -74,25 +86,37 @@ def _distortion_from_coeffs(coeffs: list[float]) -> BrownConradyDistortion | Non
     return BrownConradyDistortion(*values)
 
 
-def oak_calibration_to_pinholes(calibs: list[OakCameraCalib]) -> dict[str, PinholeParameters]:
-    """Convert extracted OAK calibrations into simplecv pinholes keyed by label.
+def oak_calibration_to_rig(calibs: list[OakCameraCalib]) -> RigCalibration:
+    """Convert extracted OAK calibrations into a generic :class:`RigCalibration`.
 
-    Intrinsics use the OpenCV ``RDF`` convention (DepthAI/OpenCV native). The K
-    matrix must already correspond to the encoded resolution so the projected
-    video fills the camera frustum.
+    ``calibs`` is ordered (reference first); each camera's list position becomes
+    its ``cam_<index>`` entity index. Intrinsics use the OpenCV ``RDF`` convention
+    (DepthAI/OpenCV native); the K matrix must already correspond to the encoded
+    resolution so the projected video fills the camera frustum. Exactly one
+    camera must be the reference (``ref_T_cam_cm is None``, the rig origin); it
+    defines ``reference_index``. A ``ValueError`` is raised otherwise, so a
+    malformed backend can't silently mislabel a non-identity camera as the origin.
     """
-    pinholes: dict[str, PinholeParameters] = {}
-    for calib in calibs:
+    reference_indices: list[int] = [index for index, calib in enumerate(calibs) if calib.ref_T_cam_cm is None]
+    if len(reference_indices) != 1:
+        raise ValueError(
+            f"a rig needs exactly one reference camera (the rig origin, with ref_T_cam_cm=None); "
+            f"got {len(reference_indices)} of {len(calibs)} cameras"
+        )
+    reference_index: int = reference_indices[0]
+    cameras: list[CameraSensor] = []
+    for index, calib in enumerate(calibs):
         intrinsics: Intrinsics = Intrinsics.from_k_matrix(
             camera_conventions="RDF",
             k_matrix=np.asarray(calib.k_matrix, dtype=float),
             height=calib.height,
             width=calib.width,
         )
-        pinholes[calib.label] = PinholeParameters(
-            name=f"oak_{calib.label}",
+        pinhole = PinholeParameters(
+            name=entity_id("cam", index),
             extrinsics=_extrinsics_from_ref(calib.ref_T_cam_cm),
             intrinsics=intrinsics,
             distortion=_distortion_from_coeffs(calib.distortion),
         )
-    return pinholes
+        cameras.append(CameraSensor(index=index, name=calib.label, kind=calib.kind, pinhole=pinhole))
+    return RigCalibration(cameras=cameras, reference_index=reference_index)

--- a/packages/live-rerun/src/live_rerun/rerun_video_logger.py
+++ b/packages/live-rerun/src/live_rerun/rerun_video_logger.py
@@ -1,10 +1,28 @@
-"""Generic, sensor-agnostic logging of encoded video into Rerun ``VideoStream``.
+"""Generic, system-agnostic logging of encoded video into Rerun ``VideoStream``.
 
-This core knows nothing about DepthAI. It logs a stationary multi-camera rig
-(intrinsics + extrinsics as pinholes, once, statically) and then forwards each
-already-encoded H.264/H.265 sample straight into ``rr.VideoStream`` on a shared
-``device_time`` timeline. No decode/encode happens here — the camera's hardware
-encoder bytes pass through untouched.
+This core knows nothing about any specific camera vendor. It logs a multi-sensor
+**rig** (per :mod:`live_rerun.rig`) following the COLMAP-aligned entity layout
+shared with ``packages/slam-evals`` and then forwards each already-encoded
+H.264/H.265 sample straight into ``rr.VideoStream`` on a shared ``device_time``
+timeline. No decode/encode happens here — the camera's hardware encoder bytes
+pass through untouched.
+
+Entity layout (see ``packages/live-rerun/docs/rig_schema.md``)::
+
+    /world                              ViewCoordinates (static)
+      /rig_00                           AnyValues schema metadata (static); NO
+                                        transform -> implicit identity now. A
+                                        future SLAM pass logs world_T_rig here
+                                        *temporally*.
+        /cam_00                         Transform3D = rig_T_cam (static)
+                                        + AnyValues(name, kind) (static)
+          /pinhole                      Pinhole/PinholeWithDistortion (static)
+            /video                      VideoStream (encoded samples)
+
+The rig is stationary for now, so the per-sensor transforms/pinholes are logged
+once as static and the rig node carries no transform at all (implicit identity);
+the per-frame samples are the only time-varying data. Driving the rig node
+dynamically (a SLAM trajectory) then moves every sensor rigidly with it.
 """
 
 from __future__ import annotations
@@ -13,8 +31,9 @@ from pathlib import Path
 from typing import Literal
 
 import rerun as rr
-from simplecv.camera_parameters import PinholeParameters
 from simplecv.rerun_log_utils import log_pinhole
+
+from live_rerun.rig import RigCalibration, entity_id
 
 Codec = Literal["h264", "h265"]
 
@@ -23,54 +42,88 @@ _RR_CODECS: dict[Codec, rr.VideoCodec] = {
     "h265": rr.VideoCodec.H265,
 }
 
-#: Shared duration timeline (seconds) all camera streams are placed on so the
+#: Shared duration timeline (seconds) all sensor streams are placed on so the
 #: viewer can scrub every view together. See the Rerun video concept docs.
 DEVICE_TIMELINE: str = "device_time"
+
+#: Schema identifier logged on the rig root so loaders can validate the layout.
+SCHEMA_VERSION: str = "live-rerun-rig:v1"
+
+#: Frustum wireframe colour for the reference sensor (the rig origin), so it's
+#: trivially distinguishable in a multi-camera view. Matches slam-evals' green.
+REFERENCE_CAM_COLOR: tuple[int, int, int, int] = (40, 200, 80, 255)
 
 
 class RerunVideoLogger:
     """Logs a stationary encoded-video camera rig to Rerun.
 
-    Entity layout (per the repo idiom, e.g. multiview_calibration / quest3_oakd):
-    ``{world}`` (view coordinates) -> ``{rig}/{label}`` (Transform3D) ->
-    ``{rig}/{label}/pinhole`` (Pinhole) -> ``{rig}/{label}/pinhole/video``
-    (VideoStream). The video must sit under ``pinhole`` so it projects onto the
-    camera frustum.
+    Consumes a generic :class:`~live_rerun.rig.RigCalibration`; the entity paths,
+    reference highlight, and per-sensor metadata all follow from it, so this core
+    stays vendor-agnostic.
     """
 
     def __init__(
         self,
-        cameras: dict[str, PinholeParameters],
+        rig: RigCalibration,
         codec: Codec,
         *,
         world_path: str = "world",
-        rig_name: str = "oak",
+        rig_name: str = "rig_00",
         image_plane_distance: float = 0.02,
         view_coordinates: rr.components.ViewCoordinates | None = None,
     ) -> None:
-        self.cameras: dict[str, PinholeParameters] = cameras
+        self.rig: RigCalibration = rig
         self.codec: Codec = codec
         self.world_path: str = world_path
         self.rig_path: str = f"{world_path}/{rig_name}"
         self.image_plane_distance: float = image_plane_distance
         # Note: rr.ViewCoordinates.RDF is a *component* instance, not the archetype.
         self.view_coordinates: rr.components.ViewCoordinates = view_coordinates if view_coordinates is not None else rr.ViewCoordinates.RDF
-        self.video_paths: dict[str, str] = {label: f"{self.rig_path}/{label}/pinhole/video" for label in cameras}
+        # Frames are routed by the sensor's role name (the source yields that label);
+        # the cam_<NN> entity path is the canonical identity.
+        self.video_paths: dict[str, str] = {cam.name: f"{self.rig_path}/{entity_id('cam', cam.index)}/pinhole/video" for cam in rig.cameras}
+        # Keyed by the canonical cam_<NN> id for the blueprint, so 2D panels carry the
+        # same names as the 3D entity tree (role label lives in each sensor's metadata).
+        self.pinhole_paths: dict[str, str] = {entity_id("cam", cam.index): f"{self.rig_path}/{entity_id('cam', cam.index)}/pinhole" for cam in rig.cameras}
 
     def log_static(self) -> None:
-        """Log the world frame, per-camera pinholes/extrinsics, and codec — all static."""
+        """Log the world frame, rig schema, per-sensor pinholes/metadata, codec — all static."""
         rr.log(self.world_path, self.view_coordinates, static=True)
+        # The rig node carries NO static transform: it stays at implicit identity
+        # while stationary, leaving it free for a future SLAM pass to log
+        # ``world_T_rig`` *temporally* here. A static identity transform would
+        # shadow that temporal pose and trip Rerun's "static + temporal" warning.
+        rr.log(
+            self.rig_path,
+            rr.AnyValues(
+                schema_version=SCHEMA_VERSION,
+                reference=entity_id("cam", self.rig.reference_index),
+                num_cameras=len(self.rig.cameras),
+            ),
+            static=True,
+        )
         codec: rr.VideoCodec = _RR_CODECS[self.codec]
-        for label, pinhole in self.cameras.items():
+        for cam in self.rig.cameras:
+            cam_path: str = f"{self.rig_path}/{entity_id('cam', cam.index)}"
+            # log_pinhole logs the rig_T_cam Transform3D at cam_path and the
+            # PinholeWithDistortion at cam_path/pinhole.
             log_pinhole(
-                pinhole,
-                cam_log_path=Path(self.rig_path) / label,
+                cam.pinhole,
+                cam_log_path=Path(cam_path),
                 image_plane_distance=self.image_plane_distance,
                 static=True,
             )
-            rr.log(self.video_paths[label], rr.VideoStream(codec=codec), static=True)
+            if cam.index == self.rig.reference_index:
+                # Partial update: tint the reference sensor's frustum wireframe.
+                rr.log(
+                    f"{cam_path}/pinhole",
+                    rr.Pinhole.from_fields(image_plane_distance=self.image_plane_distance, color=REFERENCE_CAM_COLOR),
+                    static=True,
+                )
+            rr.log(cam_path, rr.AnyValues(name=cam.name, kind=cam.kind), static=True)
+            rr.log(self.video_paths[cam.name], rr.VideoStream(codec=codec), static=True)
 
-    def log_sample(self, label: str, sample: bytes, *, is_keyframe: bool, device_time_s: float) -> None:
-        """Forward one encoded frame to its camera's VideoStream on the shared timeline."""
+    def log_sample(self, name: str, sample: bytes, *, is_keyframe: bool, device_time_s: float) -> None:
+        """Forward one encoded frame to its sensor's VideoStream on the shared timeline."""
         rr.set_time(DEVICE_TIMELINE, duration=device_time_s)
-        rr.log(self.video_paths[label], rr.VideoStream.from_fields(sample=sample, is_keyframe=is_keyframe))
+        rr.log(self.video_paths[name], rr.VideoStream.from_fields(sample=sample, is_keyframe=is_keyframe))

--- a/packages/live-rerun/src/live_rerun/rig.py
+++ b/packages/live-rerun/src/live_rerun/rig.py
@@ -1,0 +1,69 @@
+"""Generic, system-agnostic rig schema (COLMAP-style), shared by the logging
+core and any sensor backend under ``sources/``.
+
+A **rig** is a set of sensors with fixed relative poses; one **reference
+sensor** defines the rig origin (its ``rig_T_sensor`` is identity) and every
+other sensor is a fixed offset from it. A future SLAM pass drives the rig pose
+(``world_T_rig``) over time; the whole rig then moves rigidly with the reference
+sensor.
+
+This mirrors the entity layout in ``packages/slam-evals/docs/schema.md``
+(``/world/rig_<i>/cam_<i>``, peer ``/world/rig_<i>/imu_<i>``) so a recording made
+here drops into the same mental model. Backends translate their device-specific
+calibration into these generic descriptors; the core never learns a vendor name.
+See ``packages/live-rerun/docs/rig_schema.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from simplecv.camera_parameters import PinholeParameters
+
+#: Reserved sensor kinds. Only ``rgb``/``grayscale`` (cameras) are emitted today.
+#: ``depth``/``imu`` are reserved so a future backend slots a new peer sensor in
+#: (e.g. ``/world/rig_00/imu_00``) without a vocabulary change — no IMU exists yet
+#: (it crashes the target OAK-D-W; see the README).
+SensorKind = Literal["rgb", "grayscale", "depth", "imu"]
+
+#: Zero-padded width for rig/sensor entity indices (``rig_00``, ``cam_00``,
+#: ``imu_00``). Two digits so ids sort lexicographically for any realistic rig
+#: (``cam_02`` before ``cam_10``); a single digit would sort ``cam_10`` first.
+INDEX_WIDTH: int = 2
+
+
+def entity_id(prefix: str, index: int) -> str:
+    """Format a zero-padded rig/sensor entity id, e.g. ``cam_03`` / ``rig_00``."""
+    return f"{prefix}_{index:0{INDEX_WIDTH}d}"
+
+
+@dataclass
+class CameraSensor:
+    """One camera in a rig.
+
+    ``pinhole`` carries intrinsics plus extrinsics expressed **relative to the
+    rig frame** — i.e. ``rig_T_cam`` — so the reference sensor's extrinsics are
+    identity. ``index`` selects the entity path ``cam_<NN>`` (zero-padded via
+    :func:`entity_id`, e.g. ``cam_00``); ``name`` is the human role label (e.g.
+    ``"left"``) logged as metadata; ``kind`` is the image content
+    (``"rgb"`` / ``"grayscale"``).
+    """
+
+    index: int
+    name: str
+    kind: SensorKind
+    pinhole: PinholeParameters
+
+
+@dataclass
+class RigCalibration:
+    """A rig's cameras plus which one is the reference (identity) sensor.
+
+    ``reference_index`` is the ``index`` of the camera whose ``rig_T_cam`` is
+    identity (the rig origin); it gets a distinct frustum colour in the viewer
+    and is recorded in the rig's schema metadata.
+    """
+
+    cameras: list[CameraSensor] = field(default_factory=list)
+    reference_index: int = 0

--- a/packages/live-rerun/src/live_rerun/sources/depthai.py
+++ b/packages/live-rerun/src/live_rerun/sources/depthai.py
@@ -22,16 +22,19 @@ import numpy as np
 
 from live_rerun.calibration import OakCameraCalib
 from live_rerun.rerun_video_logger import Codec
+from live_rerun.rig import SensorKind
 
-# label -> board socket. RGB is the rig reference frame (CAM_A). Ordered
-# left -> rgb -> right to match the physical layout; this order flows through to
-# the calibration list, video paths, and the side-by-side 2D views.
-_SOCKETS: dict[str, dai.CameraBoardSocket] = {
-    "left": dai.CameraBoardSocket.CAM_B,
-    "rgb": dai.CameraBoardSocket.CAM_A,
-    "right": dai.CameraBoardSocket.CAM_C,
-}
-_REFERENCE_LABEL: str = "rgb"
+# (label, board socket, image kind). Ordered reference-first: the LEFT mono
+# camera (CAM_B) is the rig reference frame (identity -> cam_00); rgb (CAM_A) and
+# right (CAM_C) follow. This order flows through to the calibration list, the
+# cam_<index> entity paths, the video paths, and the side-by-side 2D views.
+_SENSORS: tuple[tuple[str, dai.CameraBoardSocket, SensorKind], ...] = (
+    ("left", dai.CameraBoardSocket.CAM_B, "grayscale"),
+    ("rgb", dai.CameraBoardSocket.CAM_A, "rgb"),
+    ("right", dai.CameraBoardSocket.CAM_C, "grayscale"),
+)
+_REFERENCE_LABEL: str = "left"
+_SOCKETS: dict[str, dai.CameraBoardSocket] = {label: socket for label, socket, _ in _SENSORS}
 
 _PROFILES: dict[Codec, dai.VideoEncoderProperties.Profile] = {
     "h264": dai.VideoEncoderProperties.Profile.H264_MAIN,
@@ -129,11 +132,11 @@ def _read_calibration(device: dai.Device, encoded_size: dict[str, tuple[int, int
     calib: dai.CalibrationHandler = device.readCalibration()
     reference_socket: dai.CameraBoardSocket = _SOCKETS[_REFERENCE_LABEL]
     calibs: list[OakCameraCalib] = []
-    for label, socket in _SOCKETS.items():
+    for label, socket, kind in _SENSORS:
         width, height = encoded_size[label]
         k_matrix = np.asarray(calib.getCameraIntrinsics(socket, width, height), dtype=float)
         distortion = [float(c) for c in calib.getDistortionCoefficients(socket)]
-        # RGB (reference) has the identity pose; the others are relative to it.
+        # The reference camera (left) has the identity pose; the others are relative to it.
         ref_T_cam_cm = (
             None if label == _REFERENCE_LABEL else np.asarray(calib.getCameraExtrinsics(reference_socket, socket, False), dtype=float)
         )
@@ -144,6 +147,7 @@ def _read_calibration(device: dai.Device, encoded_size: dict[str, tuple[int, int
                 height=height,
                 k_matrix=k_matrix,
                 distortion=distortion,
+                kind=kind,
                 ref_T_cam_cm=ref_T_cam_cm,
             )
         )

--- a/packages/live-rerun/tests/test_calibration.py
+++ b/packages/live-rerun/tests/test_calibration.py
@@ -1,46 +1,116 @@
-"""Device-free tests for the OAK calibration -> simplecv pinhole conversion.
+"""Device-free tests for the OAK calibration -> generic rig conversion.
 
 These guard the unit-prone bits: cm->m on extrinsic translation, the K matrix
-flowing through at the encoded resolution, reference-camera identity pose, and
-distortion handling. No OAK device required.
+flowing through at the encoded resolution, the reference camera (left) getting
+the identity pose, index/name/kind propagation, and distortion handling. No OAK
+device required.
 """
 
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
-from live_rerun.calibration import OakCameraCalib, oak_calibration_to_pinholes
+from live_rerun.calibration import OakCameraCalib, oak_calibration_to_rig
+from live_rerun.rig import RigCalibration, entity_id
 
 
 def _k(fx: float = 800.0, fy: float = 800.0, cx: float = 640.0, cy: float = 360.0) -> np.ndarray:
     return np.array([[fx, 0.0, cx], [0.0, fy, cy], [0.0, 0.0, 1.0]], dtype=float)
 
 
-def test_reference_camera_has_identity_pose() -> None:
-    rgb = OakCameraCalib(label="rgb", width=1920, height=1080, k_matrix=_k(), distortion=[], ref_T_cam_cm=None)
-    pinholes = oak_calibration_to_pinholes([rgb])
+def _calib(
+    label: str,
+    kind: str,
+    ref_T_cam_cm: np.ndarray | None,
+    *,
+    k_matrix: np.ndarray | None = None,
+    width: int = 1280,
+    height: int = 720,
+    distortion: list[float] | None = None,
+) -> OakCameraCalib:
+    return OakCameraCalib(
+        label=label,
+        width=width,
+        height=height,
+        k_matrix=_k() if k_matrix is None else k_matrix,
+        distortion=distortion or [],
+        kind=kind,  # type: ignore[arg-type]
+        ref_T_cam_cm=ref_T_cam_cm,
+    )
 
-    pose = pinholes["rgb"].extrinsics
+
+def _ordered_rig() -> RigCalibration:
+    """A realistic left(reference)/rgb/right rig as the source yields it."""
+    rgb_ext = np.eye(4)
+    rgb_ext[:3, 3] = [7.5, -2.0, 0.0]  # centimetres, as DepthAI reports
+    right_ext = np.eye(4)
+    right_ext[:3, 3] = [-7.5, 0.0, 0.0]
+    return oak_calibration_to_rig(
+        [
+            _calib("left", "grayscale", None),
+            _calib("rgb", "rgb", rgb_ext),
+            _calib("right", "grayscale", right_ext),
+        ]
+    )
+
+
+def test_entity_id_is_zero_padded_and_sorts_lexicographically() -> None:
+    assert entity_id("cam", 0) == "cam_00"
+    assert entity_id("rig", 0) == "rig_00"
+    assert entity_id("imu", 7) == "imu_07"
+    assert entity_id("cam", 12) == "cam_12"
+    # The reason for padding: lexicographic order matches numeric order.
+    ids = [entity_id("cam", i) for i in (10, 2, 0, 12)]
+    assert sorted(ids) == ["cam_00", "cam_02", "cam_10", "cam_12"]
+
+
+def test_left_is_reference_with_identity_pose() -> None:
+    rig = _ordered_rig()
+
+    assert rig.reference_index == 0
+    cam0 = rig.cameras[0]
+    assert (cam0.index, cam0.name, cam0.kind) == (0, "left", "grayscale")
+    pose = cam0.pinhole.extrinsics
     assert pose.cam_t_world is not None
     np.testing.assert_allclose(pose.world_T_cam, np.eye(4))
     np.testing.assert_allclose(pose.cam_t_world, np.zeros(3))
-    assert pinholes["rgb"].name == "oak_rgb"
+    assert cam0.pinhole.name == "cam_00"
 
 
-def test_extrinsic_translation_converted_cm_to_m() -> None:
-    ref_T_cam_cm = np.eye(4)
-    ref_T_cam_cm[:3, 3] = [7.5, -2.0, 0.0]  # centimetres, as DepthAI reports
-    left = OakCameraCalib(label="left", width=1280, height=800, k_matrix=_k(), distortion=[], ref_T_cam_cm=ref_T_cam_cm)
+def test_indices_names_kinds_follow_input_order() -> None:
+    rig = _ordered_rig()
 
-    pose = oak_calibration_to_pinholes([left])["left"].extrinsics
-    assert pose.world_t_cam is not None
-    np.testing.assert_allclose(pose.world_t_cam, [0.075, -0.02, 0.0])
+    assert [(c.index, c.name, c.kind) for c in rig.cameras] == [
+        (0, "left", "grayscale"),
+        (1, "rgb", "rgb"),
+        (2, "right", "grayscale"),
+    ]
+
+
+def test_non_reference_translation_converted_cm_to_m() -> None:
+    rig = _ordered_rig()
+
+    rgb_pose = rig.cameras[1].pinhole.extrinsics
+    assert rgb_pose.world_t_cam is not None
+    np.testing.assert_allclose(rgb_pose.world_t_cam, [0.075, -0.02, 0.0])
+
+
+def test_requires_exactly_one_reference_camera() -> None:
+    offset = np.eye(4)
+    offset[:3, 3] = [1.0, 0.0, 0.0]
+    # zero reference cameras (none at identity)
+    with pytest.raises(ValueError, match="exactly one reference"):
+        oak_calibration_to_rig([_calib("left", "grayscale", offset), _calib("rgb", "rgb", offset)])
+    # multiple reference cameras (two at identity)
+    with pytest.raises(ValueError, match="exactly one reference"):
+        oak_calibration_to_rig([_calib("left", "grayscale", None), _calib("rgb", "rgb", None)])
 
 
 def test_intrinsics_use_encoded_resolution_and_k() -> None:
     k = _k(fx=1234.0, fy=1240.0, cx=960.0, cy=540.0)
-    rgb = OakCameraCalib(label="rgb", width=1920, height=1080, k_matrix=k, distortion=[], ref_T_cam_cm=None)
-    intr = oak_calibration_to_pinholes([rgb])["rgb"].intrinsics
+    rig = oak_calibration_to_rig([_calib("left", "grayscale", None, k_matrix=k, width=1920, height=1080)])
+    intr = rig.cameras[0].pinhole.intrinsics
 
     assert (intr.width, intr.height) == (1920, 1080)
     assert intr.fl_x == 1234.0 and intr.fl_y == 1240.0
@@ -50,10 +120,10 @@ def test_intrinsics_use_encoded_resolution_and_k() -> None:
 
 def test_distortion_built_from_coeffs_and_skipped_when_too_few() -> None:
     coeffs = [0.1, -0.2, 0.001, -0.002, 0.05] + [0.0] * 9  # 14 DepthAI coeffs
-    with_dist = OakCameraCalib(label="rgb", width=1920, height=1080, k_matrix=_k(), distortion=coeffs, ref_T_cam_cm=None)
-    dist = oak_calibration_to_pinholes([with_dist])["rgb"].distortion
+    with_dist = oak_calibration_to_rig([_calib("left", "grayscale", None, distortion=coeffs)])
+    dist = with_dist.cameras[0].pinhole.distortion
     assert dist is not None
     assert (dist.k1, dist.k2, dist.p1, dist.p2, dist.k3) == (0.1, -0.2, 0.001, -0.002, 0.05)
 
-    no_dist = OakCameraCalib(label="rgb", width=1920, height=1080, k_matrix=_k(), distortion=[0.1, 0.2], ref_T_cam_cm=None)
-    assert oak_calibration_to_pinholes([no_dist])["rgb"].distortion is None
+    no_dist = oak_calibration_to_rig([_calib("left", "grayscale", None, distortion=[0.1, 0.2])])
+    assert no_dist.cameras[0].pinhole.distortion is None

--- a/packages/live-rerun/tests/test_import.py
+++ b/packages/live-rerun/tests/test_import.py
@@ -8,6 +8,7 @@ import importlib
 def test_modules_import() -> None:
     for name in (
         "live_rerun",
+        "live_rerun.rig",
         "live_rerun.calibration",
         "live_rerun.rerun_video_logger",
         "live_rerun.blueprint",

--- a/packages/live-rerun/tests/test_logger.py
+++ b/packages/live-rerun/tests/test_logger.py
@@ -1,0 +1,116 @@
+"""Device-free tests for RerunVideoLogger + create_blueprint.
+
+The dev-env rerun (0.33) exposes no dataframe read API, so instead of reading an
+``.rrd`` back we (a) assert the deterministic path dicts directly and (b) capture
+``rr.log`` calls via monkeypatch to verify the exact entity layout ``log_static``
+produces — including the load-bearing invariants the refactor introduced (the rig
+node has NO transform; the green reference tint lands on ``cam_00`` only).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import rerun as rr
+
+from live_rerun.blueprint import create_blueprint
+from live_rerun.calibration import OakCameraCalib, oak_calibration_to_rig
+from live_rerun.rerun_video_logger import SCHEMA_VERSION, RerunVideoLogger
+
+
+def _k() -> np.ndarray:
+    return np.array([[800.0, 0.0, 640.0], [0.0, 800.0, 360.0], [0.0, 0.0, 1.0]], dtype=float)
+
+
+def _rig():
+    """A left(reference)/rgb/right rig, as the OAK source yields it (left = cam_00)."""
+    rgb_ext = np.eye(4)
+    rgb_ext[:3, 3] = [-3.7, 0.0, 0.0]
+    right_ext = np.eye(4)
+    right_ext[:3, 3] = [-7.5, 0.0, 0.0]
+    return oak_calibration_to_rig(
+        [
+            OakCameraCalib("left", 1280, 720, _k(), [], "grayscale", None),
+            OakCameraCalib("rgb", 1280, 720, _k(), [], "rgb", rgb_ext),
+            OakCameraCalib("right", 1280, 720, _k(), [], "grayscale", right_ext),
+        ]
+    )
+
+
+def _capture(monkeypatch) -> list[tuple[str, list[str]]]:
+    """Patch ``rr.log`` to record (entity_path, [component type names]) per call."""
+    calls: list[tuple[str, list[str]]] = []
+
+    def fake_log(entity_path, *components, **_):
+        calls.append((str(entity_path), [type(c).__name__ for c in components]))
+
+    monkeypatch.setattr(rr, "log", fake_log)
+    return calls
+
+
+def test_video_and_pinhole_path_dicts() -> None:
+    logger = RerunVideoLogger(_rig(), "h265")
+    # video_paths: keyed by role name (frames route by label), value ends at /video
+    assert logger.video_paths == {
+        "left": "world/rig_00/cam_00/pinhole/video",
+        "rgb": "world/rig_00/cam_01/pinhole/video",
+        "right": "world/rig_00/cam_02/pinhole/video",
+    }
+    # pinhole_paths: keyed by canonical cam_NN (blueprint panels), value ends at /pinhole
+    assert logger.pinhole_paths == {
+        "cam_00": "world/rig_00/cam_00/pinhole",
+        "cam_01": "world/rig_00/cam_01/pinhole",
+        "cam_02": "world/rig_00/cam_02/pinhole",
+    }
+
+
+def test_log_static_entity_layout(monkeypatch) -> None:
+    calls = _capture(monkeypatch)
+    RerunVideoLogger(_rig(), "h265").log_static()
+
+    pairs = [(entity, comp) for entity, comps in calls for comp in comps]
+    entities = {entity for entity, _ in calls}
+
+    assert {"world", "world/rig_00"} <= entities
+    for cam in ("cam_00", "cam_01", "cam_02"):
+        assert {f"world/rig_00/{cam}", f"world/rig_00/{cam}/pinhole", f"world/rig_00/{cam}/pinhole/video"} <= entities
+
+    # The rig node carries metadata but deliberately NO Transform3D (implicit
+    # identity, so a SLAM pass can drive world_T_rig temporally without a clash).
+    rig_components = [c for e, c in pairs if e == "world/rig_00"]
+    assert "AnyValues" in rig_components
+    assert not any("Transform3D" in c for c in rig_components)
+
+    # Each camera DOES carry a Transform3D (rig_T_cam) plus name/kind metadata.
+    for cam in ("cam_00", "cam_01", "cam_02"):
+        cam_components = [c for e, c in pairs if e == f"world/rig_00/{cam}"]
+        assert any("Transform3D" in c for c in cam_components)
+        assert "AnyValues" in cam_components
+
+    # The green reference tint (a bare Pinhole partial-update, distinct from
+    # log_pinhole's PinholeWithDistortion) lands on cam_00 (the reference) ONLY.
+    assert [e for e, c in pairs if c == "Pinhole"] == ["world/rig_00/cam_00/pinhole"]
+
+    # Every video entity gets a VideoStream (codec).
+    for cam in ("cam_00", "cam_01", "cam_02"):
+        assert any("VideoStream" in c for c in (comp for e, comp in pairs if e == f"world/rig_00/{cam}/pinhole/video"))
+
+
+def test_log_sample_routes_by_name_and_rejects_unknown(monkeypatch) -> None:
+    calls = _capture(monkeypatch)
+    logger = RerunVideoLogger(_rig(), "h265")
+    with rr.RecordingStream("test_live_rerun"):  # active recording so set_time is happy
+        logger.log_sample("rgb", b"\x00\x00\x00\x01x", is_keyframe=True, device_time_s=0.1)
+        assert calls[-1][0] == "world/rig_00/cam_01/pinhole/video"
+        with pytest.raises(KeyError):
+            logger.log_sample("bogus", b"", is_keyframe=False, device_time_s=0.0)
+
+
+def test_schema_version_constant() -> None:
+    assert SCHEMA_VERSION == "live-rerun-rig:v1"
+
+
+def test_create_blueprint_builds_from_pinhole_paths() -> None:
+    # Smoke: the wiring oak_live_rerun.py uses (logger.pinhole_paths -> panels) builds without error.
+    logger = RerunVideoLogger(_rig(), "h265")
+    assert create_blueprint(logger.pinhole_paths) is not None


### PR DESCRIPTION
## What & why

Refactors `live-rerun`'s Rerun entity model from OAK-specific paths (`world/oak/<cam>/…`) into a **generic, SLAM-ready multi-system rig schema**, COLMAP-style and aligned with the existing `packages/slam-evals` layout. A different multicam system (other camera, phone, …) now maps onto the same tree and opens identically. **No SLAM is implemented** — this is the entity/naming refactor only.

## Schema

```
/world                       ViewCoordinates.RDF (static)
  /rig_00                    schema metadata (static); NO transform = implicit
                             identity now — a SLAM pass logs world_T_rig here
    /cam_00                  left  — reference sensor (identity), frustum tinted green
      /pinhole/video         VideoStream (encoded H.265/H.264 samples)
    /cam_01                  rgb
    /cam_02                  right
```

- **Reference sensor `rgb` → `left` (CAM_B):** left is the identity rig origin (`cam_00`); rgb/right are expressed relative to it. SLAM runs around the left camera, so the whole rig moves rigidly with it.
- **System-agnostic indexed naming** `rig_NN`/`cam_NN` (no `oak`), zero-padded to two digits so ids sort lexicographically (`cam_02` before `cam_10`). The human role (`left`/`rgb`/`right`) and `kind` (`rgb`/`grayscale`; `depth`/`imu` reserved) ride in per-sensor static `rr.AnyValues`, not the path.
- **Rig node carries no static transform** (implicit identity) so a future SLAM pass can log `world_T_rig` temporally there without a static+temporal conflict.
- Schema block (`schema_version="live-rerun-rig:v1"`, `reference`, `num_cameras`) on the rig node; reference frustum tinted green.

## Code

- **New `live_rerun/rig.py`** — generic `SensorKind` / `CameraSensor` / `RigCalibration` + `entity_id()`. The logging core and blueprint never reference "oak".
- `calibration.py` — `oak_calibration_to_pinholes` → `oak_calibration_to_rig` (returns `RigCalibration`); requires exactly one reference camera (raises otherwise).
- `sources/depthai.py` — a `_SENSORS` table drives labels/sockets/kinds; OAK specifics stay in the backend.
- `blueprint.py` — 2D panels named by `cam_NN` to match the 3D entity tree.
- New `docs/rig_schema.md`; `README` updated.

## Testing

- Device-free unit tests: `oak_calibration_to_rig` (left = identity, cm→m, intrinsics, distortion, index/name/kind), `entity_id` zero-padding, the exactly-one-reference guard, and the logger/blueprint entity layout (incl. the no-transform-on-rig invariant and the `cam_00`-only green tint).
- `lint` / `typecheck` / `deadcode` / `tests` all green; on-device hardware capture test passes on a real OAK-D-W.
- Verified live on hardware, including a synthetic demo driving the rig node in a circle to confirm all sensors move rigidly with it.

## Notes

- Reviewed by a multi-agent adversarial pass (docs + correctness): no real bugs; one low-severity hardening (the exactly-one-reference guard) applied.
- Out of scope: simplecv's shared `log_pinhole` still passes the deprecated `from_parent=` to `Transform3D` — a monorepo-wide cleanup for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
