### PR TITLE
arkitscenes: typed, grouped recording properties (42 flat string columns → 15 typed)

### DIFF
--- a/packages/arkitscenes-download/README.md
+++ b/packages/arkitscenes-download/README.md
@@ -87,15 +87,15 @@ Facts that shape consumption:
   captures (only those whose laser registration succeeded), and within a capture
   the GT frames can start late, end early, or have interior holes (e.g.
   `42898570` has no GT for its first 16.4 s). Per-capture coverage and quality
-  ship as `property:gt_*` segment-table columns (`gt_start_s`, `gt_end_s`,
-  `gt_max_interior_gap_s`, `gt_umeyama_rms_m`, …). A capture without the `gt_*`
-  layers has no laser GT — that absence is the intended marker.
+  ship as typed `property:gt:*` segment-table columns (`start_s`, `end_s`,
+  `max_interior_gap_s`, `umeyama_rms_m`, `provenance`). A capture without the
+  `gt_*` layers has no laser GT — that absence is the intended marker.
 - **GT is ~10 Hz** (the hi-res frame grid) on the shared `video_time` timeline;
   the 60 Hz device streams simply coexist with it.
 - **Frames are already upright** in CA-1M; the tool applies no rotation.
 - **Coordinate frames:** CA-1M poses live in the FARO venue frame. A per-capture
-  rigid Umeyama fit (residual in `gt_umeyama_rms_m`) connects them to the ARKit
-  `/world` via a static transform at `/world/gt`.
+  rigid Umeyama fit (residual in `property:gt:umeyama_rms_m`) connects them to
+  the ARKit `/world` via a static transform at `/world/gt`.
 - **License:** CA-1M data is **CC BY-NC-ND 4.0** — internal research use only;
   do **not** publicly redistribute RRDs derived from it. The original
   ARKitScenes-derived layers keep the far more permissive

--- a/packages/arkitscenes-download/arkitscenes_download/ca1m/ingest.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ca1m/ingest.py
@@ -28,9 +28,7 @@ MANIFEST_URLS: dict[str, str] = {
     "train": "https://raw.githubusercontent.com/apple/ml-cubifyanything/main/data/train.txt",
     "val": "https://raw.githubusercontent.com/apple/ml-cubifyanything/main/data/val.txt",
 }
-SOURCE_URL: str = "https://github.com/apple/ml-cubifyanything"
 PROVENANCE: str = "ca1m-v1"
-LICENSE: str = "CC-BY-NC-ND-4.0 (internal use only)"
 DEGENERATE_EXTENT2_M: float = 0.05
 """Second principal trajectory extent below which the Umeyama roll is weakly observable."""
 
@@ -186,15 +184,15 @@ def read_capture_epoch(base_rrd: Path) -> float:
     """Read the ARKit uptime at ``video_time == 0`` from a base-layer RRD."""
     reader: RrdReader = RrdReader(base_rrd)
     for chunk in reader.stream():
-        if str(chunk.entity_path).rsplit("/", 1)[-1] != "uptime_epoch_seconds":
+        if str(chunk.entity_path).rsplit("/", 1)[-1] != "capture":
             continue
         batch: Any = chunk.to_record_batch()
-        if "value" not in batch.schema.names:
+        if "uptime_epoch_seconds" not in batch.schema.names:
             continue
-        values: list[Any] = batch.column("value").to_pylist()
-        if values and values[0]:
+        values: list[Any] = batch.column("uptime_epoch_seconds").to_pylist()
+        if values and values[0] is not None and len(values[0]):
             return float(values[0][0])
-    raise ValueError(f"base layer {base_rrd} is missing the uptime_epoch_seconds property")
+    raise ValueError(f"base layer {base_rrd} is missing the capture:uptime_epoch_seconds property")
 
 
 def _component_array(batch: Any, name: str, width: int) -> Float64[np.ndarray, "n width"]:
@@ -252,33 +250,25 @@ def _write_pose_layer(
     video_times_s: Float64[np.ndarray, "n"],
     faro_from_rig_n44: Float64[np.ndarray, "n 4 4"],
     alignment: RigidAlignment,
-    diagnostics: ClockDiagnostics,
-    num_pairs: int,
     coverage: GtCoverage,
 ) -> None:
-    """Write aligned GT poses plus per-capture GT metadata as recording properties.
+    """Write aligned GT poses plus the typed ``gt`` recording-property group.
 
-    Metadata goes into recording properties (``property:gt_*`` segment-table
-    columns, like base's ``uptime_epoch_seconds``) rather than entity data, so
-    provenance and quality are sortable in the catalog without an entity reader.
-    Values are stringified to match base's property convention.
+    Provenance, alignment quality, and coverage become ``property:gt:<field>``
+    segment-table columns so segments are sortable and filterable in the
+    catalog without an entity reader. Deeper diagnostics stay in the audit log.
     """
-    gt_properties: dict[str, object] = {
-        "gt_provenance": PROVENANCE,
-        "gt_license": LICENSE,
-        "gt_source": SOURCE_URL,
-        "gt_umeyama_rms_m": alignment.rms_m,
-        "gt_umeyama_extent2_m": alignment.source_extent2_m,
-        "gt_umeyama_pairs": num_pairs,
-        "gt_clock_median_delta_ms": diagnostics.median_delta_s * 1000.0,
-        "gt_clock_max_delta_ms": diagnostics.max_delta_s * 1000.0,
-        "gt_start_s": coverage.gt_start_s,
-        "gt_end_s": coverage.gt_end_s,
-        "gt_max_interior_gap_s": coverage.max_interior_gap_s,
-    }
     with atomic_recording(output_path, video_id, send_properties=False) as recording:
-        for name, value in gt_properties.items():
-            recording.send_property(name, rr.AnyValues(value=str(value)))
+        recording.send_property(
+            "gt",
+            rr.AnyValues(
+                provenance=PROVENANCE,
+                umeyama_rms_m=float(alignment.rms_m),
+                start_s=float(coverage.gt_start_s),
+                end_s=float(coverage.gt_end_s),
+                max_interior_gap_s=float(coverage.max_interior_gap_s),
+            ),
+        )
         recording.log(GT, rr.Transform3D(translation=alignment.translation_xyz, mat3x3=alignment.rotation_33), static=True)
         rr.send_columns(
             GT_RIG,
@@ -367,7 +357,7 @@ def ingest_capture(spec: CaptureSpec, config: Config) -> CaptureResult:
     depth_dir: Path = config.output / GT_DEPTH_LAYER
     poses_dir.mkdir(parents=True, exist_ok=True)
     depth_dir.mkdir(parents=True, exist_ok=True)
-    _write_pose_layer(poses_dir / f"{spec.video_id}.rrd", spec.video_id, video_times_s, faro_from_rig_n44, alignment, diagnostics, num_pairs, coverage)
+    _write_pose_layer(poses_dir / f"{spec.video_id}.rrd", spec.video_id, video_times_s, faro_from_rig_n44, alignment, coverage)
     _write_depth_layer(depth_dir / f"{spec.video_id}.rrd", spec.video_id, video_times_s, frames)
     if not config.keep_tars:
         tar_path.unlink()

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/cli.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/cli.py
@@ -371,29 +371,6 @@ def ingest_sequence(config: Config) -> Path:
     CONSOLE.print(f"IMU frame: original_cam_from_device={device_fit.quaternion_xyzw.tolist()} residual={np.rad2deg(device_fit.rms_residual_rad):.3f}deg")
     sequence_output: Path = config.output / config.video_id
     sequence_output.mkdir(parents=True, exist_ok=True)
-    properties: dict[str, object] = {
-        "video_id": config.video_id,
-        "visit_id": metadata["visit_id"],
-        "sky_direction_label": sky_direction,
-        "orientation_source": "measured_gravity",
-        "orientation_quarter_turns_ccw": quarter_turns,
-        "orientation_ambiguous": orientation_is_ambiguous,
-        "orientation_circular_spread_rad": circular_spread,
-        "split": metadata["fold"],
-        "schema_version": "arkitscenes:v2",
-        "clock_offset_seconds": alignment.offset_seconds,
-        "clock_offset_dispersion_seconds": alignment.dispersion_seconds,
-        "clock_drift_seconds_per_second": alignment.drift_seconds_per_second,
-        "ultrawide_clock_offset_seconds": alignment.ultrawide_offset_seconds,
-        "ultrawide_clock_agreement_seconds": alignment.ultrawide_agreement_seconds,
-        "pose_source": pose_source,
-        "pose_fit_rotation_rms_rad": pose_selection.rotation_rms_rad,
-        "pose_fit_translation_rms_m": pose_selection.translation_rms_m,
-        "original_camera_from_device_quaternion_xyzw": device_fit.quaternion_xyzw.tolist(),
-        "device_frame_fit_rms_residual_rad": device_fit.rms_residual_rad,
-        "accel_samples": len(imu.accel_timestamps),
-        "gyro_samples": len(imu.gyro_timestamps),
-    }
 
     # Rebase the shared timeline so t=0 is the first instant BOTH cameras have
     # a frame: leading frames of the earlier camera are trimmed at transcode
@@ -403,15 +380,6 @@ def ingest_sequence(config: Config) -> Path:
     ultrawide_source_times: np.ndarray = track_packet_times(mov_path, 2) + alignment.ultrawide_offset_seconds
     epoch, wide_drop, ultrawide_drop = shared_epoch(wide_source_times, ultrawide_source_times)
     portrait: bool = wide_resolution[0] < wide_resolution[1]
-    properties.update(
-        {
-            "uptime_epoch_seconds": epoch,
-            "epoch_source": "first_frame_both_cameras",
-            "leading_frames_dropped_wide": wide_drop,
-            "leading_frames_dropped_ultrawide": ultrawide_drop,
-            "portrait": portrait,
-        }
-    )
     CONSOLE.print(f"Timeline: epoch={epoch:.6f}s dropped_leading=(wide={wide_drop}, ultrawide={ultrawide_drop}) portrait={portrait}")
 
     wide_video: VideoSamples = prepare_video_track(mov_path, 0, quarter_turns, config.keep_transcode_cache, drop_leading=wide_drop)
@@ -445,14 +413,6 @@ def ingest_sequence(config: Config) -> Path:
     trajectory: Trajectory = rotate_trajectory(trajectory_unbaked, quarter_turns)
     before: int = int(np.count_nonzero(wide_video_timestamps < pose_trajectory_unbaked.timestamps[0]))
     after: int = int(np.count_nonzero(wide_video_timestamps > pose_trajectory_unbaked.timestamps[-1]))
-    properties.update(
-        {
-            "pose_span_start": pose_trajectory_unbaked.timestamps[0],
-            "pose_span_end": pose_trajectory_unbaked.timestamps[-1],
-            "n_frames_before_pose_span": before,
-            "n_frames_after_pose_span": after,
-        }
-    )
     CONSOLE.print(
         f"Pose coverage: source={pose_source} span={pose_trajectory_unbaked.timestamps[0]:.6f}..{pose_trajectory_unbaked.timestamps[-1]:.6f} before={before} after={after}"
     )
@@ -515,8 +475,32 @@ def ingest_sequence(config: Config) -> Path:
         send_properties=True,
         default_blueprint=make_blueprint(portrait, framing=(mesh_summary.mesh_center_xyz, mesh_summary.bounding_radius_m)),
     ) as recording:
-        for name, value in properties.items():
-            recording.send_property(name, rr.AnyValues(value=str(value)))
+        # Typed, grouped recording properties (segment-table columns property:<group>:<field>).
+        # The bar for a field: someone filters or sorts segments by it. Pipeline
+        # diagnostics stay in the console log, not the table.
+        # Some metadata rows carry visit_id='NA': omit the field (null segment-table
+        # cell) rather than invent a sentinel venue id.
+        visit_id_field: dict[str, int] = {} if metadata["visit_id"] == "NA" else {"visit_id": int(metadata["visit_id"])}
+        recording.send_property(
+            "capture",
+            rr.AnyValues(
+                **visit_id_field,
+                split=metadata["fold"],
+                orientation="portrait" if portrait else "landscape",
+                orientation_quarter_turns_ccw=int(quarter_turns),
+                pose_source=pose_source,
+                uptime_epoch_seconds=float(epoch),
+                schema_version="arkitscenes:v2",
+            ),
+        )
+        recording.send_property(
+            "quality",
+            rr.AnyValues(
+                pose_fit_translation_rms_m=float(pose_selection.translation_rms_m),
+                orientation_ambiguous=bool(orientation_is_ambiguous),
+            ),
+        )
+        recording.send_property("faro", rr.AnyValues(has_scans=metadata["has_laser_scanner_point_clouds"] == "True"))
         _log_rig_grammar(recording)
     layer_paths: list[Path] = [sequence_output / f"{name}.rrd" for name in REQUIRED_LAYER_NAMES]
     verify_rrd(layer_paths)

--- a/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_arkitscenes.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_arkitscenes.py
@@ -133,21 +133,23 @@ class ResilientVideoFrameDecoder(VideoFrameDecoder):
 
 
 def portrait_from_segment_row(row: dict[str, Any]) -> bool:
-    """Parse the required catalog portrait property from one segment row."""
-    property_name: str = "property:portrait:value"
+    """Parse the required catalog orientation property from one segment row."""
+    property_name: str = "property:capture:orientation"
     if property_name not in row or row[property_name] is None:
-        raise KeyError(f"segment {row.get('rerun_segment_id', '<unknown>')!r} is missing the portrait property")
+        raise KeyError(f"segment {row.get('rerun_segment_id', '<unknown>')!r} is missing the orientation property")
     value: Any = row[property_name]
     if isinstance(value, (list, np.ndarray)):
         if len(value) == 0:
-            raise ValueError(f"segment {row.get('rerun_segment_id', '<unknown>')!r} has an empty portrait property")
+            raise ValueError(f"segment {row.get('rerun_segment_id', '<unknown>')!r} has an empty orientation property")
         value = value[0]
-    return str(value) == "True"
+    if value not in ("portrait", "landscape"):
+        raise ValueError(f"segment {row.get('rerun_segment_id', '<unknown>')!r} has an invalid orientation property: {value!r}")
+    return value == "portrait"
 
 
 def orientation_quarter_turns_from_segment_row(row: dict[str, Any]) -> int:
     """Parse the ingest rotation needed to undo a stored portrait segment."""
-    property_name: str = "property:orientation_quarter_turns_ccw:value"
+    property_name: str = "property:capture:orientation_quarter_turns_ccw"
     if property_name not in row or row[property_name] is None:
         raise KeyError(f"segment {row.get('rerun_segment_id', '<unknown>')!r} is missing the orientation quarter-turn property")
     value: Any = row[property_name]

--- a/packages/prompt-da/tests/test_prompt_da_arkitscenes.py
+++ b/packages/prompt-da/tests/test_prompt_da_arkitscenes.py
@@ -23,8 +23,8 @@ from rerun_prompt_da.apis.prompt_da_arkitscenes import (  # noqa: E402
 
 def test_portrait_property_parses_catalog_list_value() -> None:
     """Interpret the first catalog property value instead of list truthiness."""
-    assert portrait_from_segment_row({"property:portrait:value": ["True"]}) is True
-    assert portrait_from_segment_row({"property:portrait:value": ["False"]}) is False
+    assert portrait_from_segment_row({"property:capture:orientation": ["portrait"]}) is True
+    assert portrait_from_segment_row({"property:capture:orientation": ["landscape"]}) is False
 
 
 def test_portrait_property_is_required() -> None:
@@ -35,7 +35,7 @@ def test_portrait_property_is_required() -> None:
 
 def test_orientation_quarter_turns_parses_catalog_list_value() -> None:
     """Preserve ingest's stored rotation direction for portrait inference."""
-    assert orientation_quarter_turns_from_segment_row({"property:orientation_quarter_turns_ccw:value": ["3"]}) == 3
+    assert orientation_quarter_turns_from_segment_row({"property:capture:orientation_quarter_turns_ccw": [3]}) == 3
 
 
 def test_portrait_rotation_round_trip_preserves_asymmetric_layout() -> None:


### PR DESCRIPTION
## Typed, grouped recording properties: 42 flat string columns → 15

**Stacked on #94.** Final piece of the v2 rework: the segment table's property columns follow Rerun's documented convention (semantic groups of typed `AnyValues` fields) and carry only what someone would filter or sort segments by.

| group (layer) | fields |
|---|---|
| `capture` (base) | `visit_id:int` (null on the 8 NA-venue captures), `split`, `orientation` (`portrait`|`landscape`), `orientation_quarter_turns_ccw:int` (consumed by prompt-da's portrait unbake), `pose_source`, `uptime_epoch_seconds:float` (the timestamp contract for layer producers), `schema_version="arkitscenes:v2"` |
| `quality` (base) | `pose_fit_translation_rms_m:float`, `orientation_ambiguous:bool` |
| `faro` (base) | `has_scans:bool` — venue has released raw FARO laser point clouds (3,028/5,015; from Apple's `metadata.csv`) |
| `gt` (gt_poses) | `provenance`, `umeyama_rms_m:float`, `start_s`, `end_s`, `max_interior_gap_s` |

Native Arrow types mean `filter(col("property:faro:has_scans")[0])` just works — no more `'True'` string comparisons. Laser-GT coverage itself intentionally has **no** `has_*` property: layer presence in `rerun_layer_names` is that flag (per Rerun's own guidance).

**Dropped (28 columns):** pipeline internals (clock recovery, device-fit quaternion/residual, pose spans, leading-frame drops, sample counts), corpus constants that were documentation rather than data (`orientation_source`, `epoch_source`, `sky_direction_label`, `gt_license`, `gt_source`), the segment-id duplicate `video_id`, and the 99.4%-null `gt_umeyama_extent2_m`. The producer-side property code was pruned; per-run values remain in the audit JSONLs and console logs. `schema_version` was also backfilled — it read `arkitscenes:v1` on all 5,015 migrated captures.

## Dataset migration (already executed)

`base.rrd` (5,015) and `gt_poses.rrd` (3,057) rewritten in place with the one-shot script below (chunk passthrough; old flat property values carried over with casts, not recomputed; `RecordingInfo` preserved; base's stale embedded v1 blueprint dropped — the operative v2 blueprint rides in `arkit_mesh.rrd` since the taxonomy migration). Bulk took ~5 min; re-registration ~65 s.

Validation on the re-registered `arkitscenes-v2` (5,015 segments, 5,015 complete, 3,057 gt-covered):
- exactly 16 property columns (15 + `RecordingInfo:start_time`), no stale columns
- `schema_version=arkitscenes:v2` on all 5,015; `visit_id` null on exactly the 8 NA captures
- `faro:has_scans` True on 3,028 — exact match with an independent recount from `metadata.csv`
- typed values verified (`bool`/`int`/`float`, not strings)
- pixel-validated in the viewer: a migrated capture renders identically (world + world GT tabs, boxes, video, laser depth)

<details>
<summary><code>migrate_properties.py</code> (one-shot, ran 2026-08-12, kept out of the repo on purpose)</summary>

```python
"""One-shot migration: flat stringified recording properties -> typed grouped schema (2026-08-12).

Per capture, rewriting IN PLACE via temp+atomic-replace (the server keeps serving the
old inode until its next restart + re-register):

  base.rrd      drop every /__properties/<name> custom-property chunk (28 flat string
                columns), keep the /__properties RecordingInfo chunk and all data chunks,
                append typed groups:
                  capture: visit_id(int) split(str) portrait(bool)
                           orientation_quarter_turns_ccw(int) pose_source(str)
                           uptime_epoch_seconds(float) schema_version="arkitscenes:v2"
                  quality: pose_fit_translation_rms_m(float) orientation_ambiguous(bool)
                  faro:    has_scans(bool)  [from the official metadata.csv]
                base's embedded v1 blueprint is dropped on purpose: since the taxonomy
                migration, the operative v2 per-sequence blueprint rides in arkit_mesh.rrd.
  gt_poses.rrd  drop /__properties/gt_* (11 flat columns), keep pose/transform chunks,
                append typed group:
                  gt: provenance(str) umeyama_rms_m(float) start_s(float) end_s(float)
                      max_interior_gap_s(float)

Values are carried over from each file's own old string properties (cast, not recomputed);
the dropped diagnostics are intentionally discarded (Pablo: no snapshot needed).
One-shot by design: lives in /tmp, referenced from the PR; the permanent schema is the
patched ingest/ca1m code this migration mirrors. Resumable: a base.rrd that already has
/__properties/capture is skipped. Run with the arkitscenes-download-dev env python:

  .pixi/envs/arkitscenes-download-dev/bin/python /tmp/arkitscenes-props-migration/migrate_properties.py \
      --metadata-csv /tmp/arkit_metadata.csv [--output <scratch>] [--video-ids ...]
"""

import csv
import json
import time
import traceback
from concurrent.futures import ProcessPoolExecutor, as_completed
from dataclasses import dataclass
from pathlib import Path

import rerun as rr
import tyro
from rerun.experimental import RrdReader, send_chunks

from arkitscenes_download.ingest.recording import atomic_recording

PROPERTIES_ROOT = "/__properties"


@dataclass(frozen=True)
class Config:
    dataset_root: Path = Path("/mnt/nas/datasets/arkitscenes/arkitscenes.2026.07.22")
    """Existing dataset root: reads base/ and gt_poses/."""
    output: Path = Path("/mnt/nas/datasets/arkitscenes/arkitscenes.2026.07.22")
    """Output root (default: in place)."""
    metadata_csv: Path = Path("/tmp/arkit_metadata.csv")
    """Official ARKitScenes metadata.csv (video_id -> has_laser_scanner_point_clouds)."""
    video_ids: tuple[str, ...] = ()
    """Subset; default = every id in <dataset_root>/base/."""
    workers: int = 8
    force: bool = False
    """Rewrite even when the new-format capture group is already present."""


def read_flat_properties(rrd_path: Path) -> tuple[dict[str, str], list]:
    """Return the old flat string properties and the non-property passthrough chunks."""
    properties: dict[str, str] = {}
    passthrough: list = []
    for chunk in RrdReader(str(rrd_path)).stream():
        entity_path = str(chunk.entity_path)
        if entity_path.startswith(PROPERTIES_ROOT + "/"):
            name = entity_path.removeprefix(PROPERTIES_ROOT + "/")
            batch = chunk.to_record_batch()
            if "value" in batch.schema.names:
                values = batch.column("value").to_pylist()
                if values and values[0]:
                    properties[name] = str(values[0][0])
                continue
            # Not the flat string layout (e.g. an already-migrated typed group).
            properties[f"__typed__{name}"] = ""
            continue
        # Keeps the /__properties RecordingInfo chunk itself and every data chunk.
        passthrough.append(chunk)
    return properties, passthrough


def migrate_one(config: Config, video_id: str, has_faro_scans: bool) -> dict:
    started = time.perf_counter()
    out = {"video_id": video_id, "status": "ok"}

    base_in = config.dataset_root / "base" / f"{video_id}.rrd"
    base_out = config.output / "base" / f"{video_id}.rrd"
    base_out.parent.mkdir(parents=True, exist_ok=True)
    old, passthrough = read_flat_properties(base_in)
    if "__typed__capture" in old and not config.force:
        out["status"] = "skipped"
    else:
        required = [
            "visit_id", "split", "portrait", "orientation_quarter_turns_ccw",
            "pose_source", "uptime_epoch_seconds", "pose_fit_translation_rms_m", "orientation_ambiguous",
        ]
        missing = [name for name in required if name not in old]
        if missing:
            raise ValueError(f"base.rrd missing old properties: {missing}")
        # 8 corpus captures have visit_id='NA' in Apple's metadata: omit the field
        # (null segment-table cell) rather than invent a sentinel venue id.
        capture_fields: dict = {} if old["visit_id"] == "NA" else {"visit_id": int(old["visit_id"])}
        with atomic_recording(base_out, video_id, send_properties=False) as rec:
            send_chunks(iter(passthrough), recording=rec)
            rec.send_property(
                "capture",
                rr.AnyValues(
                    **capture_fields,
                    split=old["split"],
                    portrait=old["portrait"] == "True",
                    orientation_quarter_turns_ccw=int(old["orientation_quarter_turns_ccw"]),
                    pose_source=old["pose_source"],
                    uptime_epoch_seconds=float(old["uptime_epoch_seconds"]),
                    schema_version="arkitscenes:v2",
                ),
            )
            rec.send_property(
                "quality",
                rr.AnyValues(
                    pose_fit_translation_rms_m=float(old["pose_fit_translation_rms_m"]),
                    orientation_ambiguous=old["orientation_ambiguous"] == "True",
                ),
            )
            rec.send_property("faro", rr.AnyValues(has_scans=has_faro_scans))
        out["base_chunks"] = len(passthrough)

    gt_in = config.dataset_root / "gt_poses" / f"{video_id}.rrd"
    if gt_in.is_file():
        gt_out = config.output / "gt_poses" / f"{video_id}.rrd"
        gt_out.parent.mkdir(parents=True, exist_ok=True)
        old_gt, passthrough_gt = read_flat_properties(gt_in)
        if "__typed__gt" in old_gt and not config.force:
            out["gt_status"] = "skipped"
        else:
            required_gt = ["gt_provenance", "gt_umeyama_rms_m", "gt_start_s", "gt_end_s", "gt_max_interior_gap_s"]
            missing_gt = [name for name in required_gt if name not in old_gt]
            if missing_gt:
                raise ValueError(f"gt_poses.rrd missing old properties: {missing_gt}")
            with atomic_recording(gt_out, video_id, send_properties=False) as rec:
                send_chunks(iter(passthrough_gt), recording=rec)
                rec.send_property(
                    "gt",
                    rr.AnyValues(
                        provenance=old_gt["gt_provenance"],
                        umeyama_rms_m=float(old_gt["gt_umeyama_rms_m"]),
                        start_s=float(old_gt["gt_start_s"]),
                        end_s=float(old_gt["gt_end_s"]),
                        max_interior_gap_s=float(old_gt["gt_max_interior_gap_s"]),
                    ),
                )
            out["gt_chunks"] = len(passthrough_gt)

    out["seconds"] = round(time.perf_counter() - started, 2)
    return out


def main(config: Config) -> None:
    with open(config.metadata_csv, newline="") as metadata_file:
        faro_by_video = {row["video_id"]: row["has_laser_scanner_point_clouds"] == "True" for row in csv.DictReader(metadata_file)}
    video_ids = list(config.video_ids) or sorted(p.stem for p in (config.dataset_root / "base").glob("*.rrd"))
    missing_meta = [vid for vid in video_ids if vid not in faro_by_video]
    if missing_meta:
        raise SystemExit(f"{len(missing_meta)} video_ids absent from metadata.csv: {missing_meta[:5]}")
    print(f"migrating {len(video_ids)} captures -> {config.output} (workers={config.workers})")
    results, failures = [], []
    log_path = Path("/tmp/arkitscenes-props-migration/migration_log.jsonl")
    with ProcessPoolExecutor(max_workers=config.workers) as pool, open(log_path, "a") as log:
        futures = {pool.submit(migrate_one, config, vid, faro_by_video[vid]): vid for vid in video_ids}
        for i, future in enumerate(as_completed(futures), 1):
            vid = futures[future]
            try:
                result = future.result()
            except Exception:
                result = {"video_id": vid, "status": "failed", "error": traceback.format_exc(limit=3)}
                failures.append(vid)
            results.append(result)
            log.write(json.dumps(result) + "\n")
            if result["status"] == "failed" or i % 250 == 0:
                print(f"[{i}/{len(video_ids)}] {vid}: {result['status']}")
    done = sum(1 for r in results if r["status"] == "ok")
    skipped = sum(1 for r in results if r["status"] == "skipped")
    print(f"done: {done} migrated, {skipped} skipped, {len(failures)} failed")
    if failures:
        print("FAILED:", " ".join(sorted(failures)))
        raise SystemExit(1)


if __name__ == "__main__":
    main(tyro.cli(Config))
```

</details>

<details>
<summary><code>switch_orientation.py</code> (follow-up one-shot: portrait bool → orientation literal, ran 2026-08-12)</summary>

```python
"""One-shot follow-up patch: capture.portrait(bool) -> capture.orientation("portrait"|"landscape") (2026-08-12).

Targeted property patch over base.rrd only (gt_poses untouched): pass every chunk
through EXCEPT /__properties/capture, whose typed fields are read back and re-emitted
with `orientation` replacing `portrait`. Demonstrates the cheap recipe for schema
tweaks on a small dedicated property layer. Resumable: files whose capture chunk
already has `orientation` are skipped.

  .pixi/envs/arkitscenes-download-dev/bin/python /tmp/arkitscenes-props-migration/switch_orientation.py
"""

import json
import time
import traceback
from concurrent.futures import ProcessPoolExecutor, as_completed
from dataclasses import dataclass
from pathlib import Path

import rerun as rr
import tyro
from rerun.experimental import RrdReader, send_chunks

from arkitscenes_download.ingest.recording import atomic_recording

CAPTURE_PATH = "/__properties/capture"


@dataclass(frozen=True)
class Config:
    dataset_root: Path = Path("/mnt/nas/datasets/arkitscenes/arkitscenes.2026.07.22")
    output: Path = Path("/mnt/nas/datasets/arkitscenes/arkitscenes.2026.07.22")
    video_ids: tuple[str, ...] = ()
    workers: int = 8


def patch_one(config: Config, video_id: str) -> dict:
    started = time.perf_counter()
    base_in = config.dataset_root / "base" / f"{video_id}.rrd"
    passthrough: list = []
    capture: dict = {}
    for chunk in RrdReader(str(base_in)).stream():
        if str(chunk.entity_path) == CAPTURE_PATH:
            batch = chunk.to_record_batch()
            for index, field in enumerate(batch.schema):
                if field.name.startswith("rerun."):  # control columns (RowId), not user fields
                    continue
                values = batch.column(index).to_pylist()
                if values and values[0] is not None and len(values[0]):
                    capture[field.name] = values[0][0]
        else:
            passthrough.append(chunk)
    if "orientation" in capture:
        return {"video_id": video_id, "status": "skipped"}
    if "portrait" not in capture:
        raise ValueError(f"base.rrd capture group has no portrait field: {sorted(capture)}")
    portrait = bool(capture.pop("portrait"))
    capture["orientation"] = "portrait" if portrait else "landscape"

    base_out = config.output / "base" / f"{video_id}.rrd"
    base_out.parent.mkdir(parents=True, exist_ok=True)
    with atomic_recording(base_out, video_id, send_properties=False) as rec:
        send_chunks(iter(passthrough), recording=rec)
        rec.send_property("capture", rr.AnyValues(**capture))
    return {"video_id": video_id, "status": "ok", "seconds": round(time.perf_counter() - started, 2)}


def main(config: Config) -> None:
    video_ids = list(config.video_ids) or sorted(p.stem for p in (config.dataset_root / "base").glob("*.rrd"))
    print(f"patching {len(video_ids)} base layers -> {config.output}")
    failures = []
    with ProcessPoolExecutor(max_workers=config.workers) as pool, open("/tmp/arkitscenes-props-migration/orientation_log.jsonl", "a") as log:
        futures = {pool.submit(patch_one, config, vid): vid for vid in video_ids}
        for i, future in enumerate(as_completed(futures), 1):
            vid = futures[future]
            try:
                result = future.result()
            except Exception:
                result = {"video_id": vid, "status": "failed", "error": traceback.format_exc(limit=3)}
                failures.append(vid)
            log.write(json.dumps(result) + "\n")
            if result["status"] == "failed" or i % 500 == 0:
                print(f"[{i}/{len(video_ids)}] {vid}: {result['status']}")
    print(f"done: {len(video_ids) - len(failures)} ok, {len(failures)} failed")
    if failures:
        print("FAILED:", " ".join(sorted(failures)))
        raise SystemExit(1)


if __name__ == "__main__":
    main(tyro.cli(Config))
```

</details>
