### PR TITLE
mv-api + mamma: adopt posekit (GPU decode, dynamic-batch TRT, rig-path fixes)

### DIFF
--- a/packages/mamma/src/mamma/landmarks/posekit_role.py
+++ b/packages/mamma/src/mamma/landmarks/posekit_role.py
@@ -1,0 +1,119 @@
+"""MammaNet behind posekit's ``TopDownDenseLandmarks2d`` role.
+
+The adapter that lets mamma's dense-landmark net slot into any posekit
+pipeline (posekit docs/design.md §6): detections with masks in — the tracker's
+``BoxDetections`` carries both — dense landmarks with log-variance /
+visibility / contact heads out, all GPU tensors. Crop math, normalization, and
+precision match ``LandmarkEstimator.estimate`` exactly (same mamma ops).
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import torch
+from jaxtyping import Float, Float32, Float64, UInt8
+from numpy import ndarray
+from posekit.models import TopDownDenseLandmarks2d
+from posekit.predictions import BoxDetections, DenseLandmarks2d, validate_frames_rgb
+from torch import Tensor
+
+from mamma.landmarks.config import DEFAULT_MAMMANET_CONFIG, MammaNetConfig
+from mamma.landmarks.crops import box_geometry, gpu_crop_batch, gpu_mask_crop_batch, unproject_joints2d
+from mamma.landmarks.mammanet import MammaNet, load_mammanet
+
+MAMMANET_WEIGHTS_REPO: str = "pablovela5620/mamma-streaming-data"
+MAMMANET_WEIGHTS_FILE: str = "weights/ma_2d/mamma_mask_full_cvpr.safetensors"
+
+
+@dataclass(frozen=True, slots=True)
+class MammaNetLandmarksConfig:
+    """MammaNet dense-landmark estimator configuration (torch backend)."""
+
+    weights_path: Path | None = None
+    """Local safetensors checkpoint; ``None`` downloads mamma's HF weights."""
+    device: str = "cuda"
+    """Inference device."""
+
+    def setup(self) -> "MammaNetLandmarks":
+        """Load weights and return a ready estimator."""
+        return MammaNetLandmarks(self)
+
+
+class MammaNetLandmarks(TopDownDenseLandmarks2d):
+    """Batched GPU MammaNet dense-landmark estimator (mask-conditioned)."""
+
+    def __init__(self, config: MammaNetLandmarksConfig) -> None:
+        """Load the checkpoint.
+
+        Args:
+            config: Weights source and device.
+        """
+        from huggingface_hub import hf_hub_download
+
+        self.config: MammaNetLandmarksConfig = config
+        weights_path: Path = (
+            config.weights_path
+            if config.weights_path is not None
+            else Path(hf_hub_download(repo_id=MAMMANET_WEIGHTS_REPO, repo_type="dataset", filename=MAMMANET_WEIGHTS_FILE))
+        )
+        self.mamma_config: MammaNetConfig = DEFAULT_MAMMANET_CONFIG
+        self.model: MammaNet = load_mammanet(weights_path, device=config.device, config=self.mamma_config)
+        self.num_landmarks = int(self.mamma_config.num_landmarks)
+
+    @torch.no_grad()
+    def __call__(self, frames_rgb: UInt8[Tensor, "b h w 3"], detections: BoxDetections) -> DenseLandmarks2d:
+        """Estimate dense landmarks for every detection.
+
+        Args:
+            frames_rgb: uint8 RGB NHWC frame batch on the inference device.
+            detections: Instance boxes referencing ``frames_rgb`` by index;
+                ``masks`` must be populated (MammaNet is mask-conditioned).
+
+        Returns:
+            Dense landmarks, one instance per detection row.
+
+        Raises:
+            ValueError: If ``detections.masks`` is ``None``.
+        """
+        if detections.masks is None:
+            raise ValueError("MammaNetLandmarks requires detections.masks (mask-conditioned crops).")
+        validate_frames_rgb(frames_rgb)
+        device: torch.device = frames_rgb.device
+        num_instances: int = detections.num_detections
+        if num_instances == 0:
+            empty_xy: Float32[Tensor, "0 p 2"] = torch.empty((0, self.num_landmarks, 2), dtype=torch.float32, device=device)
+            empty_p: Float32[Tensor, "0 p"] = torch.empty((0, self.num_landmarks), dtype=torch.float32, device=device)
+            return DenseLandmarks2d(empty_xy, empty_p, empty_p, empty_p, empty_p, detections.frame_indices)
+
+        boxes_np: Float32[ndarray, "n 4"] = detections.xyxy.detach().cpu().numpy().astype(np.float32, copy=False)
+        geometry: list[tuple[Float64[ndarray, "2"], Float64[ndarray, "2"]]] = [
+            box_geometry(boxes_np[row], self.mamma_config) for row in range(num_instances)
+        ]
+        centers: Float64[ndarray, "n 2"] = np.stack([center for center, _ in geometry], axis=0)
+        sizes: Float64[ndarray, "n 2"] = np.stack([size for _, size in geometry], axis=0)
+        # Gather per-detection frames while still uint8, then convert only the
+        # gathered subset to float (4x lighter than float-converting all views).
+        gathered: Float[Tensor, "n 3 h w"] = frames_rgb.permute(0, 3, 1, 2)[detections.frame_indices].float()
+        masks_batch: Float[Tensor, "n 1 h w"] = detections.masks.unsqueeze(1).float() * 255.0
+        img_crops, _ = gpu_crop_batch(gathered, centers, sizes, None, self.mamma_config)
+        mask_crops = gpu_mask_crop_batch(masks_batch, centers, sizes, self.mamma_config)
+        with torch.autocast("cuda", dtype=torch.float16, enabled="cuda" in self.config.device):
+            out: dict[str, Tensor | None] = self.model(img_crops, mask_crops)
+        joints2d_raw = out["joints2d"]
+        visibility_raw = out["visibility"]
+        contact_raw = out["contact"]
+        floor_raw = out["floor_contact"]
+        assert joints2d_raw is not None and visibility_raw is not None and contact_raw is not None and floor_raw is not None
+        joints2d_px: Float32[Tensor, "n p 3"] = unproject_joints2d(joints2d_raw.float(), centers, sizes, self.mamma_config)
+        return DenseLandmarks2d(
+            xy=joints2d_px[:, :, 0:2].contiguous(),
+            log_variance=joints2d_px[:, :, 2].contiguous(),
+            visibility=torch.sigmoid(visibility_raw.squeeze(-1).float()),
+            contact=torch.sigmoid(contact_raw.squeeze(-1).float()),
+            floor_contact=torch.sigmoid(floor_raw.squeeze(-1).float()),
+            frame_indices=detections.frame_indices,
+        )
+
+
+__all__ = ("MammaNetLandmarks", "MammaNetLandmarksConfig")

--- a/packages/mv-api/src/mv_api/api/catalog_prediction_layer.py
+++ b/packages/mv-api/src/mv_api/api/catalog_prediction_layer.py
@@ -12,9 +12,12 @@ from typing import Any, Literal
 
 import numpy as np
 import pyarrow as pa
+import torch
+from einops import rearrange
 from jaxtyping import Bool, Float32, Float64, Int, UInt8
 from numpy import ndarray
 from simplecv.camera_parameters import PinholeParameters
+from simplecv.data.skeleton.coco_133 import COCO_133_IDS
 
 CATALOG_DATASET_NAME: str = "assembly101"
 CATALOG_TIMELINE: str = "video_time"
@@ -383,38 +386,6 @@ def validate_exo_camera_calibration(schema: Any, streams: list[ExoCameraStream])
 
     if missing_fields:
         raise ValueError(f"Selected exo cameras are missing calibration components: {missing_fields}")
-
-
-def rgb_chw_to_bgr_hwc(rgb_chw: Any) -> UInt8[ndarray, "h w 3"]:
-    """Convert a dataloader RGB CHW image to MVAPI's BGR HWC NumPy contract.
-
-    Args:
-        rgb_chw: Torch-like or NumPy-like RGB image with shape ``3 h w``.
-
-    Returns:
-        BGR image with shape ``h w 3`` and dtype ``uint8``.
-
-    Raises:
-        ValueError: If the input does not have shape ``3 h w``.
-    """
-    image_obj: Any = rgb_chw
-    detach: Any = getattr(image_obj, "detach", None)
-    if callable(detach):
-        image_obj = detach()
-    cpu: Any = getattr(image_obj, "cpu", None)
-    if callable(cpu):
-        image_obj = cpu()
-    numpy_method: Any = getattr(image_obj, "numpy", None)
-    if callable(numpy_method):
-        image_obj = numpy_method()
-
-    rgb_array: UInt8[ndarray, "3 h w"] = np.asarray(image_obj, dtype=np.uint8)
-    if rgb_array.ndim != 3 or rgb_array.shape[0] != 3:
-        raise ValueError(f"Expected RGB CHW image with shape (3, h, w), got {rgb_array.shape}.")
-
-    rgb_hwc: UInt8[ndarray, "h w 3"] = np.moveaxis(rgb_array, 0, -1)
-    bgr_hwc: UInt8[ndarray, "h w 3"] = rgb_hwc[..., ::-1].astype(np.uint8, copy=False)
-    return bgr_hwc
 
 
 def build_prediction_rrd_path(
@@ -1147,7 +1118,6 @@ def _log_prediction_static_metadata(
 ) -> None:
     import rerun as rr
     from simplecv.data.skeleton.coco133_layers import Coco133AnnotationLayer
-    from simplecv.data.skeleton.coco_133 import COCO_133_IDS
     from simplecv.rerun_custom_types import Points2DWithConfidence, Points3DWithConfidence
 
     rr.log(
@@ -1218,6 +1188,11 @@ def _run_mvapi_inference(
         tracker_config,
         filter_body_idxes=upper_body_filter_idx,
     )
+    if pose_tracker.num_keypoints != len(COCO_133_IDS):
+        raise ValueError(
+            f"The catalog prediction layer logs COCO-133 overlays; tracker mode {config.tracker_mode!r} "
+            f"yields {pose_tracker.num_keypoints} keypoints. Use tracker_mode='wholebody'."
+        )
     mv_state: MVHistory = MVHistory()
 
     rrd_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1243,13 +1218,16 @@ def _run_mvapi_inference(
 
         _segment_meta, index_value = rerun_dataset.sample_index.global_to_local(sample_idx)
         timestamp_ns: int = index_value_to_time_ns(index_value)
-        bgr_list: list[UInt8[ndarray, "H W 3"]] = []
-        for stream in streams:
-            rgb_chw: Any = sample[stream.name]
-            bgr_list.append(rgb_chw_to_bgr_hwc(rgb_chw))
+        # Dataloader samples are RGB CHW uint8 tensors already — upload once,
+        # then view as NHWC for the tracker (a wrong dtype fails loudly in the
+        # tracker's frame validation rather than being silently cast here).
+        frames_rgb: UInt8[torch.Tensor, "n_views h w 3"] = rearrange(
+            torch.stack([torch.as_tensor(sample[stream.name]) for stream in streams]).to(config.tracker_device, non_blocking=True),
+            "views c h w -> views h w c",
+        )
 
         mv_state = pose_tracker(
-            bgr_list=bgr_list,
+            frames_rgb=frames_rgb,
             pinhole_list=pinholes,
             pred_state=mv_state,
             recording=recording,

--- a/packages/mv-api/src/mv_api/api/exoego_nodes.py
+++ b/packages/mv-api/src/mv_api/api/exoego_nodes.py
@@ -8,6 +8,7 @@ from numpy import ndarray
 from simplecv.apis.view_exoego import SceneSetupResult, setup_scene
 from simplecv.data.exoego.base_exoego import BaseExoEgoSequence
 from simplecv.data.exoego.exoego_config import BaseExoEgoDatasetConfig
+from simplecv.rerun_rig_logger import log_rig_static
 
 from mv_api.api import full_exoego_pipeline
 from mv_api.api.full_exoego_pipeline import RRDPipelineConfig
@@ -39,6 +40,10 @@ class ScenePreparationResult:
     """Timeline name used for frame-aligned exo/ego logs."""
     shortest_timestamp: Int[ndarray, "n_frames"]
     """Common timestamp sequence produced by scene setup."""
+    exo_cam_paths: dict[str, Path]
+    """Rig-layout camera node path per exo stream name (exoego:v2 layout)."""
+    ego_cam_paths: dict[str, Path]
+    """Rig-layout camera node path per ego stream name (exoego:v2 layout)."""
 
 
 class ScenePreparationNode:
@@ -65,8 +70,17 @@ class ScenePreparationNode:
         rr.log("/", exoego_sequence.world_coordinate_system, static=True, recording=recording)
         full_exoego_pipeline.set_annotation_context(recording=recording)
 
+        # COLMAP-style rig layout (exoego:v2): assign cameras to rig nodes and
+        # log the static skeletons before ingesting the per-frame videos.
+        rig_layout = exoego_sequence.build_rig_layout(
+            world_path=self.parent_log_path, log_exo=self.config.log_exo, log_ego=self.config.log_ego
+        )
+        for rig in rig_layout.rigs:
+            log_rig_static(rig, world_path=str(self.parent_log_path), recording=recording)
+
         scene_setup_result: SceneSetupResult = setup_scene(
             exoego_sequence,
+            rig_layout=rig_layout,
             parent_log_path=self.parent_log_path,
             timeline=self.timeline,
             log_ego=self.config.log_ego,
@@ -81,6 +95,8 @@ class ScenePreparationNode:
             parent_log_path=self.parent_log_path,
             timeline=self.timeline,
             shortest_timestamp=scene_setup_result.shortest_timestamp,
+            exo_cam_paths=dict(rig_layout.exo_cam_paths),
+            ego_cam_paths=dict(rig_layout.ego_cam_paths),
         )
 
 
@@ -127,6 +143,8 @@ class ModelBackedPipelineNode:
             scene_setup_result=scene.scene_setup_result,
             parent_log_path=self.parent_log_path,
             timeline=self.timeline,
+            exo_cam_paths=scene.exo_cam_paths,
+            ego_cam_paths=scene.ego_cam_paths,
             recording=recording,
         )
         return ModelBackedPipelineResult(processed_timestamps=scene.shortest_timestamp)

--- a/packages/mv-api/src/mv_api/api/full_exoego_pipeline.py
+++ b/packages/mv-api/src/mv_api/api/full_exoego_pipeline.py
@@ -10,6 +10,7 @@ import rerun as rr
 import rerun.blueprint as rrb
 import torch
 import tyro
+from einops import rearrange
 from jaxtyping import Bool, Float, Float32, Int, UInt8
 from monopriors.apis.multiview_calibration import MultiViewCalibrator, MultiViewCalibratorConfig, MVCalibResults
 from numpy import ndarray
@@ -231,15 +232,20 @@ def _dataset_exo_pinhole_params(
     exo_cam_by_name: dict[str, PinholeParameters] = {}
     try:
         exo_cam_list: list[PinholeParameters | None] = exo_sequence.exo_cam_list
+        exo_video_names: list[str] = list(exo_sequence.exo_video_names)
     except AttributeError:
         return None
     for camera in exo_cam_list:
         if isinstance(camera, PinholeParameters):
             exo_cam_by_name[camera.name] = camera
 
+    # The rig layout renames camera entity nodes to cam_<MM>, so stream names
+    # can no longer be parsed from the log paths; the log-path order matches
+    # the stream order, so resolve names positionally.
+    if len(exo_video_names) != len(exo_video_log_paths):
+        return None
     ordered_cameras: list[PinholeParameters] = []
-    for video_log_path in exo_video_log_paths:
-        camera_name: str = video_log_path.parent.parent.name
+    for camera_name in exo_video_names:
         camera: PinholeParameters | None = exo_cam_by_name.get(camera_name)
         if camera is None:
             return None
@@ -255,11 +261,13 @@ def _dataset_ego_pinhole_param_lists(
     """Return dataset-provided ego pinhole trajectories ordered like the logged ego videos, if available."""
     try:
         ego_cam_dict: dict[Any, list[Any]] = cast(dict[Any, list[Any]], ego_sequence.ego_cam_dict)
+        ego_video_names: list[str] = list(ego_sequence.ego_video_names)
     except AttributeError:
         return None
+    if len(ego_video_names) != len(ego_video_log_paths):
+        return None
     ordered_camera_lists: list[list[PinholeParameters]] = []
-    for video_log_path in ego_video_log_paths:
-        camera_name: str = video_log_path.parent.parent.name
+    for camera_name in ego_video_names:
         camera_list_raw: list[Any] | None = ego_cam_dict.get(camera_name)
         if not camera_list_raw:
             return None
@@ -428,6 +436,35 @@ def _extract_wilor_uv(wilor_pred: FinalWilorPred | KeypointResults) -> Float32[n
     return pred_uv
 
 
+def _cam_pinhole_log_path(cam_paths: dict[str, Path] | None, name: str, view_idx: int, *, parent_log_path: Path, side: str) -> Path:
+    """Resolve a camera's pinhole entity path from the rig layout.
+
+    Estimated (calibrator-named) cameras don't share the dataset stream names
+    the rig map is keyed by, but they DO share the stream order, so the lookup
+    is by name first and by view index second. Falls back to the legacy flat
+    ``<world>/<side>/<name>`` layout when no rig map is available, so pre-rig
+    recordings keep working.
+
+    Args:
+        cam_paths: Rig-layout camera node path per stream name (insertion
+            order matches the stream/view order), or ``None``.
+        name: Camera/stream name.
+        view_idx: Camera index in stream order.
+        parent_log_path: World root entity path.
+        side: Legacy side segment (``"exo"`` or ``"ego"``).
+
+    Returns:
+        Entity path of the camera's pinhole node.
+    """
+    if cam_paths is not None:
+        if name in cam_paths:
+            return cam_paths[name] / "pinhole"
+        ordered_paths: list[Path] = list(cam_paths.values())
+        if 0 <= view_idx < len(ordered_paths):
+            return ordered_paths[view_idx] / "pinhole"
+    return parent_log_path / side / name / "pinhole"
+
+
 def predict_kpts3d_from_calibrated_videos(
     *,
     exo_video_readers: MultiVideoReader | TorchCodecMultiVideoReader,
@@ -437,6 +474,7 @@ def predict_kpts3d_from_calibrated_videos(
     shortest_timestamp: Int[ndarray, "num_frames"],
     parent_log_path: Path,
     timeline: str,
+    exo_pinhole_log_paths: list[Path] | None = None,
     max_frames: int | None = None,
     recording: rr.RecordingStream | None = None,
 ) -> list[Float32[ndarray, "n_kpts 4"]]:
@@ -467,15 +505,16 @@ def predict_kpts3d_from_calibrated_videos(
             timestamp_to_frame_index(time_ns=timestamp_ns, frame_timestamps_ns=frame_timestamps)
             for frame_timestamps in exo_frame_timestamps_list
         ]
-        bgr_list: list[UInt8[ndarray, "H W 3"]] = [
-            _read_bgr_frame(reader=video_reader, frame_idx=frame_idx, stream_name=f"exo/{frame_idx}")
-            for video_reader, frame_idx in zip(exo_video_readers.video_readers, frame_indices, strict=True)
-        ]
-
+        # One reader-agnostic call: RGB CHW tensors per view (camera-parallel
+        # NVDEC on torchcodec readers), stacked and viewed NHWC for the tracker.
+        frames_rgb: UInt8[torch.Tensor, "n_views h w 3"] = rearrange(
+            torch.stack(exo_video_readers.get_frames_at(frame_indices)), "views c h w -> views h w c"
+        )
         mv_output = pose_tracker(
-            bgr_list=bgr_list,
+            frames_rgb=frames_rgb,
             pinhole_list=exo_cam_list,
             pred_state=mv_output,
+            pinhole_log_paths=exo_pinhole_log_paths,
             recording=recording,
         )
         xyzc_frame: Float32[ndarray, "n_kpts 4"] = (
@@ -535,7 +574,7 @@ def predict_kpts3d_from_calibrated_videos(
             P=projection_matrices,
         )
         uv_exo: Float32[ndarray, "n_views n_kpts 2"] = uv_exo_stack[0].astype(np.float32, copy=False)
-        for uv_view, exo_cam in zip(uv_exo, exo_cam_list, strict=True):
+        for exo_view_idx, (uv_view, exo_cam) in enumerate(zip(uv_exo, exo_cam_list, strict=True)):
             uv: Float32[ndarray, "n_kpts 2"] = uv_view.astype(np.float32, copy=True)
             confidences_view: Float32[ndarray, "n_kpts"] = vis_scores_3d.astype(np.float32, copy=True)
             masked_points: MaskedPoints2D = _mask_points_outside_intrinsics(
@@ -545,7 +584,11 @@ def predict_kpts3d_from_calibrated_videos(
             )
             uv = masked_points.uv
             confidences_view = masked_points.confidences
-            pinhole_log_path: Path = parent_log_path / "exo" / exo_cam.name / "pinhole"
+            pinhole_log_path: Path = (
+                exo_pinhole_log_paths[exo_view_idx]
+                if exo_pinhole_log_paths is not None
+                else parent_log_path / "exo" / exo_cam.name / "pinhole"
+            )
             confidence_rgb_view_stack: UInt8[ndarray, "1 n_kpts 3"] = confidence_scores_to_rgb(
                 confidences_view[np.newaxis, :, np.newaxis]
             )
@@ -575,6 +618,8 @@ def run_model_backed_pipeline(
     scene_setup_result: SceneSetupResult,
     parent_log_path: Path,
     timeline: str,
+    exo_cam_paths: dict[str, Path] | None = None,
+    ego_cam_paths: dict[str, Path] | None = None,
     recording: rr.RecordingStream | None,
 ) -> None:
     """Run the model-backed calibration and prediction section."""
@@ -606,6 +651,19 @@ def run_model_backed_pipeline(
     ego_sequence: BaseEgoSequence = cast(BaseEgoSequence, ego_sequence_obj)
     exo_mv_reader: MultiVideoReader | TorchCodecMultiVideoReader = exo_sequence.exo_video_readers
     ego_mv_reader: MultiVideoReader | TorchCodecMultiVideoReader = ego_sequence.ego_video_readers
+    if not isinstance(exo_mv_reader, TorchCodecMultiVideoReader):
+        # NVDEC decode is THE exo path — a failure here should be loud, not a
+        # silent 2.4x CPU-decode regression. Only readers without real video
+        # files (test doubles, in-memory sources) keep their own decode.
+        exo_video_paths: list[Path] = list(getattr(exo_mv_reader, "video_paths", []))
+        if exo_video_paths and all(path.exists() for path in exo_video_paths):
+            exo_mv_reader = TorchCodecMultiVideoReader(list(exo_video_paths), device="cuda")
+    exo_resolutions: set[tuple[int, int]] = {(int(reader.height), int(reader.width)) for reader in exo_mv_reader.video_readers}
+    if len(exo_resolutions) > 1:
+        raise ValueError(
+            f"Exo camera streams have mixed resolutions {sorted(exo_resolutions)}; the GPU-batched tracker "
+            "stacks all views into one tensor. Transcode/resize the streams to a shared resolution first."
+        )
 
     ego_camera_names: list[str] = [path.parent.parent.name for path in ego_video_log_paths]
     ego_rgb_indices: list[int] = [
@@ -785,6 +843,18 @@ def run_model_backed_pipeline(
     pose_exo_pinhole_param_list: list[PinholeParameters] = camera_selection.exo_pinhole_param_list
     pose_ego_pinhole_param_lists: list[list[PinholeParameters]] = camera_selection.ego_pinhole_param_lists
 
+    # Resolve every camera's pinhole entity path ONCE (rig-layout name match,
+    # view-index fallback for estimated-camera names, legacy flat layout last);
+    # downstream loggers just index these lists.
+    exo_pinhole_log_paths: list[Path] = [
+        _cam_pinhole_log_path(exo_cam_paths, camera.name, view_idx, parent_log_path=parent_log_path, side="exo")
+        for view_idx, camera in enumerate(pose_exo_pinhole_param_list)
+    ]
+    ego_pinhole_log_paths: list[Path] = [
+        _cam_pinhole_log_path(ego_cam_paths, camera_list[0].name, view_idx, parent_log_path=parent_log_path, side="ego")
+        for view_idx, camera_list in enumerate(pose_ego_pinhole_param_lists)
+    ]
+
     upper_body_filter_idx: Int[ndarray, "upper_body"] = np.array([5, 6, 7, 8, 9, 10], dtype=np.int64)
     wb_upper_body_filter_idx: Int[ndarray, "upper_body_plus"] = np.concatenate(
         [upper_body_filter_idx, FACE_IDX, LEFT_HAND_IDX, RIGHT_HAND_IDX]
@@ -794,6 +864,12 @@ def run_model_backed_pipeline(
         config.tracker_config,
         filter_body_idxes=wb_upper_body_filter_idx,
     )
+    if pose_tracker.num_keypoints != len(COCO_133_IDS):
+        raise ValueError(
+            f"This pipeline's masking/hand-refinement/logging assumes COCO-133 keypoints; tracker mode "
+            f"{config.tracker_config.mode!r} yields {pose_tracker.num_keypoints}. Use mode='wholebody' "
+            "(or inject a COCO-133 pose model)."
+        )
     xyzc_list: list[Float32[ndarray, "n_kpts 4"]] = predict_kpts3d_from_calibrated_videos(
         exo_video_readers=exo_mv_reader,
         exo_cam_list=pose_exo_pinhole_param_list,
@@ -802,6 +878,7 @@ def run_model_backed_pipeline(
         shortest_timestamp=shortest_timestamp,
         parent_log_path=parent_log_path,
         timeline=timeline,
+        exo_pinhole_log_paths=exo_pinhole_log_paths,
         max_frames=config.max_frames,
         recording=recording,
     )
@@ -856,7 +933,7 @@ def run_model_backed_pipeline(
             uv_ego: Float32[ndarray, "n_views n_kpts 2"] = uv_ego_stack[0].astype(np.float32, copy=False)
 
             for view_idx, (uv_view, ego_cam) in enumerate(zip(uv_ego, ego_pose_pinhole_param_list, strict=True)):
-                pinhole_log_path: Path = parent_log_path / "ego" / ego_cam.name / "pinhole"
+                pinhole_log_path: Path = ego_pinhole_log_paths[view_idx]
                 uv: Float32[ndarray, "n_kpts 2"] = uv_view.astype(np.float32, copy=True)
                 projection_matrix: Float32[ndarray, "3 4"] = ego_cam.projection_matrix.astype(np.float32, copy=False)
                 homog_cam: Float32[ndarray, "n_kpts 3"] = np.einsum("ij,nj->ni", projection_matrix, xyz_hom)

--- a/packages/mv-api/src/mv_api/multiview_pose_estimator.py
+++ b/packages/mv-api/src/mv_api/multiview_pose_estimator.py
@@ -1,17 +1,22 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from pathlib import Path
 from typing import Literal
 
 import numpy as np
 import rerun as rr
-from einops import rearrange
+import torch
 from jaxtyping import Bool, Float, Float32, Float64, Int, UInt8
 from numpy import ndarray
-from rtmlib import YOLOX, RTMPose
+from posekit.models import PersonDetector, RtmPoseConfig, TopDownPose2d, YoloxDetectorConfig
+from posekit.predictions import BoxDetections, Keypoints2d
+from posekit.runtimes import TensorRtBackendConfig
+from posekit.zoo import PRESETS, PosePreset
 from simplecv.camera_parameters import PinholeParameters
 from simplecv.data.skeleton.coco133_layers import COCO133_PREDICTION_LAYER_TO_PATH, Coco133AnnotationLayer
 from simplecv.data.skeleton.coco_133 import COCO_133_IDS, LEFT_HAND_IDX, RIGHT_HAND_IDX
 from simplecv.ops.triangulate import batch_triangulate, projectN3
 from simplecv.rerun_custom_types import Points2DWithConfidence, confidence_scores_to_rgb
+from torch import Tensor
 from wilor_nano.hand_keypoints import (
     FinalWilorPred,
     HandKeypointDetectorConfig,
@@ -79,44 +84,17 @@ class MVHistory:
     """Per-view 2D projections from temporally extrapolated 3D keypoints."""
 
 
-@dataclass(frozen=True, slots=True)
-class ModelAssets:
-    """ONNX detector and pose model assets."""
-
-    det: str
-    """Download URL or local path to the YOLOX ONNX model."""
-    det_input_size: tuple[int, int]
-    """Input width-height pair expected by YOLOX."""
-    pose: str
-    """Download URL or local path to the RTMPose ONNX model."""
-    pose_input_size: tuple[int, int]
-    """Input width-height pair expected by RTMPose."""
-
-
-MODE: dict[str, ModelAssets] = {
-    "performance": ModelAssets(
-        det="https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/yolox_x_8xb8-300e_humanart-a39d44ed.zip",
-        det_input_size=(640, 640),
-        pose="https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/rtmpose-x_simcc-body7_pt-body7_700e-384x288-71d7b7e9_20230629.zip",
-        pose_input_size=(288, 384),
-    ),
-    "lightweight": ModelAssets(
-        det="https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/yolox_tiny_8xb8-300e_humanart-6f3252f9.zip",
-        det_input_size=(416, 416),
-        pose="https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/rtmpose-s_simcc-body7_pt-body7_420e-256x192-acd4a1ef_20230504.zip",
-        pose_input_size=(192, 256),
-    ),
-    "balanced": ModelAssets(
-        det="https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/yolox_m_8xb8-300e_humanart-c2c7a14a.zip",
-        det_input_size=(640, 640),
-        pose="https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/rtmpose-m_simcc-body7_pt-body7_420e-256x192-e48f03d0_20230504.zip",
-        pose_input_size=(192, 256),
-    ),
-    "wholebody": ModelAssets(
-        det="https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/yolox_m_8xb8-300e_humanart-c2c7a14a.zip",
-        det_input_size=(640, 640),
-        pose="https://download.openmmlab.com/mmpose/v1/projects/rtmw/onnx_sdk/rtmw-dw-x-l_simcc-cocktail14_270e-256x192_20231122.zip",
-        pose_input_size=(192, 256),
+# mv-api mode -> posekit zoo preset (same OpenMMLab weights rtmlib served,
+# maintained in ONE place: posekit.zoo). "lightweight" is a local pairing —
+# yolox-tiny with the balanced rtmpose-m net (posekit carries no rtmpose-s).
+MODE_PRESETS: dict[str, PosePreset] = {
+    "performance": PRESETS["body-performance"],
+    "balanced": PRESETS["body"],
+    "wholebody": PRESETS["wholebody"],
+    "lightweight": PosePreset(
+        YoloxDetectorConfig(variant="yolox-tiny-humanart"),
+        RtmPoseConfig(variant="rtmpose-m-coco17"),
+        "Smallest detector with the balanced pose net.",
     ),
 }
 
@@ -127,10 +105,14 @@ class MultiviewBodyTrackerConfig:
 
     mode: Literal["lightweight", "balanced", "performance", "wholebody"] = "wholebody"
     """Preset selecting detector and pose assets tuned for latency versus accuracy."""
-    backend: Literal["onnxruntime"] = "onnxruntime"
-    """Inference backend used to execute ONNX models."""
+    backend: Literal["onnxruntime", "tensorrt"] = "tensorrt"
+    """Inference backend for the posekit models. tensorrt (default) loads cached dynamic-batch
+    engines (~13s deserialize per process; first run on a new GPU builds them, taking minutes);
+    onnxruntime skips that fixed cost — better for quick short-clip experiments."""
     device: Literal["cpu", "cuda"] = "cuda"
-    """Hardware accelerator requested by the ONNX runtime backend."""
+    """Device the frame tensors are staged on before the models. The posekit
+    models themselves are CUDA-resident; ``cpu`` only makes sense with injected
+    CPU-capable test doubles."""
     keypoint_threshold: float = 0.7
     """Minimum 2D keypoint confidence required for a detection to be kept."""
     cams_for_detection_idx: list[int] | None = None
@@ -148,28 +130,45 @@ class MultiviewBodyTracker:
         self,
         config: MultiviewBodyTrackerConfig,
         filter_body_idxes: Int[ndarray, "idx"] | None = None,
+        *,
+        detector: PersonDetector | None = None,
+        pose: TopDownPose2d | None = None,
     ) -> None:
-        """Create detector and pose models for single-person multiview tracking."""
+        """Create detector and pose models for single-person multiview tracking.
+
+        Args:
+            config: Runtime options; ``config.mode`` picks the default posekit
+                detector/pose pairing (same OpenMMLab weights rtmlib served).
+            filter_body_idxes: Optional keypoint subset kept in the outputs.
+            detector: Override detector implementing the posekit role; any
+                :class:`posekit.models.PersonDetector` slots in (RT-DETRv2,
+                a tracker adapter, ...).
+            pose: Override top-down pose estimator; any
+                :class:`posekit.models.TopDownPose2d` slots in (ViTPose,
+                Sapiens2, a TensorRT-backed RTMW, ...).
+        """
         self.config: MultiviewBodyTrackerConfig = config
-        self.num_keypoints: int = 133
+        preset: PosePreset = MODE_PRESETS[config.mode]
+        det_config = preset.detector
+        pose_config = preset.pose
+        # All mv-api mode presets pair the ONNX-artifact models, whose configs
+        # carry the swappable onnx/tensorrt backend field.
+        assert isinstance(det_config, YoloxDetectorConfig) and isinstance(pose_config, RtmPoseConfig)
+        if config.backend == "tensorrt":
+            trt_backend = TensorRtBackendConfig()
+            det_config = replace(det_config, backend=trt_backend)
+            pose_config = replace(pose_config, backend=trt_backend)
+        self.det_model: PersonDetector = detector if detector is not None else det_config.setup()
+        self.pose_model: TopDownPose2d = pose if pose is not None else pose_config.setup()
+        self.num_keypoints: int = self.pose_model.skeleton.num_keypoints
         self.filter_body_idxes: Int[ndarray, "idx"] = (
             filter_body_idxes if filter_body_idxes is not None else np.arange(self.num_keypoints, dtype=np.intp)
         )
-
-        assets: ModelAssets = MODE[config.mode]
-        self.det_model = YOLOX(
-            assets.det,
-            model_input_size=assets.det_input_size,
-            backend=config.backend,
-            device=config.device,
-        )
-        self.pose_model = RTMPose(
-            assets.pose,
-            model_input_size=assets.pose_input_size,
-            to_openpose=False,
-            backend=config.backend,
-            device=config.device,
-        )
+        if self.filter_body_idxes.size and int(self.filter_body_idxes.max()) >= self.num_keypoints:
+            raise ValueError(
+                f"filter_body_idxes max index {int(self.filter_body_idxes.max())} exceeds the "
+                f"{self.pose_model.skeleton.name} skeleton's {self.num_keypoints} keypoints."
+            )
         self.hand_keypoint_engine: WilorHandKeypointDetector | None = None
         if self.config.use_wilor:
             self.hand_keypoint_engine = WilorHandKeypointDetector(HandKeypointDetectorConfig(verbose=False))
@@ -177,25 +176,45 @@ class MultiviewBodyTracker:
     def __call__(
         self,
         *,
-        bgr_list: list[UInt8[ndarray, "H W 3"]],
+        frames_rgb: UInt8[Tensor, "n_total_views H W 3"],
         pinhole_list: list[PinholeParameters],
         pred_state: MVHistory,
+        pinhole_log_paths: list[Path] | None = None,
         recording: rr.RecordingStream | None = None,
     ) -> MVHistory:
-        """Estimate and triangulate one COCO-133 person across camera views."""
+        """Estimate and triangulate one COCO-133 person across camera views.
+
+        Args:
+            frames_rgb: One uint8 RGB NHWC tensor holding every camera view
+                (torchcodec CUDA decode path) — frames never touch the host on
+                the way to the models.
+            pinhole_list: Calibrated camera per view, aligned with the frames.
+            pred_state: Temporal tracking state, updated in place.
+            pinhole_log_paths: Pre-resolved pinhole entity path per view
+                (rig layout) for the verbose 2D layers, aligned with
+                ``pinhole_list``; ``None`` falls back to the legacy
+                ``/world/exo/<name>`` layout.
+            recording: Optional explicit Rerun recording stream.
+        """
+        num_total_views: int = int(frames_rgb.shape[0])
         selected_view_indices: list[int] = (
             [idx for idx in self.config.cams_for_detection_idx]
             if self.config.cams_for_detection_idx is not None
-            else list(range(len(bgr_list)))
+            else list(range(num_total_views))
         )
         if not selected_view_indices:
             raise ValueError("At least one camera must be selected for multiview body tracking.")
         for selected_view_idx in selected_view_indices:
-            if selected_view_idx < 0 or selected_view_idx >= len(bgr_list) or selected_view_idx >= len(pinhole_list):
+            if selected_view_idx < 0 or selected_view_idx >= num_total_views or selected_view_idx >= len(pinhole_list):
                 msg: str = f"Selected camera index {selected_view_idx} is outside the available view range."
                 raise IndexError(msg)
 
-        selected_bgr_list: list[UInt8[ndarray, "H W 3"]] = [bgr_list[idx] for idx in selected_view_indices]
+        device: torch.device = torch.device(self.config.device)
+        selected_frames_rgb: UInt8[Tensor, "n_views H W 3"] = (
+            frames_rgb.to(device)
+            if self.config.cams_for_detection_idx is None
+            else frames_rgb[torch.tensor(selected_view_indices, dtype=torch.long, device=frames_rgb.device)].to(device)
+        )
         selected_pinhole_list: list[PinholeParameters] = [pinhole_list[idx] for idx in selected_view_indices]
         pall: Float32[ndarray, "n_views 3 4"] = np.array(
             [pinhole.projection_matrix for pinhole in selected_pinhole_list], dtype=np.float32
@@ -215,38 +234,57 @@ class MultiviewBodyTracker:
             uv_min: Float[ndarray, "n_views 2"] = np.nanmin(uvc_extrap[:, :, 0:2], axis=1)
             bboxes_extrap = np.concatenate([uv_min, uv_max], axis=1).astype(np.float32)
 
-        uvc_list: list[Float32[ndarray, "n_kpts 3"]] = []
-        for selected_idx, (original_view_idx, bgr, pinhole) in enumerate(
-            zip(selected_view_indices, selected_bgr_list, selected_pinhole_list, strict=True)
-        ):
-            if xyzc_extrap is not None and bboxes_extrap is not None:
-                bboxes: Float32[ndarray, "n_dets 4"] = rearrange(bboxes_extrap[selected_idx], "b -> 1 b")
-            else:
-                det_output: np.ndarray | tuple[np.ndarray, ...] = self.det_model(bgr)
-                det_bboxes_np: np.ndarray = det_output[0] if isinstance(det_output, tuple) else det_output
-                bboxes = np.asarray(det_bboxes_np, dtype=np.float32)
+        # One detector call and one pose call over all selected views, on the
+        # GPU-resident uint8 RGB tensor (the posekit contract).
+        num_selected: int = len(selected_view_indices)
+        uvc_by_selected: dict[int, Float32[ndarray, "n_kpts 3"]] = {}
+        if bboxes_extrap is not None:
+            detections: BoxDetections = BoxDetections(
+                xyxy=torch.from_numpy(bboxes_extrap).to(device=device, dtype=torch.float32),
+                scores=torch.ones((num_selected,), dtype=torch.float32, device=device),
+                frame_indices=torch.arange(num_selected, dtype=torch.long, device=device),
+            )
+        else:
+            all_detections: BoxDetections = self.det_model(selected_frames_rgb)
+            # Pick the best-scoring detection per view on the host: two small
+            # transfers instead of a GPU sync per view.
+            det_views: list[int] = all_detections.frame_indices.cpu().tolist()
+            det_scores: list[float] = all_detections.scores.cpu().tolist()
+            best_by_view: dict[int, int] = {}
+            for row, (view, score) in enumerate(zip(det_views, det_scores, strict=True)):
+                if view not in best_by_view or score > det_scores[best_by_view[view]]:
+                    best_by_view[view] = row
+            rows: Tensor = torch.tensor([best_by_view[view] for view in sorted(best_by_view)], dtype=torch.long, device=device)
+            detections = BoxDetections(
+                xyxy=all_detections.xyxy[rows], scores=all_detections.scores[rows], frame_indices=all_detections.frame_indices[rows]
+            )
+        keypoints2d: Keypoints2d = self.pose_model(selected_frames_rgb, detections)
+        xy: Float32[ndarray, "n_dets n_kpts 2"] = keypoints2d.xy_numpy()
+        kpt_scores: Float32[ndarray, "n_dets n_kpts"] = keypoints2d.scores_numpy()
+        for row, local_idx in enumerate(detections.frame_indices.cpu().tolist()):
+            uvc_by_selected[local_idx] = np.concatenate([xy[row], kpt_scores[row][:, None]], axis=1).astype(np.float32)
 
-            if bboxes.shape[0] == 0:
+        uvc_list: list[Float32[ndarray, "n_kpts 3"]] = []
+        for selected_idx, (original_view_idx, pinhole) in enumerate(zip(selected_view_indices, selected_pinhole_list, strict=True)):
+            view_uvc: Float32[ndarray, "n_kpts 3"] | None = uvc_by_selected.get(selected_idx)
+            if view_uvc is None:
                 uvc_list.append(np.zeros((self.num_keypoints, 3), dtype=np.float32))
                 continue
-
-            selected_bboxes: Float32[ndarray, "1 4"] = bboxes[0:1]
-            bbox_list: list[list[float]] = selected_bboxes.astype(np.float32).tolist()
-            pose_output: tuple[Float64[ndarray, "n_dets n_kpts=133 2"], Float32[ndarray, "n_dets n_kpts=133"]] = (
-                self.pose_model(bgr, bboxes=bbox_list)
-            )
-            keypoints: Float32[ndarray, "n_dets n_kpts=133 2"] = pose_output[0].astype(np.float32)
-            scores: Float32[ndarray, "n_dets n_kpts=133"] = pose_output[1]
-            filtered_keypoints, filtered_scores = self.filter_kpt_outputs(keypoints, scores)
+            filtered_keypoints: Float32[ndarray, "n_kpts 2"] = view_uvc[:, 0:2]
+            filtered_scores: Float32[ndarray, "n_kpts"] = view_uvc[:, 2]
 
             if self.config.use_wilor:
+                # WiLoR is a numpy/CPU engine; materialize the BGR view lazily
+                # so the GPU frames only pay this when hands are refined.
+                view_bgr: UInt8[ndarray, "H W 3"] = np.ascontiguousarray(selected_frames_rgb[selected_idx].cpu().numpy()[..., ::-1])
                 filtered_keypoints = self._refine_hand_keypoints_with_wilor(
-                    bgr=bgr,
+                    bgr=view_bgr,
                     keypoints=filtered_keypoints,
                     confidences=filtered_scores,
                 )
 
             if self.config.verbose:
+                view_pinhole_path: Path | None = pinhole_log_paths[original_view_idx] if pinhole_log_paths is not None else None
                 self._log_uvc_layer(
                     view_idx=original_view_idx,
                     pinhole=pinhole,
@@ -254,6 +292,7 @@ class MultiviewBodyTracker:
                     confidences=filtered_scores,
                     layer=Coco133AnnotationLayer.RAW_2D,
                     mask_below_threshold=True,
+                    pinhole_log_path=view_pinhole_path,
                     recording=recording,
                 )
                 if tracked_confidences is not None and pred_state.uvc_extrap is not None:
@@ -265,6 +304,7 @@ class MultiviewBodyTracker:
                         confidences=tracked_confidences,
                         layer=Coco133AnnotationLayer.TRACKED_2D,
                         mask_below_threshold=False,
+                        pinhole_log_path=view_pinhole_path,
                         recording=recording,
                     )
 
@@ -291,10 +331,12 @@ class MultiviewBodyTracker:
         confidences: Float32[ndarray, "n_kpts"],
         layer: Coco133AnnotationLayer,
         mask_below_threshold: bool,
+        pinhole_log_path: Path | None,
         recording: rr.RecordingStream | None,
     ) -> None:
         """Log a COCO-133 2D layer for a single view."""
         view_name: str = pinhole.name if pinhole.name else f"view_{view_idx}"
+        pinhole_path: str = str(pinhole_log_path) if pinhole_log_path is not None else f"/world/exo/{view_name}/pinhole"
         if mask_below_threshold:
             visibility_mask: Bool[ndarray, "n_kpts"] = confidences >= float(self.config.keypoint_threshold)
             filtered_keypoints: Float32[ndarray, "n_kpts 2"] = np.where(visibility_mask[:, None], keypoints, np.nan)
@@ -313,7 +355,7 @@ class MultiviewBodyTracker:
         )[0]
         layer_segment: str = COCO133_PREDICTION_LAYER_TO_PATH[layer]
         rr.log(
-            f"/world/exo/{view_name}/pinhole/pred/coco133_uv/{layer_segment}",
+            f"{pinhole_path}/pred/coco133_uv/{layer_segment}",
             Points2DWithConfidence(
                 positions=filtered_keypoints,
                 confidences=filtered_confidences,
@@ -391,13 +433,3 @@ class MultiviewBodyTracker:
         """Linearly extrapolate keypoints from the previous two frames."""
         xyzc_extrap: Float32[ndarray, "n_kpts 4"] = 2 * xyzc_t - xyzc_t1
         return xyzc_extrap
-
-    def filter_kpt_outputs(
-        self,
-        keypoints: Float32[ndarray, "n_dets n_kpts 2"],
-        scores: Float32[ndarray, "n_dets n_kpts"],
-    ) -> tuple[Float32[ndarray, "n_kpts 2"], Float32[ndarray, "n_kpts"]]:
-        """Select the detection with the highest maximum keypoint score."""
-        max_scores: Float32[ndarray, "n_dets"] = scores.max(axis=1)
-        max_idx: int = int(max_scores.argmax())
-        return keypoints[max_idx], scores[max_idx]

--- a/packages/mv-api/tests/test_catalog_prediction_layer.py
+++ b/packages/mv-api/tests/test_catalog_prediction_layer.py
@@ -28,7 +28,6 @@ from mv_api.api.catalog_prediction_layer import (
     none_decoded_exo_stream_names,
     prediction_visualization_colors,
     register_prediction_layer,
-    rgb_chw_to_bgr_hwc,
     save_exo_viewer_blueprint,
     select_catalog_segment,
     validate_exo_camera_calibration,
@@ -346,28 +345,6 @@ def test_validate_exo_camera_calibration_fails_when_transform_is_missing() -> No
 
     with pytest.raises(ValueError, match="C10095.*Transform3D:translation"):
         validate_exo_camera_calibration(schema, streams)
-
-
-def test_rgb_chw_to_bgr_hwc_converts_channel_order_and_layout() -> None:
-    rgb_chw: np.ndarray = np.array(
-        [
-            [[1, 2], [3, 4]],
-            [[10, 20], [30, 40]],
-            [[100, 110], [120, 130]],
-        ],
-        dtype=np.uint8,
-    )
-
-    bgr_hwc = rgb_chw_to_bgr_hwc(rgb_chw)
-
-    expected_bgr_hwc: np.ndarray = np.array(
-        [
-            [[100, 10, 1], [110, 20, 2]],
-            [[120, 30, 3], [130, 40, 4]],
-        ],
-        dtype=np.uint8,
-    )
-    np.testing.assert_array_equal(bgr_hwc, expected_bgr_hwc)
 
 
 def test_build_prediction_rrd_path_uses_dataset_sequence_and_layer_name() -> None:

--- a/packages/mv-api/tests/test_full_exoego_pipeline_rrd.py
+++ b/packages/mv-api/tests/test_full_exoego_pipeline_rrd.py
@@ -7,6 +7,7 @@ import numpy as np
 import open3d as o3d
 import pytest
 import rerun as rr
+import torch
 from jaxtyping import Float32, Int, UInt8
 from monopriors.apis.multiview_calibration import MultiViewCalibrator, MVCalibResults
 from numpy import ndarray
@@ -15,7 +16,7 @@ from simplecv.apis.view_exoego import LogPaths, SceneSetupResult
 from simplecv.camera_parameters import Extrinsics, Intrinsics, PinholeParameters
 from simplecv.data.ego.base_ego import BaseEgoSequence, CameraParam, EgoData
 from simplecv.data.exo.base_exo import BaseExoSequence, ExoData
-from simplecv.data.exoego.base_exoego import BaseExoEgoSequence, ExoEgoLabels, ExoEgoSample
+from simplecv.data.exoego.base_exoego import BaseExoEgoSequence, ExoEgoLabels, ExoEgoSample, RigLayout
 from simplecv.data.exoego.hocap import HocapConfig
 from simplecv.rerun_log_utils import RerunTyroConfig
 from simplecv.video_io import MultiVideoReader, VideoReader
@@ -28,7 +29,17 @@ from mv_api.multiview_pose_estimator import MultiviewBodyTracker, MultiviewBodyT
 
 class FakeExoEgoSequence(BaseExoEgoSequence[HocapConfig]):
     def __init__(self) -> None:
-        pass
+        # Skip the base timeline machinery but provide the side sequences the
+        # real build_rig_layout reads (both None -> empty rig layout).
+        self.ego_sequence = None
+        self.exo_sequence = None
+
+    def build_rig_layout(self, *, world_path: Path = Path("world"), log_exo: bool = True, log_ego: bool = True) -> RigLayout:
+        # The fakes don't model the camera lists the real layout walks; an
+        # empty layout keeps rig logging a no-op and exercises the pipeline's
+        # legacy flat-path fallback the assertions below encode.
+        del world_path, log_exo, log_ego
+        return RigLayout(rigs=[], exo_cam_paths={}, ego_cam_paths={})
 
     @property
     def world_coordinate_system(self) -> ViewCoordinates:
@@ -77,6 +88,10 @@ class FakeVideoReader(VideoReader):
             return [np.zeros((32, 32, 3), dtype=np.uint8) for _ in range(*index.indices(self._frame_cnt))]
         return np.zeros((32, 32, 3), dtype=np.uint8)
 
+    def get_frame(self, frame_id: int) -> UInt8[ndarray, "h w 3"]:
+        del frame_id
+        return np.zeros((32, 32, 3), dtype=np.uint8)
+
 
 class FakeMultiVideoReader(MultiVideoReader):
     def __init__(self) -> None:
@@ -93,6 +108,8 @@ class FakeMultiVideoReader(MultiVideoReader):
 class FakeExoSequence(BaseExoSequence[HocapConfig]):
     def __init__(self) -> None:
         self.exo_video_readers: MultiVideoReader = FakeMultiVideoReader()
+        self._video_path_list: list[Path] = []
+        self._exo_cam_list: list[PinholeParameters | None] = []
 
     def __getitem__(self, idx: int) -> ExoData:
         del idx
@@ -112,6 +129,7 @@ class FakeExoSequence(BaseExoSequence[HocapConfig]):
 class FakeEgoSequence(BaseEgoSequence[HocapConfig]):
     def __init__(self) -> None:
         self.ego_video_readers: MultiVideoReader = FakeMultiVideoReader()
+        self._ego_video_name_list: list[str] = []
 
     def __getitem__(self, idx: int) -> EgoData:
         del idx
@@ -144,7 +162,12 @@ class FakeModelBackedSequence(FakeExoEgoSequence):
 class FakeDatasetCameraExoSequence(FakeExoSequence):
     def __init__(self) -> None:
         super().__init__()
-        self._exo_cam_list: list[PinholeParameters | None] = [_fake_pinhole("cam0")]
+        self._exo_cam_list = [_fake_pinhole("cam0")]
+        self._video_path_list = [Path("cam0.mp4")]
+
+    @property
+    def exo_video_names(self) -> list[str]:
+        return ["cam0"]
 
 
 class FakeDatasetCameraEgoSequence(FakeEgoSequence):
@@ -153,6 +176,7 @@ class FakeDatasetCameraEgoSequence(FakeEgoSequence):
         self._dataset_ego_cam_dict: dict[str, list[CameraParam]] = {
             "hololens_kv5h72": [_fake_pinhole("hololens_kv5h72")]
         }
+        self._ego_video_name_list = ["hololens_kv5h72"]
 
     @property
     def ego_cam_dict(self) -> dict[str, list[CameraParam]]:
@@ -207,12 +231,13 @@ class FakeBodyTracker(MultiviewBodyTracker):
     def __call__(
         self,
         *,
-        bgr_list: list[UInt8[ndarray, "H W 3"]],
+        frames_rgb: UInt8[torch.Tensor, "n_views h w 3"],
         pinhole_list: list[PinholeParameters],
         pred_state: MVHistory,
+        pinhole_log_paths: list[Path] | None = None,
         recording: rr.RecordingStream | None = None,
     ) -> MVHistory:
-        del bgr_list, pinhole_list, recording
+        del frames_rgb, pinhole_list, pinhole_log_paths, recording
         xyzc: Float32[ndarray, "133 4"] = np.full((133, 4), np.nan, dtype=np.float32)
         xyzc[:, 0:3] = np.array([0.0, 0.0, 2.0], dtype=np.float32)
         xyzc[:, 3] = 1.0
@@ -242,13 +267,14 @@ def test_pipeline_writes_rrd_with_expected_scene_paths(
     def fake_setup_scene(
         exoego_sequence: FakeExoEgoSequence,
         *,
+        rig_layout: object,
         parent_log_path: Path,
         timeline: str,
         log_ego: bool,
         log_exo: bool,
         recording: rr.RecordingStream | None = None,
     ) -> SceneSetupResult:
-        del exoego_sequence, log_ego, log_exo
+        del exoego_sequence, rig_layout, log_ego, log_exo
         rr.set_time(timeline, sequence=0, recording=recording)
         rr.log(str(parent_log_path / "exo" / "cam0" / "pinhole" / "video"), rr.TextDocument("exo"), recording=recording)
         rr.log(str(parent_log_path / "ego" / "rgb" / "pinhole" / "video"), rr.TextDocument("ego"), recording=recording)
@@ -268,9 +294,11 @@ def test_pipeline_writes_rrd_with_expected_scene_paths(
         scene_setup_result: SceneSetupResult,
         parent_log_path: Path,
         timeline: str,
+        exo_cam_paths: dict[str, Path] | None = None,
+        ego_cam_paths: dict[str, Path] | None = None,
         recording: rr.RecordingStream | None = None,
     ) -> None:
-        del config, exoego_sequence, scene_setup_result, timeline
+        del config, exoego_sequence, scene_setup_result, timeline, exo_cam_paths, ego_cam_paths
         points3d: Float32[ndarray, "1 3"] = np.array([[0.0, 0.0, 0.0]], dtype=np.float32)
         points2d: Float32[ndarray, "1 2"] = np.array([[12.0, 24.0]], dtype=np.float32)
         rr.log(str(parent_log_path / "gt" / "coco133_xyz"), rr.Points3D(points3d), recording=recording)
@@ -330,13 +358,14 @@ def test_model_backed_hook_logs_calibrated_predictions_with_fake_models(
     def fake_setup_scene(
         exoego_sequence: FakeModelBackedSequence,
         *,
+        rig_layout: object,
         parent_log_path: Path,
         timeline: str,
         log_ego: bool,
         log_exo: bool,
         recording: rr.RecordingStream | None = None,
     ) -> SceneSetupResult:
-        del exoego_sequence, log_ego, log_exo
+        del exoego_sequence, rig_layout, log_ego, log_exo
         rr.set_time(timeline, duration=np.timedelta64(0, "ns"), recording=recording)
         rr.log(str(parent_log_path / "exo" / "cam0" / "pinhole" / "video"), rr.TextDocument("exo"), recording=recording)
         rr.log(
@@ -405,13 +434,14 @@ def test_dataset_camera_sources_skip_estimated_environment_logging(
     def fake_setup_scene(
         exoego_sequence: FakeDatasetCameraModelBackedSequence,
         *,
+        rig_layout: object,
         parent_log_path: Path,
         timeline: str,
         log_ego: bool,
         log_exo: bool,
         recording: rr.RecordingStream | None = None,
     ) -> SceneSetupResult:
-        del exoego_sequence, log_ego, log_exo
+        del exoego_sequence, rig_layout, log_ego, log_exo
         rr.set_time(timeline, duration=np.timedelta64(0, "ns"), recording=recording)
         rr.log(str(parent_log_path / "exo" / "cam0" / "pinhole" / "video"), rr.TextDocument("exo"), recording=recording)
         rr.log(

--- a/packages/mv-api/tests/test_multiview_pose_estimator.py
+++ b/packages/mv-api/tests/test_multiview_pose_estimator.py
@@ -2,9 +2,13 @@ from typing import Any, cast
 
 import numpy as np
 import pytest
+import torch
 from jaxtyping import Float32, Float64, UInt8
 from numpy import ndarray
+from posekit.predictions import BoxDetections, Keypoints2d
+from posekit.skeletons import COCO_133
 from simplecv.camera_parameters import Extrinsics, Intrinsics, PinholeParameters
+from torch import Tensor
 
 from mv_api import multiview_pose_estimator as estimator_module
 from mv_api.multiview_pose_estimator import MultiviewBodyTracker, MultiviewBodyTrackerConfig, MVHistory
@@ -50,26 +54,26 @@ def _fake_pinhole(name: str) -> PinholeParameters:
 
 
 class _FailingDetector:
-    def __call__(self, bgr: UInt8[ndarray, "h w 3"]) -> ndarray:
-        del bgr
+    def __call__(self, frames_rgb: UInt8[Tensor, "b h w 3"]) -> BoxDetections:
+        del frames_rgb
         raise AssertionError("tracking should provide the selected-view bbox without running detection")
 
 
 class _RecordingPoseModel:
     def __init__(self) -> None:
         self.seen_pixel_values: list[int] = []
+        self.skeleton = COCO_133
 
-    def __call__(
-        self,
-        bgr: UInt8[ndarray, "h w 3"],
-        *,
-        bboxes: list[list[float]],
-    ) -> tuple[Float64[ndarray, "1 133 2"], Float32[ndarray, "1 133"]]:
-        assert bboxes
-        self.seen_pixel_values.append(int(bgr[0, 0, 0]))
-        keypoints: Float64[ndarray, "1 133 2"] = np.zeros((1, 133, 2), dtype=np.float64)
-        scores: Float32[ndarray, "1 133"] = np.ones((1, 133), dtype=np.float32)
-        return keypoints, scores
+    def __call__(self, frames_rgb: UInt8[Tensor, "b h w 3"], detections: BoxDetections) -> Keypoints2d:
+        assert detections.num_detections > 0
+        self.seen_pixel_values.append(int(frames_rgb[0, 0, 0, 0]))
+        num_instances: int = detections.num_detections
+        return Keypoints2d(
+            xy=torch.zeros((num_instances, 133, 2), dtype=torch.float32),
+            scores=torch.ones((num_instances, 133), dtype=torch.float32),
+            frame_indices=detections.frame_indices,
+            skeleton=COCO_133,
+        )
 
 
 def test_multiview_tracker_filters_images_and_pinholes_for_selected_detection_cameras(
@@ -87,7 +91,7 @@ def test_multiview_tracker_filters_images_and_pinholes_for_selected_detection_ca
 
     monkeypatch.setattr(estimator_module, "batch_triangulate", fake_batch_triangulate)
     tracker: MultiviewBodyTracker = object.__new__(MultiviewBodyTracker)
-    tracker.config = MultiviewBodyTrackerConfig(cams_for_detection_idx=[1], perform_tracking=True)
+    tracker.config = MultiviewBodyTrackerConfig(cams_for_detection_idx=[1], perform_tracking=True, device="cpu")
     tracker.num_keypoints = 133
     tracker.filter_body_idxes = np.arange(133, dtype=np.intp)
     tracker.det_model = cast(Any, _FailingDetector())
@@ -99,14 +103,16 @@ def test_multiview_tracker_filters_images_and_pinholes_for_selected_detection_ca
     xyzc_t[:, 2] = 2.0
     xyzc_t[:, 3] = 1.0
     pred_state: MVHistory = MVHistory(xyzc_t=xyzc_t, xyzc_t1=xyzc_t.copy())
-    bgr_list: list[UInt8[ndarray, "32 32 3"]] = [
-        np.full((32, 32, 3), 10, dtype=np.uint8),
-        np.full((32, 32, 3), 20, dtype=np.uint8),
-    ]
+    frames_rgb: UInt8[Tensor, "2 32 32 3"] = torch.stack(
+        [
+            torch.full((32, 32, 3), 10, dtype=torch.uint8),
+            torch.full((32, 32, 3), 20, dtype=torch.uint8),
+        ]
+    )
     pinhole_list: list[PinholeParameters] = [_fake_pinhole("cam0"), _fake_pinhole("cam1")]
 
     output_state: MVHistory = tracker(
-        bgr_list=bgr_list,
+        frames_rgb=frames_rgb,
         pinhole_list=pinhole_list,
         pred_state=pred_state,
     )

--- a/pixi.lock
+++ b/pixi.lock
@@ -8541,6 +8541,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
       - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-10.13.3.9.tar.gz
       - pypi: packages/mamma
+      - pypi: packages/posekit
       - pypi: packages/sam2-streaming
       - pypi: packages/simplecv
   mamma-dev:
@@ -9109,6 +9110,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
       - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-10.13.3.9.tar.gz
       - pypi: packages/mamma
+      - pypi: packages/posekit
       - pypi: packages/sam2-streaming
       - pypi: packages/simplecv
   mast3r-slam:
@@ -11805,9 +11807,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/liblzf-3.6-hb9d3cd8_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libmagma-2.10.0-hd93470c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmagma_sparse-2.10.0-hbc3fd83_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnetcdf-4.10.0-nompi_hb6f1874_104.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnpp-13.0.1.2-h676940d_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnvjitlink-13.3.33-hecca717_0.conda
@@ -11950,6 +11954,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tokenizers-0.22.2-py312hf875000_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/torchcodec-0.14.0-cuda130_py312_h0ea267f_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/torchvision-0.27.1-cuda130_py312_h2966ecb_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.7-py312h4c3975b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/triton-3.7.0-cuda130py312hc6dca4b_0.conda
@@ -12207,6 +12212,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/38/31/7ff3f7768eded7535c621abc2fecb9d181a34ea4cae3afe682feb796f242/cuda_python-13.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3f/95/0ad40fb92ba3e6fe36182f722f81d69842a1e93cab1d9c6171256ef55418/gradio-6.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl
@@ -12234,6 +12240,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a1/4d/603557ab3cb171cc2a61d3678a39cb4dae3fd21275078bfbd1c0b0b5230b/cuda_core-1.0.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/ce/a2fb0d865c3d6ac7be80c96d32d6dbe728ebc54010cf2d4e563576265787/tensorrt_cu13_libs-10.13.3.9.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/a7/00/4823f06357892d1e60d6f34e7299d2ba4ed2108c487cc394f7ce85a3ff14/onnx-1.21.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a8/db/253133d7e7cb40d3af384bb2f5c0b4a2b7fdcffbc95c688cc67a20a3c103/accelerate-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b1/29/c028a0731e202035f0e2e0bfbf1a3e46ad6c628cbb17f6f1cc9eea5d9ff1/pathlib_abc-0.5.2-py3-none-any.whl
@@ -12262,6 +12269,7 @@ environments:
       - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-10.13.3.9.tar.gz
       - pypi: packages/monoprior
       - pypi: packages/mv-api
+      - pypi: packages/posekit
       - pypi: packages/sam3
       - pypi: packages/simplecv
       - pypi: packages/wilor-nano
@@ -12472,9 +12480,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/liblzf-3.6-hb9d3cd8_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libmagma-2.10.0-hd93470c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmagma_sparse-2.10.0-hbc3fd83_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnetcdf-4.10.0-nompi_hb6f1874_104.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnpp-13.0.1.2-h676940d_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnvjitlink-13.3.33-hecca717_0.conda
@@ -12614,6 +12624,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tokenizers-0.22.2-py312hf875000_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/torchcodec-0.14.0-cuda130_py312_h0ea267f_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/torchvision-0.27.1-cuda130_py312_h2966ecb_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/triton-3.7.0-cuda130py312hc6dca4b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
@@ -12796,6 +12807,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/35/bf/9cad857b630c840738003eb24c1adb63490a1024ec40a9dcc3a753300c38/asciimatics-1.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/31/7ff3f7768eded7535c621abc2fecb9d181a34ea4cae3afe682feb796f242/cuda_python-13.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3f/3f/7469c46e9d22307ea686bab687d70e6bf328722952f9d10339f5e913e608/diffusers-0.39.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/55/bd/dd56edc2680df7658c7bdeeb58270ab35dfcdc0e2670899ce9771604b436/roma-1.5.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/10/ffb85fa380bc9c9000dc35f40f44954dde49023018501c54faab94b3a39e/polars_runtime_32-1.42.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -12818,6 +12830,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a1/4d/603557ab3cb171cc2a61d3678a39cb4dae3fd21275078bfbd1c0b0b5230b/cuda_core-1.0.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/ce/a2fb0d865c3d6ac7be80c96d32d6dbe728ebc54010cf2d4e563576265787/tensorrt_cu13_libs-10.13.3.9.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/a7/00/4823f06357892d1e60d6f34e7299d2ba4ed2108c487cc394f7ce85a3ff14/onnx-1.21.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a8/db/253133d7e7cb40d3af384bb2f5c0b4a2b7fdcffbc95c688cc67a20a3c103/accelerate-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/29/c028a0731e202035f0e2e0bfbf1a3e46ad6c628cbb17f6f1cc9eea5d9ff1/pathlib_abc-0.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl
@@ -12845,6 +12858,7 @@ environments:
       - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-10.13.3.9.tar.gz
       - pypi: packages/monoprior
       - pypi: packages/mv-api
+      - pypi: packages/posekit
       - pypi: packages/sam3
       - pypi: packages/simplecv
       - pypi: packages/wilor-nano
@@ -13055,9 +13069,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/liblzf-3.6-hb9d3cd8_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libmagma-2.10.0-hd93470c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmagma_sparse-2.10.0-hbc3fd83_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnetcdf-4.10.0-nompi_hb6f1874_104.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnpp-13.0.1.2-h676940d_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnvjitlink-13.3.33-hecca717_0.conda
@@ -13199,6 +13215,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tokenizers-0.22.2-py312hf875000_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/torchcodec-0.14.0-cuda130_py312_h0ea267f_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/torchvision-0.27.1-cuda130_py312_h2966ecb_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/triton-3.7.0-cuda130py312hc6dca4b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
@@ -13389,6 +13406,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/35/bf/9cad857b630c840738003eb24c1adb63490a1024ec40a9dcc3a753300c38/asciimatics-1.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/31/7ff3f7768eded7535c621abc2fecb9d181a34ea4cae3afe682feb796f242/cuda_python-13.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3f/3f/7469c46e9d22307ea686bab687d70e6bf328722952f9d10339f5e913e608/diffusers-0.39.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/e8/61d95bfd49d1609fb8e8c5e06f4a094183411988a6f448873f5de6602499/types_tqdm-4.68.0.20260608-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/55/bd/dd56edc2680df7658c7bdeeb58270ab35dfcdc0e2670899ce9771604b436/roma-1.5.6-py3-none-any.whl
@@ -13412,6 +13430,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a1/4d/603557ab3cb171cc2a61d3678a39cb4dae3fd21275078bfbd1c0b0b5230b/cuda_core-1.0.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/ce/a2fb0d865c3d6ac7be80c96d32d6dbe728ebc54010cf2d4e563576265787/tensorrt_cu13_libs-10.13.3.9.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/a7/00/4823f06357892d1e60d6f34e7299d2ba4ed2108c487cc394f7ce85a3ff14/onnx-1.21.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a8/db/253133d7e7cb40d3af384bb2f5c0b4a2b7fdcffbc95c688cc67a20a3c103/accelerate-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/29/c028a0731e202035f0e2e0bfbf1a3e46ad6c628cbb17f6f1cc9eea5d9ff1/pathlib_abc-0.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl
@@ -13439,6 +13458,7 @@ environments:
       - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-10.13.3.9.tar.gz
       - pypi: packages/monoprior
       - pypi: packages/mv-api
+      - pypi: packages/posekit
       - pypi: packages/sam3
       - pypi: packages/simplecv
       - pypi: packages/wilor-nano
@@ -13923,9 +13943,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/liblzf-3.6-hb9d3cd8_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libmagma-2.10.0-hd93470c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmagma_sparse-2.10.0-hbc3fd83_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnetcdf-4.10.0-nompi_hb6f1874_104.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnpp-13.0.1.2-h676940d_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libnvjitlink-13.3.33-hecca717_0.conda
@@ -14070,6 +14092,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tokenizers-0.22.2-py312hf875000_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/torchcodec-0.14.0-cuda130_py312_h0ea267f_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/torchvision-0.27.1-cuda130_py312_h2966ecb_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.7-py312h4c3975b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/triton-3.7.0-cuda130py312hc6dca4b_0.conda
@@ -14334,6 +14357,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/38/31/7ff3f7768eded7535c621abc2fecb9d181a34ea4cae3afe682feb796f242/cuda_python-13.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3f/95/0ad40fb92ba3e6fe36182f722f81d69842a1e93cab1d9c6171256ef55418/gradio-6.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl
@@ -14362,6 +14386,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a1/4d/603557ab3cb171cc2a61d3678a39cb4dae3fd21275078bfbd1c0b0b5230b/cuda_core-1.0.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/ce/a2fb0d865c3d6ac7be80c96d32d6dbe728ebc54010cf2d4e563576265787/tensorrt_cu13_libs-10.13.3.9.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/a7/00/4823f06357892d1e60d6f34e7299d2ba4ed2108c487cc394f7ce85a3ff14/onnx-1.21.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a8/db/253133d7e7cb40d3af384bb2f5c0b4a2b7fdcffbc95c688cc67a20a3c103/accelerate-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b1/29/c028a0731e202035f0e2e0bfbf1a3e46ad6c628cbb17f6f1cc9eea5d9ff1/pathlib_abc-0.5.2-py3-none-any.whl
@@ -14390,6 +14415,7 @@ environments:
       - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-10.13.3.9.tar.gz
       - pypi: packages/monoprior
       - pypi: packages/mv-api
+      - pypi: packages/posekit
       - pypi: packages/sam3
       - pypi: packages/simplecv
       - pypi: packages/wilor-nano

--- a/pixi.toml
+++ b/pixi.toml
@@ -672,6 +672,7 @@ h5py = ">=3.13.0,<4"
 natsort = ">=8.4.0,<9"
 open3d = ">=0.19.0,<0.20"
 scikit-image = ">=0.24.0,<0.25"
+torchcodec = "*"
 tyro = ">=0.9.1,<0.10"
 
 [feature.mv-api.target.linux-64.dependencies]
@@ -680,6 +681,8 @@ datasets = ">=4.0.0"
 [feature.mv-api.pypi-dependencies]
 mv-api = { path = "packages/mv-api", editable = true }
 monopriors = { path = "packages/monoprior", editable = true }
+posekit = { path = "packages/posekit", editable = true }
+onnx = "*"
 sam3 = { path = "packages/sam3", editable = true }
 wilor_nano = { path = "packages/wilor-nano", editable = true }
 rtmlib = { git = "https://github.com/pablovela5620/rtmlib.git", rev = "98bca2193c39b349034b280803b54c9ee58f7c68" }
@@ -1906,6 +1909,7 @@ natsort = ">=8.4.0,<9"
 
 [feature.mamma.pypi-dependencies]
 mamma = { path = "packages/mamma", editable = true }
+posekit = { path = "packages/posekit", editable = true }
 # Vendored cjaverliat/sam2 fork (streaming predictor + forgetful memory bank +
 # EfficientTAM); distribution name is `sam2`, needs no-build-isolation (torch
 # at build time). See packages/sam2-streaming/VENDOR.md.


### PR DESCRIPTION
Top of the stack (#62 → #63 → #64 → this). Swaps mv-api and mamma onto posekit.

**mv-api**
- `MultiviewBodyTracker` runs on posekit roles, batched per tick and tensor-only (`frames_rgb: uint8 NHWC CUDA`; `bgr_list` removed). Roles injectable via `detector=`/`pose=`. Parity vs the old rtmlib path: 0.3–0.6 px on confident keypoints.
- The exoego pipeline decodes through simplecv's `get_frames_at` (#63) — one reader-agnostic call, camera-parallel NVDEC via `TorchCodecMultiVideoReader(device="cuda")`, no CPU/GPU if/else.
- Default backend is TensorRT with dynamic-batch engines — the static-batch knob is gone; any rig ≤32 views just works.
- **Full exoego app wall time: 78 s → ~17 s** (steady-state ~44 ticks/s for the 2D stage).

**Pre-existing rig-migration fixes** (found because 2D overlays showed "2D visualizers require a pinhole ancestor" on HEAD):
- `setup_scene` now builds and logs the rig layout.
- Overlays resolve rig camera pinhole paths name-first with view-index fallback, instead of legacy `/world/{exo,ego}/<name>` paths.
- Dataset pinhole params resolve camera names positionally — parsing them from log paths always yielded `cam_00` under rigs and silently fell back to estimated cameras.

**Guards from the adversarial review:** mixed-resolution rigs fail loudly at reader construction; COCO-17 presets rejected by COCO-133 pipelines; `filter_body_idxes` bounds-checked.

**mamma:** ships the MammaNet `TopDownDenseLandmarks2d` adapter (`mamma.landmarks.posekit_role`), bitwise-equal to its native estimator.

Checks: mv-api 53 tests + full matrix, mamma lint/deadcode green; full pipeline validated end-to-end in the Rerun viewer (native headless + WebViewer playheads).