### PR TITLE
arkitscenes: per-page blueprints with Splat + chase-cam pages; DEPTH_RANGE_MM moves to schema

### DIFF
--- a/packages/arkitscenes-download/arkitscenes_download/ingest/blueprint.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/blueprint.py
@@ -13,59 +13,123 @@ from arkitscenes_download.ingest.paths import (
     CONFIDENCE,
     DEPTH,
     DEPTH_PROMPTDA,
+    DEPTH_SPLAT_ULTRAWIDE,
+    DEPTH_SPLAT_WIDE,
+    DEPTH_ULTRAWIDE_RECT,
+    ERROR_DEPTH_ULTRAWIDE_RECT,
+    ERROR_NORMAL_ULTRAWIDE_RECT,
+    ERROR_RGB_ULTRAWIDE_RECT,
     GT,
     GT_BOXES,
     GT_DEPTH,
     GT_PINHOLE_WIDE,
     IMU_ACCEL,
     IMU_GYRO,
+    NORMALS_MOGE,
+    NORMALS_SPLAT_ULTRAWIDE_RECT,
+    NORMALS_SPLAT_WIDE,
+    NORMALS_ULTRAWIDE_RECT,
+    PINHOLE_MOGE,
     PINHOLE_ULTRAWIDE,
+    PINHOLE_ULTRAWIDE_RECT,
     PINHOLE_WIDE,
     PINHOLE_WIDE_LOWRES,
+    PROMPTDA,
+    PROMPTDA_MESH,
+    RGB_SPLAT_ULTRAWIDE_RECT,
+    RGB_ULTRAWIDE_RECT,
+    RIG,
+    SHARPNESS_ULTRAWIDE,
+    SHARPNESS_WIDE,
+    SPLATS,
     TIMELINE,
     VIDEO_ULTRAWIDE,
     VIDEO_WIDE,
     WORLD,
 )
+from arkitscenes_download.schema import DEPTH_RANGE_MM
 
 # TODO(rerun#upstream): remove once the viewer auto-ranges encoded depth from the
 # decoded values instead of the PNG bit depth (broken in 0.34.1, no issue filed yet).
 # Delete this constant, the per-view overrides below, and the `depth_range=` kwargs
 # at every EncodedDepthImage logging site — each is marked with a TODO pointing here
 # (ingest/cli.py, prompt_da_arkitscenes.py, prompt_da_arkitscenes_raw.py).
-DEPTH_RANGE_MM: tuple[float, float] = (0.0, 4000.0)
-"""Colormap range for the depth views, in native mm units.
-
-Without it the viewer guesses the range from the PNG bit depth (0-65535 for
-uint16), squashing real indoor depths into the bottom of the colormap — a
-near-flat dark purple. Sampled data: lowres ARKit depth is mostly <=4 m
-(rarely up to ~5 m), GT laser depth <=3.5 m; pixels beyond clamp to the
-colormap max, which stays readable.
-"""
-
 FIT_DISTANCE_FACTOR: float = 2.2
 """Eye distance per bounding-sphere radius that keeps the whole mesh in frame (tuned visually)."""
 EXTRA_ZOOM_OUT: float = 1.25
 """Additional margin beyond the tight fit."""
 SPIN_SPEED: float = 0.25
 """Slow orbit around the look target."""
+INSIDE_DISTANCE_FACTOR: float = 0.12
+"""Eye offset per bounding-sphere radius for the Fit-triage splat view, orbiting just off the scene center.
+
+Mesh views render front faces only, so an outside orbit still sees into the room; a splat is
+view-blocking from every side, so splat-containing views need an inside or chase eye instead."""
 
 
 MeshFraming: TypeAlias = tuple[Float64[np.ndarray, "3"], float]
 """ARKit-mesh framing geometry: (world-frame AABB center, bounding-sphere radius in metres)."""
 
 
-def _eye_controls(framing: MeshFraming | None) -> rrb.archetypes.EyeControls3D:
-    """Frame the ARKit mesh when its geometry is known; otherwise keep the viewer's default framing."""
+def _orbit_eye_controls(
+    framing: MeshFraming | None,
+    distance_factor: float,
+    direction_xyz: tuple[float, float, float] = (1.0, 1.0, 1.0),
+) -> rrb.archetypes.EyeControls3D:
+    """Orbit the scene center at the given distance when framing is known; otherwise keep the viewer default."""
     if framing is None:
         return rrb.archetypes.EyeControls3D(spin_speed=SPIN_SPEED)
     mesh_center_xyz, bounding_radius_m = framing
     return rrb.archetypes.EyeControls3D(
         kind=rrb.components.Eye3DKind.Orbital,
-        position=orbit_eye_position(mesh_center_xyz, bounding_radius_m, FIT_DISTANCE_FACTOR * EXTRA_ZOOM_OUT),
+        position=orbit_eye_position(mesh_center_xyz, bounding_radius_m, distance_factor, direction_xyz=direction_xyz),
         look_target=mesh_center_xyz,
         eye_up=(0.0, 0.0, 1.0),
         spin_speed=SPIN_SPEED,
+    )
+
+
+def _eye_controls(framing: MeshFraming | None) -> rrb.archetypes.EyeControls3D:
+    """Frame the whole mesh from outside (front-face rendering lets this see into the room)."""
+    return _orbit_eye_controls(framing, FIT_DISTANCE_FACTOR * EXTRA_ZOOM_OUT)
+
+
+CHASE_OFFSET_RIG_XYZ: tuple[float, float, float] = (0.0, -0.6, -2.2)
+"""Chase-eye offset in the rig's RDF camera frame: slightly above (-y) and behind (-z) the camera."""
+
+
+def _follow_eye_controls() -> rrb.archetypes.EyeControls3D:
+    """Third-person chase eye, fixed in the rig frame so it moves and turns with the camera.
+
+    Pairs with a view whose ``origin`` is the moving rig entity: the eye pose is expressed
+    in that frame, so as the rig's world transform updates each frame, the eye rides along
+    behind it — no live blueprint logging needed (the NTU VIRAL pattern from
+    rerun-io/eye_control_example).
+
+    TODO(rerun#upstream): replace with ``EyeControls3D(tracking_entity=...)`` once its
+    follow-at-offset modes engage from a static blueprint — in 0.36.0a1 they silently
+    never latch (only FirstPerson on a camera entity works); no issue filed yet.
+    """
+    return rrb.archetypes.EyeControls3D(
+        kind=rrb.components.Eye3DKind.Orbital,
+        position=CHASE_OFFSET_RIG_XYZ,
+        look_target=(0.0, 0.0, 0.0),
+        eye_up=(0.0, -1.0, 0.0),
+    )
+
+
+def _inside_eye_controls(framing: MeshFraming | None) -> rrb.archetypes.EyeControls3D:
+    """Orbit just off the scene center at eye height, so the Fit-triage splat spins around the viewer."""
+    return _orbit_eye_controls(framing, INSIDE_DISTANCE_FACTOR, direction_xyz=(1.0, 1.0, 0.0))
+
+
+def _depth_view(name: str, origin: str, entity_path: str) -> rrb.Spatial2DView:
+    """One encoded-depth view with the explicit colormap range the viewer cannot infer (see ``DEPTH_RANGE_MM``)."""
+    return rrb.Spatial2DView(
+        name=name,
+        origin=origin,
+        contents=[f"/{entity_path}"],
+        overrides={f"/{entity_path}": rr.EncodedDepthImage.from_fields(depth_range=DEPTH_RANGE_MM)},
     )
 
 
@@ -107,74 +171,216 @@ def make_table_blueprint() -> rrb.Blueprint:
     )
 
 
-def make_blueprint(portrait: bool = False, framing: MeshFraming | None = None, include_promptda: bool = False) -> rrb.Blueprint:
-    """Build the multi-camera, depth, and IMU layout.
-
-    The layout is identical for both orientations; only the column widths
-    change. Portrait camera views are tall and narrow, so the 3D world view
-    takes a wider share of the row. When the ARKit mesh framing is provided
-    (per-sequence embedded blueprints), the 3D eye orbits the mesh center
-    with the whole mesh in frame; dataset-default blueprints omit it.
-
-    With ``include_promptda`` the depth tabs gain an active "depth PromptDA"
-    tab and the 3D area gains a "world PromptDA" tab that swaps the ARKit mesh (and the other depth
-    backprojections) for the PromptDA depth + TSDF-fused mesh.
-    """
-    world_view = rrb.Spatial3DView(
-        name="world",
-        origin=f"/{WORLD}",
-        contents=["$origin/**", f"- /{GT}/**"],
-        eye_controls=_eye_controls(framing),
-    )
-    world_gt_view = rrb.Spatial3DView(
-        name="world GT",
-        origin=f"/{WORLD}",
-        contents=["$origin/**", f"- /{ARKIT_MESH}/**", f"- /{GT_BOXES}/**", f"- /{DEPTH}/**", f"- /{CONFIDENCE}/**"],
-        eye_controls=_eye_controls(framing),
-    )
-    world_tabs: list[rrb.Spatial3DView] = [world_view, world_gt_view]
-    depth_range = rr.EncodedDepthImage.from_fields(depth_range=DEPTH_RANGE_MM)
-    depth_tabs = [
-        rrb.Spatial2DView(name="depth ARKit", origin=PINHOLE_WIDE_LOWRES, contents=["$origin/depth"], overrides={f"/{DEPTH}": depth_range}),
-        rrb.Spatial2DView(name="depth GT (laser)", origin=GT_PINHOLE_WIDE, contents=["$origin/depth"], overrides={f"/{GT_DEPTH}": depth_range}),
-    ]
-    active_depth_tab: int = 0
-    if include_promptda:
-        depth_tabs.append(
-            rrb.Spatial2DView(
-                name="depth PromptDA", origin=PINHOLE_WIDE, contents=["$origin/depth_promptda"], overrides={f"/{DEPTH_PROMPTDA}": depth_range}
-            )
-        )
-        active_depth_tab = len(depth_tabs) - 1
-        world_tabs.append(
+def make_capture_page(portrait: bool = False, framing: MeshFraming | None = None) -> rrb.Vertical:
+    """Build the Capture page with camera, depth, confidence, and IMU views."""
+    return rrb.Vertical(
+        rrb.Horizontal(
             rrb.Spatial3DView(
-                name="world PromptDA",
+                name="world",
                 origin=f"/{WORLD}",
-                contents=["$origin/**", f"- /{ARKIT_MESH}/**", f"- /{GT_DEPTH}/**", f"- /{PINHOLE_WIDE_LOWRES}/**"],
+                contents=["$origin/**", f"- /{GT}/**", f"- /{SPLATS}/**", f"- /{PROMPTDA}/**"],
                 eye_controls=_eye_controls(framing),
-            )
-        )
-    world_area = rrb.Tabs(*world_tabs, active_tab=0)
-    column_shares: list[float] = [2.6, 1.0, 1.0] if portrait else [2.0, 1.0, 1.0]
-    return rrb.Blueprint(
-        rrb.Vertical(
-            rrb.Horizontal(
-                world_area,
-                rrb.Vertical(
-                    rrb.Spatial2DView(name="wide", origin=PINHOLE_WIDE, contents=["$origin/video", f"/{GT_BOXES}/**"]),
-                    rrb.Spatial2DView(name="ultrawide", origin=PINHOLE_ULTRAWIDE, contents=["$origin/video", f"/{GT_BOXES}/**"]),
-                ),
-                rrb.Vertical(
-                    rrb.Tabs(*depth_tabs, active_tab=active_depth_tab),
-                    rrb.Spatial2DView(name="confidence", origin=PINHOLE_WIDE_LOWRES, contents=["$origin/confidence"]),
-                ),
-                column_shares=column_shares,
             ),
-            rrb.Horizontal(
-                rrb.TimeSeriesView(name="gyro", origin=IMU_GYRO, axis_x=_imu_axis()),
-                rrb.TimeSeriesView(name="accel", origin=IMU_ACCEL, axis_x=_imu_axis()),
+            rrb.Vertical(
+                rrb.Spatial2DView(name="wide", origin=PINHOLE_WIDE, contents=["$origin/video", f"/{GT_BOXES}/**"]),
+                rrb.Spatial2DView(name="ultrawide", origin=PINHOLE_ULTRAWIDE, contents=["$origin/video", f"/{GT_BOXES}/**"]),
             ),
-            row_shares=[3, 1],
+            rrb.Vertical(
+                _depth_view("depth ARKit", PINHOLE_WIDE_LOWRES, DEPTH),
+                rrb.Spatial2DView(name="confidence", origin=PINHOLE_WIDE_LOWRES, contents=["$origin/confidence"]),
+            ),
+            column_shares=[2.6, 1.0, 1.0] if portrait else [2.0, 1.0, 1.0],
         ),
+        rrb.Horizontal(
+            rrb.TimeSeriesView(name="gyro", origin=IMU_GYRO, axis_x=_imu_axis()),
+            rrb.TimeSeriesView(name="accel", origin=IMU_ACCEL, axis_x=_imu_axis()),
+        ),
+        row_shares=[3, 1],
+        name="Capture",
+    )
+
+
+def make_gt_page(portrait: bool = False, framing: MeshFraming | None = None) -> rrb.Horizontal:
+    """Build the ground-truth page."""
+    return rrb.Horizontal(
+        rrb.Spatial3DView(
+            name="world GT",
+            origin=f"/{WORLD}",
+            contents=["$origin/**", f"- /{ARKIT_MESH}/**", f"- /{GT_BOXES}/**", f"- /{DEPTH}/**", f"- /{CONFIDENCE}/**"],
+            eye_controls=_eye_controls(framing),
+        ),
+        rrb.Vertical(
+            rrb.Spatial2DView(name="wide", origin=PINHOLE_WIDE, contents=["$origin/video", f"/{GT_BOXES}/**"]),
+            _depth_view("depth GT (laser)", GT_PINHOLE_WIDE, GT_DEPTH),
+            rrb.Spatial2DView(name="ultrawide", origin=PINHOLE_ULTRAWIDE, contents=["$origin/video", f"/{GT_BOXES}/**"]),
+        ),
+        column_shares=[2.6, 1.0] if portrait else [2.0, 1.0],
+        name="GT",
+    )
+
+
+def make_promptda_page(portrait: bool = False, framing: MeshFraming | None = None) -> rrb.Horizontal:
+    """Build the PromptDA comparison page."""
+    return rrb.Horizontal(
+        rrb.Spatial3DView(
+            name="world PromptDA",
+            origin=f"/{WORLD}",
+            contents=["$origin/**", f"- /{ARKIT_MESH}/**", f"- /{GT_DEPTH}/**", f"- /{PINHOLE_WIDE_LOWRES}/**"],
+            eye_controls=_eye_controls(framing),
+        ),
+        rrb.Vertical(
+            rrb.Spatial2DView(name="wide video", origin=PINHOLE_WIDE, contents=["$origin/video"]),
+            _depth_view("depth PromptDA", PINHOLE_WIDE, DEPTH_PROMPTDA),
+            _depth_view("depth ARKit", PINHOLE_WIDE_LOWRES, DEPTH),
+        ),
+        column_shares=[2.6, 1.0] if portrait else [2.0, 1.0],
+        name="PromptDA",
+    )
+
+
+def make_splat_page(portrait: bool = False) -> rrb.Vertical:
+    """Build the rendered-splat inspection page."""
+    return rrb.Vertical(
+        rrb.Horizontal(
+            rrb.Spatial3DView(
+                name="world Splat",
+                # Rooting the view at the moving rig makes the chase eye ride along with it;
+                # the wide frustum + its video plane keep the followed camera visible.
+                origin=f"/{RIG}",
+                contents=[f"/{SPLATS}/**", f"/{PROMPTDA_MESH}", f"/{RIG}", f"/{PINHOLE_WIDE}", f"/{VIDEO_WIDE}"],
+                eye_controls=_follow_eye_controls(),
+                # The ghost mesh stays in the view (toggle it on via the eye icon) but is hidden by
+                # default: seen from inside, the splat is constantly viewed *through* it.
+                overrides={
+                    f"/{PROMPTDA_MESH}": [
+                        rrb.EntityBehavior(visible=False),
+                        rr.Mesh3D.from_fields(albedo_factor=(0, 255, 0, 96)),
+                    ]
+                },
+            ),
+            rrb.Vertical(
+                rrb.Spatial2DView(name="wide video", origin=PINHOLE_WIDE, contents=["$origin/video"]),
+                rrb.Tabs(
+                    rrb.Spatial2DView(name="video", origin=PINHOLE_ULTRAWIDE, contents=["$origin/video"]),
+                    rrb.Spatial2DView(name="rect RGB", origin=PINHOLE_ULTRAWIDE_RECT, contents=[f"/{RGB_ULTRAWIDE_RECT}"]),
+                    rrb.Spatial2DView(name="splat RGB", origin=PINHOLE_ULTRAWIDE_RECT, contents=[f"/{RGB_SPLAT_ULTRAWIDE_RECT}"]),
+                    active_tab=0,
+                ),
+            ),
+            rrb.Vertical(
+                rrb.Tabs(
+                    _depth_view("splat depth", PINHOLE_WIDE, DEPTH_SPLAT_WIDE),
+                    _depth_view("PromptDA depth", PINHOLE_WIDE, DEPTH_PROMPTDA),
+                    active_tab=0,
+                ),
+                rrb.Tabs(
+                    rrb.Spatial2DView(
+                        name="splat normals",
+                        origin=PINHOLE_WIDE,
+                        contents=[f"/{NORMALS_SPLAT_WIDE}"],
+                    ),
+                    rrb.Spatial2DView(name="MoGe normals", origin=PINHOLE_MOGE, contents=[f"/{NORMALS_MOGE}"]),
+                    active_tab=0,
+                ),
+                rrb.Tabs(
+                    _depth_view("splat depth", PINHOLE_ULTRAWIDE_RECT, DEPTH_SPLAT_ULTRAWIDE),
+                    _depth_view("raycast depth", PINHOLE_ULTRAWIDE_RECT, DEPTH_ULTRAWIDE_RECT),
+                    active_tab=0,
+                ),
+                rrb.Tabs(
+                    rrb.Spatial2DView(
+                        name="splat normals",
+                        origin=PINHOLE_ULTRAWIDE_RECT,
+                        contents=[f"/{NORMALS_SPLAT_ULTRAWIDE_RECT}"],
+                    ),
+                    rrb.Spatial2DView(
+                        name="MoGe rect normals",
+                        origin=PINHOLE_ULTRAWIDE_RECT,
+                        contents=[f"/{NORMALS_ULTRAWIDE_RECT}"],
+                    ),
+                    active_tab=0,
+                ),
+            ),
+            column_shares=[3.4, 2.0, 1.0] if portrait else [4.8, 2.2, 1.0],
+        ),
+        rrb.TimeSeriesView(
+            name="sharpness",
+            origin=f"/{WORLD}",
+            contents=[f"/{SHARPNESS_WIDE}", f"/{SHARPNESS_ULTRAWIDE}"],
+            axis_x=_imu_axis(),
+        ),
+        row_shares=[6, 1],
+        name="Splat",
+    )
+
+
+def make_fit_triage_page(framing: MeshFraming | None = None) -> rrb.Horizontal:
+    """Build the 3D and three-by-three fit-triage page."""
+    triage_grid = rrb.Vertical(
+        rrb.Horizontal(
+            rrb.Spatial2DView(name="Source RGB", origin=PINHOLE_ULTRAWIDE_RECT, contents=[f"/{RGB_ULTRAWIDE_RECT}"]),
+            rrb.Spatial2DView(name="Fitted RGB", origin=PINHOLE_ULTRAWIDE_RECT, contents=[f"/{RGB_SPLAT_ULTRAWIDE_RECT}"]),
+            rrb.Spatial2DView(name="RGB error [0, 0.5]", origin=PINHOLE_ULTRAWIDE_RECT, contents=[f"/{ERROR_RGB_ULTRAWIDE_RECT}"]),
+        ),
+        rrb.Horizontal(
+            _depth_view("Source depth", PINHOLE_ULTRAWIDE_RECT, DEPTH_ULTRAWIDE_RECT),
+            _depth_view("Fitted depth", PINHOLE_ULTRAWIDE_RECT, DEPTH_SPLAT_ULTRAWIDE),
+            rrb.Spatial2DView(
+                name="Depth error [0, 0.5 m]",
+                origin=PINHOLE_ULTRAWIDE_RECT,
+                contents=[f"/{ERROR_DEPTH_ULTRAWIDE_RECT}"],
+            ),
+        ),
+        rrb.Horizontal(
+            rrb.Spatial2DView(name="Source normal", origin=PINHOLE_ULTRAWIDE_RECT, contents=[f"/{NORMALS_ULTRAWIDE_RECT}"]),
+            rrb.Spatial2DView(name="Fitted normal", origin=PINHOLE_ULTRAWIDE_RECT, contents=[f"/{NORMALS_SPLAT_ULTRAWIDE_RECT}"]),
+            rrb.Spatial2DView(
+                name="Normal error [0, 45 deg]",
+                origin=PINHOLE_ULTRAWIDE_RECT,
+                contents=[f"/{ERROR_NORMAL_ULTRAWIDE_RECT}"],
+            ),
+        ),
+        row_shares=[1.0, 1.0, 1.0],
+        name="Triage grid",
+    )
+    return rrb.Horizontal(
+        rrb.Spatial3DView(
+            name="Triage 3D splat",
+            origin=f"/{WORLD}",
+            contents=[f"/{SPLATS}/**", f"/{PROMPTDA_MESH}"],
+            eye_controls=_inside_eye_controls(framing),
+            overrides={f"/{PROMPTDA_MESH}": rr.Mesh3D.from_fields(albedo_factor=(0, 255, 0, 96))},
+        ),
+        triage_grid,
+        column_shares=[1.0, 2.0],
+        name="Fit triage",
+    )
+
+
+def make_blueprint(
+    portrait: bool = False,
+    framing: MeshFraming | None = None,
+    include_promptda: bool = False,
+    include_gauss_surf: bool = False,
+) -> rrb.Blueprint:
+    """Build per-source Capture, GT, PromptDA, Splat, and Fit-triage tabs.
+
+    Capture and GT are always present. PromptDA is optional, while Splat and
+    Fit triage are added together for the gauss-surf extension. Portrait mode
+    gives the 3D views more width. Per-sequence framing keeps every 3D page on
+    the same mesh-centered orbital eye controls. When present, Splat opens as
+    the active source page.
+    """
+    pages: list[rrb.Container] = [make_capture_page(portrait, framing), make_gt_page(portrait, framing)]
+    if include_promptda:
+        pages.append(make_promptda_page(portrait, framing))
+
+    splat_tab_index: int | None = None
+    if include_gauss_surf:
+        splat_tab_index = len(pages)
+        pages.extend((make_splat_page(portrait), make_fit_triage_page(framing)))
+
+    return rrb.Blueprint(
+        rrb.Tabs(*pages, active_tab=splat_tab_index if splat_tab_index is not None else 0, name="ARKitScenes"),
         collapse_panels=True,
     )

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/cli.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/cli.py
@@ -35,7 +35,7 @@ from arkitscenes_download.ingest.clock import (
     shared_epoch,
 )
 from arkitscenes_download.ingest.depth import ArkitDepthConfidence, encode_depth_png, sorted_timestamped_paths
-from arkitscenes_download.ingest.distortion import AppleDistortionProvenance, OpenCVRationalFit, opencv_rational_from_apple
+from arkitscenes_download.ingest.distortion import OpenCVRationalFit, opencv_rational_from_apple
 from arkitscenes_download.ingest.gt import ArkitMeshSummary, log_arkit_mesh, log_gt_boxes
 from arkitscenes_download.ingest.imu import ImuSamples, decode_imu
 from arkitscenes_download.ingest.metadata import (
@@ -295,7 +295,7 @@ def _log_distortions(
     pinhole_intrinsics_by_camera: dict[str, SimpleCVIntrinsics],
     quarter_turns: int,
 ) -> None:
-    """Log a standard fit plus exact first-sample Apple provenance statically."""
+    """Log a standard fit and the framing metadata needed by rectification."""
     camera_paths: dict[str, str] = {
         "wide": PINHOLE_WIDE,
         "ultrawide": PINHOLE_ULTRAWIDE,
@@ -329,16 +329,9 @@ def _log_distortions(
         )
         recording.log(
             path,
-            AppleDistortionProvenance(distortion.coefficients, distortion.inverse_coefficients),
-            static=True,
-        )
-        recording.log(
-            path,
             rr.AnyValues(
                 distortion_center_xy=center_xy.tolist(),
                 reference_dimensions_wh=list(baked_dimensions_wh),
-                distortion_source="mebx_stream_10",
-                distortion_temporal_sample_count=distortion.temporal_sample_count,
             ),
             static=True,
         )

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/cli.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/cli.py
@@ -296,7 +296,15 @@ def _log_distortions(recording: rr.RecordingStream, distortions: list[CameraDist
         center_xy: np.ndarray = rotate_pixels(distortion.center_xy, dimensions_wh, quarter_turns)
         baked_dimensions_wh: tuple[int, int] = rotate_resolution(dimensions_wh, quarter_turns)
         path: str = camera_paths[distortion.camera_name]
-        recording.log(path, RerunCameraDistortion(model="brown_conrady", coefficients=distortion.coefficients), static=True)
+        recording.log(
+            path,
+            RerunCameraDistortion(
+                model="apple_radial_poly",
+                coefficients=distortion.coefficients,
+                inverse_coefficients=distortion.inverse_coefficients,
+            ),
+            static=True,
+        )
         recording.log(
             path,
             rr.AnyValues(
@@ -421,7 +429,7 @@ def ingest_sequence(config: Config) -> Path:
     distortions: list[CameraDistortion] = decode_camera_distortions_from_packets(metadata_packets[10])
     for distortion in distortions:
         CONSOLE.print(
-            f"Distortion {distortion.camera_name}: model=brown_conrady coefficients={distortion.coefficients.tolist()} "
+            f"Distortion {distortion.camera_name}: model=apple_radial_poly coefficients={distortion.coefficients.tolist()} "
             f"inverse={distortion.inverse_coefficients.tolist()} center={distortion.center_xy.tolist()} "
             f"reference={distortion.reference_dimensions_wh.tolist()} temporal_samples={distortion.temporal_sample_count}"
         )

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/cli.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/cli.py
@@ -20,7 +20,10 @@ from PIL import Image
 from rich.console import Console
 from rich.progress import Progress, TaskID
 from scipy.spatial.transform import Rotation
+from simplecv.camera_parameters import Extrinsics, PinholeParameters
+from simplecv.camera_parameters import Intrinsics as SimpleCVIntrinsics
 from simplecv.rerun_custom_types import CameraDistortion as RerunCameraDistortion
+from simplecv.rerun_custom_types import PinholeWithDistortion
 
 from arkitscenes_download.ingest.blueprint import DEPTH_RANGE_MM, make_blueprint
 from arkitscenes_download.ingest.clock import (
@@ -32,6 +35,7 @@ from arkitscenes_download.ingest.clock import (
     shared_epoch,
 )
 from arkitscenes_download.ingest.depth import ArkitDepthConfidence, encode_depth_png, sorted_timestamped_paths
+from arkitscenes_download.ingest.distortion import AppleDistortionProvenance, OpenCVRationalFit, opencv_rational_from_apple
 from arkitscenes_download.ingest.gt import ArkitMeshSummary, log_arkit_mesh, log_gt_boxes
 from arkitscenes_download.ingest.imu import ImuSamples, decode_imu
 from arkitscenes_download.ingest.metadata import (
@@ -285,8 +289,13 @@ def _log_calibration_rig(
     recording.log(IMU, rr.AnyValues(values_frame="CoreMotion device; entity transform maps values into baked rig frame"), static=True)
 
 
-def _log_distortions(recording: rr.RecordingStream, distortions: list[CameraDistortion], quarter_turns: int) -> None:
-    """Log the first temporal stream-10 polynomial calibration statically."""
+def _log_distortions(
+    recording: rr.RecordingStream,
+    distortions: list[CameraDistortion],
+    pinhole_intrinsics_by_camera: dict[str, SimpleCVIntrinsics],
+    quarter_turns: int,
+) -> None:
+    """Log a standard fit plus exact first-sample Apple provenance statically."""
     camera_paths: dict[str, str] = {
         "wide": PINHOLE_WIDE,
         "ultrawide": PINHOLE_ULTRAWIDE,
@@ -296,13 +305,31 @@ def _log_distortions(recording: rr.RecordingStream, distortions: list[CameraDist
         center_xy: np.ndarray = rotate_pixels(distortion.center_xy, dimensions_wh, quarter_turns)
         baked_dimensions_wh: tuple[int, int] = rotate_resolution(dimensions_wh, quarter_turns)
         path: str = camera_paths[distortion.camera_name]
+        pinhole_intrinsics: SimpleCVIntrinsics = pinhole_intrinsics_by_camera[distortion.camera_name]
+        fit: OpenCVRationalFit = opencv_rational_from_apple(
+            np.asarray(pinhole_intrinsics.k_matrix, dtype=np.float64),
+            distortion.coefficients,
+            center_xy,
+            baked_dimensions_wh,
+            (pinhole_intrinsics.width, pinhole_intrinsics.height),
+        )
+        camera: PinholeParameters = PinholeParameters(
+            name=distortion.camera_name,
+            extrinsics=Extrinsics(cam_R_world=np.eye(3, dtype=np.float64), cam_t_world=np.zeros(3, dtype=np.float64)),
+            intrinsics=pinhole_intrinsics,
+            distortion=fit.distortion,
+        )
+        standard_components: RerunCameraDistortion | None = PinholeWithDistortion.from_camera(camera).distortion
+        if standard_components is None:
+            raise AssertionError("Brown-Conrady fit did not produce Rerun distortion components")
         recording.log(
             path,
-            RerunCameraDistortion(
-                model="apple_radial_poly",
-                coefficients=distortion.coefficients,
-                inverse_coefficients=distortion.inverse_coefficients,
-            ),
+            standard_components,
+            static=True,
+        )
+        recording.log(
+            path,
+            AppleDistortionProvenance(distortion.coefficients, distortion.inverse_coefficients),
             static=True,
         )
         recording.log(
@@ -314,6 +341,10 @@ def _log_distortions(recording: rr.RecordingStream, distortions: list[CameraDist
                 distortion_temporal_sample_count=distortion.temporal_sample_count,
             ),
             static=True,
+        )
+        CONSOLE.print(
+            f"Distortion fit {distortion.camera_name}: model=brown_conrady center=pinhole_principal_point "
+            f"max_residual={fit.max_residual_px:.6f}px"
         )
 
 
@@ -433,6 +464,20 @@ def ingest_sequence(config: Config) -> Path:
             f"inverse={distortion.inverse_coefficients.tolist()} center={distortion.center_xy.tolist()} "
             f"reference={distortion.reference_dimensions_wh.tolist()} temporal_samples={distortion.temporal_sample_count}"
         )
+    pinhole_intrinsics_by_camera: dict[str, SimpleCVIntrinsics] = {}
+    for camera_name, intrinsics, resolution in (
+        ("wide", wide_intrinsics, wide_resolution),
+        ("ultrawide", ultrawide_intrinsics, ultrawide_resolution),
+    ):
+        logged_indices: np.ndarray = np.flatnonzero(intrinsics.timestamps >= epoch)
+        if len(logged_indices) == 0:
+            raise ValueError(f"{camera_name} has no pinhole calibration at or after the shared epoch")
+        pinhole_intrinsics_by_camera[camera_name] = SimpleCVIntrinsics.from_k_matrix(
+            camera_conventions="RDF",
+            k_matrix=intrinsics.matrices[int(logged_indices[0])],
+            width=resolution[0],
+            height=resolution[1],
+        )
     calibration_path: Path = sequence_output / "calibration.rrd"
     with atomic_recording(calibration_path, config.video_id, send_properties=False) as recording:
         _log_intrinsics(recording, PINHOLE_WIDE, wide_intrinsics, wide_resolution, epoch)
@@ -442,7 +487,7 @@ def ingest_sequence(config: Config) -> Path:
         _log_sky_angles(recording, SKY_ANGLE_WIDE, trajectory.timestamps, sky_angles(trajectory.quaternion_xyzw), epoch)
         ultrawide_sky_angles: np.ndarray = interpolate_sky_angles(trajectory_sparse, ultrawide_video_timestamps)
         _log_sky_angles(recording, SKY_ANGLE_ULTRAWIDE, ultrawide_video_timestamps, ultrawide_sky_angles, epoch)
-        _log_distortions(recording, distortions, quarter_turns)
+        _log_distortions(recording, distortions, pinhole_intrinsics_by_camera, quarter_turns)
 
     confidence: list[Path] = sorted_timestamped_paths(sequence_dir / "confidence")
     depth_started: float = time.perf_counter()

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/distortion.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/distortion.py
@@ -4,57 +4,10 @@ from dataclasses import dataclass
 
 import cv2
 import numpy as np
-import pyarrow as pa
-import rerun as rr
 from jaxtyping import Float, Float32, Float64
 from numpy import ndarray
 from scipy.optimize import least_squares
 from simplecv.camera_parameters import BrownConradyDistortion
-
-APPLE_FORWARD_DISTORTION_COMPONENT: str = "arkitscenes.components.AppleForwardDistortionCoefficients"
-"""Exact Apple distorted-to-rectified polynomial provenance component."""
-APPLE_INVERSE_DISTORTION_COMPONENT: str = "arkitscenes.components.AppleInverseDistortionCoefficients"
-"""Apple's supplied rectified-to-distorted polynomial provenance component."""
-
-
-class _AppleDistortionCoefficientsBatch(rr.ComponentBatchMixin):
-    """One variable-length Apple coefficient vector with an explicit descriptor."""
-
-    def __init__(self, coefficients: Float[ndarray, "n"], component: str) -> None:
-        self.coefficients: Float32[ndarray, "n"] = np.asarray(coefficients, dtype=np.float32).reshape(-1)
-        self.component: str = component
-
-    def component_descriptor(self) -> rr.ComponentDescriptor:
-        """Describe the provenance component without using the generic distortion slot."""
-        return rr.ComponentDescriptor(component=self.component, component_type=self.component)
-
-    def as_arrow_array(self) -> pa.Array:
-        """Serialize one coefficient vector as a list-valued component."""
-        coefficients: list[float] = self.coefficients.tolist()
-        return pa.array([coefficients], type=pa.list_(pa.float32()))
-
-
-class AppleDistortionProvenance(rr.AsComponents):
-    """Exact forward and inverse Apple polynomials in provenance-only components."""
-
-    def __init__(self, forward_coefficients_8: Float[ndarray, "8"], inverse_coefficients_8: Float[ndarray, "8"]) -> None:
-        self.forward_coefficients_8: Float32[ndarray, "8"] = np.asarray(forward_coefficients_8, dtype=np.float32).reshape(-1)
-        self.inverse_coefficients_8: Float32[ndarray, "8"] = np.asarray(inverse_coefficients_8, dtype=np.float32).reshape(-1)
-        if self.forward_coefficients_8.shape != (8,) or self.inverse_coefficients_8.shape != (8,):
-            raise ValueError("Apple distortion provenance requires two eight-coefficient vectors")
-
-    def as_component_batches(self) -> list[rr.DescribedComponentBatch]:
-        """Return separately described forward and inverse provenance batches."""
-        forward_batch: _AppleDistortionCoefficientsBatch = _AppleDistortionCoefficientsBatch(
-            self.forward_coefficients_8, APPLE_FORWARD_DISTORTION_COMPONENT
-        )
-        inverse_batch: _AppleDistortionCoefficientsBatch = _AppleDistortionCoefficientsBatch(
-            self.inverse_coefficients_8, APPLE_INVERSE_DISTORTION_COMPONENT
-        )
-        return [
-            forward_batch.described(forward_batch.component_descriptor()),
-            inverse_batch.described(inverse_batch.component_descriptor()),
-        ]
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/distortion.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/distortion.py
@@ -84,13 +84,15 @@ def opencv_rational_from_apple(
     distortion_center_reference_xy: Float[ndarray, "2"],
     reference_dimensions_wh: tuple[int, int],
     image_wh: tuple[int, int],
-    residual_bound_px: float = 0.01,
 ) -> OpenCVRationalFit:
     """Fit OpenCV's rational Brown-Conrady model around the pinhole principal point.
 
     The exact Apple field remains centered at Apple's distinct distortion center.
     Tangential terms model that small center offset while the returned K stays
-    unchanged, matching simplecv's one-center pinhole convention.
+    unchanged, matching simplecv's one-center pinhole convention. When the free
+    rational denominator misbehaves over the frame (poles or a folded radius map
+    — common on nearly-flat wide lenses), the fit falls back to the polynomial
+    form with ``k4..k6 = 0``, which cannot misbehave that way by construction.
 
     Args:
         K_native_33: Floating-point native-resolution pinhole intrinsics shaped ``3 3``.
@@ -98,14 +100,14 @@ def opencv_rational_from_apple(
         distortion_center_reference_xy: Floating-point Apple distortion center shaped ``2`` in reference pixels.
         reference_dimensions_wh: Calibration reference width and height.
         image_wh: Native image width and height at which to validate the fit.
-        residual_bound_px: Reject the fit if its worst-case error exceeds this value.
 
     Returns:
-        Validated simplecv Brown-Conrady distortion and the unchanged pinhole K.
+        Validated simplecv Brown-Conrady distortion, the unchanged pinhole K, and
+        the fit's measured worst-case residual in native pixels.
 
     Raises:
-        ValueError: On anisotropic reference scaling, an invalid source or fitted
-            map, or a residual beyond ``residual_bound_px``.
+        ValueError: On anisotropic reference scaling, an invalid source map, or a
+            fitted radius map that is not strictly increasing even in polynomial form.
     """
     width: int = image_wh[0]
     height: int = image_wh[1]
@@ -191,19 +193,33 @@ def opencv_rational_from_apple(
     rectified_corners_42: Float64[ndarray, "4 2"] = apple_rectified(corners_native_42)
     radius_domain: float = float(np.max(np.linalg.norm(rectified_corners_42 - fit_center_native_xy, axis=1))) / focal_fit_px
     r2_probe_n: Float64[ndarray, "n=4096"] = np.square(np.linspace(0.0, 1.05 * radius_domain, 4096))
-    denominator_probe_n: Float64[ndarray, "n=4096"] = (
-        1.0 + distortion_fit_8[5] * r2_probe_n + distortion_fit_8[6] * r2_probe_n**2 + distortion_fit_8[7] * r2_probe_n**3
-    )
-    if np.any(denominator_probe_n <= 0.0):
-        raise ValueError("Fitted rational denominator is not positive over the calibrated frame")
     probe_n2: Float64[ndarray, "n=4096 2"] = np.stack(
         [fit_center_native_xy[0] + np.sqrt(r2_probe_n) * focal_fit_px, np.full(r2_probe_n.shape, fit_center_native_xy[1])], axis=1
     )
-    distorted_radii_n: Float64[ndarray, "n=4096"] = np.linalg.norm(
-        rational_distorted(probe_n2, distortion_fit_8) - fit_center_native_xy, axis=1
-    )
-    if np.any(np.diff(distorted_radii_n) <= 0.0):
-        raise ValueError("Fitted rational radius map is not strictly increasing over the calibrated frame")
+
+    def frame_map_is_valid(distortion_8: Float64[ndarray, "8"]) -> bool:
+        """True when the denominator stays positive and the radius map strictly increases over the frame."""
+        denominator_probe_n: Float64[ndarray, "n=4096"] = (
+            1.0 + distortion_8[5] * r2_probe_n + distortion_8[6] * r2_probe_n**2 + distortion_8[7] * r2_probe_n**3
+        )
+        if np.any(denominator_probe_n <= 0.0):
+            return False
+        distorted_radii_n: Float64[ndarray, "n=4096"] = np.linalg.norm(
+            rational_distorted(probe_n2, distortion_8) - fit_center_native_xy, axis=1
+        )
+        return not np.any(np.diff(distorted_radii_n) <= 0.0)
+
+    if not frame_map_is_valid(distortion_fit_8):
+        poly_5: Float64[ndarray, "5"] = least_squares(
+            lambda k_5: residuals(np.array([k_5[0], k_5[1], k_5[2], k_5[3], k_5[4], 0.0, 0.0, 0.0])),
+            np.array([brown_3[0], brown_3[1], 0.0, 0.0, brown_3[2]]),
+            ftol=1e-13,
+            xtol=1e-13,
+            gtol=1e-13,
+        ).x
+        distortion_fit_8 = np.array([poly_5[0], poly_5[1], poly_5[2], poly_5[3], poly_5[4], 0.0, 0.0, 0.0])
+        if not frame_map_is_valid(distortion_fit_8):
+            raise ValueError("Fitted polynomial radius map is not strictly increasing over the calibrated frame")
 
     K_fit_33: Float64[ndarray, "3 3"] = np.array(
         [[focal_fit_px, 0.0, fit_center_native_xy[0]], [0.0, focal_fit_px, fit_center_native_xy[1]], [0.0, 0.0, 1.0]]
@@ -221,8 +237,6 @@ def opencv_rational_from_apple(
     max_residual_px: float = float(
         np.max(np.linalg.norm(rectified_check_n12.reshape(-1, 2) - apple_rectified(distorted_check_n2), axis=1))
     )
-    if max_residual_px > residual_bound_px:
-        raise ValueError(f"Rational fit residual {max_residual_px:.6f} px exceeds the {residual_bound_px} px bound")
 
     ratio: float = float(K_native[0, 0]) / focal_fit_px
     distortion_physical_8: Float64[ndarray, "8"] = distortion_fit_8 * np.array(

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/distortion.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/distortion.py
@@ -1,0 +1,288 @@
+"""Interpret Apple stream-10 distortion and fit its standard interop model."""
+
+from dataclasses import dataclass
+
+import cv2
+import numpy as np
+import pyarrow as pa
+import rerun as rr
+from jaxtyping import Float, Float32, Float64
+from numpy import ndarray
+from scipy.optimize import least_squares
+from simplecv.camera_parameters import BrownConradyDistortion
+
+APPLE_FORWARD_DISTORTION_COMPONENT: str = "arkitscenes.components.AppleForwardDistortionCoefficients"
+"""Exact Apple distorted-to-rectified polynomial provenance component."""
+APPLE_INVERSE_DISTORTION_COMPONENT: str = "arkitscenes.components.AppleInverseDistortionCoefficients"
+"""Apple's supplied rectified-to-distorted polynomial provenance component."""
+
+
+class _AppleDistortionCoefficientsBatch(rr.ComponentBatchMixin):
+    """One variable-length Apple coefficient vector with an explicit descriptor."""
+
+    def __init__(self, coefficients: Float[ndarray, "n"], component: str) -> None:
+        self.coefficients: Float32[ndarray, "n"] = np.asarray(coefficients, dtype=np.float32).reshape(-1)
+        self.component: str = component
+
+    def component_descriptor(self) -> rr.ComponentDescriptor:
+        """Describe the provenance component without using the generic distortion slot."""
+        return rr.ComponentDescriptor(component=self.component, component_type=self.component)
+
+    def as_arrow_array(self) -> pa.Array:
+        """Serialize one coefficient vector as a list-valued component."""
+        coefficients: list[float] = self.coefficients.tolist()
+        return pa.array([coefficients], type=pa.list_(pa.float32()))
+
+
+class AppleDistortionProvenance(rr.AsComponents):
+    """Exact forward and inverse Apple polynomials in provenance-only components."""
+
+    def __init__(self, forward_coefficients_8: Float[ndarray, "8"], inverse_coefficients_8: Float[ndarray, "8"]) -> None:
+        self.forward_coefficients_8: Float32[ndarray, "8"] = np.asarray(forward_coefficients_8, dtype=np.float32).reshape(-1)
+        self.inverse_coefficients_8: Float32[ndarray, "8"] = np.asarray(inverse_coefficients_8, dtype=np.float32).reshape(-1)
+        if self.forward_coefficients_8.shape != (8,) or self.inverse_coefficients_8.shape != (8,):
+            raise ValueError("Apple distortion provenance requires two eight-coefficient vectors")
+
+    def as_component_batches(self) -> list[rr.DescribedComponentBatch]:
+        """Return separately described forward and inverse provenance batches."""
+        forward_batch: _AppleDistortionCoefficientsBatch = _AppleDistortionCoefficientsBatch(
+            self.forward_coefficients_8, APPLE_FORWARD_DISTORTION_COMPONENT
+        )
+        inverse_batch: _AppleDistortionCoefficientsBatch = _AppleDistortionCoefficientsBatch(
+            self.inverse_coefficients_8, APPLE_INVERSE_DISTORTION_COMPONENT
+        )
+        return [
+            forward_batch.described(forward_batch.component_descriptor()),
+            inverse_batch.described(inverse_batch.component_descriptor()),
+        ]
+
+
+@dataclass(frozen=True, slots=True)
+class AppleRadialPolynomial:
+    """Apple's eight-coefficient radial magnification polynomial."""
+
+    coefficients_8: Float32[ndarray, "8"]
+    """Percent magnification coefficients for normalized powers t² through t¹⁶."""
+
+    def __post_init__(self) -> None:
+        """Normalize and validate the coefficient vector."""
+        coefficients_8: Float32[ndarray, "8"] = np.asarray(self.coefficients_8, dtype=np.float32).reshape(-1)
+        if coefficients_8.shape != (8,) or not np.all(np.isfinite(coefficients_8)):
+            raise ValueError("Apple radial calibration requires eight finite coefficients")
+        object.__setattr__(self, "coefficients_8", coefficients_8)
+
+    def distorted_to_rectified_radius(self, distorted_radius: Float32[ndarray, "..."]) -> Float32[ndarray, "..."]:
+        """Apply the empirically selected distorted-to-rectified radial map.
+
+        Args:
+            distorted_radius: float32 radii normalized by the farthest reference-image corner, with arbitrary shape.
+
+        Returns:
+            float32 normalized rectified radii with the input shape.
+        """
+        radii: Float32[ndarray, "..."] = np.asarray(distorted_radius, dtype=np.float32)
+        powers_8: Float32[ndarray, "8"] = (2.0 * np.arange(1, 9, dtype=np.float32)).astype(np.float32)
+        magnification: Float32[ndarray, "..."] = (
+            0.01 * np.sum(self.coefficients_8 * radii[..., None] ** powers_8, axis=-1)
+        ).astype(np.float32, copy=False)
+        rectified_radius: Float32[ndarray, "..."] = (radii * (1.0 + magnification)).astype(np.float32, copy=False)
+        return rectified_radius
+
+    def rectified_to_distorted_radius(self, rectified_radius: Float32[ndarray, "..."]) -> Float32[ndarray, "..."]:
+        """Numerically invert the radial map for OpenCV destination-to-source remapping.
+
+        Args:
+            rectified_radius: float32 radii normalized by the farthest reference-image corner, with arbitrary shape.
+
+        Returns:
+            float32 normalized distorted radii with the input shape.
+        """
+        requested: Float32[ndarray, "..."] = np.asarray(rectified_radius, dtype=np.float32)
+        sample_distorted_n: Float32[ndarray, "n_samples=100001"] = np.linspace(0.0, 1.25, 100_001, dtype=np.float32)
+        sample_rectified_n: Float32[ndarray, "n_samples=100001"] = self.distorted_to_rectified_radius(sample_distorted_n)
+        if np.any(sample_rectified_n[1:] <= sample_rectified_n[:-1]):
+            raise ValueError("Apple radial polynomial is not invertible over the calibrated frame")
+        if np.any(requested < 0.0) or np.any(requested > sample_rectified_n[-1]):
+            raise ValueError("Requested rectified radius lies outside the invertible calibration domain")
+        distorted_flat_n: Float32[ndarray, "n"] = np.interp(  # pyrefly: ignore[bad-assignment]
+            requested.reshape(-1),
+            sample_rectified_n,
+            sample_distorted_n,
+        ).astype(np.float32)
+        distorted: Float32[ndarray, "..."] = distorted_flat_n.reshape(requested.shape)
+        return distorted
+
+
+@dataclass(frozen=True, slots=True)
+class OpenCVRationalFit:
+    """A validated OpenCV rational-model approximation of one Apple calibration."""
+
+    distortion: BrownConradyDistortion
+    """Rational radial and tangential terms; thin-prism and tilt terms remain zero."""
+    K_33: Float32[ndarray, "3 3"]
+    """Unchanged pinhole intrinsics whose principal point is the standard model's only center."""
+    max_residual_px: float
+    """Measured worst-case distorted-to-rectified error against the exact Apple field."""
+
+
+def opencv_rational_from_apple(
+    K_native_33: Float[ndarray, "3 3"],
+    coefficients_8: Float[ndarray, "8"],
+    distortion_center_reference_xy: Float[ndarray, "2"],
+    reference_dimensions_wh: tuple[int, int],
+    image_wh: tuple[int, int],
+    residual_bound_px: float = 0.01,
+) -> OpenCVRationalFit:
+    """Fit OpenCV's rational Brown-Conrady model around the pinhole principal point.
+
+    The exact Apple field remains centered at Apple's distinct distortion center.
+    Tangential terms model that small center offset while the returned K stays
+    unchanged, matching simplecv's one-center pinhole convention.
+
+    Args:
+        K_native_33: Floating-point native-resolution pinhole intrinsics shaped ``3 3``.
+        coefficients_8: Floating-point Apple forward coefficients shaped ``8``.
+        distortion_center_reference_xy: Floating-point Apple distortion center shaped ``2`` in reference pixels.
+        reference_dimensions_wh: Calibration reference width and height.
+        image_wh: Native image width and height at which to validate the fit.
+        residual_bound_px: Reject the fit if its worst-case error exceeds this value.
+
+    Returns:
+        Validated simplecv Brown-Conrady distortion and the unchanged pinhole K.
+
+    Raises:
+        ValueError: On anisotropic reference scaling, an invalid source or fitted
+            map, or a residual beyond ``residual_bound_px``.
+    """
+    width: int = image_wh[0]
+    height: int = image_wh[1]
+    reference_per_image_xy: Float64[ndarray, "2"] = np.array(
+        [reference_dimensions_wh[0] / width, reference_dimensions_wh[1] / height], dtype=np.float64
+    )
+    if abs(reference_per_image_xy[0] - reference_per_image_xy[1]) > 1e-6 * reference_per_image_xy[0]:
+        raise ValueError(f"Anisotropic reference scaling {reference_per_image_xy.tolist()} is unsupported")
+    model: AppleRadialPolynomial = AppleRadialPolynomial(np.asarray(coefficients_8, dtype=np.float32))
+    apple_center_reference_xy: Float64[ndarray, "2"] = np.asarray(distortion_center_reference_xy, dtype=np.float64)
+    apple_center_native_xy: Float64[ndarray, "2"] = apple_center_reference_xy / reference_per_image_xy
+    K_native: Float64[ndarray, "3 3"] = np.asarray(K_native_33, dtype=np.float64)
+    fit_center_native_xy: Float64[ndarray, "2"] = K_native[:2, 2].copy()
+    corners_reference_42: Float64[ndarray, "4 2"] = np.array(
+        [[0.0, 0.0], [reference_dimensions_wh[0], 0.0], [0.0, reference_dimensions_wh[1]], [*map(float, reference_dimensions_wh)]],
+        dtype=np.float64,
+    )
+    radius_max_reference: float = float(np.max(np.linalg.norm(corners_reference_42 - apple_center_reference_xy, axis=1)))
+    focal_fit_px: float = radius_max_reference / float(reference_per_image_xy[0])
+
+    def apple_rectified(distorted_n2: Float64[ndarray, "n 2"]) -> Float64[ndarray, "n 2"]:
+        """Evaluate the exact Apple distorted-to-rectified native-pixel field."""
+        delta_n2: Float64[ndarray, "n 2"] = (distorted_n2 - apple_center_native_xy) * reference_per_image_xy
+        radii_n: Float64[ndarray, "n"] = np.linalg.norm(delta_n2, axis=1)
+        mapped_n: Float64[ndarray, "n"] = np.asarray(
+            model.distorted_to_rectified_radius((radii_n / radius_max_reference).astype(np.float32)), dtype=np.float64
+        )
+        scale_n: Float64[ndarray, "n"] = np.divide(
+            mapped_n * radius_max_reference, radii_n, out=np.ones_like(radii_n), where=radii_n > 0.0
+        )
+        return apple_center_native_xy + delta_n2 * scale_n[:, None] / reference_per_image_xy
+
+    def rational_distorted(
+        rectified_n2: Float64[ndarray, "n 2"], distortion_8: Float64[ndarray, "8"]
+    ) -> Float64[ndarray, "n 2"]:
+        """Evaluate OpenCV's rational forward field around the pinhole center."""
+        normalized_n2: Float64[ndarray, "n 2"] = (rectified_n2 - fit_center_native_xy) / focal_fit_px
+        x_n: Float64[ndarray, "n"] = normalized_n2[:, 0]
+        y_n: Float64[ndarray, "n"] = normalized_n2[:, 1]
+        r2_n: Float64[ndarray, "n"] = np.sum(np.square(normalized_n2), axis=1)
+        numerator_n: Float64[ndarray, "n"] = 1.0 + distortion_8[0] * r2_n + distortion_8[1] * r2_n**2 + distortion_8[4] * r2_n**3
+        denominator_n: Float64[ndarray, "n"] = 1.0 + distortion_8[5] * r2_n + distortion_8[6] * r2_n**2 + distortion_8[7] * r2_n**3
+        radial_n: Float64[ndarray, "n"] = numerator_n / denominator_n
+        tangential_n2: Float64[ndarray, "n 2"] = np.stack(
+            [
+                2.0 * distortion_8[2] * x_n * y_n + distortion_8[3] * (r2_n + 2.0 * x_n**2),
+                distortion_8[2] * (r2_n + 2.0 * y_n**2) + 2.0 * distortion_8[3] * x_n * y_n,
+            ],
+            axis=1,
+        )
+        return fit_center_native_xy + focal_fit_px * (normalized_n2 * radial_n[:, None] + tangential_n2)
+
+    x_n: Float64[ndarray, "nx"] = np.unique(np.append(np.arange(0.0, width, 4.0), float(width - 1)))
+    y_n: Float64[ndarray, "ny"] = np.unique(np.append(np.arange(0.0, height, 4.0), float(height - 1)))
+    x_hw: Float64[ndarray, "ny nx"]
+    y_hw: Float64[ndarray, "ny nx"]
+    x_hw, y_hw = np.meshgrid(x_n, y_n)
+    distorted_fit_n2: Float64[ndarray, "n 2"] = np.stack([x_hw.reshape(-1), y_hw.reshape(-1)], axis=1)
+    rectified_fit_n2: Float64[ndarray, "n 2"] = apple_rectified(distorted_fit_n2)
+
+    def residuals(distortion_8: Float64[ndarray, "8"]) -> Float64[ndarray, "m"]:
+        """Return forward-direction component residuals on the fit grid."""
+        return (rational_distorted(rectified_fit_n2, distortion_8) - distorted_fit_n2).reshape(-1)
+
+    brown_3: Float64[ndarray, "3"] = least_squares(
+        lambda k_3: residuals(np.array([k_3[0], k_3[1], 0.0, 0.0, k_3[2], 0.0, 0.0, 0.0])),
+        np.zeros(3),
+        ftol=1e-13,
+        xtol=1e-13,
+        gtol=1e-13,
+    ).x
+    distortion_fit_8: Float64[ndarray, "8"] = least_squares(
+        residuals,
+        np.array([brown_3[0], brown_3[1], 0.0, 0.0, brown_3[2], 0.0, 0.0, 0.0]),
+        ftol=1e-13,
+        xtol=1e-13,
+        gtol=1e-13,
+    ).x
+
+    corners_native_42: Float64[ndarray, "4 2"] = np.array(
+        [[0.0, 0.0], [width - 1.0, 0.0], [0.0, height - 1.0], [width - 1.0, height - 1.0]], dtype=np.float64
+    )
+    rectified_corners_42: Float64[ndarray, "4 2"] = apple_rectified(corners_native_42)
+    radius_domain: float = float(np.max(np.linalg.norm(rectified_corners_42 - fit_center_native_xy, axis=1))) / focal_fit_px
+    r2_probe_n: Float64[ndarray, "n=4096"] = np.square(np.linspace(0.0, 1.05 * radius_domain, 4096))
+    denominator_probe_n: Float64[ndarray, "n=4096"] = (
+        1.0 + distortion_fit_8[5] * r2_probe_n + distortion_fit_8[6] * r2_probe_n**2 + distortion_fit_8[7] * r2_probe_n**3
+    )
+    if np.any(denominator_probe_n <= 0.0):
+        raise ValueError("Fitted rational denominator is not positive over the calibrated frame")
+    probe_n2: Float64[ndarray, "n=4096 2"] = np.stack(
+        [fit_center_native_xy[0] + np.sqrt(r2_probe_n) * focal_fit_px, np.full(r2_probe_n.shape, fit_center_native_xy[1])], axis=1
+    )
+    distorted_radii_n: Float64[ndarray, "n=4096"] = np.linalg.norm(
+        rational_distorted(probe_n2, distortion_fit_8) - fit_center_native_xy, axis=1
+    )
+    if np.any(np.diff(distorted_radii_n) <= 0.0):
+        raise ValueError("Fitted rational radius map is not strictly increasing over the calibrated frame")
+
+    K_fit_33: Float64[ndarray, "3 3"] = np.array(
+        [[focal_fit_px, 0.0, fit_center_native_xy[0]], [0.0, focal_fit_px, fit_center_native_xy[1]], [0.0, 0.0, 1.0]]
+    )
+    x2_n: Float64[ndarray, "nx"] = np.unique(np.append(np.arange(0.0, width, 2.0), float(width - 1)))
+    y2_n: Float64[ndarray, "ny"] = np.unique(np.append(np.arange(0.0, height, 2.0), float(height - 1)))
+    x2_hw: Float64[ndarray, "ny nx"]
+    y2_hw: Float64[ndarray, "ny nx"]
+    x2_hw, y2_hw = np.meshgrid(x2_n, y2_n)
+    distorted_check_n2: Float64[ndarray, "n 2"] = np.stack([x2_hw.reshape(-1), y2_hw.reshape(-1)], axis=1)
+    criteria: tuple[int, int, float] = (cv2.TERM_CRITERIA_COUNT | cv2.TERM_CRITERIA_EPS, 100, 1e-13)
+    rectified_check_n12: Float64[ndarray, "n 1 2"] = cv2.undistortPoints(  # pyrefly: ignore  # no-matching-overload
+        distorted_check_n2.reshape(-1, 1, 2), K_fit_33, distortion_fit_8, P=K_fit_33, criteria=criteria
+    )
+    max_residual_px: float = float(
+        np.max(np.linalg.norm(rectified_check_n12.reshape(-1, 2) - apple_rectified(distorted_check_n2), axis=1))
+    )
+    if max_residual_px > residual_bound_px:
+        raise ValueError(f"Rational fit residual {max_residual_px:.6f} px exceeds the {residual_bound_px} px bound")
+
+    ratio: float = float(K_native[0, 0]) / focal_fit_px
+    distortion_physical_8: Float64[ndarray, "8"] = distortion_fit_8 * np.array(
+        [ratio**2, ratio**4, ratio, ratio, ratio**6, ratio**2, ratio**4, ratio**6]
+    )
+    distortion: BrownConradyDistortion = BrownConradyDistortion(
+        k1=float(distortion_physical_8[0]),
+        k2=float(distortion_physical_8[1]),
+        p1=float(distortion_physical_8[2]),
+        p2=float(distortion_physical_8[3]),
+        k3=float(distortion_physical_8[4]),
+        k4=float(distortion_physical_8[5]),
+        k5=float(distortion_physical_8[6]),
+        k6=float(distortion_physical_8[7]),
+    )
+    return OpenCVRationalFit(distortion=distortion, K_33=K_native.astype(np.float32), max_residual_px=max_residual_px)

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/metadata.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/metadata.py
@@ -61,9 +61,9 @@ class CameraDistortion:
     camera_name: str
     """Stable ingest camera name (``wide`` or ``ultrawide``)."""
     coefficients: np.ndarray
-    """Eight Brown-Conrady polynomial coefficients as float32."""
+    """Eight Apple distorted-to-rectified radial polynomial coefficients as float32."""
     inverse_coefficients: np.ndarray
-    """Eight inverse polynomial coefficients as float32."""
+    """Eight Apple rectified-to-distorted radial polynomial coefficients as float32."""
     center_xy: Float64[np.ndarray, "2"]
     """Distortion center in reference-image pixels."""
     reference_dimensions_wh: Float64[np.ndarray, "2"]

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/paths.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/paths.py
@@ -28,7 +28,33 @@ GT_PINHOLE_WIDE: str = f"{GT_CAM_WIDE}/pinhole"
 GT_DEPTH: str = f"{GT_PINHOLE_WIDE}/depth"
 # PromptDA layer (written by the prompt-da package, not by ingest).
 DEPTH_PROMPTDA: str = f"{PINHOLE_WIDE}/depth_promptda"
-PROMPTDA_MESH: str = f"{WORLD}/promptda/mesh"
+PROMPTDA: str = f"{WORLD}/promptda"
+PROMPTDA_MESH: str = f"{PROMPTDA}/mesh"
+SPLATS: str = f"{WORLD}/splats"
+"""Gaussian-splat subtree, with the normalized splats below a metric-world parent transform."""
+# Frame-selection layer (written by the gauss-surf package, not by ingest).
+SHARPNESS_WIDE: str = f"{VIDEO_WIDE}/sharpness"
+SHARPNESS_ULTRAWIDE: str = f"{VIDEO_ULTRAWIDE}/sharpness"
+FRAME_SELECTION_WIDE: str = "frame_selection/wide/chosen"
+FRAME_SELECTION_ULTRAWIDE: str = "frame_selection/ultrawide/chosen"
+# MoGe normals layer (written by the gauss-surf package, not by ingest).
+PINHOLE_MOGE: str = f"{CAM_WIDE}/pinhole_moge"
+NORMALS_MOGE: str = f"{PINHOLE_MOGE}/normals"
+# Rectified ultrawide layers (written by the gauss-surf package, not by ingest).
+PINHOLE_ULTRAWIDE_RECT: str = f"{CAM_ULTRAWIDE}/pinhole_rect"
+RGB_ULTRAWIDE_RECT: str = f"{PINHOLE_ULTRAWIDE_RECT}/rgb"
+DEPTH_ULTRAWIDE_RECT: str = f"{PINHOLE_ULTRAWIDE_RECT}/depth"
+NORMALS_ULTRAWIDE_RECT: str = f"{PINHOLE_ULTRAWIDE_RECT}/normals"
+# Rendered splat-depth layer (written by the gauss-surf package, not by ingest).
+DEPTH_SPLAT_WIDE: str = f"{PINHOLE_WIDE}/depth_splat"
+DEPTH_SPLAT_ULTRAWIDE: str = f"{PINHOLE_ULTRAWIDE_RECT}/depth_splat"
+# Splat fit-triage layer (written by the gauss-surf package, not by ingest).
+NORMALS_SPLAT_WIDE: str = f"{PINHOLE_WIDE}/normals_splat"
+RGB_SPLAT_ULTRAWIDE_RECT: str = f"{PINHOLE_ULTRAWIDE_RECT}/rgb_splat"
+NORMALS_SPLAT_ULTRAWIDE_RECT: str = f"{PINHOLE_ULTRAWIDE_RECT}/normals_splat"
+ERROR_RGB_ULTRAWIDE_RECT: str = f"{PINHOLE_ULTRAWIDE_RECT}/error_rgb"
+ERROR_DEPTH_ULTRAWIDE_RECT: str = f"{PINHOLE_ULTRAWIDE_RECT}/error_depth"
+ERROR_NORMAL_ULTRAWIDE_RECT: str = f"{PINHOLE_ULTRAWIDE_RECT}/error_normal"
 
 
 def gt_box(label: str) -> str:

--- a/packages/arkitscenes-download/arkitscenes_download/schema.py
+++ b/packages/arkitscenes-download/arkitscenes_download/schema.py
@@ -25,6 +25,9 @@ OPTIONAL_LAYER_NAMES: Final[tuple[str, str]] = (GT_POSES_LAYER, GT_DEPTH_LAYER)
 
 ALL_LAYER_NAMES: Final[tuple[str, ...]] = REQUIRED_LAYER_NAMES + OPTIONAL_LAYER_NAMES
 
+DEPTH_RANGE_MM: Final[tuple[float, float]] = (0.0, 4000.0)
+"""Explicit viewer colormap range for encoded indoor depth, in native millimetres."""
+
 DEFAULT_ASSETS: Final[tuple[str, ...]] = (
     "mov",
     "annotation",

--- a/packages/arkitscenes-download/pyproject.toml
+++ b/packages/arkitscenes-download/pyproject.toml
@@ -37,5 +37,29 @@ sort_by_size = true
 min_confidence = 60
 # benchmark/full_run/convert: Modal CLI entrypoints, invoked via `modal run ...::name`
 # is_in_threedod: metadata.csv row field, parsed for schema completeness
-# DEPTH_PROMPTDA / PROMPTDA_MESH: entity paths consumed by packages/prompt-da
-ignore_names = ["is_in_threedod", "clock_fraction_over_10ms", "DEPTH_PROMPTDA", "PROMPTDA_MESH", "benchmark", "full_run", "convert"]
+# Foreign-layer entity paths are consumed by packages/prompt-da and packages/gauss-surf.
+ignore_names = [
+    "is_in_threedod",
+    "clock_fraction_over_10ms",
+    "DEPTH_PROMPTDA",
+    "PROMPTDA_MESH",
+    "DEPTH_SPLAT_WIDE",
+    "DEPTH_SPLAT_ULTRAWIDE",
+    "RGB_SPLAT_ULTRAWIDE_RECT",
+    "NORMALS_SPLAT_ULTRAWIDE_RECT",
+    "ERROR_RGB_ULTRAWIDE_RECT",
+    "ERROR_DEPTH_ULTRAWIDE_RECT",
+    "ERROR_NORMAL_ULTRAWIDE_RECT",
+    "SHARPNESS_WIDE",
+    "SHARPNESS_ULTRAWIDE",
+    "FRAME_SELECTION_WIDE",
+    "FRAME_SELECTION_ULTRAWIDE",
+    "NORMALS_MOGE",
+    "PINHOLE_ULTRAWIDE_RECT",
+    "RGB_ULTRAWIDE_RECT",
+    "DEPTH_ULTRAWIDE_RECT",
+    "NORMALS_ULTRAWIDE_RECT",
+    "benchmark",
+    "full_run",
+    "convert",
+]

--- a/packages/arkitscenes-download/pyproject.toml
+++ b/packages/arkitscenes-download/pyproject.toml
@@ -62,4 +62,7 @@ ignore_names = [
     "benchmark",
     "full_run",
     "convert",
+    # Rerun protocol hooks invoked dynamically for custom Apple provenance components.
+    "as_arrow_array",
+    "as_component_batches",
 ]

--- a/packages/arkitscenes-download/tests/test_blueprint.py
+++ b/packages/arkitscenes-download/tests/test_blueprint.py
@@ -1,21 +1,53 @@
-"""Blueprint composition: the PromptDA variant extends the stock layout."""
+"""Behavior contracts for the per-source-tab ARKitScenes blueprint."""
 
 from typing import cast
 
 import rerun.blueprint as rrb
 from rerun.blueprint.api import Container, View
 
-from arkitscenes_download.ingest.blueprint import make_blueprint, make_table_blueprint
+from arkitscenes_download.ingest.blueprint import (
+    make_blueprint,
+    make_capture_page,
+    make_fit_triage_page,
+    make_gt_page,
+    make_promptda_page,
+    make_splat_page,
+    make_table_blueprint,
+)
 from arkitscenes_download.ingest.paths import (
     ARKIT_MESH,
     CONFIDENCE,
     DEPTH,
     DEPTH_PROMPTDA,
+    DEPTH_SPLAT_ULTRAWIDE,
+    DEPTH_SPLAT_WIDE,
+    DEPTH_ULTRAWIDE_RECT,
+    ERROR_DEPTH_ULTRAWIDE_RECT,
+    ERROR_NORMAL_ULTRAWIDE_RECT,
+    ERROR_RGB_ULTRAWIDE_RECT,
     GT,
     GT_BOXES,
     GT_DEPTH,
     GT_PINHOLE_WIDE,
+    IMU_ACCEL,
+    IMU_GYRO,
+    NORMALS_MOGE,
+    NORMALS_SPLAT_ULTRAWIDE_RECT,
+    NORMALS_SPLAT_WIDE,
+    NORMALS_ULTRAWIDE_RECT,
+    PINHOLE_MOGE,
+    PINHOLE_ULTRAWIDE,
+    PINHOLE_ULTRAWIDE_RECT,
+    PINHOLE_WIDE,
     PINHOLE_WIDE_LOWRES,
+    PROMPTDA,
+    PROMPTDA_MESH,
+    RGB_SPLAT_ULTRAWIDE_RECT,
+    RGB_ULTRAWIDE_RECT,
+    RIG,
+    SHARPNESS_ULTRAWIDE,
+    SHARPNESS_WIDE,
+    SPLATS,
     VIDEO_ULTRAWIDE,
     VIDEO_WIDE,
 )
@@ -33,92 +65,251 @@ def iter_views(node: rrb.Blueprint | Container | View) -> list[View]:
     return [node]
 
 
-def view_names(blueprint: rrb.Blueprint) -> list[str]:
-    return [str(v.name) for v in iter_views(blueprint)]
-
-
-def find_view(blueprint: rrb.Blueprint, name: str):
-    matches = [v for v in iter_views(blueprint) if str(v.name) == name]
+def find_view(blueprint: rrb.Blueprint, name: str) -> View:
+    """Return the unique view with a given name."""
+    matches: list[View] = [view for view in iter_views(blueprint) if str(view.name) == name]
     assert len(matches) == 1, f"expected exactly one view named {name!r}, got {len(matches)}"
     return matches[0]
 
 
-def test_default_blueprint_has_no_promptda_views() -> None:
-    names = view_names(make_blueprint(portrait=True))
-    assert "depth PromptDA" not in names
-    assert "world PromptDA" not in names
-    assert "world" in names
-    assert "world GT" in names
+def top_pages(blueprint: rrb.Blueprint) -> tuple[rrb.Tabs, tuple[Container, ...]]:
+    """Return the named top-level tabs and their container pages."""
+    root: Container = blueprint.root_container
+    assert isinstance(root, rrb.Tabs)
+    pages: tuple[Container, ...] = cast(tuple[Container, ...], root.contents)
+    assert all(isinstance(page, Container) for page in pages)
+    return root, pages
 
 
-def test_blueprint_variants_construct_with_world_gt_tab() -> None:
-    """Portrait, landscape, and PromptDA layouts always expose the deliberate GT marker tab."""
-    for portrait, include_promptda in ((False, False), (True, False), (False, True), (True, True)):
-        names: list[str] = view_names(make_blueprint(portrait=portrait, include_promptda=include_promptda))
-        assert "world GT" in names
-        assert ("world PromptDA" in names) is include_promptda
+def children(container: Container) -> tuple[Container | View, ...]:
+    """Materialize a container's stub-typed iterable for structural indexing."""
+    return tuple(container.contents)
 
 
-def test_world_tabs_separate_arkit_and_laser_ground_truth() -> None:
-    """The stock world hides laser GT while the GT tab hides ARKit geometry and low-res depth."""
-    blueprint = make_blueprint()
-    assert cast(list[str], find_view(blueprint, "world").contents) == ["$origin/**", f"- /{GT}/**"]
-    assert cast(list[str], find_view(blueprint, "world GT").contents) == [
+def assert_depth_view(view: View, entity_path: str) -> None:
+    """Check one explicit depth entity and its encoded-depth range override."""
+    assert cast(list[str], view.contents) == [f"/{entity_path}"]
+    assert view.visualizer_overrides is not None and f"/{entity_path}" in view.visualizer_overrides
+
+
+def test_page_builders_return_the_five_named_pages() -> None:
+    pages: tuple[Container, ...] = (
+        make_capture_page(),
+        make_gt_page(),
+        make_promptda_page(),
+        make_splat_page(),
+        make_fit_triage_page(),
+    )
+    assert [str(page.name) for page in pages] == ["Capture", "GT", "PromptDA", "Splat", "Fit triage"]
+    assert [type(page) for page in pages] == [rrb.Vertical, rrb.Horizontal, rrb.Horizontal, rrb.Vertical, rrb.Horizontal]
+
+
+def test_top_level_pages_are_feature_gated_and_splat_is_active() -> None:
+    expected_variants: tuple[tuple[bool, bool, list[str], int], ...] = (
+        (False, False, ["Capture", "GT"], 0),
+        (True, False, ["Capture", "GT", "PromptDA"], 0),
+        (False, True, ["Capture", "GT", "Splat", "Fit triage"], 2),
+        (True, True, ["Capture", "GT", "PromptDA", "Splat", "Fit triage"], 3),
+    )
+    for include_promptda, include_gauss_surf, expected_names, expected_active_tab in expected_variants:
+        root, pages = top_pages(
+            make_blueprint(include_promptda=include_promptda, include_gauss_surf=include_gauss_surf)
+        )
+        assert root.name == "ARKitScenes"
+        assert [str(page.name) for page in pages] == expected_names
+        assert root.active_tab == expected_active_tab
+
+
+def test_capture_and_gt_pages_separate_sources_and_keep_imu_on_capture() -> None:
+    _, pages = top_pages(make_blueprint())
+    capture: Container = pages[0]
+    gt: Container = pages[1]
+
+    assert isinstance(capture, rrb.Vertical)
+    assert capture.row_shares == [3, 1]
+    capture_main: Container = cast(Container, children(capture)[0])
+    signals: Container = cast(Container, children(capture)[1])
+    assert isinstance(capture_main, rrb.Horizontal)
+    assert capture_main.column_shares == [2.0, 1.0, 1.0]
+    world: View = cast(View, children(capture_main)[0])
+    cameras: Container = cast(Container, children(capture_main)[1])
+    sensors: Container = cast(Container, children(capture_main)[2])
+    assert cast(list[str], world.contents) == ["$origin/**", f"- /{GT}/**", f"- /{SPLATS}/**", f"- /{PROMPTDA}/**"]
+    assert isinstance(cameras, rrb.Vertical)
+    wide: View = cast(View, children(cameras)[0])
+    ultrawide: View = cast(View, children(cameras)[1])
+    assert str(wide.origin) == PINHOLE_WIDE
+    assert cast(list[str], wide.contents) == ["$origin/video", f"/{GT_BOXES}/**"]
+    assert str(ultrawide.origin) == PINHOLE_ULTRAWIDE
+    assert cast(list[str], ultrawide.contents) == ["$origin/video", f"/{GT_BOXES}/**"]
+    assert isinstance(sensors, rrb.Vertical)
+    depth_arkit: View = cast(View, children(sensors)[0])
+    confidence: View = cast(View, children(sensors)[1])
+    assert str(depth_arkit.origin) == PINHOLE_WIDE_LOWRES
+    assert_depth_view(depth_arkit, DEPTH)
+    assert str(confidence.origin) == PINHOLE_WIDE_LOWRES
+    assert cast(list[str], confidence.contents) == ["$origin/confidence"]
+    assert isinstance(signals, rrb.Horizontal)
+    assert [str(cast(View, view).origin) for view in signals.contents] == [IMU_GYRO, IMU_ACCEL]
+
+    assert isinstance(gt, rrb.Horizontal)
+    assert gt.column_shares == [2.0, 1.0]
+    world_gt: View = cast(View, children(gt)[0])
+    gt_cameras: Container = cast(Container, children(gt)[1])
+    assert cast(list[str], world_gt.contents) == [
         "$origin/**",
         f"- /{ARKIT_MESH}/**",
         f"- /{GT_BOXES}/**",
         f"- /{DEPTH}/**",
         f"- /{CONFIDENCE}/**",
     ]
-
-    laser_depth_view = find_view(blueprint, "depth GT (laser)")
-    assert str(laser_depth_view.origin) == GT_PINHOLE_WIDE
-    assert cast(list[str], laser_depth_view.contents) == ["$origin/depth"]
-
-
-def test_promptda_blueprint_adds_depth_tab_and_world_tab() -> None:
-    blueprint = make_blueprint(portrait=True, include_promptda=True)
-    names = view_names(blueprint)
-    assert "depth PromptDA" in names
-    assert "world PromptDA" in names
-    # The stock views survive untouched.
-    for kept in ("world", "wide", "ultrawide", "depth ARKit", "depth GT (laser)", "confidence", "gyro", "accel"):
-        assert kept in names
-
-    depth_view = find_view(blueprint, "depth PromptDA")
-    assert cast(list[str], depth_view.contents) == ["$origin/depth_promptda"]
+    assert isinstance(gt_cameras, rrb.Vertical)
+    gt_wide: View = cast(View, children(gt_cameras)[0])
+    gt_depth: View = cast(View, children(gt_cameras)[1])
+    gt_ultrawide: View = cast(View, children(gt_cameras)[2])
+    assert cast(list[str], gt_wide.contents) == ["$origin/video", f"/{GT_BOXES}/**"]
+    assert str(gt_depth.origin) == GT_PINHOLE_WIDE
+    assert_depth_view(gt_depth, GT_DEPTH)
+    assert cast(list[str], gt_ultrawide.contents) == ["$origin/video", f"/{GT_BOXES}/**"]
+    assert all(str(view.name) not in {"gyro", "accel"} for view in iter_views(gt))
 
 
-def test_depth_views_override_colormap_range() -> None:
-    """Encoded uint16 depth defaults to a 0-65535 colormap range in the viewer; the views must pin a sane one."""
-    blueprint = make_blueprint(include_promptda=True)
-    for view_name, entity_path in (("depth ARKit", DEPTH), ("depth GT (laser)", GT_DEPTH), ("depth PromptDA", DEPTH_PROMPTDA)):
-        overrides = find_view(blueprint, view_name).visualizer_overrides
-        assert overrides is not None and f"/{entity_path}" in overrides, f"{view_name} is missing its depth_range override"
+def test_portrait_uses_wider_world_column_shares() -> None:
+    _, pages = top_pages(make_blueprint(portrait=True, include_promptda=True, include_gauss_surf=True))
+    capture: Container = pages[0]
+    gt: Container = pages[1]
+    promptda: Container = pages[2]
+    splat: Container = pages[3]
+    assert cast(Container, children(capture)[0]).column_shares == [2.6, 1.0, 1.0]
+    assert gt.column_shares == [2.6, 1.0]
+    assert promptda.column_shares == [2.6, 1.0]
+    assert cast(Container, children(splat)[0]).column_shares == [3.4, 2.0, 1.0]
 
 
-def test_promptda_world_tab_hides_arkit_mesh_and_other_depths() -> None:
-    blueprint = make_blueprint(include_promptda=True)
-    world_promptda = find_view(blueprint, "world PromptDA")
-    contents = cast(list[str], world_promptda.contents)
-    assert f"- /{ARKIT_MESH}/**" in contents
-    assert f"- /{GT_DEPTH}/**" in contents
-    assert f"- /{PINHOLE_WIDE_LOWRES}/**" in contents
-    # Everything else under /world stays visible (boxes, frustum, promptda mesh).
-    assert "$origin/**" in contents
+def test_promptda_page_has_its_world_video_and_two_depth_sources() -> None:
+    _, pages = top_pages(make_blueprint(include_promptda=True))
+    promptda: Container = pages[2]
+    assert isinstance(promptda, rrb.Horizontal)
+    assert promptda.column_shares == [2.0, 1.0]
+    world_promptda: View = cast(View, children(promptda)[0])
+    source_column: Container = cast(Container, children(promptda)[1])
+    assert cast(list[str], world_promptda.contents) == [
+        "$origin/**",
+        f"- /{ARKIT_MESH}/**",
+        f"- /{GT_DEPTH}/**",
+        f"- /{PINHOLE_WIDE_LOWRES}/**",
+    ]
+    assert isinstance(source_column, rrb.Vertical)
+    wide_video: View = cast(View, children(source_column)[0])
+    promptda_depth: View = cast(View, children(source_column)[1])
+    arkit_depth: View = cast(View, children(source_column)[2])
+    assert str(wide_video.origin) == PINHOLE_WIDE
+    assert cast(list[str], wide_video.contents) == ["$origin/video"]
+    assert_depth_view(promptda_depth, DEPTH_PROMPTDA)
+    assert_depth_view(arkit_depth, DEPTH)
 
 
-def test_camera_views_overlay_gt_boxes() -> None:
-    """Both RGB views project the new top-level GT-box subtree."""
-    blueprint = make_blueprint(include_promptda=True)
-    for view_name in ("wide", "ultrawide"):
-        assert f"/{GT_BOXES}/**" in cast(list[str], find_view(blueprint, view_name).contents)
+def test_splat_page_puts_videos_and_predictions_beside_a_dominant_world_view() -> None:
+    _, pages = top_pages(make_blueprint(include_promptda=True, include_gauss_surf=True))
+    splat: Container = pages[3]
+    assert isinstance(splat, rrb.Vertical)
+    assert splat.row_shares == [6, 1]
+    main: Container = cast(Container, children(splat)[0])
+    sharpness: View = cast(View, children(splat)[1])
+    assert isinstance(main, rrb.Horizontal)
+    assert main.column_shares == [4.8, 2.2, 1.0]
+    world_splat: View = cast(View, children(main)[0])
+    videos: Container = cast(Container, children(main)[1])
+    predictions: Container = cast(Container, children(main)[2])
+    assert cast(list[str], world_splat.contents) == [
+        f"/{SPLATS}/**",
+        f"/{PROMPTDA_MESH}",
+        f"/{RIG}",
+        f"/{PINHOLE_WIDE}",
+        f"/{VIDEO_WIDE}",
+    ]
+    mesh_override = cast(list[object], (world_splat.visualizer_overrides or {})[f"/{PROMPTDA_MESH}"])
+    assert any(isinstance(o, rrb.EntityBehavior) for o in mesh_override), "ghost mesh must default to hidden in the Splat tab"
+
+    assert isinstance(videos, rrb.Vertical)
+    wide_video: View = cast(View, children(videos)[0])
+    rgb_tabs: Container = cast(Container, children(videos)[1])
+    assert str(wide_video.name) == "wide video"
+    assert str(wide_video.origin) == PINHOLE_WIDE
+    assert cast(list[str], wide_video.contents) == ["$origin/video"]
+
+    assert isinstance(predictions, rrb.Vertical)
+    wide_depth_tabs: Container = cast(Container, children(predictions)[0])
+    wide_normal_tabs: Container = cast(Container, children(predictions)[1])
+    depth_tabs: Container = cast(Container, children(predictions)[2])
+    normal_tabs: Container = cast(Container, children(predictions)[3])
+    assert isinstance(wide_depth_tabs, rrb.Tabs) and wide_depth_tabs.active_tab == 0
+    wide_splat_depth: View = cast(View, children(wide_depth_tabs)[0])
+    wide_promptda_depth: View = cast(View, children(wide_depth_tabs)[1])
+    assert [str(cast(View, view).name) for view in wide_depth_tabs.contents] == ["splat depth", "PromptDA depth"]
+    assert_depth_view(wide_splat_depth, DEPTH_SPLAT_WIDE)
+    assert_depth_view(wide_promptda_depth, DEPTH_PROMPTDA)
+    assert isinstance(wide_normal_tabs, rrb.Tabs) and wide_normal_tabs.active_tab == 0
+    wide_splat_normals: View = cast(View, children(wide_normal_tabs)[0])
+    wide_moge_normals: View = cast(View, children(wide_normal_tabs)[1])
+    assert [str(cast(View, view).name) for view in wide_normal_tabs.contents] == ["splat normals", "MoGe normals"]
+    assert str(wide_splat_normals.origin) == PINHOLE_WIDE
+    assert cast(list[str], wide_splat_normals.contents) == [f"/{NORMALS_SPLAT_WIDE}"]
+    assert str(wide_moge_normals.origin) == PINHOLE_MOGE
+    assert cast(list[str], wide_moge_normals.contents) == [f"/{NORMALS_MOGE}"]
+    assert isinstance(rgb_tabs, rrb.Tabs) and rgb_tabs.active_tab == 0
+    assert [str(cast(View, view).name) for view in rgb_tabs.contents] == ["video", "rect RGB", "splat RGB"]
+    rgb_video: View = cast(View, children(rgb_tabs)[0])
+    rect_rgb: View = cast(View, children(rgb_tabs)[1])
+    splat_rgb: View = cast(View, children(rgb_tabs)[2])
+    assert str(rgb_video.origin) == PINHOLE_ULTRAWIDE
+    assert cast(list[str], rgb_video.contents) == ["$origin/video"]
+    assert str(rect_rgb.origin) == PINHOLE_ULTRAWIDE_RECT
+    assert str(splat_rgb.origin) == PINHOLE_ULTRAWIDE_RECT
+    assert cast(list[str], rect_rgb.contents) == [f"/{RGB_ULTRAWIDE_RECT}"]
+    assert cast(list[str], splat_rgb.contents) == [f"/{RGB_SPLAT_ULTRAWIDE_RECT}"]
+    assert isinstance(depth_tabs, rrb.Tabs) and depth_tabs.active_tab == 0
+    assert [str(cast(View, view).name) for view in depth_tabs.contents] == ["splat depth", "raycast depth"]
+    assert_depth_view(cast(View, children(depth_tabs)[0]), DEPTH_SPLAT_ULTRAWIDE)
+    assert_depth_view(cast(View, children(depth_tabs)[1]), DEPTH_ULTRAWIDE_RECT)
+    assert isinstance(normal_tabs, rrb.Tabs) and normal_tabs.active_tab == 0
+    assert [str(cast(View, view).name) for view in normal_tabs.contents] == ["splat normals", "MoGe rect normals"]
+    assert cast(list[str], cast(View, children(normal_tabs)[0]).contents) == [f"/{NORMALS_SPLAT_ULTRAWIDE_RECT}"]
+    assert cast(list[str], cast(View, children(normal_tabs)[1]).contents) == [f"/{NORMALS_ULTRAWIDE_RECT}"]
+
+    assert str(sharpness.name) == "sharpness"
+    assert cast(list[str], sharpness.contents) == [f"/{SHARPNESS_WIDE}", f"/{SHARPNESS_ULTRAWIDE}"]
+
+
+def test_fit_triage_page_keeps_the_three_by_three_diagnostic_grid() -> None:
+    _, pages = top_pages(make_blueprint(include_gauss_surf=True))
+    triage: Container = pages[3]
+    assert isinstance(triage, rrb.Horizontal)
+    assert triage.column_shares == [1.0, 2.0]
+    triage_world: View = cast(View, children(triage)[0])
+    grid: Container = cast(Container, children(triage)[1])
+    assert cast(list[str], triage_world.contents) == [f"/{SPLATS}/**", f"/{PROMPTDA_MESH}"]
+    assert isinstance(grid, rrb.Vertical)
+    assert grid.row_shares == [1.0, 1.0, 1.0]
+    triage_entities: dict[str, str] = {
+        "Source RGB": RGB_ULTRAWIDE_RECT,
+        "Fitted RGB": RGB_SPLAT_ULTRAWIDE_RECT,
+        "RGB error [0, 0.5]": ERROR_RGB_ULTRAWIDE_RECT,
+        "Source depth": DEPTH_ULTRAWIDE_RECT,
+        "Fitted depth": DEPTH_SPLAT_ULTRAWIDE,
+        "Depth error [0, 0.5 m]": ERROR_DEPTH_ULTRAWIDE_RECT,
+        "Source normal": NORMALS_ULTRAWIDE_RECT,
+        "Fitted normal": NORMALS_SPLAT_ULTRAWIDE_RECT,
+        "Normal error [0, 45 deg]": ERROR_NORMAL_ULTRAWIDE_RECT,
+    }
+    grid_views: dict[str, View] = {str(view.name): view for view in iter_views(grid)}
+    for view_name, entity_path in triage_entities.items():
+        assert cast(list[str], grid_views[view_name].contents) == [f"/{entity_path}"]
 
 
 def test_table_blueprint_hides_video_depth_and_confidence() -> None:
     """The segment-table preview cards must not pay AV1 decode or depth/confidence uploads."""
-    contents = cast(list[str], find_view(make_table_blueprint(), "world").contents)
+    contents: list[str] = cast(list[str], find_view(make_table_blueprint(), "world").contents)
     for excluded in (VIDEO_WIDE, VIDEO_ULTRAWIDE, GT_DEPTH, DEPTH, CONFIDENCE):
         assert f"- /{excluded}/**" in contents
-    # Mesh, boxes, and frusta stay: everything else under /world remains included.
     assert "$origin/**" in contents

--- a/packages/arkitscenes-download/tests/test_blueprint_framing.py
+++ b/packages/arkitscenes-download/tests/test_blueprint_framing.py
@@ -6,7 +6,7 @@ import numpy as np
 import rerun.blueprint as rrb
 from simplecv.rerun_log_utils import mesh_bounding_geometry, orbit_eye_position
 
-from arkitscenes_download.ingest.blueprint import EXTRA_ZOOM_OUT, FIT_DISTANCE_FACTOR, make_blueprint
+from arkitscenes_download.ingest.blueprint import EXTRA_ZOOM_OUT, FIT_DISTANCE_FACTOR, INSIDE_DISTANCE_FACTOR, make_blueprint
 
 FRAMING_FACTOR: float = FIT_DISTANCE_FACTOR * EXTRA_ZOOM_OUT
 
@@ -29,6 +29,18 @@ class OrbitEyePositionTest(unittest.TestCase):
         large: np.ndarray = orbit_eye_position(center, 10.0, FRAMING_FACTOR)
         self.assertGreater(small[2], 0.0)
         np.testing.assert_allclose(small / np.linalg.norm(small), large / np.linalg.norm(large), atol=1e-12)
+
+
+class InsideEyePositionTest(unittest.TestCase):
+    """Splat views orbit from inside the scene: splats are view-blocking, unlike front-face-only meshes."""
+
+    def test_inside_factor_places_eye_within_the_scene_at_center_height(self) -> None:
+        """The splat eye offset stays well inside the bounding sphere with no vertical offset."""
+        center: np.ndarray = np.array([2.566, -1.774, 0.062])
+        radius: float = 5.44
+        position: np.ndarray = orbit_eye_position(center, radius, INSIDE_DISTANCE_FACTOR, direction_xyz=(1.0, 1.0, 0.0))
+        self.assertLess(float(np.linalg.norm(position - center)), 0.5 * radius)
+        self.assertAlmostEqual(float(position[2]), float(center[2]), places=12)
 
 
 class MeshBoundingGeometryTest(unittest.TestCase):

--- a/packages/arkitscenes-download/tests/test_distortion.py
+++ b/packages/arkitscenes-download/tests/test_distortion.py
@@ -1,0 +1,71 @@
+"""Behavior checks for Apple distortion evaluation and standard-model fitting."""
+
+import numpy as np
+import pytest
+from jaxtyping import Float32
+from numpy import ndarray
+
+from arkitscenes_download.ingest.distortion import AppleRadialPolynomial, OpenCVRationalFit, opencv_rational_from_apple
+
+REAL_ULTRAWIDE_COEFFICIENTS_8: Float32[ndarray, "8"] = np.array(
+    [-0.08353952, -6.350463, 5.248554, -1.9897834, 0.5831521, -0.10259675, 0.009266047, -0.0003309832],
+    dtype=np.float32,
+)
+
+
+def test_apple_even_percent_polynomial_round_trips_real_frame_radii() -> None:
+    """The empirically selected even-power forward model inverts within 0.1 px."""
+    model: AppleRadialPolynomial = AppleRadialPolynomial(REAL_ULTRAWIDE_COEFFICIENTS_8)
+    distorted_radii_n: Float32[ndarray, "n=5"] = np.array([0.0, 0.25, 0.5, 0.75, 1.0], dtype=np.float32)
+
+    rectified_radii_n: Float32[ndarray, "n=5"] = model.distorted_to_rectified_radius(distorted_radii_n)
+    recovered_radii_n: Float32[ndarray, "n=5"] = model.rectified_to_distorted_radius(rectified_radii_n)
+
+    np.testing.assert_allclose(
+        rectified_radii_n,
+        [0.0, 0.24992806, 0.49828497, 0.7403127, 0.97314256],
+        atol=2e-7,
+        rtol=0.0,
+    )
+    max_round_trip_error_px: float = float(np.max(np.abs(recovered_radii_n - distorted_radii_n)) * 2315.9016)
+    assert max_round_trip_error_px < 0.1
+
+
+def test_opencv_rational_fit_conforms_to_the_pinhole_principal_point() -> None:
+    """The standard fit keeps K unchanged and stays below 0.01 px on segment 47115416."""
+    center_reference_xy: Float32[ndarray, "2"] = np.array([1853.150634765625, 1371.03173828125], dtype=np.float32)
+    K_native_33: Float32[ndarray, "3 3"] = np.array(
+        [[245.39100646972656, 0.0, 321.8739929199219], [0.0, 245.39100646972656, 238.02699279785156], [0.0, 0.0, 1.0]],
+        dtype=np.float32,
+    )
+
+    fit: OpenCVRationalFit = opencv_rational_from_apple(
+        K_native_33,
+        REAL_ULTRAWIDE_COEFFICIENTS_8,
+        center_reference_xy,
+        (3680, 2760),
+        (640, 480),
+    )
+
+    assert fit.max_residual_px == pytest.approx(0.005637342, abs=5e-6)
+    np.testing.assert_array_equal(fit.K_33, K_native_33)
+    assert fit.distortion.k1 == pytest.approx(0.1422690471, rel=1e-3)
+    assert fit.distortion.p1 == pytest.approx(-1.7744861e-5, rel=1e-3)
+    assert fit.distortion.p2 == pytest.approx(-1.9211448e-5, rel=1e-3)
+
+
+def test_opencv_rational_fit_rejects_a_non_invertible_calibration() -> None:
+    """A pathological polynomial fails validation instead of returning a bad fit."""
+    collapsing_8: Float32[ndarray, "8"] = np.array([-200.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+    K_native_33: Float32[ndarray, "3 3"] = np.array(
+        [[245.0, 0.0, 320.0], [0.0, 245.0, 240.0], [0.0, 0.0, 1.0]], dtype=np.float32
+    )
+
+    with pytest.raises(ValueError):
+        opencv_rational_from_apple(
+            K_native_33,
+            collapsing_8,
+            np.array([1840.0, 1380.0], dtype=np.float32),
+            (3680, 2760),
+            (640, 480),
+        )

--- a/packages/arkitscenes-download/tests/test_distortion.py
+++ b/packages/arkitscenes-download/tests/test_distortion.py
@@ -54,6 +54,29 @@ def test_opencv_rational_fit_conforms_to_the_pinhole_principal_point() -> None:
     assert fit.distortion.p2 == pytest.approx(-1.9211448e-5, rel=1e-3)
 
 
+def test_opencv_fit_falls_back_to_polynomial_when_the_rational_denominator_misbehaves() -> None:
+    """Segment 42898472's wide lens breaks the free rational denominator; the fit returns the k4..k6=0 polynomial form instead."""
+    coefficients_8: Float32[ndarray, "8"] = np.array(
+        [-0.00605488, -1.2373285, -0.27187824, 0.56518984, -0.19173706, 0.022887468, -0.00016848743, -9.48729e-5],
+        dtype=np.float32,
+    )
+    K_native_33: Float32[ndarray, "3 3"] = np.array(
+        [[1588.395, 0.0, 956.03998], [0.0, 1588.395, 739.82251], [0.0, 0.0, 1.0]], dtype=np.float32
+    )
+
+    fit: OpenCVRationalFit = opencv_rational_from_apple(
+        K_native_33,
+        coefficients_8,
+        np.array([2008.1995, 1554.1533], dtype=np.float32),
+        (4032, 3024),
+        (1920, 1440),
+    )
+
+    assert (fit.distortion.k4, fit.distortion.k5, fit.distortion.k6) == (0.0, 0.0, 0.0)
+    assert fit.max_residual_px < 0.1
+    np.testing.assert_array_equal(fit.K_33, K_native_33)
+
+
 def test_opencv_rational_fit_rejects_a_non_invertible_calibration() -> None:
     """A pathological polynomial fails validation instead of returning a bad fit."""
     collapsing_8: Float32[ndarray, "8"] = np.array([-200.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)

--- a/packages/arkitscenes-download/tests/test_ingest_distortion.py
+++ b/packages/arkitscenes-download/tests/test_ingest_distortion.py
@@ -6,29 +6,53 @@ from pathlib import Path
 import numpy as np
 import rerun as rr
 from rerun.experimental import RrdReader
+from simplecv.camera_parameters import Intrinsics as SimpleCVIntrinsics
 
 from arkitscenes_download.ingest.cli import _log_distortions
+from arkitscenes_download.ingest.distortion import (
+    APPLE_FORWARD_DISTORTION_COMPONENT,
+    APPLE_INVERSE_DISTORTION_COMPONENT,
+)
 from arkitscenes_download.ingest.metadata import CameraDistortion, decode_camera_distortions
 from arkitscenes_download.ingest.paths import PINHOLE_ULTRAWIDE
 
 
-def test_calibration_rrd_persists_both_apple_polynomial_directions(tmp_path: Path) -> None:
-    """The calibration contract labels Apple data and stores both coefficient arrays."""
-    forward_8: np.ndarray = np.arange(8, dtype=np.float32)
-    inverse_8: np.ndarray = -forward_8
+def test_calibration_rrd_logs_canonical_brown_conrady_and_apple_provenance(tmp_path: Path) -> None:
+    """The pinhole gets standard coefficients while both exact Apple arrays remain separate."""
+    forward_8: np.ndarray = np.array(
+        [-0.08353952, -6.350463, 5.248554, -1.9897834, 0.5831521, -0.10259675, 0.009266047, -0.0003309832],
+        dtype=np.float32,
+    )
+    inverse_8: np.ndarray = np.array(
+        [0.06613547, 7.4000044, -8.394783, 5.206168, -1.9468352, 0.3531596, -0.028574973, 0.000752457],
+        dtype=np.float32,
+    )
     calibration = CameraDistortion(
         camera_name="ultrawide",
         coefficients=forward_8,
         inverse_coefficients=inverse_8,
-        center_xy=np.array([100.0, 80.0], dtype=np.float64),
-        reference_dimensions_wh=np.array([200.0, 160.0], dtype=np.float64),
+        center_xy=np.array([1853.150634765625, 1371.03173828125], dtype=np.float64),
+        reference_dimensions_wh=np.array([3680.0, 2760.0], dtype=np.float64),
         timestamp=0.0,
         temporal_sample_count=3,
+    )
+    pinhole_intrinsics = SimpleCVIntrinsics.from_k_matrix(
+        camera_conventions="RDF",
+        k_matrix=np.array(
+            [[245.3910065, 0.0, 321.8739929], [0.0, 245.3910065, 238.0269928], [0.0, 0.0, 1.0]], dtype=np.float32
+        ),
+        width=640,
+        height=480,
     )
     rrd_path: Path = tmp_path / "calibration.rrd"
     with rr.RecordingStream(application_id="distortion_test", recording_id="segment", send_properties=False) as recording:
         recording.save(rrd_path)
-        _log_distortions(recording, [calibration], quarter_turns=0)
+        _log_distortions(
+            recording,
+            [calibration],
+            pinhole_intrinsics_by_camera={"ultrawide": pinhole_intrinsics},
+            quarter_turns=0,
+        )
 
     reader = RrdReader(rrd_path)
     batches = [chunk.to_record_batch() for chunk in reader.stream() if str(chunk.entity_path) == f"/{PINHOLE_ULTRAWIDE}"]
@@ -38,9 +62,19 @@ def test_calibration_rrd_persists_both_apple_polynomial_directions(tmp_path: Pat
             if "Distortion" in name:
                 values_by_component[name] = column.to_pylist()[0][0]
 
-    assert values_by_component["simplecv.components.DistortionModel"] == "apple_radial_poly"
-    np.testing.assert_array_equal(values_by_component["simplecv.components.DistortionCoefficients"], forward_8)
-    np.testing.assert_array_equal(values_by_component["simplecv.components.InverseDistortionCoefficients"], inverse_8)
+    assert values_by_component["simplecv.components.DistortionModel"] == "brown_conrady"
+    standard_14: np.ndarray = np.asarray(values_by_component["simplecv.components.DistortionCoefficients"], dtype=np.float32)
+    assert standard_14.shape == (14,)
+    np.testing.assert_allclose(
+        standard_14[:8],
+        [0.14226905, -0.03264365, -1.7744861e-5, -1.9211448e-5, 0.00754465, 0.14195952, -0.04144133, 0.00897725],
+        atol=3e-5,
+        rtol=0.0,
+    )
+    np.testing.assert_array_equal(standard_14[8:], np.zeros(6, dtype=np.float32))
+    np.testing.assert_array_equal(values_by_component[APPLE_FORWARD_DISTORTION_COMPONENT], forward_8)
+    np.testing.assert_array_equal(values_by_component[APPLE_INVERSE_DISTORTION_COMPONENT], inverse_8)
+    assert "simplecv.components.InverseDistortionCoefficients" not in values_by_component
 
 
 class CameraDistortionTest(unittest.TestCase):

--- a/packages/arkitscenes-download/tests/test_ingest_distortion.py
+++ b/packages/arkitscenes-download/tests/test_ingest_distortion.py
@@ -4,8 +4,43 @@ import unittest
 from pathlib import Path
 
 import numpy as np
+import rerun as rr
+from rerun.experimental import RrdReader
 
-from arkitscenes_download.ingest.metadata import decode_camera_distortions
+from arkitscenes_download.ingest.cli import _log_distortions
+from arkitscenes_download.ingest.metadata import CameraDistortion, decode_camera_distortions
+from arkitscenes_download.ingest.paths import PINHOLE_ULTRAWIDE
+
+
+def test_calibration_rrd_persists_both_apple_polynomial_directions(tmp_path: Path) -> None:
+    """The calibration contract labels Apple data and stores both coefficient arrays."""
+    forward_8: np.ndarray = np.arange(8, dtype=np.float32)
+    inverse_8: np.ndarray = -forward_8
+    calibration = CameraDistortion(
+        camera_name="ultrawide",
+        coefficients=forward_8,
+        inverse_coefficients=inverse_8,
+        center_xy=np.array([100.0, 80.0], dtype=np.float64),
+        reference_dimensions_wh=np.array([200.0, 160.0], dtype=np.float64),
+        timestamp=0.0,
+        temporal_sample_count=3,
+    )
+    rrd_path: Path = tmp_path / "calibration.rrd"
+    with rr.RecordingStream(application_id="distortion_test", recording_id="segment", send_properties=False) as recording:
+        recording.save(rrd_path)
+        _log_distortions(recording, [calibration], quarter_turns=0)
+
+    reader = RrdReader(rrd_path)
+    batches = [chunk.to_record_batch() for chunk in reader.stream() if str(chunk.entity_path) == f"/{PINHOLE_ULTRAWIDE}"]
+    values_by_component: dict[str, object] = {}
+    for batch in batches:
+        for name, column in zip(batch.schema.names, batch.columns, strict=True):
+            if "Distortion" in name:
+                values_by_component[name] = column.to_pylist()[0][0]
+
+    assert values_by_component["simplecv.components.DistortionModel"] == "apple_radial_poly"
+    np.testing.assert_array_equal(values_by_component["simplecv.components.DistortionCoefficients"], forward_8)
+    np.testing.assert_array_equal(values_by_component["simplecv.components.InverseDistortionCoefficients"], inverse_8)
 
 
 class CameraDistortionTest(unittest.TestCase):

--- a/packages/arkitscenes-download/tests/test_ingest_distortion.py
+++ b/packages/arkitscenes-download/tests/test_ingest_distortion.py
@@ -9,16 +9,12 @@ from rerun.experimental import RrdReader
 from simplecv.camera_parameters import Intrinsics as SimpleCVIntrinsics
 
 from arkitscenes_download.ingest.cli import _log_distortions
-from arkitscenes_download.ingest.distortion import (
-    APPLE_FORWARD_DISTORTION_COMPONENT,
-    APPLE_INVERSE_DISTORTION_COMPONENT,
-)
 from arkitscenes_download.ingest.metadata import CameraDistortion, decode_camera_distortions
 from arkitscenes_download.ingest.paths import PINHOLE_ULTRAWIDE
 
 
-def test_calibration_rrd_logs_canonical_brown_conrady_and_apple_provenance(tmp_path: Path) -> None:
-    """The pinhole gets standard coefficients while both exact Apple arrays remain separate."""
+def test_calibration_rrd_logs_only_canonical_brown_conrady_distortion(tmp_path: Path) -> None:
+    """The pinhole stores the standard model and 14-vector without Apple coefficient components."""
     forward_8: np.ndarray = np.array(
         [-0.08353952, -6.350463, 5.248554, -1.9897834, 0.5831521, -0.10259675, 0.009266047, -0.0003309832],
         dtype=np.float32,
@@ -56,9 +52,11 @@ def test_calibration_rrd_logs_canonical_brown_conrady_and_apple_provenance(tmp_p
 
     reader = RrdReader(rrd_path)
     batches = [chunk.to_record_batch() for chunk in reader.stream() if str(chunk.entity_path) == f"/{PINHOLE_ULTRAWIDE}"]
+    component_names: set[str] = set()
     values_by_component: dict[str, object] = {}
     for batch in batches:
         for name, column in zip(batch.schema.names, batch.columns, strict=True):
+            component_names.add(name)
             if "Distortion" in name:
                 values_by_component[name] = column.to_pylist()[0][0]
 
@@ -72,9 +70,10 @@ def test_calibration_rrd_logs_canonical_brown_conrady_and_apple_provenance(tmp_p
         rtol=0.0,
     )
     np.testing.assert_array_equal(standard_14[8:], np.zeros(6, dtype=np.float32))
-    np.testing.assert_array_equal(values_by_component[APPLE_FORWARD_DISTORTION_COMPONENT], forward_8)
-    np.testing.assert_array_equal(values_by_component[APPLE_INVERSE_DISTORTION_COMPONENT], inverse_8)
     assert "simplecv.components.InverseDistortionCoefficients" not in values_by_component
+    assert not any(name.startswith("arkitscenes.components.Apple") for name in component_names)
+    assert "distortion_source" not in component_names
+    assert "distortion_temporal_sample_count" not in component_names
 
 
 class CameraDistortionTest(unittest.TestCase):

--- a/packages/arkitscenes-download/tests/test_paths.py
+++ b/packages/arkitscenes-download/tests/test_paths.py
@@ -1,6 +1,17 @@
 """Canonical ARKitScenes entity-path checks."""
 
-from arkitscenes_download.ingest.paths import ARKIT_MESH, GT, GT_BOXES, GT_CAM_WIDE, GT_DEPTH, GT_PINHOLE_WIDE, GT_RIG, gt_box
+from arkitscenes_download.ingest.paths import (
+    ARKIT_MESH,
+    GT,
+    GT_BOXES,
+    GT_CAM_WIDE,
+    GT_DEPTH,
+    GT_PINHOLE_WIDE,
+    GT_RIG,
+    NORMALS_SPLAT_WIDE,
+    PINHOLE_WIDE,
+    gt_box,
+)
 
 
 def test_arkit_and_laser_ground_truth_paths_are_separate() -> None:
@@ -13,3 +24,7 @@ def test_arkit_and_laser_ground_truth_paths_are_separate() -> None:
     assert GT_CAM_WIDE == "world/gt/rig_00/cam_00"
     assert GT_PINHOLE_WIDE == "world/gt/rig_00/cam_00/pinhole"
     assert GT_DEPTH == "world/gt/rig_00/cam_00/pinhole/depth"
+
+
+def test_wide_splat_normals_share_the_wide_pinhole() -> None:
+    assert f"{PINHOLE_WIDE}/normals_splat" == NORMALS_SPLAT_WIDE


### PR DESCRIPTION
ARKitScenes viewer blueprints, rebuilt as per-page builders (stack 2/5).

- `make_blueprint` split into five page builders — **Capture / GT / PromptDA / Splat / Fit triage** — composed by option gates in one place (no feature checks scattered through builders).
- New **Splat page**: 3-column layout with a camera-chase 3D view (rig-relative eye offset, NTU-VIRAL pattern; `tracking_entity` follow modes don't engage from static blueprints — documented upstream TODO), ghost PromptDA mesh hidden by default via `EntityBehavior`.
- `DEPTH_RANGE_MM`'s canonical home moves to `arkitscenes_download.schema` (blueprint re-exports for existing callers).
- cli/metadata/paths updates + blueprint/framing/distortion/path tests.
- **Canonical distortion logging**: pinholes carry the standard simplecv `model="brown_conrady"` + 14-coefficient components, fitted per calibration at ingest (tangential terms absorb Apple's 0.41 px center offset; worst-case 0.006–0.008 px vs ~10.8 px distortion). The exact mebx polynomials are NOT logged — they remain ingest-internal (decode + fit in `ingest/distortion.py`); recordings carry the standard model only, plus center/reference framing metadata. `AppleRadialPolynomial` + the validated rational fit live here (`ingest/distortion.py`) — ingest owns the mebx decode.

**Behavior proof**: the per-page split was verified structurally identical to the pre-split blueprint across all 8 option combinations (UUID-stripped structural dump; raw `.rbl` bytes are nondeterministic even between two saves of unchanged code, which is why bytes aren't the golden).

**Testing**: arkitscenes-download-dev lint/typecheck/deadcode/tests — 56 passed, 4 skipped. Known follow-up (deliberately not in this stack): the layout test's cast-density cleanup.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


