### PR TITLE
live-rerun: fix inverted OAK extrinsics (cam_T_world, not world_T_cam)

### DIFF
--- a/packages/live-rerun/src/live_rerun/calibration.py
+++ b/packages/live-rerun/src/live_rerun/calibration.py
@@ -64,18 +64,23 @@ def _extrinsics_from_ref(ref_T_cam_cm: Float[ndarray, "4 4"] | None) -> Extrinsi
 
     The reference camera (``None``) is the rig origin (identity pose). For the
     others, DepthAI's ``getCameraExtrinsics(reference, socket)`` returns the 4x4
-    that maps a point from the reference frame into ``socket``'s frame. Because
-    the reference camera *is* the rig frame, that rotation/translation map
-    straight onto ``world_R_cam`` / ``world_t_cam`` (here "world" == rig frame),
-    i.e. ``rig_T_cam``.
+    that maps a point **from the reference frame into ``socket``'s frame** — that
+    is ``cam_T_world`` (world->camera, "world" == rig), the matrix used directly in
+    the projection ``K @ cam_T_world``. So it fills ``cam_R_world`` / ``cam_t_world``;
+    the camera's *pose in the rig* (``world_T_cam``) is its inverse.
+
+    This is the subtle bit: feeding the transform into ``world_R_cam`` /
+    ``world_t_cam`` instead **inverts every non-reference camera** — frusta land on
+    the wrong side and triangulated points fall *behind* the cameras (verified on
+    an OAK-D-W: the person triangulated to negative depth until this was fixed).
     """
     if ref_T_cam_cm is None:
-        return Extrinsics(world_R_cam=np.eye(3), world_t_cam=np.zeros(3))
+        return Extrinsics(cam_R_world=np.eye(3), cam_t_world=np.zeros(3))
 
     transform: Float[ndarray, "4 4"] = np.asarray(ref_T_cam_cm, dtype=float)
-    world_R_cam: Float[ndarray, "3 3"] = transform[:3, :3].copy()
-    world_t_cam: Float[ndarray, "3"] = transform[:3, 3].copy() * _CM_TO_M
-    return Extrinsics(world_R_cam=world_R_cam, world_t_cam=world_t_cam)
+    cam_R_world: Float[ndarray, "3 3"] = transform[:3, :3].copy()
+    cam_t_world: Float[ndarray, "3"] = transform[:3, 3].copy() * _CM_TO_M
+    return Extrinsics(cam_R_world=cam_R_world, cam_t_world=cam_t_world)
 
 
 def _distortion_from_coeffs(coeffs: list[float]) -> BrownConradyDistortion | None:

--- a/packages/live-rerun/tests/test_calibration.py
+++ b/packages/live-rerun/tests/test_calibration.py
@@ -92,8 +92,25 @@ def test_non_reference_translation_converted_cm_to_m() -> None:
     rig = _ordered_rig()
 
     rgb_pose = rig.cameras[1].pinhole.extrinsics
-    assert rgb_pose.world_t_cam is not None
-    np.testing.assert_allclose(rgb_pose.world_t_cam, [0.075, -0.02, 0.0])
+    # DepthAI's getCameraExtrinsics(ref, socket) is cam_T_world (rig->cam), so the
+    # raw cm translation (scaled to m) is cam_t_world; the camera's pose in the rig
+    # (world_t_cam) is its inverse.
+    assert rgb_pose.cam_t_world is not None
+    np.testing.assert_allclose(rgb_pose.cam_t_world, [0.075, -0.02, 0.0])
+    np.testing.assert_allclose(rgb_pose.world_t_cam, [-0.075, 0.02, 0.0])
+
+
+def test_non_reference_camera_pose_is_inverse_of_depthai_transform() -> None:
+    """Regression: the depthai transform is cam_T_world (rig->cam), so the camera's
+    position in the rig is its INVERSE. The right camera (depthai -X translation)
+    must sit on the +X side; using the transform as world_T_cam inverts this, which
+    places the frustum on the wrong side and triangulates points behind the cameras.
+    """
+    rig = _ordered_rig()
+    right = rig.cameras[2].pinhole.extrinsics
+    # right_ext (depthai) translation was [-7.5, 0, 0] cm -> right camera sits at +X.
+    np.testing.assert_allclose(right.world_t_cam, [0.075, 0.0, 0.0], atol=1e-9)
+    np.testing.assert_allclose(right.cam_t_world, [-0.075, 0.0, 0.0], atol=1e-9)
 
 
 def test_requires_exactly_one_reference_camera() -> None:


### PR DESCRIPTION
## What

DepthAI's `getCameraExtrinsics(reference, socket)` returns `cam_T_world` (rig→cam) — the matrix used directly in projection as `K @ cam_T_world`. `oak_calibration_to_rig` was feeding it into simplecv's `Extrinsics(world_R_cam=…, world_t_cam=…)` (cam→world) slots, which **inverts every non-reference camera**: frusta land on the wrong side of the rig, and any downstream triangulation puts points behind the cameras.

**Fix:** build `Extrinsics(cam_R_world=…, cam_t_world=…)`. The camera's pose in the rig (`world_T_cam`, frustum placement) is then the inverse, computed by simplecv — not the raw matrix stored as a pose.

## Why it matters / how it was found

The reference (left) camera is unaffected because identity is its own inverse, so the bug only shows as the *other* cameras being mirrored — easy to miss visually.

Verified live on an OAK-D-W with a stereo rtmlib pose pipeline:

| | right-cam position in rig | triangulated nose depth (Z) |
|---|---|---|
| before (`world_T_cam`) | `[-0.075, 0, 0]` (wrong side) | **−0.62 m → behind the camera** |
| after (`cam_T_world`) | `[+0.075, 0, 0]` (correct side) | **+0.95 m → ~1 m in front** |

Post-fix stability ~6–8 mm lateral / 28 mm depth at ~1 m (consistent with a 7.5 cm baseline).

> ⚠️ Notably, **median reprojection residual stayed ~3.8 px even with every point behind the cameras** — reprojection residual is necessary but not sufficient to validate stereo geometry; depth sign must also be checked.

## Tests

- Corrected `test_non_reference_translation_converted_cm_to_m` to the right convention (the raw cm translation is `cam_t_world`; the camera's pose `world_t_cam` is its inverse).
- Added `test_non_reference_camera_pose_is_inverse_of_depthai_transform` pinning the right camera to the **+X** side so the inversion can't silently return.
- All 8 device-free calibration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
