### PR TITLE
simplecv: MAMMA exoego dataset + SMPL/SMPL-X body labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,8 @@ cython_debug/
 # Package top-level data directories (downloaded assets, not Python package data/)
 packages/monoprior/data/
 packages/simplecv/data/
+# License-gated SMPL-X body model (lazily downloaded; the MANO pkls next to it stay tracked)
+packages/simplecv/simplecv/data/body_models/
 packages/prompt-da/data/
 packages/wilor-nano/data/
 packages/sam3d-body/data/

--- a/packages/simplecv/README.md
+++ b/packages/simplecv/README.md
@@ -95,7 +95,8 @@ pixi run -e simplecv --frozen python tools/view_exoego.py mamma --sequence-name 
 
 MAMMA ships 4:4:4-chroma H.264/H.265 videos, which NVDEC and the Rerun viewer cannot decode
 on the fast path; `simplecv-preprocess-mamma` builds the AV1 `yuv420p` mirror the loader
-prefers automatically. Use `--crf` (default 30) and `--encoder {av1_nvenc,libsvtav1}` to tune it.
+prefers automatically. Use `--cq` (constant-quality target, default 30; maps to NVENC `-cq` /
+SVT-AV1 `-crf`) and `--encoder {av1_nvenc,libsvtav1}` to tune it.
 
 ### Ingest Exo/Ego Recordings
 Ingest synchronized exo/ego captures into Rerun (spawns the viewer unless told otherwise).

--- a/packages/simplecv/README.md
+++ b/packages/simplecv/README.md
@@ -69,6 +69,34 @@ If you have a Polycam zip file or extracted directory:
 pixi run -e simplecv --frozen python tools/view_polycam.py --polycam-zip-path $PATH-TO-POLYCAM-ZIP
 ```
 
+### MAMMA dataset (exo-only multi-view)
+
+[MAMMA](https://mamma.is.tue.mpg.de/) is a markerless multi-person mocap dataset. It is
+brought in as an **exo-only** ExoEgo dataset (a rig of static IOI/iPhone cameras, no ego
+device), with per-camera calibration in NPZ (`cam_int` K, `cam_ext` world→cam) and
+per-person SMPL-X fits under `pred/params_XX.npz`.
+
+Downloads are license-gated — register at <https://mamma.is.tue.mpg.de/register.php>, then:
+
+```bash
+export MAMMA_USERNAME='your_email'
+export MAMMA_PASSWORD='your_password'
+
+# One sequence per subset (dance, multi-people, iphone, eval, syn) into packages/simplecv/data/mamma/:
+pixi run -e simplecv --frozen simplecv-download-mamma
+
+# Re-encode the shipped yuv444 videos to AV1 yuv420 (videos_av1/ mirror) for the NVDEC/rerun hot path:
+pixi run -e simplecv --frozen simplecv-preprocess-mamma
+
+# View one sequence (defaults to the iPhone crossing_arms scene; SMPL-X meshes logged under /world/gt/smplx):
+pixi run -e simplecv --frozen simplecv-view-exoego-data mamma
+pixi run -e simplecv --frozen python tools/view_exoego.py mamma --sequence-name mamma_eval_singles/230929_WhiteRabbit_CatchBall_50048_1
+```
+
+MAMMA ships 4:4:4-chroma H.264/H.265 videos, which NVDEC and the Rerun viewer cannot decode
+on the fast path; `simplecv-preprocess-mamma` builds the AV1 `yuv420p` mirror the loader
+prefers automatically. Use `--crf` (default 30) and `--encoder {av1_nvenc,libsvtav1}` to tune it.
+
 ### Ingest Exo/Ego Recordings
 Ingest synchronized exo/ego captures into Rerun (spawns the viewer unless told otherwise).
 ```bash

--- a/packages/simplecv/simplecv/apis/batch_raw_to_rrd.py
+++ b/packages/simplecv/simplecv/apis/batch_raw_to_rrd.py
@@ -41,6 +41,8 @@ class BatchConvertConfig:
     """Enable derived MANO mesh/keypoint logging during conversion."""
     log_mano_vertex_normals: bool = False
     """Compute and log dynamic MANO mesh vertex normals during conversion."""
+    log_smplx: bool = True
+    """Enable derived SMPL/SMPL-X body mesh logging during conversion."""
 
 
 def main(config: BatchConvertConfig):
@@ -85,6 +87,7 @@ def main(config: BatchConvertConfig):
                 log_labels=config.log_labels,
                 log_mano=config.log_mano,
                 log_mano_vertex_normals=config.log_mano_vertex_normals,
+                log_smplx=config.log_smplx,
             )
             rec: rr.RecordingStream = current_cfg.rr_config.rec_stream
             rr.send_recording_name(identity.sequence_key, recording=rec)

--- a/packages/simplecv/simplecv/apis/download_mamma.py
+++ b/packages/simplecv/simplecv/apis/download_mamma.py
@@ -1,0 +1,251 @@
+"""Download one MAMMA sequence per subset from the MPI download gateway.
+
+Register at https://mamma.is.tue.mpg.de/register.php first, then export the
+credentials (the gateway rejects anonymous requests with HTTP 401)::
+
+    export MAMMA_USERNAME='your_email'
+    export MAMMA_PASSWORD='your_password'
+    pixi run -e simplecv simplecv-download-mamma
+
+By default this fetches ONE sequence from each subset (dance, multi-people,
+iphone, eval, syn) with the smallest video variant (``videos_crf24`` for IOI
+rigs, ``videos_light`` for iPhones — both H.265 yuv444, so run
+``simplecv-preprocess-mamma`` afterwards to build the AV1 yuv420 mirror).
+Existing valid files are skipped, so reruns only fetch what is missing.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import requests
+from tqdm import tqdm
+
+BASE_URL: str = "https://download.is.tue.mpg.de/download.php?domain=mamma&resume=1"
+REGISTER_URL: str = "https://mamma.is.tue.mpg.de/register.php"
+
+IOI_CAMERAS_32: tuple[str, ...] = tuple(f"IOI_{i:02d}" for i in range(1, 33))
+IOI_CAMERAS_16: tuple[str, ...] = IOI_CAMERAS_32[:16]
+IPHONE_CAMERAS: tuple[str, ...] = ("A001", "B001", "C001", "D001")
+
+MammaSubset = Literal["dance", "multi-people", "iphone", "eval", "syn"]
+
+
+@dataclass
+class SubsetSpec:
+    """Remote layout of one MAMMA subset's default sequence."""
+
+    sequence: str
+    """Sequence path relative to the remote ``datasets/`` root (and the local output dir)."""
+    cameras: tuple[str, ...]
+    """Camera names (`meta|gt/<cam>.npz` + `<video_dir>/<cam>.mp4`)."""
+    video_dir: str
+    """Remote video variant to fetch (`videos_crf24` for IOI, `videos_light` for iPhone)."""
+    calib_dir: Literal["meta", "gt"]
+    """Calibration dir: `meta` (markerless, with `pred/`) or `gt` (eval)."""
+    num_people: int
+    """Number of `pred/params_XX.npz` files (0 for eval subsets, which ship GT in `gt/global.npz`)."""
+
+
+DEFAULT_SUBSET_SPECS: dict[str, SubsetSpec] = {
+    "dance": SubsetSpec(
+        sequence="mamma_markerless_dance/050825_WestCoastSwing_CutOff_03688_03689_1",
+        cameras=IOI_CAMERAS_32,
+        video_dir="videos_crf24",
+        calib_dir="meta",
+        num_people=2,
+    ),
+    "multi-people": SubsetSpec(
+        sequence="mamma_markerless_multiple_people/260216_MultiMama_3_accidental_bump_000111_1",
+        cameras=IOI_CAMERAS_32,
+        video_dir="videos_crf24",
+        calib_dir="meta",
+        num_people=3,
+    ),
+    "iphone": SubsetSpec(
+        sequence="mamma_markerless_iphones/indoors/crossing_arms",
+        cameras=IPHONE_CAMERAS,
+        video_dir="videos_light",
+        calib_dir="meta",
+        num_people=1,
+    ),
+    "eval": SubsetSpec(
+        sequence="mamma_eval_singles/230929_WhiteRabbit_CatchBall_50048_1",
+        cameras=IOI_CAMERAS_16,
+        video_dir="videos_crf24",
+        calib_dir="gt",
+        num_people=0,
+    ),
+}
+
+
+@dataclass
+class DownloadConfig:
+    """Configuration for the single-sequence-per-subset MAMMA download."""
+
+    output_dir: Path = Path("data/mamma")
+    """Local root; files land at ``<output_dir>/<subset>/<sequence>/...``."""
+    subsets: tuple[MammaSubset, ...] = ("dance", "multi-people", "iphone", "eval", "syn")
+    """Subsets to fetch (one default sequence each)."""
+    username: str | None = None
+    """MAMMA account username; falls back to the MAMMA_USERNAME env var."""
+    password: str | None = None
+    """MAMMA account password; falls back to the MAMMA_PASSWORD env var."""
+    max_cameras: int | None = None
+    """Optional cap on cameras per sequence for quick tests (None = all)."""
+    syn_dataset: str = "moyo_4-6_C_200_00"
+    """MammaSyn WebDataset to sample from (synthetic training data)."""
+    max_syn_shards: int = 1
+    """Number of WebDataset shards to fetch from the syn manifest."""
+
+
+def _looks_like_error_payload(head: bytes) -> bool:
+    """Detect the gateway's HTML/error bodies served instead of a real file."""
+    head_stripped: bytes = head.lstrip()[:64].lower()
+    return head_stripped.startswith((b"error:", b"<!doctype html", b"<html"))
+
+
+def is_valid_download(path: Path) -> bool:
+    """True when ``path`` exists, is non-empty, and is not a gateway error page."""
+    if not path.is_file() or path.stat().st_size == 0:
+        return False
+    with open(path, "rb") as f:
+        return not _looks_like_error_payload(f.read(256))
+
+
+def download_mamma_file(sfile: str, dest_path: Path, *, username: str, password: str) -> bool:
+    """Fetch one remote file via credentialed POST; returns False when missing remotely.
+
+    Args:
+        sfile: Remote path passed as the gateway's ``sfile=`` query value
+            (e.g. ``datasets/<sequence>/meta/global.npz``).
+        dest_path: Local destination; skipped when already valid.
+        username: MAMMA account username.
+        password: MAMMA account password.
+
+    Returns:
+        True when the file exists locally and is valid after the call.
+
+    Raises:
+        RuntimeError: On authentication failure (HTTP 401).
+    """
+    if is_valid_download(dest_path):
+        print(f"  [skip] {sfile}")
+        return True
+
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path: Path = dest_path.with_name(f"{dest_path.name}.part")
+    url: str = f"{BASE_URL}&sfile={sfile}"
+    try:
+        response: requests.Response = requests.post(
+            url,
+            data={"username": username, "password": password},
+            stream=True,
+            timeout=(30, 300),
+        )
+        if response.status_code == 401:
+            raise RuntimeError(f"MAMMA credentials rejected (HTTP 401). Register at {REGISTER_URL} and set MAMMA_USERNAME/MAMMA_PASSWORD.")
+        if not response.ok:
+            print(f"  [FAIL] {sfile} (HTTP {response.status_code})")
+            return False
+
+        total_size: int = int(response.headers.get("content-length", 0))
+        first_chunk: bool = True
+        with open(tmp_path, "wb") as f, tqdm(total=total_size, unit="B", unit_scale=True, desc=dest_path.name, leave=False) as pbar:
+            for chunk in response.iter_content(chunk_size=1 << 20):
+                if first_chunk and _looks_like_error_payload(chunk):
+                    tmp_path.unlink(missing_ok=True)
+                    print(f"  [missing] {sfile}")
+                    return False
+                first_chunk = False
+                f.write(chunk)
+                pbar.update(len(chunk))
+    except requests.RequestException as exc:
+        # Isolate transient network failures per file so one drop mid-run does
+        # not abort the remaining files/subsets (rerun resumes the [FAIL]s).
+        tmp_path.unlink(missing_ok=True)
+        print(f"  [FAIL] {sfile} ({type(exc).__name__}: {exc})")
+        return False
+
+    if not is_valid_download(tmp_path):
+        tmp_path.unlink(missing_ok=True)
+        print(f"  [FAIL] {sfile} (empty or error payload)")
+        return False
+    tmp_path.replace(dest_path)
+    print(f"  [ok] {sfile}")
+    return True
+
+
+def sequence_files_for_spec(spec: SubsetSpec, max_cameras: int | None) -> list[str]:
+    """Per-sequence remote file list (relative to the sequence dir)."""
+    cameras: tuple[str, ...] = spec.cameras[:max_cameras] if max_cameras is not None else spec.cameras
+    files: list[str] = [f"{spec.calib_dir}/global.npz"]
+    files += [f"{spec.calib_dir}/{cam}.npz" for cam in cameras]
+    files += [f"pred/params_{person_idx:02d}.npz" for person_idx in range(spec.num_people)]
+    files += [f"{spec.video_dir}/{cam}.mp4" for cam in cameras]
+    return files
+
+
+def download_subset(spec: SubsetSpec, config: DownloadConfig, *, username: str, password: str) -> tuple[int, int]:
+    """Download one subset's default sequence; returns (num_ok, num_total)."""
+    files: list[str] = sequence_files_for_spec(spec, config.max_cameras)
+    num_ok: int = 0
+    for rel_file in files:
+        ok: bool = download_mamma_file(
+            f"datasets/{spec.sequence}/{rel_file}",
+            config.output_dir / spec.sequence / rel_file,
+            username=username,
+            password=password,
+        )
+        num_ok += int(ok)
+    return num_ok, len(files)
+
+
+def download_syn_shards(config: DownloadConfig, *, username: str, password: str) -> tuple[int, int]:
+    """Download the syn manifest plus the first ``max_syn_shards`` WebDataset shards.
+
+    MammaSyn is served under ``datasets/training_webdataset/`` and is flagged
+    "coming soon" upstream, so missing files are tolerated (not an error).
+    """
+    local_root: Path = config.output_dir / "mamma_syn_wd" / config.syn_dataset
+    remote_root: str = f"datasets/training_webdataset/{config.syn_dataset}"
+    manifest_path: Path = local_root / "tar_train_list.txt"
+    if not download_mamma_file(f"{remote_root}/tar_train_list.txt", manifest_path, username=username, password=password):
+        print(f"  [warn] MammaSyn manifest unavailable for {config.syn_dataset} (upstream marks syn data 'coming soon')")
+        return 0, 1
+
+    shard_names: list[str] = [line.strip() for line in manifest_path.read_text().splitlines() if line.strip()]
+    shard_names = shard_names[: config.max_syn_shards]
+    num_ok: int = 1
+    for shard in shard_names:
+        ok: bool = download_mamma_file(f"{remote_root}/{shard}", local_root / shard, username=username, password=password)
+        num_ok += int(ok)
+    return num_ok, 1 + len(shard_names)
+
+
+def main(config: DownloadConfig) -> None:
+    """Download one MAMMA sequence per requested subset."""
+    username: str | None = config.username or os.environ.get("MAMMA_USERNAME")
+    password: str | None = config.password or os.environ.get("MAMMA_PASSWORD")
+    if not username or not password:
+        raise RuntimeError(
+            f"MAMMA credentials required: register at {REGISTER_URL}, then set MAMMA_USERNAME and MAMMA_PASSWORD "
+            "(or pass --username/--password)."
+        )
+
+    totals: dict[str, tuple[int, int]] = {}
+    for subset in config.subsets:
+        print(f"\n=== {subset} ===")
+        if subset == "syn":
+            totals[subset] = download_syn_shards(config, username=username, password=password)
+        else:
+            totals[subset] = download_subset(DEFAULT_SUBSET_SPECS[subset], config, username=username, password=password)
+
+    print(f"\nDone. Files under {config.output_dir}:")
+    for subset, (num_ok, num_total) in totals.items():
+        print(f"  {subset}: {num_ok}/{num_total} files present")
+    if any(subset != "syn" for subset in config.subsets):
+        print("Next: pixi run -e simplecv simplecv-preprocess-mamma  (AV1 yuv420 re-encode for the fast decode path)")

--- a/packages/simplecv/simplecv/apis/preprocess_mamma.py
+++ b/packages/simplecv/simplecv/apis/preprocess_mamma.py
@@ -1,0 +1,183 @@
+"""Build the AV1 yuv420 mirror for downloaded MAMMA sequences.
+
+MAMMA ships yuv444 video (H.264 CRF5 originals, H.265 CRF16/24 variants,
+H.265 Rext ``videos_light`` for iPhones). NVDEC and the rerun viewer have no
+4:4:4 fast path (see docs/video_decode_format_tradeoffs.md), so every camera
+clip is re-encoded once to AV1 Main yuv420p into a ``videos_av1/`` dir next to
+its source dir. The MAMMA exoego adapter prefers ``videos_av1`` automatically.
+
+Existing valid targets are probed and skipped, mirroring the EPFL mirror tool.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from simplecv.apis.preprocess_epfl_smart_kitchen import VideoProbe, probe_video
+from simplecv.data.exoego.mamma import VIDEO_DIR_PREFERENCE, discover_sequence_names
+
+
+@dataclass
+class PreprocessConfig:
+    """Configuration for the MAMMA AV1 yuv420 re-encode."""
+
+    root_directory: Path = Path("data/mamma")
+    """Root containing downloaded MAMMA sequences (see download_mamma)."""
+    target_dir_name: str = "videos_av1"
+    """Per-sequence output dir for the AV1 yuv420 mirror."""
+    encoder: Literal["av1_nvenc", "libsvtav1"] = "av1_nvenc"
+    """AV1 encoder: NVENC hardware (default) or SVT-AV1 CPU fallback."""
+    preset: str | None = None
+    """Encoder preset (`p1`-`p7` for av1_nvenc, `0`-`13` for libsvtav1). None picks the encoder default (`p5` / `8`)."""
+    cq: int = 30
+    """Constant-quality target (NVENC `-cq` / SVT-AV1 `-crf`); repo storage default is 30."""
+    force: bool = False
+    """Re-encode even when a valid target already exists."""
+    ffmpeg_path: str = "ffmpeg"
+    """ffmpeg executable."""
+    ffprobe_path: str = "ffprobe"
+    """ffprobe executable."""
+    duration_tolerance_sec: float = 0.25
+    """Maximum source/target duration difference before validation fails."""
+
+
+def _resolve_preset(config: PreprocessConfig) -> str:
+    """Resolve (and validate) the preset for the chosen encoder.
+
+    Returns the encoder default when unset (``p5`` for av1_nvenc, ``8`` for
+    libsvtav1); raises when an explicit preset does not match the encoder's form
+    (av1_nvenc wants ``pN``, libsvtav1 wants an integer) instead of silently
+    substituting one.
+    """
+    if config.encoder == "av1_nvenc":
+        if config.preset is None:
+            return "p5"
+        if not (config.preset.startswith("p") and config.preset[1:].isdigit()):
+            raise ValueError(f"av1_nvenc preset must look like 'p1'..'p7', got {config.preset!r}")
+        return config.preset
+    if config.preset is None:
+        return "8"
+    if not config.preset.isdigit():
+        raise ValueError(f"libsvtav1 preset must be an integer 0..13, got {config.preset!r}")
+    return config.preset
+
+
+def _encode_command(source_path: Path, tmp_path: Path, config: PreprocessConfig) -> list[str]:
+    """Build the ffmpeg AV1 yuv420 command for one video."""
+    preset: str = _resolve_preset(config)
+    if config.encoder == "av1_nvenc":
+        encoder_args: list[str] = ["-c:v", "av1_nvenc", "-preset", preset, "-tune", "hq", "-rc", "vbr", "-cq", str(config.cq), "-b:v", "0"]
+    else:
+        encoder_args = ["-c:v", "libsvtav1", "-preset", preset, "-crf", str(config.cq)]
+    return [
+        config.ffmpeg_path,
+        "-hide_banner",
+        "-y",
+        "-loglevel",
+        "error",
+        "-i",
+        str(source_path),
+        "-map",
+        "0:v:0",
+        *encoder_args,
+        "-pix_fmt",
+        "yuv420p",
+        "-movflags",
+        "+faststart",
+        # Force the mp4 muxer: the tmp file has a non-.mp4 suffix so a crashed
+        # encode never leaves a partial file that the adapter's *.mp4 glob picks up.
+        "-f",
+        "mp4",
+        str(tmp_path),
+    ]
+
+
+def _validate_target(source_probe: VideoProbe, target_probe: VideoProbe, duration_tolerance_sec: float) -> None:
+    """Raise unless the target is a same-size, same-duration AV1 yuv420p stream."""
+    if target_probe.codec_name != "av1":
+        raise ValueError(f"Expected AV1 target codec, got {target_probe.codec_name}: {target_probe.path}")
+    if target_probe.pix_fmt != "yuv420p":
+        raise ValueError(f"Expected yuv420p target pixel format, got {target_probe.pix_fmt}: {target_probe.path}")
+    if (target_probe.width, target_probe.height) != (source_probe.width, source_probe.height):
+        raise ValueError(
+            f"Target dimensions do not match source: {source_probe.width}x{source_probe.height} -> {target_probe.width}x{target_probe.height}"
+        )
+    if source_probe.duration_sec is not None and target_probe.duration_sec is not None:
+        duration_delta_sec: float = abs(source_probe.duration_sec - target_probe.duration_sec)
+        if duration_delta_sec > duration_tolerance_sec:
+            raise ValueError(f"Target duration differs from source by {duration_delta_sec:.3f}s (tolerance {duration_tolerance_sec:.3f}s)")
+
+
+def encode_video(source_path: Path, target_path: Path, config: PreprocessConfig) -> str:
+    """Encode one video (or validate an existing target); returns 'encoded' or 'skipped'."""
+    source_probe: VideoProbe = probe_video(source_path, ffprobe_path=config.ffprobe_path)
+    if target_path.exists() and not config.force:
+        target_probe: VideoProbe = probe_video(target_path, ffprobe_path=config.ffprobe_path)
+        _validate_target(source_probe, target_probe, config.duration_tolerance_sec)
+        return "skipped"
+
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    # Non-.mp4 suffix so a crashed/killed encode leaves nothing the adapter's
+    # *.mp4 glob would treat as a real camera video.
+    tmp_path: Path = target_path.with_name(f"{target_path.name}.part")
+    tmp_path.unlink(missing_ok=True)
+    command: list[str] = _encode_command(source_path, tmp_path, config)
+    try:
+        subprocess.run(command, check=True, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"ffmpeg executable not found: {config.ffmpeg_path}") from exc
+    except subprocess.CalledProcessError as exc:
+        tmp_path.unlink(missing_ok=True)
+        stderr: str = exc.stderr or ""
+        if "av1_nvenc" in stderr:
+            raise RuntimeError(
+                "ffmpeg failed with av1_nvenc. Confirm this build has NVIDIA AV1 NVENC support "
+                "and an AV1-capable GPU, or rerun with --encoder libsvtav1."
+            ) from exc
+        raise
+    tmp_path.replace(target_path)
+
+    target_probe = probe_video(target_path, ffprobe_path=config.ffprobe_path)
+    _validate_target(source_probe, target_probe, config.duration_tolerance_sec)
+    return "encoded"
+
+
+def source_video_dir_for_sequence(sequence_dir: Path, target_dir_name: str) -> Path | None:
+    """First existing source video dir by preference, excluding the AV1 target dir."""
+    for name in VIDEO_DIR_PREFERENCE:
+        if name == target_dir_name:
+            continue
+        video_dir: Path = sequence_dir / name
+        if video_dir.is_dir() and any(video_dir.glob("*.mp4")):
+            return video_dir
+    return None
+
+
+def main(config: PreprocessConfig) -> None:
+    """Re-encode every downloaded MAMMA sequence's videos to AV1 yuv420."""
+    sequence_names: list[str] = discover_sequence_names(config.root_directory)
+    if not sequence_names:
+        raise FileNotFoundError(f"No MAMMA sequences under {config.root_directory} (run simplecv-download-mamma first)")
+
+    num_encoded: int = 0
+    num_skipped: int = 0
+    for sequence_name in sequence_names:
+        sequence_dir: Path = config.root_directory / sequence_name
+        source_dir: Path | None = source_video_dir_for_sequence(sequence_dir, config.target_dir_name)
+        if source_dir is None:
+            print(f"[warn] {sequence_name}: no source video dir, skipping")
+            continue
+        target_dir: Path = sequence_dir / config.target_dir_name
+        for source_path in sorted(source_dir.glob("*.mp4")):
+            start_time: float = time.perf_counter()
+            status: str = encode_video(source_path, target_dir / source_path.name, config)
+            elapsed_sec: float = time.perf_counter() - start_time
+            print(f"[{status}] {sequence_name}/{source_dir.name}/{source_path.name} -> {config.target_dir_name}/ ({elapsed_sec:.1f}s)")
+            num_encoded += int(status == "encoded")
+            num_skipped += int(status == "skipped")
+
+    print(f"\nDone. {num_encoded} encoded, {num_skipped} already valid, root: {config.root_directory}")

--- a/packages/simplecv/simplecv/apis/view_exoego.py
+++ b/packages/simplecv/simplecv/apis/view_exoego.py
@@ -18,7 +18,7 @@ from tqdm import tqdm
 from simplecv.camera_parameters import Fisheye62Parameters, PinholeParameters
 from simplecv.configs.exoego_dataset_configs import AnnotatedExoEgoDatasetUnion
 from simplecv.data.ego.base_ego import BaseEgoSequence
-from simplecv.data.exo.base_exo import BaseExoSequence, ManoStack
+from simplecv.data.exo.base_exo import BaseExoSequence, ManoStack, SmplxStack
 from simplecv.data.exoego.base_exoego import BaseExoEgoSequence, EnvironmentMesh, ExoEgoLabels, ExoEgoSample, RigLayout
 from simplecv.data.skeleton.coco_133 import (
     COCO_133_ID2NAME,
@@ -71,6 +71,9 @@ class VisualizeConfig:
 
     log_mano_vertex_normals: bool = False
     """Compute and log dynamic MANO mesh vertex normals. Disabled by default for faster RRD ingest."""
+
+    log_smplx: bool = True
+    """Enable streaming of SMPL/SMPL-X body meshes derived from the dataset."""
 
     log_labels: bool = True
     """Control whether 2D/3D keypoint annotations are logged alongside videos."""
@@ -475,6 +478,115 @@ def log_mano_batch(
             )
 
 
+# Translucent per-person mesh tints, cycled when a sequence has more people.
+SMPLX_PERSON_COLORS: tuple[tuple[int, int, int, int], ...] = (
+    (66, 135, 245, 120),
+    (245, 130, 48, 120),
+    (60, 180, 75, 120),
+    (240, 50, 230, 120),
+    (255, 225, 25, 120),
+    (70, 240, 240, 120),
+)
+
+
+def log_smplx_batch(
+    exoego_sequence: BaseExoEgoSequence,
+    smplx_parent_log_path: Path,
+    timeline: str,
+    timestamps_ns: Int[ndarray, "n_frames"],
+    log_smplx: bool,
+) -> None:
+    """Stream SMPL/SMPL-X body meshes to Rerun, one entity per person.
+
+    Args:
+        exoego_sequence (BaseExoEgoSequence): Sequence whose ``exoego_labels``
+            may carry a ``SmplxStack`` of body parameters.
+        smplx_parent_log_path (Path): Root Rerun entity under which the per-person
+            meshes are organized (``<root>/smplx/person_NN/mesh``).
+        timeline (str): Logical timeline label shared across logged modalities.
+        timestamps_ns (Int[np.ndarray, "n_frames"]): Nanosecond timestamps aligned
+            with the SMPL-X parameter stream.
+        log_smplx (bool): Gate controlling whether any SMPL-X data is emitted.
+
+    Returns:
+        None: Data is emitted via ``rr.log`` and ``rr.send_columns`` side effects.
+    """
+    exoego_labels: ExoEgoLabels | None = exoego_sequence.exoego_labels
+    if exoego_labels is None:
+        return
+    smplx_stack: SmplxStack | None = exoego_labels.smplx_stack
+    if smplx_stack is None or not log_smplx:
+        return
+
+    from scipy.spatial.transform import Rotation
+
+    from simplecv.ops.smplx.smplx_torch import SMPLX_FORWARD_CHUNK_FRAMES, SmplxForwardResult, SmplxLayerTorch
+
+    smplx_root_path: Path = smplx_parent_log_path / "smplx"
+    smplx_device: str = "cuda" if torch.cuda.is_available() else "cpu"
+    n_frames_total: int = min(smplx_stack.poses.shape[0], len(timestamps_ns))
+    if n_frames_total == 0:
+        return
+    n_people: int = smplx_stack.poses.shape[1]
+    for person_idx in range(n_people):
+        try:
+            smplx_layer: SmplxLayerTorch = (
+                SmplxLayerTorch(
+                    betas=smplx_stack.betas[person_idx],
+                    model_type=smplx_stack.model_type,
+                    gender=smplx_stack.gender,
+                    flat_hand_mean=smplx_stack.flat_hand_mean,
+                    v_template=smplx_stack.v_template[person_idx] if smplx_stack.v_template is not None else None,
+                )
+                .to(smplx_device)
+                .eval()
+            )
+        # Missing/unloadable body model: pip smplx raises RuntimeError for a bad
+        # model dir, ImportError/ModuleNotFoundError when a stock chumpy-bearing
+        # SMPL pkl is dropped in. Either way, warn and skip rather than crash.
+        except (RuntimeError, ImportError) as exc:
+            warnings.warn(f"Skipping SMPL-X mesh logging (body model unavailable): {exc}", stacklevel=2)
+            return
+        poses_person: Float32[ndarray, "n_frames n_pose"] = np.ascontiguousarray(smplx_stack.poses[0:n_frames_total, person_idx])
+        trans_person: Float32[ndarray, "n_frames 3"] = np.ascontiguousarray(smplx_stack.trans[0:n_frames_total, person_idx])
+        if smplx_stack.transl_pivot == "origin":
+            # EasyMocap-style params rotate the posed mesh about the origin
+            # (x = R @ v + Th) while smplx pivots at the root joint, so shift
+            # the translation by (R - I) @ j0 (cf. the EPFL MANO conversion).
+            root_joint: Float32[ndarray, "3"] = smplx_layer.rest_root_joint()
+            rotations: Float32[ndarray, "n_frames 3 3"] = Rotation.from_rotvec(poses_person[:, 0:3]).as_matrix().astype(np.float32)
+            trans_person = trans_person + (rotations - np.eye(3, dtype=np.float32)) @ root_joint
+
+        mesh_entity_path: Path = smplx_root_path / f"person_{person_idx:02d}" / "mesh"
+        faces_np: Int[ndarray, "n_faces 3"] = smplx_layer.faces.astype(np.int32)
+        rr.log(
+            f"{mesh_entity_path}",
+            rr.Mesh3D.from_fields(
+                triangle_indices=faces_np,
+                albedo_factor=SMPLX_PERSON_COLORS[person_idx % len(SMPLX_PERSON_COLORS)],
+            ),
+            static=True,
+        )
+        # Forward + send in bounded frame chunks: vertices cost ~126 KB/frame
+        # (SMPL-X), so materializing a whole sequence before sending would need
+        # ~12 GB host RAM per person on a ~100k-frame EPFL session.
+        for chunk_start in range(0, n_frames_total, SMPLX_FORWARD_CHUNK_FRAMES):
+            chunk_end: int = min(chunk_start + SMPLX_FORWARD_CHUNK_FRAMES, n_frames_total)
+            smplx_forward: SmplxForwardResult = smplx_layer.forward_batched(
+                poses_person[chunk_start:chunk_end], trans_person[chunk_start:chunk_end]
+            )
+            verts: Float32[ndarray, "chunk_frames n_verts 3"] = smplx_forward.vertices
+            vertex_positions_flat: Float32[ndarray, "chunk_total 3"] = rearrange(
+                verts,
+                "n v d -> (n v) d",
+            )
+            rr.send_columns(
+                f"{mesh_entity_path}",
+                indexes=[rr.TimeColumn(timeline, duration=1e-9 * timestamps_ns[chunk_start:chunk_end])],
+                columns=[*rr.Mesh3D.columns(vertex_positions=vertex_positions_flat).partition(lengths=[verts.shape[1]] * (chunk_end - chunk_start))],
+            )
+
+
 def log_exoego_batch(
     exoego_sequence: BaseExoEgoSequence,
     parent_log_path: Path,
@@ -486,6 +598,7 @@ def log_exoego_batch(
     log_exo: bool = True,
     log_mano: bool = False,
     log_mano_vertex_normals: bool = False,
+    log_smplx: bool = False,
 ) -> None:
     """Bulk-log 3D labels plus their ego/exo projections using columnar APIs.
 
@@ -503,6 +616,7 @@ def log_exoego_batch(
         log_mano (bool): Enable logging of MANO-derived meshes and keypoints.
         log_mano_vertex_normals (bool): Compute and log dynamic MANO mesh
             vertex normals when MANO mesh logging is enabled.
+        log_smplx (bool): Enable logging of SMPL/SMPL-X body meshes.
 
     Returns:
         None: Data is emitted via ``rr.log`` and ``rr.send_columns`` side
@@ -579,6 +693,17 @@ def log_exoego_batch(
             timestamps_ns=label_timestamps_trim,
             log_mano=log_mano,
             log_mano_vertex_normals=log_mano_vertex_normals,
+        )
+
+        ##############################
+        # batch send all SMPL-X data #
+        ##############################
+        log_smplx_batch(
+            exoego_sequence=exoego_sequence,
+            smplx_parent_log_path=gt_root_path,
+            timeline=timeline,
+            timestamps_ns=label_timestamps_trim,
+            log_smplx=log_smplx,
         )
 
     ###########################
@@ -950,6 +1075,7 @@ def visualize_exo_ego(exoego_sequence: BaseExoEgoSequence, config: VisualizeConf
             log_exo=config.log_exo,
             log_mano=config.log_mano,
             log_mano_vertex_normals=config.log_mano_vertex_normals,
+            log_smplx=config.log_smplx,
         )
 
     scene_setup_result: SceneSetupResult = setup_scene(

--- a/packages/simplecv/simplecv/configs/exoego_dataset_configs.py
+++ b/packages/simplecv/simplecv/configs/exoego_dataset_configs.py
@@ -12,6 +12,7 @@ from simplecv.data.exoego.ego_dex import EgoDexConfig
 from simplecv.data.exoego.epfl_smart_kitchen import EpflSmartKitchenConfig
 from simplecv.data.exoego.hocap import HocapConfig
 from simplecv.data.exoego.hot3d import Hot3dConfig
+from simplecv.data.exoego.mamma import MammaConfig
 from simplecv.data.exoego.robocap import RobocapConfig
 from simplecv.data.exoego.rrd_exoego import RRDExoEgoConfig
 from simplecv.data.exoego.umetrack import UmeTrackConfig
@@ -25,6 +26,7 @@ dataset_defaults = {
     "hocap": HocapConfig(),
     "ego-dex": EgoDexConfig(),
     "hot3d": Hot3dConfig(),
+    "mamma": MammaConfig(),
     "robocap": RobocapConfig(),
     "rrd": RRDExoEgoConfig(),
     "umetrack": UmeTrackConfig(),

--- a/packages/simplecv/simplecv/data/exo/base_exo.py
+++ b/packages/simplecv/simplecv/data/exo/base_exo.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Generator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Generic, TypeVar
+from typing import Generic, Literal, TypeVar
 
 from jaxtyping import Float32
 from numpy import ndarray
@@ -43,6 +43,37 @@ class ManoStack:
         if b.ndim == 1:
             return b
         return b[hand_idx]
+
+
+@dataclass
+class SmplxStack:
+    """Per-sequence SMPL/SMPL-X body parameters for one or more people.
+
+    Poses are axis-angle full-pose vectors per frame/person: 165-dim for SMPL-X
+    (global 0:3, body 3:66, jaw 66:69, eyes 69:75, left hand 75:120, right hand
+    120:165) or 72-dim for plain SMPL (global 0:3, body 3:72). Translations are
+    world-space meters.
+    """
+
+    betas: Float32[ndarray, "n_people n_betas"]
+    """Per-person shape coefficients (SMPL-X commonly 16, SMPL 10)."""
+    poses: Float32[ndarray, "n_frames n_people n_pose"]
+    """Axis-angle full pose per frame and person (165 SMPL-X / 72 SMPL)."""
+    trans: Float32[ndarray, "n_frames n_people 3"]
+    """World translation per frame and person, meters."""
+    model_type: Literal["smplx", "smpl"] = "smplx"
+    """Body model family the parameters were fit with."""
+    flat_hand_mean: bool = False
+    """SMPL-X hand rest convention: False = zero hand pose rests at the MANO mean."""
+    gender: str = "neutral"
+    """Body model gender the parameters were fit with."""
+    transl_pivot: Literal["root_joint", "origin"] = "root_joint"
+    """Rotation pivot convention for ``trans``: ``root_joint`` = native smplx
+    (``x = R @ (v - j0) + j0 + t``), ``origin`` = EasyMocap-style
+    (``x = R @ v + Th``, e.g. EPFL Smart Kitchen), converted at logging time."""
+    v_template: Float32[ndarray, "n_people n_verts 3"] | None = None
+    """Optional per-person subject rest mesh replacing the model's mean template
+    (MoSh ``mosh_v_template`` GT, e.g. MAMMA eval); ``betas`` are zero when set."""
 
 
 @dataclass

--- a/packages/simplecv/simplecv/data/exo/mamma_exo.py
+++ b/packages/simplecv/simplecv/data/exo/mamma_exo.py
@@ -1,0 +1,52 @@
+from functools import cached_property
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from simplecv.camera_parameters import PinholeParameters
+from simplecv.data.exo.base_exo import BaseExoSequence, ExoData
+from simplecv.data.exoego.mamma import MammaSequenceLayout, pinhole_from_camera_npz, resolve_sequence_layout
+
+if TYPE_CHECKING:
+    from simplecv.data.exoego.mamma import MammaConfig
+else:
+    from simplecv.data.exoego.exoego_config import BaseExoEgoDatasetConfig as MammaConfig
+
+
+class MammaExoSequence(BaseExoSequence[MammaConfig]):
+    """Static exocentric RGB streams for MAMMA (IOI rig or iPhone captures)."""
+
+    @cached_property
+    def _layout(self) -> MammaSequenceLayout:
+        """Calibration dir, video dir, and camera names — resolved once per sequence."""
+        return resolve_sequence_layout(self.config)
+
+    def load_video_paths(self) -> list[Path]:
+        video_paths: list[Path] = []
+        for camera_name in self._layout.camera_names:
+            video_path: Path = self._layout.video_dir / f"{camera_name}.mp4"
+            if not video_path.exists():
+                raise FileNotFoundError(f"MAMMA exo video not found for {camera_name}: {video_path}")
+            video_paths.append(video_path)
+        return video_paths
+
+    def load_exo_cams(self) -> list[PinholeParameters | None]:
+        cameras: list[PinholeParameters | None] = []
+        for camera_name in self._layout.camera_names:
+            npz_path: Path = self._layout.calib_dir / f"{camera_name}.npz"
+            if not npz_path.exists():
+                raise FileNotFoundError(f"MAMMA calibration NPZ not found for {camera_name}: {npz_path}")
+            cameras.append(pinhole_from_camera_npz(npz_path, self._layout.video_dir / f"{camera_name}.mp4"))
+        return cameras
+
+    def __getitem__(self, idx: int) -> ExoData:
+        bgr_list = self.exo_video_readers[idx]
+        return ExoData(
+            cam_params_list=[cam for cam in self.exo_cam_list if cam is not None],
+            bgr_list=bgr_list,
+            xyz=None,
+            uv_dict=None,
+        )
+
+    @property
+    def image_plane_distance(self) -> int | float:
+        return 0.5

--- a/packages/simplecv/simplecv/data/exoego/base_exoego.py
+++ b/packages/simplecv/simplecv/data/exoego/base_exoego.py
@@ -15,7 +15,7 @@ from typing_extensions import Self
 
 from simplecv.camera_parameters import Extrinsics, Fisheye62Parameters, PinholeParameters
 from simplecv.data.ego.base_ego import BaseEgoSequence
-from simplecv.data.exo.base_exo import BaseExoSequence, ManoStack
+from simplecv.data.exo.base_exo import BaseExoSequence, ManoStack, SmplxStack
 from simplecv.data.exoego.exoego_config import BaseExoEgoDatasetConfig
 from simplecv.data.exoego.sequence_identity import SequenceIdentity
 from simplecv.image_types import BGRList
@@ -61,11 +61,19 @@ class ExoEgoLabels:
         behaviour but risking drift when label and video frame rates differ.
     mano_stack:
         Optional MANO parameters associated with the same frames.
+    smplx_stack:
+        Optional SMPL/SMPL-X body parameters associated with the same frames.
     """
 
+    # TODO(multi-person-keypoints): xyzc_stack holds ONE skeleton, so multi-person
+    # datasets (MAMMA dance/multi-people) only get keypoints for person 0 — extra
+    # people get SMPL-X meshes only (SmplxStack has an n_people axis; ManoStack and
+    # this field do not). Lifting it means a people axis here, per-person entity
+    # paths in view_exoego's 3D/2D keypoint logging, and updating rrd_exoego.load_labels.
     xyzc_stack: Float[ndarray, "num_frames 133 4"]
     timestamps_ns: Int[ndarray, "num_frames"] | None = None
     mano_stack: ManoStack | None = None
+    smplx_stack: SmplxStack | None = None
 
 
 @dataclass
@@ -506,6 +514,7 @@ class BaseExoEgoSequence(Generic[ConfigT], ABC):  # noqa: UP046
             xyzc_stack=xyzc_stack_frame[np.newaxis, ...],
             timestamps_ns=labels.timestamps_ns,
             mano_stack=labels.mano_stack,
+            smplx_stack=labels.smplx_stack,
         )
 
     @abstractmethod

--- a/packages/simplecv/simplecv/data/exoego/epfl_smart_kitchen.py
+++ b/packages/simplecv/simplecv/data/exoego/epfl_smart_kitchen.py
@@ -20,7 +20,7 @@ from serde import field as serde_field
 
 from simplecv.camera_parameters import BrownConradyDistortion, Extrinsics, Intrinsics, PinholeParameters
 from simplecv.data.ego.base_ego import BaseEgoSequence
-from simplecv.data.exo.base_exo import BaseExoSequence, ManoStack
+from simplecv.data.exo.base_exo import BaseExoSequence, ManoStack, SmplxStack
 from simplecv.data.exoego.base_exoego import BaseExoEgoSequence, ExoEgoLabels, ExoEgoSample
 from simplecv.data.exoego.exoego_config import BaseExoEgoDatasetConfig
 from simplecv.data.exoego.sequence_identity import SequenceIdentity
@@ -237,6 +237,12 @@ class HoloLensPoses:
     ``world2holo`` cell was blank (``[]``) because tracking dropped out."""
 
 
+# TODO(epfl-ego-drift): some segments have valid-looking world2holo poses whose camera
+# center drifts far from the body (e.g. train/YH2040/2023_09_12_09_50_41 around 60-70s:
+# ego cam ends up 0.3-1.3m from the SMPL head keypoint vs ~0.1m normally, on interspersed
+# frames with no tracking dropouts). Cause not yet investigated. To debug: plot per-frame
+# distance between the ego camera center and the head keypoint, and inspect the raw
+# world2holo rows at the flagged frames.
 def load_hololens_world_to_camera_poses(cfg: EpflSmartKitchenConfig) -> HoloLensPoses:
     """Load per-frame HoloLens world-to-camera transforms from ``holo_data_wpose.csv``."""
     path: Path = holo_pose_path(cfg)
@@ -392,6 +398,26 @@ class EpflBodyPoseRow:
     """Optional per-body-keypoint confidence values."""
     l2_dist: float | None = serde_field(default=None, deserializer=_deserialize_optional_float)
     """Optional EPFL body reprojection/error filter value."""
+    poses: Float32[ndarray, "pose_coeffs"] | None = serde_field(
+        default=None,
+        deserializer=_deserialize_optional_float32_array,
+    )
+    """Optional SMPL 72-vector axis-angle pose with a zeroed root placeholder."""
+    Rh: Float32[ndarray, "3"] | Float32[ndarray, "3 3"] | None = serde_field(
+        default=None,
+        deserializer=_deserialize_optional_float32_array,
+    )
+    """Optional SMPL root orientation as axis-angle or a rotation matrix."""
+    Th: Float32[ndarray, "3"] | None = serde_field(
+        default=None,
+        deserializer=_deserialize_optional_float32_array,
+    )
+    """Optional SMPL translation in world coordinates, expressed in meters."""
+    shapes: Float32[ndarray, "betas=10"] | None = serde_field(
+        default=None,
+        deserializer=_deserialize_optional_float32_array,
+    )
+    """Optional SMPL shape coefficients."""
 
 
 @serde(type_check=coerce)
@@ -683,6 +709,54 @@ def _load_mano_stack(hand_rows: list[EpflHandPoseRow]) -> ManoStack:
     return ManoStack(betas=betas, so3=so3, trans=trans, use_pca=False)
 
 
+def _load_smpl_stack(body_rows: list[EpflBodyPoseRow]) -> SmplxStack | None:
+    """Build the per-sequence plain-SMPL ``SmplxStack`` from ``pose3d_smpl.csv`` rows.
+
+    EPFL releases EasyMocap-style SMPL fits alongside the regressed keypoints:
+    ``poses`` (72 axis-angle with zeroed root placeholder), ``Rh`` (root
+    axis-angle), ``Th`` (world translation, meters, origin-pivot), ``shapes``
+    (10 betas). Returns ``None`` when the parameter columns are absent (older
+    slices or synthetic fixtures). Translations keep the EasyMocap origin-pivot
+    convention (``transl_pivot="origin"``); the logging layer converts to the
+    smplx root-joint pivot. The release does not state the SMPL gender, so
+    neutral is assumed.
+    """
+    num_frames: int = len(body_rows)
+    shapes_rows: list[Float32[ndarray, "betas=10"]] = []
+    poses: Float32[ndarray, "num_frames n_people=1 72"] = np.zeros((num_frames, 1, 72), dtype=np.float32)
+    trans: Float32[ndarray, "num_frames n_people=1 3"] = np.zeros((num_frames, 1, 3), dtype=np.float32)
+    for frame_idx, row in enumerate(body_rows):
+        # Use the row fields directly instead of union-annotated locals: under the
+        # beartype import hook a `X | None` hint on an in-loop annotated assignment
+        # is re-evaluated (and its checker re-compiled) every iteration, which takes
+        # hours on a ~100k-row session. The fields are already typed on
+        # ``EpflBodyPoseRow`` and checked at row construction.
+        if row.poses is None or row.Rh is None or row.Th is None or row.shapes is None:
+            return None
+        shapes_rows.append(_vector_from_array(row.shapes, expected_len=10, field_name="shapes").astype(np.float32, copy=False))
+        pose: Float32[ndarray, "72"] = _vector_from_array(row.poses, expected_len=72, field_name="poses").astype(np.float32, copy=True)
+        pose[:3] = _root_axis_angle(row.Rh, field_name="Rh")
+        poses[frame_idx, 0] = pose
+        trans[frame_idx, 0] = _vector_from_array(row.Th, expected_len=3, field_name="Th")
+
+    shapes_stack: Float32[ndarray, "num_frames betas=10"] = np.stack(shapes_rows)
+    shapes_delta: float = float(np.nanmax(np.abs(shapes_stack - shapes_stack[0])))
+    if shapes_delta > 1e-2:
+        warnings.warn(
+            f"EPFL SMPL shape parameters drift over time (max={shapes_delta:.6f}); using first-frame values.",
+            stacklevel=2,
+        )
+
+    return SmplxStack(
+        betas=shapes_stack[0][np.newaxis, :],
+        poses=poses,
+        trans=trans,
+        model_type="smpl",
+        gender="neutral",
+        transl_pivot="origin",
+    )
+
+
 class EpflSmartKitchenSequence(BaseExoEgoSequence[EpflSmartKitchenConfig]):
     """EPFL-Smart-Kitchen ExoEgo dataset adapter."""
 
@@ -822,7 +896,8 @@ class EpflSmartKitchenSequence(BaseExoEgoSequence[EpflSmartKitchenConfig]):
         xyzc_stack[:, RIGHT_HAND_IDX, 3] = hand_conf[:, 21:]
 
         mano_stack: ManoStack = _load_mano_stack(hand_rows)
-        return ExoEgoLabels(xyzc_stack=xyzc_stack, timestamps_ns=label_timestamps_ns, mano_stack=mano_stack)
+        smplx_stack: SmplxStack | None = _load_smpl_stack(body_rows)
+        return ExoEgoLabels(xyzc_stack=xyzc_stack, timestamps_ns=label_timestamps_ns, mano_stack=mano_stack, smplx_stack=smplx_stack)
 
     @classmethod
     def iter_episode_sequences(cls, cfg: EpflSmartKitchenConfig) -> Generator["EpflSmartKitchenSequence", None, None]:

--- a/packages/simplecv/simplecv/data/exoego/mamma.py
+++ b/packages/simplecv/simplecv/data/exoego/mamma.py
@@ -348,12 +348,13 @@ class MammaSequence(BaseExoEgoSequence[MammaConfig]):
         return stream_ts
 
     def load_labels(self) -> ExoEgoLabels | None:
-        """Build SMPL-X body labels from ``pred/params_XX.npz`` or the eval GT.
+        """Build SMPL-X body labels from the eval GT or ``pred/params_XX.npz``.
 
-        Markerless subsets ship MAMMA-estimated SMPL-X params per person in
-        ``pred/params_XX.npz``; eval subsets instead carry MoSh GT (with a
-        subject ``v_template``) in ``gt/global.npz``. Both become a
-        ``SmplxStack`` (see the two ``_smplx_stack_from_*`` builders).
+        Eval subsets carry MoSh GT (with a subject ``v_template``) in
+        ``gt/global.npz``; markerless subsets ship MAMMA-estimated SMPL-X params
+        per person in ``pred/params_XX.npz``. Both become a ``SmplxStack`` (see
+        the two ``_smplx_stack_from_*`` builders), and the GT wins when both are
+        present — the labels are logged as ground truth.
 
         MAMMA ships no COCO-133 keypoints directly, so they are derived from the
         SMPL-X forward's regressed joints (person 0 — ``ExoEgoLabels.xyzc_stack``
@@ -362,12 +363,11 @@ class MammaSequence(BaseExoEgoSequence[MammaConfig]):
         the NaN placeholder (robocap-style) and the viewer skips keypoints.
         """
         sequence_dir: Path = sequence_dir_for_config(self.config)
-        params_paths: list[Path] = natsorted((sequence_dir / "pred").glob("params_*.npz"))
-        smplx_stack: SmplxStack | None = (
-            _smplx_stack_from_pred_params(params_paths)
-            if params_paths
-            else _smplx_stack_from_eval_gt(sequence_dir / "gt" / "global.npz")
-        )
+        smplx_stack: SmplxStack | None = _smplx_stack_from_eval_gt(sequence_dir / "gt" / "global.npz")
+        if smplx_stack is None:
+            params_paths: list[Path] = natsorted((sequence_dir / "pred").glob("params_*.npz"))
+            if params_paths:
+                smplx_stack = _smplx_stack_from_pred_params(params_paths)
         if smplx_stack is None:
             return None
 

--- a/packages/simplecv/simplecv/data/exoego/mamma.py
+++ b/packages/simplecv/simplecv/data/exoego/mamma.py
@@ -1,0 +1,395 @@
+"""MAMMA (MPI markerless multi-person mocap) exoego adapter.
+
+Exo-only multi-view rig: per-camera calibration ships as NPZ files
+(``cam_int`` 3x3 K, ``cam_ext`` 4x4 world->camera, ``cam_img_w``/``cam_img_h``)
+under ``meta/`` (markerless subsets) or ``gt/`` (MammaEval subsets), with one
+``<CAM>.mp4`` per camera. Download with ``tools/download_mamma.py`` and build
+the AV1 yuv420 mirror with ``tools/preprocess_mamma.py`` (the shipped videos
+are yuv444 H.264/H.265, which the NVDEC/rerun hot path cannot decode).
+
+Expected per-sequence layout under ``root_directory``::
+
+    <subset>/<sequence>/
+      meta/{<CAM>.npz, global.npz}   # or gt/ for mamma_eval_* subsets
+      videos_av1/<CAM>.mp4           # preferred (preprocess_mamma output)
+      videos_light/<CAM>.mp4         # iPhone subsets (H.265 CRF24 yuv444)
+      videos_crf24/<CAM>.mp4         # IOI subsets (H.265 CRF24 yuv444)
+"""
+
+import warnings
+from collections.abc import Generator
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import NamedTuple
+
+import cv2
+import numpy as np
+import rerun as rr
+from jaxtyping import Float, Float32, Int
+from natsort import natsorted
+from numpy import ndarray
+from rerun.components.view_coordinates import ViewCoordinates
+
+from simplecv.camera_parameters import Extrinsics, Intrinsics, PinholeParameters
+from simplecv.data.ego.base_ego import BaseEgoSequence
+from simplecv.data.exo.base_exo import BaseExoSequence, SmplxStack
+from simplecv.data.exoego.base_exoego import BaseExoEgoSequence, ExoEgoLabels, ExoEgoSample
+from simplecv.data.exoego.exoego_config import BaseExoEgoDatasetConfig
+from simplecv.data.exoego.sequence_identity import SequenceIdentity
+
+VIDEO_DIR_PREFERENCE: tuple[str, ...] = ("videos_av1", "videos_light", "videos_crf24", "videos_crf16", "videos")
+"""Per-sequence video directories, most preferred first (AV1 mirror, then smallest source)."""
+
+CALIB_DIR_CANDIDATES: tuple[str, ...] = ("meta", "gt")
+"""Calibration directory names: ``meta/`` (markerless subsets) or ``gt/`` (MammaEval subsets)."""
+
+DOWNLOAD_HINT: str = "Run `pixi run -e simplecv simplecv-download-mamma` (and `simplecv-preprocess-mamma`) first."
+"""Recovery hint appended to missing-data errors."""
+
+
+@dataclass
+class MammaConfig(BaseExoEgoDatasetConfig):
+    """MAMMA dataset config (exo-only multi-view rig)."""
+
+    _target: type = field(default_factory=lambda: MammaSequence)
+    """Target sequence class to instantiate."""
+    root_directory: Path = Path("data/mamma")
+    """Root directory containing ``<subset>/<sequence>/{meta|gt,videos*}`` trees."""
+    sequence_name: str = "mamma_markerless_iphones/indoors/crossing_arms"
+    """Sequence directory relative to ``root_directory`` (slash-separated)."""
+    camera_names: tuple[str, ...] = ()
+    """Cameras to load; empty auto-discovers calibrated cameras that have a video."""
+
+
+def sequence_dir_for_config(cfg: MammaConfig) -> Path:
+    """Return the sequence directory (``root_directory / sequence_name``)."""
+    return cfg.root_directory / cfg.sequence_name
+
+
+def calibration_dir_for_sequence(sequence_dir: Path) -> Path:
+    """Return the calibration dir (``meta/`` or ``gt/``) for one sequence."""
+    for name in CALIB_DIR_CANDIDATES:
+        calib_dir: Path = sequence_dir / name
+        if (calib_dir / "global.npz").exists():
+            return calib_dir
+    raise FileNotFoundError(
+        f"No MAMMA calibration dir ({'/'.join(CALIB_DIR_CANDIDATES)} with global.npz) under {sequence_dir}. {DOWNLOAD_HINT}"
+    )
+
+
+def video_dir_for_sequence(sequence_dir: Path) -> Path:
+    """Return the first existing non-empty video dir by preference order."""
+    for name in VIDEO_DIR_PREFERENCE:
+        video_dir: Path = sequence_dir / name
+        if video_dir.is_dir() and any(video_dir.glob("*.mp4")):
+            return video_dir
+    raise FileNotFoundError(f"No MAMMA video dir ({'/'.join(VIDEO_DIR_PREFERENCE)}) with mp4s under {sequence_dir}. {DOWNLOAD_HINT}")
+
+
+def _cameras_with_video(sequence_dir: Path, calib_dir: Path, video_dir: Path) -> tuple[str, ...]:
+    """Cameras with both a calibration NPZ and a video in the given dirs.
+
+    Warns when the video dir covers fewer cameras than the calibration dir —
+    e.g. an interrupted ``simplecv-preprocess-mamma`` leaves a partial
+    ``videos_av1/`` mirror that would otherwise silently shrink the rig.
+    """
+    calibrated: list[str] = natsorted(npz_path.stem for npz_path in calib_dir.glob("*.npz") if npz_path.stem != "global")
+    names: list[str] = [name for name in calibrated if (video_dir / f"{name}.mp4").exists()]
+    if not names:
+        raise FileNotFoundError(
+            f"No camera with both {calib_dir.name}/<cam>.npz and {video_dir.name}/<cam>.mp4 under {sequence_dir}. {DOWNLOAD_HINT}"
+        )
+    if len(names) < len(calibrated):
+        missing: list[str] = [name for name in calibrated if name not in names]
+        warnings.warn(
+            f"MAMMA sequence {sequence_dir.name}: {video_dir.name}/ has videos for {len(names)}/{len(calibrated)} calibrated "
+            f"cameras (missing {missing}). Loading a reduced rig; re-run simplecv-preprocess-mamma if this mirror is incomplete.",
+            stacklevel=2,
+        )
+    return tuple(names)
+
+
+def discover_camera_names(sequence_dir: Path) -> tuple[str, ...]:
+    """Cameras with both a calibration NPZ and a video, naturally sorted."""
+    return _cameras_with_video(sequence_dir, calibration_dir_for_sequence(sequence_dir), video_dir_for_sequence(sequence_dir))
+
+
+class MammaSequenceLayout(NamedTuple):
+    """Resolved on-disk layout of one MAMMA sequence (computed once)."""
+
+    calib_dir: Path
+    video_dir: Path
+    camera_names: tuple[str, ...]
+
+
+def resolve_sequence_layout(cfg: MammaConfig) -> MammaSequenceLayout:
+    """Resolve the calibration dir, video dir, and camera names for a config once.
+
+    Avoids re-globbing when both ``load_video_paths`` and ``load_exo_cams`` need
+    the same immutable layout; honors an explicit ``cfg.camera_names`` override.
+    """
+    sequence_dir: Path = sequence_dir_for_config(cfg)
+    calib_dir: Path = calibration_dir_for_sequence(sequence_dir)
+    video_dir: Path = video_dir_for_sequence(sequence_dir)
+    camera_names: tuple[str, ...] = cfg.camera_names or _cameras_with_video(sequence_dir, calib_dir, video_dir)
+    return MammaSequenceLayout(calib_dir=calib_dir, video_dir=video_dir, camera_names=camera_names)
+
+
+def discover_sequence_names(root_directory: Path) -> list[str]:
+    """Find all sequence dirs (holding ``meta/global.npz`` or ``gt/global.npz``) under the root."""
+    names: set[str] = set()
+    for global_npz in root_directory.rglob("global.npz"):
+        if global_npz.parent.name in CALIB_DIR_CANDIDATES:
+            names.add(global_npz.parent.parent.relative_to(root_directory).as_posix())
+    return natsorted(names)
+
+
+def pinhole_from_camera_npz(npz_path: Path, video_path: Path) -> PinholeParameters:
+    """Build ``PinholeParameters`` from one MAMMA camera NPZ.
+
+    Mirrors the MAMMA reference loader: ``cam_ext`` is world->camera
+    (``x_cam = cam_ext @ x_world``); translations with ``|t| > 200`` are
+    millimeters and are normalized to meters. Intrinsics are given at the
+    native capture resolution — when the video was re-encoded at a different
+    size, K is rescaled to the video resolution.
+    """
+    data = np.load(npz_path, allow_pickle=True)
+    name: str = str(data["cam_name"]) if "cam_name" in data.files else npz_path.stem
+    k_matrix: Float[ndarray, "3 3"] = np.asarray(data["cam_int"], dtype=np.float64)
+    cam_T_world: Float[ndarray, "4 4"] = np.asarray(data["cam_ext"], dtype=np.float64)
+    if np.abs(cam_T_world[:3, 3]).max() > 200:
+        cam_T_world = cam_T_world.copy()
+        cam_T_world[:3, 3] /= 1000.0
+    native_width: int = int(data["cam_img_w"])
+    native_height: int = int(data["cam_img_h"])
+
+    capture = cv2.VideoCapture(str(video_path))
+    video_width: int = int(capture.get(cv2.CAP_PROP_FRAME_WIDTH))
+    video_height: int = int(capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    capture.release()
+    if video_width <= 0 or video_height <= 0:
+        raise ValueError(f"Could not probe video resolution for {video_path}")
+    if (video_width, video_height) != (native_width, native_height):
+        scale: Float[ndarray, "3 3"] = np.diag([video_width / native_width, video_height / native_height, 1.0])
+        k_matrix = scale @ k_matrix
+
+    intrinsics: Intrinsics = Intrinsics.from_k_matrix(
+        camera_conventions="RDF",
+        k_matrix=k_matrix,
+        width=video_width,
+        height=video_height,
+    )
+    extrinsics: Extrinsics = Extrinsics(
+        cam_R_world=cam_T_world[:3, :3],
+        cam_t_world=cam_T_world[:3, 3],
+    )
+    return PinholeParameters(name=name, intrinsics=intrinsics, extrinsics=extrinsics)
+
+
+def _coco133_from_smplx_person(smplx_stack: SmplxStack, *, person_idx: int) -> Float32[ndarray, "num_frames 133 4"]:
+    """Derive one person's COCO-133 keypoints from the SMPL-X forward's joints.
+
+    Runs the (chunked, GPU when available) SMPL-X forward with the face contour
+    enabled so all 133 keypoints — body, feet, 68 face, 42 hands — are mapped.
+    Raises RuntimeError/ImportError when the body model cannot be loaded.
+    """
+    import torch
+
+    from simplecv.ops.smplx.smplx_coco133 import smplx_joints_to_coco133_xyzc
+    from simplecv.ops.smplx.smplx_torch import SmplxForwardResult, SmplxLayerTorch
+
+    device: str = "cuda" if torch.cuda.is_available() else "cpu"
+    smplx_layer: SmplxLayerTorch = (
+        SmplxLayerTorch(
+            betas=smplx_stack.betas[person_idx],
+            model_type=smplx_stack.model_type,
+            gender=smplx_stack.gender,
+            flat_hand_mean=smplx_stack.flat_hand_mean,
+            use_face_contour=True,
+            v_template=smplx_stack.v_template[person_idx] if smplx_stack.v_template is not None else None,
+        )
+        .to(device)
+        .eval()
+    )
+    poses_person: Float32[ndarray, "num_frames n_pose"] = np.ascontiguousarray(smplx_stack.poses[:, person_idx])
+    trans_person: Float32[ndarray, "num_frames 3"] = np.ascontiguousarray(smplx_stack.trans[:, person_idx])
+    smplx_forward: SmplxForwardResult = smplx_layer.forward_batched(poses_person, trans_person)
+    return smplx_joints_to_coco133_xyzc(smplx_forward.joints)
+
+
+def _warn_on_mixed_person_model_settings(*, genders: list[str], flat_hand_means: list[bool], source: Path) -> None:
+    """Warn when people in one sequence were fit with different body-model settings.
+
+    ``SmplxStack`` carries a single ``gender``/``flat_hand_mean`` for all people
+    (multi-person label support is a deferred TODO — see ``ExoEgoLabels``), so a
+    mixed fit would silently forward later persons through the wrong model. All
+    data seen so far is uniform (markerless preds are all-neutral, eval singles
+    are one person); this makes the day that changes loud instead of silent.
+    """
+    if len(set(genders)) > 1:
+        warnings.warn(f"{source}: people mix body-model genders {genders}; using person 0's ({genders[0]!r}) for ALL people", stacklevel=3)
+    if len(set(flat_hand_means)) > 1:
+        warnings.warn(f"{source}: people mix flat_hand_mean {flat_hand_means}; using person 0's ({flat_hand_means[0]}) for ALL people", stacklevel=3)
+
+
+def _smplx_stack_from_pred_params(params_paths: list[Path]) -> SmplxStack:
+    """Build a ``SmplxStack`` from the markerless subsets' ``pred/params_XX.npz`` files.
+
+    Each per-person NPZ ships MAMMA-estimated SMPL-X params: ``poses (n_frames, 165)``
+    axis-angle full pose, ``betas (16,)``, and ``trans (n_frames, 3)`` in world meters.
+    """
+    poses_list: list[Float[ndarray, "n_frames 165"]] = []
+    betas_list: list[Float[ndarray, "n_betas"]] = []
+    trans_list: list[Float[ndarray, "n_frames 3"]] = []
+    flat_hand_means: list[bool] = []
+    genders: list[str] = []
+    for params_path in params_paths:
+        data = np.load(params_path, allow_pickle=True)
+        poses_list.append(np.asarray(data["poses"], dtype=np.float32))
+        betas_list.append(np.asarray(data["betas"], dtype=np.float32).reshape(-1))
+        trans_list.append(np.asarray(data["trans"], dtype=np.float32))
+        flat_hand_means.append(bool(data["flat_hand_mean"]) if "flat_hand_mean" in data.files else False)
+        genders.append(str(data["gender"]) if "gender" in data.files else "neutral")
+    _warn_on_mixed_person_model_settings(genders=genders, flat_hand_means=flat_hand_means, source=params_paths[0].parent)
+
+    num_frames: int = min(person_poses.shape[0] for person_poses in poses_list)
+    return SmplxStack(
+        betas=np.stack(betas_list, axis=0),
+        poses=np.stack([person_poses[:num_frames] for person_poses in poses_list], axis=1),
+        trans=np.stack([person_trans[:num_frames] for person_trans in trans_list], axis=1),
+        model_type="smplx",
+        flat_hand_mean=flat_hand_means[0],
+        gender=genders[0],
+    )
+
+
+def _smplx_stack_from_eval_gt(gt_npz_path: Path) -> SmplxStack | None:
+    """Build a ``SmplxStack`` from an eval subset's MoSh GT ``gt/global.npz``.
+
+    Eval GT ships ``pose_world (n_frames, n_people, 165)`` axis-angle full pose,
+    ``pose_trans_world (n_frames, n_people, 3)`` in world meters (native smplx
+    root-joint pivot), ``shape (n_people, 300)`` betas (all zeros — the subject
+    geometry lives in ``v_template (n_people, 10475, 3)``, MoSh's
+    ``mosh_v_template`` output), a per-person ``gender``, and ``flat_hand_mean``.
+    Returns None when the file is missing or holds no SMPL-X params.
+    """
+    if not gt_npz_path.exists():
+        return None
+    data = np.load(gt_npz_path, allow_pickle=True)
+    if "pose_world" not in data.files:
+        return None
+    genders: list[str] = [str(person_gender) for person_gender in np.atleast_1d(data["gender"])]
+    flat_hand_mean: bool = bool(data["flat_hand_mean"])
+    _warn_on_mixed_person_model_settings(genders=genders, flat_hand_means=[flat_hand_mean], source=gt_npz_path)
+    return SmplxStack(
+        betas=np.asarray(data["shape"], dtype=np.float32),
+        poses=np.asarray(data["pose_world"], dtype=np.float32),
+        trans=np.asarray(data["pose_trans_world"], dtype=np.float32),
+        model_type="smplx",
+        flat_hand_mean=flat_hand_mean,
+        gender=genders[0],
+        v_template=np.asarray(data["v_template"], dtype=np.float32),
+    )
+
+
+class MammaSequence(BaseExoEgoSequence[MammaConfig]):
+    """MAMMA adapter (exo-only static rig; COCO-133 keypoints derived from SMPL-X)."""
+
+    def __init__(self, cfg: MammaConfig) -> None:
+        self._ego_stream_names: list[str] = []
+        self._exo_stream_names: list[str] = []
+        super().__init__(cfg)
+
+    @classmethod
+    def sequence_identity_for_config(cls, cfg: MammaConfig) -> SequenceIdentity:
+        return SequenceIdentity(dataset="mamma", parts=tuple(cfg.sequence_name.split("/")))
+
+    def __getitem__(self, idx: int | None = None, ts_nano: np.timedelta64 | None = None) -> ExoEgoSample:
+        canonical_idx, ts_ns = self._resolve_canonical(idx=idx, ts_nano=ts_nano)
+        exo_cam_params_list, exo_bgr_list = self._sample_exo(ts_ns)
+        labels: ExoEgoLabels | None = self._sample_labels(canonical_idx, ts_ns)
+
+        return ExoEgoSample(
+            canonical_index=canonical_idx,
+            canonical_timestamp_ns=ts_ns,
+            ego_cam_params_list=None,
+            ego_bgr_list=None,
+            exo_cam_params_list=exo_cam_params_list,
+            exo_bgr_list=exo_bgr_list,
+            labels=labels,
+        )
+
+    def _build_ego(self) -> BaseEgoSequence[MammaConfig] | None:
+        return None  # exo-only
+
+    def _build_exo(self) -> BaseExoSequence[MammaConfig] | None:
+        # Deferred to break the mamma <-> mamma_exo import cycle (mamma_exo
+        # imports the module-level helpers above at its module top).
+        from simplecv.data.exo.mamma_exo import MammaExoSequence
+
+        return MammaExoSequence(cfg=self.config)
+
+    def load_stream_timestamps_ns(self) -> dict[str, Int[ndarray, "n_frames"]]:
+        """Return per-stream timestamps for the exo videos."""
+        stream_ts: dict[str, Int[ndarray, "n_frames"]] = {}
+        self._exo_stream_names.clear()
+
+        if self.exo_sequence is not None:
+            for name, video_path in zip(
+                self.exo_sequence.exo_video_names,
+                self.exo_sequence.exo_video_paths,
+                strict=True,
+            ):
+                stream_name: str = f"exo/{name}"
+                timestamps: Int[ndarray, "n_frames"] = rr.AssetVideo(path=video_path).read_frame_timestamps_nanos()
+                stream_ts[stream_name] = timestamps
+                self._exo_stream_names.append(stream_name)
+
+        return stream_ts
+
+    def load_labels(self) -> ExoEgoLabels | None:
+        """Build SMPL-X body labels from ``pred/params_XX.npz`` or the eval GT.
+
+        Markerless subsets ship MAMMA-estimated SMPL-X params per person in
+        ``pred/params_XX.npz``; eval subsets instead carry MoSh GT (with a
+        subject ``v_template``) in ``gt/global.npz``. Both become a
+        ``SmplxStack`` (see the two ``_smplx_stack_from_*`` builders).
+
+        MAMMA ships no COCO-133 keypoints directly, so they are derived from the
+        SMPL-X forward's regressed joints (person 0 — ``ExoEgoLabels.xyzc_stack``
+        is single-skeleton; every person still gets a mesh via ``smplx_stack``).
+        When the license-gated body model is unavailable the stack degrades to
+        the NaN placeholder (robocap-style) and the viewer skips keypoints.
+        """
+        sequence_dir: Path = sequence_dir_for_config(self.config)
+        params_paths: list[Path] = natsorted((sequence_dir / "pred").glob("params_*.npz"))
+        smplx_stack: SmplxStack | None = (
+            _smplx_stack_from_pred_params(params_paths)
+            if params_paths
+            else _smplx_stack_from_eval_gt(sequence_dir / "gt" / "global.npz")
+        )
+        if smplx_stack is None:
+            return None
+
+        num_frames: int = smplx_stack.poses.shape[0]
+        xyzc_stack: Float32[ndarray, "num_frames 133 4"] = np.full((num_frames, 133, 4), np.nan, dtype=np.float32)
+        xyzc_stack[..., 3] = np.float32(0.0)
+        try:
+            xyzc_stack = _coco133_from_smplx_person(smplx_stack, person_idx=0)
+        except (RuntimeError, ImportError) as exc:
+            warnings.warn(f"MAMMA COCO-133 keypoints unavailable (SMPL-X body model failed to load): {exc}", stacklevel=2)
+        return ExoEgoLabels(xyzc_stack=xyzc_stack, smplx_stack=smplx_stack)
+
+    @classmethod
+    def iter_episode_sequences(cls, cfg: MammaConfig) -> Generator["MammaSequence", None, None]:
+        """Yield one sequence per discovered sequence dir under the root."""
+        for sequence_name in discover_sequence_names(cfg.root_directory):
+            yield cls(replace(cfg, sequence_name=sequence_name))
+
+    @classmethod
+    def num_sequences_for_config(cls, cfg: MammaConfig) -> int:
+        return len(discover_sequence_names(cfg.root_directory))
+
+    @property
+    def world_coordinate_system(self) -> ViewCoordinates:
+        return ViewCoordinates.RIGHT_HAND_Z_UP

--- a/packages/simplecv/simplecv/ops/smplx/smplx_coco133.py
+++ b/packages/simplecv/simplecv/ops/smplx/smplx_coco133.py
@@ -1,0 +1,115 @@
+"""Map SMPL-X regressed joints to the COCO-133 (COCO-WholeBody) keypoint layout.
+
+The ``smplx`` package's SMPL-X forward regresses 127 joints (55 kinematic tree
+joints, then vertex-picked landmarks: nose/eyes/ears, toes/heels, fingertips,
+and the 51 iBUG face landmarks), or 144 with ``use_face_contour=True`` (adds
+the 17 jawline contour points). Every COCO-133 keypoint has a named SMPL-X
+counterpart, so the mapping is built by name against
+``smplx.joint_names.JOINT_NAMES`` — an index shift in either vocabulary fails
+loudly instead of silently mismapping.
+"""
+
+from functools import lru_cache
+
+import numpy as np
+from jaxtyping import Bool, Float, Float32, Int
+from numpy import ndarray
+
+from simplecv.data.skeleton.coco_133 import COCO_133_ID2NAME
+
+# COCO-133 names that differ from their SMPL-X joint name (identical names —
+# body joints, toes/heels — map implicitly).
+_COCO_TO_SMPLX_NAME: dict[str, str] = {
+    "left_hand_root": "left_wrist",
+    "right_hand_root": "right_wrist",
+    # COCO finger chains are <finger>1..4 (root->tip); SMPL-X names the three
+    # kinematic segments <finger>1..3 and the vertex-picked tip "<side>_<finger>".
+    "left_thumb4": "left_thumb",
+    "right_thumb4": "right_thumb",
+    "left_forefinger1": "left_index1",
+    "left_forefinger2": "left_index2",
+    "left_forefinger3": "left_index3",
+    "left_forefinger4": "left_index",
+    "right_forefinger1": "right_index1",
+    "right_forefinger2": "right_index2",
+    "right_forefinger3": "right_index3",
+    "right_forefinger4": "right_index",
+    "left_middle_finger1": "left_middle1",
+    "left_middle_finger2": "left_middle2",
+    "left_middle_finger3": "left_middle3",
+    "left_middle_finger4": "left_middle",
+    "right_middle_finger1": "right_middle1",
+    "right_middle_finger2": "right_middle2",
+    "right_middle_finger3": "right_middle3",
+    "right_middle_finger4": "right_middle",
+    "left_ring_finger1": "left_ring1",
+    "left_ring_finger2": "left_ring2",
+    "left_ring_finger3": "left_ring3",
+    "left_ring_finger4": "left_ring",
+    "right_ring_finger1": "right_ring1",
+    "right_ring_finger2": "right_ring2",
+    "right_ring_finger3": "right_ring3",
+    "right_ring_finger4": "right_ring",
+    "left_pinky_finger1": "left_pinky1",
+    "left_pinky_finger2": "left_pinky2",
+    "left_pinky_finger3": "left_pinky3",
+    "left_pinky_finger4": "left_pinky",
+    "right_pinky_finger1": "right_pinky1",
+    "right_pinky_finger2": "right_pinky2",
+    "right_pinky_finger3": "right_pinky3",
+    "right_pinky_finger4": "right_pinky",
+}
+
+# The 68 iBUG face points ("face-0".."face-67" in COCO-133): 0-16 are the
+# jawline contour, 17-67 the inner landmarks. SMPL-X's JOINT_NAMES lists the 51
+# inner landmarks (indices 76..126) and the contour (127..143) each in iBUG
+# order, so face-n maps positionally within those two blocks.
+_SMPLX_FACE_LANDMARKS_START: int = 76
+_SMPLX_FACE_CONTOUR_START: int = 127
+_NUM_FACE_CONTOUR: int = 17
+
+
+@lru_cache(maxsize=1)
+def _coco133_to_smplx_indices() -> tuple[Int[ndarray, "n_mapped"], Int[ndarray, "n_mapped"]]:
+    """Build (coco_ids, smplx_ids) index arrays for all 133 mappable keypoints."""
+    from smplx.joint_names import JOINT_NAMES
+
+    smplx_name_to_idx: dict[str, int] = {name: idx for idx, name in enumerate(JOINT_NAMES)}
+    coco_ids: list[int] = []
+    smplx_ids: list[int] = []
+    for coco_id in range(133):
+        coco_name: str = COCO_133_ID2NAME[coco_id]
+        if coco_name.startswith("face-"):
+            face_idx: int = int(coco_name.removeprefix("face-"))
+            smplx_idx: int = (
+                _SMPLX_FACE_CONTOUR_START + face_idx if face_idx < _NUM_FACE_CONTOUR else _SMPLX_FACE_LANDMARKS_START + face_idx - _NUM_FACE_CONTOUR
+            )
+        else:
+            smplx_idx = smplx_name_to_idx[_COCO_TO_SMPLX_NAME.get(coco_name, coco_name)]
+        coco_ids.append(coco_id)
+        smplx_ids.append(smplx_idx)
+    return np.asarray(coco_ids, dtype=np.int64), np.asarray(smplx_ids, dtype=np.int64)
+
+
+def smplx_joints_to_coco133_xyzc(joints: Float[ndarray, "n_frames n_joints 3"]) -> Float32[ndarray, "n_frames 133 4"]:
+    """Scatter SMPL-X regressed joints into a COCO-133 ``[x, y, z, conf]`` stack.
+
+    Args:
+        joints: SMPL-X forward joints in meters — 127 per frame (or 144 with
+            ``use_face_contour=True``; without the contour the 17 jawline
+            keypoints stay NaN with confidence 0).
+
+    Returns:
+        COCO-133 keypoint stack; mapped joints carry confidence 1.0, unmapped
+        entries are NaN with confidence 0.0.
+    """
+    indices: tuple[Int[ndarray, "n_mapped"], Int[ndarray, "n_mapped"]] = _coco133_to_smplx_indices()
+    coco_ids: Int[ndarray, "n_mapped"] = indices[0]
+    smplx_ids: Int[ndarray, "n_mapped"] = indices[1]
+    num_joints: int = joints.shape[1]
+    available: Bool[ndarray, "n_mapped"] = smplx_ids < num_joints
+    xyzc_stack: Float32[ndarray, "n_frames 133 4"] = np.full((joints.shape[0], 133, 4), np.nan, dtype=np.float32)
+    xyzc_stack[..., 3] = np.float32(0.0)
+    xyzc_stack[:, coco_ids[available], :3] = joints[:, smplx_ids[available]].astype(np.float32)
+    xyzc_stack[:, coco_ids[available], 3] = np.float32(1.0)
+    return xyzc_stack

--- a/packages/simplecv/simplecv/ops/smplx/smplx_torch.py
+++ b/packages/simplecv/simplecv/ops/smplx/smplx_torch.py
@@ -1,0 +1,259 @@
+"""Torch SMPL/SMPL-X body layer wrapping the pip ``smplx`` package.
+
+Mirrors ``simplecv.ops.mano.mano_torch.MANOLayerTorch``: betas are baked in at
+construction, the forward is fully batched over frames, and the license-gated
+model file is lazily downloaded when no explicit root is given (SMPL-X neutral
+from the private HF dataset ``pablovela5620/mamma-streaming-data`` — requires
+``hf auth login``; plain SMPL has no hosted copy and must be provided via
+``model_root_dir``).
+"""
+
+import shutil
+from pathlib import Path
+from typing import Literal, NamedTuple, cast
+
+import numpy as np
+import torch
+from beartype.roar import BeartypeException
+from huggingface_hub import hf_hub_download
+from jaxtyping import Float32, Int64
+from numpy import ndarray
+from torch import Tensor
+from torch.nn import Module
+
+SMPLX_HF_REPO_ID: str = "pablovela5620/mamma-streaming-data"
+"""Private HF dataset hosting ``body_models/smplx/SMPLX_NEUTRAL.npz`` (SMPL-X v1.1)."""
+
+# Standard SMPL-X 165-dim axis-angle full-pose layout (matches MAMMA pred/params NPZs).
+_SMPLX_GLOBAL: slice = slice(0, 3)
+_SMPLX_BODY: slice = slice(3, 66)
+_SMPLX_JAW: slice = slice(66, 69)
+_SMPLX_LEYE: slice = slice(69, 72)
+_SMPLX_REYE: slice = slice(72, 75)
+_SMPLX_LHAND: slice = slice(75, 120)
+_SMPLX_RHAND: slice = slice(120, 165)
+
+SMPLX_NUM_POSE: int = 165
+SMPL_NUM_POSE: int = 72
+
+# SMPL-X LBS materializes (frames, n_verts, 4, 4) skinning transforms, so a
+# whole multi-thousand-frame sequence in one forward peaks at several GB. Chunk
+# batched forwards to bound peak memory (EPFL sessions run to ~100k frames).
+SMPLX_FORWARD_CHUNK_FRAMES: int = 512
+
+
+class SmplxForwardResult(NamedTuple):
+    """Host-numpy vertices and joints from a batched SMPL/SMPL-X forward."""
+
+    vertices: Float32[ndarray, "n_frames n_verts 3"]
+    joints: Float32[ndarray, "n_frames n_joints 3"]
+
+
+class SmplxLayerTorch(Module):
+    """Batched SMPL/SMPL-X forward returning world-space vertices and joints."""
+
+    def __init__(
+        self,
+        *,
+        betas: Float32[ndarray, "n_betas"],
+        model_type: Literal["smplx", "smpl"] = "smplx",
+        gender: str = "neutral",
+        flat_hand_mean: bool = False,
+        use_face_contour: bool = False,
+        model_root_dir: Path | None = None,
+        v_template: Float32[ndarray, "n_verts 3"] | None = None,
+    ) -> None:
+        """
+        Args:
+            betas: Shape coefficients baked into every forward (SMPL-X commonly 16, SMPL 10).
+            model_type: Body model family; both are served by the ``smplx`` package.
+            gender: Model gender ("neutral", "male", "female").
+            flat_hand_mean: SMPL-X only — False means a zero hand pose rests at the
+                MANO mean (the MAMMA convention), matching the ``smplx`` package flag.
+            use_face_contour: SMPL-X only — also regress the 17 jawline contour
+                landmarks (joints output grows from 127 to 144). Needed for the
+                full COCO-133 face mapping.
+            model_root_dir: Body-model root containing ``smplx/SMPLX_<GENDER>.npz``
+                or ``smpl/SMPL_<GENDER>.{npz,pkl}``. If None, defaults to the module
+                data dir ``simplecv/data/body_models`` and lazily downloads the
+                SMPL-X neutral model from Hugging Face when missing.
+            v_template: Optional subject-specific rest mesh replacing the model's
+                mean template (MoSh ``mosh_v_template`` GT, e.g. MAMMA eval). Shape
+                blendshapes still apply on top, so pair with zero ``betas``.
+        """
+        super().__init__()
+        import smplx
+
+        if model_root_dir is None:
+            module_root: Path = Path(__file__).resolve().parents[2]
+            model_root_dir = module_root / "data" / "body_models"
+
+        ext: str = self._ensure_model_file(model_root_dir, model_type=model_type, gender=gender)
+        create_kwargs: dict = dict(
+            model_type=model_type,
+            gender=gender,
+            ext=ext,
+            num_betas=int(betas.shape[0]),
+            flat_hand_mean=flat_hand_mean,
+            use_pca=False,
+            use_face_contour=use_face_contour,
+        )
+        if v_template is not None:
+            create_kwargs["v_template"] = np.ascontiguousarray(v_template, dtype=np.float32)
+        # The smplx package's SMPL loader hardcodes a .pkl path + pickle.load and
+        # ignores ``ext`` (unlike SMPLX, which honors npz), so a chumpy-free
+        # SMPL .npz would never be found. Load it ourselves and hand smplx a
+        # pre-built ``data_struct`` to bypass its file loader.
+        if model_type == "smpl" and ext == "npz":
+            from smplx.utils import Struct
+
+            npz_path: Path = model_root_dir / f"smpl/SMPL_{gender.upper()}.npz"
+            model_npz = np.load(npz_path, allow_pickle=True)
+            create_kwargs["data_struct"] = Struct(**{key: model_npz[key] for key in model_npz.files})
+        self.model = smplx.create(str(model_root_dir), **create_kwargs)
+        self.model_type: Literal["smplx", "smpl"] = model_type
+        betas_torch: Float32[Tensor, "1 n_betas"] = torch.from_numpy(np.ascontiguousarray(betas, dtype=np.float32)).reshape(1, -1)
+        self.register_buffer("betas_buffer", betas_torch)
+        # Cache faces on host before any .to(device) move.
+        self._faces: Int64[ndarray, "n_faces 3"] = np.asarray(self.model.faces, dtype=np.int64)
+
+    @staticmethod
+    def _ensure_model_file(model_root_dir: Path, *, model_type: str, gender: str) -> str:
+        """Resolve (downloading if needed) the model file; returns the smplx ``ext``."""
+        model_stem: str = f"{model_type}/{model_type.upper()}_{gender.upper()}"
+        # Prefer .npz: stock SMPL/SMPL-X .pkl releases embed chumpy arrays that
+        # need chumpy (not in the env) to unpickle, so a dropped-in .pkl would
+        # raise ModuleNotFoundError deep inside the smplx package.
+        for ext in ("npz", "pkl"):
+            if (model_root_dir / f"{model_stem}.{ext}").exists():
+                return ext
+        if model_type != "smplx":
+            raise RuntimeError(
+                f"No {model_type.upper()} model file at {model_root_dir / model_stem}.npz. "
+                f"Download {model_type.upper()}_{gender.upper()} from https://smpl.is.tue.mpg.de/, convert it to a "
+                f"chumpy-free .npz, and place it there (or pass 'model_root_dir')."
+            )
+        hf_filename: str = f"body_models/{model_stem}.npz"
+        dest_path: Path = model_root_dir / f"{model_stem}.npz"
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            downloaded_path: Path = Path(
+                hf_hub_download(
+                    repo_id=SMPLX_HF_REPO_ID,
+                    repo_type="dataset",
+                    filename=hf_filename,
+                    local_dir=model_root_dir.parent,
+                )
+            )
+            if downloaded_path != dest_path:
+                shutil.copy2(downloaded_path, dest_path)
+        except BeartypeException:
+            raise
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to download the SMPL-X model from {SMPLX_HF_REPO_ID} (license-gated; run 'hf auth login'). "
+                "Provide 'model_root_dir' manually or download from https://smpl-x.is.tue.mpg.de/. Original error: " + str(e)
+            ) from e
+        return "npz"
+
+    @property
+    def faces(self) -> Int64[ndarray, "n_faces 3"]:
+        """Triangle indices of the body mesh (host numpy)."""
+        return self._faces
+
+    def forward(
+        self,
+        poses: Float32[Tensor, "b n_pose"],
+        transl: Float32[Tensor, "b 3"],
+    ) -> tuple[Float32[Tensor, "b n_verts 3"], Float32[Tensor, "b n_joints 3"]]:
+        """Run the batched body forward.
+
+        Args:
+            poses: Axis-angle full pose per frame — 165-dim for SMPL-X
+                (global/body/jaw/eyes/hands), 72-dim for SMPL (global/body).
+            transl: World translation per frame in meters.
+
+        Returns:
+            Vertices (10475 for SMPL-X, 6890 for SMPL) and regressed joints, meters.
+        """
+        batch_size: int = poses.shape[0]
+        betas: Float32[Tensor, "b n_betas"] = cast(Tensor, self.betas_buffer).expand(batch_size, -1)
+        if self.model_type == "smplx":
+            assert poses.shape[1] == SMPLX_NUM_POSE, f"SMPL-X expects {SMPLX_NUM_POSE}-dim poses, got {poses.shape[1]}"
+            expression: Float32[Tensor, "b n_expr"] = torch.zeros(
+                (batch_size, self.model.num_expression_coeffs), dtype=poses.dtype, device=poses.device
+            )
+            output = self.model(
+                betas=betas,
+                global_orient=poses[:, _SMPLX_GLOBAL],
+                body_pose=poses[:, _SMPLX_BODY],
+                jaw_pose=poses[:, _SMPLX_JAW],
+                leye_pose=poses[:, _SMPLX_LEYE],
+                reye_pose=poses[:, _SMPLX_REYE],
+                left_hand_pose=poses[:, _SMPLX_LHAND],
+                right_hand_pose=poses[:, _SMPLX_RHAND],
+                expression=expression,
+                transl=transl,
+            )
+        else:
+            assert poses.shape[1] == SMPL_NUM_POSE, f"SMPL expects {SMPL_NUM_POSE}-dim poses, got {poses.shape[1]}"
+            output = self.model(
+                betas=betas,
+                global_orient=poses[:, 0:3],
+                body_pose=poses[:, 3:SMPL_NUM_POSE],
+                transl=transl,
+            )
+        vertices: Float32[Tensor, "b n_verts 3"] = output.vertices
+        joints: Float32[Tensor, "b n_joints 3"] = output.joints
+        return vertices, joints
+
+    def forward_batched(
+        self,
+        poses: Float32[ndarray, "n_frames n_pose"],
+        transl: Float32[ndarray, "n_frames 3"],
+    ) -> SmplxForwardResult:
+        """Forward a whole numpy sequence in frame chunks, returning host arrays.
+
+        Chunks the batch by ``SMPLX_FORWARD_CHUNK_FRAMES`` to bound peak GPU
+        memory, moves each chunk to the layer's device, and concatenates on the
+        host. Returns both vertices and joints so callers that need only one
+        avoid a second forward.
+
+        Args:
+            poses: Axis-angle full pose per frame (165 SMPL-X / 72 SMPL).
+            transl: World translation per frame in meters.
+
+        Returns:
+            Vertices and joints for all frames, in meters, on the host.
+        """
+        device: torch.device = cast(Tensor, self.betas_buffer).device
+        num_frames: int = poses.shape[0]
+        verts_chunks: list[Float32[ndarray, "chunk n_verts 3"]] = []
+        joints_chunks: list[Float32[ndarray, "chunk n_joints 3"]] = []
+        for chunk_start in range(0, num_frames, SMPLX_FORWARD_CHUNK_FRAMES):
+            chunk_end: int = min(chunk_start + SMPLX_FORWARD_CHUNK_FRAMES, num_frames)
+            with torch.no_grad():
+                chunk_output: tuple[Float32[Tensor, "chunk n_verts 3"], Float32[Tensor, "chunk n_joints 3"]] = self.forward(
+                    torch.from_numpy(np.ascontiguousarray(poses[chunk_start:chunk_end])).float().to(device),
+                    torch.from_numpy(np.ascontiguousarray(transl[chunk_start:chunk_end])).float().to(device),
+                )
+            verts_chunks.append(chunk_output[0].cpu().numpy())
+            joints_chunks.append(chunk_output[1].cpu().numpy())
+        return SmplxForwardResult(vertices=np.concatenate(verts_chunks, axis=0), joints=np.concatenate(joints_chunks, axis=0))
+
+    def rest_root_joint(self) -> Float32[ndarray, "3"]:
+        """Root (pelvis) joint position at zero pose and zero translation.
+
+        Used to convert origin-pivot translations (EasyMocap convention:
+        ``x = R @ lbs(pose) + Th``) into the smplx root-joint-pivot convention:
+        ``transl = Th + (R - I) @ root_joint``.
+        """
+        n_pose: int = SMPLX_NUM_POSE if self.model_type == "smplx" else SMPL_NUM_POSE
+        device: torch.device = cast(Tensor, self.betas_buffer).device
+        with torch.no_grad():
+            rest_output: tuple[Float32[Tensor, "1 n_verts 3"], Float32[Tensor, "1 n_joints 3"]] = self.forward(
+                torch.zeros((1, n_pose), dtype=torch.float32, device=device),
+                torch.zeros((1, 3), dtype=torch.float32, device=device),
+            )
+        root_joint: Float32[ndarray, "3"] = rest_output[1][0, 0].cpu().numpy()
+        return root_joint

--- a/packages/simplecv/simplecv/rerun_log_utils.py
+++ b/packages/simplecv/simplecv/rerun_log_utils.py
@@ -151,7 +151,7 @@ class RerunTyroConfig:
     file simultaneously (via ``set_sinks``), instead of ``save`` being file-only.
     Ignored when ``headless`` (no viewer), or when ``serve``/``connect`` is set."""
     port: int = 9876
-    """Port for the spawned viewer's gRPC proxy (used by ``spawn`` and ``live`` + ``save``)."""
+    """Port of the viewer's gRPC proxy (used by ``spawn``, ``live`` + ``save``, and ``connect``)."""
     server_memory_limit: str = "4GB"
     """Memory budget for the spawned viewer's gRPC proxy buffer. The SDK default
     (~1 GiB) silently drops the oldest messages on long multi-camera recordings
@@ -175,10 +175,9 @@ class RerunTyroConfig:
             rr.serve_grpc(server_memory_limit=self.server_memory_limit)
             rr.serve_web_viewer(open_browser=not self.headless)
         elif self.connect:
-            # Send logging data to separate `rerun` process.
-            # You can omit the argument to connect to the default address,
-            # which is `127.0.0.1:9876`.
-            rr.connect_grpc()
+            # Send logging data to a separate, already-running `rerun` process
+            # (honors ``port`` so multiple viewers can coexist on one machine).
+            rr.connect_grpc(f"rerun+http://127.0.0.1:{self.port}/proxy")
         elif self.save is not None and self.live and not self.headless:
             # Stream to a spawned viewer AND save to a .rrd at the same time by
             # fanning out through explicit sinks. ``spawn``/``save`` each install a

--- a/packages/simplecv/simplecv/sensors/camera/brown_conrady.py
+++ b/packages/simplecv/simplecv/sensors/camera/brown_conrady.py
@@ -348,17 +348,17 @@ def project_brown_conrady_grid(
     if not filter_invalid:
         return uv_stack
 
-    # 4. Filter out-of-bounds points (if needed)
-    # check that all cameras have same image size for now, could be extended later
-    h: int = pinholes_per_view[0].intrinsics.height
-    w: int = pinholes_per_view[0].intrinsics.width
-    assert all((pinhole.intrinsics.height == h and pinhole.intrinsics.width == w) for pinhole in pinholes_per_view), (
-        "All pinhole cameras must have the same image size for batched Brown–Conrady projection."
-    )
-    uv_filtered: Float[ndarray, "n_frames n_views n_points 2"] = filter_out_of_bounds(
-        uv_batch=uv_stack, xyz_cam_batch=xyz_stack_cam, h=h, w=w
-    )
-    return uv_filtered
+    # 4. Filter out-of-bounds points per view — image sizes may differ across a
+    # rig (e.g. MAMMA eval mixes landscape and portrait-mounted cameras). The
+    # filter NaN-masks in place, and basic view slices write through to uv_stack.
+    for view_idx, pinhole in enumerate(pinholes_per_view):
+        filter_out_of_bounds(
+            uv_batch=uv_stack[:, view_idx : view_idx + 1],
+            xyz_cam_batch=xyz_stack_cam[:, view_idx : view_idx + 1],
+            h=pinhole.intrinsics.height,
+            w=pinhole.intrinsics.width,
+        )
+    return uv_stack
 
 
 def project_brown_conrady_diagonal(

--- a/packages/simplecv/tests/test_epfl_smart_kitchen.py
+++ b/packages/simplecv/tests/test_epfl_smart_kitchen.py
@@ -779,3 +779,29 @@ def test_epfl_smart_kitchen_label_load_fails_on_timestamp_count_mismatch(tmp_pat
 
     with pytest.raises(ValueError, match="label frame count must match RGB timestamp count"):
         EpflSmartKitchenSequence(cfg)
+
+
+def test_epfl_load_smpl_stack_from_rows() -> None:
+    raw_row: dict[str, str] = {
+        "kp3ds": json.dumps([[0.0, 0.0, 0.0]] * 17),
+        "poses": json.dumps([0.0] * 72),
+        "Rh": json.dumps([0.1, 0.2, 0.3]),
+        "Th": json.dumps([1.0, 2.0, 3.0]),
+        "shapes": json.dumps([0.5] * 10),
+    }
+    rows = epfl_module._parse_body_pose_rows([raw_row, raw_row], path=Path("pose3d_smpl.csv"))
+    stack = epfl_module._load_smpl_stack(rows)
+    assert stack is not None
+    assert stack.model_type == "smpl"
+    assert stack.transl_pivot == "origin"
+    assert stack.betas.shape == (1, 10)
+    assert stack.poses.shape == (2, 1, 72)
+    assert stack.trans.shape == (2, 1, 3)
+    np.testing.assert_allclose(stack.poses[0, 0, :3], [0.1, 0.2, 0.3], atol=1e-6)
+    np.testing.assert_allclose(stack.trans[0, 0], [1.0, 2.0, 3.0], atol=1e-6)
+
+
+def test_epfl_load_smpl_stack_returns_none_without_param_columns() -> None:
+    raw_row: dict[str, str] = {"kp3ds": json.dumps([[0.0, 0.0, 0.0]] * 17)}
+    rows = epfl_module._parse_body_pose_rows([raw_row], path=Path("pose3d_smpl.csv"))
+    assert epfl_module._load_smpl_stack(rows) is None

--- a/packages/simplecv/tests/test_exoego_catalog.py
+++ b/packages/simplecv/tests/test_exoego_catalog.py
@@ -38,6 +38,7 @@ from simplecv.data.exoego.ego_dex import EgoDexConfig, EgoDexSequence
 from simplecv.data.exoego.epfl_smart_kitchen import EpflSmartKitchenConfig, EpflSmartKitchenSequence
 from simplecv.data.exoego.hocap import HocapConfig, HocapSequence
 from simplecv.data.exoego.hot3d import Hot3dConfig, Hot3dSequence
+from simplecv.data.exoego.mamma import MammaConfig, MammaSequence
 from simplecv.data.exoego.sequence_identity import SequenceIdentity
 from simplecv.data.exoego.umetrack import UmeTrackConfig, UmeTrackSequence
 from simplecv.rig import entity_id
@@ -101,6 +102,14 @@ def test_sequence_identity_rejects_recording_id_separator(
             "hot3d-quest3",
             "P0001_10a27bf7",
             "hot3d-quest3__P0001_10a27bf7",
+        ),
+        (
+            MammaSequence.sequence_identity_for_config(
+                MammaConfig(sequence_name="mamma_markerless_iphones/indoors/crossing_arms")
+            ),
+            "mamma",
+            "mamma_markerless_iphones/indoors/crossing_arms",
+            "mamma__mamma_markerless_iphones__indoors__crossing_arms",
         ),
         (
             UmeTrackSequence.sequence_identity_for_config(
@@ -196,6 +205,7 @@ def test_discover_rrd_paths_raises_when_no_requested_dataset_has_rrds(tmp_path: 
         ("hot3d-quest3", "hot3d_quest3_table"),
         ("umetrack", "umetrack_table"),
         ("ego-dex", "ego_dex_table"),
+        ("mamma", "mamma_table"),
     ],
 )
 def test_table_name_for_dataset(dataset_name: str, table_name: str) -> None:

--- a/packages/simplecv/tests/test_mamma.py
+++ b/packages/simplecv/tests/test_mamma.py
@@ -227,6 +227,20 @@ def test_mamma_load_labels_from_eval_gt_warns_on_mixed_genders(tmp_path: Path) -
     assert labels.xyzc_stack.shape == (3, 133, 4)
 
 
+def test_mamma_load_labels_prefers_eval_gt_over_pred(tmp_path: Path) -> None:
+    sequence_dir: Path = _write_synthetic_sequence(tmp_path)
+    _write_params_npz(sequence_dir / "pred" / "params_00.npz", num_frames=3, seed=0)
+    _write_eval_gt_npz(sequence_dir / "gt" / "global.npz", genders=("male",))
+
+    sequence: MammaSequence = MammaSequence(MammaConfig(root_directory=tmp_path, sequence_name=SEQUENCE_NAME))
+    labels = sequence.exoego_labels
+    assert labels is not None
+    assert labels.smplx_stack is not None
+    # The MoSh GT (subject v_template, 300 betas) must win over the pred fits.
+    assert labels.smplx_stack.v_template is not None
+    assert labels.smplx_stack.betas.shape == (1, 300)
+
+
 def test_mamma_pred_params_warn_on_mixed_genders(tmp_path: Path) -> None:
     sequence_dir: Path = _write_synthetic_sequence(tmp_path)
     _write_params_npz(sequence_dir / "pred" / "params_00.npz", num_frames=3, seed=0, gender="neutral")

--- a/packages/simplecv/tests/test_mamma.py
+++ b/packages/simplecv/tests/test_mamma.py
@@ -1,0 +1,280 @@
+from pathlib import Path
+
+import av
+import numpy as np
+import pytest
+from jaxtyping import Float, UInt8
+from numpy import ndarray
+
+from simplecv.camera_parameters import PinholeParameters
+from simplecv.data.exoego.mamma import (
+    MammaConfig,
+    MammaSequence,
+    calibration_dir_for_sequence,
+    discover_camera_names,
+    discover_sequence_names,
+    pinhole_from_camera_npz,
+    video_dir_for_sequence,
+)
+
+SEQUENCE_NAME: str = "mamma_markerless_test/indoors/seq_a"
+CAMERA_NAMES: tuple[str, ...] = ("A001", "B001")
+VIDEO_WIDTH: int = 32
+VIDEO_HEIGHT: int = 32
+
+PROJECT_ROOT: Path = Path(__file__).resolve().parents[1]
+
+
+def _have_smplx_model() -> bool:
+    return (PROJECT_ROOT / "simplecv" / "data" / "body_models" / "smplx" / "SMPLX_NEUTRAL.npz").exists()
+
+
+def _write_synthetic_mp4(path: Path, num_frames: int = 3) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    container: av.container.OutputContainer = av.open(str(path), mode="w")
+    stream: av.video.stream.VideoStream = container.add_stream("h264", rate=30, options={"preset": "ultrafast", "crf": "0"})
+    stream.width = VIDEO_WIDTH
+    stream.height = VIDEO_HEIGHT
+    stream.pix_fmt = "yuv420p"
+    stream.max_b_frames = 0
+    for frame_idx in range(num_frames):
+        pixels: UInt8[ndarray, "h w 3"] = np.full((VIDEO_HEIGHT, VIDEO_WIDTH, 3), frame_idx * 40, dtype=np.uint8)
+        frame: av.VideoFrame = av.VideoFrame.from_ndarray(pixels, format="rgb24")
+        for packet in stream.encode(frame):
+            container.mux(packet)
+    for packet in stream.encode():
+        container.mux(packet)
+    container.close()
+
+
+def _write_camera_npz(path: Path, name: str, *, translation_m: float = 1.6, native_size: tuple[int, int] = (VIDEO_WIDTH, VIDEO_HEIGHT)) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cam_ext: Float[ndarray, "4 4"] = np.eye(4, dtype=np.float32)
+    cam_ext[:3, 3] = np.float32(translation_m)
+    cam_int: Float[ndarray, "3 3"] = np.array(
+        [[100.0, 0.0, native_size[0] / 2], [0.0, 100.0, native_size[1] / 2], [0.0, 0.0, 1.0]],
+        dtype=np.float32,
+    )
+    np.savez(
+        path,
+        cam_name=name,
+        cam_int=cam_int,
+        cam_ext=cam_ext,
+        cam_img_w=native_size[0],
+        cam_img_h=native_size[1],
+    )
+
+
+def _write_synthetic_sequence(root: Path, sequence_name: str = SEQUENCE_NAME, video_dir_name: str = "videos_light") -> Path:
+    sequence_dir: Path = root / sequence_name
+    meta_dir: Path = sequence_dir / "meta"
+    meta_dir.mkdir(parents=True, exist_ok=True)
+    np.savez(meta_dir / "global.npz", seq_name=sequence_name.rsplit("/", maxsplit=1)[-1], fps=30, frame_start=0, frame_end=3)
+    for camera_name in CAMERA_NAMES:
+        _write_camera_npz(meta_dir / f"{camera_name}.npz", camera_name)
+        _write_synthetic_mp4(sequence_dir / video_dir_name / f"{camera_name}.mp4")
+    return sequence_dir
+
+
+def test_discovery_and_video_dir_preference(tmp_path: Path) -> None:
+    sequence_dir: Path = _write_synthetic_sequence(tmp_path)
+    assert discover_sequence_names(tmp_path) == [SEQUENCE_NAME]
+    assert calibration_dir_for_sequence(sequence_dir).name == "meta"
+    assert video_dir_for_sequence(sequence_dir).name == "videos_light"
+    assert discover_camera_names(sequence_dir) == CAMERA_NAMES
+
+    # The AV1 mirror wins over the shipped yuv444 variants once present.
+    for camera_name in CAMERA_NAMES:
+        _write_synthetic_mp4(sequence_dir / "videos_av1" / f"{camera_name}.mp4")
+    assert video_dir_for_sequence(sequence_dir).name == "videos_av1"
+
+
+def test_pinhole_from_camera_npz_normalizes_millimeters(tmp_path: Path) -> None:
+    npz_path: Path = tmp_path / "A001.npz"
+    video_path: Path = tmp_path / "A001.mp4"
+    _write_camera_npz(npz_path, "A001", translation_m=1600.0)
+    _write_synthetic_mp4(video_path)
+
+    pinhole: PinholeParameters = pinhole_from_camera_npz(npz_path, video_path)
+    assert pinhole.name == "A001"
+    np.testing.assert_allclose(pinhole.extrinsics.cam_t_world, np.full(3, 1.6), rtol=1e-6)
+
+
+def test_pinhole_from_camera_npz_rescales_k_to_video_resolution(tmp_path: Path) -> None:
+    npz_path: Path = tmp_path / "A001.npz"
+    video_path: Path = tmp_path / "A001.mp4"
+    _write_camera_npz(npz_path, "A001", native_size=(VIDEO_WIDTH * 2, VIDEO_HEIGHT * 2))
+    _write_synthetic_mp4(video_path)
+
+    pinhole: PinholeParameters = pinhole_from_camera_npz(npz_path, video_path)
+    assert (pinhole.intrinsics.width, pinhole.intrinsics.height) == (VIDEO_WIDTH, VIDEO_HEIGHT)
+    assert pinhole.intrinsics.fl_x == pytest.approx(50.0)
+    assert pinhole.intrinsics.cx == pytest.approx(VIDEO_WIDTH / 2)
+
+
+def test_mamma_sequence_is_exo_only(tmp_path: Path) -> None:
+    _write_synthetic_sequence(tmp_path)
+    config: MammaConfig = MammaConfig(root_directory=tmp_path, sequence_name=SEQUENCE_NAME)
+    sequence: MammaSequence = MammaSequence(config)
+
+    assert sequence.ego_sequence is None
+    assert sequence.exo_sequence is not None
+    assert sequence.exo_sequence.exo_video_names == list(CAMERA_NAMES)
+    assert sorted(sequence.stream_timestamps_ns) == [f"exo/{name}" for name in CAMERA_NAMES]
+    assert len(sequence) == 3
+
+    sample = sequence[0]
+    assert sample.ego_bgr_list is None
+    assert sample.exo_bgr_list is not None
+    assert len(sample.exo_bgr_list) == len(CAMERA_NAMES)
+    assert sample.exo_bgr_list[0].shape == (VIDEO_HEIGHT, VIDEO_WIDTH, 3)
+
+    assert MammaSequence.num_sequences_for_config(config) == 1
+    episode_identities: list[str] = [type(seq).sequence_identity_for_config(seq.config).recording_id for seq in MammaSequence.iter_episode_sequences(config)]
+    assert episode_identities == ["mamma__mamma_markerless_test__indoors__seq_a"]
+
+
+def _write_params_npz(path: Path, num_frames: int, seed: int, gender: str = "neutral") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rng: np.random.Generator = np.random.default_rng(seed)
+    np.savez(
+        path,
+        poses=rng.normal(scale=0.1, size=(num_frames, 165)).astype(np.float32),
+        betas=rng.normal(scale=0.5, size=16).astype(np.float32),
+        trans=rng.normal(size=(num_frames, 3)).astype(np.float32),
+        num_betas=16,
+        flat_hand_mean=False,
+        gender=gender,
+        mocap_frame_rate=30,
+    )
+
+
+def _write_eval_gt_npz(path: Path, *, num_frames: int = 3, genders: tuple[str, ...] = ("male", "female")) -> None:
+    """Synthetic ``gt/global.npz`` in the eval subsets' MoSh GT layout."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    n_people: int = len(genders)
+    rng: np.random.Generator = np.random.default_rng(7)
+    np.savez(
+        path,
+        seq_name="seq",
+        frames_len=num_frames,
+        fps=30,
+        people_len=n_people,
+        subject_name=np.array([f"{50000 + i}" for i in range(n_people)]),
+        gender=np.array(genders),
+        shape=np.zeros((n_people, 300)),
+        pose_world=rng.normal(scale=0.05, size=(num_frames, n_people, 165)),
+        pose_trans_world=rng.normal(size=(num_frames, n_people, 3)),
+        flat_hand_mean=True,
+        v_template=np.zeros((n_people, 10475, 3)),
+        method_used="mosh_v_template",
+    )
+
+
+def test_mamma_load_labels_builds_multi_person_smplx_stack(tmp_path: Path) -> None:
+    sequence_dir: Path = _write_synthetic_sequence(tmp_path)
+    _write_params_npz(sequence_dir / "pred" / "params_00.npz", num_frames=3, seed=0)
+    _write_params_npz(sequence_dir / "pred" / "params_01.npz", num_frames=3, seed=1)
+
+    sequence: MammaSequence = MammaSequence(MammaConfig(root_directory=tmp_path, sequence_name=SEQUENCE_NAME))
+    labels = sequence.exoego_labels
+    assert labels is not None
+    assert labels.smplx_stack is not None
+    assert labels.smplx_stack.model_type == "smplx"
+    assert labels.smplx_stack.betas.shape == (2, 16)
+    assert labels.smplx_stack.poses.shape == (3, 2, 165)
+    assert labels.smplx_stack.trans.shape == (3, 2, 3)
+    assert labels.smplx_stack.gender == "neutral"
+    assert labels.smplx_stack.transl_pivot == "root_joint"
+    assert labels.xyzc_stack.shape == (3, 133, 4)
+    if _have_smplx_model():
+        # COCO-133 keypoints are derived from the SMPL-X forward (person 0).
+        assert np.all(np.isfinite(labels.xyzc_stack[..., :3]))
+        assert np.all(labels.xyzc_stack[..., 3] == 1.0)
+    else:
+        assert np.all(np.isnan(labels.xyzc_stack[..., :3]))
+
+    # Per-frame sampling passes the stack through whole.
+    sample = sequence[0]
+    assert sample.labels is not None
+    assert sample.labels.smplx_stack is labels.smplx_stack
+
+
+def test_mamma_load_labels_without_pred_returns_none(tmp_path: Path) -> None:
+    _write_synthetic_sequence(tmp_path)
+    sequence: MammaSequence = MammaSequence(MammaConfig(root_directory=tmp_path, sequence_name=SEQUENCE_NAME))
+    assert sequence.exoego_labels is None
+
+
+def test_mamma_load_labels_from_eval_gt_warns_on_mixed_genders(tmp_path: Path) -> None:
+    sequence_dir: Path = _write_synthetic_sequence(tmp_path)
+    _write_eval_gt_npz(sequence_dir / "gt" / "global.npz")
+
+    # SmplxStack carries one gender for all people, so a mixed-gender GT must
+    # degrade loudly (person 0 wins) rather than silently.
+    with pytest.warns(UserWarning, match="mix body-model genders"):
+        sequence: MammaSequence = MammaSequence(MammaConfig(root_directory=tmp_path, sequence_name=SEQUENCE_NAME))
+    labels = sequence.exoego_labels
+    assert labels is not None
+    assert labels.smplx_stack is not None
+    assert labels.smplx_stack.gender == "male"
+    assert labels.smplx_stack.flat_hand_mean is True
+    assert labels.smplx_stack.betas.shape == (2, 300)
+    assert labels.smplx_stack.poses.shape == (3, 2, 165)
+    assert labels.smplx_stack.trans.shape == (3, 2, 3)
+    assert labels.smplx_stack.v_template is not None
+    assert labels.smplx_stack.v_template.shape == (2, 10475, 3)
+    assert labels.xyzc_stack.shape == (3, 133, 4)
+
+
+def test_mamma_pred_params_warn_on_mixed_genders(tmp_path: Path) -> None:
+    sequence_dir: Path = _write_synthetic_sequence(tmp_path)
+    _write_params_npz(sequence_dir / "pred" / "params_00.npz", num_frames=3, seed=0, gender="neutral")
+    _write_params_npz(sequence_dir / "pred" / "params_01.npz", num_frames=3, seed=1, gender="female")
+
+    with pytest.warns(UserWarning, match="mix body-model genders"):
+        sequence: MammaSequence = MammaSequence(MammaConfig(root_directory=tmp_path, sequence_name=SEQUENCE_NAME))
+    labels = sequence.exoego_labels
+    assert labels is not None
+    assert labels.smplx_stack is not None
+    assert labels.smplx_stack.gender == "neutral"
+
+
+@pytest.mark.skipif(not _have_smplx_model(), reason="SMPL-X model file not available under simplecv/data/body_models/")
+def test_log_smplx_batch_streams_meshes_in_chunks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The mesh logger must forward + send in bounded frame chunks, covering every frame.
+
+    Materializing a whole sequence of vertices before sending costs ~126 KB/frame
+    (SMPL-X) — several GB on long EPFL sessions — so this pins the streaming shape.
+    """
+    import rerun as rr
+
+    import simplecv.ops.smplx.smplx_torch as smplx_torch
+    from simplecv.apis.view_exoego import log_smplx_batch
+
+    sequence_dir: Path = _write_synthetic_sequence(tmp_path)
+    _write_params_npz(sequence_dir / "pred" / "params_00.npz", num_frames=3, seed=0)
+    sequence: MammaSequence = MammaSequence(MammaConfig(root_directory=tmp_path, sequence_name=SEQUENCE_NAME))
+
+    monkeypatch.setattr(smplx_torch, "SMPLX_FORWARD_CHUNK_FRAMES", 2)
+    forward_chunk_frames: list[int] = []
+    original_forward_batched = smplx_torch.SmplxLayerTorch.forward_batched
+
+    def _spy_forward_batched(self: smplx_torch.SmplxLayerTorch, poses: ndarray, transl: ndarray) -> smplx_torch.SmplxForwardResult:
+        forward_chunk_frames.append(poses.shape[0])
+        return original_forward_batched(self, poses, transl)
+
+    monkeypatch.setattr(smplx_torch.SmplxLayerTorch, "forward_batched", _spy_forward_batched)
+    send_columns_calls: list[str] = []
+    monkeypatch.setattr(rr, "send_columns", lambda entity_path, indexes, columns: send_columns_calls.append(str(entity_path)))
+
+    rr.init("test_log_smplx_batch_chunks", spawn=False)
+    log_smplx_batch(
+        exoego_sequence=sequence,
+        smplx_parent_log_path=Path("world/gt"),
+        timeline="video_time",
+        timestamps_ns=(np.arange(3, dtype=np.int64) * 33_333_333),
+        log_smplx=True,
+    )
+    assert forward_chunk_frames == [2, 1]
+    assert len(send_columns_calls) == 2

--- a/packages/simplecv/tests/test_smplx_layer.py
+++ b/packages/simplecv/tests/test_smplx_layer.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from jaxtyping import Float32
+from numpy import ndarray
+
+from simplecv.ops.smplx.smplx_torch import SmplxLayerTorch
+
+PROJECT_ROOT: Path = Path(__file__).resolve().parents[1]
+SMPLX_MODEL_ROOT: Path = PROJECT_ROOT / "simplecv" / "data" / "body_models"
+
+
+def _have_smplx_model() -> bool:
+    return (SMPLX_MODEL_ROOT / "smplx" / "SMPLX_NEUTRAL.npz").exists()
+
+
+@pytest.mark.skipif(not _have_smplx_model(), reason="SMPL-X model file not available under simplecv/data/body_models/")
+def test_smplx_layer_forward_shapes() -> None:
+    betas: Float32[ndarray, "16"] = np.zeros(16, dtype=np.float32)
+    layer: SmplxLayerTorch = SmplxLayerTorch(betas=betas, model_root_dir=SMPLX_MODEL_ROOT).eval()
+    with torch.no_grad():
+        verts, joints = layer(torch.zeros((2, 165), dtype=torch.float32), torch.zeros((2, 3), dtype=torch.float32))
+    assert verts.shape == (2, 10475, 3)
+    assert joints.shape[0] == 2 and joints.shape[2] == 3
+    assert layer.faces.shape == (20908, 3)
+
+
+@pytest.mark.skipif(not _have_smplx_model(), reason="SMPL-X model file not available under simplecv/data/body_models/")
+def test_smplx_layer_rest_root_joint_matches_zero_pose_forward() -> None:
+    betas: Float32[ndarray, "16"] = np.zeros(16, dtype=np.float32)
+    layer: SmplxLayerTorch = SmplxLayerTorch(betas=betas, model_root_dir=SMPLX_MODEL_ROOT).eval()
+    root_joint: Float32[ndarray, "3"] = layer.rest_root_joint()
+    with torch.no_grad():
+        joints = layer(torch.zeros((1, 165), dtype=torch.float32), torch.zeros((1, 3), dtype=torch.float32))[1]
+    np.testing.assert_allclose(root_joint, joints[0, 0].numpy(), atol=1e-6)
+
+
+def test_smplx_layer_missing_smpl_model_raises(tmp_path: Path) -> None:
+    betas: Float32[ndarray, "10"] = np.zeros(10, dtype=np.float32)
+    with pytest.raises(RuntimeError, match="No SMPL model file"):
+        SmplxLayerTorch(betas=betas, model_type="smpl", model_root_dir=tmp_path)
+
+
+def test_coco133_mapping_is_complete_and_semantically_consistent() -> None:
+    from smplx.joint_names import JOINT_NAMES
+
+    from simplecv.data.skeleton.coco_133 import COCO_133_ID2NAME
+    from simplecv.ops.smplx.smplx_coco133 import _coco133_to_smplx_indices
+
+    coco_ids, smplx_ids = _coco133_to_smplx_indices()
+    assert len(coco_ids) == 133
+    assert smplx_ids.max() < len(JOINT_NAMES)
+    # Left/right sides must not cross: any coco name containing left/right maps
+    # to a smplx name on the same side (face-N points are positional, skip them).
+    for coco_id, smplx_id in zip(coco_ids, smplx_ids, strict=True):
+        coco_name: str = COCO_133_ID2NAME[int(coco_id)]
+        smplx_name: str = JOINT_NAMES[int(smplx_id)]
+        if coco_name.startswith("face-"):
+            continue
+        for side, other in (("left", "right"), ("right", "left")):
+            if coco_name.startswith(side):
+                assert side in smplx_name and other not in smplx_name, f"{coco_name} -> {smplx_name}"
+    # Midline chin: face-8 -> contour_middle.
+    chin_pos = list(coco_ids).index(31)
+    assert JOINT_NAMES[int(smplx_ids[chin_pos])] == "contour_middle"
+
+
+def test_smplx_joints_to_coco133_without_contour_leaves_jawline_nan() -> None:
+    from simplecv.ops.smplx.smplx_coco133 import smplx_joints_to_coco133_xyzc
+
+    joints: Float32[ndarray, "n_frames n_joints 3"] = np.ones((2, 127, 3), dtype=np.float32)
+    xyzc: Float32[ndarray, "n_frames 133 4"] = smplx_joints_to_coco133_xyzc(joints)
+    assert xyzc.shape == (2, 133, 4)
+    # face-0..face-16 (coco ids 23..39) need the contour joints (127..143).
+    assert np.all(np.isnan(xyzc[:, 23:40, :3])) and np.all(xyzc[:, 23:40, 3] == 0.0)
+    assert np.all(np.isfinite(xyzc[:, :23, :3])) and np.all(xyzc[:, 40:, 3] == 1.0)

--- a/packages/simplecv/tools/download_mamma.py
+++ b/packages/simplecv/tools/download_mamma.py
@@ -1,0 +1,6 @@
+import tyro
+
+from simplecv.apis.download_mamma import DownloadConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(DownloadConfig, description="Download one MAMMA sequence per subset (needs MAMMA_USERNAME/MAMMA_PASSWORD)."))

--- a/packages/simplecv/tools/preprocess_mamma.py
+++ b/packages/simplecv/tools/preprocess_mamma.py
@@ -1,0 +1,6 @@
+import tyro
+
+from simplecv.apis.preprocess_mamma import PreprocessConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(PreprocessConfig, description="Re-encode downloaded MAMMA videos to AV1 yuv420 (videos_av1 mirror)."))

--- a/pixi.lock
+++ b/pixi.lock
@@ -25561,6 +25561,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ba/e8/71c2555431edb5dd115cf86a7b599aa7e1be26728d89ae59aa11251d299c/jaxlib-0.6.2-cp312-cp312-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/1f/73c53fcbfb0b5a78f91176df41945ca466e71e9d9d836e5c522abda39ee7/pydantic-2.11.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bf/4b/afc1fef8a43bafb139f57f73bbd70df82807af5934321e8112ae50668827/botocore-1.43.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c9/33/bd37416aec828e7465652d9e2525fe52de0a29a581f1519cc51a74485091/smplx-0.1.28-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dd/1a/5d9a402b39ec892d856bbdd9db502ff73ce28cdf4aff72eb1ce1d6843506/universal_pathlib-0.3.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl
@@ -26115,6 +26116,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ba/e8/71c2555431edb5dd115cf86a7b599aa7e1be26728d89ae59aa11251d299c/jaxlib-0.6.2-cp312-cp312-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bf/4b/afc1fef8a43bafb139f57f73bbd70df82807af5934321e8112ae50668827/botocore-1.43.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c9/33/bd37416aec828e7465652d9e2525fe52de0a29a581f1519cc51a74485091/smplx-0.1.28-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dd/1a/5d9a402b39ec892d856bbdd9db502ff73ce28cdf4aff72eb1ce1d6843506/universal_pathlib-0.3.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e6/e9/087a8062dcc1c63fcb8d2292d48a1195ef8b29e5c7b178c8fd371942d063/tensorrt_cu13_bindings-10.13.3.9-cp312-none-manylinux_2_28_x86_64.whl
@@ -26674,6 +26676,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ba/e8/71c2555431edb5dd115cf86a7b599aa7e1be26728d89ae59aa11251d299c/jaxlib-0.6.2-cp312-cp312-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bf/4b/afc1fef8a43bafb139f57f73bbd70df82807af5934321e8112ae50668827/botocore-1.43.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c9/33/bd37416aec828e7465652d9e2525fe52de0a29a581f1519cc51a74485091/smplx-0.1.28-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dd/1a/5d9a402b39ec892d856bbdd9db502ff73ce28cdf4aff72eb1ce1d6843506/universal_pathlib-0.3.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e6/e9/087a8062dcc1c63fcb8d2292d48a1195ef8b29e5c7b178c8fd371942d063/tensorrt_cu13_bindings-10.13.3.9-cp312-none-manylinux_2_28_x86_64.whl
@@ -27327,6 +27330,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ba/e8/71c2555431edb5dd115cf86a7b599aa7e1be26728d89ae59aa11251d299c/jaxlib-0.6.2-cp312-cp312-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/1f/73c53fcbfb0b5a78f91176df41945ca466e71e9d9d836e5c522abda39ee7/pydantic-2.11.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bf/4b/afc1fef8a43bafb139f57f73bbd70df82807af5934321e8112ae50668827/botocore-1.43.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c9/33/bd37416aec828e7465652d9e2525fe52de0a29a581f1519cc51a74485091/smplx-0.1.28-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dd/1a/5d9a402b39ec892d856bbdd9db502ff73ce28cdf4aff72eb1ce1d6843506/universal_pathlib-0.3.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl
@@ -63112,7 +63116,7 @@ packages:
   - cffi>=2.0.0 ; platform_python_implementation != 'PyPy'
   - typing-extensions>=4.13.2 ; python_full_version < '3.11'
   - bcrypt>=3.1.5 ; extra == 'ssh'
-  requires_python: '>=3.9,!=3.9.0,!=3.9.1'
+  requires_python: '!=3.9.0,>=3.9,!=3.9.1'
 - pypi: https://files.pythonhosted.org/packages/a9/65/1caac9d4cd32e8433908683446eebc953e82d22b03d10d41a5f0fefe991b/multidict-6.7.1-cp312-cp312-macosx_11_0_arm64.whl
   name: multidict
   version: 6.7.1

--- a/pixi.toml
+++ b/pixi.toml
@@ -258,6 +258,7 @@ datasets = ">=4.0.0"
 jax = ">=0.6.0,<0.7"
 jaxopt = ">=0.8.5,<0.9"
 lovely-jax = "*"
+smplx = ">=0.1.28"
 rtmlib = { git = "https://github.com/pablovela5620/rtmlib.git", rev = "98bca2193c39b349034b280803b54c9ee58f7c68" }
 wilor-nano = { path = "packages/wilor-nano", editable = true }
 timm = "<1.0"
@@ -310,6 +311,16 @@ description = "Convert Aria Gen2 Pilot VRS files to AV1 MP4 for SimpleCV"
 cmd = "python tools/preprocess_epfl_smart_kitchen.py"
 cwd = "packages/simplecv"
 description = "Build an AV1-transcoded EPFL-Smart-Kitchen mirror for SimpleCV"
+
+[feature.simplecv.tasks.simplecv-download-mamma]
+cmd = "python tools/download_mamma.py"
+cwd = "packages/simplecv"
+description = "Download one MAMMA sequence per subset (register at mamma.is.tue.mpg.de; set MAMMA_USERNAME/MAMMA_PASSWORD)"
+
+[feature.simplecv.tasks.simplecv-preprocess-mamma]
+cmd = "python tools/preprocess_mamma.py"
+cwd = "packages/simplecv"
+description = "Re-encode downloaded MAMMA yuv444 videos to AV1 yuv420 (videos_av1 mirror)"
 
 [feature.simplecv.tasks.simplecv-catalog-serve]
 # Tier 1: just the `rerun server` CLI (an empty in-memory catalog), like hiw-500's serve.


### PR DESCRIPTION
## What

Brings the [MAMMA](https://mamma.is.tue.mpg.de/) markerless multi-person mocap dataset into simplecv as a new **exo-only** exoego dataset, and adds **SMPL/SMPL-X body-label support** to the exoego framework (parallel to MANO), wired for both MAMMA and EPFL Smart Kitchen.

`pixi run -e simplecv simplecv-view-exoego-data mamma` just works after download + preprocess.

### MAMMA dataset
- **Adapter** (`data/exoego/mamma.py`, `data/exo/mamma_exo.py`): static IOI/iPhone rig from per-camera NPZs (`cam_int`/`cam_ext` world→cam, mm→m normalization, K rescaled to actual video resolution), exo-only (`_build_ego` → None).
- **Download** (`simplecv-download-mamma`): one default sequence per subset (dance / multi-people / iphone / eval / syn) from the MPI gateway; needs `MAMMA_USERNAME`/`MAMMA_PASSWORD`. `--max-cameras N` for quick tests.
- **Preprocess** (`simplecv-preprocess-mamma`): AV1 yuv420 re-encode (`av1_nvenc`, CPU `libsvtav1` fallback) — the shipped yuv444 HEVC can't be fast-decoded (NVDEC/rerun).
- **Labels**: markerless `pred/params_XX.npz` SMPL-X fits (multi-person), and eval-subset **MoSh GT** from `gt/global.npz` — subject-specific `v_template` (`mosh_v_template`) + gendered model. COCO-133 3D + per-camera 2D keypoints are **derived from the SMPL-X forward joints** (name-based map vs `smplx.joint_names`, face contour on), so MAMMA lights up the standard keypoint path.

### SMPL/SMPL-X support
- `ops/smplx/smplx_torch.py`: batched torch layer over pip `smplx` — betas baked in, chunked forward (bounds GPU memory), HF auto-download of the license-gated neutral model, `data_struct` workaround for the smplx package's pkl-only SMPL loader, optional `v_template`.
- `SmplxStack` on `ExoEgoLabels`; viewer logs one translucent mesh per person, streamed in **bounded frame chunks** (materializing a full sequence of vertices would need ~12 GB host RAM per person on a ~100k-frame EPFL session).
- EPFL Smart Kitchen now parses `pose3d_smpl.csv` (EasyMocap origin-pivot converted to smplx root-joint pivot at log time).
- Mixed per-person `gender`/`flat_hand_mean` warns loudly and uses person 0 (single-model `SmplxStack` limitation; multi-person keypoints stay a documented TODO on `ExoEgoLabels`).

### Fixes surfaced along the way
- `brown_conrady.project_brown_conrady_grid`: **per-view** out-of-bounds filtering — the uniform-image-size assert broke rigs mixing landscape and portrait mounts (MAMMA eval: IOI_01–09 landscape 4112×3008, IOI_10–16 portrait 3008×4112).
- `RerunTyroConfig`: `--rr-config.connect` now honors `--rr-config.port` (was hardcoded to 9876).
- EPFL `_load_smpl_stack`: union-typed annotated locals inside the per-row loop made dev-mode beartype **re-compile a type-checker every iteration** (~200 µs/call and degrading → 2h+ hang on a ~100k-row session). Removed the redundant locals; the hanging test now runs in 115 s.

## Verification

- Full dev suite green: **159 passed, 27 skipped** (new tests: MAMMA adapter/labels, eval-GT parse incl. mixed-gender warning, SMPL-X layer parity, chunked-mesh-logging shape).
- Visual pass over every affected dataset via the experimental headless `ViewerClient` (`spawn(headless=True)` + `save_screenshot`): **MAMMA iphone** (4×4K, SMPL-X + keypoints), **MAMMA dance** (16 cams, 2 people), **MAMMA eval** (16 mixed-orientation 12.4MP cams, MoSh GT `v_template` + male model, projections land correctly), **EPFL** (SMPL through the chunked path + MANO + keypoints). Eval GT sanity: projected nose lands mid-frame at 4.3 m depth across the clip; SMPL-X verts previously verified 0.00 mm vs the MAMMA golden.
- **HoCap** shows black video panes with correct keypoints in this environment — proven **pre-existing**: a single H.264 video logged in isolation through the untouched `log_video` helper reproduces it (rerun 0.33 H.264 `VideoStream` decode; all AV1 datasets render fine), and its RRD time extents are exactly aligned with the keypoints.

License-gated body models (`SMPLX_*.npz`, `SMPL_*.npz`) stay out of the repo (gitignored under `simplecv/data/body_models/`); the neutral SMPL-X auto-downloads from HF.