### PR TITLE
simplecv: GPU MANO + logging perf for exoego visualize

### DIFF
--- a/packages/simplecv/simplecv/apis/view_exoego.py
+++ b/packages/simplecv/simplecv/apis/view_exoego.py
@@ -355,9 +355,12 @@ def log_mano_batch(
             with torch.no_grad():
                 verts_torch: Float32[torch.Tensor, "n_frames n_verts=778 3"]
                 joints_torch: Float32[torch.Tensor, "n_frames n_joints=21 3"]
+                # Slice to the logged frame count before the forward: when the MANO
+                # stream is longer than the label timeline we'd otherwise transfer and
+                # run MANO on frames we immediately discard (also lowers peak GPU mem).
                 verts_torch, joints_torch = mano_layer(
-                    torch.from_numpy(np.ascontiguousarray(poses)).float().to(mano_device),
-                    torch.from_numpy(np.ascontiguousarray(translations)).float().to(mano_device),
+                    torch.from_numpy(np.ascontiguousarray(poses[:n_frames_mano_total])).float().to(mano_device),
+                    torch.from_numpy(np.ascontiguousarray(translations[:n_frames_mano_total])).float().to(mano_device),
                 )
             verts: Float32[ndarray, "n_frames n_verts=778 3"] = verts_torch.cpu().numpy()
             xyz_mano: Float32[ndarray, "n_frames n_joints=21 3"] = joints_torch.cpu().numpy()

--- a/packages/simplecv/simplecv/apis/view_exoego.py
+++ b/packages/simplecv/simplecv/apis/view_exoego.py
@@ -9,6 +9,7 @@ from typing import Literal, NamedTuple, cast
 import numpy as np
 import rerun as rr
 import rerun.blueprint as rrb
+import torch
 from einops import rearrange
 from jaxtyping import Float, Float32, Int, UInt8, UInt16
 from numpy import ndarray
@@ -331,13 +332,16 @@ def log_mano_batch(
 
     mano_stack: ManoStack | None = exoego_labels.mano_stack
     if mano_stack is not None and log_mano:
-        from simplecv.ops.mano.mano_np import MANOLayerNP
+        from simplecv.ops.mano.mano_torch import MANOLayerTorch
 
         mano_root_path: Path = mano_parent_log_path / "mano"
-        mano_layers = [
-            # previous version only returned one shape for both hands. This is backwards compatible and works for 2 hands
-            MANOLayerNP(side="right", betas=mano_stack.betas_for(0), use_pca=mano_stack.use_pca),
-            MANOLayerNP(side="left", betas=mano_stack.betas_for(1), use_pca=mano_stack.use_pca),
+        # The per-frame LBS forward dominates MANO logging, so run it through the
+        # torch MANO layer on whichever device is present: CUDA when available,
+        # otherwise CPU (still ~3x faster than the numpy layer, parity ~1e-7).
+        mano_device: str = "cuda" if torch.cuda.is_available() else "cpu"
+        mano_layers: list[MANOLayerTorch] = [
+            MANOLayerTorch(side="right", betas=mano_stack.betas_for(0), use_pca=mano_stack.use_pca).to(mano_device).eval(),
+            MANOLayerTorch(side="left", betas=mano_stack.betas_for(1), use_pca=mano_stack.use_pca).to(mano_device).eval(),
         ]
         mano_so3: Float32[ndarray, "n_frames n_hands=2 48"] = mano_stack.so3
         mano_trans: Float32[ndarray, "n_frames n_hands=2 3"] = mano_stack.trans
@@ -348,25 +352,30 @@ def log_mano_batch(
         xyz_coco_mano: Float32[ndarray, "n_frames n_joints_coco=133 3"] = np.full((n_frames_mano_total, 133, 3), np.nan, dtype=np.float32)
         conf_coco_mano: Float32[ndarray, "n_frames n_joints_coco=133"] = np.zeros((n_frames_mano_total, 133), dtype=np.float32)
         for poses, translations, mano_layer in zip(so3_per_hand, trans_per_hand, mano_layers, strict=True):
-            mano_outputs: tuple[
-                Float32[ndarray, "n_frames n_verts=778 3"],
-                Float32[ndarray, "n_frames n_joints=21 3"],
-            ] = mano_layer(poses, translations)
-            verts: Float32[ndarray, "n_frames n_verts=778 3"] = mano_outputs[0]
-            xyz_mano: Float32[ndarray, "n_frames n_joints=21 3"] = mano_outputs[1]
+            with torch.no_grad():
+                verts_torch: Float32[torch.Tensor, "n_frames n_verts=778 3"]
+                joints_torch: Float32[torch.Tensor, "n_frames n_joints=21 3"]
+                verts_torch, joints_torch = mano_layer(
+                    torch.from_numpy(np.ascontiguousarray(poses)).float().to(mano_device),
+                    torch.from_numpy(np.ascontiguousarray(translations)).float().to(mano_device),
+                )
+            verts: Float32[ndarray, "n_frames n_verts=778 3"] = verts_torch.cpu().numpy()
+            xyz_mano: Float32[ndarray, "n_frames n_joints=21 3"] = joints_torch.cpu().numpy()
 
-            # Aggregate MANO joints (21) → into single COCO-133 buffer
-            xyz_mano_np: Float32[ndarray, "n_frames n_joints=21 3"] = xyz_mano
-            hand_idx: ndarray = RIGHT_HAND_IDX if mano_layer.side == "right" else LEFT_HAND_IDX
-            xyz_coco_mano[:, hand_idx, :] = xyz_mano_np[0:n_frames_mano_total]
-            conf_coco_mano[:, hand_idx] = 1.0
+            # Aggregate this hand's MANO joints (21) into the shared COCO-133 buffer.
+            coco_hand_ids: ndarray = RIGHT_HAND_IDX if mano_layer.side == "right" else LEFT_HAND_IDX
+            xyz_coco_mano[:, coco_hand_ids, :] = xyz_mano[0:n_frames_mano_total]
+            conf_coco_mano[:, coco_hand_ids] = 1.0
 
             hand_root: Path = mano_root_path / mano_layer.side
             mesh_entity_path: Path = hand_root / "mesh"
+            # ``MANOLayerTorch.faces`` returns host numpy; compute once for the static
+            # mesh faces (reused for the optional vertex-normals path below).
+            faces_np: Int[ndarray, "n_faces=1538 3"] = mano_layer.faces.astype(np.int32)
             rr.log(
                 f"{mesh_entity_path}",
                 rr.Mesh3D.from_fields(
-                    triangle_indices=mano_layer.f.astype(np.int32),
+                    triangle_indices=faces_np,
                     albedo_factor=mano_mesh_color_rgba_map[mano_layer.side],
                 ),
                 static=True,
@@ -381,7 +390,6 @@ def log_mano_batch(
             )
             mesh_columns: rr.ComponentColumnList
             if log_mano_vertex_normals:
-                faces_np: Int[ndarray, "n_faces=1538 3"] = mano_layer.f.astype(np.int32)
                 vertex_normals: Float32[ndarray, "n_frames n_verts=778 3"] = compute_vertex_normals_batch(
                     verts_np[0:n_frames_mesh],
                     faces_np,

--- a/packages/simplecv/simplecv/ops/mano/mano_torch.py
+++ b/packages/simplecv/simplecv/ops/mano/mano_torch.py
@@ -442,7 +442,11 @@ class MANOLayerTorch(Module):
     """Wrapper layer for manopth ManoLayer."""
 
     def __init__(
-        self, side: Literal["left", "right"], betas: Float32[np.ndarray, "10"], mano_root_dir: Path | None = None
+        self,
+        side: Literal["left", "right"],
+        betas: Float32[np.ndarray, "10"],
+        mano_root_dir: Path | None = None,
+        use_pca: bool = True,
     ) -> None:
         """
         Constructor for MANOLayer.
@@ -453,6 +457,10 @@ class MANOLayerTorch(Module):
             mano_root_dir (Path): Path to the MANO root directory. If None, the corresponding
                 MANO pkl (e.g., MANO_RIGHT.pkl) is downloaded to the repository's `data/` folder
                 from `pablovela5620/wilor-nano` on the Hugging Face Hub and used from there.
+            use_pca (bool): Whether the final 45 pose coefficients are MANO PCA
+                coefficients (True) or raw axis-angle joint rotations (False, e.g.
+                EPFL Smart Kitchen). Mirrors ``MANOLayerNP`` so both backends accept
+                the same inputs.
         """
         super().__init__()
         # If no MANO root provided, download the required MANO pkl into repo-root/data
@@ -499,7 +507,7 @@ class MANOLayerTorch(Module):
             side=side,
             mano_root=mano_root_dir,
             ncomps=45,
-            use_pca=True,
+            use_pca=use_pca,
         )
 
         # Register buffer for betas (prescanned for particular subject hand)
@@ -509,6 +517,9 @@ class MANOLayerTorch(Module):
         # Register buffer for faces
         f: Int64[Tensor, "num_faces=1538 3"] = self._mano_layer.th_faces
         self.register_buffer("f", f)
+        # Host-numpy copy of the static faces for mesh logging (parity with ``MANOLayerNP.f``).
+        # Computed once here from the CPU tensor (before any ``.to(device)``).
+        self._faces_np: Int64[ndarray, "num_faces=1538 3"] = f.cpu().numpy()
 
         # Register buffer for root translation
         shapedirs: Float32[Tensor, "n_verts=778 3 10"] = self._mano_layer.th_shapedirs
@@ -568,6 +579,11 @@ class MANOLayerTorch(Module):
     def side(self) -> Literal["left", "right"]:
         """Return the side of the hand."""
         return self._side
+
+    @property
+    def faces(self) -> Int64[ndarray, "n_faces=1538 3"]:
+        """Mesh triangle indices as host numpy (parity with ``MANOLayerNP.f``)."""
+        return self._faces_np
 
     @property
     def num_verts(self) -> int:

--- a/packages/simplecv/simplecv/rerun_custom_types.py
+++ b/packages/simplecv/simplecv/rerun_custom_types.py
@@ -123,6 +123,53 @@ def _flatten_confidences(confidences: Float[ndarray, "..."]) -> Float[ndarray, "
     return conf_array.astype(np.float32, copy=False)
 
 
+def _segment_nanmean(values: Float[ndarray, "n"], lengths: Int[ndarray, "m"]) -> Float[ndarray, "m"]:
+    """Per-segment NaN-aware mean over a flat array partitioned by ``lengths``.
+
+    Empty segments and all-NaN segments yield NaN, matching ``np.nanmean`` on the
+    valid entries. A fast vectorized path handles equal-length segments (the
+    common keypoint-per-frame case); a ``reduceat`` path covers ragged and
+    zero-length segments without a Python loop.
+
+    Args:
+        values (Float[np.ndarray, "n"]): Flat confidence values across all segments.
+        lengths (Int[np.ndarray, "m"]): Contiguous segment lengths summing to ``n``.
+
+    Returns:
+        Float[np.ndarray, "m"]: Per-segment NaN-aware means (float32).
+    """
+    m: int = int(lengths.shape[0])
+    averages: Float[ndarray, "m"] = np.full(m, np.nan, dtype=np.float32)
+    if m == 0:
+        return averages
+    finite_mask: ndarray = ~np.isnan(values)
+    # Accumulate in float64 so the per-segment mean is deterministic and does not
+    # depend on float32 reduction order (this is only an auxiliary display scalar).
+    filled: Float[ndarray, "n"] = np.where(finite_mask, values, np.float64(0.0)).astype(np.float64)
+
+    uniform_len: int = int(lengths[0])
+    if uniform_len > 0 and bool(np.all(lengths == uniform_len)):
+        # Fast path: equal-length segments → reshape and reduce along axis 1.
+        seg_counts: Int[ndarray, "m"] = finite_mask.reshape(m, uniform_len).sum(axis=1)
+        seg_sums: Float[ndarray, "m"] = filled.reshape(m, uniform_len).sum(axis=1)
+        nonzero: ndarray = seg_counts > 0
+        averages[nonzero] = (seg_sums[nonzero] / seg_counts[nonzero]).astype(np.float32)
+        return averages
+
+    # General path: contiguous segments of arbitrary (possibly zero) length.
+    offsets: Int[ndarray, "m_plus_one"] = np.concatenate(
+        (np.array([0], dtype=np.int64), np.cumsum(lengths, dtype=np.int64))
+    )
+    nonempty: ndarray = lengths > 0
+    if not bool(np.any(nonempty)):
+        return averages
+    safe_starts: Int[ndarray, "k"] = offsets[:-1][nonempty]
+    seg_sums = np.add.reduceat(filled, safe_starts)
+    seg_counts = np.add.reduceat(finite_mask.astype(np.int64), safe_starts)
+    averages[nonempty] = np.where(seg_counts > 0, seg_sums / np.maximum(seg_counts, 1), np.nan).astype(np.float32)
+    return averages
+
+
 class _ConfidenceAwareColumnList(rr.ComponentColumnList):
     """Extend a column list with confidence and per-frame averages for send_columns.
 
@@ -169,17 +216,7 @@ class _ConfidenceAwareColumnList(rr.ComponentColumnList):
                 raise ValueError("Provided average confidences must match number of partitions.")
             averages = self._provided_average.astype(np.float32, copy=False)
         else:
-            offsets: Int[ndarray, "m_plus_one"] = np.concatenate(
-                (np.array([0], dtype=np.int64), np.cumsum(lengths_arr, dtype=np.int64))
-            )
-            averages = np.empty(lengths_arr.shape[0], dtype=np.float32)
-            for idx, (start, end) in enumerate(zip(offsets[:-1], offsets[1:], strict=False)):
-                if end <= start:
-                    averages[idx] = np.nan
-                    continue
-                segment: Float[ndarray, "k"] = self._raw_confidences[start:end]
-                valid = segment[~np.isnan(segment)]
-                averages[idx] = float(np.nanmean(valid)) if valid.size > 0 else np.nan
+            averages = _segment_nanmean(self._raw_confidences, lengths_arr)
 
         avg_column = rr.ComponentColumn(
             self._average_descriptor,

--- a/packages/simplecv/simplecv/rerun_log_utils.py
+++ b/packages/simplecv/simplecv/rerun_log_utils.py
@@ -152,6 +152,11 @@ class RerunTyroConfig:
     Ignored when ``headless`` (no viewer), or when ``serve``/``connect`` is set."""
     port: int = 9876
     """Port for the spawned viewer's gRPC proxy (used by ``spawn`` and ``live`` + ``save``)."""
+    server_memory_limit: str = "4GB"
+    """Memory budget for the spawned viewer's gRPC proxy buffer. The SDK default
+    (~1 GiB) silently drops the oldest messages on long multi-camera recordings
+    (e.g. a 46-min EPFL session), so the viewer shows truncated history. Accepts a
+    size (``"4GB"``) or a percentage of RAM (``"25%"``)."""
     executable_name: str = "rerun"
     """Executable name passed to ``rerun.spawn`` when launching the viewer."""
     executable_path: str | None = None
@@ -167,7 +172,7 @@ class RerunTyroConfig:
         self.rec_stream: rr.RecordingStream = rr.get_global_data_recording()  # type: ignore[assignment]
 
         if self.serve:
-            rr.serve_grpc()
+            rr.serve_grpc(server_memory_limit=self.server_memory_limit)
             rr.serve_web_viewer(open_browser=not self.headless)
         elif self.connect:
             # Send logging data to separate `rerun` process.
@@ -182,6 +187,7 @@ class RerunTyroConfig:
             rr.spawn(
                 port=self.port,
                 connect=False,
+                server_memory_limit=self.server_memory_limit,
                 executable_name=self.executable_name,
                 executable_path=self.executable_path,
             )
@@ -194,6 +200,7 @@ class RerunTyroConfig:
         elif not self.headless:
             rr.spawn(
                 port=self.port,
+                server_memory_limit=self.server_memory_limit,
                 executable_name=self.executable_name,
                 executable_path=self.executable_path,
             )


### PR DESCRIPTION
## What

Performance wins for `visualize_exo_ego` (the exo/ego Rerun logger). No behavior change beyond float-epsilon.

- **GPU/torch MANO.** The per-frame MANO LBS forward now runs through `MANOLayerTorch` on the available device (CUDA when present, otherwise CPU) instead of the numpy layer — one runtime path instead of numpy+torch. Measured numpy vs torch: **torch-CPU ~2.8×**, **torch-CUDA ~68×** faster, parity ~1e-7. `MANOLayerTorch` gains a `use_pca` arg (mirrors `MANOLayerNP`) and a numpy `faces` accessor so it fully replaces the numpy layer here.
- **Vectorized nanmean.** `_ConfidenceAwareColumnList.partition` computed a per-frame average-confidence scalar with a Python loop calling `np.nanmean` per frame; replaced with a vectorized `_segment_nanmean` (uniform-length reshape fast path + `reduceat` fallback). **~8× faster** at the hot 133-keypoints-per-frame size, parity ~1e-7.
- **gRPC buffer knob.** `RerunTyroConfig.server_memory_limit` (default `"4GB"`) so long multi-camera recordings (e.g. a 46-min EPFL session) don't silently drop history from the viewer's ~1 GiB default buffer.

## Numbers

End-to-end `visualize_exo_ego` on EPFL `YH2040/2023_09_12_09_50_41` (~23k frames, CUDA, warm): **~16s → ~10s**.

## Verification

`pixi run -e simplecv-dev --frozen {lint,typecheck,deadcode,tests}` — ruff clean, pyrefly 0 errors, vulture clean, full suite **139 passed / 27 skipped**. `_segment_nanmean` equivalence and numpy↔torch MANO parity checked with hypothesis + a parity benchmark.

## Not in this PR

The EPFL ego "black video + camera desync" **bug fix** (HoloLens dying mid-session) is intentionally split into a separate follow-up PR.
