### PR TITLE
simplecv: fix EPFL ego frustum freeze on HoloLens tracking dropouts

### DIFF
--- a/packages/simplecv/simplecv/data/ego/epfl_smart_kitchen_ego.py
+++ b/packages/simplecv/simplecv/data/ego/epfl_smart_kitchen_ego.py
@@ -4,7 +4,8 @@ import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from jaxtyping import Float32
+import numpy as np
+from jaxtyping import Bool, Float32
 from numpy import ndarray
 from rerun.components.view_coordinates import ViewCoordinates
 
@@ -12,6 +13,7 @@ from simplecv.camera_parameters import BrownConradyDistortion, Extrinsics, Intri
 from simplecv.data.ego.base_ego import BaseEgoSequence, CameraParam, CamNameType, EgoData
 from simplecv.data.exoego.epfl_smart_kitchen import (
     EPFL_EGO_CAMERA_NAME,
+    HoloLensPoses,
     _camera_size,
     _distortion_from_entry,
     _matrix3,
@@ -52,13 +54,31 @@ class EpflSmartKitchenEgoSequence(BaseEgoSequence[EpflSmartKitchenConfig]):
             height=height,
         )
         distortion: BrownConradyDistortion | None = _distortion_from_entry(EPFL_EGO_CAMERA_NAME, entry)
-        cam_T_world_list: list[Float32[ndarray, "4 4"]] = load_hololens_world_to_camera_poses(self.config)
+        holo_poses: HoloLensPoses = load_hololens_world_to_camera_poses(self.config)
+        cam_T_world_list: list[Float32[ndarray, "4 4"]] = holo_poses.cam_T_world_list
+        pose_valid_mask: Bool[ndarray, "n_frames"] = holo_poses.valid_mask
+        # Where the HoloLens lost tracking (blank world2holo) the loader carried the last
+        # good pose forward as a placeholder. Rendering that stale pose is exactly the bug:
+        # it freezes the ego frustum and paints 2D keypoints through a dead camera. Hand
+        # those frames NaN extrinsics instead -- Rerun draws no frustum for a NaN transform,
+        # and the keypoint projection comes out NaN (so no 2D dots), while the black
+        # "tracking died here" video is left untouched. Genuine poses are unchanged, so
+        # clean sessions (and every non-EPFL dataset) render byte-for-byte as before.
+        nan_cam_R_world: Float32[ndarray, "3 3"] = np.full((3, 3), np.nan, dtype=np.float32)
+        nan_cam_t_world: Float32[ndarray, "3"] = np.full(3, np.nan, dtype=np.float32)
         camera_list: list[CameraParam] = []
-        for cam_T_world in cam_T_world_list:
-            extrinsics: Extrinsics = Extrinsics(
-                cam_R_world=cam_T_world[:3, :3],
-                cam_t_world=cam_T_world[:3, 3],
-            )
+        for frame_idx, cam_T_world in enumerate(cam_T_world_list):
+            extrinsics: Extrinsics
+            if bool(pose_valid_mask[frame_idx]):
+                extrinsics = Extrinsics(
+                    cam_R_world=cam_T_world[:3, :3],
+                    cam_t_world=cam_T_world[:3, 3],
+                )
+            else:
+                extrinsics = Extrinsics(
+                    cam_R_world=nan_cam_R_world.copy(),
+                    cam_t_world=nan_cam_t_world.copy(),
+                )
             camera_params: PinholeParameters = PinholeParameters(
                 name=EPFL_EGO_CAMERA_NAME,
                 intrinsics=intrinsics,

--- a/packages/simplecv/simplecv/data/exoego/epfl_smart_kitchen.py
+++ b/packages/simplecv/simplecv/data/exoego/epfl_smart_kitchen.py
@@ -11,7 +11,7 @@ from typing import Literal, cast
 
 import cv2
 import numpy as np
-from jaxtyping import Float32, Int
+from jaxtyping import Bool, Float32, Int
 from natsort import natsorted
 from numpy import ndarray
 from rerun.components.view_coordinates import ViewCoordinates
@@ -219,7 +219,25 @@ def _pinhole_from_entry(
     )
 
 
-def load_hololens_world_to_camera_poses(cfg: EpflSmartKitchenConfig) -> list[ndarray]:
+@dataclass(frozen=True)
+class HoloLensPoses:
+    """Per-frame HoloLens world-to-camera transforms plus a tracking-validity mask.
+
+    A ``@dataclass`` rather than ``NamedTuple`` on purpose: a ``NamedTuple`` with a
+    ``list[Float32[ndarray, "4 4"]]`` field trips beartype's forward-ref resolution
+    under ``from __future__ import annotations``.
+    """
+
+    cam_T_world_list: list[Float32[ndarray, "4 4"]]
+    """World-to-camera transforms, one per video frame. Frames where the HoloLens
+    lost tracking hold a carried-forward placeholder so the list stays frame-aligned;
+    that placeholder is never rendered (the viewer keys off ``valid_mask``)."""
+    valid_mask: Bool[ndarray, "n_frames"]
+    """``True`` where the HoloLens reported a genuine pose; ``False`` where the
+    ``world2holo`` cell was blank (``[]``) because tracking dropped out."""
+
+
+def load_hololens_world_to_camera_poses(cfg: EpflSmartKitchenConfig) -> HoloLensPoses:
     """Load per-frame HoloLens world-to-camera transforms from ``holo_data_wpose.csv``."""
     path: Path = holo_pose_path(cfg)
     if not path.exists():
@@ -255,7 +273,11 @@ def load_hololens_world_to_camera_poses(cfg: EpflSmartKitchenConfig) -> list[nda
             stacklevel=2,
         )
 
-    transforms: list[ndarray] = []
+    valid_mask: Bool[ndarray, "n_frames"] = np.array(
+        [transform is not None for transform in transforms_raw],
+        dtype=bool,
+    )
+    transforms: list[Float32[ndarray, "4 4"]] = []
     last_valid: Float32[ndarray, "4 4"] | None = None
     for transform in transforms_raw:
         if transform is None:
@@ -264,7 +286,7 @@ def load_hololens_world_to_camera_poses(cfg: EpflSmartKitchenConfig) -> list[nda
         else:
             transforms.append(transform)
             last_valid = transform
-    return transforms
+    return HoloLensPoses(cam_T_world_list=transforms, valid_mask=valid_mask)
 
 
 def load_rgb_timestamps_ns(cfg: EpflSmartKitchenConfig) -> Int[ndarray, "n_frames"]:

--- a/packages/simplecv/tests/test_epfl_smart_kitchen.py
+++ b/packages/simplecv/tests/test_epfl_smart_kitchen.py
@@ -403,12 +403,16 @@ def test_epfl_smart_kitchen_hololens_pose_loader_carries_previous_pose_for_empty
         writer.writerow({"world2holo": json.dumps(last_pose)})
 
     with pytest.warns(UserWarning, match="missing 1 HoloLens world2holo"):
-        poses = load_hololens_world_to_camera_poses(cfg)
+        holo_poses = load_hololens_world_to_camera_poses(cfg)
 
+    poses = holo_poses.cam_T_world_list
     assert len(poses) == 3
     np.testing.assert_allclose(poses[0], np.array(first_pose, dtype=np.float32))
+    # The dropout frame still holds a carried-forward placeholder (so the list stays
+    # frame-aligned), but valid_mask flags it so the viewer never renders that stale pose.
     np.testing.assert_allclose(poses[1], np.array(first_pose, dtype=np.float32))
     np.testing.assert_allclose(poses[2], np.array(last_pose, dtype=np.float32))
+    np.testing.assert_array_equal(holo_poses.valid_mask, np.array([True, False, True]))
 
 
 def test_epfl_smart_kitchen_hololens_pose_loader_warns_when_leading_rows_use_first_valid_pose(
@@ -435,11 +439,13 @@ def test_epfl_smart_kitchen_hololens_pose_loader_warns_when_leading_rows_use_fir
         writer.writerow({"world2holo": json.dumps(first_valid_pose)})
 
     with pytest.warns(UserWarning, match="first valid pose for leading gaps"):
-        poses = load_hololens_world_to_camera_poses(cfg)
+        holo_poses = load_hololens_world_to_camera_poses(cfg)
 
+    poses = holo_poses.cam_T_world_list
     assert len(poses) == 2
     np.testing.assert_allclose(poses[0], np.array(first_valid_pose, dtype=np.float32))
     np.testing.assert_allclose(poses[1], np.array(first_valid_pose, dtype=np.float32))
+    np.testing.assert_array_equal(holo_poses.valid_mask, np.array([False, True]))
 
 
 def test_epfl_smart_kitchen_sequence_loads_coco133_labels_and_mano_stack(tmp_path: Path) -> None:
@@ -542,6 +548,40 @@ def test_epfl_smart_kitchen_ego_sequence_warns_when_reusing_final_pose(tmp_path:
 
     with pytest.warns(UserWarning, match="reusing the final pose"):
         ego_sequence[2]
+
+
+def test_epfl_smart_kitchen_ego_cams_use_nan_extrinsics_on_tracking_dropouts(tmp_path: Path) -> None:
+    _write_minimal_public_release(tmp_path)
+    holo_path: Path = tmp_path / "Public_release_videos" / "train" / "YH2002" / "2023_12_04_10_15_23" / "meta_data" / "holo_data_wpose.csv"
+    identity_pose: list[list[float]] = [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]]
+    with holo_path.open("w", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=["world2holo"])
+        writer.writeheader()
+        writer.writerow({"world2holo": json.dumps(identity_pose)})
+        writer.writerow({"world2holo": "[]"})  # HoloLens tracking lost this frame
+        writer.writerow({"world2holo": json.dumps(identity_pose)})
+    from simplecv.data.ego.epfl_smart_kitchen_ego import EpflSmartKitchenEgoSequence
+
+    cfg = EpflSmartKitchenConfig(
+        root_directory=tmp_path,
+        split="train",
+        participant_id="YH2002",
+        session_name="2023_12_04_10_15_23",
+    )
+
+    with pytest.warns(UserWarning, match="missing 1 HoloLens world2holo"):
+        ego_sequence = EpflSmartKitchenEgoSequence(cfg)
+
+    cams = ego_sequence.ego_cam_dict["hololens"]
+    assert len(cams) == 3
+    # Live frames keep finite extrinsics; the dropout frame is NaN so Rerun renders no
+    # ego frustum and the keypoint projection comes out NaN (no 2D dots) instead of
+    # freezing on the carried-forward pose. The video is logged untouched elsewhere.
+    assert np.isfinite(cams[0].extrinsics.cam_t_world).all()
+    assert np.isnan(cams[1].extrinsics.cam_t_world).all()
+    assert np.isnan(cams[1].extrinsics.world_t_cam).all()
+    assert np.isnan(cams[1].extrinsics.cam_T_world[:3]).all()
+    assert np.isfinite(cams[2].extrinsics.cam_t_world).all()
 
 
 def test_epfl_smart_kitchen_visualized_rrd_contains_video_labels_and_mano(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem
EPFL Smart Kitchen's HoloLens ego stream loses tracking mid-session in 33 of 51 sessions. When it does, `meta_data/holo_data_wpose.csv`'s `world2holo` cell goes blank AND `hololens.mp4` goes black together (inherent to the upstream release). The loader carried the last valid pose forward, which froze the ego frustum at a stale pose (the "desync") and projected 2D keypoints through a dead camera while exo cams + 3D skeleton kept advancing.

Dropouts are NOT only trailing — only 8/33 are end-only; 24/33 have interior/mid-recording gaps and 14/33 have multiple separate gaps (up to 6), so "trim the tail" would not cover them.

## Fix (data layer only — no viewer changes)
- `load_hololens_world_to_camera_poses` now returns `HoloLensPoses{cam_T_world_list, valid_mask}` (carry-forward kept only as a frame-aligned placeholder; `valid_mask` is False where `world2holo` is blank).
- `EpflSmartKitchenEgoSequence.load_ego_cams` hands NaN extrinsics to the dropout frames.

Rerun draws no frustum for a NaN `Transform3D`, and the existing keypoint projection comes out NaN (no 2D dots) — automatically, with zero changes to `view_exoego.py`. The black video is deliberately kept as the honest "tracking died here" marker. Genuine poses are untouched, so clean and non-EPFL sessions render byte-identically.

## Verification
- `pixi run -e simplecv-dev`: lint, typecheck (0 errors), deadcode, tests (23/23, incl. a new test asserting NaN extrinsics on dropout frames vs finite on live frames).
- Real data: on `YH2002/2023_12_04_10_15_23` the loader flags the 20,022-frame dead tail (frame 63408 -> end); those extrinsics are NaN while frame 63407 stays finite.

## Note
Materializing this in the RRD catalog needs a regen (`batch_raw_to_rrd.py`, train+test, 51 sessions, ~150 GB, ~66 min sequential) — not part of this PR.
