### PR TITLE
Monorepo quality sweep: stale imports, Optional narrowing, missing package .envrc files

### DIFF
--- a/packages/live-rerun/.envrc
+++ b/packages/live-rerun/.envrc
@@ -1,0 +1,4 @@
+watch_file ../../pixi.lock
+PIXI_ENV="${PIXI_ENV:-live-rerun-dev}"
+source_env_if_exists .envrc.local
+eval "$(pixi shell-hook -e "$PIXI_ENV" --manifest-path ../.. --frozen)"

--- a/packages/live-rerun/tests/test_calibration.py
+++ b/packages/live-rerun/tests/test_calibration.py
@@ -95,7 +95,7 @@ def test_non_reference_translation_converted_cm_to_m() -> None:
     # DepthAI's getCameraExtrinsics(ref, socket) is cam_T_world (rig->cam), so the
     # raw cm translation (scaled to m) is cam_t_world; the camera's pose in the rig
     # (world_t_cam) is its inverse.
-    assert rgb_pose.cam_t_world is not None
+    assert rgb_pose.cam_t_world is not None and rgb_pose.world_t_cam is not None
     np.testing.assert_allclose(rgb_pose.cam_t_world, [0.075, -0.02, 0.0])
     np.testing.assert_allclose(rgb_pose.world_t_cam, [-0.075, 0.02, 0.0])
 
@@ -108,6 +108,7 @@ def test_non_reference_camera_pose_is_inverse_of_depthai_transform() -> None:
     """
     rig = _ordered_rig()
     right = rig.cameras[2].pinhole.extrinsics
+    assert right.world_t_cam is not None and right.cam_t_world is not None
     # right_ext (depthai) translation was [-7.5, 0, 0] cm -> right camera sits at +X.
     np.testing.assert_allclose(right.world_t_cam, [0.075, 0.0, 0.0], atol=1e-9)
     np.testing.assert_allclose(right.cam_t_world, [-0.075, 0.0, 0.0], atol=1e-9)

--- a/packages/mamma/.envrc
+++ b/packages/mamma/.envrc
@@ -1,0 +1,4 @@
+watch_file ../../pixi.lock
+PIXI_ENV="${PIXI_ENV:-mamma-dev}"
+source_env_if_exists .envrc.local
+eval "$(pixi shell-hook -e "$PIXI_ENV" --manifest-path ../.. --frozen)"

--- a/packages/posekit/.envrc
+++ b/packages/posekit/.envrc
@@ -1,0 +1,4 @@
+watch_file ../../pixi.lock
+PIXI_ENV="${PIXI_ENV:-posekit-dev}"
+source_env_if_exists .envrc.local
+eval "$(pixi shell-hook -e "$PIXI_ENV" --manifest-path ../.. --frozen)"

--- a/packages/sam3d-body/src/sam3d_body/api/demo_mv_body.py
+++ b/packages/sam3d-body/src/sam3d_body/api/demo_mv_body.py
@@ -20,6 +20,7 @@ See Also:
 
 from __future__ import annotations
 
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -506,12 +507,21 @@ def main(cfg: Sam3MVBodyDemoConfig) -> None:
                 if exo_video_blobs and stream_name in exo_video_blobs
                 else video_file
             )
-            # Skip if file path doesn't exist (shouldn't happen with blobs)
-            if isinstance(video_source, Path) and not video_source.exists():
-                continue
+            # log_video (rr.AssetVideo / Mp4Reader) accepts only file paths —
+            # spill RRD blobs to a temp file first.
+            if isinstance(video_source, bytes):
+                with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as blob_file:
+                    blob_file.write(video_source)
+                video_path: Path = Path(blob_file.name)
+            else:
+                if not video_source.exists():
+                    continue
+                video_path = video_source
             timestamps_ns: Int[ndarray, "n_frames"] = log_video(
-                video_source, video_log_path, timeline=timeline
+                video_path, video_log_path, timeline=timeline
             )
+            if isinstance(video_source, bytes):
+                video_path.unlink()
             video_timestamps[stream_name] = timestamps_ns
 
     total_frames: int = len(sequence)

--- a/packages/sapiens-coco133-pose/.envrc
+++ b/packages/sapiens-coco133-pose/.envrc
@@ -1,0 +1,4 @@
+watch_file ../../pixi.lock
+PIXI_ENV="${PIXI_ENV:-sapiens-coco133-pose-dev}"
+source_env_if_exists .envrc.local
+eval "$(pixi shell-hook -e "$PIXI_ENV" --manifest-path ../.. --frozen)"

--- a/packages/sapiens-coco133-pose/src/sapiens_coco133_pose/api/iterable.py
+++ b/packages/sapiens-coco133-pose/src/sapiens_coco133_pose/api/iterable.py
@@ -23,6 +23,48 @@ from sapiens2_pose.api.runtime import (
 from sapiens_coco133_pose.api.artifact import Coco133PoseFrame, write_video_pose_rrd
 
 TrackerMode = Literal["lightweight", "balanced", "performance", "wholebody"]
+
+
+@dataclass(frozen=True, slots=True)
+class _RtmlibAssets:
+    """RTMLib ONNX deploy-zip URLs and input sizes for one detector+pose preset."""
+
+    det: str
+    """Download URL for the YOLOX detector ONNX deploy zip."""
+    det_input_size: tuple[int, int]
+    """Input width-height pair expected by the detector."""
+    pose: str
+    """Download URL for the RTMPose ONNX deploy zip."""
+    pose_input_size: tuple[int, int]
+    """Input width-height pair expected by RTMPose."""
+
+
+RTMLIB_ASSETS: dict[TrackerMode, _RtmlibAssets] = {
+    "performance": _RtmlibAssets(
+        det="https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/yolox_x_8xb8-300e_humanart-a39d44ed.zip",
+        det_input_size=(640, 640),
+        pose="https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/rtmpose-x_simcc-body7_pt-body7_700e-384x288-71d7b7e9_20230629.zip",
+        pose_input_size=(288, 384),
+    ),
+    "lightweight": _RtmlibAssets(
+        det="https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/yolox_tiny_8xb8-300e_humanart-6f3252f9.zip",
+        det_input_size=(416, 416),
+        pose="https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/rtmpose-s_simcc-body7_pt-body7_420e-256x192-acd4a1ef_20230504.zip",
+        pose_input_size=(192, 256),
+    ),
+    "balanced": _RtmlibAssets(
+        det="https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/yolox_m_8xb8-300e_humanart-c2c7a14a.zip",
+        det_input_size=(640, 640),
+        pose="https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/rtmpose-m_simcc-body7_pt-body7_420e-256x192-e48f03d0_20230504.zip",
+        pose_input_size=(192, 256),
+    ),
+    "wholebody": _RtmlibAssets(
+        det="https://download.openmmlab.com/mmpose/v1/projects/rtmposev1/onnx_sdk/yolox_m_8xb8-300e_humanart-c2c7a14a.zip",
+        det_input_size=(640, 640),
+        pose="https://download.openmmlab.com/mmpose/v1/projects/rtmw/onnx_sdk/rtmw-dw-x-l_simcc-cocktail14_270e-256x192_20231122.zip",
+        pose_input_size=(192, 256),
+    ),
+}
 PoseBackend = Literal["sapiens", "rtmlib"]
 RtmlibBackend = Literal["onnxruntime", "opencv"]
 RtmlibDevice = Literal["cpu", "cuda"]
@@ -141,10 +183,9 @@ class RtmlibYoloxPersonDetector:
         Args:
             config: RTMLib detector backend, device, preset, and thresholds.
         """
-        from mv_api.multiview_pose_estimator import MODE
         from rtmlib import YOLOX
 
-        assets = MODE[config.mode]
+        assets = RTMLIB_ASSETS[config.mode]
         self._model = YOLOX(
             assets.det,
             model_input_size=assets.det_input_size,
@@ -181,10 +222,9 @@ class RtmlibCoco133PoseEstimator:
         Args:
             config: RTMLib pose backend, device, and preset.
         """
-        from mv_api.multiview_pose_estimator import MODE
         from rtmlib import RTMPose
 
-        assets = MODE[config.mode]
+        assets = RTMLIB_ASSETS[config.mode]
         self._model = RTMPose(
             assets.pose,
             model_input_size=assets.pose_input_size,

--- a/packages/sapiens2-pose/.envrc
+++ b/packages/sapiens2-pose/.envrc
@@ -1,0 +1,4 @@
+watch_file ../../pixi.lock
+PIXI_ENV="${PIXI_ENV:-sapiens2-pose-dev}"
+source_env_if_exists .envrc.local
+eval "$(pixi shell-hook -e "$PIXI_ENV" --manifest-path ../.. --frozen)"

--- a/packages/simplecv/pyproject.toml
+++ b/packages/simplecv/pyproject.toml
@@ -68,3 +68,5 @@ exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modu
 sort_by_size = true
 # SimpleCV exposes many public APIs and schema fields that Vulture reports at 60%.
 min_confidence = 80
+# Monkeypatched rr.send_columns lambdas must keep the API's keyword parameter names.
+ignore_names = ["indexes"]

--- a/packages/vistadream/src/vistadream/api/multi_image_pipeline.py
+++ b/packages/vistadream/src/vistadream/api/multi_image_pipeline.py
@@ -13,7 +13,8 @@ from einops import rearrange
 from jaxtyping import Bool, Float, Float32, UInt8
 from monopriors.apis.multiview_calibration import load_rgb_images
 from monopriors.depth_utils import depth_edges_mask, multidepth_to_points
-from monopriors.models.multiview.vggt_model import MultiviewPred, VGGTPredictor, robust_filter_confidences
+from monopriors.models.multiview.multiview_model import MultiviewPred, robust_filter_confidences
+from monopriors.models.multiview.multiview_predictor import MultiviewPredictor, MultiviewPredictorConfig
 from monopriors.models.relative_depth import (
     RelativeDepthPrediction,
     get_relative_predictor,
@@ -460,11 +461,8 @@ def run_inference(config: VGGTInferenceConfig) -> None:
     rr.send_blueprint(blueprint=blueprint)
     rr.log(f"{parent_log_path}", rr.ViewCoordinates.RFU, static=True)
 
-    vggt_predictor = VGGTPredictor(
-        device=device,
-        preprocessing_mode=config.preprocessing_mode,
-    )
-    mv_pred_list: list[MultiviewPred] = vggt_predictor(rgb_list=rgb_list)
+    vggt_predictor = MultiviewPredictor(MultiviewPredictorConfig(model_name="vggt", device=device))
+    mv_pred_list: list[MultiviewPred] = vggt_predictor(rgb_list, preprocessing_mode=config.preprocessing_mode)
 
     mv_pred_list = orient_mv_pred_list(mv_pred_list)
     pointcloud: Float32[ndarray, "num_points 3"] = mv_pred_to_pointcloud(mv_pred_list)


### PR DESCRIPTION
Independent fixes split out of #82; found by running lint/typecheck/deadcode across all 23 dev envs. No trtkit dependency.

- **sapiens-coco133-pose**: rtmlib fallback crashed at runtime — it imported `MODE` from mv-api, deleted in the posekit migration. Asset table (recovered from git history) is now inlined; drops the package's only mv-api dep.
- **sam3d-body**: RRD video blobs were passed as `bytes` to `log_video`, which only takes paths — that branch crashed. Blobs now spill to a temp file.
- **vistadream**: ported to the renamed monoprior multiview API (`VGGTPredictor` → `MultiviewPredictor`).
- **live-rerun / simplecv**: Optional narrowing in tests; vulture ignore for `send_columns` lambdas.
- **Missing `.envrc`** in posekit, mamma, sapiens2-pose, sapiens-coco133-pose, live-rerun — direnv loaded the root env instead, so `python tools/...` failed with `ModuleNotFoundError`.

All gates and touched-package test suites green.