### PR TITLE
arkitscenes: CA-1M laser ground-truth ingest tool (gt_poses + gt_depth)

### DIFF
--- a/packages/arkitscenes-download/README.md
+++ b/packages/arkitscenes-download/README.md
@@ -60,6 +60,65 @@ Covered captures may also carry `gt_poses` and `gt_depth`, both produced by the
 separate CA-1M tool. Neither is required for ingest completeness; absence means no
 laser GT is available for that capture.
 
+## Laser ground truth (CA-1M) and provenance
+
+The layer names state *what* the data is; recording properties state *where it
+came from*. What is actually ground truth:
+
+| layer | provenance | ground truth? |
+|---|---|---|
+| `arkit_depth` | on-device ARKit depth + confidence | no — device estimate |
+| `arkit_mesh` | reconstructed from device depth | no — device estimate |
+| `gt_boxes` | human-annotated 3DOD boxes (on the ARKit mesh) | labels yes, geometry approximate |
+| `gt_poses` | per-frame camera poses registered to the FARO laser scan | **yes** |
+| `gt_depth` | 512×384 depth rendered from the FARO scan, per-frame `K` | **yes** |
+
+`gt_poses`/`gt_depth` currently come from Apple's
+[CA-1M release](https://github.com/apple/ml-cubifyanything) via:
+
+```bash
+# --output is required (the layer-major dataset root the new dirs land beside)
+pixi run -e arkitscenes-download arkitscenes-download-ca1m --output /path/to/dataset-root
+```
+
+Facts that shape consumption:
+
+- **Coverage is partial by construction.** CA-1M covers ~61% of the original
+  captures (only those whose laser registration succeeded), and within a capture
+  the GT frames can start late, end early, or have interior holes (e.g.
+  `42898570` has no GT for its first 16.4 s). Per-capture coverage and quality
+  ship as `property:gt_*` segment-table columns (`gt_start_s`, `gt_end_s`,
+  `gt_max_interior_gap_s`, `gt_umeyama_rms_m`, …). A capture without the `gt_*`
+  layers has no laser GT — that absence is the intended marker.
+- **GT is ~10 Hz** (the hi-res frame grid) on the shared `video_time` timeline;
+  the 60 Hz device streams simply coexist with it.
+- **Frames are already upright** in CA-1M; the tool applies no rotation.
+- **Coordinate frames:** CA-1M poses live in the FARO venue frame. A per-capture
+  rigid Umeyama fit (residual in `gt_umeyama_rms_m`) connects them to the ARKit
+  `/world` via a static transform at `/world/gt`.
+- **License:** CA-1M data is **CC BY-NC-ND 4.0** — internal research use only;
+  do **not** publicly redistribute RRDs derived from it. The original
+  ARKitScenes-derived layers keep the far more permissive
+  [ARKitScenes license](https://github.com/apple/ARKitScenes/blob/main/LICENSE).
+
+### TODO
+
+- **FARO-based regeneration of `gt_poses`/`gt_depth`** (unblocks public
+  redistribution): the released FARO scans registered scanner-to-scanner only;
+  the camera→FARO transform was never published
+  ([ARKitScenes#41](https://github.com/apple/ARKitScenes/issues/41)), so this
+  means reimplementing Apple's registration pipeline (synthetic laser views,
+  feature matching, PnP/RANSAC, photometric refinement). Same layer names,
+  different `gt_provenance`.
+- **Better mesh:** TSDF-fuse the laser `gt_depth` into a true GT mesh
+  (`arkit_mesh` is a device product).
+- **Mesh in the `world GT` tab** once wanted (excluded for now).
+- **RGB under the GT camera:** blocked on
+  [rerun#10422](https://github.com/rerun-io/rerun/issues/10422)
+  (`VideoFrameReference` cannot reference a `VideoStream`); until then the
+  `world GT` view includes the wide-camera frustum for RGB context. Duplicating
+  pixels instead would cost ~545 GB.
+
 ## Where the good data hides
 
 The `.mov` is the master, not just video. Its `mebx` metadata streams carry what

--- a/packages/arkitscenes-download/arkitscenes_download/ca1m/__init__.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ca1m/__init__.py
@@ -1,0 +1,1 @@
+"""CA-1M laser ground-truth ingestion."""

--- a/packages/arkitscenes-download/arkitscenes_download/ca1m/alignment.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ca1m/alignment.py
@@ -1,0 +1,116 @@
+"""Clock diagnostics and FARO-to-ARKit rigid alignment for CA-1M."""
+
+from dataclasses import dataclass
+
+import numpy as np
+from jaxtyping import Bool, Float64, Int64
+
+
+@dataclass(frozen=True, slots=True)
+class RigidAlignment:
+    """Proper rigid transform mapping source points into target coordinates."""
+
+    rotation_33: Float64[np.ndarray, "3 3"]
+    """Target-from-source rotation matrix."""
+    translation_xyz: Float64[np.ndarray, "3"]
+    """Target-frame translation in metres."""
+    rms_m: float
+    """Root-mean-square correspondence residual in metres."""
+    source_extent2_m: float
+    """Second principal extent of the source trajectory in metres.
+
+    Rank-1 (collinear) trajectories leave rotation about the motion axis
+    unobservable while still reporting a perfect RMS, so a small second
+    extent means the fitted orientation cannot be trusted.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class ClockDiagnostics:
+    """Nearest-calibration timestamp matching statistics."""
+
+    nearest_indices: Int64[np.ndarray, "n"]
+    """Nearest calibration sample index for each GT timestamp."""
+    deltas_s: Float64[np.ndarray, "n"]
+    """Absolute timestamp differences in seconds."""
+    median_delta_s: float
+    """Median absolute timestamp difference in seconds."""
+    max_delta_s: float
+    """Maximum absolute timestamp difference in seconds."""
+    fraction_over_10ms: float
+    """Fraction of matches farther than ten milliseconds."""
+    should_warn: bool
+    """Whether the measured clock agreement violates the warning policy."""
+
+
+def rigid_umeyama(
+    source_xyz: Float64[np.ndarray, "n 3"], target_xyz: Float64[np.ndarray, "n 3"]
+) -> RigidAlignment:
+    """Fit a no-scale proper rigid transform from source to target.
+
+    Args:
+        source_xyz: Float64 source points with shape ``(n, 3)``.
+        target_xyz: Float64 corresponding target points with shape ``(n, 3)``.
+
+    Returns:
+        The proper target-from-source rotation, translation, and RMS residual.
+    """
+    num_points: int = source_xyz.shape[0]
+    if num_points < 3:
+        raise ValueError(f"at least three correspondences are required, got {num_points}")
+
+    source_mean_xyz: Float64[np.ndarray, "3"] = np.mean(source_xyz, axis=0)
+    target_mean_xyz: Float64[np.ndarray, "3"] = np.mean(target_xyz, axis=0)
+    source_centered_xyz: Float64[np.ndarray, "n 3"] = source_xyz - source_mean_xyz
+    target_centered_xyz: Float64[np.ndarray, "n 3"] = target_xyz - target_mean_xyz
+    covariance_33: Float64[np.ndarray, "3 3"] = source_centered_xyz.T @ target_centered_xyz
+    svd_result: tuple[np.ndarray, np.ndarray, np.ndarray] = np.linalg.svd(covariance_33)
+    left_33: Float64[np.ndarray, "3 3"] = svd_result[0]
+    right_transposed_33: Float64[np.ndarray, "3 3"] = svd_result[2]
+    reflection_fix_33: Float64[np.ndarray, "3 3"] = np.eye(3, dtype=np.float64)
+    if np.linalg.det(right_transposed_33.T @ left_33.T) < 0.0:
+        reflection_fix_33[2, 2] = -1.0
+    rotation_33: Float64[np.ndarray, "3 3"] = right_transposed_33.T @ reflection_fix_33 @ left_33.T
+    translation_xyz: Float64[np.ndarray, "3"] = target_mean_xyz - rotation_33 @ source_mean_xyz
+    fitted_xyz: Float64[np.ndarray, "n 3"] = (rotation_33 @ source_xyz.T).T + translation_xyz
+    residual_xyz: Float64[np.ndarray, "n 3"] = target_xyz - fitted_xyz
+    rms_m: float = float(np.sqrt(np.mean(np.sum(residual_xyz * residual_xyz, axis=1))))
+    source_singular_values: Float64[np.ndarray, "3"] = np.linalg.svd(source_centered_xyz, compute_uv=False)
+    source_extent2_m: float = float(source_singular_values[1] / np.sqrt(num_points))
+    return RigidAlignment(rotation_33, translation_xyz, rms_m, source_extent2_m)
+
+
+def diagnose_clock(
+    gt_times_s: Float64[np.ndarray, "n"], calibration_times_s: Float64[np.ndarray, "m"]
+) -> ClockDiagnostics:
+    """Match GT times to the nearest calibration samples and warn on drift.
+
+    Args:
+        gt_times_s: Float64 capture-relative GT times with shape ``(n,)``.
+        calibration_times_s: Float64 sorted calibration times with shape ``(m,)``.
+
+    Returns:
+        Nearest indices and clock-agreement statistics.
+    """
+    insertion_indices: Int64[np.ndarray, "n"] = np.searchsorted(calibration_times_s, gt_times_s).astype(np.int64)
+    left_indices: Int64[np.ndarray, "n"] = np.clip(insertion_indices - 1, 0, len(calibration_times_s) - 1)
+    right_indices: Int64[np.ndarray, "n"] = np.clip(insertion_indices, 0, len(calibration_times_s) - 1)
+    left_deltas_s: Float64[np.ndarray, "n"] = np.abs(gt_times_s - calibration_times_s[left_indices])
+    right_deltas_s: Float64[np.ndarray, "n"] = np.abs(gt_times_s - calibration_times_s[right_indices])
+    choose_right: Bool[np.ndarray, "n"] = right_deltas_s < left_deltas_s
+    nearest_indices: Int64[np.ndarray, "n"] = np.where(choose_right, right_indices, left_indices).astype(np.int64)
+    deltas_s: Float64[np.ndarray, "n"] = np.abs(gt_times_s - calibration_times_s[nearest_indices])
+    median_delta_s: float = float(np.median(deltas_s))
+    max_delta_s: float = float(np.max(deltas_s))
+    fraction_over_10ms: float = float(np.mean(deltas_s > 0.010))
+    # Diagnostics only — the capture-aware warning is printed at the ingest
+    # boundary (ingest_capture), which knows the video id.
+    should_warn: bool = median_delta_s > 0.002 or fraction_over_10ms > 0.05
+    return ClockDiagnostics(
+        nearest_indices,
+        deltas_s,
+        median_delta_s,
+        max_delta_s,
+        fraction_over_10ms,
+        should_warn,
+    )

--- a/packages/arkitscenes-download/arkitscenes_download/ca1m/archive.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ca1m/archive.py
@@ -1,0 +1,108 @@
+"""Read the laser-GT subset of a CA-1M tar without altering pixels."""
+
+import io
+import json
+import re
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypeAlias
+
+import numpy as np
+from jaxtyping import Float64
+from PIL import Image
+
+
+@dataclass(frozen=True, slots=True)
+class Ca1mFrame:
+    """One complete CA-1M high-resolution laser-GT frame."""
+
+    timestamp_ns: int
+    """ARKit uptime timestamp encoded in the member name, in nanoseconds."""
+    faro_from_camera_44: Float64[np.ndarray, "4 4"]
+    """FARO-world-from-camera pose from ``RT.json``."""
+    depth_png: bytes
+    """Original encoded uint16 depth PNG bytes."""
+    intrinsics_33: Float64[np.ndarray, "3 3"]
+    """OpenCV/RDF image-from-camera matrix."""
+    resolution_wh: tuple[int, int]
+    """Actual PNG width and height."""
+
+
+FrameParts: TypeAlias = dict[str, bytes]
+
+_MEMBER_PATTERN: re.Pattern[str] = re.compile(r"^(?P<video_id>[^/]+)/(?P<timestamp_ns>\d+)(?P<suffix>.*)$")
+_REQUIRED_SUFFIXES: dict[str, str] = {
+    ".gt/RT.json": "rt",
+    ".gt/depth.png": "depth",
+    ".gt/depth/K.json": "intrinsics",
+}
+
+
+def _read_member(archive: tarfile.TarFile, member: tarfile.TarInfo) -> bytes:
+    """Return one regular tar member's bytes."""
+    extracted = archive.extractfile(member)
+    if extracted is None:
+        raise ValueError(f"could not read CA-1M tar member {member.name}")
+    return extracted.read()
+
+
+def _decode_frame(timestamp_ns: int, parts: FrameParts) -> Ca1mFrame:
+    """Validate and decode one complete grouped frame."""
+    missing_parts: list[str] = sorted(set(_REQUIRED_SUFFIXES.values()) - parts.keys())
+    if missing_parts:
+        raise ValueError(f"CA-1M frame {timestamp_ns} is missing {', '.join(missing_parts)}")
+
+    faro_from_camera_44: np.ndarray = np.asarray(json.loads(parts["rt"].decode()), dtype=np.float64)
+    intrinsics_33: np.ndarray = np.asarray(json.loads(parts["intrinsics"].decode()), dtype=np.float64)
+    if faro_from_camera_44.shape != (4, 4):
+        raise ValueError(f"CA-1M frame {timestamp_ns} RT has shape {faro_from_camera_44.shape}, expected (4, 4)")
+    if intrinsics_33.shape != (3, 3):
+        raise ValueError(f"CA-1M frame {timestamp_ns} K has shape {intrinsics_33.shape}, expected (3, 3)")
+
+    # Header-level validation only: the PNG bytes are forwarded unchanged, so a
+    # full pixel decode per frame (millions across the corpus) buys nothing.
+    # Mode "I;16" is PIL's 16-bit grayscale; verify() checks stream integrity.
+    with Image.open(io.BytesIO(parts["depth"])) as image:
+        resolution_wh: tuple[int, int] = image.size
+        image_format: str | None = image.format
+        image_mode: str = image.mode
+        image.verify()
+    if image_format != "PNG" or image_mode != "I;16":
+        raise ValueError(f"CA-1M frame {timestamp_ns} depth must be a 2D uint16 PNG, got {image_format} {image_mode}")
+    return Ca1mFrame(timestamp_ns, faro_from_camera_44, parts["depth"], intrinsics_33, resolution_wh)
+
+
+def parse_archive(archive_path: Path, expected_video_id: str | None = None) -> list[Ca1mFrame]:
+    """Read complete laser-GT frame groups from a plain CA-1M tar.
+
+    Args:
+        archive_path: Path to a plain, uncompressed CA-1M tar.
+        expected_video_id: Optional capture identifier required in every selected member.
+
+    Returns:
+        Complete frames sorted by their nanosecond uptime timestamp.
+    """
+    grouped_parts: dict[int, FrameParts] = {}
+    with tarfile.open(archive_path, mode="r:") as archive:
+        for member in archive:
+            if not member.isfile():
+                continue
+            match: re.Match[str] | None = _MEMBER_PATTERN.fullmatch(member.name)
+            if match is None:
+                continue
+            suffix: str = match.group("suffix")
+            part_name: str | None = _REQUIRED_SUFFIXES.get(suffix)
+            if part_name is None:
+                continue
+            video_id: str = match.group("video_id")
+            if expected_video_id is not None and video_id != expected_video_id:
+                raise ValueError(f"CA-1M tar contains video_id {video_id}, expected {expected_video_id}")
+            timestamp_ns: int = int(match.group("timestamp_ns"))
+            parts: FrameParts = grouped_parts.setdefault(timestamp_ns, {})
+            if part_name in parts:
+                raise ValueError(f"duplicate {part_name} member for CA-1M frame {timestamp_ns}")
+            parts[part_name] = _read_member(archive, member)
+    if not grouped_parts:
+        raise ValueError(f"no CA-1M laser-GT frames found in {archive_path}")
+    return [_decode_frame(timestamp_ns, grouped_parts[timestamp_ns]) for timestamp_ns in sorted(grouped_parts)]

--- a/packages/arkitscenes-download/arkitscenes_download/ca1m/ingest.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ca1m/ingest.py
@@ -1,7 +1,6 @@
 """Ingest Apple's CA-1M laser ground truth as stackable ARKitScenes layers."""
 
 import json
-import subprocess
 import time
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass
@@ -17,10 +16,11 @@ from scipy.spatial.transform import Rotation
 
 from arkitscenes_download.ca1m.alignment import ClockDiagnostics, RigidAlignment, diagnose_clock, rigid_umeyama
 from arkitscenes_download.ca1m.archive import Ca1mFrame, parse_archive
-from arkitscenes_download.download_dataset import head_content_length
+from arkitscenes_download.download_dataset import download_file
 from arkitscenes_download.ingest.blueprint import DEPTH_RANGE_MM
-from arkitscenes_download.ingest.cli import atomic_recording
+from arkitscenes_download.ingest.layers import GT_DEPTH_LAYER, GT_POSES_LAYER
 from arkitscenes_download.ingest.paths import CAM_WIDE, GT, GT_DEPTH, GT_PINHOLE_WIDE, GT_RIG, RIG, TIMELINE
+from arkitscenes_download.ingest.recording import atomic_recording
 
 DEFAULT_DATASET_ROOT: Path = Path("/mnt/nas/datasets/arkitscenes/arkitscenes.2026.07.22")
 DEFAULT_SCRATCH: Path = Path("/var/tmp/ca1m-scratch")
@@ -142,30 +142,14 @@ class CaptureFailure:
     """Wall time before the failure in seconds."""
 
 
-def _download(url: str, output_path: Path) -> None:
-    """Download one file with curl resume support."""
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    completed: subprocess.CompletedProcess[str] = subprocess.run(
-        ["curl", "--fail", "--location", "--continue-at", "-", "--output", str(output_path), url],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    if completed.returncode != 0:
-        detail: str = completed.stderr.strip() or completed.stdout.strip()
-        raise RuntimeError(f"curl failed for {url}: {detail}")
-
-
 def _manifest_paths(config: Config) -> dict[str, Path]:
     """Fetch each pinned manifest once into scratch."""
     manifest_root: Path = config.scratch / "manifests"
     manifest_root.mkdir(parents=True, exist_ok=True)
     paths: dict[str, Path] = {split: manifest_root / f"{split}.txt" for split in MANIFEST_URLS}
     for split, path in paths.items():
-        if not path.is_file():
-            partial_path: Path = path.with_suffix(".txt.part")
-            _download(MANIFEST_URLS[split], partial_path)
-            partial_path.replace(path)
+        if download_file(MANIFEST_URLS[split], path) is None:
+            raise RuntimeError(f"failed to download the CA-1M {split} manifest from {MANIFEST_URLS[split]}")
     return paths
 
 
@@ -337,16 +321,10 @@ def ingest_capture(spec: CaptureSpec, config: Config) -> CaptureResult:
     """Download/cache, align, and atomically write both layers for one capture."""
     started: float = time.perf_counter()
     tar_path: Path = config.scratch / f"ca1m-{spec.split}-{spec.video_id}.tar"
-    # A cached tar counts only when its size matches the CDN: an interrupted
-    # first pass leaves a partial at the final path, and blindly trusting it
-    # poisons every later parse. Size mismatch (or unknown remote size) re-invokes
-    # curl, whose --continue-at resumes the partial. No cached file needs no HEAD.
-    tar_complete: bool = False
-    if tar_path.is_file():
-        expected_bytes: int | None = head_content_length(spec.url)
-        tar_complete = expected_bytes is not None and tar_path.stat().st_size == expected_bytes
-    if not tar_complete:
-        _download(spec.url, tar_path)
+    # download_file is atomic (.part + rename), resumable, and retrying, so a
+    # tar at the final path is complete by construction and reused as-is.
+    if download_file(spec.url, tar_path) is None:
+        raise RuntimeError(f"failed to download the CA-1M tar from {spec.url}")
 
     epoch_seconds: float = read_capture_epoch(config.dataset_root / "base" / f"{spec.video_id}.rrd")
     calibration: CalibrationTrajectory = read_calibration_trajectory(config.dataset_root / "calibration" / f"{spec.video_id}.rrd")
@@ -385,8 +363,8 @@ def ingest_capture(spec: CaptureSpec, config: Config) -> CaptureResult:
         max_interior_gap_s=float(np.diff(video_times_s).max()) if len(video_times_s) > 1 else 0.0,
     )
 
-    poses_dir: Path = config.output / "gt_poses"
-    depth_dir: Path = config.output / "gt_depth"
+    poses_dir: Path = config.output / GT_POSES_LAYER
+    depth_dir: Path = config.output / GT_DEPTH_LAYER
     poses_dir.mkdir(parents=True, exist_ok=True)
     depth_dir.mkdir(parents=True, exist_ok=True)
     _write_pose_layer(poses_dir / f"{spec.video_id}.rrd", spec.video_id, video_times_s, faro_from_rig_n44, alignment, diagnostics, num_pairs, coverage)
@@ -430,8 +408,8 @@ def run(config: Config) -> list[str]:
     selected_specs: list[CaptureSpec] = load_capture_specs(config)
     specs: list[CaptureSpec] = []
     for spec in selected_specs:
-        poses_path: Path = config.output / "gt_poses" / f"{spec.video_id}.rrd"
-        depth_path: Path = config.output / "gt_depth" / f"{spec.video_id}.rrd"
+        poses_path: Path = config.output / GT_POSES_LAYER / f"{spec.video_id}.rrd"
+        depth_path: Path = config.output / GT_DEPTH_LAYER / f"{spec.video_id}.rrd"
         if not config.force and poses_path.is_file() and depth_path.is_file():
             print(f"id={spec.video_id} skipped=both_outputs_exist")
         else:

--- a/packages/arkitscenes-download/arkitscenes_download/ca1m/ingest.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ca1m/ingest.py
@@ -1,0 +1,463 @@
+"""Ingest Apple's CA-1M laser ground truth as stackable ARKitScenes layers."""
+
+import json
+import subprocess
+import time
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import rerun as rr
+from beartype.roar import BeartypeException
+from jaxtyping import Float64, Int64
+from rerun.experimental import RrdReader
+from scipy.spatial.transform import Rotation
+
+from arkitscenes_download.ca1m.alignment import ClockDiagnostics, RigidAlignment, diagnose_clock, rigid_umeyama
+from arkitscenes_download.ca1m.archive import Ca1mFrame, parse_archive
+from arkitscenes_download.download_dataset import head_content_length
+from arkitscenes_download.ingest.blueprint import DEPTH_RANGE_MM
+from arkitscenes_download.ingest.cli import atomic_recording
+from arkitscenes_download.ingest.paths import CAM_WIDE, GT, GT_DEPTH, GT_PINHOLE_WIDE, GT_RIG, RIG, TIMELINE
+
+DEFAULT_DATASET_ROOT: Path = Path("/mnt/nas/datasets/arkitscenes/arkitscenes.2026.07.22")
+DEFAULT_SCRATCH: Path = Path("/var/tmp/ca1m-scratch")
+MANIFEST_URLS: dict[str, str] = {
+    "train": "https://raw.githubusercontent.com/apple/ml-cubifyanything/main/data/train.txt",
+    "val": "https://raw.githubusercontent.com/apple/ml-cubifyanything/main/data/val.txt",
+}
+SOURCE_URL: str = "https://github.com/apple/ml-cubifyanything"
+PROVENANCE: str = "ca1m-v1"
+LICENSE: str = "CC-BY-NC-ND-4.0 (internal use only)"
+DEGENERATE_EXTENT2_M: float = 0.05
+"""Second principal trajectory extent below which the Umeyama roll is weakly observable."""
+
+
+@dataclass(frozen=True, slots=True)
+class Config:
+    """Configuration for concurrent CA-1M ingestion."""
+
+    output: Path
+    """Layer-major output root; ``gt_poses`` and ``gt_depth`` are created beneath it."""
+    dataset_root: Path = DEFAULT_DATASET_ROOT
+    """Existing ARKitScenes layer-major root containing ``base`` and ``calibration``."""
+    scratch: Path = DEFAULT_SCRATCH
+    """Manifest and resumable tar download/cache directory."""
+    video_ids: list[str] | None = None
+    """Capture subset; all manifested captures with a base layer when omitted."""
+    workers: int = 4
+    """Maximum number of captures downloaded and converted concurrently."""
+    force: bool = False
+    """Rewrite captures even when both output layers already exist."""
+    keep_tars: bool = False
+    """Keep downloaded or pre-populated tar files after successful conversion."""
+
+
+@dataclass(frozen=True, slots=True)
+class CaptureSpec:
+    """One manifested CA-1M capture download."""
+
+    video_id: str
+    """ARKitScenes capture identifier."""
+    split: str
+    """CA-1M split, ``train`` or ``val``."""
+    url: str
+    """Tar download URL."""
+
+
+@dataclass(frozen=True, slots=True)
+class CalibrationTrajectory:
+    """Existing ARKit world-from-rig trajectory."""
+
+    video_times_s: Float64[np.ndarray, "n"]
+    """Capture-relative trajectory times in seconds."""
+    translations_xyz: Float64[np.ndarray, "n 3"]
+    """ARKit-world rig translations in metres."""
+
+
+@dataclass(frozen=True, slots=True)
+class GtCoverage:
+    """Where CA-1M's frames sit inside the capture's video timeline.
+
+    Apple only releases frames whose laser registration succeeded, so captures
+    can miss GT at the head/tail (e.g. 42898570 starts at +16.4 s) or have
+    interior holes. This is a property of the CA-1M release, not of ingestion.
+    """
+
+    gt_start_s: float
+    """video_time of the first written GT frame."""
+    gt_end_s: float
+    """video_time of the last written GT frame."""
+    video_end_s: float
+    """End of the capture's calibration timeline (video_time seconds)."""
+    max_interior_gap_s: float
+    """Largest gap between consecutive GT frames."""
+
+
+@dataclass(frozen=True, slots=True)
+class CaptureResult:
+    """Successful capture conversion and audit fields."""
+
+    video_id: str
+    """ARKitScenes capture identifier."""
+    frames: int
+    """Number of CA-1M frames written."""
+    clock_delta_ms_median: float
+    """Median nearest-calibration timestamp delta in milliseconds."""
+    clock_delta_ms_max: float
+    """Maximum nearest-calibration timestamp delta in milliseconds."""
+    clock_fraction_over_10ms: float
+    """Fraction of timestamp matches farther than ten milliseconds."""
+    umeyama_rms_mm: float
+    """Rigid-alignment RMS residual in millimetres."""
+    umeyama_pairs: int
+    """Number of correspondences within ten milliseconds used for alignment."""
+    seconds: float
+    """Capture conversion wall time in seconds."""
+    coverage: GtCoverage
+    """GT frame span vs the video timeline (release property, see GtCoverage)."""
+
+    def summary_line(self) -> str:
+        """Return the one-line capture audit summary."""
+        return (
+            f"id={self.video_id} frames={self.frames} "
+            f"clock_delta_ms_median={self.clock_delta_ms_median:.3f} clock_delta_ms_max={self.clock_delta_ms_max:.3f} "
+            f"umeyama_rms_mm={self.umeyama_rms_mm:.3f} umeyama_pairs={self.umeyama_pairs} "
+            f"gt_span={self.coverage.gt_start_s:.1f}..{self.coverage.gt_end_s:.1f}/{self.coverage.video_end_s:.1f}s "
+            f"max_gap={self.coverage.max_interior_gap_s:.1f}s seconds={self.seconds:.2f}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CaptureFailure:
+    """One capture failure that must not stop other workers."""
+
+    video_id: str
+    """ARKitScenes capture identifier."""
+    message: str
+    """Human-readable exception summary."""
+    seconds: float
+    """Wall time before the failure in seconds."""
+
+
+def _download(url: str, output_path: Path) -> None:
+    """Download one file with curl resume support."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    completed: subprocess.CompletedProcess[str] = subprocess.run(
+        ["curl", "--fail", "--location", "--continue-at", "-", "--output", str(output_path), url],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        detail: str = completed.stderr.strip() or completed.stdout.strip()
+        raise RuntimeError(f"curl failed for {url}: {detail}")
+
+
+def _manifest_paths(config: Config) -> dict[str, Path]:
+    """Fetch each pinned manifest once into scratch."""
+    manifest_root: Path = config.scratch / "manifests"
+    manifest_root.mkdir(parents=True, exist_ok=True)
+    paths: dict[str, Path] = {split: manifest_root / f"{split}.txt" for split in MANIFEST_URLS}
+    for split, path in paths.items():
+        if not path.is_file():
+            partial_path: Path = path.with_suffix(".txt.part")
+            _download(MANIFEST_URLS[split], partial_path)
+            partial_path.replace(path)
+    return paths
+
+
+def load_capture_specs(config: Config) -> list[CaptureSpec]:
+    """Load manifested captures and apply explicit or base-layer selection."""
+    specs_by_id: dict[str, CaptureSpec] = {}
+    for split, manifest_path in _manifest_paths(config).items():
+        for line in manifest_path.read_text().splitlines():
+            url: str = line.strip()
+            if not url or url.startswith("#"):
+                continue
+            filename: str = url.rsplit("/", 1)[-1]
+            prefix: str = f"ca1m-{split}-"
+            if not filename.startswith(prefix) or not filename.endswith(".tar"):
+                raise ValueError(f"unexpected {split} CA-1M manifest entry: {url}")
+            video_id: str = filename[len(prefix) : -len(".tar")]
+            if not video_id.isdigit():
+                raise ValueError(f"unexpected CA-1M video_id in manifest entry: {url}")
+            if video_id in specs_by_id:
+                raise ValueError(f"duplicate CA-1M video_id in manifests: {video_id}")
+            specs_by_id[video_id] = CaptureSpec(video_id, split, url)
+
+    if config.video_ids is None:
+        selected_ids: list[str] = sorted(video_id for video_id in specs_by_id if (config.dataset_root / "base" / f"{video_id}.rrd").is_file())
+    else:
+        selected_ids = list(dict.fromkeys(config.video_ids))
+    missing_ids: list[str] = [video_id for video_id in selected_ids if video_id not in specs_by_id]
+    if missing_ids:
+        raise ValueError(f"video_ids absent from CA-1M manifests: {missing_ids}")
+    return [specs_by_id[video_id] for video_id in selected_ids]
+
+
+def read_capture_epoch(base_rrd: Path) -> float:
+    """Read the ARKit uptime at ``video_time == 0`` from a base-layer RRD."""
+    reader: RrdReader = RrdReader(base_rrd)
+    for chunk in reader.stream():
+        if str(chunk.entity_path).rsplit("/", 1)[-1] != "uptime_epoch_seconds":
+            continue
+        batch: Any = chunk.to_record_batch()
+        if "value" not in batch.schema.names:
+            continue
+        values: list[Any] = batch.column("value").to_pylist()
+        if values and values[0]:
+            return float(values[0][0])
+    raise ValueError(f"base layer {base_rrd} is missing the uptime_epoch_seconds property")
+
+
+def _component_array(batch: Any, name: str, width: int) -> Float64[np.ndarray, "n width"]:
+    """Flatten a singleton-list Rerun vector component into a numeric array."""
+    values: list[Any] = batch.column(name).to_pylist()
+    array: np.ndarray = np.asarray(values, dtype=np.float64)
+    return array.reshape(len(values), width)
+
+
+def read_calibration_trajectory(calibration_rrd: Path) -> CalibrationTrajectory:
+    """Read world-from-rig samples, requiring the wide camera to be the rig reference."""
+    times_parts: list[np.ndarray] = []
+    translation_parts: list[np.ndarray] = []
+    cam_translation_xyz: Float64[np.ndarray, "3"] | None = None
+    cam_rotation_xyzw: Float64[np.ndarray, "4"] | None = None
+    reader: RrdReader = RrdReader(calibration_rrd)
+    for chunk in reader.stream():
+        entity_path: str = str(chunk.entity_path)
+        batch: Any = chunk.to_record_batch()
+        if entity_path == f"/{RIG}" and not chunk.is_static:
+            required: set[str] = {TIMELINE, "Transform3D:translation"}
+            if not required.issubset(batch.schema.names):
+                continue
+            times_ns: np.ndarray = np.asarray(batch.column(TIMELINE)).astype("timedelta64[ns]").astype(np.int64)
+            times_parts.append(times_ns.astype(np.float64) / 1e9)
+            translation_parts.append(_component_array(batch, "Transform3D:translation", 3))
+        elif entity_path == f"/{CAM_WIDE}" and chunk.is_static:
+            if "Transform3D:translation" in batch.schema.names:
+                cam_translation_xyz = _component_array(batch, "Transform3D:translation", 3)[0]
+            if "Transform3D:quaternion" in batch.schema.names:
+                cam_rotation_xyzw = _component_array(batch, "Transform3D:quaternion", 4)[0]
+    if not times_parts or not translation_parts:
+        raise ValueError(f"calibration layer {calibration_rrd} has no world/rig_00 trajectory")
+    if cam_translation_xyz is None or cam_rotation_xyzw is None:
+        raise ValueError(f"calibration layer {calibration_rrd} has no static cam_00 transform")
+
+    # CA-1M RT.json is FARO-world-from-camera; treating it as FARO-world-from-rig
+    # is only valid while cam_00 IS the rig reference (identity extrinsic), which
+    # our own ingest guarantees. Fail loudly if that schema assumption ever breaks.
+    rig_from_cam00_44: Float64[np.ndarray, "4 4"] = np.eye(4, dtype=np.float64)
+    rig_from_cam00_44[:3, :3] = Rotation.from_quat(cam_rotation_xyzw).as_matrix()
+    rig_from_cam00_44[:3, 3] = cam_translation_xyz
+    if not np.allclose(rig_from_cam00_44, np.eye(4), rtol=0.0, atol=1e-6):
+        raise ValueError(f"calibration layer {calibration_rrd}: cam_00 is not the rig reference; CA-1M poses assume camera == rig")
+
+    video_times_s: Float64[np.ndarray, "n"] = np.concatenate(times_parts).astype(np.float64)
+    translations_xyz: Float64[np.ndarray, "n 3"] = np.concatenate(translation_parts).astype(np.float64)
+    order: Int64[np.ndarray, "n"] = np.argsort(video_times_s).astype(np.int64)
+    return CalibrationTrajectory(video_times_s[order], translations_xyz[order])
+
+
+def _write_pose_layer(
+    output_path: Path,
+    video_id: str,
+    video_times_s: Float64[np.ndarray, "n"],
+    faro_from_rig_n44: Float64[np.ndarray, "n 4 4"],
+    alignment: RigidAlignment,
+    diagnostics: ClockDiagnostics,
+    num_pairs: int,
+    coverage: GtCoverage,
+) -> None:
+    """Write aligned GT poses plus per-capture GT metadata as recording properties.
+
+    Metadata goes into recording properties (``property:gt_*`` segment-table
+    columns, like base's ``uptime_epoch_seconds``) rather than entity data, so
+    provenance and quality are sortable in the catalog without an entity reader.
+    Values are stringified to match base's property convention.
+    """
+    gt_properties: dict[str, object] = {
+        "gt_provenance": PROVENANCE,
+        "gt_license": LICENSE,
+        "gt_source": SOURCE_URL,
+        "gt_umeyama_rms_m": alignment.rms_m,
+        "gt_umeyama_extent2_m": alignment.source_extent2_m,
+        "gt_umeyama_pairs": num_pairs,
+        "gt_clock_median_delta_ms": diagnostics.median_delta_s * 1000.0,
+        "gt_clock_max_delta_ms": diagnostics.max_delta_s * 1000.0,
+        "gt_start_s": coverage.gt_start_s,
+        "gt_end_s": coverage.gt_end_s,
+        "gt_max_interior_gap_s": coverage.max_interior_gap_s,
+    }
+    with atomic_recording(output_path, video_id, send_properties=False) as recording:
+        for name, value in gt_properties.items():
+            recording.send_property(name, rr.AnyValues(value=str(value)))
+        recording.log(GT, rr.Transform3D(translation=alignment.translation_xyz, mat3x3=alignment.rotation_33), static=True)
+        rr.send_columns(
+            GT_RIG,
+            indexes=[rr.TimeColumn(TIMELINE, duration=video_times_s)],
+            columns=rr.Transform3D.columns(translation=faro_from_rig_n44[:, :3, 3], mat3x3=faro_from_rig_n44[:, :3, :3]),
+            recording=recording,
+        )
+
+
+def _write_depth_layer(output_path: Path, video_id: str, video_times_s: Float64[np.ndarray, "n"], frames: list[Ca1mFrame]) -> None:
+    """Write unchanged depth PNG columns and timestamped pinhole calibration (K varies per frame)."""
+    intrinsics_n33: Float64[np.ndarray, "n 3 3"] = np.stack([frame.intrinsics_33 for frame in frames])
+    resolutions_wh: list[tuple[int, int]] = [frame.resolution_wh for frame in frames]
+    depth_pngs: list[bytes] = [frame.depth_png for frame in frames]
+    with atomic_recording(output_path, video_id, send_properties=False) as recording:
+        rr.send_columns(
+            GT_PINHOLE_WIDE,
+            indexes=[rr.TimeColumn(TIMELINE, duration=video_times_s)],
+            columns=rr.Pinhole.columns(
+                image_from_camera=intrinsics_n33,
+                resolution=resolutions_wh,
+                camera_xyz=[rr.ViewCoordinates.RDF] * len(frames),
+            ),
+            recording=recording,
+        )
+        rr.send_columns(
+            GT_DEPTH,
+            indexes=[rr.TimeColumn(TIMELINE, duration=video_times_s)],
+            columns=rr.EncodedDepthImage.columns(
+                blob=depth_pngs,
+                media_type=["image/png"] * len(frames),
+                meter=[1000.0] * len(frames),
+                depth_range=[DEPTH_RANGE_MM] * len(frames),
+            ),
+            recording=recording,
+        )
+
+
+def ingest_capture(spec: CaptureSpec, config: Config) -> CaptureResult:
+    """Download/cache, align, and atomically write both layers for one capture."""
+    started: float = time.perf_counter()
+    tar_path: Path = config.scratch / f"ca1m-{spec.split}-{spec.video_id}.tar"
+    # A cached tar counts only when its size matches the CDN: an interrupted
+    # first pass leaves a partial at the final path, and blindly trusting it
+    # poisons every later parse. Size mismatch (or unknown remote size) re-invokes
+    # curl, whose --continue-at resumes the partial. No cached file needs no HEAD.
+    tar_complete: bool = False
+    if tar_path.is_file():
+        expected_bytes: int | None = head_content_length(spec.url)
+        tar_complete = expected_bytes is not None and tar_path.stat().st_size == expected_bytes
+    if not tar_complete:
+        _download(spec.url, tar_path)
+
+    epoch_seconds: float = read_capture_epoch(config.dataset_root / "base" / f"{spec.video_id}.rrd")
+    calibration: CalibrationTrajectory = read_calibration_trajectory(config.dataset_root / "calibration" / f"{spec.video_id}.rrd")
+    frames: list[Ca1mFrame] = parse_archive(tar_path, expected_video_id=spec.video_id)
+    timestamps_ns: Int64[np.ndarray, "n"] = np.asarray([frame.timestamp_ns for frame in frames], dtype=np.int64)
+    # parse_archive sorts by timestamp, so video_times_s is ascending.
+    video_times_s: Float64[np.ndarray, "n"] = timestamps_ns.astype(np.float64) / 1e9 - epoch_seconds
+    if video_times_s[0] < 0.0:
+        raise ValueError(f"CA-1M frames precede video_time zero (first at {video_times_s[0]:.3f}s); never seen in the corpus")
+
+    diagnostics: ClockDiagnostics = diagnose_clock(video_times_s, calibration.video_times_s)
+    if diagnostics.should_warn:
+        print(
+            f"WARN id={spec.video_id}: CA-1M clock assumption may be broken; median={diagnostics.median_delta_s * 1000.0:.3f}ms "
+            f"over_10ms={diagnostics.fraction_over_10ms:.3%}"
+        )
+    faro_from_rig_n44: Float64[np.ndarray, "n 4 4"] = np.stack([frame.faro_from_camera_44 for frame in frames])
+    pair_mask: np.ndarray = diagnostics.deltas_s <= 0.010
+    num_pairs: int = int(np.count_nonzero(pair_mask))
+    if num_pairs < 3:
+        raise ValueError(f"only {num_pairs} CA-1M/calibration pairs are within 10 ms")
+    alignment: RigidAlignment = rigid_umeyama(
+        faro_from_rig_n44[pair_mask, :3, 3],
+        calibration.translations_xyz[diagnostics.nearest_indices[pair_mask]],
+    )
+    if alignment.source_extent2_m < DEGENERATE_EXTENT2_M:
+        print(
+            f"WARN id={spec.video_id}: near-collinear trajectory (second extent "
+            f"{alignment.source_extent2_m * 100.0:.1f} cm) — Umeyama roll is weakly observable; rms alone cannot be trusted"
+        )
+
+    coverage: GtCoverage = GtCoverage(
+        gt_start_s=float(video_times_s[0]),
+        gt_end_s=float(video_times_s[-1]),
+        video_end_s=float(calibration.video_times_s.max()),
+        max_interior_gap_s=float(np.diff(video_times_s).max()) if len(video_times_s) > 1 else 0.0,
+    )
+
+    poses_dir: Path = config.output / "gt_poses"
+    depth_dir: Path = config.output / "gt_depth"
+    poses_dir.mkdir(parents=True, exist_ok=True)
+    depth_dir.mkdir(parents=True, exist_ok=True)
+    _write_pose_layer(poses_dir / f"{spec.video_id}.rrd", spec.video_id, video_times_s, faro_from_rig_n44, alignment, diagnostics, num_pairs, coverage)
+    _write_depth_layer(depth_dir / f"{spec.video_id}.rrd", spec.video_id, video_times_s, frames)
+    if not config.keep_tars:
+        tar_path.unlink()
+    return CaptureResult(
+        video_id=spec.video_id,
+        frames=len(frames),
+        clock_delta_ms_median=diagnostics.median_delta_s * 1000.0,
+        clock_delta_ms_max=diagnostics.max_delta_s * 1000.0,
+        clock_fraction_over_10ms=diagnostics.fraction_over_10ms,
+        umeyama_rms_mm=alignment.rms_m * 1000.0,
+        umeyama_pairs=num_pairs,
+        seconds=time.perf_counter() - started,
+        coverage=coverage,
+    )
+
+
+def _ingest_capture_safely(spec: CaptureSpec, config: Config) -> CaptureResult | CaptureFailure:
+    """Convert one capture while preserving beartype failures for the coordinator."""
+    started: float = time.perf_counter()
+    try:
+        return ingest_capture(spec, config)
+    except BeartypeException:
+        raise
+    except Exception as error:
+        return CaptureFailure(spec.video_id, f"{type(error).__name__}: {error}", time.perf_counter() - started)
+
+
+def _append_audit_log(log_path: Path, result: CaptureResult) -> None:
+    """Append one successful capture result as a JSON line."""
+    with log_path.open("a", encoding="utf-8") as audit_file:
+        audit_file.write(json.dumps(asdict(result), sort_keys=True) + "\n")
+
+
+def run(config: Config) -> list[str]:
+    """Run the selected concurrent batch and return failed capture identifiers."""
+    config.scratch.mkdir(parents=True, exist_ok=True)
+    config.output.mkdir(parents=True, exist_ok=True)
+    selected_specs: list[CaptureSpec] = load_capture_specs(config)
+    specs: list[CaptureSpec] = []
+    for spec in selected_specs:
+        poses_path: Path = config.output / "gt_poses" / f"{spec.video_id}.rrd"
+        depth_path: Path = config.output / "gt_depth" / f"{spec.video_id}.rrd"
+        if not config.force and poses_path.is_file() and depth_path.is_file():
+            print(f"id={spec.video_id} skipped=both_outputs_exist")
+        else:
+            specs.append(spec)
+
+    failed_ids: list[str] = []
+    audit_path: Path = config.output / "ca1m_ingest_log.jsonl"
+    with ThreadPoolExecutor(max_workers=config.workers) as pool:
+        futures: list[Future[CaptureResult | CaptureFailure]] = [pool.submit(_ingest_capture_safely, spec, config) for spec in specs]
+        for future in as_completed(futures):
+            # BeartypeException propagates from future.result() and kills the batch:
+            # a type-contract violation is a code bug, not a per-capture failure.
+            result: CaptureResult | CaptureFailure = future.result()
+            if isinstance(result, CaptureFailure):
+                failed_ids.append(result.video_id)
+                print(f"FAILED id={result.video_id} seconds={result.seconds:.2f} error={result.message}")
+            else:
+                print(result.summary_line())
+                _append_audit_log(audit_path, result)
+    failed_ids.sort()
+    if failed_ids:
+        print(f"failed_ids={failed_ids}")
+    return failed_ids
+
+
+def main(config: Config) -> None:
+    """Run CA-1M ingestion and exit nonzero when any capture failed."""
+    failed_ids: list[str] = run(config)
+    raise SystemExit(1 if failed_ids else 0)

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/__init__.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/__init__.py
@@ -1,5 +1,1 @@
-"""Convert a raw ARKitScenes sequence to a Rerun recording."""
-
-from arkitscenes_download.ingest.cli import Config, ingest_sequence
-
-__all__: list[str] = ["Config", "ingest_sequence"]
+"""Convert a raw ARKitScenes sequence to layered Rerun recordings."""

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/cli.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/cli.py
@@ -6,19 +6,15 @@ they are frame-agnostic scalar channels, not spatial vector archetypes.
 """
 
 import csv
-import os
 import subprocess
-import tempfile
 import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
 import rerun as rr
-import rerun.blueprint as rrb
 from PIL import Image
 from rich.console import Console
 from rich.progress import Progress, TaskID
@@ -75,6 +71,7 @@ from arkitscenes_download.ingest.paths import (
     VIDEO_WIDE,
     WORLD,
 )
+from arkitscenes_download.ingest.recording import atomic_recording
 from arkitscenes_download.ingest.rig import (
     DeviceFrameFit,
     Intrinsics,
@@ -96,23 +93,6 @@ from arkitscenes_download.ingest.rig import (
 
 BATCH_SIZE: int = 1000
 CONSOLE: Console = Console(markup=False)
-
-
-@contextmanager
-def atomic_recording(output_path: Path, recording_id: str, *, send_properties: bool, default_blueprint: rrb.Blueprint | None = None):
-    """Yield a recording that is finalized before atomically replacing its target."""
-    descriptor, temp_name = tempfile.mkstemp(dir=output_path.parent, suffix=".rrd.tmp")
-    os.close(descriptor)
-    temp_path: Path = Path(temp_name)
-    try:
-        with rr.RecordingStream(application_id="arkitscenes", recording_id=recording_id, send_properties=send_properties) as recording:
-            recording.save(temp_path, default_blueprint=default_blueprint)
-            yield recording
-        temp_path.chmod(0o644)  # mkstemp temps are 0600; NFS mounts and the catalog server need world-readable files
-        os.replace(temp_path, output_path)
-    except BaseException:
-        temp_path.unlink(missing_ok=True)
-        raise
 
 
 def verify_rrd(path: Path | list[Path]) -> str:

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/layers.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/layers.py
@@ -25,7 +25,9 @@ LAYERS: tuple[Layer, ...] = (
     Layer("gt_boxes", False),
 )
 LAYER_NAMES: tuple[str, ...] = tuple(layer.name for layer in LAYERS)
-OPTIONAL_LAYER_NAMES: tuple[str, str] = ("gt_poses", "gt_depth")
+GT_POSES_LAYER: str = "gt_poses"
+GT_DEPTH_LAYER: str = "gt_depth"
+OPTIONAL_LAYER_NAMES: tuple[str, str] = (GT_POSES_LAYER, GT_DEPTH_LAYER)
 """Laser-GT layers produced by the CA-1M tool, present only on covered captures; absence = no GT."""
 ALL_LAYER_NAMES: tuple[str, ...] = LAYER_NAMES + OPTIONAL_LAYER_NAMES
 LAYERS_BY_NAME: dict[str, Layer] = {layer.name: layer for layer in LAYERS}

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/recording.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/recording.py
@@ -1,0 +1,26 @@
+"""Atomic publication of layer RRDs."""
+
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+
+import rerun as rr
+import rerun.blueprint as rrb
+
+
+@contextmanager
+def atomic_recording(output_path: Path, recording_id: str, *, send_properties: bool, default_blueprint: rrb.Blueprint | None = None):
+    """Yield a recording that is finalized before atomically replacing its target."""
+    descriptor, temp_name = tempfile.mkstemp(dir=output_path.parent, suffix=".rrd.tmp")
+    os.close(descriptor)
+    temp_path: Path = Path(temp_name)
+    try:
+        with rr.RecordingStream(application_id="arkitscenes", recording_id=recording_id, send_properties=send_properties) as recording:
+            recording.save(temp_path, default_blueprint=default_blueprint)
+            yield recording
+        temp_path.chmod(0o644)  # mkstemp temps are 0600; NFS mounts and the catalog server need world-readable files
+        os.replace(temp_path, output_path)
+    except BaseException:
+        temp_path.unlink(missing_ok=True)
+        raise

--- a/packages/arkitscenes-download/pyproject.toml
+++ b/packages/arkitscenes-download/pyproject.toml
@@ -38,4 +38,4 @@ min_confidence = 60
 # benchmark/full_run/convert: Modal CLI entrypoints, invoked via `modal run ...::name`
 # is_in_threedod: metadata.csv row field, parsed for schema completeness
 # DEPTH_PROMPTDA / PROMPTDA_MESH: entity paths consumed by packages/prompt-da
-ignore_names = ["is_in_threedod", "DEPTH_PROMPTDA", "PROMPTDA_MESH", "benchmark", "full_run", "convert"]
+ignore_names = ["is_in_threedod", "clock_fraction_over_10ms", "DEPTH_PROMPTDA", "PROMPTDA_MESH", "benchmark", "full_run", "convert"]

--- a/packages/arkitscenes-download/tests/test_ca1m_alignment.py
+++ b/packages/arkitscenes-download/tests/test_ca1m_alignment.py
@@ -1,0 +1,85 @@
+"""Behavior checks for CA-1M clock mapping and rigid alignment."""
+
+import warnings
+
+import numpy as np
+import pytest
+from scipy.spatial.transform import Rotation
+
+from arkitscenes_download.ca1m.alignment import diagnose_clock, rigid_umeyama
+
+
+def test_rigid_umeyama_recovers_known_transform_with_noise() -> None:
+    """A noisy proper rigid transform is recovered without estimating scale."""
+    rng: np.random.Generator = np.random.default_rng(42898570)
+    faro_xyz: np.ndarray = rng.normal(size=(200, 3)).astype(np.float64)
+    expected_rotation_33: np.ndarray = Rotation.from_euler("xyz", [17.0, -8.0, 31.0], degrees=True).as_matrix()
+    expected_translation_xyz: np.ndarray = np.asarray([1.2, -0.7, 0.35], dtype=np.float64)
+    arkit_xyz: np.ndarray = (expected_rotation_33 @ faro_xyz.T).T + expected_translation_xyz
+    arkit_xyz += rng.normal(scale=1e-4, size=arkit_xyz.shape)
+
+    alignment = rigid_umeyama(faro_xyz, arkit_xyz)
+
+    np.testing.assert_allclose(alignment.rotation_33, expected_rotation_33, atol=3e-5)
+    np.testing.assert_allclose(alignment.translation_xyz, expected_translation_xyz, atol=3e-5)
+    assert alignment.rms_m < 2e-4
+
+
+def test_rigid_umeyama_rejects_reflection_solution() -> None:
+    """Reflected correspondences still produce a proper rotation."""
+    faro_xyz: np.ndarray = np.asarray(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0], [1.0, 2.0, 3.0]], dtype=np.float64
+    )
+    reflection_33: np.ndarray = np.diag(np.asarray([-1.0, 1.0, 1.0], dtype=np.float64))
+    arkit_xyz: np.ndarray = (reflection_33 @ faro_xyz.T).T + np.asarray([4.0, -2.0, 1.0], dtype=np.float64)
+
+    alignment = rigid_umeyama(faro_xyz, arkit_xyz)
+
+    assert np.linalg.det(alignment.rotation_33) == pytest.approx(1.0, abs=1e-12)
+    assert alignment.rms_m > 0.0
+
+
+def test_clock_diagnostic_warns_when_threshold_is_exceeded() -> None:
+    """A broken clock mapping sets the should_warn flag for the ingest boundary."""
+    gt_times_s: np.ndarray = np.asarray([0.100, 0.110, 0.120], dtype=np.float64)
+    calibration_times_s: np.ndarray = np.asarray([0.0, 0.010, 0.020], dtype=np.float64)
+
+    diagnostics = diagnose_clock(gt_times_s, calibration_times_s)
+
+    assert diagnostics.median_delta_s > 0.002
+    assert diagnostics.fraction_over_10ms > 0.05
+    assert diagnostics.should_warn
+
+
+def test_clock_diagnostic_accepts_nearby_samples() -> None:
+    """Sub-millisecond matches remain below every warning threshold."""
+    gt_times_s: np.ndarray = np.asarray([0.0004, 0.0103, 0.0198], dtype=np.float64)
+    calibration_times_s: np.ndarray = np.asarray([0.0, 0.010, 0.020], dtype=np.float64)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        diagnostics = diagnose_clock(gt_times_s, calibration_times_s)
+
+    assert diagnostics.median_delta_s < 0.002
+    assert diagnostics.fraction_over_10ms == 0.0
+    assert not diagnostics.should_warn
+
+
+def test_rigid_umeyama_flags_collinear_trajectories() -> None:
+    """Rank-1 motion reports a tiny second extent even when the residual is zero."""
+    line_xyz: np.ndarray = np.stack([np.linspace(0.0, 2.0, 8), np.zeros(8), np.zeros(8)], axis=1)
+
+    alignment = rigid_umeyama(line_xyz, line_xyz.copy())
+
+    assert alignment.rms_m == pytest.approx(0.0, abs=1e-12)
+    assert alignment.source_extent2_m == pytest.approx(0.0, abs=1e-12)
+
+
+def test_rigid_umeyama_reports_planar_extent() -> None:
+    """Well-spread planar motion keeps a healthy second extent."""
+    rng = np.random.default_rng(7)
+    plane_xyz: np.ndarray = np.column_stack([rng.uniform(-1.0, 1.0, 64), rng.uniform(-1.0, 1.0, 64), np.zeros(64)])
+
+    alignment = rigid_umeyama(plane_xyz, plane_xyz.copy())
+
+    assert alignment.source_extent2_m > 0.3

--- a/packages/arkitscenes-download/tests/test_ca1m_archive.py
+++ b/packages/arkitscenes-download/tests/test_ca1m_archive.py
@@ -1,0 +1,54 @@
+"""Behavior checks for reading CA-1M frame groups without image rotation."""
+
+import io
+import json
+import tarfile
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+from arkitscenes_download.ca1m.archive import Ca1mFrame, parse_archive
+
+
+def _png_bytes(depth_hw: np.ndarray) -> bytes:
+    buffer = io.BytesIO()
+    Image.fromarray(depth_hw).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _add_bytes(archive: tarfile.TarFile, name: str, payload: bytes) -> None:
+    member = tarfile.TarInfo(name)
+    member.size = len(payload)
+    archive.addfile(member, io.BytesIO(payload))
+
+
+def test_archive_frames_roundtrip_in_timestamp_order(tmp_path: Path) -> None:
+    """Grouped RT, K, and unchanged uint16 PNG payloads become sorted frames."""
+    archive_path: Path = tmp_path / "ca1m-val-00000001.tar"
+    expected_depth: dict[int, np.ndarray] = {
+        2_000_000_000: np.asarray([[0, 1000, 2000], [3000, 4000, 5000]], dtype=np.uint16),
+        1_000_000_000: np.asarray([[7, 8], [9, 10], [11, 12]], dtype=np.uint16),
+    }
+    expected_png: dict[int, bytes] = {stamp_ns: _png_bytes(depth_hw) for stamp_ns, depth_hw in expected_depth.items()}
+    with tarfile.open(archive_path, mode="w") as archive:
+        for frame_index, stamp_ns in enumerate(expected_depth):
+            faro_from_camera_44: np.ndarray = np.eye(4, dtype=np.float64)
+            faro_from_camera_44[:3, 3] = [float(frame_index), 2.0, 3.0]
+            intrinsics_33: np.ndarray = np.asarray([[500.0, 0.0, 1.0], [0.0, 501.0, 0.5], [0.0, 0.0, 1.0]], dtype=np.float64)
+            prefix: str = f"00000001/{stamp_ns}"
+            _add_bytes(archive, f"{prefix}.gt/RT.json", json.dumps(faro_from_camera_44.tolist()).encode())
+            _add_bytes(archive, f"{prefix}.gt/depth.png", expected_png[stamp_ns])
+            _add_bytes(archive, f"{prefix}.gt/depth/K.json", json.dumps(intrinsics_33.tolist()).encode())
+            _add_bytes(archive, f"{prefix}.wide/image.png", b"ignored")
+
+    frames: list[Ca1mFrame] = parse_archive(archive_path, expected_video_id="00000001")
+
+    assert [frame.timestamp_ns for frame in frames] == [1_000_000_000, 2_000_000_000]
+    for frame in frames:
+        assert frame.depth_png == expected_png[frame.timestamp_ns]
+        with Image.open(io.BytesIO(frame.depth_png)) as decoded:
+            decoded_depth_hw: np.ndarray = np.asarray(decoded)
+        np.testing.assert_array_equal(decoded_depth_hw, expected_depth[frame.timestamp_ns])
+        expected_hw: tuple[int, int] = expected_depth[frame.timestamp_ns].shape
+        assert frame.resolution_wh == (expected_hw[1], expected_hw[0])

--- a/packages/arkitscenes-download/tools/apps/ca1m_ingest.py
+++ b/packages/arkitscenes-download/tools/apps/ca1m_ingest.py
@@ -1,0 +1,6 @@
+import tyro
+
+from arkitscenes_download.ca1m.ingest import Config, main
+
+if __name__ == "__main__":
+    main(tyro.cli(Config))

--- a/pixi.toml
+++ b/pixi.toml
@@ -2274,6 +2274,11 @@ cwd = "packages/arkitscenes-download"
 depends-on = ["arkitscenes-download-sample"]
 description = "Ingest every downloaded sequence into layered .rrd files under data/rrd/"
 
+[feature.arkitscenes-download.tasks.arkitscenes-download-ca1m]
+cmd = "python tools/apps/ca1m_ingest.py"
+cwd = "packages/arkitscenes-download"
+description = "Ingest CA-1M laser GT into stackable gt_poses and gt_depth layer RRDs"
+
 [feature.arkitscenes-download.tasks.arkitscenes-download-serve]
 # Rerun keeps one handle open per registered RRD. One full corpus has
 # 5015 segments * 8 layers = 40120 RRDs, so 65536 cannot hold two corpora.


### PR DESCRIPTION
## CA-1M laser ground truth → `gt_poses` + `gt_depth`

**Stacked on #92** (taxonomy v2) — merge that first; this PR adds the generator for the two optional laser-GT layers the base PR taught the catalog to recognize.

New `arkitscenes_download/ca1m/` package + `arkitscenes-download-ca1m` task. Per covered capture it:

1. downloads/caches Apple's CA-1M tar ([ml-cubifyanything](https://github.com/apple/ml-cubifyanything); resumable `curl -C -`, cache validated against the CDN Content-Length so an interrupted first pass can't poison a re-parse);
2. reads the laser-GT frames (camera→FARO-world `RT.json`, 512×384 uint16 mm depth PNGs forwarded **byte-for-byte**, per-frame `K`) and rebases their uptime stamps onto the capture's `video_time` via the base layer's `uptime_epoch_seconds`;
3. aligns FARO world to the existing ARKit `/world` with a per-capture rigid Umeyama fit (no scale) on trajectory correspondences within 10 ms — clock deltas are diagnostics only, never joins;
4. writes two stackable layer RRDs mirroring the rig schema:
   - **`gt_poses`** — static `/world/gt` Umeyama transform + ~10 Hz `/world/gt/rig_00` pose columns, with provenance/quality/coverage as recording properties (`property:gt_*` segment-table columns: `gt_umeyama_rms_m`, `gt_start_s`, `gt_end_s`, `gt_max_interior_gap_s`, `gt_provenance`, `gt_license`, …)
   - **`gt_depth`** — `EncodedDepthImage` columns under `/world/gt/rig_00/cam_00/pinhole` with timestamped per-frame `K` (K varies every frame in practice)

Near-collinear trajectories are flagged via the second principal extent — a rank-1 trajectory leaves Umeyama roll unobservable while reporting a perfect RMS (17 such sliver captures in the corpus).

## Corpus run (already executed)

Ran over the full NAS dataset: **3,057/3,057 attainable captures** (2 upstream tars are permanently empty 61 KB stubs). Clock agreement ≤0.026 ms everywhere; Umeyama residual median 24.5 mm / p90 62 mm. Registered as `arkitscenes-v2`: 5,015 segments, **3,057 gt-covered**.

The tool was then trimmed against the run's full audit log (3,074 rows = a complete execution census): every branch the corpus never took was deleted (static-pinhole fallback, cam_00-extrinsic composition — identity by construction, now a loud error; pre-epoch frame dropping; unused offline-manifest knob) and the trimmed tool re-verified to reproduce a capture's audit numbers exactly.

## License

CA-1M is **CC BY-NC-ND 4.0**.

## Validation

- `tests` / `lint` / `typecheck` green at this commit (52 passed / 4 skipped).
- End-to-end re-run of capture `42897442` after the trim reproduces the bulk-run audit line exactly (frames=3, rms 128.236 mm, clock 0.016/0.026 ms).
- Pixel-validated in the viewer: GT frustum/trajectory in the `world GT` tab, laser depth in the retargeted `depth GT (laser)` tab, GT starting at 16.385 s on the known late-start capture.
