### PR TITLE
arkitscenes: GT-clean sub-dataset tool

### DIFF
--- a/packages/arkitscenes-download/README.md
+++ b/packages/arkitscenes-download/README.md
@@ -96,6 +96,11 @@ Facts that shape consumption:
 - **Coordinate frames:** CA-1M poses live in the FARO venue frame. A per-capture
   rigid Umeyama fit (residual in `property:gt:umeyama_rms_m`) connects them to
   the ARKit `/world` via a static transform at `/world/gt`.
+- **GT-clean sub-dataset:** `pixi run -e arkitscenes-download arkitscenes-download-gt-subdataset`
+  derives `arkitscenes-v2-gt-clean` — only captures with laser GT whose largest
+  interior gap is ≤ 1 s (2,036 of 5,015) — by re-registering the same RRD storage
+  (no copying, ~1 s). The in-memory catalog drops it on server restart; re-run
+  after re-registering the source dataset.
 - **License:** CA-1M data is **CC BY-NC-ND 4.0** — internal research use only;
   do **not** publicly redistribute RRDs derived from it. The original
   ARKitScenes-derived layers keep the far more permissive

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/catalog.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/catalog.py
@@ -129,6 +129,33 @@ def register_layer(config: Config, layer_name: str, paths: list[Path], progress:
     CONSOLE.print(f"{layer_name}: {expected} files in {time.perf_counter() - started:.1f}s")
 
 
+def register_default_blueprints(dataset: DatasetEntry, dataset_name: str, blueprint_dir: Path) -> None:
+    """Register generic portrait/landscape view defaults and the segment-table blueprint.
+
+    Most ARKitScenes captures are handheld portrait scans, so the portrait layout
+    is the dataset default; landscape stays selectable in the viewer. The
+    segment-table blueprint provides 3D preview cards in the dataset review
+    (experimental, needs "Table cards and blueprints" enabled in the viewer's
+    settings); its failure must not abort registration — the layers are already
+    registered by the time this runs.
+    """
+    blueprint_dir.mkdir(parents=True, exist_ok=True)
+    for orientation, is_portrait in (("landscape", False), ("portrait", True)):
+        blueprint_path: Path = blueprint_dir / f"{dataset_name}-{orientation}.rbl"
+        make_blueprint(is_portrait).save("arkitscenes", blueprint_path)
+        blueprint_path.chmod(0o644)  # uid-squashing NFS mounts can land fresh writes as mode 0000
+        dataset.register_blueprint(blueprint_path.resolve().as_uri(), set_default=is_portrait)
+    table_blueprint_path: Path = blueprint_dir / f"{dataset_name}-table.rbl"
+    make_table_blueprint().save("arkitscenes", table_blueprint_path)
+    table_blueprint_path.chmod(0o644)  # uid-squashing NFS mounts can land fresh writes as mode 0000
+    try:
+        dataset.register_blueprint(table_blueprint_path.resolve().as_uri(), segment_table=True)
+    except BeartypeException:
+        raise
+    except Exception as error:  # noqa: BLE001
+        CONSOLE.print(f"segment-table blueprint (experimental) failed: {str(error)[:70]} — skipping")
+
+
 def register_sequences(config: Config) -> DatasetEntry:
     """Create (or resume) the dataset and register every RRD in ``rrd_dir``."""
     layer_paths: dict[str, list[Path]] = layer_files(config)
@@ -151,28 +178,7 @@ def register_sequences(config: Config) -> DatasetEntry:
             current_progress.remove_task(current_task)
             overall_progress.advance(overall_task)
 
-    # Most ARKitScenes captures are handheld portrait scans, so the portrait
-    # layout is the dataset default; landscape stays selectable in the viewer.
-    blueprint_dir: Path = config.rrd_dir / "blueprints"
-    blueprint_dir.mkdir(parents=True, exist_ok=True)
-    for orientation, is_portrait in (("landscape", False), ("portrait", True)):
-        blueprint_path: Path = blueprint_dir / f"{config.dataset_name}-{orientation}.rbl"
-        make_blueprint(is_portrait).save("arkitscenes", blueprint_path)
-        blueprint_path.chmod(0o644)  # uid-squashing NFS mounts can land fresh writes as mode 0000
-        dataset.register_blueprint(blueprint_path.resolve().as_uri(), set_default=is_portrait)
-    # Segment-table blueprint: 3D preview cards in the dataset review (experimental,
-    # needs "Table cards and blueprints" enabled in the viewer's settings). A failure
-    # here must not abort the run: the layers are already registered, and aborting
-    # would also skip main()'s completeness verification.
-    table_blueprint_path: Path = blueprint_dir / f"{config.dataset_name}-table.rbl"
-    make_table_blueprint().save("arkitscenes", table_blueprint_path)
-    table_blueprint_path.chmod(0o644)  # uid-squashing NFS mounts can land fresh writes as mode 0000
-    try:
-        dataset.register_blueprint(table_blueprint_path.resolve().as_uri(), segment_table=True)
-    except BeartypeException:
-        raise
-    except Exception as error:  # noqa: BLE001
-        CONSOLE.print(f"segment-table blueprint (experimental) failed: {str(error)[:70]} — skipping")
+    register_default_blueprints(dataset, config.dataset_name, config.rrd_dir / "blueprints")
     return dataset
 
 

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/cli.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/cli.py
@@ -12,6 +12,7 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import rerun as rr
@@ -480,7 +481,7 @@ def ingest_sequence(config: Config) -> Path:
         # diagnostics stay in the console log, not the table.
         # Some metadata rows carry visit_id='NA': omit the field (null segment-table
         # cell) rather than invent a sentinel venue id.
-        visit_id_field: dict[str, int] = {} if metadata["visit_id"] == "NA" else {"visit_id": int(metadata["visit_id"])}
+        visit_id_field: dict[str, Any] = {} if metadata["visit_id"] == "NA" else {"visit_id": int(metadata["visit_id"])}
         recording.send_property(
             "capture",
             rr.AnyValues(

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/subdataset.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/subdataset.py
@@ -1,0 +1,73 @@
+"""Create a laser-GT-clean sub-dataset from a registered ARKitScenes dataset.
+
+Selection: captures carrying the CA-1M laser-GT layers whose largest interior
+GT gap is at most a threshold (``property:gt:max_interior_gap_s``). The
+sub-dataset references the source's registered RRD storage — nothing is
+copied, so creation takes ~a second. The OSS ``rerun server`` catalog is
+in-memory: re-run this after every server restart, after re-registering the
+source dataset.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+from rerun.catalog import CatalogClient, DatasetEntry
+
+from arkitscenes_download.download_dataset import CONSOLE
+from arkitscenes_download.ingest.catalog import DEFAULT_CATALOG_URL, register_default_blueprints
+
+
+@dataclass(frozen=True, slots=True)
+class Config:
+    """Configuration for deriving the GT-clean sub-dataset."""
+
+    source_dataset: str = "arkitscenes-v2"
+    """Registered dataset to filter."""
+    dataset_name: str = "arkitscenes-v2-gt-clean"
+    """Sub-dataset to create."""
+    catalog_url: str = DEFAULT_CATALOG_URL
+    """gRPC URL of the local Rerun catalog (``rerun server``)."""
+    max_interior_gap_s: float = 1.0
+    """Largest tolerated hole between consecutive GT frames (10 Hz grid = 0.1 s)."""
+    blueprint_dir: Path = Path("/var/tmp/arkitscenes-blueprints")
+    """Where the generated .rbl blueprint files live (the server may read them lazily)."""
+
+
+def _first(cell: Any) -> Any:
+    """Unwrap a segment-table property cell (a component batch) to its scalar."""
+    return cell[0] if cell is not None and hasattr(cell, "__len__") and len(cell) else None
+
+
+def gt_clean_mask(segment_table: pd.DataFrame, max_interior_gap_s: float) -> pd.Series:
+    """Select segments with laser GT whose largest interior gap is within tolerance."""
+    has_gt: pd.Series = segment_table["property:gt:provenance"].map(_first).notna()
+    max_gap: pd.Series = segment_table["property:gt:max_interior_gap_s"].map(_first)
+    return has_gt & (max_gap <= max_interior_gap_s).fillna(False)
+
+
+def main(config: Config) -> None:
+    """Create the sub-dataset by registering the selected segments' existing storage."""
+    client = CatalogClient(config.catalog_url)
+    source: DatasetEntry = client.get_dataset(name=config.source_dataset)
+    segment_table: pd.DataFrame = source.segment_table().df.to_pandas()
+    selected: pd.DataFrame = segment_table[gt_clean_mask(segment_table, config.max_interior_gap_s)]
+
+    uris: list[str] = []
+    layers: list[str] = []
+    for _, row in selected.iterrows():
+        uris.extend(row["rerun_storage_urls"])
+        layers.extend(row["rerun_layer_names"])
+    if not uris:
+        raise SystemExit(f"no segments in {config.source_dataset!r} pass gt gap <= {config.max_interior_gap_s}s")
+
+    if config.dataset_name in client.dataset_names():
+        raise SystemExit(f"dataset {config.dataset_name!r} already exists; the in-memory catalog drops it on server restart")
+    sub_dataset: DatasetEntry = client.create_dataset(config.dataset_name)
+    sub_dataset.register(uris, layer_name=layers).wait()
+    register_default_blueprints(sub_dataset, config.dataset_name, config.blueprint_dir)
+    CONSOLE.print(
+        f"sub-dataset '{config.dataset_name}' at {config.catalog_url}: {len(selected)} of {len(segment_table)} segments "
+        f"(laser GT present, interior gaps <= {config.max_interior_gap_s}s)"
+    )

--- a/packages/arkitscenes-download/tests/test_subdataset.py
+++ b/packages/arkitscenes-download/tests/test_subdataset.py
@@ -1,0 +1,20 @@
+"""Behavior checks for the GT-clean sub-dataset selection."""
+
+import pandas as pd
+
+from arkitscenes_download.ingest.subdataset import gt_clean_mask
+
+
+def test_gt_clean_mask_requires_gt_and_bounded_interior_gaps() -> None:
+    """Only gt-covered segments within the gap tolerance are selected; missing GT never passes."""
+    table = pd.DataFrame(
+        {
+            "rerun_segment_id": ["clean", "gappy", "boundary", "no_gt"],
+            "property:gt:provenance": [["ca1m-v1"], ["ca1m-v1"], ["ca1m-v1"], None],
+            "property:gt:max_interior_gap_s": [[0.117], [30.5], [1.0], None],
+        }
+    )
+
+    mask = gt_clean_mask(table, max_interior_gap_s=1.0)
+
+    assert list(table[mask]["rerun_segment_id"]) == ["clean", "boundary"]

--- a/packages/arkitscenes-download/tools/apps/make_gt_subdataset.py
+++ b/packages/arkitscenes-download/tools/apps/make_gt_subdataset.py
@@ -1,0 +1,6 @@
+import tyro
+
+from arkitscenes_download.ingest.subdataset import Config, main
+
+if __name__ == "__main__":
+    main(tyro.cli(Config))

--- a/pixi.toml
+++ b/pixi.toml
@@ -2279,6 +2279,11 @@ cmd = "python tools/apps/ca1m_ingest.py"
 cwd = "packages/arkitscenes-download"
 description = "Ingest CA-1M laser GT into stackable gt_poses and gt_depth layer RRDs"
 
+[feature.arkitscenes-download.tasks.arkitscenes-download-gt-subdataset]
+cmd = "python tools/apps/make_gt_subdataset.py"
+cwd = "packages/arkitscenes-download"
+description = "Create the GT-clean sub-dataset (laser GT present, bounded interior gaps) on the local catalog"
+
 [feature.arkitscenes-download.tasks.arkitscenes-download-serve]
 # Rerun keeps one handle open per registered RRD. One full corpus has
 # 5015 segments * 8 layers = 40120 RRDs, so 65536 cannot hold two corpora.


### PR DESCRIPTION
## GT-clean sub-dataset tool

**Stacked on #96.** Adds `arkitscenes-download-gt-subdataset`: derive a sub-dataset containing only captures that (a) carry the CA-1M laser-GT layers and (b) have no interior GT hole larger than a threshold (default 1 s, via `property:gt:max_interior_gap_s`).

```bash
pixi run -e arkitscenes-download arkitscenes-download-gt-subdataset
# sub-dataset 'arkitscenes-v2-gt-clean' at rerun+http://127.0.0.1:51235: 2036 of 5015 segments
```

Follows the [documented sub-dataset recipe](https://rerun.io/docs/howto/query-and-transform/sub_dataset): filter the source segment table, re-register the selected segments' **existing** storage URLs with their layer names. No data is copied; creation takes ~1 s because the server already holds the files.

Why a permanent tool rather than a one-off: the OSS `rerun server` catalog is in-memory, so every sub-dataset evaporates on restart — the reproducible CLI is what makes it durable in practice (re-run after re-registering the source), and the gap threshold is a flag for tuning.

Context for the default: GT timing analysis over all 3,057 covered captures showed GT is a rock-solid 10 Hz grid, but 1,021 captures have at least one >1 s interior registration hole (worst: 30.5 s mid-capture blackout). The 2,036 survivors are the "supervise without gap-handling" set.

## Validation

- `tests` (53 passed / 4 skipped) / `lint` / `typecheck` / `deadcode` green.
- Run end-to-end against the live catalog: creates the 2,036-segment sub-dataset in ~1 s; the already-exists guard and threshold filtering covered by unit test + live check.
