### PR TITLE
trtkit: fusion escape hatch + correct output buffers for materialized intermediates

### DIFF
--- a/packages/trtkit/src/trtkit/backends.py
+++ b/packages/trtkit/src/trtkit/backends.py
@@ -61,6 +61,9 @@ class TensorRtBackendConfig:
     """Capture and replay CUDA graphs around the engine launch (one per batch size)."""
     cache_dir: Path = field(default_factory=lambda: DEFAULT_TRT_CACHE_DIR)
     """Machine-local engine cache directory."""
+    extra_output_patterns: tuple[str, ...] = ()
+    """Tensor-name substrings to materialize as extra engine outputs (defeats
+    miscompiled fusions; see :class:`trtkit.trt_builder.TrtBuildConfig`)."""
 
 
 if TYPE_CHECKING:
@@ -96,6 +99,7 @@ def create_runtime_from_onnx(onnx_path: Path, backend: "OnnxBackendConfig | Tens
     build_config = TrtBuildConfig(
         max_batch_size=static_batch if static_batch is not None else backend.max_batch_size,
         opt_batch_size=static_batch if static_batch is not None else backend.opt_batch_size,
+        extra_output_patterns=backend.extra_output_patterns,
     )
     engine_path: Path = ensure_engine(onnx_path, build_config, cache_dir=backend.cache_dir)
     return TensorRtRuntime(engine_path, use_cuda_graph=backend.use_cuda_graph)

--- a/packages/trtkit/src/trtkit/tensorrt_runtime.py
+++ b/packages/trtkit/src/trtkit/tensorrt_runtime.py
@@ -80,13 +80,20 @@ class TensorRtRuntime:
         self._input_buffers: dict[str, Tensor] = {
             spec.name: torch.zeros((max_batch, *spec.shape), dtype=spec.dtype, device=self._device) for spec in self._spec.inputs
         }
+        self._active_batch: int = -1
+        self._set_active_batch(max_batch)
+        # Output buffers size from the context's concrete max-batch shapes, not
+        # (max_batch, *per_sample): an extra materialized intermediate (see
+        # TrtBuildConfig.extra_output_patterns) may scale its leading dim by more
+        # than the batch (e.g. batch*views), and undersized buffers corrupt memory.
         self._output_buffers: dict[str, Tensor] = {
-            spec.name: torch.empty((max_batch, *spec.shape), dtype=spec.dtype, device=self._device) for spec in self._spec.outputs
+            spec.name: torch.empty(
+                tuple(int(dim) for dim in self._context.get_tensor_shape(spec.name)), dtype=spec.dtype, device=self._device
+            )
+            for spec in self._spec.outputs
         }
         for name, tensor in {**self._input_buffers, **self._output_buffers}.items():
             self._context.set_tensor_address(name, int(tensor.data_ptr()))
-        self._active_batch: int = -1
-        self._set_active_batch(max_batch)
         self._stream: torch.cuda.Stream = torch.cuda.Stream(device=self._device)
         self._use_cuda_graph: bool = use_cuda_graph
         self._graphs: dict[int, torch.cuda.CUDAGraph] = {}
@@ -131,7 +138,12 @@ class TensorRtRuntime:
             self._graphs[graph_key].replay()
         else:
             self._execute()
-        return {name: tensor[:batch_size] for name, tensor in self._output_buffers.items()}
+        # Slice each output to the rows the context actually produced at this batch
+        # (materialized intermediates may scale their leading dim beyond the batch).
+        return {
+            name: tensor[: int(self._context.get_tensor_shape(name)[0])]
+            for name, tensor in self._output_buffers.items()
+        }
 
     def _execute(self) -> None:
         """Launch the engine on the private stream, fenced against torch's current stream.

--- a/packages/trtkit/src/trtkit/trt_builder.py
+++ b/packages/trtkit/src/trtkit/trt_builder.py
@@ -40,6 +40,12 @@ class TrtBuildConfig:
     memory, not an upfront allocation."""
     builder_optimization_level: int = 3
     """TensorRT builder optimization level (0-5)."""
+    extra_output_patterns: tuple[str, ...] = ()
+    """Mark every intermediate tensor whose name contains one of these substrings as
+    an additional engine output. Materializing a tensor bars TensorRT from fusing it
+    with its consumers — the escape hatch for miscompiled fusions (e.g. plane-sweep
+    cost-volume GridSample). Each pattern must match at least one tensor. Part of
+    the engine cache key."""
 
 
 def cached_engine_path(onnx_path: Path, config: TrtBuildConfig, *, cache_dir: Path = DEFAULT_TRT_CACHE_DIR, onnx_sha256: str | None = None) -> Path:
@@ -67,9 +73,14 @@ def cached_engine_path(onnx_path: Path, config: TrtBuildConfig, *, cache_dir: Pa
     capability: tuple[int, int] = torch.cuda.get_device_capability()
     onnx_hash: str = (onnx_sha256 or onnx_content_hash(onnx_path))[:12]
     precision_key: str = "strong" if config.allow_tf32 else "strong-notf32"
+    extra_outputs_key: str = (
+        f"_x{hashlib.sha256('|'.join(config.extra_output_patterns).encode()).hexdigest()[:8]}"
+        if config.extra_output_patterns
+        else ""
+    )
     name: str = (
         f"{onnx_path.stem}_b1-{config.opt_batch_size}-{config.max_batch_size}_{precision_key}"
-        f"_w{config.workspace_gib:g}o{config.builder_optimization_level}"
+        f"_w{config.workspace_gib:g}o{config.builder_optimization_level}{extra_outputs_key}"
         f"_trt{trt.__version__}_sm{capability[0]}{capability[1]}_{onnx_hash}.engine"
     )
     return cache_dir / name
@@ -105,6 +116,17 @@ def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig, *, 
     if not parser.parse_from_file(str(onnx_path.expanduser())):
         errors: str = "\n".join(str(parser.get_error(i)) for i in range(parser.num_errors))
         raise RuntimeError(f"ONNX parse failed for {onnx_path}:\n{errors}")
+    for pattern in config.extra_output_patterns:
+        matched: bool = False
+        for layer_index in range(int(network.num_layers)):
+            layer: Any = network.get_layer(layer_index)
+            for output_index in range(int(layer.num_outputs)):
+                candidate: Any = layer.get_output(output_index)
+                if pattern in candidate.name and not candidate.is_network_output:
+                    network.mark_output(candidate)
+                    matched = True
+        if not matched:
+            raise RuntimeError(f"extra_output_patterns entry {pattern!r} matched no network tensor in {onnx_path}.")
     builder_config: Any = builder.create_builder_config()
     builder_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, int(config.workspace_gib * (1 << 30)))
     builder_config.builder_optimization_level = int(config.builder_optimization_level)


### PR DESCRIPTION
Two TensorRT-backend fixes that the new `mvs` depth engine needs (stacked under #89); behavior is unchanged for every existing consumer.

## Fusion escape hatch: `extra_output_patterns`

TensorRT miscompiles the plane-sweep cost volume in the mvs depth model: it fuses the 64 `GridSample` ops with their consumers and the engine produces ~0.3 m mean depth error at every precision, on both static and dynamic graphs. Marking those tensors as extra engine outputs forces materialization, which bars the fusion and restores parity with ONNX Runtime (max abs diff 3.6e-3, verified at batch 1/8/32 by `test_tensorrt_engine_matches_onnx_runtime` in the mvs PR).

`TrtBuildConfig` / `TensorRtBackendConfig` gain `extra_output_patterns: tuple[str, ...]` — tensor-name substrings to mark as extra outputs. The patterns are part of the engine cache key, and a pattern that matches nothing raises at build time. Default is `()`, so existing engines and cache paths are untouched.

Lesson that produced this: golden tests on the ONNX backend alone never exercise the TRT engine. The bug was latent from day one and only surfaced when a TRT-vs-ORT parity test was added.

## Output buffers sized from the execution context

`TensorRtRuntime` allocated output buffers as `(max_batch, *per_sample_shape)`. A materialized intermediate can scale its leading dim by more than the batch (the cost-volume `GridSample` outputs are `(7·b, C, h, w)`), so batch ≥ 8 overflowed the buffer (CUDA error 700, illegal memory access). Buffers are now allocated from `context.get_tensor_shape` at max batch, and each call slices outputs to the rows the context actually produced.

## Validation

- `pixi run -e trtkit-dev --frozen {lint,typecheck,tests}` green.
- Consumer-side parity + batch tests live in the stacked mvs PR.
