### PR TITLE
arkitscenes-download: GT-mesh-framed 3D viewport, rich terminal output, download byte progress

### DIFF
--- a/packages/arkitscenes-download/README.md
+++ b/packages/arkitscenes-download/README.md
@@ -68,7 +68,7 @@ cleans staging, resumably (kill it anywhere; rerun continues from
 pixi run -e arkitscenes-download arkitscenes-download-pipeline
 
 # or to a remote destination over ssh (transport + sha256 verification per scheme)
-python -m arkitscenes_download.pipeline --destination user@host:/srv/arkitscenes/rrd --read-mount /mnt/arkitscenes/rrd
+python tools/apps/pipeline.py --destination user@host:/srv/arkitscenes/rrd --read-mount /mnt/arkitscenes/rrd
 ```
 
 Failures record to `failed.txt` and never block; `--retry-failed` re-queues them

--- a/packages/arkitscenes-download/arkitscenes_download/__init__.py
+++ b/packages/arkitscenes-download/arkitscenes_download/__init__.py
@@ -2,7 +2,8 @@
 
 Mirrors the official Apple downloader (https://github.com/apple/ARKitScenes)
 and the Rerun example port, restructured to follow the project's Python
-conventions with a `tyro` CLI and stdlib-only runtime dependencies.
+conventions with Tyro and Rich CLIs, import-cheap SimpleCV print utilities,
+and the scientific and Rerun dependencies used by ingestion.
 """
 
 import os

--- a/packages/arkitscenes-download/arkitscenes_download/__main__.py
+++ b/packages/arkitscenes-download/arkitscenes_download/__main__.py
@@ -1,6 +1,0 @@
-"""Module entry point: ``python -m arkitscenes_download``."""
-
-from arkitscenes_download.cli import main
-
-if __name__ == "__main__":
-    main()

--- a/packages/arkitscenes-download/arkitscenes_download/cli.py
+++ b/packages/arkitscenes-download/arkitscenes_download/cli.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
-import tyro
 from rich.console import Console, Group
 from rich.live import Live
 from rich.progress import BarColumn, DownloadColumn, Progress, TaskID, TextColumn, TimeRemainingColumn, TransferSpeedColumn
@@ -66,9 +65,8 @@ def _select_video_ids(config: Config, metadata: dict[str, VideoMetadata]) -> lis
     return random.Random(config.seed).sample(pool, count)
 
 
-def main() -> None:
-    """Parse CLI args and download the selected ARKitScenes sequences."""
-    config: Config = tyro.cli(Config)
+def main(config: Config) -> None:
+    """Download the selected ARKitScenes sequences."""
     console: Console = Console(markup=False)
 
     console.print(f"Loading raw metadata into {config.download_dir} ...")
@@ -159,7 +157,3 @@ def main() -> None:
     total_bytes: int = directory_size(config.download_dir)
     console.print(f"Finished {len(video_ids)} sequence(s) in {elapsed / 60:.1f} min")
     console.print(f"Total on disk under {config.download_dir}: {format_bytes(total_bytes)}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/arkitscenes-download/arkitscenes_download/cli.py
+++ b/packages/arkitscenes-download/arkitscenes_download/cli.py
@@ -9,13 +9,19 @@ from pathlib import Path
 from typing import Literal
 
 import tyro
+from rich.console import Console, Group
+from rich.live import Live
+from rich.progress import BarColumn, DownloadColumn, Progress, TaskID, TextColumn, TimeRemainingColumn, TransferSpeedColumn
+from simplecv.print_utils import format_bytes
 
 from arkitscenes_download.download_dataset import (
     ALL_ASSETS,
+    PlannedDownload,
     VideoMetadata,
     download_video,
-    human_bytes,
     load_metadata,
+    plan_video_downloads,
+    prefetch_sizes,
 )
 from arkitscenes_download.fs import directory_size
 
@@ -40,6 +46,8 @@ class Config:
     """Also download Faro laser-scan point clouds when available."""
     keep_zip: bool = False
     """Keep the downloaded ``.zip`` archives after extraction."""
+    prefetch: bool = True
+    """HEAD-request asset sizes up front for an accurate overall byte total. Disable when a wrapper (e.g. the pipeline) calls this once per sequence — the extra round-trips buy nothing there."""
 
 
 def _select_video_ids(config: Config, metadata: dict[str, VideoMetadata]) -> list[str]:
@@ -61,35 +69,96 @@ def _select_video_ids(config: Config, metadata: dict[str, VideoMetadata]) -> lis
 def main() -> None:
     """Parse CLI args and download the selected ARKitScenes sequences."""
     config: Config = tyro.cli(Config)
+    console: Console = Console(markup=False)
 
-    print(f"Loading raw metadata into {config.download_dir} ...")
+    console.print(f"Loading raw metadata into {config.download_dir} ...")
     metadata: dict[str, VideoMetadata] = load_metadata(config.download_dir)
-    print(f"  {len(metadata)} sequences in metadata")
+    console.print(f"  {len(metadata)} sequences in metadata")
 
     video_ids: list[str] = _select_video_ids(config, metadata)
-    print(f"\nSelected {len(video_ids)} sequence(s): {', '.join(video_ids)}")
-    print(f"Assets ({len(config.assets)}): {', '.join(config.assets)}")
-    print(f"Point clouds: {config.include_point_clouds} | keep zips: {config.keep_zip}\n")
+    plans_by_video: dict[str, list[PlannedDownload]] = {
+        video_id: plan_video_downloads(metadata[video_id], config.assets, config.download_dir) for video_id in video_ids
+    }
+    plans: list[PlannedDownload] = [plan for video_id in video_ids for plan in plans_by_video[video_id]]
+    if config.prefetch:
+        with console.status("Checking remote asset sizes..."):
+            sizes: dict[str, int | None] = prefetch_sizes(plans)
+    else:
+        sizes = dict.fromkeys((plan.url for plan in plans), None)
+    known_total: int = sum(size for size in sizes.values() if size is not None)
+    unknown_sizes: int = sum(size is None for size in sizes.values())
+    unknown_note: str = f" + {unknown_sizes} unknown-size assets" if unknown_sizes else ""
+    console.print(f"Plan: {len(video_ids)} sequences, {len(plans)} assets, {format_bytes(known_total)} to fetch{unknown_note}")
+    console.print(f"Point clouds: {config.include_point_clouds} | keep zips: {config.keep_zip}")
 
     start: float = time.monotonic()
-    for index, video_id in enumerate(video_ids, start=1):
-        meta: VideoMetadata = metadata[video_id]
-        tags: str = f"{meta.fold}, upsampling={meta.is_in_upsampling}, laser={meta.has_laser_scanner_point_clouds}"
-        print(f"[{index}/{len(video_ids)}] {video_id} ({tags})")
-        download_video(
-            metadata=meta,
-            assets=config.assets,
-            download_dir=config.download_dir,
-            keep_zip=config.keep_zip,
-            include_point_clouds=config.include_point_clouds,
-        )
-        video_dir: Path = config.download_dir / "raw" / meta.fold / video_id
-        print(f"    done — {human_bytes(directory_size(video_dir))} on disk")
+    bytes_done: int = 0
+    current_asset_bytes: int = 0
+    # Two Progress renderables in one Live so each task row gets fitting columns
+    # (bytes/speed for the transfer, plain counts for sequences).
+    progress: Progress = Progress(
+        TextColumn("{task.description}"),
+        BarColumn(),
+        DownloadColumn(),
+        TransferSpeedColumn(),
+        TimeRemainingColumn(),
+        console=console,
+    )
+    sequences_progress: Progress = Progress(
+        TextColumn("{task.description}"),
+        BarColumn(),
+        TimeRemainingColumn(),
+        console=console,
+    )
+
+    def on_bytes(plan: PlannedDownload, current: int) -> None:
+        """Reflect the current part-file size in overall progress."""
+        nonlocal current_asset_bytes
+        current_asset_bytes = current
+        progress.update(bytes_task, completed=bytes_done + current)
+
+    def on_asset_complete(plan: PlannedDownload) -> None:
+        """Commit one completed asset's bytes to overall progress."""
+        nonlocal bytes_done, known_total, current_asset_bytes
+        actual_bytes: int = current_asset_bytes
+        current_asset_bytes = 0
+        expected_bytes: int | None = sizes[plan.url]
+        if expected_bytes is None:
+            known_total += actual_bytes
+            progress.update(bytes_task, total=known_total)
+            committed_bytes: int = actual_bytes
+        else:
+            committed_bytes = expected_bytes
+        bytes_done += committed_bytes
+        progress.update(bytes_task, completed=bytes_done)
+        if not console.is_terminal:
+            console.print(f"asset complete: {plan.video_id} {plan.asset} ({format_bytes(actual_bytes)})")
+
+    with Live(Group(progress, sequences_progress), console=console, refresh_per_second=10.0):
+        bytes_task: TaskID = progress.add_task("download bytes", total=known_total)
+        sequences_task: TaskID = sequences_progress.add_task(f"0/{len(video_ids)} sequences, {len(video_ids)} remaining", total=len(video_ids))
+        for index, video_id in enumerate(video_ids, start=1):
+            meta: VideoMetadata = metadata[video_id]
+            download_video(
+                metadata=meta,
+                plans=plans_by_video[video_id],
+                download_dir=config.download_dir,
+                keep_zip=config.keep_zip,
+                include_point_clouds=config.include_point_clouds,
+                on_bytes=on_bytes,
+                on_asset_complete=on_asset_complete,
+            )
+            video_dir: Path = config.download_dir / "raw" / meta.fold / video_id
+            remaining: int = len(video_ids) - index
+            sequences_progress.advance(sequences_task)
+            sequences_progress.update(sequences_task, description=f"{index}/{len(video_ids)} sequences, {remaining} remaining")
+            if not console.is_terminal:
+                console.print(f"sequence complete: {video_id} ({format_bytes(directory_size(video_dir))} on disk)")
 
     elapsed: float = time.monotonic() - start
     total_bytes: int = directory_size(config.download_dir)
-    print(f"\nFinished {len(video_ids)} sequence(s) in {elapsed / 60:.1f} min")
-    print(f"Total on disk under {config.download_dir}: {human_bytes(total_bytes)}")
+    console.print(f"Finished {len(video_ids)} sequence(s) in {elapsed / 60:.1f} min")
+    console.print(f"Total on disk under {config.download_dir}: {format_bytes(total_bytes)}")
 
 
 if __name__ == "__main__":

--- a/packages/arkitscenes-download/arkitscenes_download/cli.py
+++ b/packages/arkitscenes-download/arkitscenes_download/cli.py
@@ -15,6 +15,7 @@ from simplecv.print_utils import format_bytes
 
 from arkitscenes_download.download_dataset import (
     ALL_ASSETS,
+    CONSOLE,
     PlannedDownload,
     VideoMetadata,
     download_video,
@@ -67,7 +68,9 @@ def _select_video_ids(config: Config, metadata: dict[str, VideoMetadata]) -> lis
 
 def main(config: Config) -> None:
     """Download the selected ARKitScenes sequences."""
-    console: Console = Console(markup=False)
+    # Share download_dataset's console: its failure prints would otherwise
+    # bypass this function's Live region and garble the bars.
+    console: Console = CONSOLE
 
     console.print(f"Loading raw metadata into {config.download_dir} ...")
     metadata: dict[str, VideoMetadata] = load_metadata(config.download_dir)
@@ -80,18 +83,17 @@ def main(config: Config) -> None:
     plans: list[PlannedDownload] = [plan for video_id in video_ids for plan in plans_by_video[video_id]]
     if config.prefetch:
         with console.status("Checking remote asset sizes..."):
-            sizes: dict[str, int | None] = prefetch_sizes(plans)
+            sizes: dict[str, int] = prefetch_sizes(plans)
     else:
-        sizes = dict.fromkeys((plan.url for plan in plans), None)
-    known_total: int = sum(size for size in sizes.values() if size is not None)
-    unknown_sizes: int = sum(size is None for size in sizes.values())
+        sizes = {}
+    known_total: int = sum(sizes.values())
+    unknown_sizes: int = sum(plan.url not in sizes for plan in plans)
     unknown_note: str = f" + {unknown_sizes} unknown-size assets" if unknown_sizes else ""
     console.print(f"Plan: {len(video_ids)} sequences, {len(plans)} assets, {format_bytes(known_total)} to fetch{unknown_note}")
     console.print(f"Point clouds: {config.include_point_clouds} | keep zips: {config.keep_zip}")
 
     start: float = time.monotonic()
     bytes_done: int = 0
-    current_asset_bytes: int = 0
     # Two Progress renderables in one Live so each task row gets fitting columns
     # (bytes/speed for the transfer, plain counts for sequences).
     progress: Progress = Progress(
@@ -108,33 +110,26 @@ def main(config: Config) -> None:
         TimeRemainingColumn(),
         console=console,
     )
+    bytes_task: TaskID = progress.add_task("download bytes", total=known_total)
+    sequences_task: TaskID = sequences_progress.add_task(f"0/{len(video_ids)} sequences, {len(video_ids)} remaining", total=len(video_ids))
 
-    def on_bytes(plan: PlannedDownload, current: int) -> None:
-        """Reflect the current part-file size in overall progress."""
-        nonlocal current_asset_bytes
-        current_asset_bytes = current
+    def on_bytes(current: int) -> None:
+        """Reflect the in-flight asset's current part-file size in overall progress."""
         progress.update(bytes_task, completed=bytes_done + current)
 
-    def on_asset_complete(plan: PlannedDownload) -> None:
+    def on_asset_complete(plan: PlannedDownload, actual_bytes: int) -> None:
         """Commit one completed asset's bytes to overall progress."""
-        nonlocal bytes_done, known_total, current_asset_bytes
-        actual_bytes: int = current_asset_bytes
-        current_asset_bytes = 0
-        expected_bytes: int | None = sizes[plan.url]
+        nonlocal bytes_done, known_total
+        expected_bytes: int | None = sizes.get(plan.url)
         if expected_bytes is None:
             known_total += actual_bytes
             progress.update(bytes_task, total=known_total)
-            committed_bytes: int = actual_bytes
-        else:
-            committed_bytes = expected_bytes
-        bytes_done += committed_bytes
+        bytes_done += actual_bytes if expected_bytes is None else expected_bytes
         progress.update(bytes_task, completed=bytes_done)
         if not console.is_terminal:
             console.print(f"asset complete: {plan.video_id} {plan.asset} ({format_bytes(actual_bytes)})")
 
     with Live(Group(progress, sequences_progress), console=console, refresh_per_second=10.0):
-        bytes_task: TaskID = progress.add_task("download bytes", total=known_total)
-        sequences_task: TaskID = sequences_progress.add_task(f"0/{len(video_ids)} sequences, {len(video_ids)} remaining", total=len(video_ids))
         for index, video_id in enumerate(video_ids, start=1):
             meta: VideoMetadata = metadata[video_id]
             download_video(

--- a/packages/arkitscenes-download/arkitscenes_download/download_dataset.py
+++ b/packages/arkitscenes-download/arkitscenes_download/download_dataset.py
@@ -2,8 +2,10 @@
 
 Adapted from the official Apple downloader
 (https://github.com/apple/ARKitScenes/blob/main/download_data.py) and the
-Rerun example port, using only the Python standard library at runtime (CSV via
-`csv`, extraction via `zipfile`, transfers shelled out to `curl`).
+Rerun example port. Kept deliberately light at import time (CSV via `csv`,
+extraction via `zipfile`, transfers shelled out to `curl`, rich for output,
+and only import-cheap simplecv modules) because the pipeline spawns this
+once per sequence — keep numpy/torch-weight imports out of this path.
 """
 
 from __future__ import annotations
@@ -12,9 +14,15 @@ import csv
 import shutil
 import subprocess
 import zipfile
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Final, TypeAlias
+
+from rich.console import Console
+
+CONSOLE: Final[Console] = Console(markup=False)
 
 ARKITSCENES_URL: Final = "https://docs-assets.developer.apple.com/ml-research/datasets/arkitscenes/v1"
 """Base URL for all v1 ARKitScenes assets."""
@@ -119,6 +127,24 @@ class VideoMetadata:
     """Whether the sequence is part of the 3D object detection subset."""
 
 
+@dataclass(slots=True, frozen=True)
+class PlannedDownload:
+    """One pending raw asset download."""
+
+    video_id: str
+    """Sequence identifier owning the asset."""
+    asset: RawAsset
+    """Requested raw asset kind."""
+    filename: str
+    """Remote and local asset filename."""
+    url: str
+    """Fully-qualified asset URL."""
+    dst_path: Path
+    """Local destination path."""
+    is_zip: bool
+    """Whether the downloaded file must be extracted."""
+
+
 def _parse_bool(value: str) -> bool:
     """Parse a CSV truthiness cell (``True``/``False``/``1``/``0``) into a bool."""
     return value.strip().lower() in {"true", "1", "1.0", "yes"}
@@ -138,22 +164,51 @@ def _parse_visit_id(visit_id: str) -> int | None:
     return int(as_float)
 
 
-def human_bytes(num_bytes: int) -> str:
-    """Format a byte count as a human-readable IEC string (e.g. ``1.4 GiB``)."""
-    size: float = float(num_bytes)
-    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
-        if size < 1024.0 or unit == "TiB":
-            return f"{size:.1f} {unit}"
-        size /= 1024.0
-    return f"{size:.1f} TiB"
+def parse_content_length(head_output: str) -> int | None:
+    """Parse the last Content-Length header from curl output."""
+    last_value: str | None = None
+    for line in head_output.splitlines():
+        name: str
+        separator: str
+        value: str
+        name, separator, value = line.partition(":")
+        if separator and name.strip().lower() == "content-length":
+            last_value = value.strip()
+    if last_value is None:
+        return None
+    try:
+        return int(last_value)
+    except ValueError:
+        return None
 
 
-def download_file(url: str, dst_path: Path) -> bool:
+def head_content_length(url: str) -> int | None:
+    """Fetch an asset's HTTP content length."""
+    result: subprocess.CompletedProcess[str] = subprocess.run(
+        ["curl", "-sIL", "--fail", "--max-time", "30", url],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return parse_content_length(result.stdout) if result.returncode == 0 else None
+
+
+def prefetch_sizes(plans: list[PlannedDownload], workers: int = 16) -> dict[str, int | None]:
+    """Fetch content lengths concurrently for planned downloads."""
+    urls: list[str] = list(dict.fromkeys(plan.url for plan in plans))
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        sizes: list[int | None] = list(pool.map(head_content_length, urls))
+    return dict(zip(urls, sizes, strict=True))
+
+
+def download_file(url: str, dst_path: Path, on_bytes: Callable[[int], None] | None = None) -> bool:
     """Download ``url`` to ``dst_path`` with curl (resumable, retrying).
 
     Args:
         url: Fully-qualified source URL.
         dst_path: Destination file path; parent directories are created.
+        on_bytes: Callback periodically receiving the resumable ``.part`` size
+            while curl is polled with ``Popen.wait(timeout=0.25)``.
 
     Returns:
         True on success (or if the file already exists); False if the asset is
@@ -180,15 +235,34 @@ def download_file(url: str, dst_path: Path) -> bool:
         str(part_path),
         url,
     ]
-    result: subprocess.CompletedProcess[bytes] = subprocess.run(command, check=False)
-    if result.returncode == 0:
+    def part_bytes() -> int:
+        """Return the current transfer size; the .part file may not exist yet (or just got renamed)."""
+        try:
+            return part_path.stat().st_size
+        except FileNotFoundError:
+            return 0
+
+    process: subprocess.Popen[bytes] = subprocess.Popen(command)
+    while True:
+        try:
+            # wait() returns the instant curl exits; sleeping instead would add
+            # up to 0.25 s of dead time per asset (hours across a full split).
+            process.wait(timeout=0.25)
+            break
+        except subprocess.TimeoutExpired:
+            if on_bytes is not None:
+                on_bytes(part_bytes())
+    returncode: int = process.returncode
+    if on_bytes is not None:
+        on_bytes(part_bytes())
+    if returncode == 0:
         part_path.rename(dst_path)
         return True
-    if result.returncode == 22:  # curl --fail: server returned HTTP >= 400
+    if returncode == 22:  # curl --fail: server returned HTTP >= 400
         part_path.unlink(missing_ok=True)
-        print(f"    unavailable (HTTP error): {url}")
+        CONSOLE.print(f"    unavailable (HTTP error): {url}")
         return False
-    print(f"    transfer failed (curl exit {result.returncode}; keeping .part for resume): {url}")
+    CONSOLE.print(f"    transfer failed (curl exit {returncode}; keeping .part for resume): {url}")
     return False
 
 
@@ -240,6 +314,24 @@ def asset_to_filename(video_id: str, asset: RawAsset, metadata: VideoMetadata) -
     raise ValueError(f"Unknown raw asset: {asset!r}")
 
 
+def plan_video_downloads(metadata: VideoMetadata, assets: tuple[RawAsset, ...], download_dir: Path) -> list[PlannedDownload]:
+    """Plan the still-pending applicable assets for one sequence."""
+    video_dir: Path = download_dir / "raw" / metadata.fold / metadata.video_id
+    url_prefix: str = f"{ARKITSCENES_URL}/raw/{metadata.fold}/{metadata.video_id}"
+    plans: list[PlannedDownload] = []
+    for asset in dict.fromkeys(assets):
+        filename: str | None = asset_to_filename(metadata.video_id, asset, metadata)
+        if filename is None:
+            continue
+        is_zip: bool = filename.endswith(".zip")
+        dst_path: Path = video_dir / filename
+        extracted_path: Path = video_dir / filename.removesuffix(".zip")
+        if (is_zip and extracted_path.is_dir()) or (not is_zip and dst_path.exists()):
+            continue
+        plans.append(PlannedDownload(metadata.video_id, asset, filename, f"{url_prefix}/{filename}", dst_path, is_zip))
+    return plans
+
+
 def load_metadata(download_dir: Path) -> dict[str, VideoMetadata]:
     """Download (if needed) and parse the raw dataset ``metadata.csv``.
 
@@ -288,7 +380,7 @@ def download_point_clouds(metadata: VideoMetadata, download_dir: Path) -> None:
     """Download the Faro laser-scan point clouds for a sequence's venue."""
     visit_id: int | None = _parse_visit_id(metadata.visit_id)
     if visit_id is None:
-        print(f"    skipping point clouds for {metadata.video_id}: bad visit id {metadata.visit_id!r}")
+        CONSOLE.log(f"    skipping point clouds for {metadata.video_id}: bad visit id {metadata.visit_id!r}")
         return
 
     point_cloud_ids: list[str] = _point_cloud_ids_for_visit(visit_id, download_dir)
@@ -302,47 +394,45 @@ def download_point_clouds(metadata: VideoMetadata, download_dir: Path) -> None:
 
 def download_video(
     metadata: VideoMetadata,
-    assets: tuple[RawAsset, ...],
+    plans: list[PlannedDownload],
     download_dir: Path,
     keep_zip: bool,
     include_point_clouds: bool,
+    on_bytes: Callable[[PlannedDownload, int], None] | None = None,
+    on_asset_complete: Callable[[PlannedDownload], None] | None = None,
 ) -> None:
-    """Download all requested ``assets`` for a single sequence.
+    """Download an already-filtered list of pending assets for one sequence.
 
     Assets already present on disk (extracted folder for zips, file for the
     rest) are skipped, so the call is idempotent and resumable.
 
     Args:
         metadata: Parsed metadata row for the sequence.
-        assets: Ordered asset kinds to fetch (see ``ALL_ASSETS``).
-        download_dir: Dataset root (writes to ``raw/<fold>/<video_id>/``).
+        plans: Pending assets produced by :func:`plan_video_downloads`.
+        download_dir: Dataset root used for point-cloud downloads.
         keep_zip: Keep the downloaded ``.zip`` after extraction when True.
         include_point_clouds: Also fetch laser-scan point clouds when available.
+        on_bytes: Callback receiving a plan and its current ``.part`` size.
+        on_asset_complete: Callback receiving each successfully completed plan.
     """
     video_dir: Path = download_dir / "raw" / metadata.fold / metadata.video_id
-    url_prefix: str = f"{ARKITSCENES_URL}/raw/{metadata.fold}/{metadata.video_id}"
-
-    for asset in assets:
-        filename: str | None = asset_to_filename(metadata.video_id, asset, metadata)
-        if filename is None:
+    for plan in plans:
+        # Plans snapshot disk state at planning time; re-check just before the
+        # transfer so an asset landed since then (or planned twice) is skipped
+        # instead of re-downloaded and re-extracted onto the existing directory.
+        extracted_dir: Path = video_dir / plan.filename.removesuffix(".zip")
+        if (plan.is_zip and extracted_dir.is_dir()) or (not plan.is_zip and plan.dst_path.exists()):
             continue
-
-        is_zip: bool = filename.endswith(".zip")
-        if is_zip and (video_dir / filename[: -len(".zip")]).is_dir():
-            continue  # already extracted
-
-        dst_path: Path = video_dir / filename
-        if not is_zip and dst_path.exists():
+        callback: Callable[[int], None] | None = None if on_bytes is None else lambda current, item=plan: on_bytes(item, current)
+        if not download_file(plan.url, plan.dst_path, callback):
             continue
-
-        print(f"    {asset} -> {filename}")
-        if not download_file(f"{url_prefix}/{filename}", dst_path):
-            continue
-        if is_zip:
-            extract_zip(dst_path, video_dir, filename[: -len(".zip")])
+        if plan.is_zip:
+            extract_zip(plan.dst_path, video_dir, plan.filename.removesuffix(".zip"))
             if not keep_zip:
-                dst_path.unlink(missing_ok=True)
+                plan.dst_path.unlink(missing_ok=True)
+        if on_asset_complete is not None:
+            on_asset_complete(plan)
 
     if include_point_clouds and metadata.has_laser_scanner_point_clouds:
-        print("    laser_scanner_point_clouds")
+        CONSOLE.log(f"[{metadata.video_id}] laser_scanner_point_clouds")
         download_point_clouds(metadata, download_dir)

--- a/packages/arkitscenes-download/arkitscenes_download/download_dataset.py
+++ b/packages/arkitscenes-download/arkitscenes_download/download_dataset.py
@@ -193,15 +193,15 @@ def head_content_length(url: str) -> int | None:
     return parse_content_length(result.stdout) if result.returncode == 0 else None
 
 
-def prefetch_sizes(plans: list[PlannedDownload], workers: int = 16) -> dict[str, int | None]:
-    """Fetch content lengths concurrently for planned downloads."""
+def prefetch_sizes(plans: list[PlannedDownload], workers: int = 16) -> dict[str, int]:
+    """Fetch content lengths concurrently for planned downloads; URLs with unknown size are absent."""
     urls: list[str] = list(dict.fromkeys(plan.url for plan in plans))
     with ThreadPoolExecutor(max_workers=workers) as pool:
         sizes: list[int | None] = list(pool.map(head_content_length, urls))
-    return dict(zip(urls, sizes, strict=True))
+    return {url: size for url, size in zip(urls, sizes, strict=True) if size is not None}
 
 
-def download_file(url: str, dst_path: Path, on_bytes: Callable[[int], None] | None = None) -> bool:
+def download_file(url: str, dst_path: Path, on_bytes: Callable[[int], None] | None = None) -> int | None:
     """Download ``url`` to ``dst_path`` with curl (resumable, retrying).
 
     Args:
@@ -211,12 +211,14 @@ def download_file(url: str, dst_path: Path, on_bytes: Callable[[int], None] | No
             while curl is polled with ``Popen.wait(timeout=0.25)``.
 
     Returns:
-        True on success (or if the file already exists); False if the asset is
-        unavailable (HTTP 4xx) or the transfer failed after retries.
+        The downloaded size in bytes on success (or the on-disk size if the
+        file already exists); None if the asset is unavailable (HTTP 4xx) or
+        the transfer failed after retries. Test ``is None``, not truthiness —
+        a zero-byte file is a success.
     """
     dst_path.parent.mkdir(parents=True, exist_ok=True)
     if dst_path.exists():
-        return True
+        return dst_path.stat().st_size
 
     part_path: Path = dst_path.parent / (dst_path.name + ".part")
     command: list[str] = [
@@ -253,17 +255,16 @@ def download_file(url: str, dst_path: Path, on_bytes: Callable[[int], None] | No
             if on_bytes is not None:
                 on_bytes(part_bytes())
     returncode: int = process.returncode
-    if on_bytes is not None:
-        on_bytes(part_bytes())
     if returncode == 0:
+        size: int = part_bytes()
         part_path.rename(dst_path)
-        return True
+        return size
     if returncode == 22:  # curl --fail: server returned HTTP >= 400
         part_path.unlink(missing_ok=True)
         CONSOLE.print(f"    unavailable (HTTP error): {url}")
-        return False
+        return None
     CONSOLE.print(f"    transfer failed (curl exit {returncode}; keeping .part for resume): {url}")
-    return False
+    return None
 
 
 def extract_zip(zip_path: Path, video_dir: Path, folder_name: str) -> None:
@@ -342,7 +343,7 @@ def load_metadata(download_dir: Path) -> dict[str, VideoMetadata]:
         Mapping from ``video_id`` to its parsed :class:`VideoMetadata`.
     """
     csv_path: Path = download_dir / "raw" / "metadata.csv"
-    if not download_file(f"{ARKITSCENES_URL}/raw/metadata.csv", csv_path):
+    if download_file(f"{ARKITSCENES_URL}/raw/metadata.csv", csv_path) is None:
         raise RuntimeError("Failed to download raw metadata.csv")
 
     metadata: dict[str, VideoMetadata] = {}
@@ -365,7 +366,7 @@ def _point_cloud_ids_for_visit(visit_id: int, download_dir: Path) -> list[str]:
     """Return the laser-scan point-cloud ids belonging to ``visit_id``."""
     mapping_path: Path = download_dir / POINT_CLOUDS_FOLDER / "laser_scanner_point_clouds_mapping.csv"
     mapping_url: str = f"{ARKITSCENES_URL}/raw/{POINT_CLOUDS_FOLDER}/laser_scanner_point_clouds_mapping.csv"
-    if not mapping_path.exists() and not download_file(mapping_url, mapping_path):
+    if not mapping_path.exists() and download_file(mapping_url, mapping_path) is None:
         return []
 
     point_cloud_ids: list[str] = []
@@ -398,8 +399,8 @@ def download_video(
     download_dir: Path,
     keep_zip: bool,
     include_point_clouds: bool,
-    on_bytes: Callable[[PlannedDownload, int], None] | None = None,
-    on_asset_complete: Callable[[PlannedDownload], None] | None = None,
+    on_bytes: Callable[[int], None] | None = None,
+    on_asset_complete: Callable[[PlannedDownload, int], None] | None = None,
 ) -> None:
     """Download an already-filtered list of pending assets for one sequence.
 
@@ -412,8 +413,8 @@ def download_video(
         download_dir: Dataset root used for point-cloud downloads.
         keep_zip: Keep the downloaded ``.zip`` after extraction when True.
         include_point_clouds: Also fetch laser-scan point clouds when available.
-        on_bytes: Callback receiving a plan and its current ``.part`` size.
-        on_asset_complete: Callback receiving each successfully completed plan.
+        on_bytes: Callback receiving the in-flight asset's current ``.part`` size.
+        on_asset_complete: Callback receiving each completed plan and its downloaded byte size.
     """
     video_dir: Path = download_dir / "raw" / metadata.fold / metadata.video_id
     for plan in plans:
@@ -423,15 +424,15 @@ def download_video(
         extracted_dir: Path = video_dir / plan.filename.removesuffix(".zip")
         if (plan.is_zip and extracted_dir.is_dir()) or (not plan.is_zip and plan.dst_path.exists()):
             continue
-        callback: Callable[[int], None] | None = None if on_bytes is None else lambda current, item=plan: on_bytes(item, current)
-        if not download_file(plan.url, plan.dst_path, callback):
+        size: int | None = download_file(plan.url, plan.dst_path, on_bytes)
+        if size is None:
             continue
         if plan.is_zip:
             extract_zip(plan.dst_path, video_dir, plan.filename.removesuffix(".zip"))
             if not keep_zip:
                 plan.dst_path.unlink(missing_ok=True)
         if on_asset_complete is not None:
-            on_asset_complete(plan)
+            on_asset_complete(plan, size)
 
     if include_point_clouds and metadata.has_laser_scanner_point_clouds:
         CONSOLE.log(f"[{metadata.video_id}] laser_scanner_point_clouds")

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/__main__.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/__main__.py
@@ -1,6 +1,0 @@
-"""Command-line entry point for ARKitScenes ingestion."""
-
-from arkitscenes_download.ingest.cli import main
-
-if __name__ == "__main__":
-    main()

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/batch.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/batch.py
@@ -4,7 +4,6 @@ import subprocess
 import sys
 import time
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
-from contextlib import nullcontext
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -14,7 +13,10 @@ from rich.table import Table
 
 from arkitscenes_download.ingest.layers import LAYER_NAMES
 
+# Package root is parents[2] from arkitscenes_download/ingest/batch.py. Fail at
+# import time rather than as thousands of per-sequence subprocess failures.
 INGEST_TOOL: Path = Path(__file__).resolve().parents[2] / "tools" / "apps" / "ingest_sequence.py"
+assert INGEST_TOOL.is_file(), f"ingest tool shim missing: {INGEST_TOOL}"
 
 
 @dataclass(frozen=True, slots=True)
@@ -137,17 +139,18 @@ def _print_summary(results: list[SequenceResult], summary: BatchSummary, console
     console.print(f"Effective speedup: {summary.effective_speedup:.2f}x")
 
 
-def run_batch(config: Config, progress: Progress | None = None) -> BatchSummary:
-    """Run selected sequences concurrently, reporting every completed job."""
+def run_batch(config: Config, progress: Progress) -> BatchSummary:
+    """Run selected sequences concurrently, reporting every completed job.
+
+    The caller owns the live progress region (rich Live regions cannot nest).
+    """
     if config.workers < 1:
         raise ValueError("workers must be at least 1")
-    owns_progress: bool = progress is None
-    active_progress: Progress = Progress(console=Console(markup=False)) if progress is None else progress
     selected_video_ids: list[str] = discover_video_ids(config.data_dir) if config.video_ids is None else list(dict.fromkeys(config.video_ids))
     video_ids: list[str] = []
     for video_id in selected_video_ids:
         if config.skip_existing and has_all_layers(config.output, video_id):
-            active_progress.console.print(f"[{video_id}] skipped: output already exists", markup=False)
+            progress.console.print(f"[{video_id}] skipped: output already exists", markup=False)
         else:
             video_ids.append(video_id)
 
@@ -155,28 +158,28 @@ def run_batch(config: Config, progress: Progress | None = None) -> BatchSummary:
     # 32 cores on this box; that is accepted, and workers remains the throttle.
     started: float = time.perf_counter()
     results: list[SequenceResult] = []
-    progress_context = active_progress if owns_progress else nullcontext(active_progress)
-    with progress_context, ThreadPoolExecutor(max_workers=config.workers) as pool:
+    with ThreadPoolExecutor(max_workers=config.workers) as pool:
         futures: dict[Future[SequenceResult], str] = {pool.submit(_run_sequence, video_id, config): video_id for video_id in video_ids}
         ok_count: int = 0
         failed_count: int = 0
-        task_id: TaskID = active_progress.add_task("ingest (ok=0 failed=0)", total=len(futures))
+        task_id: TaskID = progress.add_task("ingest (ok=0 failed=0)", total=len(futures))
         for future in as_completed(futures):
             result: SequenceResult = future.result()
             results.append(result)
             ok_count += int(result.ok)
             failed_count += int(not result.ok)
-            _print_prefixed_output(result, active_progress)
-            active_progress.advance(task_id)
-            active_progress.update(task_id, description=f"ingest (ok={ok_count} failed={failed_count})")
-        active_progress.remove_task(task_id)
+            _print_prefixed_output(result, progress)
+            progress.advance(task_id)
+            progress.update(task_id, description=f"ingest (ok={ok_count} failed={failed_count})")
+        progress.remove_task(task_id)
     total_wall_seconds: float = time.perf_counter() - started
     summary: BatchSummary = summarize(results, total_wall_seconds)
-    _print_summary(results, summary, active_progress.console)
+    _print_summary(results, summary, progress.console)
     return summary
 
 
 def main(config: Config) -> None:
     """Run a batch and exit unsuccessfully if any job failed."""
-    summary: BatchSummary = run_batch(config)
+    with Progress(console=Console(markup=False)) as progress:
+        summary: BatchSummary = run_batch(config, progress)
     raise SystemExit(1 if summary.failed_video_ids else 0)

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/batch.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/batch.py
@@ -4,11 +4,14 @@ import subprocess
 import sys
 import time
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from contextlib import nullcontext
 from dataclasses import dataclass
 from pathlib import Path
 
 import tyro
-from tqdm import tqdm
+from rich.console import Console
+from rich.progress import Progress, TaskID
+from rich.table import Table
 
 from arkitscenes_download.ingest.layers import LAYER_NAMES
 
@@ -56,9 +59,7 @@ class Config:
     keep_transcode_cache: bool = False
     """Keep prepared MP4 tracks after each ingest."""
     skip_existing: bool = False
-    """Skip sequence identifiers whose output RRD already exists."""
-    progress_position: int = 0
-    """Terminal row used by the batch tqdm progress bar."""
+    """Skip sequence identifiers only when all seven layer RRDs exist."""
 
 
 def discover_video_ids(data_dir: Path) -> list[str]:
@@ -115,32 +116,38 @@ def _run_sequence(video_id: str, config: Config) -> SequenceResult:
     return SequenceResult(video_id, wall_seconds, completed.returncode == 0, completed.stdout)
 
 
-def _print_prefixed_output(result: SequenceResult) -> None:
+def _print_prefixed_output(result: SequenceResult, progress: Progress) -> None:
     """Print captured subprocess output with its sequence identifier."""
     for line in result.output.splitlines():
-        tqdm.write(f"[{result.video_id}] {line}")
+        progress.console.print(f"[{result.video_id}] {line}", markup=False)
 
 
-def _print_summary(results: list[SequenceResult], summary: BatchSummary) -> None:
+def _print_summary(results: list[SequenceResult], summary: BatchSummary, console: Console) -> None:
     """Print the per-sequence and aggregate batch summary."""
-    print("\nvideo_id  wall_seconds  status")
+    table: Table = Table(title="Ingest summary")
+    table.add_column("video_id")
+    table.add_column("wall seconds", justify="right")
+    table.add_column("status")
     for result in sorted(results, key=lambda item: item.video_id):
         status: str = "ok" if result.ok else "FAILED"
-        print(f"{result.video_id:<9} {result.wall_seconds:>12.2f}  {status}")
-    print(f"Total wall time: {summary.total_wall_seconds:.2f}s")
-    print(f"Sum of sequence walls: {summary.sum_sequence_wall_seconds:.2f}s")
-    print(f"Effective speedup: {summary.effective_speedup:.2f}x")
+        table.add_row(result.video_id, f"{result.wall_seconds:.2f}", status)
+    console.print(table)
+    console.print(f"Total wall time: {summary.total_wall_seconds:.2f}s")
+    console.print(f"Sum of sequence walls: {summary.sum_sequence_wall_seconds:.2f}s")
+    console.print(f"Effective speedup: {summary.effective_speedup:.2f}x")
 
 
-def run_batch(config: Config) -> BatchSummary:
+def run_batch(config: Config, progress: Progress | None = None) -> BatchSummary:
     """Run selected sequences concurrently, reporting every completed job."""
     if config.workers < 1:
         raise ValueError("workers must be at least 1")
+    owns_progress: bool = progress is None
+    active_progress: Progress = Progress(console=Console(markup=False)) if progress is None else progress
     selected_video_ids: list[str] = discover_video_ids(config.data_dir) if config.video_ids is None else list(dict.fromkeys(config.video_ids))
     video_ids: list[str] = []
     for video_id in selected_video_ids:
         if config.skip_existing and has_all_layers(config.output, video_id):
-            tqdm.write(f"[{video_id}] skipped: output already exists")
+            active_progress.console.print(f"[{video_id}] skipped: output already exists", markup=False)
         else:
             video_ids.append(video_id)
 
@@ -148,23 +155,24 @@ def run_batch(config: Config) -> BatchSummary:
     # 32 cores on this box; that is accepted, and workers remains the throttle.
     started: float = time.perf_counter()
     results: list[SequenceResult] = []
-    with ThreadPoolExecutor(max_workers=config.workers) as pool:
+    progress_context = active_progress if owns_progress else nullcontext(active_progress)
+    with progress_context, ThreadPoolExecutor(max_workers=config.workers) as pool:
         futures: dict[Future[SequenceResult], str] = {pool.submit(_run_sequence, video_id, config): video_id for video_id in video_ids}
         ok_count: int = 0
         failed_count: int = 0
-        with tqdm(total=len(futures), position=config.progress_position, desc="ingest", unit="sequence", dynamic_ncols=True) as progress:
-            progress.set_postfix(ok=ok_count, failed=failed_count)
-            for future in as_completed(futures):
-                result: SequenceResult = future.result()
-                results.append(result)
-                ok_count += int(result.ok)
-                failed_count += int(not result.ok)
-                _print_prefixed_output(result)
-                progress.update()
-                progress.set_postfix(ok=ok_count, failed=failed_count)
+        task_id: TaskID = active_progress.add_task("ingest (ok=0 failed=0)", total=len(futures))
+        for future in as_completed(futures):
+            result: SequenceResult = future.result()
+            results.append(result)
+            ok_count += int(result.ok)
+            failed_count += int(not result.ok)
+            _print_prefixed_output(result, active_progress)
+            active_progress.advance(task_id)
+            active_progress.update(task_id, description=f"ingest (ok={ok_count} failed={failed_count})")
+        active_progress.remove_task(task_id)
     total_wall_seconds: float = time.perf_counter() - started
     summary: BatchSummary = summarize(results, total_wall_seconds)
-    _print_summary(results, summary)
+    _print_summary(results, summary, active_progress.console)
     return summary
 
 

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/batch.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/batch.py
@@ -8,12 +8,13 @@ from contextlib import nullcontext
 from dataclasses import dataclass
 from pathlib import Path
 
-import tyro
 from rich.console import Console
 from rich.progress import Progress, TaskID
 from rich.table import Table
 
 from arkitscenes_download.ingest.layers import LAYER_NAMES
+
+INGEST_TOOL: Path = Path(__file__).resolve().parents[2] / "tools" / "apps" / "ingest_sequence.py"
 
 
 @dataclass(frozen=True, slots=True)
@@ -89,8 +90,7 @@ def _run_sequence(video_id: str, config: Config) -> SequenceResult:
     """Run one single-sequence CLI subprocess and capture its combined output."""
     command: list[str] = [
         sys.executable,
-        "-m",
-        "arkitscenes_download.ingest",
+        str(INGEST_TOOL),
         "--video-id",
         video_id,
         "--data-dir",
@@ -176,11 +176,7 @@ def run_batch(config: Config, progress: Progress | None = None) -> BatchSummary:
     return summary
 
 
-def main() -> None:
-    """Parse batch CLI arguments and exit unsuccessfully if any job failed."""
-    summary: BatchSummary = run_batch(tyro.cli(Config))
+def main(config: Config) -> None:
+    """Run a batch and exit unsuccessfully if any job failed."""
+    summary: BatchSummary = run_batch(config)
     raise SystemExit(1 if summary.failed_video_ids else 0)
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/blueprint.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/blueprint.py
@@ -1,9 +1,32 @@
 """Default viewer layout for an ingested sequence."""
 
+import numpy as np
 import rerun as rr
 import rerun.blueprint as rrb
+from jaxtyping import Float64
+from simplecv.rerun_log_utils import orbit_eye_position
 
 from arkitscenes_download.ingest.paths import IMU_ACCEL, IMU_GYRO, PINHOLE_ULTRAWIDE, PINHOLE_WIDE, PINHOLE_WIDE_LOWRES, WORLD
+
+FIT_DISTANCE_FACTOR: float = 2.2
+"""Eye distance per bounding-sphere radius that keeps the whole mesh in frame (tuned visually)."""
+EXTRA_ZOOM_OUT: float = 1.25
+"""Additional margin beyond the tight fit."""
+SPIN_SPEED: float = 0.25
+"""Slow orbit around the look target."""
+
+
+def _eye_controls(mesh_center_xyz: Float64[np.ndarray, "3"] | None, bounding_radius_m: float | None) -> rrb.archetypes.EyeControls3D:
+    """Frame the GT mesh when its geometry is known; otherwise keep the viewer's default framing."""
+    if mesh_center_xyz is None or bounding_radius_m is None:
+        return rrb.archetypes.EyeControls3D(spin_speed=SPIN_SPEED)
+    return rrb.archetypes.EyeControls3D(
+        kind=rrb.components.Eye3DKind.Orbital,
+        position=orbit_eye_position(mesh_center_xyz, bounding_radius_m, FIT_DISTANCE_FACTOR * EXTRA_ZOOM_OUT),
+        look_target=mesh_center_xyz,
+        eye_up=(0.0, 0.0, 1.0),
+        spin_speed=SPIN_SPEED,
+    )
 
 
 def _imu_axis() -> rrb.archetypes.TimeAxis:
@@ -15,18 +38,24 @@ def _imu_axis() -> rrb.archetypes.TimeAxis:
     return rrb.archetypes.TimeAxis(view_range=window)
 
 
-def make_blueprint(portrait: bool = False) -> rrb.Blueprint:
+def make_blueprint(
+    portrait: bool = False,
+    mesh_center_xyz: Float64[np.ndarray, "3"] | None = None,
+    bounding_radius_m: float | None = None,
+) -> rrb.Blueprint:
     """Build the multi-camera, depth, and IMU layout.
 
     The layout is identical for both orientations; only the column widths
     change. Portrait camera views are tall and narrow, so the 3D world view
-    takes a wider share of the row.
+    takes a wider share of the row. When the GT mesh geometry is provided
+    (per-sequence embedded blueprints), the 3D eye orbits the mesh center
+    with the whole mesh in frame; dataset-default blueprints omit it.
     """
     column_shares: list[float] = [2.6, 1.0, 1.0] if portrait else [2.0, 1.0, 1.0]
     return rrb.Blueprint(
         rrb.Vertical(
             rrb.Horizontal(
-                rrb.Spatial3DView(name="world", origin=f"/{WORLD}", eye_controls=rrb.archetypes.EyeControls3D(spin_speed=0.25)),
+                rrb.Spatial3DView(name="world", origin=f"/{WORLD}", eye_controls=_eye_controls(mesh_center_xyz, bounding_radius_m)),
                 rrb.Vertical(
                     rrb.Spatial2DView(name="wide", origin=PINHOLE_WIDE, contents=["$origin/video", f"/{WORLD}/gt/boxes/**"]),
                     rrb.Spatial2DView(name="ultrawide", origin=PINHOLE_ULTRAWIDE, contents=["$origin/video", f"/{WORLD}/gt/boxes/**"]),

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/blueprint.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/blueprint.py
@@ -1,5 +1,7 @@
 """Default viewer layout for an ingested sequence."""
 
+from typing import TypeAlias
+
 import numpy as np
 import rerun as rr
 import rerun.blueprint as rrb
@@ -16,10 +18,15 @@ SPIN_SPEED: float = 0.25
 """Slow orbit around the look target."""
 
 
-def _eye_controls(mesh_center_xyz: Float64[np.ndarray, "3"] | None, bounding_radius_m: float | None) -> rrb.archetypes.EyeControls3D:
+MeshFraming: TypeAlias = tuple[Float64[np.ndarray, "3"], float]
+"""GT-mesh framing geometry: (world-frame AABB center, bounding-sphere radius in metres)."""
+
+
+def _eye_controls(framing: MeshFraming | None) -> rrb.archetypes.EyeControls3D:
     """Frame the GT mesh when its geometry is known; otherwise keep the viewer's default framing."""
-    if mesh_center_xyz is None or bounding_radius_m is None:
+    if framing is None:
         return rrb.archetypes.EyeControls3D(spin_speed=SPIN_SPEED)
+    mesh_center_xyz, bounding_radius_m = framing
     return rrb.archetypes.EyeControls3D(
         kind=rrb.components.Eye3DKind.Orbital,
         position=orbit_eye_position(mesh_center_xyz, bounding_radius_m, FIT_DISTANCE_FACTOR * EXTRA_ZOOM_OUT),
@@ -38,16 +45,12 @@ def _imu_axis() -> rrb.archetypes.TimeAxis:
     return rrb.archetypes.TimeAxis(view_range=window)
 
 
-def make_blueprint(
-    portrait: bool = False,
-    mesh_center_xyz: Float64[np.ndarray, "3"] | None = None,
-    bounding_radius_m: float | None = None,
-) -> rrb.Blueprint:
+def make_blueprint(portrait: bool = False, framing: MeshFraming | None = None) -> rrb.Blueprint:
     """Build the multi-camera, depth, and IMU layout.
 
     The layout is identical for both orientations; only the column widths
     change. Portrait camera views are tall and narrow, so the 3D world view
-    takes a wider share of the row. When the GT mesh geometry is provided
+    takes a wider share of the row. When the GT mesh framing is provided
     (per-sequence embedded blueprints), the 3D eye orbits the mesh center
     with the whole mesh in frame; dataset-default blueprints omit it.
     """
@@ -55,7 +58,7 @@ def make_blueprint(
     return rrb.Blueprint(
         rrb.Vertical(
             rrb.Horizontal(
-                rrb.Spatial3DView(name="world", origin=f"/{WORLD}", eye_controls=_eye_controls(mesh_center_xyz, bounding_radius_m)),
+                rrb.Spatial3DView(name="world", origin=f"/{WORLD}", eye_controls=_eye_controls(framing)),
                 rrb.Vertical(
                     rrb.Spatial2DView(name="wide", origin=PINHOLE_WIDE, contents=["$origin/video", f"/{WORLD}/gt/boxes/**"]),
                     rrb.Spatial2DView(name="ultrawide", origin=PINHOLE_ULTRAWIDE, contents=["$origin/video", f"/{WORLD}/gt/boxes/**"]),

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/catalog.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/catalog.py
@@ -1,9 +1,9 @@
 """Register ingested ARKitScenes RRDs into a local Rerun catalog.
 
 The local catalog is the in-memory ``rerun server`` (start it with
-``pixi run serve``). Each sequence RRD is one segment whose id is its
-``recording_id`` (the ARKitScenes video id); the shared layout is registered
-as the dataset's default blueprint.
+``pixi run serve``). Each sequence is one segment assembled from seven layer
+RRDs sharing its ``recording_id`` (the ARKitScenes video id); generic portrait
+and landscape layouts are registered as dataset blueprints.
 """
 
 from dataclasses import dataclass
@@ -11,12 +11,14 @@ from pathlib import Path
 
 import tyro
 from rerun.catalog import CatalogClient, DatasetEntry, OnDuplicateSegmentLayer
+from rich.console import Console
 
 from arkitscenes_download.ingest.blueprint import make_blueprint
 from arkitscenes_download.ingest.layers import LAYER_NAMES
 
 DEFAULT_CATALOG_URL: str = "rerun+http://127.0.0.1:51235"
 """gRPC URL of a locally-running ``rerun server`` catalog."""
+CONSOLE: Console = Console(markup=False)
 
 
 @dataclass(frozen=True, slots=True)
@@ -75,9 +77,9 @@ def main() -> None:
     config: Config = tyro.cli(Config)
     dataset: DatasetEntry = register_sequences(config)
     segment_ids: list[str] = [str(segment) for segment in dataset.segment_ids()]
-    print(f"dataset '{config.dataset_name}' at {config.catalog_url}: {len(segment_ids)} segments")
+    CONSOLE.print(f"dataset '{config.dataset_name}' at {config.catalog_url}: {len(segment_ids)} segments")
     for segment_id in segment_ids:
-        print(f"  {segment_id}")
+        CONSOLE.print(f"  {segment_id}")
 
 
 if __name__ == "__main__":

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/catalog.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/catalog.py
@@ -9,7 +9,6 @@ and landscape layouts are registered as dataset blueprints.
 from dataclasses import dataclass
 from pathlib import Path
 
-import tyro
 from rerun.catalog import CatalogClient, DatasetEntry, OnDuplicateSegmentLayer
 from rich.console import Console
 
@@ -72,15 +71,10 @@ def register_sequences(config: Config) -> DatasetEntry:
     return dataset
 
 
-def main() -> None:
-    """CLI entry point: register all ingested sequences."""
-    config: Config = tyro.cli(Config)
+def main(config: Config) -> None:
+    """Register all ingested sequences."""
     dataset: DatasetEntry = register_sequences(config)
     segment_ids: list[str] = [str(segment) for segment in dataset.segment_ids()]
     CONSOLE.print(f"dataset '{config.dataset_name}' at {config.catalog_url}: {len(segment_ids)} segments")
     for segment_id in segment_ids:
         CONSOLE.print(f"  {segment_id}")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/cli.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/cli.py
@@ -19,7 +19,6 @@ from pathlib import Path
 import numpy as np
 import rerun as rr
 import rerun.blueprint as rrb
-import tyro
 from PIL import Image
 from rich.console import Console
 from rich.progress import Progress, TaskID
@@ -580,8 +579,3 @@ def ingest_sequence(config: Config) -> Path:
     if config.spawn:
         rr.spawn()
     return sequence_output
-
-
-def main() -> None:
-    """Parse CLI arguments and ingest one sequence."""
-    ingest_sequence(tyro.cli(Config))

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/cli.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/cli.py
@@ -18,16 +18,18 @@ from pathlib import Path
 
 import numpy as np
 import rerun as rr
+import rerun.blueprint as rrb
 import tyro
 from PIL import Image
+from rich.console import Console
+from rich.progress import Progress, TaskID
 from scipy.spatial.transform import Rotation
 from simplecv.rerun_custom_types import CameraDistortion as RerunCameraDistortion
-from tqdm import tqdm
 
 from arkitscenes_download.ingest.blueprint import make_blueprint
 from arkitscenes_download.ingest.clock import CLOCK_ACCEPTANCE_FRACTION, ClockAlignment, path_timestamps, recover_clock_from_packets
 from arkitscenes_download.ingest.depth import encode_depth_png, sorted_timestamped_paths
-from arkitscenes_download.ingest.gt import log_ground_truth
+from arkitscenes_download.ingest.gt import GroundTruthSummary, log_ground_truth
 from arkitscenes_download.ingest.imu import ImuSamples, decode_imu
 from arkitscenes_download.ingest.layers import LAYERS, LAYERS_BY_NAME, Layer
 from arkitscenes_download.ingest.metadata import (
@@ -88,18 +90,19 @@ from arkitscenes_download.ingest.rig import (
 
 TIMELINE: str = "video_time"
 BATCH_SIZE: int = 1000
+CONSOLE: Console = Console(markup=False)
 
 
 @contextmanager
-def atomic_recording(output_path: Path, recording_id: str, *, send_properties: bool, embed_blueprint: bool = False, portrait: bool = False):
+def atomic_recording(output_path: Path, recording_id: str, *, send_properties: bool, default_blueprint: rrb.Blueprint | None = None):
     """Yield a recording that is finalized before atomically replacing its target."""
     descriptor, temp_name = tempfile.mkstemp(dir=output_path.parent, suffix=".rrd.tmp")
     os.close(descriptor)
     temp_path: Path = Path(temp_name)
     try:
         with rr.RecordingStream(application_id="arkitscenes", recording_id=recording_id, send_properties=send_properties) as recording:
-            if embed_blueprint:
-                recording.save(temp_path, default_blueprint=make_blueprint(portrait))
+            if default_blueprint is not None:
+                recording.save(temp_path, default_blueprint=default_blueprint)
             else:
                 recording.save(temp_path)
             yield recording
@@ -137,7 +140,7 @@ class Config:
     data_dir: Path = Path("data")
     """Dataset root containing raw/Training."""
     output: Path = Path("data/rrd")
-    """Directory in which to write the RRD."""
+    """Root for seven independently published ``<video_id>/<layer>.rrd`` files."""
     spawn: bool = False
     """Spawn a viewer after saving (disabled for headless use)."""
     keep_transcode_cache: bool = False
@@ -182,7 +185,8 @@ def _log_video(recording: rr.RecordingStream, path: str, video: VideoSamples, cl
     recording.log(path, rr.AnyValues(encoder=video.encoder, encoder_settings=video.settings, ffmpeg_version=video.ffmpeg_version), static=True)
     first_batch: bool = True
     try:
-        with tqdm(desc=description, unit="frame", leave=False) as progress:
+        with Progress(console=CONSOLE, transient=True) as progress:
+            task_id: TaskID = progress.add_task(description, total=None)
             for samples in iter_video_samples(video):
                 aligned: np.ndarray = samples.timestamps + clock_offset
                 if first_batch:
@@ -193,7 +197,7 @@ def _log_video(recording: rr.RecordingStream, path: str, video: VideoSamples, cl
                     raise ValueError("clock-aligned VideoStream timestamps are not strictly increasing")
                 _send_columns(recording, path, samples.timestamps, rr.VideoStream.columns(sample=samples.payloads, is_keyframe=samples.is_keyframes), epoch)  # pyrefly: ignore  # bad-argument-type
                 timestamp_batches.append(samples.timestamps)
-                progress.update(len(samples.timestamps))
+                progress.advance(task_id, len(samples.timestamps))
     finally:
         if video.delete_after_use:
             video.path.unlink(missing_ok=True)
@@ -239,13 +243,14 @@ def _log_baked_columns(
     if not kept_paths:
         return
     timestamps: np.ndarray = _clamped_to_epoch(all_timestamps[all_timestamps >= epoch], epoch)
-    with tqdm(total=len(kept_paths), desc=description, unit="frame", leave=False) as progress:
+    with Progress(console=CONSOLE, transient=True) as progress:
+        task_id: TaskID = progress.add_task(description, total=len(kept_paths))
         for start in range(0, len(kept_paths), BATCH_SIZE):
             batch_paths: list[Path] = kept_paths[start : start + BATCH_SIZE]
             items: list[tuple[Path, int]] = [(asset, quarter_turns) for asset in batch_paths]
             values: list[object] = list(pool.map(worker, items))
             _send_columns(recording, path, timestamps[start : start + len(batch_paths)], make_columns(values), epoch)
-            progress.update(len(batch_paths))
+            progress.advance(task_id, len(batch_paths))
 
 
 def _log_depth(recording: rr.RecordingStream, path: str, paths: list[Path], quarter_turns: int, pool: ThreadPoolExecutor, description: str, epoch: float) -> None:
@@ -346,7 +351,7 @@ def _log_imu(recording: rr.RecordingStream, imu: ImuSamples, epoch: float) -> No
 
 
 def ingest_sequence(config: Config) -> Path:
-    """Convert one raw sequence (either split) into an RRD and return its path."""
+    """Write seven layer RRDs for one raw sequence and return its output directory."""
     ingest_started: float = time.perf_counter()
     candidates: list[Path] = [config.data_dir / "raw" / split / config.video_id for split in ("Training", "Validation")]
     sequence_dir: Path = next((candidate for candidate in candidates if candidate.is_dir()), candidates[0])
@@ -359,7 +364,7 @@ def ingest_sequence(config: Config) -> Path:
     if alignment.within_two_ms_fraction < CLOCK_ACCEPTANCE_FRACTION:
         raise ValueError(f"clock validation failed: only {alignment.within_two_ms_fraction:.3%} within 2 ms")
 
-    print(
+    CONSOLE.print(
         f"Clock: wide={alignment.offset_seconds:.9f}s ultra={alignment.ultrawide_offset_seconds:.9f}s "
         f"dispersion={alignment.dispersion_seconds * 1e3:.3f}ms drift={alignment.drift_seconds_per_second * 1e6:.3f}us/s "
         f"agreement={alignment.ultrawide_agreement_seconds * 1e3:.3f}ms depth_max={alignment.max_depth_residual_seconds * 1e3:.3f}ms"
@@ -377,7 +382,7 @@ def ingest_sequence(config: Config) -> Path:
     quarter_turns: int = measured_orientation_quarter_turns(unbaked_sky_angles)
     orientation_is_ambiguous, circular_spread, boundary_distance = orientation_ambiguity(unbaked_sky_angles)
     warning: str = " WARNING: AMBIGUOUS ORIENTATION" if orientation_is_ambiguous else ""
-    print(
+    CONSOLE.print(
         f"Orientation: label={sky_direction}, source=measured_gravity, quarter_turns={quarter_turns}, "
         f"spread={np.rad2deg(circular_spread):.2f}deg boundary_distance={np.rad2deg(boundary_distance):.2f}deg{warning}"
     )
@@ -395,7 +400,7 @@ def ingest_sequence(config: Config) -> Path:
     pose_source: str = pose_selection.source
     device_fit: DeviceFrameFit = fit_original_camera_from_device(trajectory_sparse_unbaked, imu.accel_timestamps, imu.accel_ms2)
     rig_from_device: Rotation = Rotation.from_euler("z", quarter_turns * np.pi / 2.0) * Rotation.from_quat(device_fit.quaternion_xyzw)
-    print(f"IMU frame: original_cam_from_device={device_fit.quaternion_xyzw.tolist()} residual={np.rad2deg(device_fit.rms_residual_rad):.3f}deg")
+    CONSOLE.print(f"IMU frame: original_cam_from_device={device_fit.quaternion_xyzw.tolist()} residual={np.rad2deg(device_fit.rms_residual_rad):.3f}deg")
     sequence_output: Path = config.output / config.video_id
     sequence_output.mkdir(parents=True, exist_ok=True)
     properties: dict[str, object] = {
@@ -441,18 +446,16 @@ def ingest_sequence(config: Config) -> Path:
             "portrait": portrait,
         }
     )
-    print(f"Timeline: epoch={epoch:.6f}s dropped_leading=(wide={wide_drop}, ultrawide={ultrawide_drop}) portrait={portrait}")
+    CONSOLE.print(f"Timeline: epoch={epoch:.6f}s dropped_leading=(wide={wide_drop}, ultrawide={ultrawide_drop}) portrait={portrait}")
 
     wide_video: VideoSamples = prepare_video_track(mov_path, 0, quarter_turns, config.keep_transcode_cache, drop_leading=wide_drop)
-    print(f"Transcode {config.video_id} wide: {wide_video.transcode_seconds:.2f}s ({wide_video.encoder})")
+    CONSOLE.print(f"Transcode {config.video_id} wide: {wide_video.transcode_seconds:.2f}s ({wide_video.encoder})")
     ultrawide_video: VideoSamples = prepare_video_track(mov_path, 2, quarter_turns, config.keep_transcode_cache, drop_leading=ultrawide_drop)
-    print(f"Transcode {config.video_id} ultrawide: {ultrawide_video.transcode_seconds:.2f}s ({ultrawide_video.encoder})")
+    CONSOLE.print(f"Transcode {config.video_id} ultrawide: {ultrawide_video.transcode_seconds:.2f}s ({ultrawide_video.encoder})")
 
     wide_path: Path = sequence_output / "video_wide.rrd"
     wide_layer: Layer = LAYERS_BY_NAME["video_wide"]
-    with atomic_recording(
-        wide_path, config.video_id, send_properties=wide_layer.send_properties, embed_blueprint=wide_layer.embed_blueprint
-    ) as recording:
+    with atomic_recording(wide_path, config.video_id, send_properties=wide_layer.send_properties) as recording:
         wide_video_timestamps: np.ndarray = _log_video(
             recording,
             VIDEO_WIDE,
@@ -464,12 +467,7 @@ def ingest_sequence(config: Config) -> Path:
 
     ultrawide_path: Path = sequence_output / "video_ultrawide.rrd"
     ultrawide_layer: Layer = LAYERS_BY_NAME["video_ultrawide"]
-    with atomic_recording(
-        ultrawide_path,
-        config.video_id,
-        send_properties=ultrawide_layer.send_properties,
-        embed_blueprint=ultrawide_layer.embed_blueprint,
-    ) as recording:
+    with atomic_recording(ultrawide_path, config.video_id, send_properties=ultrawide_layer.send_properties) as recording:
         ultrawide_video_timestamps: np.ndarray = _log_video(
             recording,
             VIDEO_ULTRAWIDE,
@@ -491,25 +489,20 @@ def ingest_sequence(config: Config) -> Path:
             "n_frames_after_pose_span": after,
         }
     )
-    print(
+    CONSOLE.print(
         f"Pose coverage: source={pose_source} span={pose_trajectory_unbaked.timestamps[0]:.6f}..{pose_trajectory_unbaked.timestamps[-1]:.6f} before={before} after={after}"
     )
 
     distortions: list[CameraDistortion] = decode_camera_distortions_from_packets(metadata_packets[10])
     for distortion in distortions:
-        print(
+        CONSOLE.print(
             f"Distortion {distortion.camera_name}: model=brown_conrady coefficients={distortion.coefficients.tolist()} "
             f"inverse={distortion.inverse_coefficients.tolist()} center={distortion.center_xy.tolist()} "
             f"reference={distortion.reference_dimensions_wh.tolist()} temporal_samples={distortion.temporal_sample_count}"
         )
     calibration_path: Path = sequence_output / "calibration.rrd"
     calibration_layer: Layer = LAYERS_BY_NAME["calibration"]
-    with atomic_recording(
-        calibration_path,
-        config.video_id,
-        send_properties=calibration_layer.send_properties,
-        embed_blueprint=calibration_layer.embed_blueprint,
-    ) as recording:
+    with atomic_recording(calibration_path, config.video_id, send_properties=calibration_layer.send_properties) as recording:
         _log_intrinsics(recording, PINHOLE_WIDE, wide_intrinsics, wide_resolution, epoch)
         _log_intrinsics(recording, PINHOLE_WIDE_LOWRES, lowres_intrinsics, lowres_resolution, epoch)
         _log_intrinsics(recording, PINHOLE_ULTRAWIDE, ultrawide_intrinsics, ultrawide_resolution, epoch)
@@ -524,12 +517,7 @@ def ingest_sequence(config: Config) -> Path:
     depth_started: float = time.perf_counter()
     depth_path: Path = sequence_output / "depth.rrd"
     with (
-        atomic_recording(
-            depth_path,
-            config.video_id,
-            send_properties=LAYERS_BY_NAME["depth"].send_properties,
-            embed_blueprint=LAYERS_BY_NAME["depth"].embed_blueprint,
-        ) as recording,
+        atomic_recording(depth_path, config.video_id, send_properties=LAYERS_BY_NAME["depth"].send_properties) as recording,
         ThreadPoolExecutor(max_workers=8) as pool,
     ):
         _log_depth(
@@ -552,28 +540,30 @@ def ingest_sequence(config: Config) -> Path:
         )
         _log_confidence(recording, confidence, quarter_turns, pool, f"{config.video_id} confidence", epoch)
     depth_seconds: float = time.perf_counter() - depth_started
-    print(f"Depth {config.video_id}: {depth_seconds:.1f}s ({len(highres_depth)} gt + {len(lowres_depth)} arkit + {len(confidence)} conf)")
+    CONSOLE.print(f"Depth {config.video_id}: {depth_seconds:.1f}s ({len(highres_depth)} gt + {len(lowres_depth)} arkit + {len(confidence)} conf)")
 
     imu_path: Path = sequence_output / "imu.rrd"
     imu_layer: Layer = LAYERS_BY_NAME["imu"]
-    with atomic_recording(
-        imu_path, config.video_id, send_properties=imu_layer.send_properties, embed_blueprint=imu_layer.embed_blueprint
-    ) as recording:
+    with atomic_recording(imu_path, config.video_id, send_properties=imu_layer.send_properties) as recording:
         _log_imu(recording, imu, epoch)
 
     gt_path: Path = sequence_output / "gt.rrd"
     gt_layer: Layer = LAYERS_BY_NAME["gt"]
-    with atomic_recording(gt_path, config.video_id, send_properties=gt_layer.send_properties, embed_blueprint=gt_layer.embed_blueprint) as recording:
-        box_count: int = log_ground_truth(sequence_dir, config.video_id, recording)
+    with atomic_recording(gt_path, config.video_id, send_properties=gt_layer.send_properties) as recording:
+        gt_summary: GroundTruthSummary = log_ground_truth(sequence_dir, config.video_id, recording)
 
     base_path: Path = sequence_output / "base.rrd"
     base_layer: Layer = LAYERS_BY_NAME["base"]
+    framed_blueprint: rrb.Blueprint | None = (
+        make_blueprint(portrait, mesh_center_xyz=gt_summary.mesh_center_xyz, bounding_radius_m=gt_summary.bounding_radius_m)
+        if base_layer.embed_blueprint
+        else None
+    )
     with atomic_recording(
         base_path,
         config.video_id,
         send_properties=base_layer.send_properties,
-        embed_blueprint=base_layer.embed_blueprint,
-        portrait=portrait,
+        default_blueprint=framed_blueprint,
     ) as recording:
         for name, value in properties.items():
             recording.send_property(name, rr.AnyValues(value=str(value)))
@@ -582,11 +572,11 @@ def ingest_sequence(config: Config) -> Path:
     verify_rrd(layer_paths)
     verification: str = f"{len(layer_paths)}/{len(LAYERS)} layers verified"
     ingest_seconds: float = time.perf_counter() - ingest_started
-    print(
+    CONSOLE.print(
         f"Saved {sequence_output}: videos={len(wide_video_timestamps)}/{len(ultrawide_video_timestamps)}, depth={len(lowres_depth)}, "
-        f"IMU={len(imu.accel_timestamps)}/{len(imu.gyro_timestamps)}, boxes={box_count}, verify={verification}"
+        f"IMU={len(imu.accel_timestamps)}/{len(imu.gyro_timestamps)}, boxes={gt_summary.box_count}, verify={verification}"
     )
-    print(f"Ingest {config.video_id} total: {ingest_seconds:.2f}s")
+    CONSOLE.print(f"Ingest {config.video_id} total: {ingest_seconds:.2f}s")
     if config.spawn:
         rr.spawn()
     return sequence_output

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/cli.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/cli.py
@@ -100,10 +100,7 @@ def atomic_recording(output_path: Path, recording_id: str, *, send_properties: b
     temp_path: Path = Path(temp_name)
     try:
         with rr.RecordingStream(application_id="arkitscenes", recording_id=recording_id, send_properties=send_properties) as recording:
-            if default_blueprint is not None:
-                recording.save(temp_path, default_blueprint=default_blueprint)
-            else:
-                recording.save(temp_path)
+            recording.save(temp_path, default_blueprint=default_blueprint)
             yield recording
         os.replace(temp_path, output_path)
     except BaseException:
@@ -553,16 +550,11 @@ def ingest_sequence(config: Config) -> Path:
 
     base_path: Path = sequence_output / "base.rrd"
     base_layer: Layer = LAYERS_BY_NAME["base"]
-    framed_blueprint: rrb.Blueprint | None = (
-        make_blueprint(portrait, mesh_center_xyz=gt_summary.mesh_center_xyz, bounding_radius_m=gt_summary.bounding_radius_m)
-        if base_layer.embed_blueprint
-        else None
-    )
     with atomic_recording(
         base_path,
         config.video_id,
         send_properties=base_layer.send_properties,
-        default_blueprint=framed_blueprint,
+        default_blueprint=make_blueprint(portrait, framing=(gt_summary.mesh_center_xyz, gt_summary.bounding_radius_m)),
     ) as recording:
         for name, value in properties.items():
             recording.send_property(name, rr.AnyValues(value=str(value)))

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/gt.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/gt.py
@@ -10,6 +10,7 @@ import numpy as np
 import rerun as rr
 import trimesh
 from jaxtyping import Float64
+from simplecv.rerun_log_utils import mesh_bounding_geometry
 
 from arkitscenes_download.ingest.paths import GT_MESH, gt_box
 
@@ -28,6 +29,18 @@ class GroundTruthBox:
     """Semantic category label."""
     uid: str
     """Stable annotation identifier."""
+
+
+@dataclass(frozen=True, slots=True)
+class GroundTruthSummary:
+    """Box count and mesh framing geometry from the ground-truth layer."""
+
+    box_count: int
+    """Number of annotated oriented boxes."""
+    mesh_center_xyz: Float64[np.ndarray, "3"]
+    """World-frame center of the mesh's axis-aligned bounds."""
+    bounding_radius_m: float
+    """Radius of the vertex bounding sphere around that center."""
 
 
 def stable_label_color(label: str) -> tuple[int, int, int]:
@@ -54,16 +67,18 @@ def load_ground_truth_boxes(sequence_dir: Path, video_id: str) -> list[GroundTru
     return boxes
 
 
-def log_ground_truth(sequence_dir: Path, video_id: str, recording: rr.RecordingStream) -> int:
+def log_ground_truth(sequence_dir: Path, video_id: str, recording: rr.RecordingStream) -> GroundTruthSummary:
     """Log the reconstructed mesh and each annotated oriented box."""
     boxes: list[GroundTruthBox] = load_ground_truth_boxes(sequence_dir, video_id)
     loaded = trimesh.load(sequence_dir / f"{video_id}_3dod_mesh.ply", process=False)
     if not isinstance(loaded, trimesh.Trimesh):
         raise ValueError(f"expected a single triangle mesh in {video_id}_3dod_mesh.ply, got {type(loaded).__name__}")
+    vertices: Float64[np.ndarray, "n 3"] = np.asarray(loaded.vertices, dtype=np.float64)
+    mesh_center_xyz, bounding_radius_m = mesh_bounding_geometry(vertices)
     recording.log(
         GT_MESH,
         rr.Mesh3D(
-            vertex_positions=np.asarray(loaded.vertices),
+            vertex_positions=vertices,
             vertex_colors=np.asarray(loaded.visual.vertex_colors),  # pyrefly: ignore  # missing-attribute
             triangle_indices=np.asarray(loaded.faces),
             face_rendering=rr.components.MeshFaceRendering.Front,
@@ -83,4 +98,4 @@ def log_ground_truth(sequence_dir: Path, video_id: str, recording: rr.RecordingS
         # scale->rotate->translate, whereas Boxes3D centers + separate rotation rotates the center
         # around the entity origin (misplacing rotated boxes).
         recording.log(entity_path, rr.InstancePoses3D(translations=box.center_xyz, mat3x3=box.axes_33.T), static=True)
-    return len(boxes)
+    return GroundTruthSummary(box_count=len(boxes), mesh_center_xyz=mesh_center_xyz, bounding_radius_m=bounding_radius_m)

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/layers.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/layers.py
@@ -11,18 +11,17 @@ class Layer:
     """Layer file stem and catalog layer name."""
     send_properties: bool
     """Whether recording properties belong in this layer."""
-    embed_blueprint: bool
-    """Whether the default blueprint belongs in this layer."""
 
 
+# The base layer also embeds the per-sequence default blueprint (see ingest.cli).
 LAYERS: tuple[Layer, ...] = (
-    Layer("base", True, True),
-    Layer("calibration", False, False),
-    Layer("video_wide", False, False),
-    Layer("video_ultrawide", False, False),
-    Layer("depth", False, False),
-    Layer("imu", False, False),
-    Layer("gt", False, False),
+    Layer("base", True),
+    Layer("calibration", False),
+    Layer("video_wide", False),
+    Layer("video_ultrawide", False),
+    Layer("depth", False),
+    Layer("imu", False),
+    Layer("gt", False),
 )
 LAYER_NAMES: tuple[str, ...] = tuple(layer.name for layer in LAYERS)
 LAYERS_BY_NAME: dict[str, Layer] = {layer.name: layer for layer in LAYERS}

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/metadata.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/metadata.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import numpy as np
 from jaxtyping import Float64
+from rich.console import Console
 from scipy.spatial.transform import Rotation
 
 from arkitscenes_download.ingest.mov import MetadataPacket, demux_metadata
@@ -14,6 +15,7 @@ from arkitscenes_download.ingest.rig import Trajectory, resample_trajectory
 
 POSE_FIT_MAX_ROTATION_RAD: float = float(np.deg2rad(3.0))
 POSE_FIT_MAX_TRANSLATION_M: float = 0.1
+CONSOLE: Console = Console(markup=False)
 
 
 @dataclass(frozen=True, slots=True)
@@ -218,7 +220,7 @@ def select_pose_source(mov_path: Path, fallback: Trajectory, packets: list[Metad
             decode_wide_image_trajectory(mov_path, fallback) if packets is None else decode_wide_image_trajectory_from_packets(packets, fallback)
         )
     except (ValueError, KeyError) as pose_error:
-        print(f"Pose fallback: stream-4 decode failed ({pose_error}); using 10Hz trajectory")
+        CONSOLE.print(f"Pose fallback: stream-4 decode failed ({pose_error}); using 10Hz trajectory")
         return PoseSelection(fallback, "lowres_traj_slerp", float("nan"), float("nan"))
     if image_poses.rotation_rms_rad <= POSE_FIT_MAX_ROTATION_RAD and image_poses.translation_rms_m <= POSE_FIT_MAX_TRANSLATION_M:
         return PoseSelection(
@@ -227,7 +229,7 @@ def select_pose_source(mov_path: Path, fallback: Trajectory, packets: list[Metad
             image_poses.rotation_rms_rad,
             image_poses.translation_rms_m,
         )
-    print(
+    CONSOLE.print(
         f"Pose fallback: stream-4 fit {np.rad2deg(image_poses.rotation_rms_rad):.2f}deg / "
         f"{image_poses.translation_rms_m:.3f}m exceeds gate; using 10Hz trajectory"
     )

--- a/packages/arkitscenes-download/arkitscenes_download/pipeline.py
+++ b/packages/arkitscenes-download/arkitscenes_download/pipeline.py
@@ -22,9 +22,10 @@ from pathlib import Path
 from typing import Protocol, TypeAlias
 
 import tyro
-from tqdm import tqdm
+from rich.console import Console
+from rich.progress import Progress, TaskID
+from simplecv.print_utils import format_bytes
 
-from arkitscenes_download.download_dataset import human_bytes
 from arkitscenes_download.fs import directory_size
 from arkitscenes_download.ingest.batch import BatchSummary, run_batch
 from arkitscenes_download.ingest.batch import Config as BatchConfig
@@ -45,6 +46,7 @@ ASSETS: tuple[str, ...] = (
 FAILED_RAW_LIMIT_BYTES: int = 50 * 1024**3
 SSH_DESTINATION_PATTERN: re.Pattern[str] = re.compile(r"^(?P<host>[A-Za-z0-9][A-Za-z0-9._-]*@[A-Za-z0-9][A-Za-z0-9.-]*):(?P<path>/.*)$")
 VIDEO_ID_PATTERN: re.Pattern[str] = re.compile(r"^[0-9]+$")
+CONSOLE: Console = Console(markup=False)
 
 
 @dataclass(frozen=True, slots=True)
@@ -172,7 +174,7 @@ class Destination:
                 archive.stdout.close()
             archive_status: int = archive.wait()
         if ship.returncode != 0 or archive_status != 0:
-            tqdm.write(f"tar-ssh ship failed for {source.name}: {ship.stderr.strip()[-200:]}")
+            CONSOLE.print(f"tar-ssh ship failed for {source.name}: {ship.stderr.strip()[-200:]}")
             return False
         if self.read_mount is not None:
             landed = self.read_mount / source.name
@@ -275,7 +277,7 @@ def wait_for_disk_space(
     min_free_bytes: int,
     disk_usage: Callable[[Path], DiskUsage] = shutil.disk_usage,
     sleep: Callable[[float], None] = time.sleep,
-    write: Callable[[str], None] = tqdm.write,
+    write: Callable[[str], None] = CONSOLE.print,
 ) -> None:
     """Wait until staging has at least the configured free byte count."""
     notified: bool = False
@@ -309,7 +311,7 @@ def ship_verify_and_cleanup(
 ) -> bool:
     """Publish, verify, persist completion, and remove local staging."""
     if not destination.ship_and_verify(local_rrd, runner):
-        tqdm.write(f"sha256 verification failed for {local_rrd.name}")
+        CONSOLE.print(f"sha256 verification failed for {local_rrd.name}")
         return False
     if before_cleanup is not None:
         before_cleanup()
@@ -358,44 +360,47 @@ def _failed_raw_size(data_dir: Path, splits: dict[str, str], failed_ids: set[str
     return sum(directory_size(data_dir / "raw" / splits[video_id] / video_id) for video_id in failed_ids if video_id in splits)
 
 
-def _download_chunk(config: Config, chunk: list[str], splits: dict[str, str], existing_failed: set[str]) -> DownloadResult:
+def _download_chunk(config: Config, chunk: list[str], splits: dict[str, str], existing_failed: set[str], progress: Progress) -> DownloadResult:
     """Download a chunk sequentially with retry, disk guard, and safety stop."""
     successful_ids: list[str] = []
     failures: dict[str, str] = {}
     failed_raw_bytes: int = _failed_raw_size(config.data_dir, splits, existing_failed)
-    with tqdm(total=len(chunk), position=1, desc="download", unit="sequence", dynamic_ncols=True, leave=False) as progress:
-        for video_id in chunk:
-            if failed_raw_bytes > FAILED_RAW_LIMIT_BYTES:
-                return DownloadResult(successful_ids, failures, True)
-            wait_for_disk_space(config.data_dir, config.min_free_gb * 1024**3)
-            command: list[str] = [
-                sys.executable,
-                "-m",
-                "arkitscenes_download",
-                "--download-dir",
-                str(config.data_dir),
-                "--video-ids",
-                video_id,
-                "--assets",
-                *ASSETS,
-                "--no-include-point-clouds",
-            ]
-            error: str = "download failed"
-            for attempt in range(2):
-                completed: subprocess.CompletedProcess[str] = subprocess.run(
-                    command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False
-                )
-                if completed.returncode == 0:
-                    successful_ids.append(video_id)
-                    break
-                error = f"download exit {completed.returncode}: {completed.stdout.strip()[-1000:]}"
-                if attempt == 0:
-                    tqdm.write(f"[{video_id}] download failed; retrying once")
-            else:
-                failures[video_id] = error
-                if video_id in splits:
-                    failed_raw_bytes += directory_size(config.data_dir / "raw" / splits[video_id] / video_id)
-            progress.update()
+    task_id: TaskID = progress.add_task("download", total=len(chunk))
+    for video_id in chunk:
+        if failed_raw_bytes > FAILED_RAW_LIMIT_BYTES:
+            progress.remove_task(task_id)
+            return DownloadResult(successful_ids, failures, True)
+        wait_for_disk_space(config.data_dir, config.min_free_gb * 1024**3, write=progress.console.print)
+        command: list[str] = [
+            sys.executable,
+            "-m",
+            "arkitscenes_download",
+            "--download-dir",
+            str(config.data_dir),
+            "--video-ids",
+            video_id,
+            "--assets",
+            *ASSETS,
+            "--no-include-point-clouds",
+            # The pipeline invokes this once per sequence and captures stdout,
+            # so per-invocation size prefetching is pure extra CDN round-trips.
+            "--no-prefetch",
+        ]
+        error: str = "download failed"
+        for attempt in range(2):
+            completed: subprocess.CompletedProcess[str] = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False)
+            if completed.returncode == 0:
+                successful_ids.append(video_id)
+                break
+            error = f"download exit {completed.returncode}: {completed.stdout.strip()[-1000:]}"
+            if attempt == 0:
+                progress.console.print(f"[{video_id}] download failed; retrying once")
+        else:
+            failures[video_id] = error
+            if video_id in splits:
+                failed_raw_bytes += directory_size(config.data_dir / "raw" / splits[video_id] / video_id)
+        progress.advance(task_id)
+    progress.remove_task(task_id)
     return DownloadResult(successful_ids, failures, False)
 
 
@@ -419,15 +424,15 @@ def _format_duration(seconds: float | None) -> str:
 
 def _print_status(status: StatusSummary) -> None:
     """Print the human-readable status report."""
-    print(f"done: {status.done}")
-    print(f"failed: {status.failed}")
-    print(f"remaining: {status.remaining}")
+    CONSOLE.print(f"done: {status.done}")
+    CONSOLE.print(f"failed: {status.failed}")
+    CONSOLE.print(f"remaining: {status.remaining}")
     for video_id, reason in sorted(status.failed_reasons.items()):
-        print(f"  {video_id}: {reason}")
-    size: str = "unknown (no read mount)" if status.destination_bytes is None else human_bytes(status.destination_bytes)
-    print(f"destination size: {size}")
-    print(f"rolling throughput: {status.sequences_per_hour:.2f} sequences/hour")
-    print(f"rolling ETA: {_format_duration(status.eta_seconds)}")
+        CONSOLE.print(f"  {video_id}: {reason}")
+    size: str = "unknown (no read mount)" if status.destination_bytes is None else format_bytes(status.destination_bytes)
+    CONSOLE.print(f"destination size: {size}")
+    CONSOLE.print(f"rolling throughput: {status.sequences_per_hour:.2f} sequences/hour")
+    CONSOLE.print(f"rolling ETA: {_format_duration(status.eta_seconds)}")
 
 
 def _ship_and_register_chunk(
@@ -436,7 +441,8 @@ def _ship_and_register_chunk(
     successful_ingests: list[str],
     splits: dict[str, str],
     state_lock: LockType,
-    overall: tqdm,
+    progress: Progress,
+    overall_task: TaskID,
     done_ids: set[str],
     failed_reasons: dict[str, str],
     prior_failures: int,
@@ -448,22 +454,23 @@ def _ship_and_register_chunk(
     """Publish one ingested chunk, register it, and record progress."""
     shipped_ids: list[str] = []
     published_bytes: int = 0
-    with tqdm(total=len(successful_ingests), position=3, desc="ship+verify", unit="sequence", dynamic_ncols=True, leave=False) as stage:
-        for video_id in successful_ingests:
-            local_rrd: Path = config.data_dir / "rrd" / video_id
-            local_raw: Path = config.data_dir / "raw" / splits[video_id] / video_id
-            sequence_bytes: int = directory_size(local_rrd)
+    stage_task: TaskID = progress.add_task("ship+verify", total=len(successful_ingests))
+    for video_id in successful_ingests:
+        local_rrd: Path = config.data_dir / "rrd" / video_id
+        local_raw: Path = config.data_dir / "raw" / splits[video_id] / video_id
+        sequence_bytes: int = directory_size(local_rrd)
 
-            def mark_done(completed_video_id: str = video_id) -> None:
-                """Persist completion before local staging is removed."""
-                _append_line(config.state_dir / "done.txt", completed_video_id, state_lock)
+        def mark_done(completed_video_id: str = video_id) -> None:
+            """Persist completion before local staging is removed."""
+            _append_line(config.state_dir / "done.txt", completed_video_id, state_lock)
 
-            if ship_verify_and_cleanup(local_rrd, local_raw, destination, before_cleanup=mark_done):
-                shipped_ids.append(video_id)
-                published_bytes += sequence_bytes
-                done_ids.add(video_id)
-                overall.update()
-            stage.update()
+        if ship_verify_and_cleanup(local_rrd, local_raw, destination, before_cleanup=mark_done):
+            shipped_ids.append(video_id)
+            published_bytes += sequence_bytes
+            done_ids.add(video_id)
+            progress.advance(overall_task)
+        progress.advance(stage_task)
+    progress.remove_task(stage_task)
     if shipped_ids and config.register:
         registration_root: Path | None = destination.registration_root
         if registration_root is None:
@@ -473,11 +480,11 @@ def _ship_and_register_chunk(
             try:
                 register_sequences(CatalogConfig(rrd_dir=registration_root, catalog_url=config.catalog_url, video_ids=shipped_ids))
             except (OSError, RuntimeError) as error:
-                tqdm.write(f"catalog registration failed; recording unregistered IDs: {error}")
+                progress.console.print(f"catalog registration failed; recording unregistered IDs: {error}")
                 for video_id in shipped_ids:
                     _append_line(config.state_dir / "unregistered.txt", video_id, state_lock)
         else:
-            tqdm.write(f"Rerun catalog at {config.catalog_url} is unreachable; shipped IDs recorded as unregistered")
+            progress.console.print(f"Rerun catalog at {config.catalog_url} is unreachable; shipped IDs recorded as unregistered")
             for video_id in shipped_ids:
                 _append_line(config.state_dir / "unregistered.txt", video_id, state_lock)
     chunk_wall: float = time.perf_counter() - chunk_started
@@ -491,8 +498,8 @@ def _ship_and_register_chunk(
         f"\tpublished_bytes={published_bytes}\teta_seconds={eta if eta is not None else 'unknown'}"
     )
     _append_line(config.state_dir / "progress.log", record, state_lock)
-    overall.set_postfix(ok=len(done_ids), failed=len(failed_reasons), chunk=f"{chunk_index + 1}/{chunk_count}")
-    tqdm.write(record)
+    progress.update(overall_task, description=f"sequences (ok={len(done_ids)} failed={len(failed_reasons)} chunk={chunk_index + 1}/{chunk_count})")
+    progress.console.print(record)
 
 
 def run_pipeline(config: Config) -> None:
@@ -506,27 +513,24 @@ def run_pipeline(config: Config) -> None:
         return
     done_count, failed_count, remaining_count, _ = compute_state_counts(metadata_path, config.state_dir)
     if config.register and destination.registration_root is None:
-        tqdm.write("destination has no read mount; shipped IDs will be recorded as unregistered")
+        CONSOLE.print("destination has no read mount; shipped IDs will be recorded as unregistered")
     done_ids: set[str] = _read_id_lines(config.state_dir / "done.txt")
     failed_reasons: dict[str, str] = _read_failed(config.state_dir / "failed.txt")
     if config.retry_failed and failed_reasons:
         requeued: set[str] = requeue_failed(config.state_dir)
-        tqdm.write(f"retry-failed: re-queued {len(requeued)} previously failed sequences")
+        CONSOLE.print(f"retry-failed: re-queued {len(requeued)} previously failed sequences")
         failed_reasons = {}
     chunks: list[list[str]] = build_manifest(metadata_path, done_ids, set(failed_reasons), config.chunk_size, config.max_chunks, config.video_ids)
     splits: dict[str, str] = _metadata_splits(metadata_path)
     total_population: int = done_count + failed_count + remaining_count
     state_lock: LockType = threading.Lock()
     stop_requested: bool = False
-    with tqdm(
-        total=total_population,
-        initial=done_count + failed_count,
-        position=0,
-        desc="sequences",
-        unit="sequence",
-        dynamic_ncols=True,
-    ) as overall:
-        overall.set_postfix(ok=done_count, failed=failed_count, chunk=f"0/{len(chunks)}")
+    with Progress(console=CONSOLE) as progress:
+        overall_task: TaskID = progress.add_task(
+            f"sequences (ok={done_count} failed={failed_count} chunk=0/{len(chunks)})",
+            total=total_population,
+            completed=done_count + failed_count,
+        )
         if not chunks:
             return
         with (
@@ -534,25 +538,25 @@ def run_pipeline(config: Config) -> None:
             ThreadPoolExecutor(max_workers=1, thread_name_prefix="ship") as ship_pool,
         ):
             ship_future: Future[None] | None = None
-            download_future: Future[DownloadResult] = download_pool.submit(_download_chunk, config, chunks[0], splits, set(failed_reasons))
+            download_future: Future[DownloadResult] = download_pool.submit(_download_chunk, config, chunks[0], splits, set(failed_reasons), progress)
             for chunk_index, _chunk in enumerate(chunks):
                 chunk_started: float = time.perf_counter()
                 try:
                     download_result: DownloadResult = download_future.result()
                 except KeyboardInterrupt:
-                    tqdm.write("interrupt requested; waiting for the in-flight download sequence")
+                    progress.console.print("interrupt requested; waiting for the in-flight download sequence")
                     stop_requested = True
                     download_result = download_future.result()
                 for video_id, reason in download_result.failures.items():
                     _append_line(config.state_dir / "failed.txt", f"{video_id}\t{reason}", state_lock)
                     failed_reasons[video_id] = reason
-                    overall.update()
+                    progress.advance(overall_task)
                 if download_result.safety_stop:
-                    tqdm.write(f"failed raw staging exceeds {human_bytes(FAILED_RAW_LIMIT_BYTES)}; stopping before new downloads")
+                    progress.console.print(f"failed raw staging exceeds {format_bytes(FAILED_RAW_LIMIT_BYTES)}; stopping before new downloads")
                     stop_requested = True
                 next_future: Future[DownloadResult] | None = None
                 if not stop_requested and chunk_index + 1 < len(chunks):
-                    next_future = download_pool.submit(_download_chunk, config, chunks[chunk_index + 1], splits, set(failed_reasons))
+                    next_future = download_pool.submit(_download_chunk, config, chunks[chunk_index + 1], splits, set(failed_reasons), progress)
                 ingest_ids: list[str] = download_result.successful_ids
                 summary: BatchSummary = run_batch(
                     BatchConfig(
@@ -561,15 +565,15 @@ def run_pipeline(config: Config) -> None:
                         data_dir=config.data_dir,
                         output=config.data_dir / "rrd",
                         skip_existing=True,
-                        progress_position=2,
-                    )
+                    ),
+                    progress=progress,
                 )
                 ingest_failures: set[str] = set(summary.failed_video_ids)
                 for video_id in ingest_failures:
                     reason: str = "ingest failed"
                     _append_line(config.state_dir / "failed.txt", f"{video_id}\t{reason}", state_lock)
                     failed_reasons[video_id] = reason
-                    overall.update()
+                    progress.advance(overall_task)
                 successful_ingests: list[str] = [video_id for video_id in ingest_ids if video_id not in ingest_failures]
                 if ship_future is not None:
                     ship_future.result()
@@ -580,7 +584,8 @@ def run_pipeline(config: Config) -> None:
                     successful_ingests,
                     splits,
                     state_lock,
-                    overall,
+                    progress,
+                    overall_task,
                     done_ids,
                     failed_reasons,
                     len(download_result.failures) + len(ingest_failures),
@@ -602,7 +607,7 @@ def main() -> None:
     try:
         run_pipeline(tyro.cli(Config))
     except KeyboardInterrupt:
-        tqdm.write("pipeline interrupted cleanly; persistent state is ready to resume")
+        CONSOLE.print("pipeline interrupted cleanly; persistent state is ready to resume")
 
 
 if __name__ == "__main__":

--- a/packages/arkitscenes-download/arkitscenes_download/pipeline.py
+++ b/packages/arkitscenes-download/arkitscenes_download/pipeline.py
@@ -21,7 +21,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Protocol, TypeAlias
 
-import tyro
 from rich.console import Console
 from rich.progress import Progress, TaskID
 from simplecv.print_utils import format_bytes
@@ -43,6 +42,7 @@ ASSETS: tuple[str, ...] = (
     "ultrawide_intrinsics",
     "highres_depth",
 )
+DOWNLOAD_TOOL: Path = Path(__file__).resolve().parents[1] / "tools" / "apps" / "download.py"
 FAILED_RAW_LIMIT_BYTES: int = 50 * 1024**3
 SSH_DESTINATION_PATTERN: re.Pattern[str] = re.compile(r"^(?P<host>[A-Za-z0-9][A-Za-z0-9._-]*@[A-Za-z0-9][A-Za-z0-9.-]*):(?P<path>/.*)$")
 VIDEO_ID_PATTERN: re.Pattern[str] = re.compile(r"^[0-9]+$")
@@ -373,8 +373,7 @@ def _download_chunk(config: Config, chunk: list[str], splits: dict[str, str], ex
         wait_for_disk_space(config.data_dir, config.min_free_gb * 1024**3, write=progress.console.print)
         command: list[str] = [
             sys.executable,
-            "-m",
-            "arkitscenes_download",
+            str(DOWNLOAD_TOOL),
             "--download-dir",
             str(config.data_dir),
             "--video-ids",
@@ -602,13 +601,9 @@ def run_pipeline(config: Config) -> None:
                 ship_future.result()
 
 
-def main() -> None:
-    """Parse CLI configuration and run the pipeline."""
+def main(config: Config) -> None:
+    """Run the pipeline, handling interactive interruption cleanly."""
     try:
-        run_pipeline(tyro.cli(Config))
+        run_pipeline(config)
     except KeyboardInterrupt:
         CONSOLE.print("pipeline interrupted cleanly; persistent state is ready to resume")
-
-
-if __name__ == "__main__":
-    main()

--- a/packages/arkitscenes-download/arkitscenes_download/pipeline.py
+++ b/packages/arkitscenes-download/arkitscenes_download/pipeline.py
@@ -42,7 +42,10 @@ ASSETS: tuple[str, ...] = (
     "ultrawide_intrinsics",
     "highres_depth",
 )
+# Package root is parents[1] from arkitscenes_download/pipeline.py. Fail at
+# import time rather than as thousands of per-sequence subprocess failures.
 DOWNLOAD_TOOL: Path = Path(__file__).resolve().parents[1] / "tools" / "apps" / "download.py"
+assert DOWNLOAD_TOOL.is_file(), f"download tool shim missing: {DOWNLOAD_TOOL}"
 FAILED_RAW_LIMIT_BYTES: int = 50 * 1024**3
 SSH_DESTINATION_PATTERN: re.Pattern[str] = re.compile(r"^(?P<host>[A-Za-z0-9][A-Za-z0-9._-]*@[A-Za-z0-9][A-Za-z0-9.-]*):(?P<path>/.*)$")
 VIDEO_ID_PATTERN: re.Pattern[str] = re.compile(r"^[0-9]+$")

--- a/packages/arkitscenes-download/docs/architecture.md
+++ b/packages/arkitscenes-download/docs/architecture.md
@@ -10,28 +10,28 @@ All diagrams are Mermaid; they render on GitHub and in Obsidian.
 
 ```mermaid
 flowchart LR
-    subgraph DL["1 · DOWNLOAD  (pixi run download)"]
+    subgraph DL["1 · DOWNLOAD  (arkitscenes-download-sample task or downloader module)"]
         CDN["Apple CDN<br>docs-assets.developer.apple.com<br>/ml-research/datasets/arkitscenes/v1"]
         META["raw/metadata.csv<br>5,071 sequences<br>visit_id · fold · sky_direction*"]
         ASSETS["per-sequence raw assets<br>mov · traj · depth PNGs · intrinsics<br>annotation json · mesh ply"]
-        LASER["per-visit laser scans<br>(downloaded, not ingested:<br>no published FARO→ARKit alignment)"]
+        LASER["optional per-visit laser scans<br>(sample/pipeline disable them;<br>never ingested: no published FARO→ARKit alignment)"]
         CDN --> META
         CDN -->|"curl -C - --retry, .part → rename<br>zips: extract to staging dir → atomic rename"| ASSETS
         CDN --> LASER
     end
 
-    subgraph ING["2 · INGEST  (pixi run ingest --video-id N)"]
+    subgraph ING["2 · INGEST  (python -m arkitscenes_download.ingest --video-id N)"]
         MOV["MOV demux<br>13 streams"]
         PIPE["per-sequence DAG<br>(see §3)"]
-        RRD["data/rrd/&lt;id&gt;.rrd<br>tempfile → os.replace → rrd verify"]
+        RRD["data/rrd/&lt;id&gt;/&lt;layer&gt;.rrd<br>7 layers · each tempfile → os.replace<br>all verified together"]
         MOV --> PIPE --> RRD
     end
 
     subgraph SRV["3 · REGISTER + SERVE"]
-        SERVER["rerun server :51235<br>in-memory OSS catalog<br>(pixi run serve)"]
-        REG["catalog.py  (pixi run register)<br>idempotent segment registration<br>blueprint = dataset default"]
+        SERVER["rerun server :51235<br>in-memory OSS catalog<br>(arkitscenes-download-serve task)"]
+        REG["catalog.py  (arkitscenes-download-register task)<br>7 layers stacked per segment<br>generic blueprints = dataset defaults"]
         VIEW["viewers<br>headed desktop · headless+MCP<br>dataframe / SQL queries"]
-        RRD2["arkitscenes dataset<br>1 segment per video_id<br>properties = queryable columns"]
+        RRD2["arkitscenes dataset<br>1 layered segment per video_id<br>embedded sequence blueprint wins on open<br>properties = queryable columns"]
         REG --> SERVER --> RRD2 --> VIEW
     end
 
@@ -136,7 +136,7 @@ flowchart TB
         D4["boxes: half_sizes + labels;<br>InstancePoses3D(translations=centroid,<br>mat3x3=normalizedAxes.T)<br>2D overlay = NATIVE viewer reprojection"]
     end
 
-    PUB["atomic publish (cli.py)<br>tempfile.mkstemp(dir=output) → RecordingStream ctx<br>(blocking finalize) → os.replace → rerun rrd verify"]
+    PUB["atomic layer publish (cli.py)<br>for each of 7 layers: tempfile.mkstemp(dir=output)<br>→ RecordingStream ctx → blocking finalize → os.replace<br>then rerun rrd verify all layers together"]
 
     IMOV --> CLOCK & MDEC & IMU & VID
     ITRAJ --> ORIENT
@@ -155,7 +155,7 @@ flowchart TB
     POSE --> RIGTREE
     V6 --> RIGTREE
     D1 & D2 & D3 & D4 --> RIGTREE
-    RIGTREE["rig entity tree + blueprint<br>(§4) — everything on ONE timeline:<br>video_time = ARKit uptime seconds"]
+    RIGTREE["entity data split across 7 layers (base, calibration,<br>video_wide, video_ultrawide, depth, imu, gt)<br>base embeds GT-mesh-framed blueprint (§4)<br>ONE timeline: video_time = ARKit uptime seconds"]
     RIGTREE --> PUB
 ```
 
@@ -190,6 +190,8 @@ Recording properties (queryable as catalog columns): `video_id`, `visit_id`, `sp
 
 **Timeline**: a single `video_time` duration timeline whose values are ARKit device-uptime seconds — scrubber positions match raw asset filenames exactly. Each camera's samples are placed with its own independently recovered clock offset.
 
+**Blueprints**: the base layer embeds a per-sequence default blueprint. Its `EyeControls3D` orbits the GT mesh center, using `mesh_bounding_geometry` and `orbit_eye_position` to frame the mesh at `2.2 × 1.25 ×` its bounding radius. Generic portrait and landscape blueprints remain catalog dataset defaults, but the embedded blueprint takes precedence when a segment opens.
+
 ---
 
 ## 5. Publication & catalog lifecycle
@@ -197,23 +199,25 @@ Recording properties (queryable as catalog columns): `video_id`, `visit_id`, `sp
 ```mermaid
 sequenceDiagram
     participant CLI as ingest CLI
-    participant TMP as tempfile (same dir)
-    participant FS as data/rrd/
+    participant TMP as layer tempfile (same dir)
+    participant FS as data/rrd/<id>/
     participant CAT as catalog.py
     participant SRV as rerun server :51235
     participant V as viewers
 
-    CLI->>TMP: mkstemp(suffix=.rrd.tmp) · RecordingStream sink
-    CLI->>TMP: stream chunks while logging (bounded batches)
-    CLI->>TMP: context exit = blocking finalize
-    alt success
-        CLI->>FS: os.replace(tmp, <id>.rrd)  — atomic
-        CLI->>FS: rerun rrd verify
-    else any failure
-        CLI->>TMP: unlink — previous good .rrd untouched
+    loop base, calibration, video_wide, video_ultrawide, depth, imu, gt
+        CLI->>TMP: mkstemp(suffix=.rrd.tmp) · RecordingStream sink
+        CLI->>TMP: stream layer chunks (bounded batches)
+        CLI->>TMP: context exit = blocking finalize
+        alt success
+            CLI->>FS: os.replace(tmp, <layer>.rrd) — atomic
+        else any failure
+            CLI->>TMP: unlink — previous good layer untouched
+        end
     end
-    CAT->>SRV: register data/rrd/*.rrd (idempotent,<br>REPLACE per segment, --recreate opt-in)
-    CAT->>SRV: register blueprint .rbl as dataset default<br>(only after all segments succeed)
+    CLI->>FS: rerun rrd verify all 7 layer files together
+    CAT->>SRV: register each layer with shared recording id<br>(idempotent REPLACE per segment layer, --recreate opt-in)
+    CAT->>SRV: register generic portrait/landscape .rbl defaults<br>(base's embedded sequence blueprint wins on open)
     V->>SRV: rerun+http://127.0.0.1:51235<br>segment table → open → stream VideoStream samples
 ```
 
@@ -243,5 +247,5 @@ sequenceDiagram
 
 - All RGB in the `.rrd` is a single-generation near-lossless AV1 transcode (NVENC CQ30, SSIM ≈0.984); the original `.mov` on disk stays the master. Encoder provenance is recorded; bit-exact determinism is not promised.
 - Portrait/landscape mix across sequences is correct (aspect follows device grip).
-- Laser point clouds are downloaded but not ingested (no published FARO→ARKit alignment).
-- Batch-runner concurrency/backpressure for the eventual ~5,000-sequence run is future work; per-sequence memory is bounded.
+- Laser point clouds are optionally downloadable but excluded from the sample task and full pipeline; they are never ingested (no published FARO→ARKit alignment).
+- The batch runner executes sequence subprocesses concurrently. The full pipeline overlaps downloading, ingestion, and shipping with shared Rich progress; per-sequence memory remains bounded.

--- a/packages/arkitscenes-download/docs/architecture.md
+++ b/packages/arkitscenes-download/docs/architecture.md
@@ -20,7 +20,7 @@ flowchart LR
         CDN --> LASER
     end
 
-    subgraph ING["2 · INGEST  (python -m arkitscenes_download.ingest --video-id N)"]
+    subgraph ING["2 · INGEST  (python tools/apps/ingest_sequence.py --video-id N)"]
         MOV["MOV demux<br>13 streams"]
         PIPE["per-sequence DAG<br>(see §3)"]
         RRD["data/rrd/&lt;id&gt;/&lt;layer&gt;.rrd<br>7 layers · each tempfile → os.replace<br>all verified together"]

--- a/packages/arkitscenes-download/pyproject.toml
+++ b/packages/arkitscenes-download/pyproject.toml
@@ -5,8 +5,8 @@ authors = [{name = "Pablo Vela", email = "pablovela5620@gmail.com"}]
 requires-python = ">=3.12"
 dependencies = [
     # common/catalog-common: numpy, scipy, jaxtyping, rerun-sdk, av, opencv,
-    #                        tqdm, pyserde, huggingface_hub, hf-transfer
-    # feature deps (conda): ffmpeg (av1_nvenc/libsvtav1), imagecodecs, trimesh, pillow, curl
+    #                        pyserde, huggingface_hub, hf-transfer
+    # feature deps (conda): ffmpeg (av1_nvenc/libsvtav1), imagecodecs, trimesh, pillow, curl, rich
     "tyro",
 ]
 

--- a/packages/arkitscenes-download/pyproject.toml
+++ b/packages/arkitscenes-download/pyproject.toml
@@ -31,7 +31,7 @@ ignore = [
 ]
 
 [tool.vulture]
-paths = ["arkitscenes_download", "tests"]
+paths = ["arkitscenes_download", "tests", "tools"]
 exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*"]
 sort_by_size = true
 min_confidence = 60

--- a/packages/arkitscenes-download/tests/test_blueprint_framing.py
+++ b/packages/arkitscenes-download/tests/test_blueprint_framing.py
@@ -1,0 +1,58 @@
+"""Behavior checks for the per-sequence 3D viewport framing."""
+
+import unittest
+
+import numpy as np
+import rerun.blueprint as rrb
+from simplecv.rerun_log_utils import mesh_bounding_geometry, orbit_eye_position
+
+from arkitscenes_download.ingest.blueprint import EXTRA_ZOOM_OUT, FIT_DISTANCE_FACTOR, make_blueprint
+
+FRAMING_FACTOR: float = FIT_DISTANCE_FACTOR * EXTRA_ZOOM_OUT
+
+
+class OrbitEyePositionTest(unittest.TestCase):
+    """The framed eye sits on the viewing direction at the padded fit distance."""
+
+    def test_distance_is_fit_factor_times_margin(self) -> None:
+        """Eye distance from the look target is fit factor x bounding radius x extra zoom-out."""
+        center: np.ndarray = np.array([1.0, -2.0, 0.5])
+        radius: float = 3.0
+        position: np.ndarray = orbit_eye_position(center, radius, FRAMING_FACTOR)
+        distance: float = float(np.linalg.norm(position - center))
+        self.assertAlmostEqual(distance, FRAMING_FACTOR * radius, places=9)
+
+    def test_direction_is_elevated_and_scale_invariant(self) -> None:
+        """The eye looks down from above (+Z offset) along the same direction at any scale."""
+        center: np.ndarray = np.zeros(3)
+        small: np.ndarray = orbit_eye_position(center, 1.0, FRAMING_FACTOR)
+        large: np.ndarray = orbit_eye_position(center, 10.0, FRAMING_FACTOR)
+        self.assertGreater(small[2], 0.0)
+        np.testing.assert_allclose(small / np.linalg.norm(small), large / np.linalg.norm(large), atol=1e-12)
+
+
+class MeshBoundingGeometryTest(unittest.TestCase):
+    """Bounding geometry frames every vertex around the box center."""
+
+    def test_center_and_radius_cover_all_vertices(self) -> None:
+        """The center is the AABB midpoint and the radius reaches the farthest vertex."""
+        vertices: np.ndarray = np.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0], [2.0, 4.0, 6.0]])
+        center, radius = mesh_bounding_geometry(vertices)
+        np.testing.assert_allclose(center, [1.0, 2.0, 3.0])
+        distances: np.ndarray = np.linalg.norm(vertices - center, axis=1)
+        self.assertAlmostEqual(radius, float(distances.max()), places=12)
+        self.assertTrue(np.all(distances <= radius + 1e-12))
+
+
+class MakeBlueprintTest(unittest.TestCase):
+    """Blueprint construction succeeds with and without framing geometry."""
+
+    def test_generic_and_framed_blueprints_build(self) -> None:
+        """Both the dataset-default and the per-sequence framed layout construct."""
+        self.assertIsInstance(make_blueprint(portrait=True), rrb.Blueprint)
+        framed: rrb.Blueprint = make_blueprint(portrait=False, mesh_center_xyz=np.array([1.0, 2.0, 3.0]), bounding_radius_m=2.5)
+        self.assertIsInstance(framed, rrb.Blueprint)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/arkitscenes-download/tests/test_blueprint_framing.py
+++ b/packages/arkitscenes-download/tests/test_blueprint_framing.py
@@ -50,7 +50,7 @@ class MakeBlueprintTest(unittest.TestCase):
     def test_generic_and_framed_blueprints_build(self) -> None:
         """Both the dataset-default and the per-sequence framed layout construct."""
         self.assertIsInstance(make_blueprint(portrait=True), rrb.Blueprint)
-        framed: rrb.Blueprint = make_blueprint(portrait=False, mesh_center_xyz=np.array([1.0, 2.0, 3.0]), bounding_radius_m=2.5)
+        framed: rrb.Blueprint = make_blueprint(portrait=False, framing=(np.array([1.0, 2.0, 3.0]), 2.5))
         self.assertIsInstance(framed, rrb.Blueprint)
 
 

--- a/packages/arkitscenes-download/tests/test_download_dataset.py
+++ b/packages/arkitscenes-download/tests/test_download_dataset.py
@@ -1,0 +1,58 @@
+"""Behavior checks for ARKitScenes download planning."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from arkitscenes_download.download_dataset import VideoMetadata, download_video, parse_content_length, plan_video_downloads
+
+
+class DownloadDatasetTest(unittest.TestCase):
+    """Check download planning and HTTP size parsing."""
+
+    def test_plan_video_downloads_returns_only_pending_applicable_assets(self) -> None:
+        """Planning skips existing outputs and assets gated by metadata."""
+        metadata: VideoMetadata = VideoMetadata("123", "7", "Training", "Up", False, False, True)
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            download_dir: Path = Path(temporary_directory)
+            video_dir: Path = download_dir / "raw" / "Training" / "123"
+            (video_dir / "lowres_depth").mkdir(parents=True)
+            (video_dir / "123.mov").touch()
+
+            plans = plan_video_downloads(metadata, ("mov", "lowres_depth", "confidence", "highres_depth", "annotation"), download_dir)
+
+            self.assertEqual([plan.asset for plan in plans], ["confidence", "annotation"])
+            self.assertEqual(plans[0].filename, "confidence.zip")
+            self.assertEqual(plans[0].dst_path, video_dir / "confidence.zip")
+            self.assertTrue(plans[0].is_zip)
+            self.assertTrue(plans[0].url.endswith("/raw/Training/123/confidence.zip"))
+
+    def test_plan_video_downloads_deduplicates_repeated_assets(self) -> None:
+        """A ZIP asset requested twice is planned exactly once."""
+        metadata: VideoMetadata = VideoMetadata("123", "7", "Training", "Up", False, False, True)
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            plans = plan_video_downloads(metadata, ("confidence", "confidence"), Path(temporary_directory))
+
+            self.assertEqual([plan.asset for plan in plans], ["confidence"])
+
+    def test_download_video_skips_plans_already_satisfied_on_disk(self) -> None:
+        """An asset extracted after planning is not re-downloaded or re-extracted."""
+        metadata: VideoMetadata = VideoMetadata("123", "7", "Training", "Up", False, False, True)
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            download_dir: Path = Path(temporary_directory)
+            plans = plan_video_downloads(metadata, ("confidence",), download_dir)
+            # Simulate the extraction landing between planning and transfer.
+            (download_dir / "raw" / "Training" / "123" / "confidence").mkdir(parents=True)
+
+            download_video(metadata, plans, download_dir, keep_zip=False, include_point_clouds=False)  # would hit the network if not skipped
+
+    def test_parse_content_length_uses_last_case_insensitive_header(self) -> None:
+        """Redirect response headers contribute only their final content length."""
+        headers: str = "HTTP/1.1 302 Found\r\nContent-Length: 12\r\n\r\nHTTP/2 200\r\ncontent-length: 345\r\n"
+
+        self.assertEqual(parse_content_length(headers), 345)
+        self.assertIsNone(parse_content_length("HTTP/2 200\r\ncontent-type: application/zip\r\n"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/arkitscenes-download/tools/apps/download.py
+++ b/packages/arkitscenes-download/tools/apps/download.py
@@ -1,0 +1,6 @@
+import tyro
+
+from arkitscenes_download.cli import Config, main
+
+if __name__ == "__main__":
+    main(tyro.cli(Config))

--- a/packages/arkitscenes-download/tools/apps/ingest_batch.py
+++ b/packages/arkitscenes-download/tools/apps/ingest_batch.py
@@ -1,0 +1,6 @@
+import tyro
+
+from arkitscenes_download.ingest.batch import Config, main
+
+if __name__ == "__main__":
+    main(tyro.cli(Config))

--- a/packages/arkitscenes-download/tools/apps/ingest_sequence.py
+++ b/packages/arkitscenes-download/tools/apps/ingest_sequence.py
@@ -1,0 +1,6 @@
+import tyro
+
+from arkitscenes_download.ingest.cli import Config, ingest_sequence
+
+if __name__ == "__main__":
+    ingest_sequence(tyro.cli(Config))

--- a/packages/arkitscenes-download/tools/apps/pipeline.py
+++ b/packages/arkitscenes-download/tools/apps/pipeline.py
@@ -1,0 +1,6 @@
+import tyro
+
+from arkitscenes_download.pipeline import Config, main
+
+if __name__ == "__main__":
+    main(tyro.cli(Config))

--- a/packages/arkitscenes-download/tools/apps/register_catalog.py
+++ b/packages/arkitscenes-download/tools/apps/register_catalog.py
@@ -1,0 +1,6 @@
+import tyro
+
+from arkitscenes_download.ingest.catalog import Config, main
+
+if __name__ == "__main__":
+    main(tyro.cli(Config))

--- a/packages/simplecv/simplecv/print_utils.py
+++ b/packages/simplecv/simplecv/print_utils.py
@@ -1,8 +1,7 @@
+# This module must stay importable without heavy deps: stdlib-light CLIs
+# (e.g. the arkitscenes downloader subprocess) import format_bytes at startup.
 from collections.abc import Callable
 from typing import Any
-
-import numpy as np
-from lovely_numpy import lo
 
 
 def format_bytes(num_bytes: int) -> str:
@@ -15,10 +14,13 @@ def format_bytes(num_bytes: int) -> str:
     return f"{value:.1f} PiB"
 
 
-def debug_numpy(tensor: np.ndarray | Any) -> Callable:
+def debug_numpy(tensor: Any) -> Callable:
     """
     Convert a tensor to a numpy array if it is not already one.
     """
+    import numpy as np
+    from lovely_numpy import lo
+
     if isinstance(tensor, np.ndarray):
         return lo(tensor)
     tensor = tensor.clone().detach().cpu().numpy()

--- a/packages/simplecv/simplecv/rerun_log_utils.py
+++ b/packages/simplecv/simplecv/rerun_log_utils.py
@@ -13,7 +13,7 @@ from typing import Any, Literal
 import av
 import numpy as np
 import rerun as rr
-from jaxtyping import Int
+from jaxtyping import Float64, Int
 from numpy import ndarray
 from pyarrow import ChunkedArray, LargeListArray, ListArray
 
@@ -664,3 +664,27 @@ def mux_h264_to_mp4(times: ChunkedArray, samples: ChunkedArray, output_path: str
 
     input_container.close()
     output_container.close()
+
+
+def mesh_bounding_geometry(vertices: Float64[ndarray, "n 3"]) -> tuple[Float64[ndarray, "3"], float]:
+    """Return the AABB center and the radius of the vertex bounding sphere around it."""
+    center: Float64[ndarray, "3"] = (vertices.min(axis=0) + vertices.max(axis=0)) / 2.0
+    radius: float = float(np.linalg.norm(vertices - center, axis=1).max())
+    return center, radius
+
+
+def orbit_eye_position(
+    look_target_xyz: Float64[ndarray, "3"],
+    bounding_radius_m: float,
+    distance_factor: float,
+    direction_xyz: tuple[float, float, float] = (1.0, 1.0, 1.0),
+) -> Float64[ndarray, "3"]:
+    """Place a 3D-view eye along ``direction_xyz`` at ``distance_factor x bounding_radius_m`` from the target.
+
+    Pairs with ``rrb.archetypes.EyeControls3D``: use the returned position together
+    with ``look_target=look_target_xyz`` so the whole bounding sphere stays in frame
+    (a ``distance_factor`` around 2.2 tightly fits a default-FOV view).
+    """
+    direction: Float64[ndarray, "3"] = np.asarray(direction_xyz, dtype=np.float64)
+    unit: Float64[ndarray, "3"] = direction / np.linalg.norm(direction)
+    return look_target_xyz + distance_factor * bounding_radius_m * unit

--- a/pixi.toml
+++ b/pixi.toml
@@ -2137,18 +2137,18 @@ tyro = ">=0.9,<1"
 PACKAGE_DIR = "packages/arkitscenes-download"
 
 [feature.arkitscenes-download.tasks.arkitscenes-download-sample]
-cmd = "python -m arkitscenes_download --download-dir data --num-random 5 --seed 42 --no-include-point-clouds --assets mov annotation mesh lowres_wide.traj confidence lowres_depth lowres_wide_intrinsics ultrawide_intrinsics highres_depth"
+cmd = "python tools/apps/download.py --download-dir data --num-random 5 --seed 42 --no-include-point-clouds --assets mov annotation mesh lowres_wide.traj confidence lowres_depth lowres_wide_intrinsics ultrawide_intrinsics highres_depth"
 cwd = "packages/arkitscenes-download"
 description = "Download a 5-sequence ARKitScenes sample (mov + depth + calibration, no point clouds)"
 
 [feature.arkitscenes-download.tasks.arkitscenes-download-ingest]
-cmd = "python -m arkitscenes_download.ingest.batch --workers 2"
+cmd = "python tools/apps/ingest_batch.py --workers 2"
 cwd = "packages/arkitscenes-download"
 depends-on = ["arkitscenes-download-sample"]
 description = "Ingest every downloaded sequence into layered .rrd files under data/rrd/"
 
 [feature.arkitscenes-download.tasks.arkitscenes-download-pipeline]
-cmd = "python -m arkitscenes_download.pipeline --chunk-size 5 --destination data/published"
+cmd = "python tools/apps/pipeline.py --chunk-size 5 --destination data/published"
 cwd = "packages/arkitscenes-download"
 description = "Resumable download→ingest→verify→publish pipeline (local destination; see --help for ssh targets)"
 
@@ -2158,7 +2158,7 @@ cwd = "packages/arkitscenes-download"
 description = "Serve a Rerun catalog for registered ARKitScenes recordings"
 
 [feature.arkitscenes-download.tasks.arkitscenes-download-register]
-cmd = "python -m arkitscenes_download.ingest.catalog --rrd-dir data/rrd"
+cmd = "python tools/apps/register_catalog.py --rrd-dir data/rrd"
 cwd = "packages/arkitscenes-download"
 env = { RERUN_INSECURE_SKIP_HOST_CHECK = "1" }
 description = "Register ingested layer .rrds into the catalog on :51235"

--- a/pixi.toml
+++ b/pixi.toml
@@ -2127,6 +2127,7 @@ imagecodecs = ">=2024.9.22"
 trimesh = "*"
 pillow = "*"
 curl = "*"
+rich = "*"
 
 [feature.arkitscenes-download.pypi-dependencies]
 arkitscenes-download = { path = "packages/arkitscenes-download", editable = true }

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -87,6 +87,7 @@ site-package-path = [
     ".pixi/envs/simplecv-dev/lib/python3.12/site-packages",
     ".pixi/envs/simplecv-dev/lib/python3.12/site-packages/rerun_sdk",
     ".pixi/envs/arkitscenes-download-dev/lib/python3.12/site-packages",
+    ".pixi/envs/arkitscenes-download-dev/lib/python3.12/site-packages/rerun_sdk",
     ".pixi/envs/prompt-da-dev/lib/python3.12/site-packages",
     ".pixi/envs/wilor-nano-dev/lib/python3.12/site-packages",
     ".pixi/envs/sam3d-body-dev/lib/python3.12/site-packages",


### PR DESCRIPTION
## What

Three user-facing changes to `packages/arkitscenes-download`, plus review-driven hardening:

### 1. 3D viewport framing (per-sequence)
Each sequence's `base.rrd` now embeds a blueprint whose `EyeControls3D` **orbits the GT mesh center** with the whole mesh in frame plus a 25% margin (`eye distance = 2.2 × 1.25 × bounding-sphere radius`, elevated (1,1,1) view, Z-up, spin kept at 0.25). Catalog dataset-default blueprints stay generic — the embedded blueprint wins when a segment opens.

The framing math lives in **simplecv** now (`mesh_bounding_geometry`, `orbit_eye_position` in `rerun_log_utils`) since `gsplat-rust-renderer` hand-rolls the identical pattern (`apis/log_gaussian_ply.py`) and can adopt it as a follow-up.

### 2. tqdm → rich everywhere
One `Live` region with fitted columns per task: overall **bytes bar** (HEAD-prefetched total, live `.part`-file polling, transfer speed) + **sequences-remaining bar** for the downloader; shared thread-safe `Progress` across the pipeline's download/ingest/ship stages; batch summary table; plain-line fallback on non-TTY stdout.

### 3. Download progress with real totals
`PlannedDownload` planner (order-preserving dedupe + just-in-time disk re-check), concurrent HEAD size prefetch, and `download_file` polling curl via `Popen.wait(timeout=0.25)` (no dead sleep after small assets). The pipeline passes `--no-prefetch` since it invokes the downloader once per sequence.

### Hardening / cleanup (from adversarial review + 3-reviewer simplify pass)
- Fixed: duplicate ZIP asset args previously re-downloaded the archive and crashed `extract_zip` (regression-tested)
- `human_bytes` deduped into `simplecv.print_utils.format_bytes`; `print_utils`' numpy/lovely_numpy imports made lazy so the per-sequence downloader subprocess stays at 0.07 s startup (naive dedupe would have cost ~47 min of import overhead across a full 5,071-sequence run)
- `docs/architecture.md` + docstrings updated for the 7-layer RRD reality; stale `stdlib-only`/`tqdm` claims removed
- pyrefly: `arkitscenes-download-dev` rerun_sdk site-package path added so the package typechecks standalone

## Verification

- Full flow on the 5-sequence sample: download → ingest (7/7 layers verified × 5) → serve → register (5 segments) → native viewer
- Gates: ruff ✓, pyrefly 0 errors ✓, pytest 38 passed ✓, vulture ✓; simplecv's `test_print_utils` ✓
- Portrait (`43896478`) and landscape sequences both ingest with framed blueprints

Prior art: #70