### PR TITLE
mast3r-slam: fix Mojo kernel build on current nightly

### DIFF
--- a/packages/mast3r-slam/mast3r_slam/backend/mojo/OPTIMIZATION_GUIDE.md
+++ b/packages/mast3r-slam/mast3r_slam/backend/mojo/OPTIMIZATION_GUIDE.md
@@ -175,7 +175,7 @@ score += (v32 * other_v32).reduce_add()
 
 ### Cross-stream synchronization (REQUIRED)
 ```mojo
-ctx_ptr[].enqueue_function[kernel, kernel](args, grid_dim=..., block_dim=...)
+ctx_ptr[].enqueue_function[kernel](args, grid_dim=..., block_dim=...)
 # MUST sync — Mojo uses a different CUDA stream than PyTorch
 Python.import_module("torch").cuda.synchronize()
 ```

--- a/packages/mast3r-slam/mast3r_slam/backend/mojo/gn.mojo
+++ b/packages/mast3r-slam/mast3r_slam/backend/mojo/gn.mojo
@@ -227,7 +227,7 @@ def pose_retr_py(
         RuntimeLayout[DX_LT].row_major(Index(num_vars, POSE_DIM)),
     )
     var ctx_ptr = get_cached_context_ptr()
-    ctx_ptr[].enqueue_function[pose_retr_kernel, pose_retr_kernel](
+    ctx_ptr[].enqueue_function[pose_retr_kernel](
         poses_lt,
         dx_lt,
         num_fix,
@@ -315,7 +315,7 @@ def gauss_newton_rays_step_py(args_obj: PythonObject) raises -> PythonObject:
         torch_float32_ptr(gs_partial), RuntimeLayout[GS_LT].row_major(Index(2, num_partials, POSE_DIM)))
 
     var ctx_ptr = get_cached_context_ptr()
-    ctx_ptr[].enqueue_function[gauss_newton_rays_step_kernel, gauss_newton_rays_step_kernel](
+    ctx_ptr[].enqueue_function[gauss_newton_rays_step_kernel](
         twc_lt, xs_lt, cs_lt, ii_lt, jj_lt, idx_lt, valid_lt, q_lt, hs_lt, gs_lt,
         num_points, num_edges, blocks_per_edge, sigma_ray, sigma_dist, c_thresh, q_thresh,
         grid_dim=num_partials,

--- a/packages/mast3r-slam/mast3r_slam/backend/mojo/mast3r_slam_mojo_backends.mojo
+++ b/packages/mast3r-slam/mast3r_slam/backend/mojo/mast3r_slam_mojo_backends.mojo
@@ -42,7 +42,7 @@ from python_interop import install_cached_context
 
 
 @export
-def PyInit_mast3r_slam_mojo_backends() -> PythonObject:
+def PyInit_mast3r_slam_mojo_backends() abi("C") -> PythonObject:
     """CPython module initialiser — called once at `import` time.
 
     Builds the module, registers all Python-callable functions, and creates

--- a/packages/mast3r-slam/mast3r_slam/backend/mojo/matching.mojo
+++ b/packages/mast3r-slam/mast3r_slam/backend/mojo/matching.mojo
@@ -134,7 +134,7 @@ def iter_proj_kernel(
     starting from an initial pixel, repeatedly adjust the pixel so the sampled
     ray in image i aligns with the target 3D direction coming from image j.
     """
-    var n: UInt = block_idx.x * block_dim.x + thread_idx.x
+    var n: UInt = UInt(block_idx.x * block_dim.x + thread_idx.x)
     var b: Int = Int(block_idx.y)
 
     if n >= UInt(num_pts):
@@ -244,7 +244,7 @@ def refine_matches_kernel_f16(
     Reads float16 descriptors via raw pointer (for SIMD-8 loads),
     accumulates dot products in float32 for precision.
     """
-    var n: UInt = block_idx.x * block_dim.x + thread_idx.x
+    var n: UInt = UInt(block_idx.x * block_dim.x + thread_idx.x)
     var b: Int = Int(block_idx.y)
 
     if n >= UInt(num_pts):
@@ -322,7 +322,7 @@ def refine_matches_kernel_f16_cached[
     half precision). Caches each thread's query descriptor in shared memory,
     compile-time-unrolls the inner dot product.
     """
-    var n: UInt = block_idx.x * block_dim.x + thread_idx.x
+    var n: UInt = UInt(block_idx.x * block_dim.x + thread_idx.x)
     var b: Int = Int(block_idx.y)
 
     if n >= UInt(num_pts):
@@ -468,7 +468,7 @@ def iter_proj_py(
     var ctx_ptr = get_cached_context_ptr()
     var block_size: Int = choose_iter_proj_block(num_pts)
     var num_blocks_x: Int = ceildiv(num_pts, block_size)
-    ctx_ptr[].enqueue_function[iter_proj_kernel, iter_proj_kernel](
+    ctx_ptr[].enqueue_function[iter_proj_kernel](
         rays_lt,
         pts_lt,
         pinit_lt,
@@ -557,7 +557,7 @@ def refine_matches_py(
     # inner dot product and we only read each query descriptor once.
     if radius == 2 and dilation_max == 2 and block_size == 8 and fdim == 16:
         comptime kernel = refine_matches_kernel_f16_cached[16, 8]
-        ctx_ptr[].enqueue_function[kernel, kernel](
+        ctx_ptr[].enqueue_function[kernel](
             d11_uptr,
             d21_uptr,
             p1_lt,
@@ -568,7 +568,7 @@ def refine_matches_py(
         )
     elif radius == 2 and dilation_max == 2 and block_size == 16 and fdim == 128:
         comptime kernel = refine_matches_kernel_f16_cached[128, 16]
-        ctx_ptr[].enqueue_function[kernel, kernel](
+        ctx_ptr[].enqueue_function[kernel](
             d11_uptr,
             d21_uptr,
             p1_lt,
@@ -578,7 +578,7 @@ def refine_matches_py(
             block_dim=block_size,
         )
     else:
-        ctx_ptr[].enqueue_function[refine_matches_kernel_f16, refine_matches_kernel_f16](
+        ctx_ptr[].enqueue_function[refine_matches_kernel_f16](
             d11_uptr,
             d21_uptr,
             p1_lt,


### PR DESCRIPTION
## What

`pixi run mast3r-slam-app` failed to start: the Mojo nightly in the env (`1.0.0b3.dev2026062206`) promoted two deprecations into hard requirements and the kernel build task died.

- **Int → UInt is no longer implicit**: the three thread-index lines in `matching.mojo` (`var n: UInt = block_idx.x * block_dim.x + thread_idx.x`) now wrap the expression in an explicit `UInt(...)`.
- **`enqueue_function[kernel, kernel]` doubled form deprecated**: all six call sites in `gn.mojo` / `matching.mojo` switched to `enqueue_function[kernel]`; `OPTIMIZATION_GUIDE.md` snippet updated to match.
- **`@export` needs an explicit ABI on the CPython entry point**: `PyInit_mast3r_slam_mojo_backends() abi("C")`.

## Verified

- `_mast3r-slam-build-mojo-kernels` builds with **zero warnings/errors**
- the extension imports and registers all functions (`gauss_newton_*`, matching ops)
- `mast3r-slam-app` starts and Gradio serves HTTP 200 on `127.0.0.1:7860`