### PR TITLE
shared libs: gauss-surf groundwork across simplecv, trtkit, monoprior, prompt-da

### DIFF
--- a/packages/monoprior/monopriors/models/surface_normal/_moge_v2_onnx_worker.py
+++ b/packages/monoprior/monopriors/models/surface_normal/_moge_v2_onnx_worker.py
@@ -1,0 +1,30 @@
+"""Uninstrumented subprocess entry point for dynamic-batch MoGe ONNX export."""
+
+import sys
+from pathlib import Path
+from typing import cast
+
+from monopriors.models.surface_normal.moge_v2_trt import Encoder, export_moge_v2_normal_onnx
+
+
+def main() -> None:
+    """Parse the parent export request and build its ONNX artifact."""
+    if len(sys.argv) != 7:
+        raise ValueError(f"Expected six MoGe v2 ONNX worker arguments, got {len(sys.argv) - 1}.")
+    encoder: Encoder = cast(Encoder, sys.argv[1])
+    height: int = int(sys.argv[2])
+    width: int = int(sys.argv[3])
+    resolution_level: int = int(sys.argv[4])
+    max_batch_size: int = int(sys.argv[5])
+    cache_dir: Path = Path(sys.argv[6])
+    export_moge_v2_normal_onnx(
+        encoder=encoder,
+        image_hw=(height, width),
+        resolution_level=resolution_level,
+        max_batch_size=max_batch_size,
+        cache_dir=cache_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/monoprior/monopriors/models/surface_normal/_moge_v2_onnx_worker.py
+++ b/packages/monoprior/monopriors/models/surface_normal/_moge_v2_onnx_worker.py
@@ -1,30 +1,41 @@
 """Uninstrumented subprocess entry point for dynamic-batch MoGe ONNX export."""
 
-import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
+
+import tyro
 
 from monopriors.models.surface_normal.moge_v2_trt import Encoder, export_moge_v2_normal_onnx
 
 
-def main() -> None:
-    """Parse the parent export request and build its ONNX artifact."""
-    if len(sys.argv) != 7:
-        raise ValueError(f"Expected six MoGe v2 ONNX worker arguments, got {len(sys.argv) - 1}.")
-    encoder: Encoder = cast(Encoder, sys.argv[1])
-    height: int = int(sys.argv[2])
-    width: int = int(sys.argv[3])
-    resolution_level: int = int(sys.argv[4])
-    max_batch_size: int = int(sys.argv[5])
-    cache_dir: Path = Path(sys.argv[6])
+@dataclass(frozen=True, slots=True)
+class Config:
+    """Export request forwarded by the parent predictor process."""
+
+    encoder: Encoder
+    """DINOv2 encoder size."""
+    height: int
+    """Static network height."""
+    width: int
+    """Static network width."""
+    resolution_level: int
+    """Detail level from 0 through 9."""
+    max_batch_size: int
+    """Largest batch encoded in the dynamic ONNX constraint."""
+    cache_dir: Path
+    """Cache root; the graph lands in ``cache_dir / "onnx"``."""
+
+
+def main(config: Config) -> None:
+    """Build the requested ONNX artifact in this clean interpreter."""
     export_moge_v2_normal_onnx(
-        encoder=encoder,
-        image_hw=(height, width),
-        resolution_level=resolution_level,
-        max_batch_size=max_batch_size,
-        cache_dir=cache_dir,
+        encoder=config.encoder,
+        image_hw=(config.height, config.width),
+        resolution_level=config.resolution_level,
+        max_batch_size=config.max_batch_size,
+        cache_dir=config.cache_dir,
     )
 
 
 if __name__ == "__main__":
-    main()
+    main(tyro.cli(Config))

--- a/packages/monoprior/monopriors/models/surface_normal/moge_v2_trt.py
+++ b/packages/monoprior/monopriors/models/surface_normal/moge_v2_trt.py
@@ -46,7 +46,14 @@ class MoGeV2NormalOutput(NamedTuple):
 
 
 class _MoGeV2NormalHeads(torch.nn.Module):
-    """Fixed-token adapter exposing the normal and mask heads as tuple outputs."""
+    """Fixed-token adapter exposing the normal and mask heads as tuple outputs.
+
+    TODO: export the full MoGe graph (points + depth heads too) once a consumer
+    needs them — the heads share the backbone, so the marginal engine cost is
+    the decoders and the extra D2H. The metric-depth recovery (affine
+    point-map postprocess, ``recover_focal_shift``) is data-dependent logic
+    outside the graph and would still run on the outputs either way.
+    """
 
     def __init__(self, model: MoGeModel, num_tokens: int) -> None:
         super().__init__()
@@ -155,11 +162,17 @@ def export_moge_v2_normal_onnx(
             sys.executable,
             "-m",
             "monopriors.models.surface_normal._moge_v2_onnx_worker",
+            "--encoder",
             encoder,
+            "--height",
             str(height),
+            "--width",
             str(width),
+            "--resolution-level",
             str(resolution_level),
+            "--max-batch-size",
             str(max_batch_size),
+            "--cache-dir",
             str(cache_dir),
         ]
         subprocess.run(worker_command, check=True, env=worker_env)
@@ -182,6 +195,10 @@ def export_moge_v2_normal_onnx(
         device="cuda",
     )
 
+    # trtkit is imported at call sites, not module top (unlike prompt-da's
+    # dedicated TRT module): this module doubles as the tensor-contract and
+    # torch-twin home, and importing trtkit pulls the tensorrt runtime, which
+    # torch-only consumers should not pay for.
     from trtkit import export_onnx, sweep_stale_onnx_exports
 
     export_onnx(
@@ -196,10 +213,9 @@ def export_moge_v2_normal_onnx(
     del dummy_image_b3hw, wrapper, model
     torch.cuda.empty_cache()
 
-    # Preserve the current external-data sidecar. trtkit publishes the ONNX
-    # protobuf atomically, while dynamo keeps its large weights in the
-    # pid-suffixed sidecar referenced by that protobuf.
-    current_sidecar: Path = onnx_path.with_name(f"{onnx_path.name}.part{os.getpid()}.data")
+    # ViT-L weights exceed the 2 GB protobuf limit, so trtkit publishes a
+    # deterministic `<name>.data` external-data sidecar beside the graph.
+    current_sidecar: Path = onnx_path.with_name(f"{onnx_path.name}.data")
     stale_prefix: str = f"moge-v2-{encoder}-normal_{height}x{width}_t{num_tokens}_"
     sweep_stale_onnx_exports(onnx_dir, stale_prefix, keep_paths={onnx_path, current_sidecar})
     return onnx_path

--- a/packages/monoprior/monopriors/models/surface_normal/moge_v2_trt.py
+++ b/packages/monoprior/monopriors/models/surface_normal/moge_v2_trt.py
@@ -1,0 +1,377 @@
+"""Batched GPU predictors for MoGe v2 camera-space surface normals.
+
+The torch and TensorRT predictors share one tensor contract: uint8 CUDA RGB
+frames shaped ``[B,H,W,3]`` in, then float32 camera-space RDF normals shaped
+``[B,H,W,3]`` and float32 validity probabilities shaped ``[B,H,W]`` out.
+Normals point toward the camera, matching :class:`MoGeV2NormalPredictor`.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Literal, NamedTuple, TypeAlias, cast
+
+import torch
+import torch.nn.functional as F
+from einops import rearrange
+from jaxtyping import Float, Float32, UInt8
+from torch import Tensor
+
+from monopriors.models.surface_normal.moge_v2 import MOGE_V2_NORMAL_CHECKPOINTS
+from monopriors.third_party.moge.model.v2 import ForwardOutput, MoGeModel
+
+Encoder: TypeAlias = Literal["vits", "vitb", "vitl"]
+
+DEFAULT_CACHE_DIR: Path = Path(os.environ.get("MONOPRIOR_TRT_CACHE", "~/.cache/monoprior")).expanduser()
+"""Cache root holding portable ``onnx/`` and machine-local ``trt/`` artifacts."""
+
+DEFAULT_IMAGE_HW: tuple[int, int] = (756, 1008)
+"""ARKitScenes-aligned MoGe network height and width."""
+
+MOGE_V2_NUM_TOKENS_RANGE: tuple[int, int] = (1200, 3600)
+"""Training-time token range shared by all pinned MoGe v2 normal checkpoints."""
+
+ONNX_EXPORT_VERSION: int = 1
+"""Cache-breaking version of the MoGe v2 normal ONNX export recipe."""
+
+_EXPORT_WORKER_ENV: str = "MONOPRIOR_MOGE_V2_ONNX_EXPORT_WORKER"
+
+
+class MoGeV2NormalOutput(NamedTuple):
+    """Owning batched normal and mask tensors returned by both predictors."""
+
+    normals_bhw3: Float32[Tensor, "b h w 3"]
+    mask_bhw: Float32[Tensor, "b h w"]
+
+
+class _MoGeV2NormalHeads(torch.nn.Module):
+    """Fixed-token adapter exposing the normal and mask heads as tuple outputs."""
+
+    def __init__(self, model: MoGeModel, num_tokens: int) -> None:
+        super().__init__()
+        self.model: MoGeModel = model
+        self.num_tokens: int = num_tokens
+
+    def forward(
+        self,
+        image_b3hw: Float[Tensor, "b 3 h w"],
+    ) -> tuple[Float[Tensor, "b h w 3"], Float[Tensor, "b h w"]]:
+        """Run only the two heads required by the surface-normal pipeline.
+
+        Args:
+            image_b3hw: Float RGB batch shaped ``b 3 h w`` in ``[0, 1]``.
+
+        Returns:
+            Camera-space unit normals and mask probabilities.
+        """
+        output: ForwardOutput = self.model(
+            image_b3hw,
+            num_tokens=self.num_tokens,
+            output_heads=("normal", "mask"),
+        )
+        normals_bhw3: Float[Tensor, "b h w 3"] = cast(Tensor, output["normal"])
+        mask_bhw: Float[Tensor, "b h w"] = cast(Tensor, output["mask"])
+        return normals_bhw3, mask_bhw
+
+
+def _resolve_num_tokens(resolution_level: int) -> int:
+    """Map a MoGe resolution level to the pinned checkpoint token range.
+
+    Args:
+        resolution_level: Detail level from 0 through 9.
+
+    Returns:
+        Fixed token count for export and inference.
+
+    Raises:
+        ValueError: If the resolution level is outside 0 through 9.
+    """
+    if not 0 <= resolution_level <= 9:
+        raise ValueError(f"resolution_level must be within [0, 9], got {resolution_level}.")
+    min_tokens: int = MOGE_V2_NUM_TOKENS_RANGE[0]
+    max_tokens: int = MOGE_V2_NUM_TOKENS_RANGE[1]
+    return int(min_tokens + (resolution_level / 9) * (max_tokens - min_tokens))
+
+
+def export_moge_v2_normal_onnx(
+    encoder: Encoder = "vitl",
+    image_hw: tuple[int, int] = DEFAULT_IMAGE_HW,
+    resolution_level: int = 9,
+    max_batch_size: int = 8,
+    cache_dir: Path = DEFAULT_CACHE_DIR,
+) -> Path:
+    """Export a pinned MoGe v2 normal checkpoint with dynamic batch only.
+
+    The graph accepts float32 RGB ``[B,3,H,W]`` in ``[0,1]`` and returns
+    float32 normals ``[B,H,W,3]`` plus masks ``[B,H,W]``. Compute is fp16,
+    image height, image width, and token count are static, and only batch is
+    dynamic. The cache identity includes all three static model dimensions,
+    this export recipe version, and the immutable checkpoint revision.
+
+    Args:
+        encoder: DINOv2 encoder size.
+        image_hw: Static network height and width.
+        resolution_level: Detail level from 0 through 9.
+        max_batch_size: Largest batch encoded in the dynamic ONNX constraint.
+        cache_dir: Cache root; the graph lands in ``cache_dir / "onnx"``.
+
+    Returns:
+        Cached or newly exported ONNX path.
+
+    Raises:
+        RuntimeError: If CUDA is unavailable.
+        ValueError: If dimensions, batch size, or checkpoint token metadata are invalid.
+    """
+    if not torch.cuda.is_available():
+        raise RuntimeError("MoGe v2 ONNX export requires CUDA.")
+    height: int = image_hw[0]
+    width: int = image_hw[1]
+    if height < 1 or width < 1:
+        raise ValueError(f"MoGe v2 network dimensions must be positive, got {image_hw}.")
+    if max_batch_size < 1:
+        raise ValueError(f"max_batch_size must be positive, got {max_batch_size}.")
+
+    num_tokens: int = _resolve_num_tokens(resolution_level)
+    checkpoint: tuple[str, str] = MOGE_V2_NORMAL_CHECKPOINTS[encoder]
+    checkpoint_revision: str = checkpoint[1][:8]
+    onnx_dir: Path = cache_dir / "onnx"
+    onnx_path: Path = onnx_dir / (
+        f"moge-v2-{encoder}-normal_{height}x{width}_t{num_tokens}_v{ONNX_EXPORT_VERSION}_{checkpoint_revision}.onnx"
+    )
+    if onnx_path.exists():
+        return onnx_path
+
+    # Beartype's dev import hook checks annotated locals inside the vendored
+    # forward. Dynamic ONNX export represents the batch as torch.SymInt, which
+    # correctly violates those eager-only ``int`` checks. Re-enter this exact
+    # export in a clean interpreter without dev instrumentation; the parent
+    # process keeps beartype active for every predictor call and test.
+    if os.environ.get("PIXI_DEV_MODE") == "1" and os.environ.get(_EXPORT_WORKER_ENV) != "1":
+        worker_env: dict[str, str] = dict(os.environ)
+        worker_env["PIXI_DEV_MODE"] = "0"
+        worker_env[_EXPORT_WORKER_ENV] = "1"
+        worker_command: list[str] = [
+            sys.executable,
+            "-m",
+            "monopriors.models.surface_normal._moge_v2_onnx_worker",
+            encoder,
+            str(height),
+            str(width),
+            str(resolution_level),
+            str(max_batch_size),
+            str(cache_dir),
+        ]
+        subprocess.run(worker_command, check=True, env=worker_env)
+        if not onnx_path.exists():
+            raise RuntimeError(f"MoGe v2 ONNX export worker did not produce {onnx_path}.")
+        return onnx_path
+
+    print(f"[monoprior] exporting MoGe v2 normals to ONNX (one-time, may take minutes): {onnx_path.name}")
+    model: MoGeModel = MoGeModel.from_pretrained(checkpoint[0], revision=checkpoint[1]).to("cuda").eval()
+    if model.num_tokens_range != MOGE_V2_NUM_TOKENS_RANGE:
+        raise ValueError(
+            f"Pinned MoGe v2 checkpoint token range changed from {MOGE_V2_NUM_TOKENS_RANGE} to {model.num_tokens_range}; bump the export recipe."
+        )
+    model.onnx_compatible_mode = True
+    wrapper: _MoGeV2NormalHeads = _MoGeV2NormalHeads(model, num_tokens).eval()
+    example_batch_size: int = min(2, max_batch_size)
+    dummy_image_b3hw: Float32[Tensor, "b 3 h w"] = torch.zeros(
+        (example_batch_size, 3, height, width),
+        dtype=torch.float32,
+        device="cuda",
+    )
+
+    from trtkit import export_onnx, sweep_stale_onnx_exports
+
+    export_onnx(
+        wrapper,
+        (dummy_image_b3hw,),
+        onnx_path,
+        input_names=["image"],
+        output_names=["normal", "mask"],
+        compute_dtype=torch.float16,
+        dynamic_batch_max=max_batch_size,
+    )
+    del dummy_image_b3hw, wrapper, model
+    torch.cuda.empty_cache()
+
+    # Preserve the current external-data sidecar. trtkit publishes the ONNX
+    # protobuf atomically, while dynamo keeps its large weights in the
+    # pid-suffixed sidecar referenced by that protobuf.
+    current_sidecar: Path = onnx_path.with_name(f"{onnx_path.name}.part{os.getpid()}.data")
+    stale_prefix: str = f"moge-v2-{encoder}-normal_{height}x{width}_t{num_tokens}_"
+    sweep_stale_onnx_exports(onnx_dir, stale_prefix, keep_paths={onnx_path, current_sidecar})
+    return onnx_path
+
+
+def _preprocess_rgb(
+    rgb_bhw3: UInt8[Tensor, "b h w 3"],
+    image_hw: tuple[int, int],
+) -> Float32[Tensor, "b 3 nh nw"]:
+    """Convert a CUDA uint8 RGB batch to fixed-resolution float network input.
+
+    Args:
+        rgb_bhw3: uint8 CUDA RGB frames shaped ``b h w 3``.
+        image_hw: Static network height and width.
+
+    Returns:
+        float32 CUDA RGB tensor shaped ``b 3 nh nw`` in ``[0, 1]``.
+
+    Raises:
+        ValueError: If the batch is empty or the network size is invalid.
+        RuntimeError: If the input is not already CUDA-resident.
+    """
+    if not rgb_bhw3.is_cuda:
+        raise RuntimeError("MoGe v2 batched normal predictors require CUDA input tensors.")
+    if rgb_bhw3.shape[0] < 1:
+        raise ValueError("MoGe v2 batched normal predictors require a non-empty batch.")
+    if image_hw[0] < 1 or image_hw[1] < 1:
+        raise ValueError(f"MoGe v2 network dimensions must be positive, got {image_hw}.")
+
+    image_b3hw: Float32[Tensor, "b 3 h w"] = rearrange(rgb_bhw3, "b h w c -> b c h w").to(dtype=torch.float32) / 255.0  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    if tuple(image_b3hw.shape[-2:]) != image_hw:
+        image_b3hw = F.interpolate(image_b3hw, size=image_hw, mode="bilinear", antialias=True)
+    return image_b3hw
+
+
+def _postprocess_normal_output(
+    normals_bnhw3: Float32[Tensor, "b nh nw 3"],
+    mask_bnhw: Float32[Tensor, "b nh nw"],
+    output_hw: tuple[int, int],
+) -> MoGeV2NormalOutput:
+    """Restore input resolution, unit-normalize, and take ownership of outputs.
+
+    Args:
+        normals_bnhw3: float32 camera-space normals at network resolution.
+        mask_bnhw: float32 mask probabilities at network resolution.
+        output_hw: Caller input height and width.
+
+    Returns:
+        Owning float32 normal and mask tensors at ``output_hw``.
+    """
+    normals_b3nhw: Float32[Tensor, "b 3 nh nw"] = rearrange(normals_bnhw3.float(), "b h w c -> b c h w")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    mask_b1nhw: Float32[Tensor, "b 1 nh nw"] = rearrange(mask_bnhw.float(), "b h w -> b 1 h w")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    if tuple(normals_b3nhw.shape[-2:]) != output_hw:
+        normals_b3hw: Float32[Tensor, "b 3 h w"] = F.interpolate(normals_b3nhw, size=output_hw, mode="bilinear", align_corners=False)
+        mask_b1hw: Float32[Tensor, "b 1 h w"] = F.interpolate(mask_b1nhw, size=output_hw, mode="bilinear", align_corners=False)
+    else:
+        normals_b3hw = normals_b3nhw.clone()
+        mask_b1hw = mask_b1nhw.clone()
+    normals_bhw3: Float32[Tensor, "b h w 3"] = F.normalize(
+        rearrange(normals_b3hw, "b c h w -> b h w c"),  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+        dim=-1,
+    )
+    mask_bhw: Float32[Tensor, "b h w"] = rearrange(mask_b1hw, "b 1 h w -> b h w")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    return MoGeV2NormalOutput(normals_bhw3=normals_bhw3, mask_bhw=mask_bhw)
+
+
+class MoGeV2TorchNormalPredictor:
+    """Plain-torch fp16-compute twin of the batched TensorRT predictor."""
+
+    def __init__(
+        self,
+        encoder: Encoder = "vitl",
+        image_hw: tuple[int, int] = DEFAULT_IMAGE_HW,
+        resolution_level: int = 9,
+    ) -> None:
+        """Load a pinned MoGe v2 normal checkpoint onto CUDA.
+
+        Args:
+            encoder: DINOv2 encoder size.
+            image_hw: Static network height and width.
+            resolution_level: Detail level from 0 through 9; level 9 uses
+                3600 tokens for the pinned checkpoints.
+
+        Raises:
+            RuntimeError: If CUDA is unavailable.
+            ValueError: If ``resolution_level`` is outside 0 through 9.
+        """
+        if not torch.cuda.is_available():
+            raise RuntimeError("MoGe v2 batched normal prediction requires CUDA.")
+        num_tokens: int = _resolve_num_tokens(resolution_level)
+        checkpoint: tuple[str, str] = MOGE_V2_NORMAL_CHECKPOINTS[encoder]
+        self.model: MoGeModel = MoGeModel.from_pretrained(checkpoint[0], revision=checkpoint[1]).to("cuda").eval()
+        if self.model.num_tokens_range != MOGE_V2_NUM_TOKENS_RANGE:
+            raise ValueError(
+                f"Pinned MoGe v2 checkpoint token range changed from {MOGE_V2_NUM_TOKENS_RANGE} to {self.model.num_tokens_range}; update the predictor."
+            )
+        self.model.onnx_compatible_mode = True
+        self.num_tokens: int = num_tokens
+        self.image_hw: tuple[int, int] = image_hw
+
+    def __call__(self, rgb_bhw3: UInt8[Tensor, "b h w 3"]) -> MoGeV2NormalOutput:
+        """Predict camera-space RDF normals and mask probabilities for a batch.
+
+        Args:
+            rgb_bhw3: uint8 CUDA RGB frames shaped ``b h w 3``.
+
+        Returns:
+            Owning float32 unit normals shaped ``b h w 3`` and float32 masks
+            shaped ``b h w``, both on CUDA. Normals point toward the camera.
+        """
+        output_hw: tuple[int, int] = (rgb_bhw3.shape[1], rgb_bhw3.shape[2])
+        image_b3hw: Float32[Tensor, "b 3 nh nw"] = _preprocess_rgb(rgb_bhw3, self.image_hw)
+        with torch.inference_mode(), torch.autocast("cuda", dtype=torch.float16):
+            output: ForwardOutput = self.model(
+                image_b3hw,
+                num_tokens=self.num_tokens,
+                output_heads=("normal", "mask"),
+            )
+        normals_bnhw3: Float32[Tensor, "b nh nw 3"] = cast(Tensor, output["normal"]).float()
+        mask_bnhw: Float32[Tensor, "b nh nw"] = cast(Tensor, output["mask"]).float()
+        return _postprocess_normal_output(normals_bnhw3, mask_bnhw, output_hw)
+
+
+class MoGeV2TrtNormalPredictor:
+    """Batched MoGe v2 normals on a cached dynamic-batch TensorRT engine."""
+
+    def __init__(
+        self,
+        encoder: Encoder = "vitl",
+        image_hw: tuple[int, int] = DEFAULT_IMAGE_HW,
+        resolution_level: int = 9,
+        batch_size: int = 8,
+        cache_dir: Path = DEFAULT_CACHE_DIR,
+    ) -> None:
+        """Export ONNX and build or load the machine-local engine on first use.
+
+        Args:
+            encoder: DINOv2 encoder size.
+            image_hw: Static network height and width.
+            resolution_level: Detail level from 0 through 9; level 9 uses
+                3600 tokens for the pinned checkpoints.
+            batch_size: Engine profile maximum and optimization batch.
+            cache_dir: Cache root for ONNX and TensorRT artifacts.
+        """
+        from trtkit import TrtBuildConfig, ensure_engine
+        from trtkit.tensorrt_runtime import TensorRtRuntime
+
+        onnx_path: Path = export_moge_v2_normal_onnx(
+            encoder=encoder,
+            image_hw=image_hw,
+            resolution_level=resolution_level,
+            max_batch_size=batch_size,
+            cache_dir=cache_dir,
+        )
+        config: TrtBuildConfig = TrtBuildConfig(max_batch_size=batch_size, opt_batch_size=batch_size)
+        engine_path: Path = ensure_engine(onnx_path, config, cache_dir=cache_dir / "trt")
+        self.runtime: TensorRtRuntime = TensorRtRuntime(engine_path)
+        self.image_hw: tuple[int, int] = image_hw
+
+    def __call__(self, rgb_bhw3: UInt8[Tensor, "b h w 3"]) -> MoGeV2NormalOutput:
+        """Predict camera-space RDF normals and mask probabilities for a batch.
+
+        Args:
+            rgb_bhw3: uint8 CUDA RGB frames shaped ``b h w 3``.
+
+        Returns:
+            Owning float32 unit normals shaped ``b h w 3`` and float32 masks
+            shaped ``b h w``, both on CUDA. Normals point toward the camera.
+        """
+        output_hw: tuple[int, int] = (rgb_bhw3.shape[1], rgb_bhw3.shape[2])
+        image_b3hw: Float32[Tensor, "b 3 nh nw"] = _preprocess_rgb(rgb_bhw3, self.image_hw)
+        runtime_output: dict[str, Tensor] = self.runtime({"image": image_b3hw})
+        normals_bnhw3: Float32[Tensor, "b nh nw 3"] = runtime_output["normal"].float()
+        mask_bnhw: Float32[Tensor, "b nh nw"] = runtime_output["mask"].float()
+        return _postprocess_normal_output(normals_bnhw3, mask_bnhw, output_hw)

--- a/packages/monoprior/tests/test_moge_v2_trt_normals.py
+++ b/packages/monoprior/tests/test_moge_v2_trt_normals.py
@@ -1,0 +1,138 @@
+"""Contract, parity, and convention tests for batched MoGe v2 normals."""
+
+import numpy as np
+import pytest
+import torch
+from jaxtyping import Bool, Float32, UInt8
+from torch import Tensor
+
+requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+
+def _synthetic_rgb_batch(batch_size: int, image_hw: tuple[int, int]) -> UInt8[Tensor, "b h w 3"]:
+    """Create deterministic RGB gradients directly on CUDA.
+
+    Args:
+        batch_size: Number of frames to create.
+        image_hw: Frame height and width.
+
+    Returns:
+        uint8 CUDA RGB frames shaped ``b h w 3``.
+    """
+    height: int = image_hw[0]
+    width: int = image_hw[1]
+    x_w: Float32[Tensor, "w"] = torch.linspace(0, 255, width, device="cuda", dtype=torch.float32)
+    y_h: Float32[Tensor, "h"] = torch.linspace(0, 255, height, device="cuda", dtype=torch.float32)
+    red_hw: Float32[Tensor, "h w"] = x_w[None, :].expand(height, width)
+    green_hw: Float32[Tensor, "h w"] = y_h[:, None].expand(height, width)
+    blue_hw: Float32[Tensor, "h w"] = (red_hw + green_hw) / 2.0
+    rgb_hw3: UInt8[Tensor, "h w 3"] = torch.stack((red_hw, green_hw, blue_hw), dim=-1).to(torch.uint8)
+    return rgb_hw3[None].expand(batch_size, -1, -1, -1).contiguous()
+
+
+@requires_cuda
+def test_torch_predictor_returns_batched_unit_normals_and_masks() -> None:
+    """The torch twin honors the shared batch, dtype, and unit-normal contract."""
+    from monopriors.models.surface_normal.moge_v2_trt import MoGeV2NormalOutput, MoGeV2TorchNormalPredictor
+
+    image_hw: tuple[int, int] = (56, 70)
+    rgb_bhw3: UInt8[Tensor, "2 56 70 3"] = _synthetic_rgb_batch(2, image_hw)
+    predictor: MoGeV2TorchNormalPredictor = MoGeV2TorchNormalPredictor(
+        encoder="vits",
+        image_hw=image_hw,
+        resolution_level=0,
+    )
+
+    prediction: MoGeV2NormalOutput = predictor(rgb_bhw3)
+
+    assert prediction.normals_bhw3.shape == (2, 56, 70, 3)
+    assert prediction.normals_bhw3.dtype == torch.float32
+    assert prediction.normals_bhw3.is_cuda
+    assert prediction.mask_bhw.shape == (2, 56, 70)
+    assert prediction.mask_bhw.dtype == torch.float32
+    assert prediction.mask_bhw.is_cuda
+    torch.testing.assert_close(
+        torch.linalg.vector_norm(prediction.normals_bhw3, dim=-1),
+        torch.ones((2, 56, 70), device="cuda"),
+        atol=2e-3,
+        rtol=0.0,
+    )
+    assert prediction.mask_bhw.min().item() >= 0.0
+    assert prediction.mask_bhw.max().item() <= 1.0
+
+
+@requires_cuda
+def test_trt_matches_torch_twin_at_default_arkitscenes_resolution() -> None:
+    """TensorRT and ONNX-compatible torch normals meet the angular parity bound."""
+    from monopriors.models.surface_normal.moge_v2_trt import (
+        DEFAULT_IMAGE_HW,
+        MoGeV2NormalOutput,
+        MoGeV2TorchNormalPredictor,
+        MoGeV2TrtNormalPredictor,
+    )
+
+    rgb_bhw3: UInt8[Tensor, "2 756 1008 3"] = _synthetic_rgb_batch(2, DEFAULT_IMAGE_HW)
+    rgb_bhw3[1] = torch.flip(rgb_bhw3[1], dims=(1,))
+    trt_predictor: MoGeV2TrtNormalPredictor = MoGeV2TrtNormalPredictor(batch_size=8)
+    torch_predictor: MoGeV2TorchNormalPredictor = MoGeV2TorchNormalPredictor()
+
+    trt_prediction: MoGeV2NormalOutput = trt_predictor(rgb_bhw3)
+    torch_prediction: MoGeV2NormalOutput = torch_predictor(rgb_bhw3)
+    torch.cuda.synchronize()
+
+    assert trt_prediction.normals_bhw3.shape == (2, 756, 1008, 3)
+    assert trt_prediction.normals_bhw3.dtype == torch.float32
+    assert trt_prediction.mask_bhw.shape == (2, 756, 1008)
+    assert trt_prediction.mask_bhw.dtype == torch.float32
+    torch.testing.assert_close(
+        torch.linalg.vector_norm(trt_prediction.normals_bhw3, dim=-1),
+        torch.ones((2, 756, 1008), device="cuda"),
+        atol=2e-3,
+        rtol=0.0,
+    )
+    cosine_bhw: Float32[Tensor, "2 756 1008"] = torch.sum(
+        trt_prediction.normals_bhw3 * torch_prediction.normals_bhw3,
+        dim=-1,
+    ).clamp(-1.0, 1.0)
+    angular_error_bhw: Float32[Tensor, "2 756 1008"] = torch.rad2deg(torch.acos(cosine_bhw))
+    mean_error_degrees: float = angular_error_bhw.mean().item()
+    p99_error_degrees: float = torch.quantile(angular_error_bhw, 0.99).item()
+
+    assert mean_error_degrees < 0.1
+    assert p99_error_degrees < 0.5
+
+    held_prediction: MoGeV2NormalOutput = trt_predictor(rgb_bhw3[:1])
+    held_normals_copy_bhw3: Float32[Tensor, "1 756 1008 3"] = held_prediction.normals_bhw3.clone()
+    reused_prediction: MoGeV2NormalOutput = trt_predictor(torch.flip(rgb_bhw3[:1], dims=(2,)))
+    assert reused_prediction.normals_bhw3.data_ptr() != held_prediction.normals_bhw3.data_ptr()
+    torch.testing.assert_close(held_prediction.normals_bhw3, held_normals_copy_bhw3)
+
+
+@requires_cuda
+def test_trt_normals_match_existing_single_image_convention() -> None:
+    """The TRT output keeps the existing camera-space layout and sign convention."""
+    from monopriors.models.surface_normal.base_normal_model import SurfaceNormalPrediction
+    from monopriors.models.surface_normal.moge_v2 import MoGeV2NormalPredictor
+    from monopriors.models.surface_normal.moge_v2_trt import (
+        DEFAULT_IMAGE_HW,
+        MoGeV2NormalOutput,
+        MoGeV2TrtNormalPredictor,
+    )
+
+    rgb_bhw3: UInt8[Tensor, "1 756 1008 3"] = _synthetic_rgb_batch(1, DEFAULT_IMAGE_HW)
+    rgb_hw3: UInt8[np.ndarray, "756 1008 3"] = rgb_bhw3[0].cpu().numpy()
+    trt_predictor: MoGeV2TrtNormalPredictor = MoGeV2TrtNormalPredictor(batch_size=8)
+    existing_predictor: MoGeV2NormalPredictor = MoGeV2NormalPredictor(device="cuda", encoder="vitl")
+
+    trt_prediction: MoGeV2NormalOutput = trt_predictor(rgb_bhw3)
+    existing_prediction: SurfaceNormalPrediction = existing_predictor(rgb_hw3)
+    existing_normals_bhw3: Float32[Tensor, "1 756 1008 3"] = torch.from_numpy(existing_prediction.normal_hw3).cuda()[None]
+    valid_bhw: Bool[Tensor, "1 756 1008"] = torch.from_numpy(existing_prediction.confidence_hw1[..., 0] > 0.5).cuda()[None]
+    assert valid_bhw.any()
+    cosine_valid: Float32[Tensor, "valid"] = torch.sum(
+        trt_prediction.normals_bhw3 * existing_normals_bhw3,
+        dim=-1,
+    )[valid_bhw]
+
+    assert cosine_valid.mean().item() > 0.999
+    assert torch.quantile(cosine_valid, 0.01).item() > 0.995

--- a/packages/prompt-da/README.md
+++ b/packages/prompt-da/README.md
@@ -64,8 +64,8 @@ To register a `promptda` layer on a **local** catalog instead (needs
 source `.mov` with torchcodec rather than reading video from the catalog:
 
 ```bash
-pixi run -e prompt-da-catalog --frozen prompt-da-arkitscenes-register --video-id 42899799
-pixi run -e prompt-da-catalog --frozen prompt-da-arkitscenes-register-raw --video-id 42899799
+pixi run -e prompt-da-stream --frozen prompt-da-arkitscenes-register --video-id 42899799
+pixi run -e prompt-da-stream --frozen prompt-da-arkitscenes-register-raw --video-id 42899799
 ```
 
 ## Acknowledgements

--- a/packages/prompt-da/pyproject.toml
+++ b/packages/prompt-da/pyproject.toml
@@ -26,6 +26,8 @@ paths = ["src/rerun_prompt_da", "tests", "tools"]
 exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modules/*"]
 sort_by_size = true
 min_confidence = 60
-# _engine: held only to keep the TRT engine alive for its execution context
-# video/depth/k/pose_t/pose_q: PromptDARow TypedDict fields, read via subscript.
-ignore_names = ["rr_config", "_engine", "video", "depth", "k", "pose_t", "pose_q"]
+# _engine: held only to keep the TRT engine alive for its execution context.
+# _sample_index: populated by the synthetic RerunIterableDataset test fixture.
+# forward: called by torch.nn.Module.__call__.
+# video/depth/conf/k/pose_t/pose_q: PromptDARow TypedDict fields, read via subscript.
+ignore_names = ["rr_config", "_engine", "_sample_index", "forward", "video", "depth", "conf", "k", "pose_t", "pose_q"]

--- a/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_arkitscenes.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_arkitscenes.py
@@ -5,12 +5,11 @@ local Rerun catalog, completes depth frame-by-frame, fuses a final TSDF mesh,
 and writes a replaceable ``promptda`` layer back to the dataset.
 """
 
-import multiprocessing
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-import av
 import cv2
 import numpy as np
 import open3d as o3d
@@ -20,23 +19,14 @@ import torch
 from arkitscenes_download.ingest.blueprint import DEPTH_RANGE_MM, make_blueprint
 from arkitscenes_download.ingest.catalog import DEFAULT_CATALOG_URL
 from arkitscenes_download.ingest.depth import encode_depth_png
-from arkitscenes_download.ingest.paths import CONFIDENCE, DEPTH, DEPTH_PROMPTDA, PINHOLE_WIDE, PROMPTDA_MESH, RIG, VIDEO_WIDE
-from jaxtyping import Float, Float32, UInt8, UInt16
+from arkitscenes_download.ingest.paths import DEPTH_PROMPTDA, PROMPTDA_MESH, TIMELINE
+from jaxtyping import Float, UInt8, UInt16
 from numpy import ndarray
 from rerun.catalog import CatalogClient, DatasetEntry, OnDuplicateSegmentLayer, RegistrationHandle
-from rerun.experimental.dataloader import (
-    DataSource,
-    Field,
-    FixedRateSampling,
-    ImageDecoder,
-    NumericDecoder,
-    RerunMapDataset,
-    VideoFrameDecoder,
-)
+from rerun.experimental.dataloader import RerunIterableDataset
 from simplecv.camera_parameters import Intrinsics, rescale_intri
 from simplecv.ops.tsdf_depth_fuser import Open3DFuser
 from simplecv.rerun_log_utils import mesh_bounding_geometry
-from torch import Tensor
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
@@ -49,9 +39,9 @@ from rerun_prompt_da.apis.arkitscenes_shared import (
     run_promptda_batch,
     segments_to_process,
     stride_for,
-    world_t_cam_from_pose,
 )
 from rerun_prompt_da.apis.prompt_da_trt_polycam import network_image_hw
+from rerun_prompt_da.promptda_stream import PromptDABatch, PromptDACollate, promptda_dataset
 from rerun_prompt_da.trt_predictor import PromptDATrtPredictor
 
 PROMPTDA_LAYER = "promptda"
@@ -74,13 +64,11 @@ class PDAArkitScenesConfig:
     output_dir: Path = Path("data/promptda")
     """Root for generated per-segment PromptDA RRD files."""
     target_fps: float = 10.0
-    """Inference rate selected by client-side stride over the native stream."""
+    """Inference rate used to build the catalog sampling grid."""
     max_image_size: int = 1008
     """Largest image dimension accepted by the PromptDA predictor."""
     batch_size: int = 8
     """Frames per TensorRT batch (the engine profile's max/opt batch)."""
-    num_workers: int = 4
-    """Spawned DataLoader worker processes fetching/decoding batches in parallel."""
     max_depth_range_meter: float = 4.0
     """Maximum predicted depth retained for TSDF fusion, in metres."""
     depth_fusion_resolution: float = 0.015
@@ -101,39 +89,31 @@ class SegmentResult:
     inferred_frames: int
     """Number of frames sent through PromptDA."""
     skipped_decodes: int
-    """Frames skipped because a field was absent (includes recovered AV1 decoder errors)."""
+    """Sampling-grid rows skipped because one or more required fields were absent."""
 
 
-class ResilientVideoFrameDecoder(VideoFrameDecoder):
-    """A ``VideoFrameDecoder`` that survives per-sample AV1 decode failures.
+@dataclass(frozen=True, slots=True)
+class CompletedPromptDABatch:
+    """CPU-resident PromptDA results ready for ordered RRD logging and fusion."""
 
-    The dataloader assembles decode windows with ``fill_latest_at`` over a
-    fixed-rate sampling grid, which silently drops a stored packet whenever
-    timestamp jitter puts two packets in one grid slot (upstream, RR-5087).
-    Every window spanning the dropped reference frame then fails
-    deterministically with ``InvalidDataError`` until the next keyframe —
-    on this dataset, a ~0.5 s dead zone per segment. Each sample is decoded
-    with a fresh codec context, so the failure is recoverable at sample
-    granularity: map it onto the decoder's existing ``None``-frame skip path
-    instead of killing the whole iteration. The caught exceptions are kept
-    alive on purpose — releasing a failed decode's traceback frees the
-    errored codec context un-drained, whose teardown at interpreter shutdown
-    can deadlock the process in ``dav1d_flush``.
-    """
-
-    def __init__(self, *, keyframe_interval: int = 30, fps_estimate: float = 30.0, codec: str = "h264") -> None:
-        super().__init__(keyframe_interval=keyframe_interval, fps_estimate=fps_estimate, codec=codec)
-        self.decode_failures: list[BaseException] = []
-
-    def decode(
-        self, raw: pa.ChunkedArray, index_value: int | np.datetime64 | np.timedelta64, segment_id: str
-    ) -> Tensor | None:
-        """Decode one sample, degrading decoder errors to a skippable ``None``."""
-        try:
-            return super().decode(raw, index_value, segment_id)
-        except av.error.InvalidDataError as error:
-            self.decode_failures.append(error)
-            return None
+    timestamps_ns: list[int]
+    """Sampling-grid timestamps in row order, in nanoseconds."""
+    quarter_turns: int
+    """Counter-clockwise quarter turns previously applied for inference."""
+    depth_mm_bhw: UInt16[ndarray, "b h w"]
+    """Full-resolution predicted depth in millimetres, in inference orientation."""
+    depth_model_mm_bhw: UInt16[ndarray, "b nh nw"]
+    """Network-resolution predicted depth in millimetres, in inference orientation."""
+    rgb_stored_bhw3: UInt8[ndarray, "b stored_h stored_w 3"]
+    """RGB frames restored to catalog orientation."""
+    confidence_bhw: UInt8[ndarray, "b stored_prompt_h stored_prompt_w"]
+    """ARKit confidence in catalog orientation."""
+    K_native_b33: Float[ndarray, "b 3 3"]
+    """Native intrinsics in catalog orientation."""
+    world_T_cam_b44: Float[ndarray, "b 4 4"]
+    """Camera-to-world transforms."""
+    stored_hw: tuple[int, int]
+    """Native frame height and width in catalog orientation."""
 
 
 def portrait_from_segment_row(row: dict[str, Any]) -> bool:
@@ -164,22 +144,79 @@ def orientation_quarter_turns_from_segment_row(row: dict[str, Any]) -> int:
     return int(value) % 4
 
 
-def rotate_portrait_to_landscape(array_hw: ndarray, quarter_turns: int) -> ndarray:
-    """Undo ingest's counter-clockwise portrait bake before inference."""
-    return np.ascontiguousarray(np.rot90(array_hw, -quarter_turns))
+def log_promptda_frame(
+    recording: rr.RecordingStream, timestamp_ns: int, predicted_depth_hw: UInt16[ndarray, "h w"]
+) -> None:
+    """Log one encoded PromptDA depth frame on the layer's duration timeline.
 
-
-def rotate_landscape_to_portrait(array_hw: ndarray, quarter_turns: int) -> ndarray:
-    """Restore ingest's counter-clockwise portrait bake after inference."""
-    return np.ascontiguousarray(np.rot90(array_hw, quarter_turns))
-
-
-def _list_collate(batch: list[dict[str, Tensor | None]]) -> list[dict[str, Tensor | None]]:
-    """Identity collate: DataLoader's default would stack per-field tensors and crash on ``None`` (skipped-decode) samples.
-
-    A module-level function rather than a lambda so spawn workers can pickle it.
+    Args:
+        recording: PromptDA layer recording stream.
+        timestamp_ns: Frame timestamp on ``video_time``, in nanoseconds.
+        predicted_depth_hw: Full-resolution uint16 depth in millimetres with shape ``(H, W)``.
     """
-    return batch
+    rr.set_time(TIMELINE, duration=np.timedelta64(timestamp_ns, "ns"), recording=recording)
+    rr.log(
+        DEPTH_PROMPTDA,
+        # TODO(rerun#upstream): drop depth_range once the viewer auto-ranges encoded depth (see DEPTH_RANGE_MM in ingest/blueprint.py).
+        rr.EncodedDepthImage(blob=encode_depth_png(predicted_depth_hw), media_type="image/png", meter=1000.0, depth_range=DEPTH_RANGE_MM),
+        recording=recording,
+    )
+
+
+def fuse_and_log_batch(
+    batch: CompletedPromptDABatch,
+    recording: rr.RecordingStream,
+    fuser: Open3DFuser,
+    config: PDAArkitScenesConfig,
+) -> int:
+    """Log and fuse one completed batch in row order.
+
+    Args:
+        batch: CPU-resident inference results and matching sensor metadata.
+        recording: PromptDA layer recording stream.
+        fuser: Segment TSDF accumulator.
+        config: Fusion depth and resolution settings.
+
+    Returns:
+        Number of rows logged and fused.
+    """
+    row: int
+    timestamp_ns: int
+    for row, timestamp_ns in enumerate(batch.timestamps_ns):
+        predicted_depth_hw: UInt16[ndarray, "h w"] = np.ascontiguousarray(np.rot90(batch.depth_mm_bhw[row], -batch.quarter_turns))
+        fusion_depth_hw: UInt16[ndarray, "fh fw"] = np.ascontiguousarray(np.rot90(batch.depth_model_mm_bhw[row], -batch.quarter_turns))
+        confidence_hw: UInt8[ndarray, "h2 w2"] = batch.confidence_bhw[row]
+        rgb_hw3: UInt8[ndarray, "h w 3"] = batch.rgb_stored_bhw3[row]
+        log_promptda_frame(recording, timestamp_ns, predicted_depth_hw)
+        filtered_depth_hw: UInt16[ndarray, "h w"] = filter_depth_for_fusion(
+            fusion_depth_hw,
+            confidence_hw,
+            config.max_depth_range_meter,
+        )
+        rgb_fusion_hw3: UInt8[ndarray, "fh fw 3"] = np.asarray(
+            cv2.resize(rgb_hw3, (fusion_depth_hw.shape[1], fusion_depth_hw.shape[0]), interpolation=cv2.INTER_AREA), dtype=np.uint8
+        )
+        stored_k_33: Float[ndarray, "3 3"] = batch.K_native_b33[row]
+        stored_intrinsics: Intrinsics = Intrinsics.from_k_matrix(
+            camera_conventions="RDF",
+            k_matrix=stored_k_33,
+            height=batch.stored_hw[0],
+            width=batch.stored_hw[1],
+        )
+        fusion_intrinsics: Intrinsics = rescale_intri(
+            stored_intrinsics,
+            target_height=fusion_depth_hw.shape[0],
+            target_width=fusion_depth_hw.shape[1],
+        )
+        assert fusion_intrinsics.k_matrix is not None
+        world_t_cam_44: Float[ndarray, "4 4"] = batch.world_T_cam_b44[row]
+        fuser.fuse_frames(
+            depth_hw=filtered_depth_hw,
+            K_33=fusion_intrinsics.k_matrix,
+            cam_T_world_44=np.linalg.inv(world_t_cam_44),
+            rgb_hw3=rgb_fusion_hw3,
+        )
+    return len(batch.timestamps_ns)
 
 
 def process_segment(
@@ -191,27 +228,26 @@ def process_segment(
     predictor: PromptDATrtPredictor,
 ) -> SegmentResult:
     """Infer and fuse one catalog segment into a PromptDA RRD."""
-    source: DataSource = DataSource(dataset=dataset_entry, segments=[segment_id])
-    video_decoder: ResilientVideoFrameDecoder = ResilientVideoFrameDecoder(codec="av1", keyframe_interval=300, fps_estimate=60.0)
-    fields: dict[str, Field] = {
-        "video": Field(f"/{VIDEO_WIDE}:VideoStream:sample", decode=video_decoder),
-        "depth": Field(f"/{DEPTH}:EncodedDepthImage:blob", decode=ImageDecoder()),
-        "conf": Field(f"/{CONFIDENCE}:SegmentationImage:buffer", decode=NumericDecoder()),
-        "pose_t": Field(f"/{RIG}:Transform3D:translation", decode=NumericDecoder()),
-        "pose_q": Field(f"/{RIG}:Transform3D:quaternion", decode=NumericDecoder()),
-        "k": Field(f"/{PINHOLE_WIDE}:Pinhole:image_from_camera", decode=NumericDecoder()),
-    }
-    # A map dataset fetches only the strided samples. In released rerun-sdk
-    # 0.34.1, the iterable dataset would decode every sample on the 60 fps grid
-    # (each decode replays the whole GOP window; TODO RR-4751), i.e. `stride`×
-    # the work for frames we throw away. RR-5167 / PR #2683 fixes this upstream.
-    rerun_dataset: RerunMapDataset = RerunMapDataset(
-        source,
-        index="video_time",
-        fields=fields,
-        timeline_sampling=FixedRateSampling(rate_hz=NATIVE_FPS),
-    )
+    device: torch.device = torch.device("cuda")
     stride: int = stride_for(NATIVE_FPS, config.target_fps)
+    sampling_fps: float = NATIVE_FPS / stride
+    samples: RerunIterableDataset = promptda_dataset(dataset_entry, segment_id, sampling_fps, device)[0]
+    # NVDEC and the collate's sampling-grid position are stateful, so iteration
+    # must remain in natural order in this process.
+    model_quarter_turns: int = (-orientation_quarter_turns) % 4 if portrait else 0
+    timestamp_step_ns: int = round(1_000_000_000 / NATIVE_FPS) * stride
+    loader: DataLoader = DataLoader(
+        samples,
+        batch_size=config.batch_size,
+        num_workers=0,
+        collate_fn=PromptDACollate(
+            samples,
+            device,
+            quarter_turns=model_quarter_turns,
+            timestamp_step_ns=timestamp_step_ns,
+        ),
+    )
+    grid_slots: int = samples.sample_index.total_samples
     rrd_path: Path = config.output_dir / segment_id / "promptda.rrd"
     rrd_path.parent.mkdir(parents=True, exist_ok=True)
     recording: rr.RecordingStream | None = None
@@ -220,111 +256,52 @@ def process_segment(
         max_fusion_depth=config.max_depth_range_meter,
     )
     inferred_frames: int = 0
-    skipped_decodes: int = 0
-    strided_indices: list[int] = list(range(0, rerun_dataset.sample_index.total_samples, stride))
-    chunks: list[list[int]] = [strided_indices[i : i + config.batch_size] for i in range(0, len(strided_indices), config.batch_size)]
-    # Fetch whole chunks, in order, on spawn-based worker processes: in released
-    # rerun-sdk 0.34.1 the batch fetch (server query + per-sample GOP decode back
-    # to the previous keyframe; TODO RR-4751) is the pipeline's slowest stage and
-    # GIL-bound in-process, so worker processes are the only way to parallelize
-    # it (incremental decoding lands upstream in RR-5167 / PR #2683). The Rerun
-    # dataloader requires ``spawn`` (forked workers deadlock on their first
-    # catalog call), and torch rejects the worker kwargs when num_workers == 0.
-    loader: DataLoader = (
-        DataLoader(rerun_dataset, batch_sampler=chunks, collate_fn=_list_collate)
-        if config.num_workers == 0
-        else DataLoader(
-            rerun_dataset,
-            batch_sampler=chunks,
-            collate_fn=_list_collate,
-            num_workers=config.num_workers,
-            multiprocessing_context=multiprocessing.get_context("spawn"),
-            prefetch_factor=2,
-        )
-    )
-    for chunk, samples in tqdm(zip(chunks, loader, strict=True), total=len(chunks), desc=f"PromptDA {segment_id}", unit="batch"):
-        valid: list[tuple[int, dict[str, Tensor]]] = [
-            (sample_idx, sample)
-            for sample_idx, sample in zip(chunk, samples, strict=True)
-            if all(sample.get(field_name) is not None for field_name in fields)
-        ]
-        skipped_decodes += len(chunk) - len(valid)
-        if not valid:
-            continue
-        rgb_arrays: list[UInt8[ndarray, "h w 3"]] = [np.asarray(sample["video"].permute(1, 2, 0).numpy(), dtype=np.uint8) for _, sample in valid]
-        prompt_arrays: list[ndarray] = [sample["depth"].numpy().squeeze(0) for _, sample in valid]
-        confidence_shape_hw: tuple[int, int] = (256, 192) if portrait else (192, 256)
-        confidence_arrays: list[UInt8[ndarray, "h w"]] = [
-            np.asarray(sample["conf"].numpy().reshape(confidence_shape_hw), dtype=np.uint8) for _, sample in valid
-        ]
-        if portrait:
-            rgb_arrays = [rotate_portrait_to_landscape(rgb_hw3, orientation_quarter_turns) for rgb_hw3 in rgb_arrays]
-            prompt_arrays = [rotate_portrait_to_landscape(prompt_hw, orientation_quarter_turns) for prompt_hw in prompt_arrays]
-            confidence_arrays = [rotate_portrait_to_landscape(confidence_hw, orientation_quarter_turns) for confidence_hw in confidence_arrays]
-        rgb_bhw3: UInt8[Tensor, "b h w 3"] = torch.from_numpy(np.stack(rgb_arrays))
-        prompt_bhw: Float32[Tensor, "b 192 256"] = torch.from_numpy(np.stack(prompt_arrays).astype(np.float32) / 1000.0)
-        depth_mm_bhw: UInt16[ndarray, "b h w"]
-        depth_model_mm_bhw: UInt16[ndarray, "b nh nw"]
-        depth_mm_bhw, depth_model_mm_bhw = run_promptda_batch(predictor, rgb_bhw3, prompt_bhw, (rgb_bhw3.shape[1], rgb_bhw3.shape[2]))
-        if recording is None:
-            recording = rr.RecordingStream(
-                application_id=ARKITSCENES_DATASET,
-                recording_id=segment_id,
-                send_properties=False,
+    pending_batch: Future[int] | None = None
+    with ThreadPoolExecutor(max_workers=1, thread_name_prefix="promptda-rrd") as executor:
+        batch: PromptDABatch | None
+        for batch in tqdm(
+            loader,
+            total=(grid_slots + config.batch_size - 1) // config.batch_size,
+            desc=f"PromptDA {segment_id}",
+            unit="batch",
+        ):
+            if batch is None:
+                continue
+            inference_result: tuple[UInt16[ndarray, "b h w"], UInt16[ndarray, "b nh nw"]] = run_promptda_batch(
+                predictor,
+                batch.rgb_bhw3,
+                batch.prompt_bhw,
+                (batch.rgb_bhw3.shape[1], batch.rgb_bhw3.shape[2]),
             )
-            recording.save(rrd_path)
-        for row, (sample_idx, sample) in enumerate(valid):
-            predicted_depth_hw: UInt16[ndarray, "h w"] = depth_mm_bhw[row]
-            fusion_depth_hw: UInt16[ndarray, "fh fw"] = depth_model_mm_bhw[row]
-            confidence_hw: UInt8[ndarray, "h2 w2"] = confidence_arrays[row]
-            rgb_hw3: UInt8[ndarray, "h w 3"] = np.asarray(rgb_bhw3[row].numpy(), dtype=np.uint8)
-            if portrait:
-                predicted_depth_hw = rotate_landscape_to_portrait(predicted_depth_hw, orientation_quarter_turns)
-                fusion_depth_hw = rotate_landscape_to_portrait(fusion_depth_hw, orientation_quarter_turns)
-                confidence_hw = rotate_landscape_to_portrait(confidence_hw, orientation_quarter_turns)
-                rgb_hw3 = rotate_landscape_to_portrait(rgb_hw3, orientation_quarter_turns)
-            timestamp: np.timedelta64 = rerun_dataset.sample_index.global_to_local(sample_idx)[1]  # pyrefly: ignore  # bad-assignment — duration timeline
-            timestamp_seconds: float = float(timestamp / np.timedelta64(1, "s"))
-            rr.set_time("video_time", duration=timestamp_seconds, recording=recording)
-            rr.log(
-                DEPTH_PROMPTDA,
-                # TODO(rerun#upstream): drop depth_range once the viewer auto-ranges encoded depth (see DEPTH_RANGE_MM in ingest/blueprint.py).
-                rr.EncodedDepthImage(blob=encode_depth_png(predicted_depth_hw), media_type="image/png", meter=1000.0, depth_range=DEPTH_RANGE_MM),
-                recording=recording,
+            rgb_stored_bhw3: UInt8[ndarray, "b stored_h stored_w 3"] = np.asarray(
+                torch.rot90(batch.rgb_bhw3, -batch.quarter_turns, dims=(1, 2)).cpu().numpy(),
+                dtype=np.uint8,
             )
-            filtered_depth_hw: UInt16[ndarray, "h w"] = filter_depth_for_fusion(
-                fusion_depth_hw,
-                confidence_hw,
-                config.max_depth_range_meter,
+            if recording is None:
+                recording = rr.RecordingStream(
+                    application_id=ARKITSCENES_DATASET,
+                    recording_id=segment_id,
+                    send_properties=False,
+                )
+                recording.save(rrd_path)
+            if pending_batch is not None:
+                inferred_frames += pending_batch.result()
+            completed_batch: CompletedPromptDABatch = CompletedPromptDABatch(
+                timestamps_ns=batch.timestamps_ns,
+                quarter_turns=batch.quarter_turns,
+                depth_mm_bhw=inference_result[0],
+                depth_model_mm_bhw=inference_result[1],
+                rgb_stored_bhw3=rgb_stored_bhw3,
+                confidence_bhw=batch.confidence_bhw,
+                K_native_b33=batch.K_native_b33,
+                world_T_cam_b44=batch.world_T_cam_b44,
+                stored_hw=batch.stored_hw,
             )
-            rgb_fusion_hw3: UInt8[ndarray, "fh fw 3"] = np.asarray(
-                cv2.resize(rgb_hw3, (fusion_depth_hw.shape[1], fusion_depth_hw.shape[0]), interpolation=cv2.INTER_AREA), dtype=np.uint8
-            )
-            # Rerun stores Pinhole image_from_camera flattened column-major.
-            stored_k_33: Float[ndarray, "3 3"] = np.asarray(sample["k"].numpy()).reshape(3, 3, order="F")
-            stored_intrinsics: Intrinsics = Intrinsics.from_k_matrix(
-                camera_conventions="RDF",
-                k_matrix=stored_k_33,
-                height=rgb_hw3.shape[0],
-                width=rgb_hw3.shape[1],
-            )
-            fusion_intrinsics: Intrinsics = rescale_intri(
-                stored_intrinsics,
-                target_height=fusion_depth_hw.shape[0],
-                target_width=fusion_depth_hw.shape[1],
-            )
-            assert fusion_intrinsics.k_matrix is not None
-            world_t_cam_44: Float[ndarray, "4 4"] = world_t_cam_from_pose(
-                np.asarray(sample["pose_t"].numpy()), np.asarray(sample["pose_q"].numpy())
-            )
-            fuser.fuse_frames(
-                depth_hw=filtered_depth_hw,
-                K_33=fusion_intrinsics.k_matrix,
-                cam_T_world_44=np.linalg.inv(world_t_cam_44),
-                rgb_hw3=rgb_fusion_hw3,
-            )
-            inferred_frames += 1
+            pending_batch = executor.submit(fuse_and_log_batch, completed_batch, recording, fuser, config)
+        if pending_batch is not None:
+            inferred_frames += pending_batch.result()
 
+    skipped_decodes: int = grid_slots - inferred_frames
     if inferred_frames == 0 or recording is None:
         raise RuntimeError(f"segment {segment_id!r} produced zero inferred frames")
     mesh: o3d.geometry.TriangleMesh = fuser.get_mesh()

--- a/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_arkitscenes.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_arkitscenes.py
@@ -67,6 +67,10 @@ class PDAArkitScenesConfig:
     """Process every segment that does not yet have a PromptDA layer."""
     catalog_url: str = DEFAULT_CATALOG_URL
     """URL of the local Rerun catalog server."""
+    dataset_name: str = "arkitscenes-v2"
+    """Catalog dataset to read segments from and register layers on. Distinct from
+    ``ARKITSCENES_DATASET``, which is the recording application id shared by every
+    layer RRD regardless of which catalog dataset serves them."""
     output_dir: Path = Path("data/promptda")
     """Root for generated per-segment PromptDA RRD files."""
     target_fps: float = 10.0
@@ -343,8 +347,8 @@ def process_segment(
 
 def main(config: PDAArkitScenesConfig) -> None:
     """Run PromptDA for selected segments and optionally update the catalog."""
-    client: CatalogClient = connect_catalog(config.catalog_url, ARKITSCENES_DATASET)
-    dataset_entry: DatasetEntry = client.get_dataset(ARKITSCENES_DATASET)
+    client: CatalogClient = connect_catalog(config.catalog_url, config.dataset_name)
+    dataset_entry: DatasetEntry = client.get_dataset(config.dataset_name)
     segment_table: pa.Table = pa.Table.from_batches(dataset_entry.segment_table().collect())
     rows: list[dict] = segment_table.to_pylist()
     segment_ids: list[str] = segments_to_process(rows, config.video_id, config.process_all, PROMPTDA_LAYER)

--- a/packages/prompt-da/src/rerun_prompt_da/promptda_stream.py
+++ b/packages/prompt-da/src/rerun_prompt_da/promptda_stream.py
@@ -14,7 +14,7 @@ from typing import TypedDict
 
 import numpy as np
 import torch
-from arkitscenes_download.ingest.paths import DEPTH, PINHOLE_WIDE, RIG, TIMELINE, VIDEO_WIDE
+from arkitscenes_download.ingest.paths import CONFIDENCE, DEPTH, PINHOLE_WIDE, RIG, TIMELINE, VIDEO_WIDE
 from einops import rearrange
 from jaxtyping import Float32, Float64, UInt8, UInt16
 from numpy import ndarray
@@ -54,6 +54,7 @@ class PromptDARow(TypedDict):
 
     video: UInt8[Tensor, "3 h w"] | None
     depth: UInt16[Tensor, "1 prompt_h prompt_w"]
+    conf: UInt8[Tensor, "n"]
     k: Float32[Tensor, "k=9"]
     pose_t: Float32[Tensor, "xyz=3"]
     pose_q: Float32[Tensor, "xyzw=4"]
@@ -75,6 +76,8 @@ class PromptDABatch:
     """Device-resident landscape LiDAR prompt depth, in metres."""
     prompt_mm_bhw: UInt16[ndarray, "b stored_prompt_h stored_prompt_w"]
     """Prompt depth in millimetres, in the stored orientation, for logging."""
+    confidence_bhw: UInt8[ndarray, "b stored_prompt_h stored_prompt_w"]
+    """ARKit confidence in the stored orientation, for fusion filtering."""
     K_native_b33: Float32[ndarray, "b 3 3"]
     """Row-major native intrinsics in the stored orientation."""
     world_T_cam_b44: Float64[ndarray, "b 4 4"]
@@ -101,6 +104,7 @@ def promptda_dataset(dataset: DatasetEntry, segment_id: str, target_fps: float, 
     fields: dict[str, Field] = {
         "video": Field(f"/{VIDEO_WIDE}:VideoStream:sample", decode=video_decoder),
         "depth": Field(f"/{DEPTH}:EncodedDepthImage:blob", decode=ImageDecoder()),
+        "conf": Field(f"/{CONFIDENCE}:SegmentationImage:buffer", decode=NumericDecoder()),
         "k": Field(f"/{PINHOLE_WIDE}:Pinhole:image_from_camera", decode=NumericDecoder()),
         "pose_t": Field(f"/{RIG}:Transform3D:translation", decode=NumericDecoder()),
         "pose_q": Field(f"/{RIG}:Transform3D:quaternion", decode=NumericDecoder()),
@@ -125,19 +129,30 @@ class PromptDACollate:
     not survive worker processes either.
     """
 
-    def __init__(self, samples: RerunIterableDataset, device: torch.device) -> None:
+    def __init__(
+        self,
+        samples: RerunIterableDataset,
+        device: torch.device,
+        quarter_turns: int | None = None,
+        timestamp_step_ns: int | None = None,
+    ) -> None:
         """Bind the collate to one dataset's sampling grid.
 
         Args:
             samples: The dataset this collate consumes (provides the grid timing).
             device: Inference device the assembled batch lands on.
+            quarter_turns: Counter-clockwise rotation to landscape, or None to infer
+                a quarter turn from a portrait frame's shape.
+            timestamp_step_ns: Output timeline step, or None to use the sampling
+                grid step. The register tool supplies the legacy native-grid step.
         """
         segment = samples.sample_index.segments[0]
         ns_per_sample: int | None = samples.sample_index.ns_per_sample
         assert ns_per_sample is not None  # FixedRateSampling on a temporal timeline always sets it
         self._index_start_ns: int = segment.index_start
-        self._ns_per_sample: int = ns_per_sample
+        self._ns_per_sample: int = ns_per_sample if timestamp_step_ns is None else timestamp_step_ns
         self._device: torch.device = device
+        self._quarter_turns: int | None = quarter_turns
         self._grid_index: int = -1
 
     def __call__(self, batch: list[PromptDARow]) -> PromptDABatch | None:
@@ -146,6 +161,7 @@ class PromptDACollate:
         timestamps_ns: list[int] = []
         frames_3hw: list[UInt8[Tensor, "3 stored_h stored_w"]] = []
         prompts_hw: list[UInt16[Tensor, "stored_prompt_h stored_prompt_w"]] = []
+        confidences_hw: list[UInt8[Tensor, "stored_prompt_h stored_prompt_w"]] = []
         k_matrices_33: list[Float32[ndarray, "3 3"]] = []
         world_T_cam_44: list[Float64[ndarray, "4 4"]] = []
         row: PromptDARow
@@ -156,15 +172,17 @@ class PromptDACollate:
             # locals, though not TypedDict fields). See PromptDARow for the two edges.
             video: Tensor | None = row["video"]
             depth: Tensor = row["depth"]
+            conf: Tensor = row["conf"]
             k: Tensor = row["k"]
             pose_t: Tensor = row["pose_t"]
             pose_q: Tensor = row["pose_q"]
             if video is None:
                 continue
-            if min(video.numel(), depth.numel(), k.numel(), pose_t.numel(), pose_q.numel()) == 0:
+            if min(video.numel(), depth.numel(), conf.numel(), k.numel(), pose_t.numel(), pose_q.numel()) == 0:
                 continue
             frame_chw: UInt8[Tensor, "3 stored_h stored_w"] = video
             depth_1hw: UInt16[Tensor, "1 stored_prompt_h stored_prompt_w"] = depth
+            confidence_n: UInt8[Tensor, "n"] = conf
             k_9: Float32[Tensor, "k=9"] = k
             pose_t_3: Float32[Tensor, "xyz=3"] = pose_t
             pose_q_4: Float32[Tensor, "xyzw=4"] = pose_q
@@ -172,6 +190,8 @@ class PromptDACollate:
             timestamps_ns.append(self._index_start_ns + self._grid_index * self._ns_per_sample)
             frames_3hw.append(frame_chw)
             prompts_hw.append(rearrange(depth_1hw, "1 h w -> h w"))  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+            confidence_hw: UInt8[Tensor, "stored_prompt_h stored_prompt_w"] = confidence_n.reshape(depth_1hw.shape[1:])
+            confidences_hw.append(confidence_hw)
             # Rerun stores Pinhole image_from_camera flattened column-major.
             k_matrices_33.append(np.asarray(k_9.numpy()).reshape(3, 3).T)
             world_T_cam_44.append(world_t_cam_from_pose(np.asarray(pose_t_3.numpy()), np.asarray(pose_q_4.numpy())))
@@ -180,10 +200,11 @@ class PromptDACollate:
             return None
         stored_hw: tuple[int, int] = (frames_3hw[0].shape[1], frames_3hw[0].shape[2])
         prompt_stored_bhw: UInt16[Tensor, "b stored_prompt_h stored_prompt_w"] = torch.stack(prompts_hw).to(self._device, non_blocking=True)
+        confidence_stored_bhw: UInt8[Tensor, "b stored_prompt_h stored_prompt_w"] = torch.stack(confidences_hw)
         # A tall frame would have its aspect ratio squashed into the engine's fixed
         # landscape input. The frame shape decides this, so no orientation property is
         # read — those are spelled differently across dataset generations.
-        quarter_turns: int = 1 if stored_hw[0] > stored_hw[1] else 0
+        quarter_turns: int = self._quarter_turns if self._quarter_turns is not None else (1 if stored_hw[0] > stored_hw[1] else 0)
         rgb_b3hw: UInt8[Tensor, "b 3 h w"] = torch.rot90(torch.stack(frames_3hw), quarter_turns, dims=(2, 3))
         prompt_bhw: UInt16[Tensor, "b prompt_h=192 prompt_w=256"] = torch.rot90(prompt_stored_bhw, quarter_turns, dims=(1, 2))
         return PromptDABatch(
@@ -193,6 +214,7 @@ class PromptDACollate:
             rgb_bhw3=rearrange(rgb_b3hw, "b c h w -> b h w c"),  # pyrefly: ignore  # bad-argument-type — einops stub false positive
             prompt_bhw=prompt_bhw.float() / 1000.0,
             prompt_mm_bhw=prompt_stored_bhw.cpu().numpy().astype(np.uint16),
+            confidence_bhw=confidence_stored_bhw.cpu().numpy().astype(np.uint8),
             K_native_b33=np.stack(k_matrices_33),
             world_T_cam_b44=np.stack(world_T_cam_44),
             stored_hw=stored_hw,

--- a/packages/prompt-da/src/rerun_prompt_da/trt_engine.py
+++ b/packages/prompt-da/src/rerun_prompt_da/trt_engine.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Literal, TypeAlias
 
 import torch
-from trtkit import TrtBuildConfig, cached_engine_path, ensure_engine
+from trtkit import TrtBuildConfig, cached_engine_path, ensure_engine, sweep_stale_onnx_exports
 
 __all__ = (
     "DEFAULT_CACHE_DIR",
@@ -135,15 +135,8 @@ def export_promptda_onnx(
     # file exists — reclaim the multi-GB they'd otherwise leak. ``.part`` temps
     # are only swept when old enough that their exporter is certainly dead, so
     # a live concurrent export's in-flight write is never yanked away.
-    import time
-
     stale_prefix: str = f"promptda-{model_type}_{height}x{width}_"
-    for stale in onnx_dir.iterdir():
-        if stale == onnx_path or not stale.name.startswith(stale_prefix):
-            continue
-        if ".part" in stale.name and time.time() - stale.stat().st_mtime < 3600.0:
-            continue
-        stale.unlink(missing_ok=True)
+    sweep_stale_onnx_exports(onnx_dir, stale_prefix, keep_paths={onnx_path})
     return onnx_path
 
 

--- a/packages/prompt-da/tests/test_import.py
+++ b/packages/prompt-da/tests/test_import.py
@@ -9,5 +9,7 @@ def test_import_rerun_prompt_da() -> None:
 
 def test_import_prompt_da_gradio_ui_without_example_data() -> None:
     """Import the Gradio UI even when optional sample data has not been downloaded."""
+    import pytest
 
+    pytest.importorskip("gradio", reason="Gradio is optional outside the PromptDA demo lane")
     import rerun_prompt_da.gradio_ui.prompt_da_ui  # noqa: F401

--- a/packages/prompt-da/tests/test_prompt_da_arkitscenes.py
+++ b/packages/prompt-da/tests/test_prompt_da_arkitscenes.py
@@ -1,24 +1,163 @@
 """Behavioral tests for the ARKitScenes PromptDA API."""
 
-import numpy as np
-import pytest
-from numpy.testing import assert_allclose, assert_array_equal
+from pathlib import Path
+from types import SimpleNamespace
 
-pytest.importorskip("pyarrow", reason="ARKitScenes catalog deps live in the prompt-da-catalog envs")
-pytest.importorskip("arkitscenes_download", reason="ARKitScenes catalog deps live in the prompt-da-catalog envs")
+import numpy as np
+import open3d as o3d
+import pytest
+import rerun as rr
+import torch
+from numpy.testing import assert_allclose, assert_array_equal
+from rerun.catalog import DatasetEntry
+from rerun.experimental import RrdReader
+from simplecv.ops.tsdf_depth_fuser import Open3DFuser
+
+pytest.importorskip("pyarrow", reason="ARKitScenes catalog deps live in the PromptDA catalog lanes")
+pytest.importorskip("arkitscenes_download", reason="ARKitScenes catalog deps live in the PromptDA catalog lanes")
+_dataloader = pytest.importorskip("rerun.experimental.dataloader")
+if not hasattr(_dataloader, "NoShuffle"):
+    pytest.skip("NVDEC tests need the prerelease Rerun dataloader", allow_module_level=True)
+
+from arkitscenes_download.ingest.paths import CONFIDENCE, DEPTH_PROMPTDA, PROMPTDA_MESH, VIDEO_WIDE  # noqa: E402
+from rerun.experimental.dataloader import RerunIterableDataset  # noqa: E402
+from simplecv.rerun_dataloader import SegmentNvdecDecoder  # noqa: E402
 
 from rerun_prompt_da.apis.arkitscenes_shared import (  # noqa: E402
     filter_depth_for_fusion,
+    log_fused_mesh,
     segments_to_process,
     stride_for,
     world_t_cam_from_pose,
 )
 from rerun_prompt_da.apis.prompt_da_arkitscenes import (  # noqa: E402
+    CompletedPromptDABatch,
+    PDAArkitScenesConfig,
+    fuse_and_log_batch,
+    log_promptda_frame,
     orientation_quarter_turns_from_segment_row,
     portrait_from_segment_row,
-    rotate_landscape_to_portrait,
-    rotate_portrait_to_landscape,
 )
+from rerun_prompt_da.promptda_stream import PromptDACollate, promptda_dataset  # noqa: E402
+
+
+def test_promptda_layer_rrd_keeps_depth_and_mesh_contract(tmp_path: Path) -> None:
+    """Write the registered layer's two entities with only depth on video_time."""
+    rrd_path: Path = tmp_path / "promptda.rrd"
+    with rr.RecordingStream("arkitscenes", recording_id="segment", send_properties=False) as recording:
+        recording.save(rrd_path)
+        log_promptda_frame(recording, 123_456_789, np.full((2, 3), 1500, dtype=np.uint16))
+        mesh: o3d.geometry.TriangleMesh = o3d.geometry.TriangleMesh(
+            o3d.utility.Vector3dVector(np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])),
+            o3d.utility.Vector3iVector(np.array([[0, 1, 2]], dtype=np.int32)),
+        )
+        mesh.compute_vertex_normals()
+        log_fused_mesh(recording, PROMPTDA_MESH, mesh)
+
+    reader: RrdReader = RrdReader(rrd_path)
+    chunks = list(reader.stream(store=reader.recordings()[0]).to_chunks())
+    chunks_by_path = {str(chunk.entity_path): chunk for chunk in chunks}
+    assert set(chunks_by_path) == {f"/{DEPTH_PROMPTDA}", f"/{PROMPTDA_MESH}"}
+    assert "video_time" in chunks_by_path[f"/{DEPTH_PROMPTDA}"].to_record_batch().schema.names
+
+
+def test_promptda_dataset_uses_nvdec_and_fetches_fusion_confidence(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Build one natural-order NVDEC query with the confidence needed by TSDF fusion."""
+    dataset = object.__new__(DatasetEntry)
+    captured: dict[str, object] = {}
+
+    def initialize_decoder(_decoder: SegmentNvdecDecoder, *args: object) -> None:
+        captured["decoder_args"] = args
+
+    def initialize_samples(_samples: RerunIterableDataset, *args: object, **kwargs: object) -> None:
+        captured["dataset_args"] = args
+        captured["dataset_kwargs"] = kwargs
+
+    monkeypatch.setattr(SegmentNvdecDecoder, "__init__", initialize_decoder)
+    monkeypatch.setattr(RerunIterableDataset, "__init__", initialize_samples)
+
+    samples, decoder = promptda_dataset(dataset, "segment", 10.0, torch.device("cuda"))
+
+    assert isinstance(samples, RerunIterableDataset)
+    assert isinstance(decoder, SegmentNvdecDecoder)
+    assert captured["decoder_args"] == (dataset, VIDEO_WIDE, "video_time", torch.device("cuda"), 60)
+    fields = captured["dataset_kwargs"]["fields"]  # type: ignore[index]
+    assert fields["video"].decode is decoder  # type: ignore[index]
+    assert fields["conf"].path == f"/{CONFIDENCE}:SegmentationImage:buffer"  # type: ignore[index]
+
+
+def test_promptda_collate_keeps_stored_confidence_and_honors_ingest_rotation() -> None:
+    """Prepare landscape model inputs while retaining confidence in catalog orientation."""
+    samples: RerunIterableDataset = object.__new__(RerunIterableDataset)
+    samples._sample_index = SimpleNamespace(  # pyrefly: ignore  # bad-assignment — minimal synthetic sampling grid
+        segments=[SimpleNamespace(index_start=100)], ns_per_sample=10
+    )
+    collate: PromptDACollate = PromptDACollate(samples, torch.device("cpu"), quarter_turns=3, timestamp_step_ns=12)
+    batch = collate([
+        {
+            "video": torch.arange(18, dtype=torch.uint8).reshape(3, 3, 2),
+            "depth": torch.zeros((1, 256, 192), dtype=torch.uint16),
+            "conf": torch.arange(256 * 192).to(torch.uint8),
+            "k": torch.eye(3, dtype=torch.float32).T.reshape(9),
+            "pose_t": torch.tensor([1.0, 2.0, 3.0]),
+            "pose_q": torch.tensor([0.0, 0.0, 0.0, 1.0]),
+        }
+    ])
+
+    assert batch is not None
+    assert batch.quarter_turns == 3
+    assert tuple(batch.rgb_bhw3.shape) == (1, 2, 3, 3)
+    assert tuple(batch.prompt_bhw.shape) == (1, 192, 256)
+    assert batch.confidence_bhw.shape == (1, 256, 192)
+    assert_array_equal(batch.confidence_bhw[0, 0, :6], np.arange(6, dtype=np.uint8))
+    assert batch.timestamps_ns == [100]
+    second_batch = collate([
+        {
+            "video": torch.arange(18, dtype=torch.uint8).reshape(3, 3, 2),
+            "depth": torch.zeros((1, 256, 192), dtype=torch.uint16),
+            "conf": torch.arange(256 * 192).to(torch.uint8),
+            "k": torch.eye(3, dtype=torch.float32).T.reshape(9),
+            "pose_t": torch.tensor([1.0, 2.0, 3.0]),
+            "pose_q": torch.tensor([0.0, 0.0, 0.0, 1.0]),
+        }
+    ])
+    assert second_batch is not None
+    assert second_batch.timestamps_ns == [112]
+
+
+def test_fuse_and_log_batch_preserves_frame_order_and_fusion_inputs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Log and fuse every completed row in timestamp order."""
+    completed = CompletedPromptDABatch(
+        timestamps_ns=[100, 200],
+        quarter_turns=0,
+        depth_mm_bhw=np.full((2, 4, 6), 1500, dtype=np.uint16),
+        depth_model_mm_bhw=np.full((2, 2, 3), 1500, dtype=np.uint16),
+        rgb_stored_bhw3=np.full((2, 4, 6, 3), 128, dtype=np.uint8),
+        confidence_bhw=np.full((2, 1, 1), 2, dtype=np.uint8),
+        K_native_b33=np.repeat(np.eye(3, dtype=np.float32)[None], 2, axis=0),
+        world_T_cam_b44=np.repeat(np.eye(4)[None], 2, axis=0),
+        stored_hw=(4, 6),
+    )
+    logged_timestamps: list[int] = []
+    fused_depths: list[np.ndarray] = []
+
+    def record_depth(_recording: rr.RecordingStream, timestamp_ns: int, _depth_hw: np.ndarray) -> None:
+        logged_timestamps.append(timestamp_ns)
+
+    def record_fusion(_fuser: object, *, depth_hw: np.ndarray, **_kwargs: object) -> None:
+        fused_depths.append(depth_hw.copy())
+
+    monkeypatch.setattr("rerun_prompt_da.apis.prompt_da_arkitscenes.log_promptda_frame", record_depth)
+    monkeypatch.setattr(Open3DFuser, "fuse_frames", record_fusion)
+    fuser: Open3DFuser = object.__new__(Open3DFuser)
+    recording = rr.RecordingStream("test", recording_id="segment", send_properties=False)
+
+    inferred_frames = fuse_and_log_batch(completed, recording, fuser, PDAArkitScenesConfig())
+
+    assert inferred_frames == 2
+    assert logged_timestamps == [100, 200]
+    assert len(fused_depths) == 2
+    assert_array_equal(fused_depths[0], np.full((2, 3), 1500, dtype=np.uint16))
 
 
 def test_portrait_property_parses_catalog_list_value() -> None:
@@ -29,22 +168,13 @@ def test_portrait_property_parses_catalog_list_value() -> None:
 
 def test_portrait_property_is_required() -> None:
     """Reject segments whose required orientation metadata is absent."""
-    with pytest.raises(KeyError, match="portrait"):
+    with pytest.raises(KeyError, match="orientation"):
         portrait_from_segment_row({})
 
 
 def test_orientation_quarter_turns_parses_catalog_list_value() -> None:
     """Preserve ingest's stored rotation direction for portrait inference."""
     assert orientation_quarter_turns_from_segment_row({"property:capture:orientation_quarter_turns_ccw": [3]}) == 3
-
-
-def test_portrait_rotation_round_trip_preserves_asymmetric_layout() -> None:
-    """Undo ingest's CCW portrait bake for inference and restore it afterward."""
-    portrait = np.array([[10, 11], [20, 21], [30, 31]], dtype=np.uint16)
-    landscape = rotate_portrait_to_landscape(portrait, 1)
-    assert_array_equal(landscape, np.array([[30, 20, 10], [31, 21, 11]], dtype=np.uint16))
-    assert_array_equal(rotate_landscape_to_portrait(landscape, 1), portrait)
-    assert_array_equal(rotate_landscape_to_portrait(rotate_portrait_to_landscape(portrait, 3), 3), portrait)
 
 
 def test_stride_for_uses_nearest_native_frame_interval() -> None:
@@ -109,22 +239,3 @@ def test_segments_to_process_requires_exactly_one_selection_mode(video_id: str |
     """Reject missing and ambiguous segment selection modes."""
     with pytest.raises(SystemExit, match="exactly one"):
         segments_to_process([], video_id, process_all, "promptda")
-
-
-def test_resilient_decoder_turns_decode_errors_into_skippable_none() -> None:
-    """A per-sample AV1 decode failure becomes a None frame, not a crash."""
-    from unittest.mock import patch
-
-    import av
-    import pyarrow as pa
-    from rerun.experimental.dataloader import VideoFrameDecoder
-
-    from rerun_prompt_da.apis.prompt_da_arkitscenes import ResilientVideoFrameDecoder
-
-    decoder = ResilientVideoFrameDecoder(codec="av1", keyframe_interval=300, fps_estimate=60.0)
-    error = av.error.InvalidDataError(1094995529, "Invalid data found when processing input")
-    with patch.object(VideoFrameDecoder, "decode", side_effect=error):
-        assert decoder.decode(pa.chunked_array([pa.array([b"packet"])]), 0, "segment") is None
-    # Retain the observed failure for diagnostics. The dav1d_flush deadlock specifically needs an
-    # errored, un-drained context finalized at interpreter shutdown; prompt del + gc is safe.
-    assert decoder.decode_failures == [error]

--- a/packages/prompt-da/tests/test_prompt_da_arkitscenes_raw.py
+++ b/packages/prompt-da/tests/test_prompt_da_arkitscenes_raw.py
@@ -11,9 +11,9 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
 
-pytest.importorskip("pyarrow", reason="ARKitScenes catalog deps live in the prompt-da-catalog envs")
-pytest.importorskip("torchcodec", reason="raw video decode deps live in the prompt-da-catalog envs")
-pytest.importorskip("arkitscenes_download", reason="ARKitScenes ingest deps live in the prompt-da-catalog envs")
+pytest.importorskip("pyarrow", reason="ARKitScenes catalog deps live in the prompt-da-stream envs")
+pytest.importorskip("torchcodec", reason="raw video decode deps live in the prompt-da-stream envs")
+pytest.importorskip("arkitscenes_download", reason="ARKitScenes ingest deps live in the prompt-da-stream envs")
 
 from rerun_prompt_da.apis.arkitscenes_shared import segments_to_process  # noqa: E402
 from rerun_prompt_da.apis.prompt_da_arkitscenes_raw import (  # noqa: E402

--- a/packages/simplecv/simplecv/rerun_custom_types.py
+++ b/packages/simplecv/simplecv/rerun_custom_types.py
@@ -347,10 +347,11 @@ class Points2DWithConfidence(rr.AsComponents):
         return instance
 
 
-# ---- Distortion components (Brown–Conrady) -----------------------------------
+# ---- Camera distortion components -------------------------------------------
 
 _DISTORTION_MODEL_COMPONENT: str = "simplecv.components.DistortionModel"
 _DISTORTION_COEFF_COMPONENT: str = "simplecv.components.DistortionCoefficients"
+_INVERSE_DISTORTION_COEFF_COMPONENT: str = "simplecv.components.InverseDistortionCoefficients"
 
 
 def _distortion_component_descriptor(component: str) -> rr.ComponentDescriptor:
@@ -385,21 +386,40 @@ class DistortionCoefficientsBatch(rr.ComponentBatchMixin):
         return pa.array([coeff_list], type=pa.list_(pa.float32()))
 
 
+class InverseDistortionCoefficientsBatch(DistortionCoefficientsBatch):
+    """Variable-length vector of inverse distortion coefficients."""
+
+    def component_descriptor(self) -> rr.ComponentDescriptor:
+        return _distortion_component_descriptor(_INVERSE_DISTORTION_COEFF_COMPONENT)
+
+
 class CameraDistortion(rr.AsComponents):
     """Bundle distortion model + coefficients as custom components."""
 
-    def __init__(self, model: str, coefficients: Float[ndarray, "n"]) -> None:
+    def __init__(
+        self,
+        model: str,
+        coefficients: Float[ndarray, "n"],
+        inverse_coefficients: Float[ndarray, "n_inverse"] | None = None,
+    ) -> None:
         self.model: str = model
         coeffs_arr: Float[ndarray, "n"] = np.asarray(coefficients, dtype=np.float32).reshape(-1)
         self.coefficients: Float[ndarray, "n"] = coeffs_arr
+        self.inverse_coefficients: Float[ndarray, "n_inverse"] | None = (
+            None if inverse_coefficients is None else np.asarray(inverse_coefficients, dtype=np.float32).reshape(-1)
+        )
 
     def as_component_batches(self) -> list[rr.DescribedComponentBatch]:
-        model_batch = DistortionModelBatch(self.model)
-        coeff_batch = DistortionCoefficientsBatch(self.coefficients)
-        return [
+        model_batch: DistortionModelBatch = DistortionModelBatch(self.model)
+        coeff_batch: DistortionCoefficientsBatch = DistortionCoefficientsBatch(self.coefficients)
+        batches: list[rr.DescribedComponentBatch] = [
             model_batch.described(model_batch.component_descriptor()),
             coeff_batch.described(coeff_batch.component_descriptor()),
         ]
+        if self.inverse_coefficients is not None:
+            inverse_batch: InverseDistortionCoefficientsBatch = InverseDistortionCoefficientsBatch(self.inverse_coefficients)
+            batches.append(inverse_batch.described(inverse_batch.component_descriptor()))
+        return batches
 
 
 class PinholeWithDistortion(rr.AsComponents):

--- a/packages/trtkit/src/trtkit/__init__.py
+++ b/packages/trtkit/src/trtkit/__init__.py
@@ -36,7 +36,7 @@ from trtkit.backends import (
 )
 from trtkit.base import RuntimeSpec, TensorRuntime, TensorSpec, run_chunked, validate_runtime_inputs
 from trtkit.onnx_cuda import OnnxCudaRuntime
-from trtkit.onnx_export import export_onnx
+from trtkit.onnx_export import export_onnx, sweep_stale_onnx_exports
 from trtkit.onnx_graph import onnx_static_batch_size
 from trtkit.tensorrt_runtime import TensorRtRuntime
 from trtkit.torch_runtime import TorchRuntime
@@ -64,5 +64,6 @@ __all__ = (
     "onnx_content_hash",
     "onnx_static_batch_size",
     "run_chunked",
+    "sweep_stale_onnx_exports",
     "validate_runtime_inputs",
 )

--- a/packages/trtkit/src/trtkit/onnx_export.py
+++ b/packages/trtkit/src/trtkit/onnx_export.py
@@ -10,7 +10,8 @@ fusion-breaker outputs) — and nothing else.
 """
 
 import os
-from collections.abc import Callable
+import time
+from collections.abc import Callable, Collection
 from pathlib import Path
 
 import torch
@@ -36,6 +37,38 @@ class _AutocastWrapper(torch.nn.Module):
         if isinstance(outputs, tuple):
             return tuple(o.float() if isinstance(o, torch.Tensor) and o.is_floating_point() else o for o in outputs)
         return outputs.float()
+
+
+def sweep_stale_onnx_exports(
+    directory: Path,
+    filename_prefix: str,
+    *,
+    keep_paths: Collection[Path],
+    partial_grace_seconds: float = 3600.0,
+) -> list[Path]:
+    """Remove obsolete exports while preserving current and in-flight files.
+
+    Args:
+        directory: Directory containing model-specific ONNX exports.
+        filename_prefix: Prefix shared only by versions of one model shape.
+        keep_paths: Complete export and sidecar paths still in use.
+        partial_grace_seconds: Minimum age before a ``.part`` file can be
+            treated as abandoned.
+
+    Returns:
+        Removed paths in deterministic filename order.
+    """
+    keep: set[Path] = set(keep_paths)
+    now: float = time.time()
+    removed: list[Path] = []
+    for path in sorted(directory.iterdir()):
+        if path in keep or not path.name.startswith(filename_prefix):
+            continue
+        if ".part" in path.name and now - path.stat().st_mtime < partial_grace_seconds:
+            continue
+        path.unlink(missing_ok=True)
+        removed.append(path)
+    return removed
 
 
 def export_onnx(

--- a/packages/trtkit/src/trtkit/onnx_export.py
+++ b/packages/trtkit/src/trtkit/onnx_export.py
@@ -10,6 +10,7 @@ fusion-breaker outputs) — and nothing else.
 """
 
 import os
+import shutil
 import time
 from collections.abc import Callable, Collection
 from pathlib import Path
@@ -66,7 +67,10 @@ def sweep_stale_onnx_exports(
             continue
         if ".part" in path.name and now - path.stat().st_mtime < partial_grace_seconds:
             continue
-        path.unlink(missing_ok=True)
+        if path.is_dir():
+            shutil.rmtree(path, ignore_errors=True)
+        else:
+            path.unlink(missing_ok=True)
         removed.append(path)
     return removed
 
@@ -87,9 +91,13 @@ def export_onnx(
     Args:
         model: Network (or output-shaping adapter around it) in eval mode.
         example_inputs: Positional example tensors, traced as given.
-        out_path: Final ONNX path, published atomically (pid-unique temp +
-            rename) so a killed export can never leave a truncated file that
-            later runs silently reuse.
+        out_path: Final ONNX path, published atomically: the export writes into
+            a pid-unique temp directory under its FINAL filename, then both the
+            protobuf and any external-data sidecar (``<name>.data``, written by
+            dynamo when weights exceed the 2 GB protobuf limit) move into
+            place. A killed export can never leave a truncated file that later
+            runs silently reuse, and the sidecar keeps a deterministic name the
+            published graph references correctly.
         input_names: ONNX input names, matching ``example_inputs`` order.
         output_names: ONNX output names, matching the model's output order.
         compute_dtype: ``torch.float16``/``torch.bfloat16`` traces the model
@@ -121,16 +129,30 @@ def export_onnx(
         kwargs["dynamic_shapes"] = (per_input,) if compute_dtype is not None else per_input
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path: Path = out_path.with_name(f"{out_path.name}.part{os.getpid()}")
-    with torch.inference_mode():
-        export_fn(
-            export_model,
-            example_inputs,
-            str(tmp_path),
-            input_names=input_names,
-            output_names=output_names,
-            opset_version=opset_version,
-            dynamo=True,
-            **kwargs,
-        )
-    tmp_path.rename(out_path)
+    # Export into a pid-unique temp DIRECTORY under the final filename, so the
+    # external-data sidecar dynamo writes for >2 GB weights is born with the
+    # deterministic name the protobuf references (`<name>.data`), instead of a
+    # permanent pid-suffixed temp name the caller would have to know about.
+    tmp_dir: Path = out_path.with_name(f"{out_path.name}.part{os.getpid()}")
+    tmp_dir.mkdir()
+    tmp_path: Path = tmp_dir / out_path.name
+    try:
+        with torch.inference_mode():
+            export_fn(
+                export_model,
+                example_inputs,
+                str(tmp_path),
+                input_names=input_names,
+                output_names=output_names,
+                opset_version=opset_version,
+                dynamo=True,
+                **kwargs,
+            )
+        # Sidecar first: the protobuf must never be visible while the data it
+        # references is missing.
+        tmp_sidecar: Path = tmp_dir / f"{out_path.name}.data"
+        if tmp_sidecar.exists():
+            os.replace(tmp_sidecar, out_path.with_name(tmp_sidecar.name))
+        os.replace(tmp_path, out_path)
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/packages/trtkit/tests/test_trtkit.py
+++ b/packages/trtkit/tests/test_trtkit.py
@@ -5,14 +5,44 @@ covered by posekit's test suite through its re-exports; this covers what
 trtkit adds: the ``allow_tf32`` build axis.
 """
 
+import os
+import time
 from pathlib import Path
 
 import pytest
 import torch
 
-from trtkit import TrtBuildConfig, cached_engine_path
+from trtkit import TrtBuildConfig, cached_engine_path, sweep_stale_onnx_exports
 
 cuda_only = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+def test_sweep_stale_onnx_exports_keeps_current_recent_and_unrelated_files(tmp_path: Path) -> None:
+    """Only obsolete exports and abandoned partial files are removed."""
+    current: Path = tmp_path / "model_v3.onnx"
+    current_sidecar: Path = tmp_path / "model_v3.onnx.part123.data"
+    old_export: Path = tmp_path / "model_v2.onnx"
+    old_partial: Path = tmp_path / "model_v1.onnx.part456"
+    recent_partial: Path = tmp_path / "model_v4.onnx.part789"
+    unrelated: Path = tmp_path / "other_v1.onnx"
+    for path in (current, current_sidecar, old_export, old_partial, recent_partial, unrelated):
+        path.write_bytes(path.name.encode())
+    stale_timestamp: float = time.time() - 7200.0
+    os.utime(old_partial, (stale_timestamp, stale_timestamp))
+
+    removed: list[Path] = sweep_stale_onnx_exports(
+        tmp_path,
+        "model_",
+        keep_paths={current, current_sidecar},
+    )
+
+    assert removed == [old_partial, old_export]
+    assert {path.name for path in tmp_path.iterdir()} == {
+        current.name,
+        current_sidecar.name,
+        recent_partial.name,
+        unrelated.name,
+    }
 
 
 @cuda_only

--- a/packages/trtkit/tests/test_trtkit.py
+++ b/packages/trtkit/tests/test_trtkit.py
@@ -12,9 +12,68 @@ from pathlib import Path
 import pytest
 import torch
 
-from trtkit import TrtBuildConfig, cached_engine_path, sweep_stale_onnx_exports
+from trtkit import TrtBuildConfig, cached_engine_path, export_onnx, sweep_stale_onnx_exports
 
 cuda_only = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+def test_export_onnx_publishes_deterministic_sidecar_and_removes_temp_dir(tmp_path: Path) -> None:
+    """External-data sidecars keep the `<name>.data` name the protobuf references."""
+    out_path: Path = tmp_path / "model_v1.onnx"
+
+    def fake_export_fn(model: object, inputs: object, path: str, **kwargs: object) -> None:
+        target: Path = Path(path)
+        target.write_bytes(b"protobuf")
+        target.with_name(f"{target.name}.data").write_bytes(b"weights")
+
+    export_onnx(
+        torch.nn.Identity(),
+        (torch.zeros(1),),
+        out_path,
+        input_names=["x"],
+        output_names=["y"],
+        export_fn=fake_export_fn,
+    )
+
+    assert out_path.read_bytes() == b"protobuf"
+    assert out_path.with_name("model_v1.onnx.data").read_bytes() == b"weights"
+    assert {path.name for path in tmp_path.iterdir()} == {"model_v1.onnx", "model_v1.onnx.data"}
+
+
+def test_export_onnx_removes_temp_dir_when_export_fails(tmp_path: Path) -> None:
+    """A crashing export leaves neither a truncated file nor a temp directory."""
+
+    def failing_export_fn(model: object, inputs: object, path: str, **kwargs: object) -> None:
+        Path(path).write_bytes(b"truncated")
+        raise RuntimeError("export died")
+
+    with pytest.raises(RuntimeError, match="export died"):
+        export_onnx(
+            torch.nn.Identity(),
+            (torch.zeros(1),),
+            tmp_path / "model_v1.onnx",
+            input_names=["x"],
+            output_names=["y"],
+            export_fn=failing_export_fn,
+        )
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_sweep_stale_onnx_exports_removes_abandoned_temp_dirs(tmp_path: Path) -> None:
+    """Abandoned pid-suffixed temp directories are swept like stale files."""
+    abandoned_dir: Path = tmp_path / "model_v1.onnx.part456"
+    abandoned_dir.mkdir()
+    (abandoned_dir / "model_v1.onnx").write_bytes(b"orphan")
+    stale_timestamp: float = time.time() - 7200.0
+    os.utime(abandoned_dir, (stale_timestamp, stale_timestamp))
+    current: Path = tmp_path / "model_v2.onnx"
+    current.write_bytes(b"current")
+
+    removed: list[Path] = sweep_stale_onnx_exports(tmp_path, "model_", keep_paths={current})
+
+    assert removed == [abandoned_dir]
+    assert {path.name for path in tmp_path.iterdir()} == {current.name}
 
 
 def test_sweep_stale_onnx_exports_keeps_current_recent_and_unrelated_files(tmp_path: Path) -> None:


### PR DESCRIPTION
Shared-library groundwork for the gauss-surf Gaussian-splat pipeline (stack 1/5). Everything here is consumed by the later PRs but stands alone.

- **monoprior**: MoGe-v2 TRT surface-normal model, with ONNX export in a subprocess worker (isolates a beartype/SymInt incompatibility at the export boundary; documented in-code). ~9 img/s at 756×1008 on a 5090.
- **trtkit**: `sweep_stale_onnx_exports` — versioned-ONNX stale-file sweep, hoisted from two near-identical caller-local copies (MoGe, PromptDA).
- **prompt-da**: per-segment PromptDA generation + catalog registration (PromptDA layers are generated per segment, ~86 s each); TRT engine touch-ups.
- **simplecv**: `InverseDistortionCoefficients` component type; batch subclasses the forward type overriding only the descriptor, so the wire layout is identical.

**Testing**: trtkit-dev full gates; monoprior + prompt-da focused suites; simplecv descriptor characterization. All green on the assembled branch (see stack PR #103 for the environment that runs everything).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
