### PR TITLE
prompt-da: PromptDA on dynamic-batch TensorRT — 50 FPS Polycam pipeline (8.9× over torch)

### DIFF
--- a/packages/monoprior/monopriors/third_party/promptda/promptda.py
+++ b/packages/monoprior/monopriors/third_party/promptda/promptda.py
@@ -106,9 +106,10 @@ class PromptDA(nn.Module):
         return self.forward(image, prompt_depth)
 
     def normalize(self, prompt_depth: torch.Tensor):
-        B, C, H, W = prompt_depth.shape
-        min_val = torch.quantile(prompt_depth.reshape(B, -1), 0.0, dim=1, keepdim=True)[:, :, None, None]
-        max_val = torch.quantile(prompt_depth.reshape(B, -1), 1.0, dim=1, keepdim=True)[:, :, None, None]
+        # amin/amax match the original quantile(0.0/1.0) exactly while staying
+        # exportable: aten::quantile has no ONNX lowering, min/max reductions do.
+        min_val = prompt_depth.amin(dim=(1, 2, 3), keepdim=True)
+        max_val = prompt_depth.amax(dim=(1, 2, 3), keepdim=True)
         prompt_depth = (prompt_depth - min_val) / (max_val - min_val)
         return prompt_depth, min_val, max_val
 

--- a/packages/prompt-da/pyproject.toml
+++ b/packages/prompt-da/pyproject.toml
@@ -19,11 +19,12 @@ line-length = 150
 
 [tool.ruff.lint]
 select = ["E", "F", "UP", "B", "SIM", "I"]
-ignore = ["E501", "F722", "F821", "UP037"]
+ignore = ["E501", "F722", "F821", "UP037", "UP040"]
 
 [tool.vulture]
 paths = ["src/rerun_prompt_da", "tests", "tools"]
 exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modules/*"]
 sort_by_size = true
 min_confidence = 60
-ignore_names = ["rr_config"]
+# _engine: held only to keep the TRT engine alive for its execution context
+ignore_names = ["rr_config", "_engine"]

--- a/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_trt_polycam.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_trt_polycam.py
@@ -1,0 +1,159 @@
+"""Batched TensorRT Polycam pipeline for Prompt Depth Anything.
+
+The TensorRT twin of :mod:`rerun_prompt_da.apis.prompt_da_polycam`: frames are
+batched (default 8) through a dynamic-batch fp16 engine with all pre/post
+processing on the GPU, then fused and logged to Rerun exactly like the torch
+demo. Prints model and end-to-end throughput so speedups are measurable.
+"""
+
+import time
+from dataclasses import dataclass, field
+from itertools import batched, chain
+from pathlib import Path
+
+import numpy as np
+import rerun as rr
+import torch
+from jaxtyping import Float32, UInt8, UInt16
+from monopriors.models.depth_completion.prompt_da import ensure_multiple_of
+from numpy import ndarray
+from simplecv.data.polycam import (
+    DepthConfidenceLevel,
+    PolycamData,
+    PolycamDataset,
+    load_polycam_data,
+)
+from simplecv.ops.tsdf_depth_fuser import Open3DFuser
+from simplecv.rerun_log_utils import RerunTyroConfig
+from torch import Tensor
+from tqdm import tqdm
+
+from rerun_prompt_da.apis.prompt_da_polycam import _log_mesh, create_blueprint, filter_depth, log_polycam_data
+from rerun_prompt_da.trt_engine import TrtPrecision
+from rerun_prompt_da.trt_predictor import PromptDATrtPredictor
+
+
+@dataclass
+class PDATrtPolycamConfig:
+    """Runtime configuration for the batched TensorRT Polycam demo."""
+
+    polycam_zip_path: Path
+    """Polycam capture zip (or extracted directory) to process."""
+    rr_config: RerunTyroConfig = field(default_factory=RerunTyroConfig)
+    """Rerun viewer/save/connect behavior."""
+    batch_size: int = 8
+    """Frames per TensorRT batch (engine profile optimum and max)."""
+    precision: TrtPrecision = "fp16"
+    """TensorRT builder precision for the engine."""
+    max_image_size: int = 1008
+    """Longest network image side; the actual size is 14-aligned from the capture resolution."""
+    max_depth_range_meter: float = 4.0
+    """Depth beyond this is dropped before TSDF fusion."""
+    depth_fusion_resolution: float = 0.04
+    """TSDF voxel size in meters."""
+    log_incremental_mesh: bool = False
+    """Log the fused mesh after every batch instead of only at the end."""
+
+
+def network_image_hw(capture_hw: tuple[int, int], max_image_size: int) -> tuple[int, int]:
+    """14-align the capture resolution scaled to fit ``max_image_size``.
+
+    Mirrors the torch predictor's preprocessing policy so both backends run
+    the network at the same resolution.
+
+    Args:
+        capture_hw: Native capture (height, width).
+        max_image_size: Longest allowed network side.
+
+    Returns:
+        Network (height, width), each a multiple of 14.
+    """
+    height, width = capture_hw
+    scale: float = min(1.0, max_image_size / max(height, width))
+    return (ensure_multiple_of(height * scale), ensure_multiple_of(width * scale))
+
+
+def pda_trt_polycam_inference(config: PDATrtPolycamConfig) -> None:
+    """Run batched TensorRT PromptDA over a Polycam capture and stream to Rerun."""
+    parent_log_path: Path = Path("world")
+    rr.log("/", rr.ViewCoordinates.RUB, static=True)
+    rr.send_blueprint(create_blueprint(parent_log_path))
+
+    polycam_dataset: PolycamDataset = load_polycam_data(polycam_zip_or_directory_path=config.polycam_zip_path)
+    pred_fuser = Open3DFuser(
+        fusion_resolution=config.depth_fusion_resolution,
+        max_fusion_depth=config.max_depth_range_meter,
+    )
+
+    # Consume the capture in batch-sized chunks so memory stays bounded on
+    # long recordings; only the first batch is peeked to size the engine.
+    batches = batched(polycam_dataset, config.batch_size)
+    first_batch: tuple[PolycamData, ...] | None = next(batches, None)
+    if first_batch is None:
+        raise ValueError(f"Polycam capture {config.polycam_zip_path} contains no frames.")
+    image_hw: tuple[int, int] = network_image_hw(first_batch[0].rgb_hw3.shape[:2], config.max_image_size)
+    predictor = PromptDATrtPredictor(
+        model_type="large",
+        image_hw=image_hw,
+        batch_size=config.batch_size,
+        precision=config.precision,
+    )
+
+    n_frames: int = 0
+    model_seconds: float = 0.0
+    wall_start: float = time.perf_counter()
+    total_batches: int = -(-len(polycam_dataset) // config.batch_size)
+    progress = tqdm(chain([first_batch], batches), desc="Inferring (TRT)", total=total_batches)
+    batch: tuple[PolycamData, ...]
+    for batch in progress:
+        batch_start: int = n_frames
+        n_frames += len(batch)
+        rgb_bhw3: UInt8[Tensor, "b h w 3"] = torch.from_numpy(np.stack([data.rgb_hw3 for data in batch]))
+        prompt_bhw: Float32[Tensor, "b 192 256"] = torch.from_numpy(
+            np.stack([data.original_depth_hw for data in batch]).astype(np.float32) / 1000.0
+        )
+
+        torch.cuda.synchronize()
+        model_start: float = time.perf_counter()
+        depth_bhw: Float32[Tensor, "b h w"] = predictor(rgb_bhw3.cuda(), prompt_bhw.cuda())
+        torch.cuda.synchronize()
+        model_seconds += time.perf_counter() - model_start
+
+        depth_mm_bhw: UInt16[ndarray, "b h w"] = (depth_bhw.cpu().numpy() * 1000).astype(np.uint16)
+        for frame_offset, polycam_data in enumerate(batch):
+            frame_idx: int = batch_start + frame_offset
+            rr.set_time("frame_idx", sequence=frame_idx)
+            depth_pred_mm: UInt16[ndarray, "h w"] = depth_mm_bhw[frame_offset]
+
+            filtered_depth_mm: UInt16[ndarray, "h w"] = filter_depth(
+                depth_mm=depth_pred_mm,
+                confidence=polycam_data.confidence_hw,
+                confidence_threshold=DepthConfidenceLevel.MEDIUM,
+                max_depth_meter=config.max_depth_range_meter,
+            )
+            k_matrix: Float32[ndarray, "3 3"] | None = polycam_data.pinhole_params.intrinsics.k_matrix
+            if k_matrix is None:
+                raise ValueError("Polycam pinhole intrinsics must include a 3x3 k_matrix for TSDF fusion.")
+            pred_fuser.fuse_frames(
+                depth_hw=filtered_depth_mm,
+                K_33=k_matrix,
+                cam_T_world_44=polycam_data.pinhole_params.extrinsics.cam_T_world,
+                rgb_hw3=polycam_data.rgb_hw3,
+            )
+            log_polycam_data(
+                parent_path=parent_log_path,
+                polycam_data=polycam_data,
+                depth_pred=depth_pred_mm,
+                rescale_factor=1,
+            )
+        if config.log_incremental_mesh:
+            _log_mesh(parent_log_path=parent_log_path, pred_fuser=pred_fuser)
+
+    _log_mesh(parent_log_path=parent_log_path, pred_fuser=pred_fuser)
+
+    wall_seconds: float = time.perf_counter() - wall_start
+    print(
+        f"[prompt-da] {n_frames} frames | model {model_seconds / n_frames * 1000:.1f} ms/frame "
+        f"({n_frames / model_seconds:.1f} FPS) | pipeline {wall_seconds / n_frames * 1000:.1f} ms/frame "
+        f"({n_frames / wall_seconds:.1f} FPS incl. fusion+logging)"
+    )

--- a/packages/prompt-da/src/rerun_prompt_da/trt_engine.py
+++ b/packages/prompt-da/src/rerun_prompt_da/trt_engine.py
@@ -1,0 +1,287 @@
+"""ONNX export and TensorRT engine caching for Prompt Depth Anything.
+
+prompt-da owns the whole acceleration path: it imports the torch PromptDA
+network from monopriors, exports the ONNX interchange graph itself, and builds
+dynamic-batch TensorRT engines from it. ONNX files are portable and cached per
+model/resolution; engines are machine-local (TensorRT-version- and SM-specific)
+and rebuilt from ONNX on each target machine, following the posekit/mamma
+convention.
+"""
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, TypeAlias
+
+import torch
+
+TrtPrecision: TypeAlias = Literal["fp32", "fp16", "bf16"]
+ModelType: TypeAlias = Literal["large", "small", "small-transparent"]
+
+DEFAULT_CACHE_DIR: Path = Path(os.environ.get("PROMPTDA_TRT_CACHE", "~/.cache/prompt-da")).expanduser()
+"""Cache root holding ``onnx/`` (portable) and ``trt/`` (machine-local) artifacts."""
+
+PROMPT_DEPTH_HW: tuple[int, int] = (192, 256)
+"""ARKit LiDAR prompt-depth resolution PromptDA was trained on."""
+
+ONNX_OPSET: int = 17
+"""Legacy-exporter opset; TRT 10.13's parser chokes on dynamo exports (see mamma)."""
+
+ONNX_EXPORT_VERSION: int = 1
+"""Bump whenever the export recipe or the vendored PromptDA implementation changes,
+so cached ONNX graphs from older code are not silently reused."""
+
+
+@dataclass(frozen=True, slots=True)
+class TrtBuildConfig:
+    """How to build (and cache-key) a PromptDA TensorRT engine."""
+
+    max_batch_size: int = 8
+    """Largest batch the dynamic-batch engine accepts (profile max)."""
+    opt_batch_size: int = 8
+    """Batch size TensorRT tunes kernels for (dynamic profile optimum)."""
+    precision: TrtPrecision = "fp16"
+    """Builder precision flag. ``fp32`` leaves the builder defaults untouched."""
+    workspace_gib: float = 8.0
+    """Workspace memory pool limit handed to the builder."""
+    builder_optimization_level: int = 3
+    """TensorRT builder optimization level (0-5)."""
+
+
+def export_promptda_onnx(
+    model_type: ModelType = "large",
+    image_hw: tuple[int, int] = (756, 1008),
+    cache_dir: Path = DEFAULT_CACHE_DIR,
+) -> Path:
+    """Export the monopriors PromptDA network to a dynamic-batch ONNX graph.
+
+    The graph takes ``image`` (float32 ``[B,3,H,W]``, RGB in [0,1]) and
+    ``prompt_depth`` (float32 ``[B,1,192,256]``, meters) and returns ``depth``
+    (float32 ``[B,1,H,W]``, meters). Only the batch axis is dynamic; H and W
+    must be multiples of the DINOv2 patch size (14).
+
+    Args:
+        model_type: PromptDA checkpoint variant (monopriors ``NAME_TO_HFNAME`` key).
+        image_hw: Static (height, width) the graph is exported at.
+        cache_dir: Cache root; the file lands in ``cache_dir / "onnx"``.
+
+    Returns:
+        Path to the cached ONNX file (exported on first use).
+    """
+    height, width = image_hw
+    if height % 14 != 0 or width % 14 != 0:
+        raise ValueError(f"PromptDA image size must be a multiple of the 14px patch size, got {image_hw}.")
+
+    from huggingface_hub import hf_hub_download
+    from monopriors.models.depth_completion.prompt_da import NAME_TO_HFNAME
+    from monopriors.third_party.promptda.promptda import PromptDA
+
+    # Resolve the checkpoint first so its HF snapshot revision is part of the
+    # cache identity — an updated checkpoint or export recipe (ONNX_EXPORT_VERSION)
+    # must not silently reuse a stale graph.
+    ckpt_path = Path(hf_hub_download(repo_id=NAME_TO_HFNAME[model_type], repo_type="model", filename="model.ckpt"))
+    ckpt_rev: str = _checkpoint_revision(ckpt_path)
+    onnx_dir: Path = cache_dir / "onnx"
+    onnx_path: Path = onnx_dir / f"promptda-{model_type}_{height}x{width}_op{ONNX_OPSET}_v{ONNX_EXPORT_VERSION}_{ckpt_rev}.onnx"
+    if onnx_path.exists():
+        return onnx_path
+
+    print(f"[prompt-da] exporting ONNX (one-time, may take a minute): {onnx_path.name}")
+    model = PromptDA.from_pretrained(str(ckpt_path)).to("cuda").eval()
+    # Trace at batch 2 so no op accidentally specializes on batch 1.
+    dummy_image: torch.Tensor = torch.zeros((2, 3, height, width), dtype=torch.float32, device="cuda")
+    dummy_prompt: torch.Tensor = torch.rand((2, 1, *PROMPT_DEPTH_HW), dtype=torch.float32, device="cuda") + 0.5
+    onnx_dir.mkdir(parents=True, exist_ok=True)
+    # pid-unique temp + atomic rename: concurrent exporters may duplicate work
+    # but can never clobber each other's in-flight writes or publish a
+    # truncated file.
+    tmp_path: Path = onnx_path.with_name(f"{onnx_path.name}.part{os.getpid()}")
+    with torch.inference_mode():
+        torch.onnx.export(
+            model,
+            (dummy_image, dummy_prompt),
+            str(tmp_path),
+            input_names=["image", "prompt_depth"],
+            output_names=["depth"],
+            opset_version=ONNX_OPSET,
+            do_constant_folding=True,
+            dynamic_axes={
+                "image": {0: "batch"},
+                "prompt_depth": {0: "batch"},
+                "depth": {0: "batch"},
+            },
+            dynamo=False,
+        )
+    tmp_path.rename(onnx_path)
+    del model
+    torch.cuda.empty_cache()
+    return onnx_path
+
+
+def cached_engine_path(onnx_path: Path, config: TrtBuildConfig, cache_dir: Path = DEFAULT_CACHE_DIR) -> Path:
+    """Return the machine-local cache path for an engine built from this ONNX file.
+
+    The name encodes everything that invalidates an engine: ONNX content hash,
+    batch range, precision, TensorRT version, and GPU compute capability.
+
+    Args:
+        onnx_path: ONNX interchange file the engine is built from.
+        config: Build configuration contributing to the cache key.
+        cache_dir: Cache root; the engine lands in ``cache_dir / "trt"``.
+
+    Returns:
+        Deterministic engine path inside ``cache_dir / "trt"``.
+    """
+    if not 1 <= config.opt_batch_size <= config.max_batch_size:
+        raise ValueError(f"opt_batch_size must be within [1, max_batch_size], got opt={config.opt_batch_size} max={config.max_batch_size}.")
+    trt: Any = _import_tensorrt()
+    capability: tuple[int, int] = torch.cuda.get_device_capability()
+    onnx_hash: str = _onnx_content_hash(onnx_path)[:12]
+    name: str = (
+        f"{onnx_path.stem}_b1-{config.opt_batch_size}-{config.max_batch_size}_{config.precision}"
+        f"_trt{trt.__version__}_sm{capability[0]}{capability[1]}_{onnx_hash}.engine"
+    )
+    return cache_dir / "trt" / name
+
+
+def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig) -> None:
+    """Build a dynamic-batch TensorRT engine from ONNX and write it plus a manifest.
+
+    Args:
+        onnx_path: ONNX interchange file with a dynamic batch axis; the
+            optimization profile spans ``1..config.max_batch_size`` with the
+            optimum at ``config.opt_batch_size``.
+        engine_path: Output engine path (a ``.json`` manifest is written beside it).
+        config: Precision/batch/workspace build options.
+
+    Raises:
+        RuntimeError: If ONNX parsing or engine serialization fails, or an
+            input has dynamic non-batch dimensions.
+    """
+    trt: Any = _import_tensorrt()
+    logger: Any = trt.Logger(trt.Logger.WARNING)
+    builder: Any = trt.Builder(logger)
+    network: Any = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
+    parser: Any = trt.OnnxParser(network, logger)
+    # parse_from_file (not parse(bytes)) so external weight data, if any,
+    # resolves relative to the model file.
+    if not parser.parse_from_file(str(onnx_path.expanduser())):
+        errors: str = "\n".join(str(parser.get_error(i)) for i in range(parser.num_errors))
+        raise RuntimeError(f"ONNX parse failed for {onnx_path}:\n{errors}")
+    builder_config: Any = builder.create_builder_config()
+    builder_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, int(config.workspace_gib * (1 << 30)))
+    builder_config.builder_optimization_level = int(config.builder_optimization_level)
+    if config.precision == "fp16":
+        builder_config.set_flag(trt.BuilderFlag.FP16)
+    elif config.precision == "bf16":
+        builder_config.set_flag(trt.BuilderFlag.BF16)
+    profile: Any = builder.create_optimization_profile()
+    for idx in range(int(network.num_inputs)):
+        tensor: Any = network.get_input(idx)
+        shape: tuple[int, ...] = tuple(int(dim) for dim in tensor.shape)
+        if any(dim < 0 for dim in shape[1:]):
+            raise RuntimeError(f"ONNX input {tensor.name!r} has dynamic non-batch dims {shape}; per-sample shapes must be static.")
+        if shape[0] >= 0:
+            raise RuntimeError(f"ONNX input {tensor.name!r} has static batch {shape[0]}; re-export with a dynamic batch axis.")
+        per_sample: tuple[int, ...] = shape[1:]
+        profile.set_shape(tensor.name, (1, *per_sample), (config.opt_batch_size, *per_sample), (config.max_batch_size, *per_sample))
+    builder_config.add_optimization_profile(profile)
+    serialized: Any = builder.build_serialized_network(network, builder_config)
+    if serialized is None:
+        raise RuntimeError(f"TensorRT engine build failed for {onnx_path}.")
+    engine_path.parent.mkdir(parents=True, exist_ok=True)
+    # pid-unique temp + atomic rename so an interrupted or concurrent build
+    # never leaves a truncated engine at the final path (ensure_engine treats
+    # existence as readiness).
+    tmp_engine_path: Path = engine_path.with_name(f"{engine_path.name}.part{os.getpid()}")
+    tmp_engine_path.write_bytes(bytes(serialized))
+    tmp_engine_path.rename(engine_path)
+    manifest: dict[str, Any] = {
+        "onnx_path": str(onnx_path),
+        "onnx_sha256": _onnx_content_hash(onnx_path),
+        "engine_path": str(engine_path),
+        "portable_engine": False,
+        "rebuild_from_onnx_on_target_machine": True,
+        "max_batch_size": config.max_batch_size,
+        "opt_batch_size": config.opt_batch_size,
+        "precision": config.precision,
+        "workspace_gib": config.workspace_gib,
+        "builder_optimization_level": config.builder_optimization_level,
+        "tensorrt_version": str(trt.__version__),
+        "cuda_device_name": torch.cuda.get_device_name(),
+        "cuda_compute_capability": list(torch.cuda.get_device_capability()),
+    }
+    engine_path.with_suffix(engine_path.suffix + ".json").write_text(json.dumps(manifest, indent=2) + "\n")
+
+
+def ensure_engine(onnx_path: Path, config: TrtBuildConfig, cache_dir: Path = DEFAULT_CACHE_DIR) -> Path:
+    """Return a cached engine for this ONNX file, building it on first use.
+
+    Args:
+        onnx_path: ONNX interchange file the engine is built from.
+        config: Precision/batch/workspace build options.
+        cache_dir: Cache root; the engine lands in ``cache_dir / "trt"``.
+
+    Returns:
+        Path to a ready-to-load engine matching this machine and config.
+    """
+    engine_path: Path = cached_engine_path(onnx_path, config, cache_dir=cache_dir)
+    if not engine_path.exists():
+        print(f"[prompt-da] building TensorRT engine (one-time, may take minutes): {engine_path.name}")
+        build_engine(onnx_path, engine_path, config)
+    return engine_path
+
+
+def _checkpoint_revision(ckpt_path: Path) -> str:
+    """Short revision identifying a resolved HF checkpoint file.
+
+    Args:
+        ckpt_path: Checkpoint path returned by ``hf_hub_download`` (its HF cache
+            layout is ``…/snapshots/<commit>/model.ckpt``).
+
+    Returns:
+        First 8 chars of the snapshot commit, or a size-based tag for
+        checkpoints outside the HF cache layout.
+    """
+    parts: tuple[str, ...] = ckpt_path.parts
+    if "snapshots" in parts:
+        return parts[parts.index("snapshots") + 1][:8]
+    return f"size{ckpt_path.stat().st_size}"
+
+
+def _onnx_content_hash(onnx_path: Path) -> str:
+    """Hex SHA-256 of an ONNX model, covering its external weight file if present.
+
+    Args:
+        onnx_path: ONNX model file (large exports may keep weights in a
+            sibling ``<name>.onnx.data`` file).
+
+    Returns:
+        Hex digest string over the proto and any external data.
+    """
+    digest = hashlib.sha256()
+    for path in (onnx_path.expanduser(), onnx_path.expanduser().with_suffix(".onnx.data")):
+        if not path.exists():
+            continue
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1 << 20), b""):
+                digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _import_tensorrt() -> Any:
+    """Import TensorRT lazily so non-TRT code paths can import this module.
+
+    Returns:
+        Imported TensorRT Python module.
+
+    Raises:
+        RuntimeError: If TensorRT bindings are not installed in the active Pixi environment.
+    """
+    try:
+        import tensorrt as trt
+    except ImportError as exc:
+        raise RuntimeError("TensorRT Python bindings are not installed in this Pixi environment.") from exc
+    return trt

--- a/packages/prompt-da/src/rerun_prompt_da/trt_predictor.py
+++ b/packages/prompt-da/src/rerun_prompt_da/trt_predictor.py
@@ -1,0 +1,254 @@
+"""Batched GPU predictors for Prompt Depth Anything (TensorRT and torch).
+
+Both predictors share one tensor contract so they are interchangeable in
+pipelines and parity tests: uint8 RGB ``[B,H,W,3]`` frames plus float32 metric
+prompt depth ``[B,192,256]`` in, float32 metric depth ``[B,H,W]`` out, all
+torch CUDA tensors. Preprocessing (resize to the 14-aligned network
+resolution, [0,1] scaling) and postprocessing (resize back to the input
+resolution) run on the GPU, so a video decoder can feed CUDA tensors straight
+through without host round-trips.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from einops import rearrange
+from jaxtyping import Float32, UInt8
+from torch import Tensor
+
+from rerun_prompt_da.trt_engine import (
+    DEFAULT_CACHE_DIR,
+    PROMPT_DEPTH_HW,
+    ModelType,
+    TrtBuildConfig,
+    TrtPrecision,
+    _import_tensorrt,
+    ensure_engine,
+    export_promptda_onnx,
+)
+
+
+def preprocess_batch(
+    rgb_bhw3: UInt8[Tensor, "b h w 3"],
+    prompt_depth_bhw: Float32[Tensor, "b 192 256"],
+    image_hw: tuple[int, int],
+) -> tuple[Float32[Tensor, "b 3 nh nw"], Float32[Tensor, "b 1 192 256"]]:
+    """Prepare a uint8 RGB batch and metric prompt depth for the network.
+
+    Args:
+        rgb_bhw3: uint8 RGB frames, any resolution (moved to CUDA if needed).
+        prompt_depth_bhw: float32 prompt depth in meters at the ARKit LiDAR resolution.
+        image_hw: Static network (height, width), multiples of 14.
+
+    Returns:
+        float32 CUDA tensors: RGB ``[B,3,nh,nw]`` in [0,1] resized to
+        ``image_hw``, and prompt depth ``[B,1,192,256]`` in meters.
+    """
+    rgb_b3hw: Float32[Tensor, "b 3 h w"] = rearrange(rgb_bhw3.to("cuda", non_blocking=True), "b h w c -> b c h w").float() / 255.0
+    if tuple(rgb_b3hw.shape[-2:]) != image_hw:
+        # antialias=True approximates the cv2 INTER_AREA downscale the torch demo uses.
+        rgb_b3hw = F.interpolate(rgb_b3hw, size=image_hw, mode="bilinear", antialias=True)
+    prompt_b1hw: Float32[Tensor, "b 1 192 256"] = rearrange(prompt_depth_bhw.to("cuda", non_blocking=True), "b h w -> b 1 h w")
+    return rgb_b3hw, prompt_b1hw
+
+
+def postprocess_depth(
+    depth_b1hw: Float32[Tensor, "b 1 nh nw"],
+    out_hw: tuple[int, int],
+) -> Float32[Tensor, "b h w"]:
+    """Resize network depth back to the input resolution.
+
+    Args:
+        depth_b1hw: float32 CUDA metric depth at the network resolution (may be
+            a view into a reused runtime buffer).
+        out_hw: Target (height, width) — the caller's input resolution.
+
+    Returns:
+        float32 CUDA metric depth at ``out_hw``, owning its memory — safe to
+        hold across predictor calls.
+    """
+    if tuple(depth_b1hw.shape[-2:]) != out_hw:
+        depth_b1hw = F.interpolate(depth_b1hw, size=out_hw, mode="bilinear", align_corners=False)
+    else:
+        depth_b1hw = depth_b1hw.clone()
+    return rearrange(depth_b1hw, "b 1 h w -> b h w")
+
+
+class PromptDATrtRuntime:
+    """A deserialized PromptDA engine with persistent torch-tensor I/O.
+
+    Buffers are allocated once at the profile's max batch and bound via
+    ``set_tensor_address``; each call copies inputs in, runs the true batch
+    size through ``execute_async_v3`` on a dedicated stream (ordered against
+    torch's current stream on both sides), and returns a view into the output
+    buffer sliced to the submitted batch. The view is overwritten by the next
+    call — clone it if it must survive.
+    """
+
+    def __init__(self, engine_path: Path) -> None:
+        """Deserialize a machine-local engine and bind persistent I/O buffers.
+
+        Args:
+            engine_path: Engine built by :func:`rerun_prompt_da.trt_engine.ensure_engine`.
+
+        Raises:
+            RuntimeError: If CUDA is unavailable or the engine fails to load.
+        """
+        if not torch.cuda.is_available():
+            raise RuntimeError("TensorRT execution requires CUDA.")
+        trt: Any = _import_tensorrt()
+        engine: Any = trt.Runtime(trt.Logger(trt.Logger.WARNING)).deserialize_cuda_engine(engine_path.expanduser().read_bytes())
+        context: Any = None if engine is None else engine.create_execution_context()
+        if engine is None or context is None:
+            raise RuntimeError(f"Could not load TensorRT engine: {engine_path}")
+        self._engine: Any = engine
+        self._context: Any = context
+        self._device: torch.device = torch.device("cuda")
+        image_shape: tuple[int, ...] = tuple(int(dim) for dim in engine.get_tensor_shape("image"))
+        prompt_shape: tuple[int, ...] = tuple(int(dim) for dim in engine.get_tensor_shape("prompt_depth"))
+        depth_shape: tuple[int, ...] = tuple(int(dim) for dim in engine.get_tensor_shape("depth"))
+        profile_max: tuple[int, ...] = tuple(int(dim) for dim in engine.get_tensor_profile_shape("image", 0)[2])
+        self.max_batch_size: int = profile_max[0]
+        self.image_hw: tuple[int, int] = (image_shape[2], image_shape[3])
+        # Persistent buffers: stable addresses are required for the one-time
+        # set_tensor_address binding.
+        self._buffers: dict[str, Tensor] = {
+            "image": torch.zeros((self.max_batch_size, *image_shape[1:]), dtype=torch.float32, device=self._device),
+            "prompt_depth": torch.zeros((self.max_batch_size, *prompt_shape[1:]), dtype=torch.float32, device=self._device),
+            "depth": torch.empty((self.max_batch_size, *depth_shape[1:]), dtype=torch.float32, device=self._device),
+        }
+        for name, tensor in self._buffers.items():
+            self._context.set_tensor_address(name, int(tensor.data_ptr()))
+        self._active_batch: int = -1
+        self._stream: torch.cuda.Stream = torch.cuda.Stream(device=self._device)
+
+    def __call__(
+        self,
+        image_b3hw: Float32[Tensor, "b 3 h w"],
+        prompt_depth_b1hw: Float32[Tensor, "b 1 192 256"],
+    ) -> Float32[Tensor, "b 1 h w"]:
+        """Run one batch at its true size through the dynamic engine.
+
+        Args:
+            image_b3hw: float32 CUDA RGB batch in [0,1] at the engine resolution.
+            prompt_depth_b1hw: float32 CUDA prompt depth in meters.
+
+        Returns:
+            float32 CUDA metric depth, a view into the reused output buffer
+            sliced to the submitted batch size.
+
+        Raises:
+            ValueError: If the batch exceeds the engine's profile max.
+            RuntimeError: If TensorRT reports a failed launch.
+        """
+        batch_size: int = image_b3hw.shape[0]
+        if batch_size > self.max_batch_size:
+            raise ValueError(f"Batch {batch_size} exceeds the engine's max batch {self.max_batch_size}; chunk the input.")
+        self._buffers["image"][:batch_size].copy_(image_b3hw)
+        self._buffers["prompt_depth"][:batch_size].copy_(prompt_depth_b1hw)
+        if batch_size != self._active_batch:
+            self._context.set_input_shape("image", (batch_size, 3, *self.image_hw))
+            self._context.set_input_shape("prompt_depth", (batch_size, 1, *PROMPT_DEPTH_HW))
+            self._active_batch = batch_size
+        current: torch.cuda.Stream = torch.cuda.current_stream(self._device)
+        self._stream.wait_stream(current)
+        with torch.cuda.stream(self._stream):
+            ok: bool = bool(self._context.execute_async_v3(stream_handle=int(self._stream.cuda_stream)))
+        if not ok:
+            raise RuntimeError("TensorRT execute_async_v3 failed.")
+        current.wait_stream(self._stream)
+        return self._buffers["depth"][:batch_size]
+
+
+class PromptDATrtPredictor:
+    """Batched PromptDA depth completion on a cached dynamic-batch TensorRT engine."""
+
+    def __init__(
+        self,
+        model_type: ModelType = "large",
+        image_hw: tuple[int, int] = (756, 1008),
+        batch_size: int = 8,
+        precision: TrtPrecision = "fp16",
+        cache_dir: Path = DEFAULT_CACHE_DIR,
+    ) -> None:
+        """Export ONNX and build/load the machine-local engine on first use.
+
+        Args:
+            model_type: PromptDA checkpoint variant.
+            image_hw: Static network (height, width), multiples of 14.
+            batch_size: Engine profile max and optimum batch.
+            precision: TensorRT builder precision.
+            cache_dir: Cache root for ONNX and engine artifacts.
+        """
+        onnx_path: Path = export_promptda_onnx(model_type=model_type, image_hw=image_hw, cache_dir=cache_dir)
+        config = TrtBuildConfig(max_batch_size=batch_size, opt_batch_size=batch_size, precision=precision)
+        engine_path: Path = ensure_engine(onnx_path, config, cache_dir=cache_dir)
+        self.runtime = PromptDATrtRuntime(engine_path)
+        self.image_hw: tuple[int, int] = image_hw
+
+    def __call__(
+        self,
+        rgb_bhw3: UInt8[Tensor, "b h w 3"],
+        prompt_depth_bhw: Float32[Tensor, "b 192 256"],
+    ) -> Float32[Tensor, "b h w"]:
+        """Complete metric depth for a batch of frames.
+
+        Args:
+            rgb_bhw3: uint8 RGB frames at any resolution.
+            prompt_depth_bhw: float32 prompt depth in meters.
+
+        Returns:
+            float32 CUDA metric depth in meters at the input resolution
+            (owning its memory — safe to hold across calls).
+        """
+        in_hw: tuple[int, int] = (rgb_bhw3.shape[1], rgb_bhw3.shape[2])
+        image_b3hw: Float32[Tensor, "b 3 nh nw"]
+        prompt_b1hw: Float32[Tensor, "b 1 192 256"]
+        image_b3hw, prompt_b1hw = preprocess_batch(rgb_bhw3, prompt_depth_bhw, self.image_hw)
+        depth_b1hw: Float32[Tensor, "b 1 nh nw"] = self.runtime(image_b3hw, prompt_b1hw)
+        return postprocess_depth(depth_b1hw, in_hw)
+
+
+class PromptDATorchPredictor:
+    """Plain-torch twin of :class:`PromptDATrtPredictor` for parity and baselines."""
+
+    def __init__(
+        self,
+        model_type: ModelType = "large",
+        image_hw: tuple[int, int] = (756, 1008),
+    ) -> None:
+        """Load the fp32 torch PromptDA network onto the GPU.
+
+        Args:
+            model_type: PromptDA checkpoint variant.
+            image_hw: Static network (height, width), multiples of 14.
+        """
+        from monopriors.models.depth_completion.prompt_da import NAME_TO_HFNAME
+        from monopriors.third_party.promptda.promptda import PromptDA
+
+        self.model = PromptDA.from_pretrained(NAME_TO_HFNAME[model_type]).to("cuda").eval()
+        self.image_hw: tuple[int, int] = image_hw
+
+    def __call__(
+        self,
+        rgb_bhw3: UInt8[Tensor, "b h w 3"],
+        prompt_depth_bhw: Float32[Tensor, "b 192 256"],
+    ) -> Float32[Tensor, "b h w"]:
+        """Complete metric depth for a batch of frames (same contract as TRT).
+
+        Args:
+            rgb_bhw3: uint8 RGB frames at any resolution.
+            prompt_depth_bhw: float32 prompt depth in meters.
+
+        Returns:
+            float32 CUDA metric depth in meters at the input resolution.
+        """
+        in_hw: tuple[int, int] = (rgb_bhw3.shape[1], rgb_bhw3.shape[2])
+        image_b3hw: Float32[Tensor, "b 3 nh nw"]
+        prompt_b1hw: Float32[Tensor, "b 1 192 256"]
+        image_b3hw, prompt_b1hw = preprocess_batch(rgb_bhw3, prompt_depth_bhw, self.image_hw)
+        with torch.inference_mode():
+            depth_b1hw: Float32[Tensor, "b 1 nh nw"] = self.model(image_b3hw, prompt_b1hw)
+        return postprocess_depth(depth_b1hw, in_hw)

--- a/packages/prompt-da/tests/test_trt_predictor.py
+++ b/packages/prompt-da/tests/test_trt_predictor.py
@@ -1,0 +1,135 @@
+"""Unit tests for the PromptDA TensorRT engine/predictor helpers.
+
+Fast checks run everywhere; GPU-only checks skip without CUDA; the full
+export->build->parity path is opt-in via ``PROMPTDA_TRT_E2E=1`` because the
+first run builds an engine (minutes).
+"""
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from rerun_prompt_da.apis.prompt_da_trt_polycam import network_image_hw
+from rerun_prompt_da.trt_engine import TrtBuildConfig, cached_engine_path
+
+requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+
+def test_network_image_hw_downscales_and_14_aligns() -> None:
+    """The Polycam capture resolution maps to the 14-aligned network size."""
+
+    assert network_image_hw((768, 1024), max_image_size=1008) == (756, 1008)
+
+
+def test_network_image_hw_never_upscales() -> None:
+    """Captures smaller than max_image_size only get 14-aligned, not enlarged."""
+
+    assert network_image_hw((280, 294), max_image_size=1008) == (280, 294)
+    assert network_image_hw((290, 300), max_image_size=1008) == (280, 294)
+
+
+def test_cached_engine_path_rejects_bad_batch_range() -> None:
+    """opt_batch_size outside [1, max_batch_size] is a configuration error."""
+
+    config = TrtBuildConfig(max_batch_size=4, opt_batch_size=8)
+    with pytest.raises(ValueError, match="opt_batch_size"):
+        cached_engine_path(Path("model.onnx"), config)
+
+
+@requires_cuda
+def test_cached_engine_path_is_deterministic_and_cache_keyed() -> None:
+    """The engine name encodes batch range, precision, TRT version, and SM."""
+
+    config = TrtBuildConfig(max_batch_size=8, opt_batch_size=8, precision="fp16")
+    first: Path = cached_engine_path(Path("promptda-large_756x1008_op17.onnx"), config)
+    second: Path = cached_engine_path(Path("promptda-large_756x1008_op17.onnx"), config)
+    assert first == second
+    assert "_b1-8-8_fp16_" in first.name
+    other: Path = cached_engine_path(Path("promptda-large_756x1008_op17.onnx"), TrtBuildConfig(max_batch_size=4, opt_batch_size=4))
+    assert other != first
+
+
+@requires_cuda
+def test_preprocess_batch_shapes_dtypes_and_range() -> None:
+    """Preprocessing yields normalized float32 CUDA tensors at the network size."""
+
+    from rerun_prompt_da.trt_predictor import preprocess_batch
+
+    rgb_bhw3 = torch.randint(0, 256, (2, 768, 1024, 3), dtype=torch.uint8)
+    prompt_bhw = torch.rand((2, 192, 256), dtype=torch.float32) * 4.0
+
+    image_b3hw, prompt_b1hw = preprocess_batch(rgb_bhw3, prompt_bhw, image_hw=(756, 1008))
+
+    assert image_b3hw.shape == (2, 3, 756, 1008)
+    assert image_b3hw.dtype == torch.float32
+    assert image_b3hw.is_cuda
+    assert image_b3hw.min().item() >= 0.0
+    assert image_b3hw.max().item() <= 1.0
+    assert prompt_b1hw.shape == (2, 1, 192, 256)
+    assert prompt_b1hw.is_cuda
+
+
+@pytest.mark.skipif(os.environ.get("PROMPTDA_TRT_E2E") != "1", reason="set PROMPTDA_TRT_E2E=1 to run the engine-building parity test")
+@requires_cuda
+def test_trt_matches_torch_on_synthetic_frames() -> None:
+    """The fp16 TRT engine agrees with the fp32 torch model within tolerance."""
+
+    from rerun_prompt_da.trt_predictor import PromptDATorchPredictor, PromptDATrtPredictor
+
+    rgb_bhw3 = torch.randint(0, 256, (8, 768, 1024, 3), dtype=torch.uint8, generator=torch.Generator().manual_seed(0))
+    prompt_bhw = torch.rand((8, 192, 256), dtype=torch.float32, generator=torch.Generator().manual_seed(1)) * 3.0 + 0.5
+
+    trt_predictor = PromptDATrtPredictor(batch_size=8, precision="fp16")
+    torch_predictor = PromptDATorchPredictor()
+    depth_trt = trt_predictor(rgb_bhw3.cuda(), prompt_bhw.cuda())
+    depth_torch = torch_predictor(rgb_bhw3.cuda(), prompt_bhw.cuda())
+    torch.cuda.synchronize()
+
+    assert depth_trt.shape == depth_torch.shape == (8, 768, 1024)
+    diff_mm = (depth_trt - depth_torch).abs().mul(1000.0)
+    assert diff_mm.median().item() < 10.0
+    # Partial batches run through the same dynamic engine.
+    depth_b3 = trt_predictor(rgb_bhw3[:3].cuda(), prompt_bhw[:3].cuda())
+    torch.cuda.synchronize()
+    np.testing.assert_allclose(
+        depth_b3.cpu().numpy(),
+        depth_trt[:3].cpu().numpy(),
+        atol=5e-2,
+    )
+
+
+@pytest.mark.skipif(os.environ.get("PROMPTDA_TRT_E2E") != "1", reason="set PROMPTDA_TRT_E2E=1 to run the engine-building parity test")
+@requires_cuda
+def test_trt_matches_original_numpy_pipeline() -> None:
+    """The TRT path agrees with monoprior's original PromptDAPredictor end to end.
+
+    This crosses the preprocessing boundary on purpose: the original uses cv2
+    INTER_AREA on uint8, the TRT path uses GPU bilinear-antialias on float. On
+    smooth (low-frequency) frames the completed depth must still match closely.
+    """
+
+    import torch.nn.functional as F
+    from monopriors.models.depth_completion.prompt_da import PromptDAPredictor
+
+    from rerun_prompt_da.trt_predictor import PromptDATrtPredictor
+
+    generator = torch.Generator().manual_seed(7)
+    low_freq = torch.rand((2, 3, 24, 32), generator=generator)
+    rgb_b3hw = F.interpolate(low_freq, size=(768, 1024), mode="bilinear", align_corners=False)
+    rgb_bhw3 = (rgb_b3hw * 255.0).to(torch.uint8).permute(0, 2, 3, 1).contiguous()
+    prompt_base = torch.rand((2, 1, 12, 16), generator=generator) * 3.0 + 0.5
+    prompt_m = F.interpolate(prompt_base, size=(192, 256), mode="bilinear", align_corners=False)[:, 0]
+
+    trt_predictor = PromptDATrtPredictor(batch_size=8, precision="fp16")
+    depth_trt_mm = (trt_predictor(rgb_bhw3.cuda(), prompt_m.cuda()) * 1000.0).cpu().numpy()
+    torch.cuda.synchronize()
+
+    original = PromptDAPredictor(device="cuda", model_type="large", max_size=1008)
+    for i in range(rgb_bhw3.shape[0]):
+        prompt_mm_u16 = (prompt_m[i].numpy() * 1000.0).astype(np.uint16)
+        depth_orig_mm = original(rgb=rgb_bhw3[i].numpy(), prompt_depth=prompt_mm_u16).depth_mm
+        diff_mm = np.abs(depth_trt_mm[i] - depth_orig_mm.astype(np.float32))
+        assert np.median(diff_mm) < 20.0, f"frame {i}: median {np.median(diff_mm):.1f} mm vs original pipeline"

--- a/packages/prompt-da/tools/prompt_da_trt_polycam.py
+++ b/packages/prompt-da/tools/prompt_da_trt_polycam.py
@@ -1,0 +1,9 @@
+import tyro
+
+from rerun_prompt_da.apis.prompt_da_trt_polycam import (
+    PDATrtPolycamConfig,
+    pda_trt_polycam_inference,
+)
+
+if __name__ == "__main__":
+    pda_trt_polycam_inference(tyro.cli(PDATrtPolycamConfig))

--- a/pixi.lock
+++ b/pixi.lock
@@ -16169,6 +16169,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/38/31/7ff3f7768eded7535c621abc2fecb9d181a34ea4cae3afe682feb796f242/cuda_python-13.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3f/95/0ad40fb92ba3e6fe36182f722f81d69842a1e93cab1d9c6171256ef55418/gradio-6.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl
@@ -16197,6 +16198,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a5/0b/f68a968b49876eae0f2a515387093cebb2eb9451380a96741cc20efac0d0/s3fs-2026.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/ce/a2fb0d865c3d6ac7be80c96d32d6dbe728ebc54010cf2d4e563576265787/tensorrt_cu13_libs-10.13.3.9.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/a7/00/4823f06357892d1e60d6f34e7299d2ba4ed2108c487cc394f7ce85a3ff14/onnx-1.21.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/db/253133d7e7cb40d3af384bb2f5c0b4a2b7fdcffbc95c688cc67a20a3c103/accelerate-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl
@@ -16770,6 +16772,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/38/31/7ff3f7768eded7535c621abc2fecb9d181a34ea4cae3afe682feb796f242/cuda_python-13.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3f/95/0ad40fb92ba3e6fe36182f722f81d69842a1e93cab1d9c6171256ef55418/gradio-6.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl
@@ -16799,6 +16802,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a5/0b/f68a968b49876eae0f2a515387093cebb2eb9451380a96741cc20efac0d0/s3fs-2026.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/ce/a2fb0d865c3d6ac7be80c96d32d6dbe728ebc54010cf2d4e563576265787/tensorrt_cu13_libs-10.13.3.9.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/a7/00/4823f06357892d1e60d6f34e7299d2ba4ed2108c487cc394f7ce85a3ff14/onnx-1.21.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/db/253133d7e7cb40d3af384bb2f5c0b4a2b7fdcffbc95c688cc67a20a3c103/accelerate-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl

--- a/pixi.toml
+++ b/pixi.toml
@@ -536,6 +536,9 @@ open3d = ">=0.19.0,<0.20"
 rerun-prompt-da = { path = "packages/prompt-da", editable = true }
 monopriors = { path = "packages/monoprior", editable = true }
 sam3 = { path = "packages/sam3", editable = true }
+# torch's legacy ONNX exporter needs the onnx package to serialize the proto
+# (TensorRT itself comes from the shared cuda feature).
+onnx = "*"
 
 [feature.prompt-da.activation.env]
 PACKAGE_DIR = "packages/prompt-da"
@@ -553,6 +556,12 @@ cmd = "python tools/prompt_da_polycam.py --polycam-zip-path data/6G-room-example
 depends-on = ["_prompt-da-download-polycam-example"]
 cwd = "packages/prompt-da"
 description = "Run PromptDA on the example Polycam dataset"
+
+[feature.prompt-da-demo.tasks.prompt-da-trt-polycam]
+cmd = "python tools/prompt_da_trt_polycam.py --polycam-zip-path data/6G-room-example.zip"
+depends-on = ["_prompt-da-download-polycam-example"]
+cwd = "packages/prompt-da"
+description = "Run batched TensorRT PromptDA on the example Polycam dataset"
 
 [feature.prompt-da-demo.tasks.prompt-da-app]
 cmd = "python tools/gradio_app.py"

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -88,6 +88,7 @@ site-package-path = [
     ".pixi/envs/simplecv-dev/lib/python3.12/site-packages/rerun_sdk",
     ".pixi/envs/arkitscenes-download-dev/lib/python3.12/site-packages",
     ".pixi/envs/prompt-da-dev/lib/python3.12/site-packages",
+    ".pixi/envs/prompt-da-dev/lib/python3.12/site-packages/rerun_sdk",
     ".pixi/envs/wilor-nano-dev/lib/python3.12/site-packages",
     ".pixi/envs/sam3d-body-dev/lib/python3.12/site-packages",
     ".pixi/envs/sam3-dev/lib/python3.12/site-packages",


### PR DESCRIPTION
Converts the PromptDA Polycam demo to a dynamic-batch fp16 TensorRT engine, with **prompt-da owning the whole acceleration path**: it exports the ONNX graph from monoprior's torch model, builds machine-local engines, and runs them with torch-tensor I/O end to end. monoprior's only change is a 3-line export-compat fix (`normalize()` quantile(0/1) → `amin`/`amax`, numerically identical).

**Numbers** (RTX 5090, 756×1008, 105-frame capture):

| backend | ms/frame (model) | FPS |
|---|---|---|
| TRT fp16, b8 | 19.5–20.2 | ~50 |
| TRT fp16, b1 | 21.3 | 47 |
| torch fp32 | 178.9 | 5.6 |

fp16 parity vs fp32 torch: **0.5 mm mean / 3.4 mm p99** (0.043% rel); batch-1 and batch-8 through the same engine are bitwise identical. Full demo (`prompt-da-trt-polycam` task): **31.5 FPS end-to-end** incl. frame decode, confidence filtering, CPU TSDF fusion, and Rerun logging — profiled per-stage, the model is now 69% of the frame; fusion is 2.6 ms.

**Design**
- `trt_engine.py` — legacy-exporter ONNX (opset 17, `dynamo=False`, batch-only dynamic axes: dynamo exports fail TRT 10.13 parsing, per mamma), dynamic profile min=1/opt=8/max=8. ONNX cached by model + resolution + **checkpoint HF revision + export version**; engines by ONNX hash + precision + TRT version + SM, all published via pid-unique temp + atomic rename. `~/.cache/prompt-da/{onnx,trt}`, `PROMPTDA_TRT_CACHE` override.
- `trt_predictor.py` — runtime with persistent max-batch CUDA buffers bound once via `set_tensor_address`, true-batch `set_input_shape`, `execute_async_v3` on a dedicated stream ordered against torch's current stream. `PromptDATrtPredictor` + a `PromptDATorchPredictor` twin share one batched GPU contract (uint8 NHWC frames + float32 metric prompt → float32 metric depth), ready for a video decoder to feed CUDA tensors directly.
- `apis/prompt_da_trt_polycam.py` + thin tool shim — streams the capture in batch-sized chunks (bounded memory on long recordings), same Rerun entity layout as the torch demo, prints model + pipeline throughput.
- TensorRT 10.13.3.9 / onnxruntime already come from the shared `cuda` feature; the only new dep is `onnx` (torch's legacy exporter needs it to serialize). Lock re-solved on linux-64 for the prompt-da group only.

**Not posekit**: #64 is unmerged, so this adapts the same dynamic-batch conventions standalone; the runtime can migrate to posekit later. Consumes nothing from #63/#65, but the batched tensor contract is shaped for simplecv `get_frames_at` GPU decode next.

**Validation**: 10 tests green — incl. two gated e2e parity tests (`PROMPTDA_TRT_E2E=1`): TRT vs the torch twin, and TRT vs the *original* numpy `PromptDAPredictor` across the cv2-INTER_AREA/GPU-bilinear preprocessing boundary (<20 mm median on smooth frames). lint/typecheck/deadcode clean for prompt-da and monoprior. Viewer-validated headless: fused mesh + both depth views render, 105-frame timeline sweep confirmed frame-by-frame. Adversarially reviewed (memory-bounded streaming, cache identity, atomic publication all came out of that pass) plus a 3-reviewer simplify pass.