### PR TITLE
trtkit: tqdm progress bar for TensorRT engine builds

### DIFF
--- a/packages/mvs/src/mvs/apis/catalog_depth.py
+++ b/packages/mvs/src/mvs/apis/catalog_depth.py
@@ -50,10 +50,12 @@ def main(config: Config) -> None:
         config: Catalog, model, backend, and Rerun options.
     """
     started: float = time.perf_counter()
+
     client: CatalogClient = CatalogClient(config.data.catalog_url)
     dataset: DatasetEntry = client.get_dataset(name=config.data.dataset_name)
     segment_ids: list[str] = list(config.data.segments) or dataset.segment_ids()
     engine: DepthEngine = DepthEngine(config.model_path, config.backend)
+
     rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
     device: torch_device = torch_device("cuda")
     total_frames: int = 0

--- a/packages/trtkit/pyproject.toml
+++ b/packages/trtkit/pyproject.toml
@@ -4,6 +4,7 @@ dependencies = [
     # common: numpy, jaxtyping
     # cuda: pytorch-gpu, onnxruntime, tensorrt-cu13
     "tyro>=0.9.1",
+    "tqdm",
 ]
 description = "One PyTorch -> ONNX -> TensorRT home: backend-neutral tensor runtimes (torch / ONNX Runtime CUDA / TensorRT) plus machine-local engine building, caching, and ONNX graph surgery"
 name = "trtkit"
@@ -29,4 +30,5 @@ paths = ["src/trtkit", "tests"]
 exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modules/*"]
 sort_by_size = true
 min_confidence = 80
-ignore_names = ["side_effect"]
+# parent_phase: fixed positional signature of TensorRT's IProgressMonitor callback.
+ignore_names = ["parent_phase", "side_effect"]

--- a/packages/trtkit/pyproject.toml
+++ b/packages/trtkit/pyproject.toml
@@ -4,7 +4,7 @@ dependencies = [
     # common: numpy, jaxtyping
     # cuda: pytorch-gpu, onnxruntime, tensorrt-cu13
     "tyro>=0.9.1",
-    "tqdm",
+    "rich",
 ]
 description = "One PyTorch -> ONNX -> TensorRT home: backend-neutral tensor runtimes (torch / ONNX Runtime CUDA / TensorRT) plus machine-local engine building, caching, and ONNX graph surgery"
 name = "trtkit"

--- a/packages/trtkit/pyproject.toml
+++ b/packages/trtkit/pyproject.toml
@@ -30,5 +30,4 @@ paths = ["src/trtkit", "tests"]
 exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modules/*"]
 sort_by_size = true
 min_confidence = 80
-# parent_phase: fixed positional signature of TensorRT's IProgressMonitor callback.
-ignore_names = ["parent_phase", "side_effect"]
+ignore_names = ["side_effect"]

--- a/packages/trtkit/src/trtkit/trt_builder.py
+++ b/packages/trtkit/src/trtkit/trt_builder.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any
 
 import torch
+from tqdm import tqdm
 
 DEFAULT_TRT_CACHE_DIR: Path = Path(os.environ.get("TRTKIT_TRT_CACHE", "~/.cache/trtkit/trt")).expanduser()
 """Machine-local engine cache; override with the ``TRTKIT_TRT_CACHE`` env var."""
@@ -149,6 +150,56 @@ def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig, *, 
             )
     if has_dynamic_batch:
         builder_config.add_optimization_profile(profile)
+
+    class BuildProgress(trt.IProgressMonitor):
+        """Drive a single tqdm bar tracking the innermost active builder phase.
+
+        TensorRT churns short-lived nested phases, which breaks tqdm's stacked
+        ``position=`` bars (their cursor bookkeeping drifts and the display
+        freezes at the initial render). One bar reset per phase always renders.
+        """
+
+        def __init__(self) -> None:
+            super().__init__()
+            self._totals: dict[str, int] = {}
+            self._steps: dict[str, int] = {}
+            self._stack: list[str] = []
+            self._target: str = ""
+            self._bar: tqdm = tqdm(total=1, desc="TensorRT build", leave=False, disable=None, dynamic_ncols=True)
+
+        def phase_start(self, phase_name: str, parent_phase: str | None, num_steps: int) -> None:
+            self._totals[phase_name] = num_steps
+            self._steps[phase_name] = 0
+            self._stack.append(phase_name)
+            self._retarget()
+
+        def step_complete(self, phase_name: str, step: int) -> bool:
+            self._steps[phase_name] = step
+            if phase_name == self._target:
+                self._bar.update(step - self._bar.n)
+            return True
+
+        def phase_finish(self, phase_name: str) -> None:
+            if phase_name in self._stack:
+                self._stack.remove(phase_name)
+            self._totals.pop(phase_name, None)
+            self._steps.pop(phase_name, None)
+            if self._stack:
+                self._retarget()
+            else:
+                self._bar.close()
+
+        def _retarget(self) -> None:
+            # Track the deepest phase with real steps; micro-phases (total <= 1) would park the bar at 0%.
+            self._target = next((name for name in reversed(self._stack) if self._totals[name] > 1), self._stack[-1])
+            root: str = self._stack[0]
+            label: str = self._target if self._target == root else f"{root} {self._steps[root]}/{self._totals[root]} · {self._target}"
+            self._bar.set_description(label, refresh=False)
+            self._bar.reset(total=max(self._totals[self._target], 1))
+            self._bar.update(self._steps[self._target])
+
+    monitor: Any = BuildProgress()
+    builder_config.progress_monitor = monitor
     serialized: Any = builder.build_serialized_network(network, builder_config)
     if serialized is None:
         raise RuntimeError(f"TensorRT engine build failed for {onnx_path}.")

--- a/packages/trtkit/src/trtkit/trt_builder.py
+++ b/packages/trtkit/src/trtkit/trt_builder.py
@@ -155,55 +155,24 @@ def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig, *, 
     if has_dynamic_batch:
         builder_config.add_optimization_profile(profile)
 
-    duration_prior: float | None = None
-    prior_mtime: float = float("-inf")
-    for manifest_path in engine_path.parent.glob("*.engine.json"):
-        try:
-            prior_manifest: Any = json.loads(manifest_path.read_text())
-            manifest_mtime: float = manifest_path.stat().st_mtime
-        except (OSError, UnicodeError, json.JSONDecodeError):
-            continue
-        if not isinstance(prior_manifest, dict):
-            continue
-        prior_onnx_path: Any = prior_manifest.get("onnx_path")
-        prior_build_seconds: Any = prior_manifest.get("build_seconds")
-        if (
-            isinstance(prior_onnx_path, str)
-            and Path(prior_onnx_path).stem == onnx_path.stem
-            # Same optimization level only: an o0 duration is no estimate for an o3 build.
-            and prior_manifest.get("builder_optimization_level") == config.builder_optimization_level
-            and isinstance(prior_build_seconds, (int, float))
-            and not isinstance(prior_build_seconds, bool)
-            and prior_build_seconds > 0.0
-            and manifest_mtime > prior_mtime
-        ):
-            duration_prior = float(prior_build_seconds)
-            prior_mtime = manifest_mtime
-
     class BuildProgress(trt.IProgressMonitor):
         """Spinner + elapsed clock + current builder phase — deliberately not a bar.
 
         A measured o3 build emits no progress callbacks for 99% of its duration
         (steps burst at start and end), and TensorRT's log stream is equally
         silent during the expensive tactic timing, so there is no data to drive
-        a fraction-complete display. A prior ``build_seconds`` from an earlier
-        manifest (same ONNX, same optimization level) appears as a static
-        "typically ~2m" hint; the phase callbacks feed the trailing context
-        text. TensorRT may invoke callbacks from multiple builder threads, so
-        one lock guards the phase state; rich's own refresh thread animates the
-        spinner and the clock.
+        a fraction-complete display or an honest time estimate. The phase
+        callbacks feed the trailing context text. TensorRT may invoke callbacks
+        from multiple builder threads, so one lock guards the phase state;
+        rich's own refresh thread animates the spinner and the clock.
         """
 
-        def __init__(self, typical_seconds: float | None) -> None:
+        def __init__(self) -> None:
             super().__init__()
             self._lock: LockType = threading.Lock()
             self._totals: dict[str, int] = {}
             self._steps: dict[str, int] = {}
             self._stack: list[str] = []
-            hint: str = ""
-            if typical_seconds is not None:
-                hint_label: str = f"~{typical_seconds / 60.0:.0f}m" if typical_seconds >= 60.0 else f"~{typical_seconds:.0f}s"
-                hint = f" (typically {hint_label} on this machine)"
             self._progress: Progress = Progress(
                 SpinnerColumn(),
                 TextColumn("[progress.description]{task.description}"),
@@ -212,7 +181,7 @@ def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig, *, 
                 transient=True,
                 disable=not Console().is_terminal,
             )
-            self._task: TaskID = self._progress.add_task(f"TensorRT build{hint}", total=None, phase="starting")
+            self._task: TaskID = self._progress.add_task("TensorRT build (one-time, can take a few minutes)", total=None, phase="starting")
             self._progress.start()
 
         def close(self) -> None:
@@ -247,7 +216,7 @@ def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig, *, 
             target: str = next((name for name in reversed(self._stack) if self._totals[name] > 1), self._stack[-1])
             self._progress.update(self._task, phase=f"{target} {self._steps[target]}/{self._totals[target]}")
 
-    monitor: Any = BuildProgress(duration_prior)
+    monitor: Any = BuildProgress()
     builder_config.progress_monitor = monitor
     build_started: float = time.perf_counter()
     try:

--- a/packages/trtkit/src/trtkit/trt_builder.py
+++ b/packages/trtkit/src/trtkit/trt_builder.py
@@ -14,6 +14,8 @@ import hashlib
 import json
 import os
 import threading
+import time
+from _thread import LockType
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -152,27 +154,68 @@ def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig, *, 
     if has_dynamic_batch:
         builder_config.add_optimization_profile(profile)
 
+    duration_prior: float | None = None
+    prior_mtime: float = float("-inf")
+    for manifest_path in engine_path.parent.glob("*.engine.json"):
+        try:
+            prior_manifest: Any = json.loads(manifest_path.read_text())
+            manifest_mtime: float = manifest_path.stat().st_mtime
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            continue
+        if not isinstance(prior_manifest, dict):
+            continue
+        prior_onnx_path: Any = prior_manifest.get("onnx_path")
+        prior_build_seconds: Any = prior_manifest.get("build_seconds")
+        if (
+            isinstance(prior_onnx_path, str)
+            and Path(prior_onnx_path).stem == onnx_path.stem
+            # Same optimization level only: an o0 duration is no estimate for an o3 build.
+            and prior_manifest.get("builder_optimization_level") == config.builder_optimization_level
+            and isinstance(prior_build_seconds, (int, float))
+            and not isinstance(prior_build_seconds, bool)
+            and prior_build_seconds > 0.0
+            and manifest_mtime > prior_mtime
+        ):
+            duration_prior = float(prior_build_seconds)
+            prior_mtime = manifest_mtime
+
     class BuildProgress(trt.IProgressMonitor):
-        """Drive a single tqdm bar tracking the innermost active builder phase.
+        """Drive one elapsed-time bar with TensorRT's current phase as context.
 
         TensorRT churns short-lived nested phases, which breaks tqdm's stacked
-        ``position=`` bars (their cursor bookkeeping drifts and the display
-        freezes at the initial render). One bar reset per phase always renders.
-        TensorRT may invoke the callbacks from multiple builder threads, so one
-        lock guards the phase state; :meth:`close` owns bar/ticker shutdown and
-        runs in the build's ``finally`` so failed builds don't leak the ticker.
+        ``position=`` bars. At optimization level 3 its step callbacks also stall
+        for almost the whole build, so they are context rather than a false
+        fraction-complete signal. A prior build duration makes elapsed time an
+        estimate; without one, the bar stays indeterminate. TensorRT may invoke
+        callbacks from multiple builder threads, so one lock guards all state.
         """
 
-        def __init__(self) -> None:
+        def __init__(self, estimated_seconds: float | None) -> None:
             super().__init__()
-            self._lock: threading.Lock = threading.Lock()
+            self._lock: LockType = threading.Lock()
             self._totals: dict[str, int] = {}
             self._steps: dict[str, int] = {}
             self._stack: list[str] = []
-            self._target: str = ""
-            self._bar: tqdm = tqdm(total=1, desc="TensorRT build", leave=False, disable=None, dynamic_ncols=True)
-            # Heavy o3 graph nodes can take tens of seconds per step; tick the
-            # display so elapsed/ETA keep moving instead of looking hung.
+            self._phase_info: str = "starting"
+            self._estimated_seconds: float | None = estimated_seconds
+            self._started: float = time.perf_counter()
+            if estimated_seconds is not None:
+                estimate_label: str = f"{estimated_seconds / 60.0:.0f}m" if estimated_seconds >= 60.0 else f"{estimated_seconds:.0f}s"
+                description: str = f"TensorRT build (~{estimate_label} est)"
+                bar_format: str = "{desc}: {percentage:3.0f}%|{bar}| {n:.0f}/{total:.0f}s{postfix}"
+            else:
+                description = "TensorRT build"
+                bar_format = "{desc}: {n:.0f}s [{elapsed}{postfix}]"
+            self._bar: tqdm = tqdm(
+                total=estimated_seconds,
+                desc=description,
+                unit="s",
+                leave=False,
+                disable=None,
+                dynamic_ncols=True,
+                bar_format=bar_format,
+            )
+            self._bar.set_postfix_str(self._phase_info, refresh=False)
             self._done: threading.Event = threading.Event()
             self._ticker: threading.Thread = threading.Thread(target=self._tick, daemon=True)
             self._ticker.start()
@@ -180,6 +223,9 @@ def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig, *, 
         def _tick(self) -> None:
             while not self._done.wait(1.0):
                 with self._lock:
+                    elapsed: float = time.perf_counter() - self._started
+                    self._bar.n = min(elapsed, self._estimated_seconds) if self._estimated_seconds is not None else int(elapsed)
+                    self._set_postfix(elapsed)
                     self._bar.refresh()
 
         def close(self) -> None:
@@ -200,8 +246,7 @@ def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig, *, 
         def step_complete(self, phase_name: str, step: int) -> bool:
             with self._lock:
                 self._steps[phase_name] = step + 1  # step is the zero-based index of the completed step
-                if phase_name == self._target:
-                    self._bar.update(step + 1 - self._bar.n)
+                self._retarget()
             return True
 
         def phase_finish(self, phase_name: str) -> None:
@@ -212,26 +257,30 @@ def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig, *, 
                 self._steps.pop(phase_name, None)
                 if self._stack:
                     self._retarget()
+                else:
+                    self._phase_info = "finalizing"
+                    self._set_postfix(time.perf_counter() - self._started)
 
         def _retarget(self) -> None:
-            # Track the deepest phase with real steps; micro-phases (total <= 1) would park the bar at 0%.
+            # Show the deepest phase with real steps; micro-phases obscure more useful parent context.
             target: str = next((name for name in reversed(self._stack) if self._totals[name] > 1), self._stack[-1])
-            root: str = self._stack[0]
-            label: str = target if target == root else f"{root} {self._steps[root]}/{self._totals[root]} · {target}"
-            self._bar.set_description(label, refresh=False)
-            # Reset only when the bar moves to a different (or restarted) phase;
-            # resetting on every micro-phase start/finish would zero the timer.
-            if target != self._target or self._bar.total != max(self._totals[target], 1) or self._steps[target] < self._bar.n:
-                self._target = target
-                self._bar.reset(total=max(self._totals[target], 1))
-                self._bar.update(self._steps[target])
+            self._phase_info = f"{target} {self._steps[target]}/{self._totals[target]}"
+            self._set_postfix(time.perf_counter() - self._started)
 
-    monitor: Any = BuildProgress()
+        def _set_postfix(self, elapsed: float) -> None:
+            postfix: str = self._phase_info
+            if self._estimated_seconds is not None and elapsed > self._estimated_seconds:
+                postfix += f" · overrun {tqdm.format_interval(elapsed)} / est {tqdm.format_interval(self._estimated_seconds)}"
+            self._bar.set_postfix_str(postfix, refresh=False)
+
+    monitor: Any = BuildProgress(duration_prior)
     builder_config.progress_monitor = monitor
+    build_started: float = time.perf_counter()
     try:
         serialized: Any = builder.build_serialized_network(network, builder_config)
     finally:
         monitor.close()
+    build_seconds: float = time.perf_counter() - build_started
     if serialized is None:
         raise RuntimeError(f"TensorRT engine build failed for {onnx_path}.")
     engine_path.parent.mkdir(parents=True, exist_ok=True)
@@ -251,6 +300,7 @@ def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig, *, 
         "allow_tf32": config.allow_tf32,
         "workspace_gib": config.workspace_gib,
         "builder_optimization_level": config.builder_optimization_level,
+        "build_seconds": build_seconds,
         "tensorrt_version": str(trt.__version__),
         "cuda_device_name": torch.cuda.get_device_name(),
         "cuda_compute_capability": list(torch.cuda.get_device_capability()),

--- a/packages/trtkit/src/trtkit/trt_builder.py
+++ b/packages/trtkit/src/trtkit/trt_builder.py
@@ -153,11 +153,8 @@ def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig, *, 
     if has_dynamic_batch:
         builder_config.add_optimization_profile(profile)
 
-    # A measured o3 build emits IProgressMonitor callbacks for only ~1% of its
-    # duration (steps burst at start and end) and TensorRT's log stream is just
-    # as silent during tactic timing, so there is no data for a real progress
-    # bar — a spinner with an elapsed clock is the honest display. rich's own
-    # refresh thread animates it while this thread blocks inside the build.
+    # Not a progress bar on purpose: TensorRT emits progress callbacks for only
+    # ~1% of an o3 build (measured), so any fraction-complete display is fiction.
     spinner: Progress = Progress(
         SpinnerColumn(),
         TextColumn("[progress.description]{task.description}"),

--- a/packages/trtkit/src/trtkit/trt_builder.py
+++ b/packages/trtkit/src/trtkit/trt_builder.py
@@ -21,7 +21,8 @@ from pathlib import Path
 from typing import Any
 
 import torch
-from tqdm import tqdm
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TaskID, TextColumn, TimeElapsedColumn
 
 DEFAULT_TRT_CACHE_DIR: Path = Path(os.environ.get("TRTKIT_TRT_CACHE", "~/.cache/trtkit/trt")).expanduser()
 """Machine-local engine cache; override with the ``TRTKIT_TRT_CACHE`` env var."""
@@ -180,73 +181,54 @@ def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig, *, 
             prior_mtime = manifest_mtime
 
     class BuildProgress(trt.IProgressMonitor):
-        """Drive one elapsed-time bar with TensorRT's current phase as context.
+        """Spinner + elapsed clock + current builder phase — deliberately not a bar.
 
-        TensorRT churns short-lived nested phases, which breaks tqdm's stacked
-        ``position=`` bars. At optimization level 3 its step callbacks also stall
-        for almost the whole build, so they are context rather than a false
-        fraction-complete signal. A prior build duration makes elapsed time an
-        estimate; without one, the bar stays indeterminate. TensorRT may invoke
-        callbacks from multiple builder threads, so one lock guards all state.
+        A measured o3 build emits no progress callbacks for 99% of its duration
+        (steps burst at start and end), and TensorRT's log stream is equally
+        silent during the expensive tactic timing, so there is no data to drive
+        a fraction-complete display. A prior ``build_seconds`` from an earlier
+        manifest (same ONNX, same optimization level) appears as a static
+        "typically ~2m" hint; the phase callbacks feed the trailing context
+        text. TensorRT may invoke callbacks from multiple builder threads, so
+        one lock guards the phase state; rich's own refresh thread animates the
+        spinner and the clock.
         """
 
-        def __init__(self, estimated_seconds: float | None) -> None:
+        def __init__(self, typical_seconds: float | None) -> None:
             super().__init__()
             self._lock: LockType = threading.Lock()
             self._totals: dict[str, int] = {}
             self._steps: dict[str, int] = {}
             self._stack: list[str] = []
-            self._phase_info: str = "starting"
-            self._estimated_seconds: float | None = estimated_seconds
-            self._started: float = time.perf_counter()
-            if estimated_seconds is not None:
-                estimate_label: str = f"{estimated_seconds / 60.0:.0f}m" if estimated_seconds >= 60.0 else f"{estimated_seconds:.0f}s"
-                description: str = f"TensorRT build (~{estimate_label} est)"
-                bar_format: str = "{desc}: {percentage:3.0f}%|{bar}| {n:.0f}/{total:.0f}s{postfix}"
-            else:
-                description = "TensorRT build"
-                bar_format = "{desc}: {n:.0f}s [{elapsed}{postfix}]"
-            self._bar: tqdm = tqdm(
-                total=estimated_seconds,
-                desc=description,
-                unit="s",
-                leave=False,
-                disable=None,
-                dynamic_ncols=True,
-                bar_format=bar_format,
+            hint: str = ""
+            if typical_seconds is not None:
+                hint_label: str = f"~{typical_seconds / 60.0:.0f}m" if typical_seconds >= 60.0 else f"~{typical_seconds:.0f}s"
+                hint = f" (typically {hint_label} on this machine)"
+            self._progress: Progress = Progress(
+                SpinnerColumn(),
+                TextColumn("[progress.description]{task.description}"),
+                TimeElapsedColumn(),
+                TextColumn("[dim]{task.fields[phase]}[/dim]"),
+                transient=True,
+                disable=not Console().is_terminal,
             )
-            self._bar.set_postfix_str(self._phase_info, refresh=False)
-            self._done: threading.Event = threading.Event()
-            self._ticker: threading.Thread = threading.Thread(target=self._tick, daemon=True)
-            self._ticker.start()
-
-        def _tick(self) -> None:
-            while not self._done.wait(1.0):
-                with self._lock:
-                    elapsed: float = time.perf_counter() - self._started
-                    self._bar.n = min(elapsed, self._estimated_seconds) if self._estimated_seconds is not None else int(elapsed)
-                    self._set_postfix(elapsed)
-                    self._bar.refresh()
+            self._task: TaskID = self._progress.add_task(f"TensorRT build{hint}", total=None, phase="starting")
+            self._progress.start()
 
         def close(self) -> None:
-            if self._done.is_set():
-                return
-            self._done.set()
-            self._ticker.join(timeout=2.0)
-            with self._lock:
-                self._bar.close()
+            self._progress.stop()
 
         def phase_start(self, phase_name: str, parent_phase: str | None, num_steps: int) -> None:
             with self._lock:
                 self._totals[phase_name] = num_steps
                 self._steps[phase_name] = 0
                 self._stack.append(phase_name)
-                self._retarget()
+                self._show_phase()
 
         def step_complete(self, phase_name: str, step: int) -> bool:
             with self._lock:
                 self._steps[phase_name] = step + 1  # step is the zero-based index of the completed step
-                self._retarget()
+                self._show_phase()
             return True
 
         def phase_finish(self, phase_name: str) -> None:
@@ -256,22 +238,14 @@ def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig, *, 
                 self._totals.pop(phase_name, None)
                 self._steps.pop(phase_name, None)
                 if self._stack:
-                    self._retarget()
+                    self._show_phase()
                 else:
-                    self._phase_info = "finalizing"
-                    self._set_postfix(time.perf_counter() - self._started)
+                    self._progress.update(self._task, phase="finalizing")
 
-        def _retarget(self) -> None:
+        def _show_phase(self) -> None:
             # Show the deepest phase with real steps; micro-phases obscure more useful parent context.
             target: str = next((name for name in reversed(self._stack) if self._totals[name] > 1), self._stack[-1])
-            self._phase_info = f"{target} {self._steps[target]}/{self._totals[target]}"
-            self._set_postfix(time.perf_counter() - self._started)
-
-        def _set_postfix(self, elapsed: float) -> None:
-            postfix: str = self._phase_info
-            if self._estimated_seconds is not None and elapsed > self._estimated_seconds:
-                postfix += f" · overrun {tqdm.format_interval(elapsed)} / est {tqdm.format_interval(self._estimated_seconds)}"
-            self._bar.set_postfix_str(postfix, refresh=False)
+            self._progress.update(self._task, phase=f"{target} {self._steps[target]}/{self._totals[target]}")
 
     monitor: Any = BuildProgress(duration_prior)
     builder_config.progress_monitor = monitor

--- a/packages/trtkit/src/trtkit/trt_builder.py
+++ b/packages/trtkit/src/trtkit/trt_builder.py
@@ -13,6 +13,7 @@ the fusion — see prompt-da's ``export_promptda_onnx`` for a worked example.
 import hashlib
 import json
 import os
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -166,6 +167,14 @@ def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig, *, 
             self._stack: list[str] = []
             self._target: str = ""
             self._bar: tqdm = tqdm(total=1, desc="TensorRT build", leave=False, disable=None, dynamic_ncols=True)
+            # Heavy o3 graph nodes can take tens of seconds per step; tick the
+            # display so elapsed/ETA keep moving instead of looking hung.
+            self._done: threading.Event = threading.Event()
+            threading.Thread(target=self._tick, daemon=True).start()
+
+        def _tick(self) -> None:
+            while not self._done.wait(1.0):
+                self._bar.refresh()
 
         def phase_start(self, phase_name: str, parent_phase: str | None, num_steps: int) -> None:
             self._totals[phase_name] = num_steps
@@ -187,16 +196,21 @@ def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig, *, 
             if self._stack:
                 self._retarget()
             else:
+                self._done.set()
                 self._bar.close()
 
         def _retarget(self) -> None:
             # Track the deepest phase with real steps; micro-phases (total <= 1) would park the bar at 0%.
-            self._target = next((name for name in reversed(self._stack) if self._totals[name] > 1), self._stack[-1])
+            target: str = next((name for name in reversed(self._stack) if self._totals[name] > 1), self._stack[-1])
             root: str = self._stack[0]
-            label: str = self._target if self._target == root else f"{root} {self._steps[root]}/{self._totals[root]} · {self._target}"
+            label: str = target if target == root else f"{root} {self._steps[root]}/{self._totals[root]} · {target}"
             self._bar.set_description(label, refresh=False)
-            self._bar.reset(total=max(self._totals[self._target], 1))
-            self._bar.update(self._steps[self._target])
+            # Reset only when the bar moves to a different (or restarted) phase;
+            # resetting on every micro-phase start/finish would zero the timer.
+            if target != self._target or self._bar.total != max(self._totals[target], 1) or self._steps[target] < self._bar.n:
+                self._target = target
+                self._bar.reset(total=max(self._totals[target], 1))
+                self._bar.update(self._steps[target])
 
     monitor: Any = BuildProgress()
     builder_config.progress_monitor = monitor

--- a/packages/trtkit/src/trtkit/trt_builder.py
+++ b/packages/trtkit/src/trtkit/trt_builder.py
@@ -158,10 +158,14 @@ def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig, *, 
         TensorRT churns short-lived nested phases, which breaks tqdm's stacked
         ``position=`` bars (their cursor bookkeeping drifts and the display
         freezes at the initial render). One bar reset per phase always renders.
+        TensorRT may invoke the callbacks from multiple builder threads, so one
+        lock guards the phase state; :meth:`close` owns bar/ticker shutdown and
+        runs in the build's ``finally`` so failed builds don't leak the ticker.
         """
 
         def __init__(self) -> None:
             super().__init__()
+            self._lock: threading.Lock = threading.Lock()
             self._totals: dict[str, int] = {}
             self._steps: dict[str, int] = {}
             self._stack: list[str] = []
@@ -170,34 +174,44 @@ def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig, *, 
             # Heavy o3 graph nodes can take tens of seconds per step; tick the
             # display so elapsed/ETA keep moving instead of looking hung.
             self._done: threading.Event = threading.Event()
-            threading.Thread(target=self._tick, daemon=True).start()
+            self._ticker: threading.Thread = threading.Thread(target=self._tick, daemon=True)
+            self._ticker.start()
 
         def _tick(self) -> None:
             while not self._done.wait(1.0):
-                self._bar.refresh()
+                with self._lock:
+                    self._bar.refresh()
+
+        def close(self) -> None:
+            if self._done.is_set():
+                return
+            self._done.set()
+            self._ticker.join(timeout=2.0)
+            with self._lock:
+                self._bar.close()
 
         def phase_start(self, phase_name: str, parent_phase: str | None, num_steps: int) -> None:
-            self._totals[phase_name] = num_steps
-            self._steps[phase_name] = 0
-            self._stack.append(phase_name)
-            self._retarget()
+            with self._lock:
+                self._totals[phase_name] = num_steps
+                self._steps[phase_name] = 0
+                self._stack.append(phase_name)
+                self._retarget()
 
         def step_complete(self, phase_name: str, step: int) -> bool:
-            self._steps[phase_name] = step
-            if phase_name == self._target:
-                self._bar.update(step - self._bar.n)
+            with self._lock:
+                self._steps[phase_name] = step + 1  # step is the zero-based index of the completed step
+                if phase_name == self._target:
+                    self._bar.update(step + 1 - self._bar.n)
             return True
 
         def phase_finish(self, phase_name: str) -> None:
-            if phase_name in self._stack:
-                self._stack.remove(phase_name)
-            self._totals.pop(phase_name, None)
-            self._steps.pop(phase_name, None)
-            if self._stack:
-                self._retarget()
-            else:
-                self._done.set()
-                self._bar.close()
+            with self._lock:
+                if phase_name in self._stack:
+                    self._stack.remove(phase_name)
+                self._totals.pop(phase_name, None)
+                self._steps.pop(phase_name, None)
+                if self._stack:
+                    self._retarget()
 
         def _retarget(self) -> None:
             # Track the deepest phase with real steps; micro-phases (total <= 1) would park the bar at 0%.
@@ -214,7 +228,10 @@ def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig, *, 
 
     monitor: Any = BuildProgress()
     builder_config.progress_monitor = monitor
-    serialized: Any = builder.build_serialized_network(network, builder_config)
+    try:
+        serialized: Any = builder.build_serialized_network(network, builder_config)
+    finally:
+        monitor.close()
     if serialized is None:
         raise RuntimeError(f"TensorRT engine build failed for {onnx_path}.")
     engine_path.parent.mkdir(parents=True, exist_ok=True)

--- a/packages/trtkit/src/trtkit/trt_builder.py
+++ b/packages/trtkit/src/trtkit/trt_builder.py
@@ -13,16 +13,14 @@ the fusion — see prompt-da's ``export_promptda_onnx`` for a worked example.
 import hashlib
 import json
 import os
-import threading
 import time
-from _thread import LockType
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import torch
 from rich.console import Console
-from rich.progress import Progress, SpinnerColumn, TaskID, TextColumn, TimeElapsedColumn
+from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 
 DEFAULT_TRT_CACHE_DIR: Path = Path(os.environ.get("TRTKIT_TRT_CACHE", "~/.cache/trtkit/trt")).expanduser()
 """Machine-local engine cache; override with the ``TRTKIT_TRT_CACHE`` env var."""
@@ -155,74 +153,22 @@ def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig, *, 
     if has_dynamic_batch:
         builder_config.add_optimization_profile(profile)
 
-    class BuildProgress(trt.IProgressMonitor):
-        """Spinner + elapsed clock + current builder phase — deliberately not a bar.
-
-        A measured o3 build emits no progress callbacks for 99% of its duration
-        (steps burst at start and end), and TensorRT's log stream is equally
-        silent during the expensive tactic timing, so there is no data to drive
-        a fraction-complete display or an honest time estimate. The phase
-        callbacks feed the trailing context text. TensorRT may invoke callbacks
-        from multiple builder threads, so one lock guards the phase state;
-        rich's own refresh thread animates the spinner and the clock.
-        """
-
-        def __init__(self) -> None:
-            super().__init__()
-            self._lock: LockType = threading.Lock()
-            self._totals: dict[str, int] = {}
-            self._steps: dict[str, int] = {}
-            self._stack: list[str] = []
-            self._progress: Progress = Progress(
-                SpinnerColumn(),
-                TextColumn("[progress.description]{task.description}"),
-                TimeElapsedColumn(),
-                TextColumn("[dim]{task.fields[phase]}[/dim]"),
-                transient=True,
-                disable=not Console().is_terminal,
-            )
-            self._task: TaskID = self._progress.add_task("TensorRT build (one-time, can take a few minutes)", total=None, phase="starting")
-            self._progress.start()
-
-        def close(self) -> None:
-            self._progress.stop()
-
-        def phase_start(self, phase_name: str, parent_phase: str | None, num_steps: int) -> None:
-            with self._lock:
-                self._totals[phase_name] = num_steps
-                self._steps[phase_name] = 0
-                self._stack.append(phase_name)
-                self._show_phase()
-
-        def step_complete(self, phase_name: str, step: int) -> bool:
-            with self._lock:
-                self._steps[phase_name] = step + 1  # step is the zero-based index of the completed step
-                self._show_phase()
-            return True
-
-        def phase_finish(self, phase_name: str) -> None:
-            with self._lock:
-                if phase_name in self._stack:
-                    self._stack.remove(phase_name)
-                self._totals.pop(phase_name, None)
-                self._steps.pop(phase_name, None)
-                if self._stack:
-                    self._show_phase()
-                else:
-                    self._progress.update(self._task, phase="finalizing")
-
-        def _show_phase(self) -> None:
-            # Show the deepest phase with real steps; micro-phases obscure more useful parent context.
-            target: str = next((name for name in reversed(self._stack) if self._totals[name] > 1), self._stack[-1])
-            self._progress.update(self._task, phase=f"{target} {self._steps[target]}/{self._totals[target]}")
-
-    monitor: Any = BuildProgress()
-    builder_config.progress_monitor = monitor
+    # A measured o3 build emits IProgressMonitor callbacks for only ~1% of its
+    # duration (steps burst at start and end) and TensorRT's log stream is just
+    # as silent during tactic timing, so there is no data for a real progress
+    # bar — a spinner with an elapsed clock is the honest display. rich's own
+    # refresh thread animates it while this thread blocks inside the build.
+    spinner: Progress = Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        TimeElapsedColumn(),
+        transient=True,
+        disable=not Console().is_terminal,
+    )
     build_started: float = time.perf_counter()
-    try:
+    with spinner:
+        spinner.add_task("TensorRT build (one-time, can take a few minutes)", total=None)
         serialized: Any = builder.build_serialized_network(network, builder_config)
-    finally:
-        monitor.close()
     build_seconds: float = time.perf_counter() - build_started
     if serialized is None:
         raise RuntimeError(f"TensorRT engine build failed for {onnx_path}.")

--- a/pixi.lock
+++ b/pixi.lock
@@ -78705,7 +78705,7 @@ packages:
   name: trtkit
   requires_dist:
   - tyro>=0.9.1
-  - tqdm
+  - rich
   requires_python: '>=3.12'
 - pypi: ./packages/vistadream
   name: vistadream

--- a/pixi.lock
+++ b/pixi.lock
@@ -78705,6 +78705,7 @@ packages:
   name: trtkit
   requires_dist:
   - tyro>=0.9.1
+  - tqdm
   requires_python: '>=3.12'
 - pypi: ./packages/vistadream
   name: vistadream

--- a/pixi.toml
+++ b/pixi.toml
@@ -1058,6 +1058,7 @@ platforms = ["linux-64", "linux-aarch64"]
 [feature.trtkit.dependencies]
 python = "3.12.*"
 tyro = ">=0.9.1,<0.10"
+tqdm = "*"
 
 [feature.trtkit.pypi-dependencies]
 trtkit = { path = "packages/trtkit", editable = true }

--- a/pixi.toml
+++ b/pixi.toml
@@ -1058,7 +1058,7 @@ platforms = ["linux-64", "linux-aarch64"]
 [feature.trtkit.dependencies]
 python = "3.12.*"
 tyro = ">=0.9.1,<0.10"
-tqdm = "*"
+rich = "*"
 
 [feature.trtkit.pypi-dependencies]
 trtkit = { path = "packages/trtkit", editable = true }


### PR DESCRIPTION
Stacked on #89. The one-time TensorRT engine build (minutes on first run) sat silent behind a single print line; it now shows a live spinner with an elapsed clock:

```
[trtkit] building TensorRT engine (one-time, may take minutes): depth_model_dot_…engine
⠧ TensorRT build (one-time, can take a few minutes) 0:00:36
```

**Why a spinner and not a progress bar** — measured, not aesthetic: a timestamped `IProgressMonitor` trace of the real o3 build (111 s) shows TensorRT emits callbacks for only ~1% of it — a burst at the start, one 110 s window with zero callbacks, a burst at the end. Its log stream is equally silent during tactic timing (188k VERBOSE messages in the first 5 s, then nothing, plus 4–9 % build-time overhead when subscribed). There is no data to drive a fraction-complete display, so any bar would be synthetic. Earlier iterations on this branch tried stacked tqdm bars (freeze under TRT's phase churn), a step-driven single bar (frozen at 8 % for minutes), and an elapsed-vs-recorded-duration bar (machinery for the rare rebuild case); each was rejected against live tmux evidence.

**What ships:**
- A rich spinner context manager wrapping `build_serialized_network` — no `IProgressMonitor`, no locks, no threads of our own; rich's refresh thread animates it, `transient=True` leaves the terminal clean, and non-tty runs disable it (CI logs unchanged).
- `build_seconds` recorded in each engine manifest as provenance.
- trtkit gains a `rich` dependency (pyproject + pixi feature; one-line lock change — every consuming env already carried it).

**Verified:** live tmux builds at o0 and o3 — spinner and clock animate throughout, clean exit, warm-cache runs print nothing; lint/typecheck/deadcode/tests green; `pixi lock --check` passes.
