### PR TITLE
simplecv: get_frames_at multi-video reader API + NVDEC worker-thread context fix

### DIFF
--- a/packages/simplecv/simplecv/video_io.py
+++ b/packages/simplecv/simplecv/video_io.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from collections import OrderedDict
-from collections.abc import Generator
+from collections.abc import Generator, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from itertools import repeat
 from pathlib import Path
@@ -340,6 +340,32 @@ class MultiVideoReader:
             if frame is not None:
                 bgr_list.append(frame)
         return bgr_list
+
+    def get_frames_at(self, frame_indices: Sequence[int]) -> list[UInt8[torch.Tensor, "3 h w"]]:
+        """Decode one RGB ``CHW`` tensor per video at per-video frame indices.
+
+        Same contract as :meth:`TorchCodecMultiVideoReader.get_frames_at` so
+        consumers stay reader-agnostic; cv2 frames are converted BGR HWC numpy
+        -> RGB CHW torch on CPU.
+
+        Args:
+            frame_indices: One frame index per video, in camera order.
+
+        Returns:
+            One uint8 RGB ``CHW`` tensor per video.
+
+        Raises:
+            ValueError: If the index count mismatches the videos or a frame is missing.
+        """
+        if len(frame_indices) != len(self.video_readers):
+            raise ValueError(f"Expected {len(self.video_readers)} frame indices, got {len(frame_indices)}.")
+        frames: list[UInt8[torch.Tensor, "3 h w"]] = []
+        for reader, frame_idx in zip(self.video_readers, frame_indices, strict=True):
+            bgr: ImageBGR | None = reader.get_frame(int(frame_idx))
+            if bgr is None:
+                raise ValueError(f"Missing frame {int(frame_idx)} in video reader.")
+            frames.append(rearrange(torch.from_numpy(np.ascontiguousarray(bgr[..., ::-1])), "h w c -> c h w"))
+        return frames
 
 
 class TorchCodecVideoReader:
@@ -698,12 +724,51 @@ class TorchCodecMultiVideoReader:
         rgb_list: list[UInt8[torch.Tensor, "3 h w"]] = [reader.get_frame(idx) for reader in self._video_readers]
         return rgb_list
 
+    def get_frames_at(self, frame_indices: Sequence[int]) -> list[UInt8[torch.Tensor, "3 h w"]]:
+        """Decode one RGB ``CHW`` tensor per video at per-video frame indices.
+
+        Unlike ``reader[idx]`` this supports per-camera indices (timestamp
+        alignment across drifting streams) and decodes camera-parallel across
+        the worker pool.
+
+        Args:
+            frame_indices: One frame index per video, in camera order.
+
+        Returns:
+            One uint8 RGB ``CHW`` tensor per video, on the reader's device.
+
+        Raises:
+            ValueError: If the index count mismatches the videos.
+        """
+        if len(frame_indices) != len(self._video_readers):
+            raise ValueError(f"Expected {len(self._video_readers)} frame indices, got {len(frame_indices)}.")
+
+        def _decode_one(reader: TorchCodecVideoReader, frame_idx: int) -> UInt8[torch.Tensor, "3 h w"]:
+            self._bind_cuda_context(reader.device)
+            return reader.get_frame(frame_idx)
+
+        with ThreadPoolExecutor(max_workers=self.num_workers) as executor:
+            return list(executor.map(_decode_one, self._video_readers, [int(idx) for idx in frame_indices]))
+
+    @staticmethod
+    def _bind_cuda_context(device: str) -> None:
+        """Bind the CUDA primary context to the calling worker thread.
+
+        NVDEC decoder creation (torchcodec's CUDA interface) fails with
+        ``CUDA_ERROR_INVALID_CONTEXT`` when the first decode of a reader runs
+        on a thread that has never touched CUDA.
+        """
+        parsed: torch.device = torch.device(device)
+        if parsed.type == "cuda":
+            torch.cuda.set_device(parsed.index if parsed.index is not None else 0)
+
     @staticmethod
     def _decode_range(
         reader: TorchCodecVideoReader,
         start: int,
         stop: int,
     ) -> UInt8[torch.Tensor, "b 3 h w"]:
+        TorchCodecMultiVideoReader._bind_cuda_context(reader.device)
         video: UInt8[torch.Tensor, "b 3 h w"] = reader.get_frames_in_range(start, stop)
         return video
 

--- a/packages/simplecv/tests/test_torchcodec_video_io.py
+++ b/packages/simplecv/tests/test_torchcodec_video_io.py
@@ -13,6 +13,7 @@ import torch
 from jaxtyping import UInt8
 
 from simplecv.video_io import (
+    MultiVideoReader,
     TorchCodecMultiVideoReader,
     TorchCodecVideoReader,
     VideoReader,
@@ -390,6 +391,86 @@ class TestTorchCodecMultiVideoReader:
         assert len(reader) > 0
         frame_list: list = reader[0]
         assert len(frame_list) == 3
+
+
+class TestGetFramesAt:
+    """Tests for the reader-agnostic per-video frame index API."""
+
+    def test_per_video_indices_decode_in_camera_order(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Each video decodes its own index; results come back in camera order."""
+        import sys
+        import types
+
+        class _Metadata:
+            width: int = 4
+            height: int = 2
+            num_frames: int = 5
+            average_fps: float = 60.0
+
+        class _FrameBatch:
+            def __init__(self, data: torch.Tensor) -> None:
+                self.data: torch.Tensor = data
+
+        class _FakeVideoDecoder:
+            def __init__(self, source: str | Path, **_kwargs: object) -> None:
+                self.source: str | Path = source
+                self.metadata: _Metadata = _Metadata()
+
+            def get_frame_at(self, frame_id: int) -> _FrameBatch:
+                frame: torch.Tensor = torch.full((3, self.metadata.height, self.metadata.width), frame_id, dtype=torch.uint8)
+                return _FrameBatch(frame)
+
+        fake_decoders_module = types.SimpleNamespace(VideoDecoder=_FakeVideoDecoder)
+        monkeypatch.setitem(sys.modules, "torchcodec.decoders", fake_decoders_module)
+
+        reader: TorchCodecMultiVideoReader = TorchCodecMultiVideoReader(
+            [Path("cam0.mp4"), Path("cam1.mp4"), Path("cam2.mp4")],
+            device="cpu",
+            num_workers=2,
+        )
+        frames: list[UInt8[torch.Tensor, "3 h w"]] = reader.get_frames_at([1, 3, 0])
+
+        assert [int(frame[0, 0, 0].item()) for frame in frames] == [1, 3, 0]
+        assert all(frame.shape == (3, 2, 4) for frame in frames)
+
+    def test_index_count_mismatch_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A wrong number of per-video indices is a loud error, not a partial decode."""
+        import sys
+        import types
+
+        class _Metadata:
+            width: int = 4
+            height: int = 2
+            num_frames: int = 5
+            average_fps: float = 60.0
+
+        class _FakeVideoDecoder:
+            def __init__(self, source: str | Path, **_kwargs: object) -> None:
+                self.source: str | Path = source
+                self.metadata: _Metadata = _Metadata()
+
+        fake_decoders_module = types.SimpleNamespace(VideoDecoder=_FakeVideoDecoder)
+        monkeypatch.setitem(sys.modules, "torchcodec.decoders", fake_decoders_module)
+
+        reader: TorchCodecMultiVideoReader = TorchCodecMultiVideoReader(
+            [Path("cam0.mp4"), Path("cam1.mp4")],
+            device="cpu",
+            num_workers=1,
+        )
+        with pytest.raises(ValueError, match="Expected 2 frame indices"):
+            reader.get_frames_at([0])
+
+    def test_cv2_reader_matches_torchcodec_contract(self, multi_video_paths: list[Path]) -> None:
+        """The cv2 MultiVideoReader satisfies the same contract: RGB CHW uint8 tensors."""
+        reader: MultiVideoReader = MultiVideoReader(multi_video_paths)
+        frames: list[UInt8[torch.Tensor, "3 h w"]] = reader.get_frames_at([0] * len(multi_video_paths))
+
+        bgr_list = reader[0]
+        assert len(frames) == len(multi_video_paths)
+        for frame, bgr in zip(frames, bgr_list, strict=True):
+            assert frame.dtype == torch.uint8
+            expected_rgb_chw: UInt8[torch.Tensor, "3 h w"] = torch.from_numpy(bgr[..., ::-1].transpose(2, 0, 1).copy())
+            assert torch.equal(frame, expected_rgb_chw)
 
 
 class TestTorchCodecMultiVideoReaderChunks:


### PR DESCRIPTION
Stacked on #62. Adds one reader-agnostic method to both multi-video readers and fixes a latent NVDEC threading bug.

**`get_frames_at(frame_indices)`** — one frame index *per video* (timestamp alignment across drifting streams, which `reader[idx]` can't express), returning uint8 RGB `CHW` tensors:
- `TorchCodecMultiVideoReader`: camera-parallel decode across the worker pool, frames stay on the reader's device (NVDEC → CUDA tensors, zero host copies).
- `MultiVideoReader` (cv2): same contract on CPU, so consumers and test fakes stay reader-agnostic.

**NVDEC context fix** — torchcodec decoder creation from a `ThreadPoolExecutor` worker that never touched CUDA fails with `CUDA_ERROR_INVALID_CONTEXT` (error 201). `_bind_cuda_context` (a `torch.cuda.set_device` pin) now runs in every decode worker — covering the new path *and* the pre-existing `iter_chunks` path, which had the same bug waiting.

Tests: fake-decoder tests for per-camera ordering + index-count validation, plus a real-video cv2-vs-contract check. Full simplecv suite: 134 passed.

Consumed by the mv-api adoption PR at the top of the stack.