### PR TITLE
gauss-surf: package foundations — contracts, SegmentReader catalog, render_io, PGSR geometry/losses

### DIFF
--- a/packages/gauss-surf/.envrc
+++ b/packages/gauss-surf/.envrc
@@ -1,0 +1,4 @@
+watch_file ../../pixi.lock
+PIXI_ENV="${PIXI_ENV:-gauss-surf-dev}"
+source_env_if_exists .envrc.local
+eval "$(pixi shell-hook -e "$PIXI_ENV" --manifest-path ../.. --frozen)"

--- a/packages/gauss-surf/pyproject.toml
+++ b/packages/gauss-surf/pyproject.toml
@@ -1,0 +1,45 @@
+[project]
+authors = [{ name = "pablo vela", email = "pablovela5620@gmail.com" }]
+dependencies = []
+description = "GausSurf splat pipeline over ARKitScenes catalog segments: frame selection, MoGe normals, ultrawide signals, and a depth+normal-supervised Gaussian splat"
+name = "gauss-surf"
+requires-python = ">= 3.12"
+version = "0.1.0"
+
+[build-system]
+build-backend = "hatchling.build"
+requires = ["hatchling"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/gauss_surf"]
+
+[tool.ruff]
+line-length = 150
+
+[tool.ruff.lint]
+select = ["E", "F", "UP", "B", "SIM", "I"]
+ignore = ["E501", "F722", "F821", "UP037", "UP040"]
+
+[tool.vulture]
+paths = ["src/gauss_surf", "tests", "tools"]
+exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modules/*"]
+sort_by_size = true
+min_confidence = 60
+ignore_names = [
+    "rr_config",
+    "recover_derived_layers",
+    "consistency_mask_fraction",
+    "kind",
+    "fx",
+    "fy",
+    "cx",
+    "cy",
+    "frames_per_second",
+    "wide_depth",
+    "ultrawide_depth",
+    "triage",
+    "rrd_paths",
+    "product_frames",
+    "wide_normal_frames",
+    "ultrawide",
+]

--- a/packages/gauss-surf/src/gauss_surf/__init__.py
+++ b/packages/gauss-surf/src/gauss_surf/__init__.py
@@ -1,0 +1,6 @@
+import os
+
+if os.environ.get("PIXI_DEV_MODE") == "1":
+    from beartype.claw import beartype_this_package
+
+    beartype_this_package()

--- a/packages/gauss-surf/src/gauss_surf/catalog.py
+++ b/packages/gauss-surf/src/gauss_surf/catalog.py
@@ -1,0 +1,297 @@
+"""Shared Rerun catalog connection, segment reads, and layer registration."""
+
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, TypeAlias
+
+import numpy as np
+import pyarrow as pa
+import torch
+from arkitscenes_download.ingest.paths import TIMELINE
+from beartype.roar import BeartypeException
+from datafusion import col
+from jaxtyping import Bool, Float32, Int64, Shaped, UInt8
+from numpy import ndarray
+from rerun.catalog import CatalogClient, DatasetEntry, DatasetView, OnDuplicateSegmentLayer, RegistrationHandle
+from simplecv.rerun_dataloader import SegmentNvdecDecoder
+from torch import Tensor
+
+DEFAULT_CATALOG_URL: str = "rerun+http://127.0.0.1:51236"
+"""Development catalog server URL for gauss-surf."""
+DEFAULT_DATASET_NAME: str = "arkitscenes-v2"
+"""Development ARKitScenes dataset used by the staged gauss-surf pipeline."""
+
+TimedeltaNs: TypeAlias = Shaped[ndarray, " n"]
+"""One-dimensional ``timedelta64[ns]`` timestamps."""
+
+
+def _single_instance(value: Any, component_name: str) -> Any:
+    """Unwrap one Rerun archetype instance from an Arrow cell."""
+    if value is None or not isinstance(value, list) or len(value) != 1:
+        raise ValueError(f"component {component_name!r} has no unambiguous single instance")
+    return value[0]
+
+
+def table_timestamps(table: pa.Table) -> TimedeltaNs:
+    """Return an Arrow table timeline as ``timedelta64[ns]`` values."""
+    values_n: ndarray = table.column(TIMELINE).combine_chunks().to_numpy(zero_copy_only=False)
+    return np.asarray(values_n, dtype="timedelta64[ns]")
+
+
+def _matrix_from_cell(value: Any, component_name: str) -> Float32[ndarray, "3 3"]:
+    """Decode one column-major Rerun 3x3 matrix cell."""
+    return np.asarray(_single_instance(value, component_name), dtype=np.float32).reshape(3, 3, order="F")
+
+
+def _resolution_from_cell(value: Any, component_name: str) -> tuple[int, int]:
+    """Decode one Rerun resolution cell as width and height."""
+    resolution_2: Float32[ndarray, "2"] = np.asarray(_single_instance(value, component_name), dtype=np.float32)
+    return int(round(float(resolution_2[0]))), int(round(float(resolution_2[1])))
+
+
+def match_exact_timestamps(packet_times_n: TimedeltaNs, target_times_n: TimedeltaNs) -> Int64[ndarray, "n_targets"]:
+    """Resolve target times to exact packet indices without nearest-neighbor drift.
+
+    Args:
+        packet_times_n: Decoder packet timestamps shaped ``n_packets``.
+        target_times_n: Target timestamps shaped ``n_targets``.
+
+    Returns:
+        int64 packet indices shaped ``n_targets``.
+
+    Raises:
+        ValueError: If either input is not one-dimensional, the packet timeline
+            is unsorted, or any target time is absent from the packet timeline.
+    """
+    if packet_times_n.ndim != 1 or target_times_n.ndim != 1:
+        raise ValueError("Packet and target timestamps must be one-dimensional")
+    packet_ns_n: TimedeltaNs = np.asarray(packet_times_n, dtype="timedelta64[ns]")
+    target_ns_n: TimedeltaNs = np.asarray(target_times_n, dtype="timedelta64[ns]")
+    if np.any(packet_ns_n[1:] < packet_ns_n[:-1]):
+        raise ValueError("Packet timestamps must be sorted")
+    matched_indices_n: Int64[ndarray, "n_targets"] = np.searchsorted(packet_ns_n, target_ns_n, side="left").astype(np.int64)
+    in_bounds_n: Bool[ndarray, "n_targets"] = matched_indices_n < len(packet_ns_n)
+    exact_n: Bool[ndarray, "n_targets"] = np.zeros(len(target_ns_n), dtype=np.bool_)
+    exact_n[in_bounds_n] = packet_ns_n[matched_indices_n[in_bounds_n]] == target_ns_n[in_bounds_n]
+    if not np.all(exact_n):
+        first_missing: np.timedelta64 = target_ns_n[int(np.flatnonzero(~exact_n)[0])]
+        raise ValueError(f"target timestamp {first_missing} has no exact video-packet match")
+    return matched_indices_n
+
+
+def connect_catalog(
+    catalog_url: str = DEFAULT_CATALOG_URL,
+    dataset_name: str = DEFAULT_DATASET_NAME,
+    *,
+    create_missing: bool = False,
+) -> CatalogClient:
+    """Connect to a catalog and optionally create the requested dataset.
+
+    Args:
+        catalog_url: Rerun catalog server URL.
+        dataset_name: Dataset to resolve on the server.
+        create_missing: Create ``dataset_name`` when it does not exist.
+
+    Returns:
+        Connected catalog client.
+    """
+    try:
+        client: CatalogClient = CatalogClient(catalog_url)
+        dataset_names: list[str] = client.dataset_names()
+        if create_missing and dataset_name not in dataset_names:
+            client.create_dataset(dataset_name, exist_ok=True)
+    except BeartypeException:
+        raise
+    except Exception as error:
+        raise SystemExit(f"catalog not reachable at {catalog_url} — start it with `pixi run gauss-surf-serve`") from error
+    if not create_missing and dataset_name not in dataset_names:
+        raise SystemExit(f"dataset {dataset_name!r} is absent — seed it with `pixi run gauss-surf-register-segment --video-id <id>`")
+    return client
+
+
+@dataclass(slots=True)
+class SegmentReader:
+    """Composable reads for one existing catalog segment."""
+
+    dataset: DatasetEntry
+    """Catalog dataset entry containing the bound segment."""
+    video_id: str
+    """Exact catalog segment identifier."""
+    _cached_row: dict[str, Any] | None = field(default=None, init=False, repr=False)
+    """Lazily cached segment-table row."""
+
+    @classmethod
+    def open(
+        cls,
+        catalog_url: str,
+        dataset_name: str,
+        video_id: str,
+    ) -> "SegmentReader":
+        """Connect to an existing dataset and bind a reader to one segment.
+
+        Args:
+            catalog_url: Rerun catalog server URL.
+            dataset_name: Existing dataset name.
+            video_id: Exact segment identifier.
+
+        Returns:
+            A reader whose individual methods load only the requested data.
+        """
+        client: CatalogClient = connect_catalog(catalog_url, dataset_name)
+        dataset: DatasetEntry = client.get_dataset(dataset_name)
+        return cls(dataset, video_id)
+
+    def row(self) -> dict[str, Any]:
+        """Return the unique segment-table row, loading and caching it on first use."""
+        if self._cached_row is not None:
+            return self._cached_row
+        segment_table: pa.Table = pa.Table.from_batches(self.dataset.segment_table().collect())
+        rows: list[dict[str, Any]] = segment_table.to_pylist()
+        matching_rows: list[dict[str, Any]] = [row for row in rows if str(row["rerun_segment_id"]) == self.video_id]
+        if not matching_rows:
+            available_ids: list[str] = [str(row["rerun_segment_id"]) for row in rows]
+            raise SystemExit(f"video id {self.video_id!r} is absent; available ids: {', '.join(available_ids)}")
+        if len(matching_rows) != 1:
+            raise SystemExit(f"catalog dataset has {len(matching_rows)} rows for segment {self.video_id!r}")
+        self._cached_row = matching_rows[0]
+        return self._cached_row
+
+    def require_layers(self, required_layers: tuple[str, ...]) -> None:
+        """Exit cleanly when the segment lacks any requested upstream layer.
+
+        Args:
+            required_layers: Layer names the caller needs before it can run.
+        """
+        layer_names: set[str] = {str(name) for name in self.row()["rerun_layer_names"]}
+        missing_layers: list[str] = sorted(set(required_layers) - layer_names)
+        if missing_layers:
+            raise SystemExit(f"segment {self.video_id} is missing required layers: {missing_layers}")
+
+    def require_zero_orientation(self, stage_context: str) -> None:
+        """Require the baked zero-quarter-turn camera orientation.
+
+        Args:
+            stage_context: Human-readable stage constraint used in errors.
+        """
+        property_name: str = "property:capture:orientation_quarter_turns_ccw"
+        property_value: Any = self.row().get(property_name)
+        if isinstance(property_value, (list, np.ndarray)):
+            if len(property_value) == 0:
+                raise SystemExit(f"segment {self.video_id} has an empty catalog property {property_name!r}")
+            property_value = property_value[0]
+        if property_value is None:
+            raise SystemExit(f"segment {self.video_id} is missing required catalog property {property_name!r}")
+        quarter_turns: int = int(property_value)
+        if quarter_turns != 0:
+            raise SystemExit(
+                f"segment {self.video_id} has {property_name}={quarter_turns}; {stage_context} supports only zero quarter-turns"
+            )
+
+    def segment_view(self) -> DatasetView:
+        """Return the catalog query view filtered to this segment."""
+        self.row()
+        return self.dataset.filter_segments(self.video_id)
+
+    def chosen_table(self, chosen_column: str, columns: tuple[str, ...]) -> pa.Table:
+        """Read chosen timestamps and requested latest-at columns in time order.
+
+        Args:
+            chosen_column: Sparse component whose non-null rows define selection.
+            columns: Components to join at each chosen timestamp.
+
+        Returns:
+            Non-empty Arrow table containing ``time`` and ``columns``.
+        """
+        segment_view: DatasetView = self.segment_view()
+        available_columns: set[str] = set(segment_view.arrow_schema().names)
+        missing_columns: list[str] = [name for name in (chosen_column, *columns) if name not in available_columns]
+        if missing_columns:
+            raise SystemExit(f"segment {self.video_id} is missing required chosen-frame columns: {missing_columns}")
+        table: pa.Table = (
+            segment_view.reader(index=TIMELINE, fill_latest_at=True)
+            .filter(col(f'"{chosen_column}"').is_not_null())
+            .select(TIMELINE, *columns)
+            .sort(TIMELINE)
+            .to_arrow_table()
+        )
+        if table.num_rows == 0:
+            raise SystemExit(f"segment {self.video_id} selection {chosen_column!r} contains no rows")
+        return table
+
+    def pose_table(self, translation_column: str, quaternion_column: str) -> pa.Table:
+        """Read a non-empty pose track in timestamp order.
+
+        Args:
+            translation_column: Transform translation component.
+            quaternion_column: Transform quaternion component.
+
+        Returns:
+            Arrow table containing exact pose timestamps and both components.
+        """
+        segment_view: DatasetView = self.segment_view()
+        available_columns: set[str] = set(segment_view.arrow_schema().names)
+        missing_columns: list[str] = [name for name in (translation_column, quaternion_column) if name not in available_columns]
+        if missing_columns:
+            raise SystemExit(f"segment {self.video_id} is missing required pose columns: {missing_columns}")
+        table: pa.Table = (
+            segment_view.reader(index=TIMELINE, fill_latest_at=False)
+            .filter(col(f'"{translation_column}"').is_not_null() & col(f'"{quaternion_column}"').is_not_null())
+            .select(TIMELINE, translation_column, quaternion_column)
+            .sort(TIMELINE)
+            .to_arrow_table()
+        )
+        if table.num_rows == 0:
+            raise SystemExit(f"segment {self.video_id} has no pose track")
+        return table
+
+    def decode_frames(
+        self,
+        entity_path: str,
+        timestamps_n: TimedeltaNs,
+        *,
+        fps: float,
+        device: torch.device,
+    ) -> Iterator[UInt8[Tensor, "3 h w"]]:
+        """Decode video frames at exact requested timestamps.
+
+        Args:
+            entity_path: VideoStream entity to decode.
+            timestamps_n: Requested ``timedelta64[ns]`` timestamps shaped ``n``.
+            fps: Nominal packet rate used by the decoder.
+            device: Torch device that receives decoded frames.
+
+        Yields:
+            uint8 RGB frames shaped ``3 h w`` in requested timestamp order.
+        """
+        decoder: SegmentNvdecDecoder = SegmentNvdecDecoder(self.dataset, entity_path, TIMELINE, device, int(fps))
+        empty_raw: pa.ChunkedArray = pa.chunked_array([], type=pa.uint8())
+        timestamps_verified: bool = False
+        for timestamp in timestamps_n:
+            frame_chw: UInt8[Tensor, "3 h w"] | None = decoder.decode(empty_raw, timestamp, self.video_id)
+            if frame_chw is None:
+                raise RuntimeError(f"{entity_path} decoder returned no frame at requested timestamp {timestamp}")
+            if not timestamps_verified:
+                matched_indices_n: Int64[ndarray, "n"] = match_exact_timestamps(decoder.times, timestamps_n)
+                if len(np.unique(matched_indices_n)) != len(matched_indices_n):
+                    raise RuntimeError(f"requested {entity_path} timestamps do not map one-to-one onto video packets")
+                timestamps_verified = True
+            yield frame_chw
+
+
+def register_layer(dataset: DatasetEntry, rrd_path: Path, layer_name: str) -> None:
+    """Register one layer RRD with clean replacement semantics.
+
+    Args:
+        dataset: Target catalog dataset.
+        rrd_path: Complete local layer recording.
+        layer_name: Catalog layer name assigned to the recording.
+    """
+    if not rrd_path.is_file():
+        raise FileNotFoundError(rrd_path)
+    registration: RegistrationHandle = dataset.register(
+        [rrd_path.resolve().as_uri()],
+        layer_name=layer_name,
+        on_duplicate=OnDuplicateSegmentLayer.REPLACE,
+    )
+    registration.wait()

--- a/packages/gauss-surf/src/gauss_surf/contracts.py
+++ b/packages/gauss-surf/src/gauss_surf/contracts.py
@@ -2,7 +2,16 @@
 
 from typing import Final, Literal, TypeAlias
 
-from arkitscenes_download.ingest.paths import CAM_ULTRAWIDE, DEPTH_PROMPTDA, FRAME_SELECTION_ULTRAWIDE, FRAME_SELECTION_WIDE, PINHOLE_WIDE, RIG
+from arkitscenes_download.ingest.distortion import APPLE_FORWARD_DISTORTION_COMPONENT, APPLE_INVERSE_DISTORTION_COMPONENT
+from arkitscenes_download.ingest.paths import (
+    CAM_ULTRAWIDE,
+    DEPTH_PROMPTDA,
+    FRAME_SELECTION_ULTRAWIDE,
+    FRAME_SELECTION_WIDE,
+    PINHOLE_ULTRAWIDE,
+    PINHOLE_WIDE,
+    RIG,
+)
 
 PROMPTDA_LAYER: Final[str] = "promptda"
 FRAME_SELECTION_LAYER: Final[str] = "frame_selection"
@@ -52,6 +61,16 @@ ULTRAWIDE_TRANSLATION_COLUMN: Final[str] = f"/{CAM_ULTRAWIDE}:Transform3D:transl
 """Static ultrawide-to-wide translation component."""
 ULTRAWIDE_QUATERNION_COLUMN: Final[str] = f"/{CAM_ULTRAWIDE}:Transform3D:quaternion"
 """Static ultrawide-to-wide quaternion component."""
+DISTORTION_MODEL_COLUMN: Final[str] = f"/{PINHOLE_ULTRAWIDE}:simplecv.components.DistortionModel"
+"""Generic standard-model label on the native ultrawide pinhole."""
+LEGACY_DISTORTION_COEFFICIENTS_COLUMN: Final[str] = f"/{PINHOLE_ULTRAWIDE}:simplecv.components.DistortionCoefficients"
+"""Generic coefficient column that held Apple data in legacy corpus recordings."""
+APPLE_FORWARD_DISTORTION_COLUMN: Final[str] = f"/{PINHOLE_ULTRAWIDE}:{APPLE_FORWARD_DISTORTION_COMPONENT}"
+"""Exact Apple distorted-to-rectified polynomial provenance."""
+APPLE_INVERSE_DISTORTION_COLUMN: Final[str] = f"/{PINHOLE_ULTRAWIDE}:{APPLE_INVERSE_DISTORTION_COMPONENT}"
+"""Apple's supplied rectified-to-distorted polynomial provenance."""
+LEGACY_APPLE_DISTORTION_MODELS: Final[frozenset[str]] = frozenset({"apple_radial_poly", "brown_conrady"})
+"""Known old labels under which corpus recordings stored Apple coefficients."""
 PROMPTDA_DEPTH_BLOB_COLUMN: Final[str] = f"/{DEPTH_PROMPTDA}:EncodedDepthImage:blob"
 """PromptDA encoded depth blob component."""
 

--- a/packages/gauss-surf/src/gauss_surf/contracts.py
+++ b/packages/gauss-surf/src/gauss_surf/contracts.py
@@ -1,0 +1,58 @@
+"""Shared catalog-layer contracts for gauss-surf."""
+
+from typing import Final, Literal, TypeAlias
+
+from arkitscenes_download.ingest.paths import CAM_ULTRAWIDE, DEPTH_PROMPTDA, FRAME_SELECTION_ULTRAWIDE, FRAME_SELECTION_WIDE, PINHOLE_WIDE, RIG
+
+PROMPTDA_LAYER: Final[str] = "promptda"
+FRAME_SELECTION_LAYER: Final[str] = "frame_selection"
+MOGE_NORMALS_LAYER: Final[str] = "moge_normals"
+ULTRAWIDE_DEPTH_LAYER: Final[str] = "ultrawide_depth"
+ULTRAWIDE_NORMALS_LAYER: Final[str] = "ultrawide_normals"
+SPLAT_LAYER: Final[str] = "splat"
+SPLAT_DEPTH_LAYER: Final[str] = "splat_depth"
+SPLAT_TRIAGE_LAYER: Final[str] = "splat_triage"
+
+LAYERS: Final[dict[str, str]] = {
+    PROMPTDA_LAYER: "data/promptda/{video_id}.rrd",
+    FRAME_SELECTION_LAYER: "data/frame_selection/{video_id}.rrd",
+    MOGE_NORMALS_LAYER: "data/moge_normals/{video_id}.rrd",
+    ULTRAWIDE_DEPTH_LAYER: "data/ultrawide_signals/{video_id}/ultrawide_depth.rrd",
+    ULTRAWIDE_NORMALS_LAYER: "data/ultrawide_signals/{video_id}/ultrawide_normals.rrd",
+    SPLAT_LAYER: "data/splat/{video_id}.rrd",
+    SPLAT_DEPTH_LAYER: "data/splat_depth/{video_id}.rrd",
+    SPLAT_TRIAGE_LAYER: "data/splat_triage/{video_id}.rrd",
+}
+"""Derived layer name to local per-segment recovery path."""
+
+WIDE_FPS: Final[float] = 60.0
+"""Nominal wide-camera packet rate."""
+ULTRAWIDE_FPS: Final[float] = 10.0
+"""Nominal ultrawide-camera packet rate."""
+MOGE_INFERENCE_BATCH_SIZE: Final[int] = 8
+"""Fixed TensorRT batch size for both MoGe normal stages."""
+RGB_JPEG_QUALITY: Final[int] = 90
+"""JPEG quality used for fitted and rectified RGB products."""
+RENDER_BACKGROUND: Final[tuple[float, float, float]] = (0.1490, 0.1647, 0.2157)
+"""Fixed RGB background shared by holdout evaluation and publication."""
+
+WIDE_CHOSEN_SHARPNESS_COLUMN: Final[str] = f"/{FRAME_SELECTION_WIDE}:sharpness"
+"""Sparse chosen-wide-frame component."""
+ULTRAWIDE_CHOSEN_SHARPNESS_COLUMN: Final[str] = f"/{FRAME_SELECTION_ULTRAWIDE}:sharpness"
+"""Sparse chosen-ultrawide-frame component."""
+WIDE_INTRINSICS_COLUMN: Final[str] = f"/{PINHOLE_WIDE}:Pinhole:image_from_camera"
+"""Temporal native wide-camera intrinsic matrix component."""
+WIDE_RESOLUTION_COLUMN: Final[str] = f"/{PINHOLE_WIDE}:Pinhole:resolution"
+"""Temporal native wide-camera resolution component."""
+RIG_TRANSLATION_COLUMN: Final[str] = f"/{RIG}:Transform3D:translation"
+"""Temporal rig translation component."""
+RIG_QUATERNION_COLUMN: Final[str] = f"/{RIG}:Transform3D:quaternion"
+"""Temporal rig quaternion component."""
+ULTRAWIDE_TRANSLATION_COLUMN: Final[str] = f"/{CAM_ULTRAWIDE}:Transform3D:translation"
+"""Static ultrawide-to-wide translation component."""
+ULTRAWIDE_QUATERNION_COLUMN: Final[str] = f"/{CAM_ULTRAWIDE}:Transform3D:quaternion"
+"""Static ultrawide-to-wide quaternion component."""
+PROMPTDA_DEPTH_BLOB_COLUMN: Final[str] = f"/{DEPTH_PROMPTDA}:EncodedDepthImage:blob"
+"""PromptDA encoded depth blob component."""
+
+CameraTag: TypeAlias = Literal["wide", "uw"]

--- a/packages/gauss-surf/src/gauss_surf/contracts.py
+++ b/packages/gauss-surf/src/gauss_surf/contracts.py
@@ -2,7 +2,6 @@
 
 from typing import Final, Literal, TypeAlias
 
-from arkitscenes_download.ingest.distortion import APPLE_FORWARD_DISTORTION_COMPONENT, APPLE_INVERSE_DISTORTION_COMPONENT
 from arkitscenes_download.ingest.paths import (
     CAM_ULTRAWIDE,
     DEPTH_PROMPTDA,
@@ -63,14 +62,8 @@ ULTRAWIDE_QUATERNION_COLUMN: Final[str] = f"/{CAM_ULTRAWIDE}:Transform3D:quatern
 """Static ultrawide-to-wide quaternion component."""
 DISTORTION_MODEL_COLUMN: Final[str] = f"/{PINHOLE_ULTRAWIDE}:simplecv.components.DistortionModel"
 """Generic standard-model label on the native ultrawide pinhole."""
-LEGACY_DISTORTION_COEFFICIENTS_COLUMN: Final[str] = f"/{PINHOLE_ULTRAWIDE}:simplecv.components.DistortionCoefficients"
-"""Generic coefficient column that held Apple data in legacy corpus recordings."""
-APPLE_FORWARD_DISTORTION_COLUMN: Final[str] = f"/{PINHOLE_ULTRAWIDE}:{APPLE_FORWARD_DISTORTION_COMPONENT}"
-"""Exact Apple distorted-to-rectified polynomial provenance."""
-APPLE_INVERSE_DISTORTION_COLUMN: Final[str] = f"/{PINHOLE_ULTRAWIDE}:{APPLE_INVERSE_DISTORTION_COMPONENT}"
-"""Apple's supplied rectified-to-distorted polynomial provenance."""
-LEGACY_APPLE_DISTORTION_MODELS: Final[frozenset[str]] = frozenset({"apple_radial_poly", "brown_conrady"})
-"""Known old labels under which corpus recordings stored Apple coefficients."""
+DISTORTION_COEFFICIENTS_COLUMN: Final[str] = f"/{PINHOLE_ULTRAWIDE}:simplecv.components.DistortionCoefficients"
+"""Standard 14-value Brown-Conrady coefficient component."""
 PROMPTDA_DEPTH_BLOB_COLUMN: Final[str] = f"/{DEPTH_PROMPTDA}:EncodedDepthImage:blob"
 """PromptDA encoded depth blob component."""
 

--- a/packages/gauss-surf/src/gauss_surf/frame_selection.py
+++ b/packages/gauss-surf/src/gauss_surf/frame_selection.py
@@ -1,0 +1,184 @@
+"""Pure sharp-frame scoring and selection policies."""
+
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+import torch.nn.functional as functional
+from einops import rearrange
+from jaxtyping import Float32, Int64, UInt8
+from numpy import ndarray
+from torch import Tensor
+
+from gauss_surf.catalog import TimedeltaNs
+
+SCORE_HEIGHT: int = 540
+"""Fixed scoring height inherited from the reference frame-selection fork."""
+SCORE_WIDTH: int = 720
+"""Fixed scoring width inherited from the reference frame-selection fork."""
+
+@dataclass(frozen=True, slots=True)
+class SelectionResult:
+    """Dense frame measurements and sparse chosen-frame metadata."""
+
+    timestamps: TimedeltaNs
+    """Packet timestamp for every scored frame, as ``timedelta64[ns]``."""
+    sharpness: Float32[ndarray, "n_frames"]
+    """Resolution-normalized variance-of-Laplacian score for every frame."""
+    chosen_indices: Int64[ndarray, "n_chosen"]
+    """Zero-based source-frame indices admitted by the selection rule."""
+    chosen_timestamps: TimedeltaNs
+    """Packet timestamps for admitted frames, as ``timedelta64[ns]``."""
+    windows: Int64[ndarray, "n_chosen"]
+    """Fixed window index for each admitted frame, or its source index when unwindowed."""
+    rules: tuple[str, ...]
+    """Small admission-rule code for each admitted frame."""
+    rejected: bool
+    """Whether the segment failed the minimum chosen-frame policy."""
+    rejection_reason: str | None
+    """Human-readable rejection reason, or None for an accepted result."""
+
+
+@dataclass(frozen=True, slots=True)
+class FrameScores:
+    """Per-frame sharpness and texture measurements."""
+
+    sharpness: Float32[Tensor, "b"]
+    """Variance of the grayscale Laplacian at the fixed scoring resolution."""
+    texture: Float32[Tensor, "b"]
+    """Grayscale population standard deviation at the fixed scoring resolution."""
+
+
+def score_frames(frames_bhw3: UInt8[Tensor, "b h w 3"]) -> FrameScores:
+    """Measure sharpness and texture for a CPU or CUDA RGB frame batch.
+
+    Every frame is first converted to grayscale and resized to 720x540. Scoring
+    at this fixed reference resolution makes scores comparable across source
+    camera resolutions.
+
+    Args:
+        frames_bhw3: uint8 RGB frames with shape ``(B, H, W, 3)`` on any Torch device.
+
+    Returns:
+        Float32 sharpness and texture tensors with shape ``(B,)`` on the input device.
+    """
+    if frames_bhw3.ndim != 4 or frames_bhw3.shape[-1] != 3:
+        raise ValueError("Frames must have shape (B, H, W, 3)")
+    if len(frames_bhw3) == 0:
+        empty_b: Float32[Tensor, "b=0"] = torch.empty(0, dtype=torch.float32, device=frames_bhw3.device)
+        return FrameScores(sharpness=empty_b, texture=empty_b)
+
+    rgb_bhw3: Float32[Tensor, "b h w 3"] = frames_bhw3.to(dtype=torch.float32)
+    luma_weights_3: Float32[Tensor, "channels=3"] = torch.tensor(
+        [0.299, 0.587, 0.114],
+        dtype=torch.float32,
+        device=frames_bhw3.device,
+    )
+    gray_bhw: Float32[Tensor, "b h w"] = torch.sum(rgb_bhw3 * luma_weights_3, dim=-1)
+    gray_b1hw: Float32[Tensor, "b 1 h w"] = rearrange(gray_bhw, "b h w -> b 1 h w")
+    reference_b1hw: Float32[Tensor, "b 1 score_h=540 score_w=720"] = functional.interpolate(
+        gray_b1hw,
+        size=(SCORE_HEIGHT, SCORE_WIDTH),
+        mode="area",
+    )
+    laplacian_kernel_1133: Float32[Tensor, "1 1 kh=3 kw=3"] = torch.tensor(
+        [[[[0.0, 1.0, 0.0], [1.0, -4.0, 1.0], [0.0, 1.0, 0.0]]]],
+        dtype=torch.float32,
+        device=frames_bhw3.device,
+    )
+    laplacian_b1hw: Float32[Tensor, "b 1 lap_h lap_w"] = functional.conv2d(reference_b1hw, laplacian_kernel_1133)
+    sharpness_b: Float32[Tensor, "b"] = torch.var(laplacian_b1hw, dim=(1, 2, 3), correction=0)
+    texture_b: Float32[Tensor, "b"] = torch.std(reference_b1hw, dim=(1, 2, 3), correction=0)
+    return FrameScores(sharpness=sharpness_b, texture=texture_b)
+
+
+def _validate_selection_inputs(
+    sharpness_n: Float32[ndarray, "n_frames"],
+    timestamps_n: TimedeltaNs,
+) -> TimedeltaNs:
+    """Validate dense score/timestamp arrays and normalize timestamp precision."""
+    if sharpness_n.ndim != 1 or timestamps_n.ndim != 1:
+        raise ValueError("Sharpness scores and timestamps must be one-dimensional")
+    if len(sharpness_n) != len(timestamps_n):
+        raise ValueError("Sharpness scores and timestamps must have the same length")
+    normalized_timestamps_n: TimedeltaNs = np.asarray(timestamps_n, dtype="timedelta64[ns]")
+    return normalized_timestamps_n
+
+
+def select_wide_frames(
+    sharpness_n: Float32[ndarray, "n_frames"],
+    timestamps_n: TimedeltaNs,
+    *,
+    window_size: int = 6,
+    min_chosen: int = 200,
+) -> SelectionResult:
+    """Select the sharpest frame in every strict window.
+
+    Args:
+        sharpness_n: Float32 sharpness score per frame with shape ``(N,)``.
+        timestamps_n: Packet timestamps with shape ``(N,)`` and dtype ``timedelta64[ns]``.
+        window_size: Number of consecutive source frames per non-overlapping window.
+        min_chosen: Minimum admitted frames required to accept the segment.
+
+    Returns:
+        Dense measurements, sparse winner metadata, and the segment rejection state.
+    """
+    normalized_timestamps_n: TimedeltaNs = _validate_selection_inputs(sharpness_n, timestamps_n)
+    if window_size < 1 or min_chosen < 1:
+        raise ValueError("window_size and min_chosen must be positive")
+
+    chosen_indices: list[int] = []
+    chosen_windows: list[int] = []
+    window_start: int
+    for window_start in range(0, len(sharpness_n), window_size):
+        window_index: int = window_start // window_size
+        window_stop: int = min(window_start + window_size, len(sharpness_n))
+        winner_index: int = window_start + int(np.argmax(sharpness_n[window_start:window_stop]))
+        chosen_indices.append(winner_index)
+        chosen_windows.append(window_index)
+
+    chosen_indices_n: Int64[ndarray, "n_chosen"] = np.asarray(chosen_indices, dtype=np.int64)
+    windows_n: Int64[ndarray, "n_chosen"] = np.asarray(chosen_windows, dtype=np.int64)
+    chosen_timestamps_n: TimedeltaNs = normalized_timestamps_n[chosen_indices_n]
+    rejected: bool = len(chosen_indices_n) < min_chosen
+    rejection_reason: str | None = None
+    if rejected:
+        rejection_reason = f"wide selection kept {len(chosen_indices_n)} frames, fewer than min_chosen={min_chosen}"
+    return SelectionResult(
+        timestamps=normalized_timestamps_n,
+        sharpness=sharpness_n,
+        chosen_indices=chosen_indices_n,
+        chosen_timestamps=chosen_timestamps_n,
+        windows=windows_n,
+        rules=("window_best",) * len(chosen_indices_n),
+        rejected=rejected,
+        rejection_reason=rejection_reason,
+    )
+
+
+def select_ultrawide_frames(
+    sharpness_n: Float32[ndarray, "n_frames"],
+    timestamps_n: TimedeltaNs,
+) -> SelectionResult:
+    """Keep every ultrawide frame.
+
+    Args:
+        sharpness_n: Float32 sharpness score per frame with shape ``(N,)``.
+        timestamps_n: Packet timestamps with shape ``(N,)`` and dtype ``timedelta64[ns]``.
+
+    Returns:
+        Dense measurements and sparse unwindowed chosen-frame metadata.
+    """
+    normalized_timestamps_n: TimedeltaNs = _validate_selection_inputs(sharpness_n, timestamps_n)
+    chosen_indices_n: Int64[ndarray, "n_chosen"] = np.arange(len(sharpness_n), dtype=np.int64)
+    chosen_timestamps_n: TimedeltaNs = normalized_timestamps_n[chosen_indices_n]
+    return SelectionResult(
+        timestamps=normalized_timestamps_n,
+        sharpness=sharpness_n,
+        chosen_indices=chosen_indices_n,
+        chosen_timestamps=chosen_timestamps_n,
+        windows=chosen_indices_n.copy(),
+        rules=("all",) * len(chosen_indices_n),
+        rejected=False,
+        rejection_reason=None,
+    )

--- a/packages/gauss-surf/src/gauss_surf/gaussurf_geometry.py
+++ b/packages/gauss-surf/src/gauss_surf/gaussurf_geometry.py
@@ -1,0 +1,130 @@
+"""Differentiable plane geometry used by the GausSurf-compatible renderer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+
+
+def quat_to_rotmat(quat_n4: torch.Tensor) -> torch.Tensor:
+    """Convert normalized WXYZ quaternions into rotation matrices."""
+    w_n, x_n, y_n, z_n = torch.unbind(quat_n4, dim=-1)
+    values_n9 = torch.stack((1 - 2 * (y_n**2 + z_n**2), 2 * (x_n * y_n - w_n * z_n), 2 * (x_n * z_n + w_n * y_n), 2 * (x_n * y_n + w_n * z_n), 1 - 2 * (x_n**2 + z_n**2), 2 * (y_n * z_n - w_n * x_n), 2 * (x_n * z_n - w_n * y_n), 2 * (y_n * z_n + w_n * x_n), 1 - 2 * (x_n**2 + y_n**2)), dim=-1)
+    return values_n9.reshape((*quat_n4.shape[:-1], 3, 3))
+
+
+@dataclass(frozen=True, slots=True)
+class SurfaceRender:
+    """Surface depth, direct Gaussian normal, and their shared validity mask."""
+
+    depth_hw1: torch.Tensor
+    normal_hw3: torch.Tensor
+    valid_hw1: torch.Tensor
+
+
+def smallest_axis_world_normals(
+    log_scales_n3: torch.Tensor,
+    quats_wxyz_n4: torch.Tensor,
+) -> torch.Tensor:
+    """Return each Gaussian rotation axis associated with its minimum scale."""
+
+    if log_scales_n3.shape[-1] != 3 or quats_wxyz_n4.shape[-1] != 4:
+        raise ValueError("expected Gaussian scales [N,3] and WXYZ quaternions [N,4]")
+    rotations_n33 = quat_to_rotmat(F.normalize(quats_wxyz_n4, dim=-1))
+    minimum_axis_n11 = log_scales_n3.argmin(dim=-1).reshape(-1, 1, 1)
+    minimum_axis_n31 = minimum_axis_n11.expand(-1, 3, 1)
+    normals_n3 = rotations_n33.gather(dim=2, index=minimum_axis_n31).squeeze(2)
+    return F.normalize(normals_n3, dim=-1)
+
+
+def gaussian_plane_features(
+    means_world_n3: torch.Tensor,
+    log_scales_n3: torch.Tensor,
+    quats_wxyz_n4: torch.Tensor,
+    world_to_camera_44: torch.Tensor,
+) -> torch.Tensor:
+    """Build camera-space normal and signed plane-offset features per Gaussian.
+
+    The minimum-scale axis is sign-oriented along the ray from the camera to
+    the Gaussian. This is the opposite sign of PGSR's camera-facing normal but
+    represents the same plane and matches this repository's depth-normal
+    convention. The plane equation is ``normal dot point = offset``.
+    """
+
+    if world_to_camera_44.shape != (4, 4):
+        raise ValueError("world_to_camera must have shape [4,4]")
+    camera_to_world_44 = torch.linalg.inv(world_to_camera_44)
+    camera_center_world_3 = camera_to_world_44[:3, 3]
+    normals_world_n3 = smallest_axis_world_normals(log_scales_n3, quats_wxyz_n4)
+    camera_rays_world_n3 = means_world_n3 - camera_center_world_3
+    flip_n1 = (normals_world_n3 * camera_rays_world_n3).sum(dim=-1, keepdim=True) < 0
+    normals_world_n3 = torch.where(flip_n1, -normals_world_n3, normals_world_n3)
+
+    rotation_33 = world_to_camera_44[:3, :3]
+    translation_3 = world_to_camera_44[:3, 3]
+    means_camera_n3 = means_world_n3 @ rotation_33.T + translation_3
+    normals_camera_n3 = F.normalize(normals_world_n3 @ rotation_33.T, dim=-1)
+    offsets_n1 = (normals_camera_n3 * means_camera_n3).sum(dim=-1, keepdim=True)
+    return torch.cat((normals_camera_n3, offsets_n1), dim=-1)
+
+
+def plane_depth_from_rendered_features(
+    rendered_features_hw4: torch.Tensor,
+    alpha_hw1: torch.Tensor,
+    intrinsics_33: torch.Tensor,
+    *,
+    min_alpha: float = 0.01,
+    min_denominator: float = 1e-4,
+    min_depth: float = 0.01,
+    max_depth: float = 1e4,
+) -> SurfaceRender:
+    """Intersect camera rays with alpha-composited Gaussian tangent planes."""
+
+    if rendered_features_hw4.ndim != 3 or rendered_features_hw4.shape[-1] != 4:
+        raise ValueError("rendered plane features must have shape [H,W,4]")
+    if alpha_hw1.shape != (*rendered_features_hw4.shape[:2], 1):
+        raise ValueError("alpha must have shape [H,W,1]")
+    if intrinsics_33.shape != (3, 3):
+        raise ValueError("intrinsics must have shape [3,3]")
+
+    height, width = rendered_features_hw4.shape[:2]
+    dtype = rendered_features_hw4.dtype
+    device = rendered_features_hw4.device
+    pixel_x, pixel_y = torch.meshgrid(
+        torch.arange(width, dtype=dtype, device=device) + 0.5,
+        torch.arange(height, dtype=dtype, device=device) + 0.5,
+        indexing="xy",
+    )
+    homogeneous_hw3 = torch.stack(
+        (pixel_x, pixel_y, torch.ones_like(pixel_x)),
+        dim=-1,
+    )
+    rays_hw3 = homogeneous_hw3 @ torch.linalg.inv(intrinsics_33).T
+
+    normal_sum_hw3 = rendered_features_hw4[..., :3]
+    offset_sum_hw1 = rendered_features_hw4[..., 3:4]
+    denominator_hw1 = (normal_sum_hw3 * rays_hw3).sum(dim=-1, keepdim=True)
+    denominator_ok_hw1 = denominator_hw1.abs() >= min_denominator
+    safe_denominator_hw1 = torch.where(
+        denominator_ok_hw1,
+        denominator_hw1,
+        torch.ones_like(denominator_hw1),
+    )
+    depth_hw1 = offset_sum_hw1 / safe_denominator_hw1
+    normal_length_hw1 = torch.linalg.vector_norm(normal_sum_hw3, dim=-1, keepdim=True)
+    normal_hw3 = F.normalize(normal_sum_hw3, dim=-1)
+    valid_hw1 = (
+        (alpha_hw1 >= min_alpha)
+        & denominator_ok_hw1
+        & (normal_length_hw1 >= min_denominator)
+        & torch.isfinite(depth_hw1)
+        & (depth_hw1 >= min_depth)
+        & (depth_hw1 <= max_depth)
+    )
+    return SurfaceRender(
+        depth_hw1=torch.where(valid_hw1, depth_hw1, torch.zeros_like(depth_hw1)),
+        normal_hw3=torch.where(valid_hw1.expand_as(normal_hw3), normal_hw3, torch.zeros_like(normal_hw3)),
+        valid_hw1=valid_hw1,
+    )

--- a/packages/gauss-surf/src/gauss_surf/gaussurf_losses.py
+++ b/packages/gauss-surf/src/gauss_surf/gaussurf_losses.py
@@ -1,0 +1,255 @@
+"""Masked normal losses from GausSurf with an optional NeuRIS gate."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+
+
+@dataclass(frozen=True, slots=True)
+class GausSurfLosses:
+    """Unweighted loss terms and active-pixel fractions for diagnostics."""
+
+    normal_prior_cosine: torch.Tensor
+    """Direct-normal cosine loss against the MoGe prior."""
+    depth_normal_cosine: torch.Tensor
+    """Direct-normal cosine loss against the depth-derived normal."""
+    normal_prior_mask_fraction: torch.Tensor
+    """Fraction of pixels supervised by the MoGe prior."""
+    consistency_mask_fraction: torch.Tensor
+    """Fraction of pixels supervised by normal consistency."""
+    consistency_weight_mean: torch.Tensor
+    """Mean optional consistency weight over valid surface pixels."""
+    consistency_weight_below_half_fraction: torch.Tensor
+    """Valid-surface fraction whose optional consistency weight is below one half."""
+
+
+@dataclass(frozen=True, slots=True)
+class GausSurfTargets:
+    """Resized normal targets in the renderer's channel-last layout."""
+
+    prior_normal_hw3: torch.Tensor
+    """Unit MoGe prior normals shaped ``h w 3``."""
+    prior_valid_hw1: torch.Tensor
+    """Nearest-resized MoGe validity mask shaped ``h w 1``."""
+
+
+def linear_ramp_weight(*, step: int, start_step: int, ramp_steps: int) -> float:
+    """Return a zero-before-start, linearly increasing, saturated loss weight."""
+
+    if start_step < 0:
+        raise ValueError("ramp start step must be non-negative")
+    if ramp_steps <= 0:
+        raise ValueError("ramp steps must be positive")
+    if step < start_step:
+        return 0.0
+    return min(1.0, (step - start_step + 1) / ramp_steps)
+
+
+def normal_contradiction_gate(
+    rendered_normal_hw3: torch.Tensor,
+    prior_normal_hw3: torch.Tensor,
+    prior_valid_hw1: torch.Tensor,
+    *,
+    maximum_angle_degrees: float = 30.0,
+) -> torch.Tensor:
+    """Return a detached NeuRIS-style angular contradiction filter."""
+
+    if rendered_normal_hw3.shape != prior_normal_hw3.shape:
+        raise ValueError("rendered and prior normals must share a shape")
+    if prior_valid_hw1.shape != (*rendered_normal_hw3.shape[:2], 1):
+        raise ValueError("prior validity must have shape [H,W,1]")
+    rendered = F.normalize(rendered_normal_hw3.detach(), dim=-1, eps=1e-6)
+    prior = F.normalize(prior_normal_hw3.detach(), dim=-1, eps=1e-6)
+    cosine_threshold = torch.cos(
+        torch.deg2rad(
+            torch.tensor(
+                maximum_angle_degrees,
+                dtype=rendered.dtype,
+                device=rendered.device,
+            )
+        )
+    )
+    cosine = (rendered * prior).sum(dim=-1, keepdim=True)
+    return (prior_valid_hw1.bool() & (cosine >= cosine_threshold)).detach()
+
+
+def pgsr_edge_weights(
+    rgb_hw3: torch.Tensor,
+    *,
+    power: float = 2.0,
+    minimum_weight: float = 0.0,
+    epsilon: float = 1e-6,
+) -> torch.Tensor:
+    """Return detached PGSR-style weights that suppress RGB edges and borders."""
+
+    if rgb_hw3.ndim != 3 or rgb_hw3.shape[-1] != 3:
+        raise ValueError("RGB image must have shape [H,W,3]")
+    height, width, _ = rgb_hw3.shape
+    if height < 3 or width < 3:
+        raise ValueError("RGB image must be at least 3x3")
+    if power <= 0.0:
+        raise ValueError("edge-weight power must be positive")
+    if not 0.0 <= minimum_weight < 1.0:
+        raise ValueError("minimum edge weight must be in [0, 1)")
+    if epsilon <= 0.0:
+        raise ValueError("epsilon must be positive")
+
+    rgb_f32 = rgb_hw3.detach().to(dtype=torch.float32)
+    gradient_x = (rgb_f32[:, 2:] - rgb_f32[:, :-2]).abs().mean(dim=-1)
+    gradient_y = (rgb_f32[:-2] - rgb_f32[2:]).abs().mean(dim=-1)
+    interior_gradient = torch.maximum(gradient_x[1:-1], gradient_y[:, 1:-1])
+    gradient_min = interior_gradient.amin()
+    gradient_span = interior_gradient.amax() - gradient_min
+    normalized = torch.where(
+        gradient_span > epsilon,
+        (interior_gradient - gradient_min) / gradient_span.clamp_min(epsilon),
+        torch.zeros_like(interior_gradient),
+    )
+    inverse_gradient = (1.0 - normalized.clamp(0.0, 1.0)).pow(power)
+    interior_weight = minimum_weight + (1.0 - minimum_weight) * inverse_gradient
+    weight = F.pad(interior_weight, (1, 1, 1, 1), mode="constant", value=0.0)
+    return weight.unsqueeze(-1).to(dtype=rgb_hw3.dtype).detach()
+
+
+def prepare_gaussurf_targets(
+    *,
+    prior_normal_3hw: torch.Tensor,
+    prior_valid_1hw: torch.Tensor,
+    height: int,
+    width: int,
+) -> GausSurfTargets:
+    """Resize prior normals and validity without blurring boolean evidence."""
+
+    if prior_normal_3hw.shape[0] != 3:
+        raise ValueError("expected prior normal [3,H,W]")
+    if prior_valid_1hw.shape[0] != 1:
+        raise ValueError("expected prior validity [1,H,W]")
+    prior_normal_3hw = F.interpolate(
+        prior_normal_3hw[None],
+        (height, width),
+        mode="bilinear",
+        align_corners=False,
+    )[0]
+    prior_normal_3hw = F.normalize(prior_normal_3hw, dim=0, eps=1e-6)
+
+    prior_valid_resized_1hw: torch.Tensor = F.interpolate(
+        prior_valid_1hw[None].float(),
+        (height, width),
+        mode="nearest",
+    )[0].bool()
+    return GausSurfTargets(
+        prior_normal_hw3=prior_normal_3hw.permute(1, 2, 0),
+        prior_valid_hw1=prior_valid_resized_1hw.permute(1, 2, 0),
+    )
+
+
+def _masked_mean(values: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    """Return a differentiable zero when the mask contains no active pixels."""
+
+    mask_float = mask.to(dtype=values.dtype)
+    safe_values = torch.where(mask.bool(), values, torch.zeros_like(values))
+    return (safe_values * mask_float).sum() / mask_float.sum().clamp_min(1.0)
+
+
+def _mask_fraction(mask: torch.Tensor) -> torch.Tensor:
+    return mask.to(dtype=torch.float32).mean()
+
+
+def compute_gaussurf_losses(
+    *,
+    direct_normal_hw3: torch.Tensor,
+    depth_normal_hw3: torch.Tensor,
+    prior_normal_hw3: torch.Tensor,
+    prior_valid_hw1: torch.Tensor,
+    surface_valid_hw1: torch.Tensor,
+    normal_prior_gate_hw1: torch.Tensor | None = None,
+    consistency_weight_hw1: torch.Tensor | None = None,
+    normalize_consistency_weights: bool = True,
+) -> GausSurfLosses:
+    """Compute monocular-normal and surface-consistency losses.
+
+    The MoGeV2 prior applies on valid prior and surface pixels, subject to the
+    optional detached NeuRIS contradiction gate. Depth-normal consistency
+    applies wherever the Gaussian surface renderer is valid.
+    """
+
+    expected_hw1: torch.Size = surface_valid_hw1.shape
+    for name, mask in (
+        ("prior_valid", prior_valid_hw1),
+        ("surface_valid", surface_valid_hw1),
+    ):
+        if mask.shape != expected_hw1:
+            raise ValueError(f"{name} mask shape must match depth")
+    if direct_normal_hw3.shape != (*expected_hw1[:2], 3):
+        raise ValueError("direct normal must have shape [H,W,3]")
+    if depth_normal_hw3.shape != direct_normal_hw3.shape:
+        raise ValueError("direct and depth-derived normal shapes must match")
+    if prior_normal_hw3.shape != direct_normal_hw3.shape:
+        raise ValueError("prior and rendered normal shapes must match")
+
+    prior_valid_hw1 = prior_valid_hw1.bool()
+    surface_valid_hw1 = surface_valid_hw1.bool()
+    prior_mask_hw1: torch.Tensor = prior_valid_hw1 & surface_valid_hw1
+    if normal_prior_gate_hw1 is not None:
+        if normal_prior_gate_hw1.shape != expected_hw1:
+            raise ValueError("normal-prior gate shape must match depth")
+        normal_prior_gate_hw1 = normal_prior_gate_hw1.detach().bool()
+        prior_mask_hw1 &= normal_prior_gate_hw1
+
+    direct_normal_hw3 = F.normalize(direct_normal_hw3, dim=-1, eps=1e-6)
+    depth_normal_hw3 = F.normalize(depth_normal_hw3, dim=-1, eps=1e-6)
+    prior_normal_hw3 = F.normalize(prior_normal_hw3, dim=-1, eps=1e-6)
+    prior_cosine_error_hw1 = 1.0 - (
+        direct_normal_hw3 * prior_normal_hw3
+    ).sum(dim=-1, keepdim=True).clamp(-1.0, 1.0)
+    consistency_error_hw1 = 1.0 - (
+        direct_normal_hw3 * depth_normal_hw3
+    ).sum(dim=-1, keepdim=True).clamp(-1.0, 1.0)
+    if consistency_weight_hw1 is None:
+        consistency_loss = _masked_mean(consistency_error_hw1, surface_valid_hw1)
+        consistency_weight_mean = torch.ones(
+            (), dtype=consistency_error_hw1.dtype, device=consistency_error_hw1.device
+        )
+        consistency_weight_below_half_fraction = torch.zeros_like(
+            consistency_weight_mean
+        )
+    else:
+        if consistency_weight_hw1.shape != expected_hw1:
+            raise ValueError("consistency weight shape must match depth")
+        consistency_weight_hw1 = consistency_weight_hw1.detach().to(
+            dtype=consistency_error_hw1.dtype
+        )
+        if not torch.isfinite(consistency_weight_hw1).all() or torch.any(
+            consistency_weight_hw1 < 0.0
+        ):
+            raise ValueError("consistency weights must be finite and non-negative")
+        surface_weight = consistency_weight_hw1 * surface_valid_hw1.to(
+            dtype=consistency_error_hw1.dtype
+        )
+        weighted_consistency = consistency_error_hw1 * surface_weight
+        if normalize_consistency_weights:
+            consistency_loss = weighted_consistency.sum() / (
+                surface_weight.sum().clamp_min(1e-6)
+            )
+        else:
+            consistency_loss = weighted_consistency.mean()
+        consistency_weight_mean = _masked_mean(
+            consistency_weight_hw1, surface_valid_hw1
+        )
+        consistency_weight_below_half_fraction = _mask_fraction(
+            surface_valid_hw1 & (consistency_weight_hw1 < 0.5)
+        ) / _mask_fraction(surface_valid_hw1).clamp_min(1e-6)
+
+    return GausSurfLosses(
+        normal_prior_cosine=_masked_mean(prior_cosine_error_hw1, prior_mask_hw1),
+        depth_normal_cosine=consistency_loss,
+        normal_prior_mask_fraction=_mask_fraction(prior_mask_hw1),
+        consistency_mask_fraction=_mask_fraction(surface_valid_hw1),
+        consistency_weight_mean=consistency_weight_mean,
+        consistency_weight_below_half_fraction=(
+            consistency_weight_below_half_fraction
+        ),
+    )

--- a/packages/gauss-surf/src/gauss_surf/gsplat_schedule.py
+++ b/packages/gauss-surf/src/gauss_surf/gsplat_schedule.py
@@ -1,0 +1,78 @@
+"""Pure schedule helpers shared by gsplat training paths."""
+
+
+def downscale_factor(step: int) -> int:
+    """Return the splatfacto quarter-to-half-to-full resolution factor."""
+    if step < 0:
+        raise ValueError("step must be non-negative")
+    return 2 ** max(2 - step // 3_000, 0)
+
+
+def sh_degree(step: int) -> int:
+    """Return the active spherical-harmonic degree for one training step."""
+    if step < 0:
+        raise ValueError("step must be non-negative")
+    return min(step // 1_000, 3)
+
+
+def should_refine(
+    *,
+    step: int,
+    num_train_frames: int,
+    refine_every: int,
+    reset_every: int,
+    refine_start: int,
+    refine_stop: int,
+) -> bool:
+    """Return splatfacto's integer refinement predicate.
+
+    The pause after each reset cycle is derived from the number of training
+    images across all camera streams plus one refinement interval.
+    """
+    if step < 0 or num_train_frames <= 0:
+        raise ValueError("step must be non-negative and the train split non-empty")
+    if refine_every <= 0 or reset_every <= 0:
+        raise ValueError("schedule intervals must be positive")
+    if refine_start < 0 or refine_stop <= refine_start:
+        raise ValueError("refinement bounds are invalid")
+    pause_after_reset: int = num_train_frames + refine_every
+    return (
+        step > refine_start
+        and step < refine_stop
+        and step % refine_every == 0
+        and step % reset_every >= pause_after_reset
+    )
+
+
+def should_reset_opacity(*, step: int, reset_every: int, refine_stop: int) -> bool:
+    """Return gsplat 1.6's opacity-reset predicate including its early stop."""
+    if step < 0:
+        raise ValueError("step must be non-negative")
+    if reset_every <= 0 or refine_stop <= 0:
+        raise ValueError("reset interval and refinement stop must be positive")
+    return step < refine_stop and step > 0 and step % reset_every == 0
+
+
+def opacity_reset_callback_step(
+    *,
+    step: int,
+    refinement_cycle_every: int,
+    opacity_reset_every: int,
+) -> int:
+    """Return the strategy step that preserves refinement while gating resets.
+
+    Gsplat's default strategy uses one cycle for both its refinement pause and
+    opacity reset. The historical gauss-surf recipe needs the 3,000-step pause
+    cycle, but its 1.5.3 opacity reset branch never ran. Moving a reset-cycle
+    callback to the following non-refinement step preserves that old behavior.
+    """
+    if step < 0:
+        raise ValueError("step must be non-negative")
+    if refinement_cycle_every <= 0 or opacity_reset_every <= 0:
+        raise ValueError("schedule intervals must be positive")
+    suppress_reset: bool = (
+        step > 0
+        and step % refinement_cycle_every == 0
+        and step % opacity_reset_every != 0
+    )
+    return step + 1 if suppress_reset else step

--- a/packages/gauss-surf/src/gauss_surf/normals_encoding.py
+++ b/packages/gauss-surf/src/gauss_surf/normals_encoding.py
@@ -1,0 +1,68 @@
+"""Pure lossless PNG encoding for signed camera-space normal maps."""
+
+from io import BytesIO
+
+import numpy as np
+from jaxtyping import Float32, UInt8
+from numpy import ndarray
+from PIL import Image
+
+from gauss_surf.render_io import encode_rgb_png
+
+
+def to_away_from_camera(normals_toward_hw3: Float32[ndarray, "h w 3"]) -> Float32[ndarray, "h w 3"]:
+    """Convert MoGe's toward-camera RDF normals to the gaussurf target convention.
+
+    Args:
+        normals_toward_hw3: float32 toward-camera normals shaped ``h w 3``.
+
+    Returns:
+        float32 away-from-camera RDF normals shaped ``h w 3``.
+    """
+    if normals_toward_hw3.ndim != 3 or normals_toward_hw3.shape[-1] != 3:
+        raise ValueError("Normals must have shape (H, W, 3)")
+    normals_away_hw3: Float32[ndarray, "h w 3"] = np.negative(normals_toward_hw3).astype(np.float32, copy=False)
+    return normals_away_hw3
+
+
+def encode_normals_png(normals_hw3: Float32[ndarray, "h w 3"]) -> bytes:
+    """Encode signed float32 normals as a lossless RGB PNG.
+
+    Args:
+        normals_hw3: float32 normal components shaped ``h w 3`` in ``[-1, 1]``.
+
+    Returns:
+        PNG bytes containing the rounded ``(normal + 1) / 2 * 255`` mapping.
+    """
+    if normals_hw3.ndim != 3 or normals_hw3.shape[-1] != 3:
+        raise ValueError("Normals must have shape (H, W, 3)")
+    if not np.all(np.isfinite(normals_hw3)):
+        raise ValueError("Normals must contain only finite values")
+    if np.any(normals_hw3 < -1.0) or np.any(normals_hw3 > 1.0):
+        raise ValueError("Normal components must lie within [-1, 1]")
+
+    rgb_hw3: UInt8[ndarray, "h w 3"] = np.rint((normals_hw3 + 1.0) / 2.0 * 255.0).astype(np.uint8)
+    return encode_rgb_png(rgb_hw3)
+
+
+def decode_normal_codes(rgb_hw3: UInt8[ndarray, "h w 3"]) -> Float32[ndarray, "h w 3"]:
+    """Decode quantized normal RGB codes and restore central code 128 to zero."""
+    if rgb_hw3.ndim != 3 or rgb_hw3.shape[-1] != 3 or rgb_hw3.dtype != np.uint8:
+        raise ValueError("Normal codes must be uint8 with shape (H, W, 3)")
+    decoded_hw3: Float32[ndarray, "h w 3"] = rgb_hw3.astype(np.float32) / 255.0 * 2.0 - 1.0
+    decoded_hw3[rgb_hw3 == 128] = 0.0
+    return decoded_hw3
+
+
+def decode_normals_png(png_bytes: bytes) -> Float32[ndarray, "h w 3"]:
+    """Decode a lossless RGB normal PNG into signed float32 components.
+
+    Args:
+        png_bytes: PNG bytes written by :func:`encode_normals_png`.
+
+    Returns:
+        float32 normal components shaped ``h w 3`` in ``[-1, 1]``.
+    """
+    with Image.open(BytesIO(png_bytes)) as image:
+        rgb_hw3: UInt8[ndarray, "h w 3"] = np.asarray(image.convert("RGB"), dtype=np.uint8)
+    return decode_normal_codes(rgb_hw3)

--- a/packages/gauss-surf/src/gauss_surf/render_io.py
+++ b/packages/gauss-surf/src/gauss_surf/render_io.py
@@ -1,0 +1,158 @@
+"""Shared readers and codecs for rendered gauss-surf artifacts."""
+
+import json
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from jaxtyping import Float32, UInt8
+from numpy import ndarray
+from PIL import Image
+
+from gauss_surf.catalog import _single_instance
+from gauss_surf.contracts import RGB_JPEG_QUALITY, CameraTag
+
+
+@dataclass(frozen=True, slots=True)
+class RenderCamera:
+    """One native-resolution camera read from the full-grid manifest."""
+
+    stem: str
+    """Stable full-grid frame stem."""
+    camera: CameraTag
+    """Wide or rectified-ultrawide tag."""
+    timestamp_ns: int
+    """Exact duration since recording start, in nanoseconds."""
+    width: int
+    """Native render width in pixels."""
+    height: int
+    """Native render height in pixels."""
+    fx: float
+    """Horizontal focal length in pixels."""
+    fy: float
+    """Vertical focal length in pixels."""
+    cx: float
+    """Principal-point horizontal coordinate in pixels."""
+    cy: float
+    """Principal-point vertical coordinate in pixels."""
+    world_from_camera_34: Float32[ndarray, "3 4"]
+    """Metric OpenGL camera-to-world pose."""
+
+
+def load_render_cameras(
+    cameras_path: Path,
+) -> list[RenderCamera]:
+    """Read metric-world full-grid render cameras."""
+    manifest: dict[str, Any] = json.loads(cameras_path.read_text(encoding="utf-8"))
+    if int(manifest.get("schema_version", -1)) != 1:
+        raise ValueError(f"{cameras_path} has unsupported camera manifest schema {manifest.get('schema_version')!r}")
+    if manifest.get("camera_model") != "OPENCV":
+        raise ValueError(f"{cameras_path} has unsupported camera model {manifest.get('camera_model')!r}")
+    raw_frames: Any = manifest.get("frames")
+    if not isinstance(raw_frames, list):
+        raise ValueError(f"{cameras_path} has no frame list")
+    cameras: list[RenderCamera] = []
+    for raw_frame in raw_frames:
+        if not isinstance(raw_frame, dict):
+            raise ValueError("camera manifest frame metadata must be an object")
+        camera: str = str(raw_frame["camera"])
+        if camera not in ("wide", "uw"):
+            raise ValueError(f"camera manifest frame has invalid camera tag {camera!r}")
+        world_from_camera_44: Float32[ndarray, "4 4"] = np.asarray(raw_frame["transform_matrix"], dtype=np.float32)
+        if world_from_camera_44.shape != (4, 4):
+            raise ValueError(f"camera manifest transform must have shape (4, 4), got {world_from_camera_44.shape}")
+        if not np.all(np.isfinite(world_from_camera_44)):
+            raise ValueError("camera manifest transform contains nonfinite values")
+        width: int = int(raw_frame["w"])
+        height: int = int(raw_frame["h"])
+        intrinsics_4: tuple[float, float, float, float] = (
+            float(raw_frame["fl_x"]),
+            float(raw_frame["fl_y"]),
+            float(raw_frame["cx"]),
+            float(raw_frame["cy"]),
+        )
+        if width <= 0 or height <= 0:
+            raise ValueError(f"camera manifest resolution must be positive, got {(width, height)}")
+        if not np.all(np.isfinite(intrinsics_4)) or intrinsics_4[0] <= 0.0 or intrinsics_4[1] <= 0.0:
+            raise ValueError(f"camera manifest intrinsics are invalid: {intrinsics_4}")
+        cameras.append(
+            RenderCamera(
+                stem=str(raw_frame["stem"]),
+                camera=camera,  # pyrefly: ignore  # bad-argument-type — validated above
+                timestamp_ns=int(raw_frame["timestamp_ns"]),
+                width=width,
+                height=height,
+                fx=intrinsics_4[0],
+                fy=intrinsics_4[1],
+                cx=intrinsics_4[2],
+                cy=intrinsics_4[3],
+                world_from_camera_34=world_from_camera_44[:3].copy(),
+            )
+        )
+    stems: list[str] = [camera.stem for camera in cameras]
+    if len(stems) != len(set(stems)):
+        raise ValueError("camera manifest frame stems are not unique")
+    camera_timestamps: list[tuple[CameraTag, int]] = [(camera.camera, camera.timestamp_ns) for camera in cameras]
+    if len(camera_timestamps) != len(set(camera_timestamps)):
+        raise ValueError("camera manifest timestamps are not unique within each camera")
+    raw_counts: Any = manifest.get("counts")
+    if not isinstance(raw_counts, dict):
+        raise ValueError("camera manifest has no count mapping")
+    actual_counts: dict[str, int] = {
+        "wide": sum(camera.camera == "wide" for camera in cameras),
+        "uw": sum(camera.camera == "uw" for camera in cameras),
+        "total": len(cameras),
+    }
+    declared_counts: dict[str, int] = {key: int(raw_counts.get(key, -1)) for key in actual_counts}
+    if declared_counts != actual_counts:
+        raise ValueError(f"camera manifest counts {declared_counts} do not match frames {actual_counts}")
+    return cameras
+
+
+def blob_bytes(value: Any, component_name: str) -> bytes:
+    """Unwrap one encoded Rerun blob instance from an Arrow cell."""
+    blob_value: Any = _single_instance(value, component_name)
+    return blob_value if isinstance(blob_value, bytes) else bytes(blob_value)
+
+
+def encode_rgb_png(rgb_hw3: UInt8[ndarray, "h w 3"]) -> bytes:
+    """Encode one uint8 RGB image as a lossless PNG."""
+    if rgb_hw3.ndim != 3 or rgb_hw3.shape[-1] != 3 or rgb_hw3.dtype != np.uint8:
+        raise ValueError("RGB image must be uint8 with shape (H, W, 3)")
+    output: BytesIO = BytesIO()
+    Image.fromarray(rgb_hw3, mode="RGB").save(output, format="PNG")
+    return output.getvalue()
+
+
+def encode_rgb_jpeg(rgb_hw3: UInt8[ndarray, "h w 3"], *, quality: int = RGB_JPEG_QUALITY) -> bytes:
+    """Encode one uint8 RGB image as a JPEG at the requested quality."""
+    if rgb_hw3.ndim != 3 or rgb_hw3.shape[-1] != 3 or rgb_hw3.dtype != np.uint8:
+        raise ValueError("RGB image must be uint8 with shape (H, W, 3)")
+    output: BytesIO = BytesIO()
+    Image.fromarray(rgb_hw3, mode="RGB").save(output, format="JPEG", quality=quality)
+    return output.getvalue()
+
+
+def decode_rgb_image(image_bytes: bytes) -> UInt8[ndarray, "h w 3"]:
+    """Decode stored image bytes to an owning uint8 RGB array."""
+    with Image.open(BytesIO(image_bytes)) as image:
+        rgb_hw3: UInt8[ndarray, "h w 3"] = np.asarray(image.convert("RGB"), dtype=np.uint8).copy()
+    return rgb_hw3
+
+
+def decode_splat_depth_png(png_bytes: bytes) -> Float32[ndarray, "h w"]:
+    """Decode a uint16 millimetre PNG into float32 metres.
+
+    Args:
+        png_bytes: Encoded 16-bit grayscale PNG bytes.
+
+    Returns:
+        Float32 metre depth shaped ``h w`` with a preserved zero sentinel.
+    """
+    with Image.open(BytesIO(png_bytes)) as image:
+        depth_mm_hw: ndarray = np.asarray(image, dtype=np.uint16)
+    if depth_mm_hw.ndim != 2:
+        raise ValueError(f"depth PNG must be grayscale, got {depth_mm_hw.shape}")
+    return (depth_mm_hw.astype(np.float32) / 1000.0).astype(np.float32, copy=False)

--- a/packages/gauss-surf/src/gauss_surf/uw_geometry.py
+++ b/packages/gauss-surf/src/gauss_surf/uw_geometry.py
@@ -1,0 +1,427 @@
+"""Ultrawide rectification, pose resolution, raycast, and depth-storage geometry."""
+
+from dataclasses import dataclass
+from typing import Any
+
+import cv2
+import numpy as np
+import open3d as o3d
+import pyarrow as pa
+from arkitscenes_download.ingest.paths import TIMELINE
+from jaxtyping import Float32, Int64, UInt8, UInt16
+from numpy import ndarray
+from scipy.spatial.transform import Rotation
+
+from gauss_surf.catalog import SegmentReader, TimedeltaNs, _single_instance, match_exact_timestamps, table_timestamps
+from gauss_surf.contracts import RIG_QUATERNION_COLUMN, RIG_TRANSLATION_COLUMN, ULTRAWIDE_QUATERNION_COLUMN, ULTRAWIDE_TRANSLATION_COLUMN
+
+
+@dataclass(frozen=True, slots=True)
+class AppleRadialPolynomial:
+    """Apple's eight-coefficient radial magnification polynomial."""
+
+    coefficients_8: Float32[ndarray, "8"]
+    """Percent magnification coefficients for normalized powers t² through t¹⁶."""
+
+    def __post_init__(self) -> None:
+        """Normalize and validate the coefficient vector."""
+        coefficients_8: Float32[ndarray, "8"] = np.asarray(self.coefficients_8, dtype=np.float32).reshape(-1)
+        if coefficients_8.shape != (8,) or not np.all(np.isfinite(coefficients_8)):
+            raise ValueError("Apple radial calibration requires eight finite coefficients")
+        object.__setattr__(self, "coefficients_8", coefficients_8)
+
+    def distorted_to_rectified_radius(self, distorted_radius: Float32[ndarray, "..."]) -> Float32[ndarray, "..."]:
+        """Apply the empirically selected distorted-to-rectified radial map.
+
+        Args:
+            distorted_radius: float32 radii normalized by the farthest reference-image corner, with arbitrary shape.
+
+        Returns:
+            float32 normalized rectified radii with the input shape.
+        """
+        radii: Float32[ndarray, "..."] = np.asarray(distorted_radius, dtype=np.float32)
+        powers_8: Float32[ndarray, "8"] = (2.0 * np.arange(1, 9, dtype=np.float32)).astype(np.float32)
+        magnification: Float32[ndarray, "..."] = (
+            0.01 * np.sum(self.coefficients_8 * radii[..., None] ** powers_8, axis=-1)
+        ).astype(np.float32, copy=False)
+        rectified_radius: Float32[ndarray, "..."] = (radii * (1.0 + magnification)).astype(np.float32, copy=False)
+        return rectified_radius
+
+    def rectified_to_distorted_radius(self, rectified_radius: Float32[ndarray, "..."]) -> Float32[ndarray, "..."]:
+        """Numerically invert the radial map for OpenCV destination-to-source remapping.
+
+        Args:
+            rectified_radius: float32 radii normalized by the farthest reference-image corner, with arbitrary shape.
+
+        Returns:
+            float32 normalized distorted radii with the input shape.
+        """
+        requested: Float32[ndarray, "..."] = np.asarray(rectified_radius, dtype=np.float32)
+        sample_distorted_n: Float32[ndarray, "n_samples=100001"] = np.linspace(0.0, 1.25, 100_001, dtype=np.float32)
+        sample_rectified_n: Float32[ndarray, "n_samples=100001"] = self.distorted_to_rectified_radius(sample_distorted_n)
+        if np.any(sample_rectified_n[1:] <= sample_rectified_n[:-1]):
+            raise ValueError("Apple radial polynomial is not invertible over the calibrated frame")
+        if np.any(requested < 0.0) or np.any(requested > sample_rectified_n[-1]):
+            raise ValueError("Requested rectified radius lies outside the invertible calibration domain")
+        distorted_flat_n: Float32[ndarray, "n"] = np.interp(  # pyrefly: ignore[bad-assignment]
+            requested.reshape(-1),
+            sample_rectified_n,
+            sample_distorted_n,
+        ).astype(np.float32)
+        distorted: Float32[ndarray, "..."] = distorted_flat_n.reshape(requested.shape)
+        return distorted
+
+
+@dataclass(frozen=True, slots=True)
+class AppleUndistortion:
+    """One reusable destination-to-source remap and its rectified pinhole."""
+
+    K_rect_33: Float32[ndarray, "3 3"]
+    """Rectified pinhole intrinsics shaped ``3 3``."""
+    source_x_hw: Float32[ndarray, "h w"]
+    """Distorted source-image x coordinate for each output pixel."""
+    source_y_hw: Float32[ndarray, "h w"]
+    """Distorted source-image y coordinate for each output pixel."""
+
+
+@dataclass(frozen=True, slots=True)
+class CameraPoses:
+    """Wide and ultrawide world poses resolved on target timelines."""
+
+    world_from_wide_n44: Float32[ndarray, "n_wide 4 4"]
+    """Resolved wide-camera poses."""
+    world_from_ultrawide_n44: Float32[ndarray, "n_uw 4 4"]
+    """Resolved ultrawide-camera poses."""
+    ultrawide_staleness_ms_n: Float32[ndarray, "n_uw"]
+    """Age of each selected causal rig pose in milliseconds."""
+
+
+@dataclass(frozen=True, slots=True)
+class CameraPoseTrack:
+    """One loaded rig-pose track and static ultrawide calibration."""
+
+    timestamps_n: TimedeltaNs
+    """Sorted rig-pose timestamps."""
+    world_from_rig_n44: Float32[ndarray, "n_poses 4 4"]
+    """RDF rig-to-world transforms at every pose timestamp."""
+    wide_from_ultrawide_44: Float32[ndarray, "4 4"]
+    """Static RDF ultrawide-to-wide transform."""
+
+
+def world_from_pose(
+    translation_3: Float32[ndarray, "3"], quaternion_xyzw_4: Float32[ndarray, "4"]
+) -> Float32[ndarray, "4 4"]:
+    """Build an RDF camera-to-world transform from Rerun pose components."""
+    world_from_camera_44: Float32[ndarray, "4 4"] = np.eye(4, dtype=np.float32)
+    world_from_camera_44[:3, :3] = Rotation.from_quat(quaternion_xyzw_4).as_matrix().astype(np.float32)
+    world_from_camera_44[:3, 3] = translation_3
+    return world_from_camera_44
+
+
+def load_camera_pose_track(
+    reader: SegmentReader,
+    *,
+    wide_from_ultrawide_44: Float32[ndarray, "4 4"] | None = None,
+) -> CameraPoseTrack:
+    """Fetch a rig-pose track and its static ultrawide calibration once."""
+    pose_table: pa.Table = reader.pose_table(RIG_TRANSLATION_COLUMN, RIG_QUATERNION_COLUMN)
+    pose_timestamps_n: TimedeltaNs = table_timestamps(pose_table)
+    world_from_rig_n44: Float32[ndarray, "n_poses 4 4"] = np.stack(
+        [
+            world_from_pose(
+                np.asarray(_single_instance(row[RIG_TRANSLATION_COLUMN], RIG_TRANSLATION_COLUMN), dtype=np.float32),
+                np.asarray(_single_instance(row[RIG_QUATERNION_COLUMN], RIG_QUATERNION_COLUMN), dtype=np.float32),
+            )
+            for row in pose_table.to_pylist()
+        ]
+    )
+    calibration_44: Float32[ndarray, "4 4"]
+    if wide_from_ultrawide_44 is None:
+        static_table: pa.Table = (
+            reader.segment_view()
+            .reader(index=TIMELINE, fill_latest_at=True)
+            .select(TIMELINE, ULTRAWIDE_TRANSLATION_COLUMN, ULTRAWIDE_QUATERNION_COLUMN)
+            .limit(1)
+            .to_arrow_table()
+        )
+        if static_table.num_rows != 1:
+            raise SystemExit("catalog segment has no static wide-from-ultrawide calibration")
+        static_row: dict[str, Any] = static_table.to_pylist()[0]
+        calibration_44 = world_from_pose(
+            np.asarray(_single_instance(static_row[ULTRAWIDE_TRANSLATION_COLUMN], ULTRAWIDE_TRANSLATION_COLUMN), dtype=np.float32),
+            np.asarray(_single_instance(static_row[ULTRAWIDE_QUATERNION_COLUMN], ULTRAWIDE_QUATERNION_COLUMN), dtype=np.float32),
+        )
+    else:
+        calibration_44 = np.asarray(wide_from_ultrawide_44, dtype=np.float32)
+    return CameraPoseTrack(pose_timestamps_n, world_from_rig_n44, calibration_44)
+
+
+def build_apple_undistortion(
+    K_uw_33: Float32[ndarray, "3 3"],
+    coefficients_8: Float32[ndarray, "8"],
+    distortion_center_reference_xy: Float32[ndarray, "2"],
+    reference_dimensions_wh: tuple[int, int],
+    image_wh: tuple[int, int],
+) -> AppleUndistortion:
+    """Build an Apple radial-polynomial remap at the video resolution.
+
+    Args:
+        K_uw_33: float32 distorted-camera intrinsics shaped ``3 3``.
+        coefficients_8: float32 Apple percent-magnification coefficients shaped ``8``.
+        distortion_center_reference_xy: float32 calibration center shaped ``2``.
+        reference_dimensions_wh: Calibration reference width and height.
+        image_wh: Output image width and height.
+
+    Returns:
+        Reusable rectified pinhole and destination-to-source remap.
+    """
+    reference_width: int = reference_dimensions_wh[0]
+    reference_height: int = reference_dimensions_wh[1]
+    width: int = image_wh[0]
+    height: int = image_wh[1]
+    if min(reference_width, reference_height, width, height) < 1:
+        raise ValueError("Reference and image dimensions must be positive")
+    K_input_33: Float32[ndarray, "3 3"] = np.asarray(K_uw_33, dtype=np.float32)
+    coefficients: Float32[ndarray, "8"] = np.asarray(coefficients_8, dtype=np.float32).reshape(-1)
+    pixel_x_hw: Float32[ndarray, "h w"]
+    pixel_y_hw: Float32[ndarray, "h w"]
+    pixel_x_hw, pixel_y_hw = np.meshgrid(np.arange(width, dtype=np.float32), np.arange(height, dtype=np.float32))
+    if np.all(coefficients == 0.0):
+        return AppleUndistortion(K_input_33.copy(), pixel_x_hw, pixel_y_hw)
+
+    model: AppleRadialPolynomial = AppleRadialPolynomial(coefficients)
+    center_reference_xy: Float32[ndarray, "2"] = np.asarray(distortion_center_reference_xy, dtype=np.float32)
+    reference_per_image_xy: Float32[ndarray, "2"] = np.array([reference_width / width, reference_height / height], dtype=np.float32)
+    center_image_xy: Float32[ndarray, "2"] = center_reference_xy / reference_per_image_xy
+    corners_reference_42: Float32[ndarray, "4 2"] = np.array(
+        [[0.0, 0.0], [float(reference_width), 0.0], [0.0, float(reference_height)], [float(reference_width), float(reference_height)]],
+        dtype=np.float32,
+    )
+    radius_max_reference: float = float(np.max(np.linalg.norm(corners_reference_42 - center_reference_xy, axis=1)))
+    output_delta_image_hw2: Float32[ndarray, "h w 2"] = np.stack(
+        [pixel_x_hw - center_image_xy[0], pixel_y_hw - center_image_xy[1]],
+        axis=-1,
+    )
+    def source_map(focal_scale: float) -> Float32[ndarray, "h w 2"]:
+        """Map one uniform rectified focal scale into distorted source pixels."""
+        rectified_delta_reference_hw2: Float32[ndarray, "h w 2"] = output_delta_image_hw2 * reference_per_image_xy / focal_scale
+        rectified_radius_hw: Float32[ndarray, "h w"] = np.linalg.norm(rectified_delta_reference_hw2, axis=-1).astype(np.float32)
+        rectified_normalized_hw: Float32[ndarray, "h w"] = rectified_radius_hw / radius_max_reference
+        distorted_normalized_hw: Float32[ndarray, "h w"] = model.rectified_to_distorted_radius(rectified_normalized_hw)
+        radial_scale_hw: Float32[ndarray, "h w"] = np.divide(
+            distorted_normalized_hw,
+            rectified_normalized_hw,
+            out=np.ones_like(distorted_normalized_hw),
+            where=rectified_normalized_hw > 0.0,
+        )
+        source_reference_hw2: Float32[ndarray, "h w 2"] = center_reference_xy + rectified_delta_reference_hw2 * radial_scale_hw[..., None]
+        return (source_reference_hw2 / reference_per_image_xy).astype(np.float32, copy=False)
+
+    def is_in_bounds(source_hw2: Float32[ndarray, "h w 2"]) -> bool:
+        """Check whether every bilinear sample lies inside the source image."""
+        return bool(
+            np.all(source_hw2[..., 0] >= 0.0)
+            and np.all(source_hw2[..., 0] <= width - 1)
+            and np.all(source_hw2[..., 1] >= 0.0)
+            and np.all(source_hw2[..., 1] <= height - 1)
+        )
+
+    lower_scale: float = 1.0
+    upper_scale: float = 1.0
+    source_image_hw2: Float32[ndarray, "h w 2"] = source_map(upper_scale)
+    while not is_in_bounds(source_image_hw2):
+        upper_scale *= 1.05
+        if upper_scale > 4.0:
+            raise ValueError("Apple radial calibration has no valid full-frame crop")
+        source_image_hw2 = source_map(upper_scale)
+    for _ in range(18):
+        candidate_scale: float = 0.5 * (lower_scale + upper_scale)
+        candidate_source_hw2: Float32[ndarray, "h w 2"] = source_map(candidate_scale)
+        if is_in_bounds(candidate_source_hw2):
+            upper_scale = candidate_scale
+            source_image_hw2 = candidate_source_hw2
+        else:
+            lower_scale = candidate_scale
+    K_rect_33: Float32[ndarray, "3 3"] = K_input_33.copy()
+    K_rect_33[0, 0] *= upper_scale
+    K_rect_33[1, 1] *= upper_scale
+    K_rect_33[0, 2] = center_image_xy[0]
+    K_rect_33[1, 2] = center_image_xy[1]
+    return AppleUndistortion(
+        K_rect_33,
+        source_image_hw2[..., 0].astype(np.float32, copy=False),
+        source_image_hw2[..., 1].astype(np.float32, copy=False),
+    )
+
+
+def undistort_rgb(
+    rgb_hw3: UInt8[ndarray, "h w 3"],
+    undistortion: AppleUndistortion,
+) -> UInt8[ndarray, "h w 3"]:
+    """Rectify one RGB frame with a reusable Apple destination-to-source remap.
+
+    Args:
+        rgb_hw3: uint8 distorted RGB image shaped ``h w 3``.
+        undistortion: Apple remap built for the same image dimensions.
+
+    Returns:
+        uint8 rectified RGB image shaped ``h w 3``.
+    """
+    if rgb_hw3.ndim != 3 or rgb_hw3.shape[2] != 3:
+        raise ValueError("RGB frame must have shape (H, W, 3)")
+    if undistortion.source_x_hw.shape != rgb_hw3.shape[:2] or undistortion.source_y_hw.shape != rgb_hw3.shape[:2]:
+        raise ValueError("Apple remap dimensions must match the RGB frame")
+    rectified_hw3: UInt8[ndarray, "h w 3"] = cv2.remap(
+        rgb_hw3,
+        undistortion.source_x_hw,
+        undistortion.source_y_hw,
+        interpolation=cv2.INTER_LINEAR,
+        borderMode=cv2.BORDER_CONSTANT,
+    )
+    return rectified_hw3
+
+
+def depth_meters_to_uint16_mm(depth_m_hw: Float32[ndarray, "h w"]) -> UInt16[ndarray, "h w"]:
+    """Quantize metre z-depth to uint16 millimetres with a zero invalid sentinel.
+
+    Positive depths above 65.535 m clamp to 65535 instead of wrapping. Nonfinite,
+    zero, and negative inputs become the zero sentinel.
+
+    Args:
+        depth_m_hw: float32 metre depth shaped ``h w``.
+
+    Returns:
+        uint16 millimetre depth shaped ``h w``.
+    """
+    valid_hw: ndarray = np.isfinite(depth_m_hw) & (depth_m_hw > 0.0)
+    safe_m_hw: Float32[ndarray, "h w"] = np.where(valid_hw, depth_m_hw, 0.0).astype(np.float32, copy=False)
+    depth_mm_float_hw: Float32[ndarray, "h w"] = np.clip(safe_m_hw * 1000.0, 0.0, 65535.0)
+    depth_mm_hw: UInt16[ndarray, "h w"] = np.rint(depth_mm_float_hw).astype(np.uint16)
+    return depth_mm_hw
+
+
+def compose_world_from_ultrawide(
+    world_from_rig_n44: Float32[ndarray, "n 4 4"],
+    wide_from_ultrawide_44: Float32[ndarray, "4 4"],
+) -> Float32[ndarray, "n 4 4"]:
+    """Compose temporal rig poses with the static ultrawide baseline.
+
+    Args:
+        world_from_rig_n44: float32 rig-to-world transforms shaped ``n 4 4``.
+        wide_from_ultrawide_44: float32 ultrawide-to-wide transform shaped ``4 4``.
+
+    Returns:
+        float32 ultrawide-to-world transforms shaped ``n 4 4``.
+    """
+    if world_from_rig_n44.ndim != 3 or world_from_rig_n44.shape[1:] != (4, 4):
+        raise ValueError("world_from_rig must have shape (N, 4, 4)")
+    if wide_from_ultrawide_44.shape != (4, 4):
+        raise ValueError("wide_from_ultrawide must have shape (4, 4)")
+    world_from_ultrawide_n44: Float32[ndarray, "n 4 4"] = np.matmul(
+        world_from_rig_n44,
+        wide_from_ultrawide_44,
+    ).astype(np.float32, copy=False)
+    return world_from_ultrawide_n44
+
+
+def pose_indices_at_or_before(pose_times_n: TimedeltaNs, target_times_n: TimedeltaNs) -> Int64[ndarray, "n_targets"]:
+    """Find the nearest causal pose sample for every target timestamp.
+
+    Args:
+        pose_times_n: Sorted pose timestamps shaped ``n_poses``.
+        target_times_n: Target timestamps shaped ``n_targets``.
+
+    Returns:
+        int64 source-pose indices shaped ``n_targets``. Every selected pose is
+        at or before its target; v1 deliberately does not interpolate.
+
+    Raises:
+        ValueError: If inputs are invalid or a target precedes the first pose.
+    """
+    if pose_times_n.ndim != 1 or target_times_n.ndim != 1:
+        raise ValueError("Pose and target timestamps must be one-dimensional")
+    if len(pose_times_n) == 0:
+        raise ValueError("Pose timeline must not be empty")
+    pose_ns_n: TimedeltaNs = np.asarray(pose_times_n, dtype="timedelta64[ns]")
+    target_ns_n: TimedeltaNs = np.asarray(target_times_n, dtype="timedelta64[ns]")
+    if np.any(pose_ns_n[1:] < pose_ns_n[:-1]):
+        raise ValueError("Pose timestamps must be sorted")
+    indices_n: Int64[ndarray, "n_targets"] = (np.searchsorted(pose_ns_n, target_ns_n, side="right") - 1).astype(np.int64)
+    if np.any(indices_n < 0):
+        first_target: np.timedelta64 = target_ns_n[int(np.flatnonzero(indices_n < 0)[0])]
+        raise ValueError(f"target timestamp {first_target} precedes the first rig pose")
+    return indices_n
+
+
+def resolve_camera_poses(
+    track: CameraPoseTrack,
+    wide_timestamps_n: TimedeltaNs,
+    ultrawide_timestamps_n: TimedeltaNs,
+    *,
+    exact_wide: bool,
+) -> CameraPoses:
+    """Resolve exact or causal wide poses and causal ultrawide poses."""
+    wide_pose_indices_n: Int64[ndarray, "n_wide"] = (
+        match_exact_timestamps(track.timestamps_n, wide_timestamps_n)
+        if exact_wide
+        else pose_indices_at_or_before(track.timestamps_n, wide_timestamps_n)
+    )
+    uw_pose_indices_n: Int64[ndarray, "n_uw"] = pose_indices_at_or_before(track.timestamps_n, ultrawide_timestamps_n)
+    staleness_ns_n: Int64[ndarray, "n_uw"] = (ultrawide_timestamps_n - track.timestamps_n[uw_pose_indices_n]).astype(
+        "timedelta64[ns]"
+    ).astype(np.int64)
+    return CameraPoses(
+        world_from_wide_n44=track.world_from_rig_n44[wide_pose_indices_n],
+        world_from_ultrawide_n44=compose_world_from_ultrawide(
+            track.world_from_rig_n44[uw_pose_indices_n],
+            track.wide_from_ultrawide_44,
+        ),
+        ultrawide_staleness_ms_n=(staleness_ns_n.astype(np.float32) / 1_000_000.0).astype(np.float32),
+    )
+
+
+def raycast_z_depth(
+    scene: o3d.t.geometry.RaycastingScene,
+    K_rect_33: Float32[ndarray, "3 3"],
+    world_from_camera_44: Float32[ndarray, "4 4"],
+    image_wh: tuple[int, int],
+) -> Float32[ndarray, "h w"]:
+    """Raycast a triangle scene into camera-space pinhole z-depth.
+
+    Open3D's pinhole rays use unnormalized camera directions ``(x, y, 1)``.
+    Therefore ``t_hit`` is already z-depth for those rays. The explicit
+    multiplication by the direction's camera-space z component below pins down
+    that convention and remains correct if the ray construction changes.
+
+    Args:
+        scene: Open3D tensor raycasting scene containing the world-space mesh.
+        K_rect_33: float32 rectified pinhole intrinsics shaped ``3 3``.
+        world_from_camera_44: float32 camera-to-world transform shaped ``4 4``.
+        image_wh: Output image width and height.
+
+    Returns:
+        float32 camera-space z-depth in metres shaped ``h w``. Misses are zero.
+    """
+    width: int = image_wh[0]
+    height: int = image_wh[1]
+    if width < 1 or height < 1:
+        raise ValueError(f"Image dimensions must be positive, got {image_wh}")
+    camera_from_world_44: Float32[ndarray, "4 4"] = np.linalg.inv(world_from_camera_44).astype(np.float32)
+    rays_hw6: o3d.core.Tensor = scene.create_rays_pinhole(
+        o3d.core.Tensor(K_rect_33.astype(np.float32, copy=False)),
+        o3d.core.Tensor(camera_from_world_44),
+        width,
+        height,
+    )
+    raycast: dict[str, o3d.core.Tensor] = scene.cast_rays(rays_hw6)
+    t_hit_hw: Float32[ndarray, "h w"] = raycast["t_hit"].numpy().astype(np.float32, copy=False)
+    ray_directions_hw3: Float32[ndarray, "h w 3"] = rays_hw6.numpy()[..., 3:].astype(np.float32, copy=False)
+    camera_directions_hw3: Float32[ndarray, "h w 3"] = np.einsum(
+        "ij,hwj->hwi",
+        camera_from_world_44[:3, :3],
+        ray_directions_hw3,
+    ).astype(np.float32, copy=False)
+    depth_hw: Float32[ndarray, "h w"] = t_hit_hw * camera_directions_hw3[..., 2]
+    depth_hw[~np.isfinite(depth_hw)] = 0.0
+    depth_hw[depth_hw <= 0.0] = 0.0
+    return depth_hw

--- a/packages/gauss-surf/src/gauss_surf/uw_geometry.py
+++ b/packages/gauss-surf/src/gauss_surf/uw_geometry.py
@@ -7,7 +7,6 @@ import cv2
 import numpy as np
 import open3d as o3d
 import pyarrow as pa
-from arkitscenes_download.ingest.distortion import AppleRadialPolynomial
 from arkitscenes_download.ingest.paths import TIMELINE
 from jaxtyping import Float32, Int64, UInt8, UInt16
 from numpy import ndarray
@@ -18,7 +17,7 @@ from gauss_surf.contracts import RIG_QUATERNION_COLUMN, RIG_TRANSLATION_COLUMN, 
 
 
 @dataclass(frozen=True, slots=True)
-class AppleUndistortion:
+class Undistortion:
     """One reusable destination-to-source remap and its rectified pinhole."""
 
     K_rect_33: Float32[ndarray, "3 3"]
@@ -101,19 +100,19 @@ def load_camera_pose_track(
     return CameraPoseTrack(pose_timestamps_n, world_from_rig_n44, calibration_44)
 
 
-def build_apple_undistortion(
+def build_brown_conrady_undistortion(
     K_uw_33: Float32[ndarray, "3 3"],
-    coefficients_8: Float32[ndarray, "8"],
+    coefficients_14: Float32[ndarray, "14"],
     distortion_center_reference_xy: Float32[ndarray, "2"],
     reference_dimensions_wh: tuple[int, int],
     image_wh: tuple[int, int],
-) -> AppleUndistortion:
-    """Build an Apple radial-polynomial remap at the video resolution.
+) -> Undistortion:
+    """Build an OpenCV Brown-Conrady remap with the established crop.
 
     Args:
         K_uw_33: float32 distorted-camera intrinsics shaped ``3 3``.
-        coefficients_8: float32 Apple percent-magnification coefficients shaped ``8``.
-        distortion_center_reference_xy: float32 calibration center shaped ``2``.
+        coefficients_14: float32 standard Brown-Conrady coefficients shaped ``14``.
+        distortion_center_reference_xy: float32 calibration center shaped ``2`` used only to preserve the output framing.
         reference_dimensions_wh: Calibration reference width and height.
         image_wh: Output image width and height.
 
@@ -127,83 +126,77 @@ def build_apple_undistortion(
     if min(reference_width, reference_height, width, height) < 1:
         raise ValueError("Reference and image dimensions must be positive")
     K_input_33: Float32[ndarray, "3 3"] = np.asarray(K_uw_33, dtype=np.float32)
-    coefficients: Float32[ndarray, "8"] = np.asarray(coefficients_8, dtype=np.float32).reshape(-1)
+    coefficients: Float32[ndarray, "14"] = np.asarray(coefficients_14, dtype=np.float32).reshape(-1)
+    if coefficients.shape != (14,) or not np.all(np.isfinite(coefficients)):
+        raise ValueError("Brown-Conrady calibration requires fourteen finite coefficients")
+    if np.any(coefficients[8:] != 0.0):
+        raise ValueError("Ultrawide rectification supports the rational Brown-Conrady eight-vector; thin-prism and tilt terms must be zero")
+    rational_coefficients_8: Float32[ndarray, "8"] = coefficients[:8]
     pixel_x_hw: Float32[ndarray, "h w"]
     pixel_y_hw: Float32[ndarray, "h w"]
     pixel_x_hw, pixel_y_hw = np.meshgrid(np.arange(width, dtype=np.float32), np.arange(height, dtype=np.float32))
     if np.all(coefficients == 0.0):
-        return AppleUndistortion(K_input_33.copy(), pixel_x_hw, pixel_y_hw)
+        return Undistortion(K_input_33.copy(), pixel_x_hw, pixel_y_hw)
 
-    model: AppleRadialPolynomial = AppleRadialPolynomial(coefficients)
     center_reference_xy: Float32[ndarray, "2"] = np.asarray(distortion_center_reference_xy, dtype=np.float32)
     reference_per_image_xy: Float32[ndarray, "2"] = np.array([reference_width / width, reference_height / height], dtype=np.float32)
     center_image_xy: Float32[ndarray, "2"] = center_reference_xy / reference_per_image_xy
-    corners_reference_42: Float32[ndarray, "4 2"] = np.array(
-        [[0.0, 0.0], [float(reference_width), 0.0], [0.0, float(reference_height)], [float(reference_width), float(reference_height)]],
-        dtype=np.float32,
-    )
-    radius_max_reference: float = float(np.max(np.linalg.norm(corners_reference_42 - center_reference_xy, axis=1)))
-    output_delta_image_hw2: Float32[ndarray, "h w 2"] = np.stack(
-        [pixel_x_hw - center_image_xy[0], pixel_y_hw - center_image_xy[1]],
-        axis=-1,
-    )
-    def source_map(focal_scale: float) -> Float32[ndarray, "h w 2"]:
-        """Map one uniform rectified focal scale into distorted source pixels."""
-        rectified_delta_reference_hw2: Float32[ndarray, "h w 2"] = output_delta_image_hw2 * reference_per_image_xy / focal_scale
-        rectified_radius_hw: Float32[ndarray, "h w"] = np.linalg.norm(rectified_delta_reference_hw2, axis=-1).astype(np.float32)
-        rectified_normalized_hw: Float32[ndarray, "h w"] = rectified_radius_hw / radius_max_reference
-        distorted_normalized_hw: Float32[ndarray, "h w"] = model.rectified_to_distorted_radius(rectified_normalized_hw)
-        radial_scale_hw: Float32[ndarray, "h w"] = np.divide(
-            distorted_normalized_hw,
-            rectified_normalized_hw,
-            out=np.ones_like(distorted_normalized_hw),
-            where=rectified_normalized_hw > 0.0,
-        )
-        source_reference_hw2: Float32[ndarray, "h w 2"] = center_reference_xy + rectified_delta_reference_hw2 * radial_scale_hw[..., None]
-        return (source_reference_hw2 / reference_per_image_xy).astype(np.float32, copy=False)
+    identity_33: Float32[ndarray, "3 3"] = np.eye(3, dtype=np.float32)
 
-    def is_in_bounds(source_hw2: Float32[ndarray, "h w 2"]) -> bool:
+    def source_map(focal_scale: float) -> Undistortion:
+        """Build one OpenCV map at a candidate uniform rectified focal scale."""
+        K_rect_33: Float32[ndarray, "3 3"] = K_input_33.copy()
+        K_rect_33[0, 0] *= focal_scale
+        K_rect_33[1, 1] *= focal_scale
+        K_rect_33[:2, 2] = center_image_xy
+        K_map_33: Float32[ndarray, "3 3"] = K_rect_33.copy()
+        # OpenCV measures rectified rays from the source pinhole principal point.
+        # Compensate its internal map matrix so the output still scales about the
+        # established framing center recorded in K_rect_33.
+        K_map_33[:2, 2] = center_image_xy + focal_scale * (K_input_33[:2, 2] - center_image_xy)
+        remap: tuple[Float32[ndarray, "h w"], Float32[ndarray, "h w"]] = cv2.initUndistortRectifyMap(
+            K_input_33,
+            rational_coefficients_8,
+            identity_33,
+            K_map_33,
+            (width, height),
+            cv2.CV_32FC1,
+        )
+        return Undistortion(K_rect_33, remap[0], remap[1])
+
+    def is_in_bounds(undistortion: Undistortion) -> bool:
         """Check whether every bilinear sample lies inside the source image."""
         return bool(
-            np.all(source_hw2[..., 0] >= 0.0)
-            and np.all(source_hw2[..., 0] <= width - 1)
-            and np.all(source_hw2[..., 1] >= 0.0)
-            and np.all(source_hw2[..., 1] <= height - 1)
+            np.all(undistortion.source_x_hw >= 0.0)
+            and np.all(undistortion.source_x_hw <= width - 1)
+            and np.all(undistortion.source_y_hw >= 0.0)
+            and np.all(undistortion.source_y_hw <= height - 1)
         )
 
     lower_scale: float = 1.0
     upper_scale: float = 1.0
-    source_image_hw2: Float32[ndarray, "h w 2"] = source_map(upper_scale)
-    while not is_in_bounds(source_image_hw2):
+    undistortion: Undistortion = source_map(upper_scale)
+    while not is_in_bounds(undistortion):
         upper_scale *= 1.05
         if upper_scale > 4.0:
-            raise ValueError("Apple radial calibration has no valid full-frame crop")
-        source_image_hw2 = source_map(upper_scale)
+            raise ValueError("Brown-Conrady calibration has no valid full-frame crop")
+        undistortion = source_map(upper_scale)
     for _ in range(18):
         candidate_scale: float = 0.5 * (lower_scale + upper_scale)
-        candidate_source_hw2: Float32[ndarray, "h w 2"] = source_map(candidate_scale)
-        if is_in_bounds(candidate_source_hw2):
+        candidate: Undistortion = source_map(candidate_scale)
+        if is_in_bounds(candidate):
             upper_scale = candidate_scale
-            source_image_hw2 = candidate_source_hw2
+            undistortion = candidate
         else:
             lower_scale = candidate_scale
-    K_rect_33: Float32[ndarray, "3 3"] = K_input_33.copy()
-    K_rect_33[0, 0] *= upper_scale
-    K_rect_33[1, 1] *= upper_scale
-    K_rect_33[0, 2] = center_image_xy[0]
-    K_rect_33[1, 2] = center_image_xy[1]
-    return AppleUndistortion(
-        K_rect_33,
-        source_image_hw2[..., 0].astype(np.float32, copy=False),
-        source_image_hw2[..., 1].astype(np.float32, copy=False),
-    )
+    return undistortion
 
 
 def undistort_rgb(
     rgb_hw3: UInt8[ndarray, "h w 3"],
-    undistortion: AppleUndistortion,
+    undistortion: Undistortion,
 ) -> UInt8[ndarray, "h w 3"]:
-    """Rectify one RGB frame with a reusable Apple destination-to-source remap.
+    """Rectify one RGB frame with a reusable destination-to-source remap.
 
     Args:
         rgb_hw3: uint8 distorted RGB image shaped ``h w 3``.
@@ -215,7 +208,7 @@ def undistort_rgb(
     if rgb_hw3.ndim != 3 or rgb_hw3.shape[2] != 3:
         raise ValueError("RGB frame must have shape (H, W, 3)")
     if undistortion.source_x_hw.shape != rgb_hw3.shape[:2] or undistortion.source_y_hw.shape != rgb_hw3.shape[:2]:
-        raise ValueError("Apple remap dimensions must match the RGB frame")
+        raise ValueError("Undistortion remap dimensions must match the RGB frame")
     rectified_hw3: UInt8[ndarray, "h w 3"] = cv2.remap(
         rgb_hw3,
         undistortion.source_x_hw,

--- a/packages/gauss-surf/src/gauss_surf/uw_geometry.py
+++ b/packages/gauss-surf/src/gauss_surf/uw_geometry.py
@@ -7,70 +7,14 @@ import cv2
 import numpy as np
 import open3d as o3d
 import pyarrow as pa
+from arkitscenes_download.ingest.distortion import AppleRadialPolynomial
 from arkitscenes_download.ingest.paths import TIMELINE
-from jaxtyping import Float32, Float64, Int64, UInt8, UInt16
+from jaxtyping import Float32, Int64, UInt8, UInt16
 from numpy import ndarray
 from scipy.spatial.transform import Rotation
-from simplecv.camera_parameters import BrownConradyDistortion
 
 from gauss_surf.catalog import SegmentReader, TimedeltaNs, _single_instance, match_exact_timestamps, table_timestamps
 from gauss_surf.contracts import RIG_QUATERNION_COLUMN, RIG_TRANSLATION_COLUMN, ULTRAWIDE_QUATERNION_COLUMN, ULTRAWIDE_TRANSLATION_COLUMN
-
-
-@dataclass(frozen=True, slots=True)
-class AppleRadialPolynomial:
-    """Apple's eight-coefficient radial magnification polynomial."""
-
-    coefficients_8: Float32[ndarray, "8"]
-    """Percent magnification coefficients for normalized powers t² through t¹⁶."""
-
-    def __post_init__(self) -> None:
-        """Normalize and validate the coefficient vector."""
-        coefficients_8: Float32[ndarray, "8"] = np.asarray(self.coefficients_8, dtype=np.float32).reshape(-1)
-        if coefficients_8.shape != (8,) or not np.all(np.isfinite(coefficients_8)):
-            raise ValueError("Apple radial calibration requires eight finite coefficients")
-        object.__setattr__(self, "coefficients_8", coefficients_8)
-
-    def distorted_to_rectified_radius(self, distorted_radius: Float32[ndarray, "..."]) -> Float32[ndarray, "..."]:
-        """Apply the empirically selected distorted-to-rectified radial map.
-
-        Args:
-            distorted_radius: float32 radii normalized by the farthest reference-image corner, with arbitrary shape.
-
-        Returns:
-            float32 normalized rectified radii with the input shape.
-        """
-        radii: Float32[ndarray, "..."] = np.asarray(distorted_radius, dtype=np.float32)
-        powers_8: Float32[ndarray, "8"] = (2.0 * np.arange(1, 9, dtype=np.float32)).astype(np.float32)
-        magnification: Float32[ndarray, "..."] = (
-            0.01 * np.sum(self.coefficients_8 * radii[..., None] ** powers_8, axis=-1)
-        ).astype(np.float32, copy=False)
-        rectified_radius: Float32[ndarray, "..."] = (radii * (1.0 + magnification)).astype(np.float32, copy=False)
-        return rectified_radius
-
-    def rectified_to_distorted_radius(self, rectified_radius: Float32[ndarray, "..."]) -> Float32[ndarray, "..."]:
-        """Numerically invert the radial map for OpenCV destination-to-source remapping.
-
-        Args:
-            rectified_radius: float32 radii normalized by the farthest reference-image corner, with arbitrary shape.
-
-        Returns:
-            float32 normalized distorted radii with the input shape.
-        """
-        requested: Float32[ndarray, "..."] = np.asarray(rectified_radius, dtype=np.float32)
-        sample_distorted_n: Float32[ndarray, "n_samples=100001"] = np.linspace(0.0, 1.25, 100_001, dtype=np.float32)
-        sample_rectified_n: Float32[ndarray, "n_samples=100001"] = self.distorted_to_rectified_radius(sample_distorted_n)
-        if np.any(sample_rectified_n[1:] <= sample_rectified_n[:-1]):
-            raise ValueError("Apple radial polynomial is not invertible over the calibrated frame")
-        if np.any(requested < 0.0) or np.any(requested > sample_rectified_n[-1]):
-            raise ValueError("Requested rectified radius lies outside the invertible calibration domain")
-        distorted_flat_n: Float32[ndarray, "n"] = np.interp(  # pyrefly: ignore[bad-assignment]
-            requested.reshape(-1),
-            sample_rectified_n,
-            sample_distorted_n,
-        ).astype(np.float32)
-        distorted: Float32[ndarray, "..."] = distorted_flat_n.reshape(requested.shape)
-        return distorted
 
 
 @dataclass(frozen=True, slots=True)
@@ -300,7 +244,6 @@ def depth_meters_to_uint16_mm(depth_m_hw: Float32[ndarray, "h w"]) -> UInt16[nda
     depth_mm_hw: UInt16[ndarray, "h w"] = np.rint(depth_mm_float_hw).astype(np.uint16)
     return depth_mm_hw
 
-
 def compose_world_from_ultrawide(
     world_from_rig_n44: Float32[ndarray, "n 4 4"],
     wide_from_ultrawide_44: Float32[ndarray, "4 4"],
@@ -426,147 +369,3 @@ def raycast_z_depth(
     depth_hw[~np.isfinite(depth_hw)] = 0.0
     depth_hw[depth_hw <= 0.0] = 0.0
     return depth_hw
-
-
-# ---- OpenCV-standard interop view of Apple calibrations ----------------------
-#
-# The Apple radial polynomial above is the exact, canonical calibration; the
-# pipeline consumes it directly. `opencv_rational_from_apple` exists solely for
-# interoperability (COLMAP exports, third-party tools): it FITS OpenCV's
-# rational model to the exact Apple field per calibration — no algebraic
-# conversion exists — and refuses to return a fit it cannot validate.
-# Measured on a real ARKitScenes ultrawide: worst-case 1e-4 px against a
-# ~10.8 px distortion (see test_uw_geometry.py golden).
-
-
-@dataclass(frozen=True, slots=True)
-class OpenCVRationalFit:
-    """A validated OpenCV rational-model approximation of one Apple calibration."""
-
-    distortion: BrownConradyDistortion
-    """k1–k6 populated (rational model); tangential/thin-prism/tilt terms zero."""
-    K_33: Float32[ndarray, "3 3"]
-    """Native-resolution intrinsics whose cx/cy is Apple's DISTORTION center — 
-    deliberately not the pinhole principal point; OpenCV distorts around K's center."""
-    max_residual_px: float
-    """Measured worst-case distorted→rectified error vs the exact Apple field."""
-
-
-def opencv_rational_from_apple(
-    K_native_33: Float32[ndarray, "3 3"],
-    coefficients_8: Float32[ndarray, "8"],
-    distortion_center_reference_xy: Float32[ndarray, "2"],
-    reference_dimensions_wh: tuple[int, int],
-    image_wh: tuple[int, int],
-    residual_bound_px: float = 0.01,
-) -> OpenCVRationalFit:
-    """Fit OpenCV's rational distortion model to an Apple radial calibration.
-
-    Args:
-        K_native_33: Native-resolution pinhole intrinsics (focal lengths are
-            reused; the principal point is replaced by Apple's center).
-        coefficients_8: Apple forward (distorted→rectified) coefficients.
-        distortion_center_reference_xy: Apple distortion center, reference px.
-        reference_dimensions_wh: Calibration reference width and height.
-        image_wh: Native image width and height the fit is validated at.
-        residual_bound_px: Reject the fit if its worst-case error exceeds this.
-
-    Returns:
-        Validated coefficients as simplecv's ``BrownConradyDistortion`` plus the
-        matching K — pass both to OpenCV (``initUndistortRectifyMap`` etc.).
-
-    Raises:
-        ValueError: On anisotropic reference scaling, a non-monotonic fitted
-            radius map, a non-positive rational denominator, or a residual
-            beyond ``residual_bound_px``.
-    """
-    from scipy.optimize import least_squares
-
-    width, height = image_wh
-    reference_per_image_xy = np.array([reference_dimensions_wh[0] / width, reference_dimensions_wh[1] / height], dtype=np.float64)
-    if abs(reference_per_image_xy[0] - reference_per_image_xy[1]) > 1e-6 * reference_per_image_xy[0]:
-        raise ValueError(f"Anisotropic reference scaling {reference_per_image_xy.tolist()} is unsupported")
-    model = AppleRadialPolynomial(np.asarray(coefficients_8, dtype=np.float32))
-    center_reference_xy = np.asarray(distortion_center_reference_xy, dtype=np.float64)
-    center_native_xy: Float64[ndarray, "2"] = center_reference_xy / reference_per_image_xy
-    corners_42 = np.array(
-        [[0.0, 0.0], [reference_dimensions_wh[0], 0.0], [0.0, reference_dimensions_wh[1]], [*map(float, reference_dimensions_wh)]],
-        dtype=np.float64,
-    )
-    radius_max_reference: float = float(np.max(np.linalg.norm(corners_42 - center_reference_xy, axis=1)))
-    # The fit is normalized by the corner radius (Apple's own convention); the
-    # returned coefficients are rescaled to K's focal length at the end.
-    focal_fit_px: float = radius_max_reference / float(reference_per_image_xy[0])
-
-    def apple_rectified(distorted_n2: Float64[ndarray, "n 2"]) -> Float64[ndarray, "n 2"]:
-        """Exact distorted→rectified native-pixel field from the Apple model."""
-        delta_n2 = (distorted_n2 - center_native_xy) * reference_per_image_xy
-        radii_n = np.linalg.norm(delta_n2, axis=1)
-        mapped_n = np.asarray(model.distorted_to_rectified_radius((radii_n / radius_max_reference).astype(np.float32)), dtype=np.float64)
-        scale_n = np.divide(mapped_n * radius_max_reference, radii_n, out=np.ones_like(radii_n), where=radii_n > 0.0)
-        return center_native_xy + delta_n2 * scale_n[:, None] / reference_per_image_xy
-
-    def rational_distorted(rectified_n2: Float64[ndarray, "n 2"], k_6: Float64[ndarray, "6"]) -> Float64[ndarray, "n 2"]:
-        """OpenCV's forward (rectified→distorted) rational model around Apple's center."""
-        normalized_n2 = (rectified_n2 - center_native_xy) / focal_fit_px
-        r2_n = np.sum(np.square(normalized_n2), axis=1)
-        numerator_n = 1.0 + k_6[0] * r2_n + k_6[1] * r2_n**2 + k_6[2] * r2_n**3
-        denominator_n = 1.0 + k_6[3] * r2_n + k_6[4] * r2_n**2 + k_6[5] * r2_n**3
-        return center_native_xy + focal_fit_px * normalized_n2 * (numerator_n / denominator_n)[:, None]
-
-    x_n = np.unique(np.append(np.arange(0.0, width, 4.0), float(width - 1)))
-    y_n = np.unique(np.append(np.arange(0.0, height, 4.0), float(height - 1)))
-    x_hw, y_hw = np.meshgrid(x_n, y_n)
-    distorted_fit_n2 = np.stack([x_hw.reshape(-1), y_hw.reshape(-1)], axis=1)
-    rectified_fit_n2 = apple_rectified(distorted_fit_n2)
-
-    def residuals(k_6: Float64[ndarray, "6"]) -> Float64[ndarray, "m"]:
-        """Forward-direction component residuals on the fit grid."""
-        return (rational_distorted(rectified_fit_n2, k_6) - distorted_fit_n2).reshape(-1)
-
-    brown_3 = least_squares(lambda k_3: residuals(np.concatenate([k_3, np.zeros(3)])), np.zeros(3), ftol=1e-13, xtol=1e-13, gtol=1e-13).x
-    k_fit_6 = least_squares(residuals, np.concatenate([brown_3, np.zeros(3)]), ftol=1e-13, xtol=1e-13, gtol=1e-13).x
-
-    # Validate over the frame's radius domain: positive denominator and a
-    # strictly increasing rectified→distorted radius map (no poles, no folds).
-    corners_native_42 = np.array([[0.0, 0.0], [width - 1.0, 0.0], [0.0, height - 1.0], [width - 1.0, height - 1.0]], dtype=np.float64)
-    rectified_corners_42 = apple_rectified(corners_native_42)
-    radius_domain: float = float(np.max(np.linalg.norm(rectified_corners_42 - center_native_xy, axis=1))) / focal_fit_px
-    r2_probe_n = np.square(np.linspace(0.0, 1.05 * radius_domain, 4096))
-    denominator_probe_n = 1.0 + k_fit_6[3] * r2_probe_n + k_fit_6[4] * r2_probe_n**2 + k_fit_6[5] * r2_probe_n**3
-    if np.any(denominator_probe_n <= 0.0):
-        raise ValueError("Fitted rational denominator is not positive over the calibrated frame")
-    probe_n2 = np.stack([center_native_xy[0] + np.sqrt(r2_probe_n) * focal_fit_px, np.full(r2_probe_n.shape, center_native_xy[1])], axis=1)
-    distorted_radii_n = np.linalg.norm(rational_distorted(probe_n2, k_fit_6) - center_native_xy, axis=1)
-    if np.any(np.diff(distorted_radii_n) <= 0.0):
-        raise ValueError("Fitted rational radius map is not strictly increasing over the calibrated frame")
-
-    # Measure the worst-case error in the direction consumers use (distorted →
-    # rectified), with OpenCV's own high-precision iterative inversion.
-    K_fit_33 = np.array([[focal_fit_px, 0.0, center_native_xy[0]], [0.0, focal_fit_px, center_native_xy[1]], [0.0, 0.0, 1.0]])
-    distortion_fit_8 = np.array([k_fit_6[0], k_fit_6[1], 0.0, 0.0, k_fit_6[2], k_fit_6[3], k_fit_6[4], k_fit_6[5]])
-    x2_n = np.unique(np.append(np.arange(0.0, width, 2.0), float(width - 1)))
-    y2_n = np.unique(np.append(np.arange(0.0, height, 2.0), float(height - 1)))
-    x2_hw, y2_hw = np.meshgrid(x2_n, y2_n)
-    distorted_check_n2 = np.stack([x2_hw.reshape(-1), y2_hw.reshape(-1)], axis=1)
-    criteria = (cv2.TERM_CRITERIA_COUNT | cv2.TERM_CRITERIA_EPS, 100, 1e-13)
-    rectified_check_n12 = cv2.undistortPoints(  # pyrefly: ignore  # no-matching-overload — cv2 stubs omit the criteria overload the binding accepts
-        distorted_check_n2.reshape(-1, 1, 2), K_fit_33, distortion_fit_8, P=K_fit_33, criteria=criteria
-    )
-    max_residual_px: float = float(np.max(np.linalg.norm(rectified_check_n12.reshape(-1, 2) - apple_rectified(distorted_check_n2), axis=1)))
-    if max_residual_px > residual_bound_px:
-        raise ValueError(f"Rational fit residual {max_residual_px:.6f} px exceeds the {residual_bound_px} px bound")
-
-    # Rescale from corner-radius normalization to K's focal length so the
-    # returned pair works directly with OpenCV.
-    K_native = np.asarray(K_native_33, dtype=np.float64)
-    ratio: float = float(K_native[0, 0]) / focal_fit_px
-    k_physical_6 = k_fit_6 * np.array([ratio**2, ratio**4, ratio**6, ratio**2, ratio**4, ratio**6])
-    K_out_33 = K_native.copy()
-    K_out_33[0, 2] = center_native_xy[0]
-    K_out_33[1, 2] = center_native_xy[1]
-    distortion = BrownConradyDistortion(
-        k1=float(k_physical_6[0]), k2=float(k_physical_6[1]), p1=0.0, p2=0.0, k3=float(k_physical_6[2]),
-        k4=float(k_physical_6[3]), k5=float(k_physical_6[4]), k6=float(k_physical_6[5]),
-    )
-    return OpenCVRationalFit(distortion=distortion, K_33=K_out_33.astype(np.float32), max_residual_px=max_residual_px)

--- a/packages/gauss-surf/src/gauss_surf/uw_geometry.py
+++ b/packages/gauss-surf/src/gauss_surf/uw_geometry.py
@@ -8,9 +8,10 @@ import numpy as np
 import open3d as o3d
 import pyarrow as pa
 from arkitscenes_download.ingest.paths import TIMELINE
-from jaxtyping import Float32, Int64, UInt8, UInt16
+from jaxtyping import Float32, Float64, Int64, UInt8, UInt16
 from numpy import ndarray
 from scipy.spatial.transform import Rotation
+from simplecv.camera_parameters import BrownConradyDistortion
 
 from gauss_surf.catalog import SegmentReader, TimedeltaNs, _single_instance, match_exact_timestamps, table_timestamps
 from gauss_surf.contracts import RIG_QUATERNION_COLUMN, RIG_TRANSLATION_COLUMN, ULTRAWIDE_QUATERNION_COLUMN, ULTRAWIDE_TRANSLATION_COLUMN
@@ -425,3 +426,147 @@ def raycast_z_depth(
     depth_hw[~np.isfinite(depth_hw)] = 0.0
     depth_hw[depth_hw <= 0.0] = 0.0
     return depth_hw
+
+
+# ---- OpenCV-standard interop view of Apple calibrations ----------------------
+#
+# The Apple radial polynomial above is the exact, canonical calibration; the
+# pipeline consumes it directly. `opencv_rational_from_apple` exists solely for
+# interoperability (COLMAP exports, third-party tools): it FITS OpenCV's
+# rational model to the exact Apple field per calibration — no algebraic
+# conversion exists — and refuses to return a fit it cannot validate.
+# Measured on a real ARKitScenes ultrawide: worst-case 1e-4 px against a
+# ~10.8 px distortion (see test_uw_geometry.py golden).
+
+
+@dataclass(frozen=True, slots=True)
+class OpenCVRationalFit:
+    """A validated OpenCV rational-model approximation of one Apple calibration."""
+
+    distortion: BrownConradyDistortion
+    """k1–k6 populated (rational model); tangential/thin-prism/tilt terms zero."""
+    K_33: Float32[ndarray, "3 3"]
+    """Native-resolution intrinsics whose cx/cy is Apple's DISTORTION center — 
+    deliberately not the pinhole principal point; OpenCV distorts around K's center."""
+    max_residual_px: float
+    """Measured worst-case distorted→rectified error vs the exact Apple field."""
+
+
+def opencv_rational_from_apple(
+    K_native_33: Float32[ndarray, "3 3"],
+    coefficients_8: Float32[ndarray, "8"],
+    distortion_center_reference_xy: Float32[ndarray, "2"],
+    reference_dimensions_wh: tuple[int, int],
+    image_wh: tuple[int, int],
+    residual_bound_px: float = 0.01,
+) -> OpenCVRationalFit:
+    """Fit OpenCV's rational distortion model to an Apple radial calibration.
+
+    Args:
+        K_native_33: Native-resolution pinhole intrinsics (focal lengths are
+            reused; the principal point is replaced by Apple's center).
+        coefficients_8: Apple forward (distorted→rectified) coefficients.
+        distortion_center_reference_xy: Apple distortion center, reference px.
+        reference_dimensions_wh: Calibration reference width and height.
+        image_wh: Native image width and height the fit is validated at.
+        residual_bound_px: Reject the fit if its worst-case error exceeds this.
+
+    Returns:
+        Validated coefficients as simplecv's ``BrownConradyDistortion`` plus the
+        matching K — pass both to OpenCV (``initUndistortRectifyMap`` etc.).
+
+    Raises:
+        ValueError: On anisotropic reference scaling, a non-monotonic fitted
+            radius map, a non-positive rational denominator, or a residual
+            beyond ``residual_bound_px``.
+    """
+    from scipy.optimize import least_squares
+
+    width, height = image_wh
+    reference_per_image_xy = np.array([reference_dimensions_wh[0] / width, reference_dimensions_wh[1] / height], dtype=np.float64)
+    if abs(reference_per_image_xy[0] - reference_per_image_xy[1]) > 1e-6 * reference_per_image_xy[0]:
+        raise ValueError(f"Anisotropic reference scaling {reference_per_image_xy.tolist()} is unsupported")
+    model = AppleRadialPolynomial(np.asarray(coefficients_8, dtype=np.float32))
+    center_reference_xy = np.asarray(distortion_center_reference_xy, dtype=np.float64)
+    center_native_xy: Float64[ndarray, "2"] = center_reference_xy / reference_per_image_xy
+    corners_42 = np.array(
+        [[0.0, 0.0], [reference_dimensions_wh[0], 0.0], [0.0, reference_dimensions_wh[1]], [*map(float, reference_dimensions_wh)]],
+        dtype=np.float64,
+    )
+    radius_max_reference: float = float(np.max(np.linalg.norm(corners_42 - center_reference_xy, axis=1)))
+    # The fit is normalized by the corner radius (Apple's own convention); the
+    # returned coefficients are rescaled to K's focal length at the end.
+    focal_fit_px: float = radius_max_reference / float(reference_per_image_xy[0])
+
+    def apple_rectified(distorted_n2: Float64[ndarray, "n 2"]) -> Float64[ndarray, "n 2"]:
+        """Exact distorted→rectified native-pixel field from the Apple model."""
+        delta_n2 = (distorted_n2 - center_native_xy) * reference_per_image_xy
+        radii_n = np.linalg.norm(delta_n2, axis=1)
+        mapped_n = np.asarray(model.distorted_to_rectified_radius((radii_n / radius_max_reference).astype(np.float32)), dtype=np.float64)
+        scale_n = np.divide(mapped_n * radius_max_reference, radii_n, out=np.ones_like(radii_n), where=radii_n > 0.0)
+        return center_native_xy + delta_n2 * scale_n[:, None] / reference_per_image_xy
+
+    def rational_distorted(rectified_n2: Float64[ndarray, "n 2"], k_6: Float64[ndarray, "6"]) -> Float64[ndarray, "n 2"]:
+        """OpenCV's forward (rectified→distorted) rational model around Apple's center."""
+        normalized_n2 = (rectified_n2 - center_native_xy) / focal_fit_px
+        r2_n = np.sum(np.square(normalized_n2), axis=1)
+        numerator_n = 1.0 + k_6[0] * r2_n + k_6[1] * r2_n**2 + k_6[2] * r2_n**3
+        denominator_n = 1.0 + k_6[3] * r2_n + k_6[4] * r2_n**2 + k_6[5] * r2_n**3
+        return center_native_xy + focal_fit_px * normalized_n2 * (numerator_n / denominator_n)[:, None]
+
+    x_n = np.unique(np.append(np.arange(0.0, width, 4.0), float(width - 1)))
+    y_n = np.unique(np.append(np.arange(0.0, height, 4.0), float(height - 1)))
+    x_hw, y_hw = np.meshgrid(x_n, y_n)
+    distorted_fit_n2 = np.stack([x_hw.reshape(-1), y_hw.reshape(-1)], axis=1)
+    rectified_fit_n2 = apple_rectified(distorted_fit_n2)
+
+    def residuals(k_6: Float64[ndarray, "6"]) -> Float64[ndarray, "m"]:
+        """Forward-direction component residuals on the fit grid."""
+        return (rational_distorted(rectified_fit_n2, k_6) - distorted_fit_n2).reshape(-1)
+
+    brown_3 = least_squares(lambda k_3: residuals(np.concatenate([k_3, np.zeros(3)])), np.zeros(3), ftol=1e-13, xtol=1e-13, gtol=1e-13).x
+    k_fit_6 = least_squares(residuals, np.concatenate([brown_3, np.zeros(3)]), ftol=1e-13, xtol=1e-13, gtol=1e-13).x
+
+    # Validate over the frame's radius domain: positive denominator and a
+    # strictly increasing rectified→distorted radius map (no poles, no folds).
+    corners_native_42 = np.array([[0.0, 0.0], [width - 1.0, 0.0], [0.0, height - 1.0], [width - 1.0, height - 1.0]], dtype=np.float64)
+    rectified_corners_42 = apple_rectified(corners_native_42)
+    radius_domain: float = float(np.max(np.linalg.norm(rectified_corners_42 - center_native_xy, axis=1))) / focal_fit_px
+    r2_probe_n = np.square(np.linspace(0.0, 1.05 * radius_domain, 4096))
+    denominator_probe_n = 1.0 + k_fit_6[3] * r2_probe_n + k_fit_6[4] * r2_probe_n**2 + k_fit_6[5] * r2_probe_n**3
+    if np.any(denominator_probe_n <= 0.0):
+        raise ValueError("Fitted rational denominator is not positive over the calibrated frame")
+    probe_n2 = np.stack([center_native_xy[0] + np.sqrt(r2_probe_n) * focal_fit_px, np.full(r2_probe_n.shape, center_native_xy[1])], axis=1)
+    distorted_radii_n = np.linalg.norm(rational_distorted(probe_n2, k_fit_6) - center_native_xy, axis=1)
+    if np.any(np.diff(distorted_radii_n) <= 0.0):
+        raise ValueError("Fitted rational radius map is not strictly increasing over the calibrated frame")
+
+    # Measure the worst-case error in the direction consumers use (distorted →
+    # rectified), with OpenCV's own high-precision iterative inversion.
+    K_fit_33 = np.array([[focal_fit_px, 0.0, center_native_xy[0]], [0.0, focal_fit_px, center_native_xy[1]], [0.0, 0.0, 1.0]])
+    distortion_fit_8 = np.array([k_fit_6[0], k_fit_6[1], 0.0, 0.0, k_fit_6[2], k_fit_6[3], k_fit_6[4], k_fit_6[5]])
+    x2_n = np.unique(np.append(np.arange(0.0, width, 2.0), float(width - 1)))
+    y2_n = np.unique(np.append(np.arange(0.0, height, 2.0), float(height - 1)))
+    x2_hw, y2_hw = np.meshgrid(x2_n, y2_n)
+    distorted_check_n2 = np.stack([x2_hw.reshape(-1), y2_hw.reshape(-1)], axis=1)
+    criteria = (cv2.TERM_CRITERIA_COUNT | cv2.TERM_CRITERIA_EPS, 100, 1e-13)
+    rectified_check_n12 = cv2.undistortPoints(  # pyrefly: ignore  # no-matching-overload — cv2 stubs omit the criteria overload the binding accepts
+        distorted_check_n2.reshape(-1, 1, 2), K_fit_33, distortion_fit_8, P=K_fit_33, criteria=criteria
+    )
+    max_residual_px: float = float(np.max(np.linalg.norm(rectified_check_n12.reshape(-1, 2) - apple_rectified(distorted_check_n2), axis=1)))
+    if max_residual_px > residual_bound_px:
+        raise ValueError(f"Rational fit residual {max_residual_px:.6f} px exceeds the {residual_bound_px} px bound")
+
+    # Rescale from corner-radius normalization to K's focal length so the
+    # returned pair works directly with OpenCV.
+    K_native = np.asarray(K_native_33, dtype=np.float64)
+    ratio: float = float(K_native[0, 0]) / focal_fit_px
+    k_physical_6 = k_fit_6 * np.array([ratio**2, ratio**4, ratio**6, ratio**2, ratio**4, ratio**6])
+    K_out_33 = K_native.copy()
+    K_out_33[0, 2] = center_native_xy[0]
+    K_out_33[1, 2] = center_native_xy[1]
+    distortion = BrownConradyDistortion(
+        k1=float(k_physical_6[0]), k2=float(k_physical_6[1]), p1=0.0, p2=0.0, k3=float(k_physical_6[2]),
+        k4=float(k_physical_6[3]), k5=float(k_physical_6[4]), k6=float(k_physical_6[5]),
+    )
+    return OpenCVRationalFit(distortion=distortion, K_33=K_out_33.astype(np.float32), max_residual_px=max_residual_px)

--- a/packages/gauss-surf/tests/test_catalog.py
+++ b/packages/gauss-surf/tests/test_catalog.py
@@ -1,0 +1,147 @@
+"""Behavior contracts for composable catalog segment reads."""
+
+from typing import Any
+
+import numpy as np
+import pyarrow as pa
+import pytest
+import torch
+from rerun.catalog import DatasetEntry
+
+from gauss_surf.catalog import SegmentReader
+
+
+class _CollectedSegmentTable:
+    """Minimal catalog segment-table query used by reader tests."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._table: pa.Table = pa.Table.from_pylist(rows)
+        self.collect_count: int = 0
+
+    def collect(self) -> list[pa.RecordBatch]:
+        """Return Arrow batches and record how often the table was read."""
+        self.collect_count += 1
+        return self._table.to_batches()
+
+
+class _Dataset(DatasetEntry):
+    """Minimal dataset boundary for segment-row behavior."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        """Create a dataset-entry test double without an SDK backend."""
+        self.table: _CollectedSegmentTable = _CollectedSegmentTable(rows)
+
+    def segment_table(self) -> _CollectedSegmentTable:
+        """Return the fake segment-table query."""
+        return self.table
+
+
+def _row(orientation: Any = 0, layers: list[str] | None = None) -> dict[str, Any]:
+    """Build one segment-table row with catalog-shaped cells."""
+    return {
+        "rerun_segment_id": "segment-a",
+        "rerun_layer_names": layers if layers is not None else ["base", "frame_selection"],
+        "property:capture:orientation_quarter_turns_ccw": orientation,
+    }
+
+
+def test_segment_reader_returns_and_caches_the_unique_row() -> None:
+    """Repeated reads do not rescan the catalog segment table."""
+    dataset: _Dataset = _Dataset([_row()])
+    reader: SegmentReader = SegmentReader(dataset, "segment-a")
+
+    assert reader.row()["rerun_segment_id"] == "segment-a"
+    assert reader.row()["rerun_segment_id"] == "segment-a"
+    assert dataset.table.collect_count == 1
+
+
+def test_segment_reader_absent_id_exits_cleanly_with_available_ids() -> None:
+    """A missing segment is a clean CLI error rather than an index failure."""
+    reader: SegmentReader = SegmentReader(_Dataset([_row()]), "missing")
+
+    with pytest.raises(SystemExit, match="available ids: segment-a"):
+        reader.row()
+
+
+def test_segment_reader_rejects_duplicate_segment_rows() -> None:
+    """Ambiguous catalog identity is refused before a stage reads data."""
+    reader: SegmentReader = SegmentReader(_Dataset([_row(), _row()]), "segment-a")
+
+    with pytest.raises(SystemExit, match="2 rows"):
+        reader.row()
+
+
+def test_segment_reader_reports_missing_upstream_layers() -> None:
+    """Layer prerequisites share one clean error path across stages."""
+    reader: SegmentReader = SegmentReader(_Dataset([_row(layers=["base"])]), "segment-a")
+
+    with pytest.raises(SystemExit, match=r"missing required layers: \['frame_selection', 'promptda'\]"):
+        reader.require_layers(("frame_selection", "promptda"))
+
+
+@pytest.mark.parametrize("stage_context", ["MoGe normal inference", "ultrawide rectification"])
+def test_none_orientation_cell_exits_cleanly_for_both_stage_contexts(stage_context: str) -> None:
+    """A catalog ``[None]`` orientation cell never reaches ``int(None)``."""
+    reader: SegmentReader = SegmentReader(_Dataset([_row(orientation=[None])]), "segment-a")
+
+    with pytest.raises(SystemExit, match="missing required catalog property"):
+        reader.require_zero_orientation(stage_context)
+
+
+def test_segment_reader_accepts_scalar_and_singleton_zero_orientation() -> None:
+    """Both catalog encodings of the supported orientation remain valid."""
+    for orientation in (0, [0], np.asarray([0])):
+        reader: SegmentReader = SegmentReader(_Dataset([_row(orientation=orientation)]), "segment-a")
+        reader.require_zero_orientation("test stage")
+
+
+def test_segment_reader_rejects_nonzero_orientation_with_stage_context() -> None:
+    """Unsupported orientation errors name the stage that imposed the limit."""
+    reader: SegmentReader = SegmentReader(_Dataset([_row(orientation=[1])]), "segment-a")
+
+    with pytest.raises(SystemExit, match="test stage supports only zero quarter-turns"):
+        reader.require_zero_orientation("test stage")
+
+
+def test_decode_frames_refuses_timestamp_drift(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The shared NVDEC seam verifies all requested timestamps exactly once."""
+
+    class _Decoder:
+        """Deterministic stand-in for the GPU decoder."""
+
+        def __init__(self, *_args: Any) -> None:
+            self.times: np.ndarray = np.asarray([10, 20], dtype=np.int64).astype("timedelta64[ns]")
+
+        def decode(self, _raw: pa.ChunkedArray, _timestamp: np.timedelta64, _video_id: str) -> torch.Tensor:
+            """Return one RGB tensor so exactness validation can run."""
+            return torch.zeros((3, 2, 2), dtype=torch.uint8)
+
+    monkeypatch.setattr("gauss_surf.catalog.SegmentNvdecDecoder", _Decoder)
+    reader: SegmentReader = SegmentReader(_Dataset([_row()]), "segment-a")
+    drifted_n: np.ndarray = np.asarray([10, 21], dtype=np.int64).astype("timedelta64[ns]")
+
+    with pytest.raises(ValueError, match="no exact video-packet match"):
+        list(reader.decode_frames("video/wide", drifted_n, fps=60.0, device=torch.device("cpu")))
+
+
+def test_decode_frames_preserves_requested_timestamp_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exact decoding yields one frame for each requested timestamp in request order."""
+
+    class _Decoder:
+        """Timestamp-valued stand-in for the GPU decoder."""
+
+        def __init__(self, *_args: Any) -> None:
+            self.times: np.ndarray = np.asarray([10, 20], dtype=np.int64).astype("timedelta64[ns]")
+
+        def decode(self, _raw: pa.ChunkedArray, timestamp: np.timedelta64, _video_id: str) -> torch.Tensor:
+            """Encode the requested nanosecond value into the returned frame."""
+            value: int = int(timestamp.astype(np.int64))
+            return torch.full((3, 1, 1), value, dtype=torch.uint8)
+
+    monkeypatch.setattr("gauss_surf.catalog.SegmentNvdecDecoder", _Decoder)
+    reader: SegmentReader = SegmentReader(_Dataset([_row()]), "segment-a")
+    requested_n: np.ndarray = np.asarray([20, 10], dtype=np.int64).astype("timedelta64[ns]")
+
+    frames: list[torch.Tensor] = list(reader.decode_frames("video/wide", requested_n, fps=60.0, device=torch.device("cpu")))
+
+    assert [int(frame[0, 0, 0]) for frame in frames] == [20, 10]

--- a/packages/gauss-surf/tests/test_contracts.py
+++ b/packages/gauss-surf/tests/test_contracts.py
@@ -1,0 +1,35 @@
+"""Public schema contracts shared by gauss-surf stages."""
+
+from gauss_surf.contracts import (
+    FRAME_SELECTION_LAYER,
+    LAYERS,
+    SPLAT_DEPTH_LAYER,
+    SPLAT_LAYER,
+    SPLAT_TRIAGE_LAYER,
+    ULTRAWIDE_FPS,
+    WIDE_FPS,
+)
+
+
+def test_layers_are_the_single_recovery_path_spec() -> None:
+    """Every derived catalog layer has one stable name and local recovery path."""
+    assert LAYERS == {
+        "promptda": "data/promptda/{video_id}.rrd",
+        "frame_selection": "data/frame_selection/{video_id}.rrd",
+        "moge_normals": "data/moge_normals/{video_id}.rrd",
+        "ultrawide_depth": "data/ultrawide_signals/{video_id}/ultrawide_depth.rrd",
+        "ultrawide_normals": "data/ultrawide_signals/{video_id}/ultrawide_normals.rrd",
+        "splat": "data/splat/{video_id}.rrd",
+        "splat_depth": "data/splat_depth/{video_id}.rrd",
+        "splat_triage": "data/splat_triage/{video_id}.rrd",
+    }
+    assert FRAME_SELECTION_LAYER in LAYERS
+    assert SPLAT_LAYER in LAYERS
+    assert SPLAT_DEPTH_LAYER in LAYERS
+    assert SPLAT_TRIAGE_LAYER in LAYERS
+
+
+def test_shared_camera_rates_match_the_source_streams() -> None:
+    """Selection and exact-decode stages use one nominal rate per camera."""
+    assert WIDE_FPS == 60.0
+    assert ULTRAWIDE_FPS == 10.0

--- a/packages/gauss-surf/tests/test_frame_selection.py
+++ b/packages/gauss-surf/tests/test_frame_selection.py
@@ -1,0 +1,100 @@
+"""Behavior checks for sharp-frame scoring and selection."""
+
+import numpy as np
+import torch
+from jaxtyping import Float32, Int64, UInt8
+from numpy import ndarray
+from torch import Tensor
+
+from gauss_surf.frame_selection import score_frames, select_ultrawide_frames, select_wide_frames
+
+
+def test_wide_selection_keeps_every_window_argmax_unconditionally() -> None:
+    """Every fixed index window contributes its argmax, including a final partial window."""
+    sharpness_n: Float32[ndarray, "n_frames=14"] = np.array(
+        [1.0, 2.0, 3.0, 4.0, 5.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 1.0, 2.0],
+        dtype=np.float32,
+    )
+    timestamps_n: ndarray = np.arange(14, dtype="timedelta64[ns]")
+
+    result = select_wide_frames(
+        sharpness_n,
+        timestamps_n,
+        window_size=6,
+        min_chosen=1,
+    )
+
+    expected_indices_n: Int64[ndarray, "n_chosen=3"] = np.array([5, 6, 13], dtype=np.int64)
+    np.testing.assert_array_equal(result.chosen_indices, expected_indices_n)
+    np.testing.assert_array_equal(result.windows, np.array([0, 1, 2], dtype=np.int64))
+    assert len(result.chosen_indices) == 3
+    assert not result.rejected
+
+
+def test_scoring_separates_a_blank_frame_from_a_textured_frame() -> None:
+    """Sharpness and texture measurements remain available as diagnostics."""
+    checkerboard_hw: UInt8[Tensor, "h=60 w=80"] = (
+        (torch.arange(60)[:, None] + torch.arange(80)[None, :]) % 2 * 255
+    ).to(torch.uint8)
+    blank_hwc: UInt8[Tensor, "h=60 w=80 3"] = torch.zeros((60, 80, 3), dtype=torch.uint8)
+    textured_hwc: UInt8[Tensor, "h=60 w=80 3"] = torch.stack((checkerboard_hw, checkerboard_hw, checkerboard_hw), dim=-1)
+    frames_bhw3: UInt8[Tensor, "b=2 h=60 w=80 3"] = torch.stack((blank_hwc, textured_hwc))
+
+    scores = score_frames(frames_bhw3)
+
+    assert scores.texture[0].item() == 0.0
+    assert scores.texture[1].item() > 10.0
+    assert scores.sharpness[0].item() == 0.0
+    assert scores.sharpness[1].item() > 100.0
+
+
+def test_ultrawide_selection_keeps_every_frame() -> None:
+    """Ultrawide selection admits the full 10 Hz sampling grid."""
+    sharpness_n: Float32[ndarray, "n_frames=5"] = np.array([99.0, 100.0, 130.0, 5.0, 100.0], dtype=np.float32)
+    timestamps_n: ndarray = np.arange(5, dtype="timedelta64[ns]")
+
+    result = select_ultrawide_frames(sharpness_n, timestamps_n)
+
+    np.testing.assert_array_equal(result.chosen_indices, np.arange(5, dtype=np.int64))
+    np.testing.assert_array_equal(result.windows, result.chosen_indices)
+    assert result.rules == ("all",) * 5
+    assert not result.rejected
+
+
+def test_wide_selection_rejects_a_segment_below_min_chosen() -> None:
+    """Coverage rejection is explicit and retains the sparse audit result."""
+    sharpness_n: Float32[ndarray, "n_frames=12"] = np.arange(12, dtype=np.float32) + 200.0
+    timestamps_n: ndarray = np.arange(12, dtype="timedelta64[ns]")
+
+    result = select_wide_frames(sharpness_n, timestamps_n, min_chosen=3)
+
+    np.testing.assert_array_equal(result.chosen_indices, np.array([5, 11], dtype=np.int64))
+    assert result.rejected
+    assert result.rejection_reason == "wide selection kept 2 frames, fewer than min_chosen=3"
+
+
+def test_scoring_is_invariant_to_source_resolution() -> None:
+    """The same pixels at two integer scales produce the same normalized score."""
+    rows_h1: Tensor = torch.arange(540, dtype=torch.int64)[:, None]
+    columns_1w: Tensor = torch.arange(720, dtype=torch.int64)[None, :]
+    pattern_hw: UInt8[Tensor, "h=540 w=720"] = ((rows_h1 * 7 + columns_1w * 11) % 251).to(torch.uint8)
+    reference_bhw3: UInt8[Tensor, "b=1 h=540 w=720 3"] = torch.stack((pattern_hw, pattern_hw, pattern_hw), dim=-1)[None]
+    doubled_bhw3: UInt8[Tensor, "b=1 h=1080 w=1440 3"] = reference_bhw3.repeat_interleave(2, dim=1).repeat_interleave(2, dim=2)
+
+    reference_scores = score_frames(reference_bhw3)
+    doubled_scores = score_frames(doubled_bhw3)
+
+    torch.testing.assert_close(reference_scores.sharpness, doubled_scores.sharpness, rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(reference_scores.texture, doubled_scores.texture, rtol=1e-5, atol=1e-5)
+
+
+def test_selection_preserves_packet_timestamps_as_timedelta64_nanoseconds() -> None:
+    """Dense and chosen timestamps remain durations and never become plain integer seconds."""
+    sharpness_n: Float32[ndarray, "n_frames=3"] = np.array([10.0, 200.0, 300.0], dtype=np.float32)
+    timestamps_us_n: ndarray = np.array([1, 2, 3], dtype="timedelta64[us]")
+
+    result = select_ultrawide_frames(sharpness_n, timestamps_us_n)
+
+    assert result.timestamps.dtype == np.dtype("timedelta64[ns]")
+    assert result.chosen_timestamps.dtype == np.dtype("timedelta64[ns]")
+    np.testing.assert_array_equal(result.chosen_timestamps, np.array([1_000, 2_000, 3_000], dtype="timedelta64[ns]"))

--- a/packages/gauss-surf/tests/test_gaussurf_geometry.py
+++ b/packages/gauss-surf/tests/test_gaussurf_geometry.py
@@ -1,0 +1,321 @@
+"""Analytic contracts for GausSurf-compatible Gaussian surface rendering."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from gauss_surf.gaussurf_geometry import (
+    gaussian_plane_features,
+    plane_depth_from_rendered_features,
+    smallest_axis_world_normals,
+)
+
+PLANE_DENOMINATOR_CUTOFF: float = 1e-4
+"""Denominators below this explicit cutoff are treated as degenerate."""
+
+
+def _rotation_xyz(rx: float, ry: float, rz: float) -> torch.Tensor:
+    """Return a float64 XYZ Euler rotation on CPU."""
+    cx: float = math.cos(rx)
+    sx: float = math.sin(rx)
+    cy: float = math.cos(ry)
+    sy: float = math.sin(ry)
+    cz: float = math.cos(rz)
+    sz: float = math.sin(rz)
+    rotation_x_33: torch.Tensor = torch.tensor(
+        [[1.0, 0.0, 0.0], [0.0, cx, -sx], [0.0, sx, cx]],
+        dtype=torch.float64,
+        device="cpu",
+    )
+    rotation_y_33: torch.Tensor = torch.tensor(
+        [[cy, 0.0, sy], [0.0, 1.0, 0.0], [-sy, 0.0, cy]],
+        dtype=torch.float64,
+        device="cpu",
+    )
+    rotation_z_33: torch.Tensor = torch.tensor(
+        [[cz, -sz, 0.0], [sz, cz, 0.0], [0.0, 0.0, 1.0]],
+        dtype=torch.float64,
+        device="cpu",
+    )
+    return rotation_z_33 @ rotation_y_33 @ rotation_x_33
+
+
+def _quaternion_align_z(normal_3: torch.Tensor) -> torch.Tensor:
+    """Return a WXYZ quaternion that maps the positive Z axis to ``normal_3``."""
+    z_axis_3: torch.Tensor = torch.tensor(
+        [0.0, 0.0, 1.0], dtype=torch.float64, device="cpu"
+    )
+    dot: float = float(torch.dot(z_axis_3, normal_3).clamp(-1.0, 1.0).item())
+    if dot < -1.0 + 1e-12:
+        return torch.tensor(
+            [0.0, 1.0, 0.0, 0.0], dtype=torch.float64, device="cpu"
+        )
+    cross_3: torch.Tensor = torch.linalg.cross(z_axis_3, normal_3)
+    quaternion_wxyz_4: torch.Tensor = torch.cat(
+        (
+            torch.tensor([1.0 + dot], dtype=torch.float64, device="cpu"),
+            cross_3,
+        )
+    )
+    return quaternion_wxyz_4 / torch.linalg.vector_norm(quaternion_wxyz_4)
+
+
+@settings(max_examples=64, deadline=None)
+@given(
+    rx=st.floats(-math.pi, math.pi, allow_nan=False, allow_infinity=False),
+    ry=st.floats(-math.pi, math.pi, allow_nan=False, allow_infinity=False),
+    rz=st.floats(-math.pi, math.pi, allow_nan=False, allow_infinity=False),
+    tx=st.floats(-1.0, 1.0, allow_nan=False, allow_infinity=False),
+    ty=st.floats(-1.0, 1.0, allow_nan=False, allow_infinity=False),
+    tz=st.floats(-1.0, 1.0, allow_nan=False, allow_infinity=False),
+    ray_x=st.floats(-1.5, 1.5, allow_nan=False, allow_infinity=False),
+    ray_y=st.floats(-1.5, 1.5, allow_nan=False, allow_infinity=False),
+    denominator=st.one_of(
+        st.sampled_from((-2e-4, -1.1e-4, -1.01e-4, 1.01e-4, 1.1e-4, 2e-4)),
+        st.floats(-0.95, -2e-4, allow_nan=False, allow_infinity=False),
+        st.floats(2e-4, 0.95, allow_nan=False, allow_infinity=False),
+    ),
+    exact_depth=st.floats(0.25, 100.0, allow_nan=False, allow_infinity=False),
+)
+def test_plane_depth_matches_exact_world_ray_plane_intersection(
+    rx: float,
+    ry: float,
+    rz: float,
+    tx: float,
+    ty: float,
+    tz: float,
+    ray_x: float,
+    ray_y: float,
+    denominator: float,
+    exact_depth: float,
+) -> None:
+    """Plane depth equals the analytic world-space intersection, including near-grazing rays.
+
+    The generated denominator is always greater than ``1e-4`` in magnitude,
+    which is the renderer's actual default cutoff. This exercises stable
+    near-grazing intersections without silently relaxing the degenerate-plane
+    threshold. The ``2e-7`` absolute oracle tolerance covers cancellation when
+    the random camera translation is removed in world-space float64 arithmetic.
+    """
+    rotation_world_from_camera_33: torch.Tensor = _rotation_xyz(rx, ry, rz)
+    camera_origin_world_3: torch.Tensor = torch.tensor(
+        [tx, ty, tz], dtype=torch.float64, device="cpu"
+    )
+    ray_camera_3: torch.Tensor = torch.tensor(
+        [ray_x, ray_y, 1.0], dtype=torch.float64, device="cpu"
+    )
+    ray_length: torch.Tensor = torch.linalg.vector_norm(ray_camera_3)
+    ray_unit_3: torch.Tensor = ray_camera_3 / ray_length
+    perpendicular_3: torch.Tensor = torch.tensor(
+        [1.0, 0.0, -ray_x], dtype=torch.float64, device="cpu"
+    )
+    perpendicular_3 = perpendicular_3 / torch.linalg.vector_norm(perpendicular_3)
+    parallel_coefficient: torch.Tensor = torch.tensor(
+        denominator, dtype=torch.float64, device="cpu"
+    ) / ray_length
+    normal_camera_3: torch.Tensor = (
+        parallel_coefficient * ray_unit_3
+        + math.sqrt(1.0 - parallel_coefficient.item() ** 2) * perpendicular_3
+    )
+    gaussian_camera_3: torch.Tensor = ray_camera_3 * exact_depth
+    normal_world_3: torch.Tensor = rotation_world_from_camera_33 @ normal_camera_3
+    tangent_camera_3: torch.Tensor = torch.linalg.cross(
+        normal_camera_3, ray_camera_3
+    )
+    tangent_camera_3 = tangent_camera_3 / torch.linalg.vector_norm(
+        tangent_camera_3
+    )
+    bitangent_camera_3: torch.Tensor = torch.linalg.cross(
+        normal_camera_3, tangent_camera_3
+    )
+    gaussian_means_camera_n3: torch.Tensor = torch.stack(
+        (
+            gaussian_camera_3,
+            gaussian_camera_3 + 0.25 * tangent_camera_3,
+            gaussian_camera_3 - 0.4 * tangent_camera_3 + 0.1 * bitangent_camera_3,
+        )
+    )
+    gaussian_means_world_n3: torch.Tensor = (
+        gaussian_means_camera_n3 @ rotation_world_from_camera_33.T
+        + camera_origin_world_3
+    )
+    plane_offset_world: torch.Tensor = normal_world_3 @ gaussian_means_world_n3[0]
+    ray_world_3: torch.Tensor = rotation_world_from_camera_33 @ ray_camera_3
+    oracle_depth: torch.Tensor = (
+        plane_offset_world - normal_world_3 @ camera_origin_world_3
+    ) / (normal_world_3 @ ray_world_3)
+
+    world_to_camera_44: torch.Tensor = torch.eye(
+        4, dtype=torch.float64, device="cpu"
+    )
+    world_to_camera_44[:3, :3] = rotation_world_from_camera_33.T
+    world_to_camera_44[:3, 3] = (
+        -rotation_world_from_camera_33.T @ camera_origin_world_3
+    )
+    log_scales_n3: torch.Tensor = torch.tensor(
+        [[0.0, 0.0, -2.0]], dtype=torch.float64, device="cpu"
+    ).repeat(3, 1)
+    quaternion_wxyz_4: torch.Tensor = _quaternion_align_z(normal_world_3)
+    quaternions_wxyz_n4: torch.Tensor = quaternion_wxyz_4.repeat(3, 1)
+    gaussian_features_n4: torch.Tensor = gaussian_plane_features(
+        gaussian_means_world_n3,
+        log_scales_n3,
+        quaternions_wxyz_n4,
+        world_to_camera_44,
+    )
+    gaussian_weights_n1: torch.Tensor = torch.tensor(
+        [[0.2], [0.3], [0.5]], dtype=torch.float64, device="cpu"
+    )
+    features_hw4: torch.Tensor = (
+        gaussian_features_n4 * gaussian_weights_n1
+    ).sum(dim=0).reshape(1, 1, 4)
+    alpha_hw1: torch.Tensor = torch.ones(
+        (1, 1, 1), dtype=torch.float64, device="cpu"
+    )
+    intrinsics_33: torch.Tensor = torch.tensor(
+        [[1.0, 0.0, 0.5 - ray_x], [0.0, 1.0, 0.5 - ray_y], [0.0, 0.0, 1.0]],
+        dtype=torch.float64,
+        device="cpu",
+    )
+
+    result = plane_depth_from_rendered_features(
+        features_hw4,
+        alpha_hw1,
+        intrinsics_33,
+        min_denominator=PLANE_DENOMINATOR_CUTOFF,
+        min_depth=0.0,
+        max_depth=1e6,
+    )
+
+    assert result.valid_hw1.item()
+    torch.testing.assert_close(
+        gaussian_means_world_n3 @ normal_world_3,
+        plane_offset_world.expand(3),
+        rtol=0.0,
+        atol=1e-12,
+    )
+    torch.testing.assert_close(
+        result.depth_hw1[0, 0, 0], oracle_depth, rtol=2e-9, atol=2e-7
+    )
+
+
+def test_plane_depth_uses_the_documented_degenerate_cutoff() -> None:
+    """A denominator below the exact cutoff is invalid; a larger grazing ray is valid."""
+    intrinsics_33: torch.Tensor = torch.eye(
+        3, dtype=torch.float64, device="cpu"
+    )
+    alpha_hw1: torch.Tensor = torch.ones(
+        (1, 2, 1), dtype=torch.float64, device="cpu"
+    )
+    below_cutoff: float = PLANE_DENOMINATOR_CUTOFF / 2.0
+    above_cutoff: float = PLANE_DENOMINATOR_CUTOFF * 2.0
+    features_hw4: torch.Tensor = torch.tensor(
+        [
+            [
+                [1.0, 0.0, -0.5 + below_cutoff, 2.0 * below_cutoff],
+                [1.0, 0.0, -1.5 + above_cutoff, 2.0 * above_cutoff],
+            ]
+        ],
+        dtype=torch.float64,
+        device="cpu",
+    )
+
+    result = plane_depth_from_rendered_features(
+        features_hw4,
+        alpha_hw1,
+        intrinsics_33,
+        min_denominator=PLANE_DENOMINATOR_CUTOFF,
+        min_depth=0.0,
+    )
+
+    assert not result.valid_hw1[0, 0, 0].item()
+    assert result.valid_hw1[0, 1, 0].item()
+    torch.testing.assert_close(
+        result.depth_hw1[0, 1, 0],
+        torch.tensor(2.0, dtype=torch.float64, device="cpu"),
+    )
+
+
+def test_smallest_axis_normal_uses_rotation_column() -> None:
+    log_scales = torch.tensor([[0.0, -3.0, -1.0]])
+    identity_wxyz = torch.tensor([[1.0, 0.0, 0.0, 0.0]])
+
+    normal = smallest_axis_world_normals(log_scales, identity_wxyz)
+
+    torch.testing.assert_close(normal, torch.tensor([[0.0, 1.0, 0.0]]))
+
+
+def test_gaussian_plane_features_face_along_camera_ray() -> None:
+    means = torch.tensor([[0.0, 0.0, 2.0], [0.0, 0.0, 3.0]])
+    log_scales = torch.tensor([[1.0, 1.0, -2.0], [1.0, 1.0, -2.0]])
+    quats = torch.tensor([[1.0, 0.0, 0.0, 0.0], [-1.0, 0.0, 0.0, 0.0]])
+    world_to_camera = torch.eye(4)
+
+    features = gaussian_plane_features(means, log_scales, quats, world_to_camera)
+
+    torch.testing.assert_close(features[:, :3], torch.tensor([[0.0, 0.0, 1.0]]).repeat(2, 1))
+    torch.testing.assert_close(features[:, 3], torch.tensor([2.0, 3.0]))
+
+
+def test_plane_intersection_depth_matches_frontal_and_slanted_planes() -> None:
+    intrinsics = torch.tensor(
+        [[2.0, 0.0, 1.5], [0.0, 2.0, 1.5], [0.0, 0.0, 1.0]]
+    )
+    alpha = torch.ones((3, 3, 1))
+
+    frontal_features = torch.zeros((3, 3, 4))
+    frontal_features[..., 2] = 1.0
+    frontal_features[..., 3] = 2.0
+    frontal = plane_depth_from_rendered_features(frontal_features, alpha, intrinsics)
+    torch.testing.assert_close(frontal.depth_hw1, torch.full((3, 3, 1), 2.0))
+    assert frontal.valid_hw1.all()
+
+    root_two = 2.0**0.5
+    slanted_features = torch.zeros((3, 3, 4))
+    slanted_features[..., 0] = 1.0 / root_two
+    slanted_features[..., 2] = 1.0 / root_two
+    slanted_features[..., 3] = 2.0 / root_two
+    slanted = plane_depth_from_rendered_features(slanted_features, alpha, intrinsics)
+    # The right-most center-row ray is [0.5, 0, 1], so z = 2 / 1.5.
+    torch.testing.assert_close(slanted.depth_hw1[1, 2, 0], torch.tensor(4.0 / 3.0))
+
+
+def test_plane_depth_masks_low_alpha_grazing_and_negative_intersections() -> None:
+    intrinsics = torch.tensor(
+        [[1.0, 0.0, 0.5], [0.0, 1.0, 0.5], [0.0, 0.0, 1.0]]
+    )
+    alpha = torch.tensor([[[1.0], [0.001], [1.0]]])
+    features = torch.tensor(
+        [[
+            [1.0, 0.0, 0.0, 2.0],
+            [0.0, 0.0, 1.0, 2.0],
+            [0.0, 0.0, 1.0, -2.0],
+        ]]
+    )
+
+    result = plane_depth_from_rendered_features(
+        features,
+        alpha,
+        intrinsics,
+        min_alpha=0.01,
+    )
+
+    assert not result.valid_hw1.any()
+    assert torch.isfinite(result.depth_hw1).all()
+    torch.testing.assert_close(result.depth_hw1, torch.zeros_like(result.depth_hw1))
+
+
+def test_plane_depth_has_finite_gradients() -> None:
+    intrinsics = torch.eye(3)
+    alpha = torch.ones((1, 1, 1))
+    features = torch.tensor([[[0.0, 0.0, 1.0, 2.0]]], requires_grad=True)
+
+    result = plane_depth_from_rendered_features(features, alpha, intrinsics)
+    result.depth_hw1.sum().backward()
+
+    assert features.grad is not None
+    assert torch.isfinite(features.grad).all()

--- a/packages/gauss-surf/tests/test_gaussurf_losses.py
+++ b/packages/gauss-surf/tests/test_gaussurf_losses.py
@@ -1,0 +1,252 @@
+"""Behavior contracts for complementary GausSurf geometry supervision."""
+
+from __future__ import annotations
+
+import torch
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+from gauss_surf.gaussurf_losses import (
+    _masked_mean,
+    compute_gaussurf_losses,
+    linear_ramp_weight,
+    normal_contradiction_gate,
+    pgsr_edge_weights,
+    prepare_gaussurf_targets,
+)
+
+
+@settings(max_examples=48, deadline=None)
+@given(
+    values=st.lists(st.integers(-1_000, 1_000), min_size=8, max_size=8),
+    mask=st.lists(st.booleans(), min_size=8, max_size=8),
+    perturbations=st.lists(
+        st.integers(-1_000_000, 1_000_000), min_size=8, max_size=8
+    ),
+)
+def test_masked_mean_is_bit_identical_after_outside_mask_perturbations(
+    values: list[int], mask: list[bool], perturbations: list[int]
+) -> None:
+    """Pixels outside a loss mask have no numerical effect on that loss."""
+    assume(any(mask))
+    values_n: torch.Tensor = torch.tensor(
+        values, dtype=torch.float64, device="cpu"
+    )
+    mask_n: torch.Tensor = torch.tensor(mask, dtype=torch.bool, device="cpu")
+    perturbations_n: torch.Tensor = torch.tensor(
+        perturbations, dtype=torch.float64, device="cpu"
+    )
+    perturbed_n: torch.Tensor = torch.where(
+        mask_n, values_n, perturbations_n
+    )
+
+    original_loss: torch.Tensor = _masked_mean(values_n, mask_n)
+    perturbed_loss: torch.Tensor = _masked_mean(perturbed_n, mask_n)
+
+    assert torch.equal(perturbed_loss, original_loss)
+
+
+def test_masked_out_nonfinite_values_do_not_poison_loss_or_gradients() -> None:
+    """A non-finite value outside the mask contributes exact zero."""
+    values_n: torch.Tensor = torch.tensor(
+        [3.0, float("inf")],
+        dtype=torch.float64,
+        device="cpu",
+        requires_grad=True,
+    )
+    mask_n: torch.Tensor = torch.tensor(
+        [True, False], dtype=torch.bool, device="cpu"
+    )
+
+    loss: torch.Tensor = _masked_mean(values_n, mask_n)
+    loss.backward()
+
+    assert torch.equal(
+        loss, torch.tensor(3.0, dtype=torch.float64, device="cpu")
+    )
+    assert values_n.grad is not None
+    assert torch.isfinite(values_n.grad).all()
+
+
+def test_linear_ramp_weight_delays_and_saturates() -> None:
+    assert linear_ramp_weight(step=9, start_step=10, ramp_steps=4) == 0.0
+    assert linear_ramp_weight(step=10, start_step=10, ramp_steps=4) == 0.25
+    assert linear_ramp_weight(step=11, start_step=10, ramp_steps=4) == 0.5
+    assert linear_ramp_weight(step=13, start_step=10, ramp_steps=4) == 1.0
+    assert linear_ramp_weight(step=20, start_step=10, ramp_steps=4) == 1.0
+
+
+def test_target_resize_keeps_masks_discrete_and_normals_unit_length() -> None:
+    targets = prepare_gaussurf_targets(
+        prior_normal_3hw=torch.tensor(
+            [
+                [[0.0, 0.0], [0.0, 0.0]],
+                [[0.0, 0.0], [0.0, 0.0]],
+                [[1.0, 1.0], [1.0, 1.0]],
+            ]
+        ),
+        prior_valid_1hw=torch.tensor([[[True, False], [False, True]]]),
+        height=4,
+        width=4,
+    )
+
+    assert targets.prior_normal_hw3.shape == (4, 4, 3)
+    assert targets.prior_valid_hw1.dtype == torch.bool
+    assert set(targets.prior_valid_hw1.unique().tolist()) == {False, True}
+    torch.testing.assert_close(
+        torch.linalg.vector_norm(targets.prior_normal_hw3, dim=-1),
+        torch.ones((4, 4)),
+    )
+
+
+def test_neuris_contradiction_gate_rejects_normals_beyond_thirty_degrees() -> None:
+    rendered = torch.tensor([[[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]])
+    prior = torch.tensor([[[0.0, 0.0, 1.0], [1.0, 0.0, 0.0]]])
+    valid = torch.ones((1, 2, 1), dtype=torch.bool)
+
+    gate = normal_contradiction_gate(rendered, prior, valid)
+
+    torch.testing.assert_close(gate, torch.tensor([[[True], [False]]]))
+    assert not gate.requires_grad
+
+
+def test_normal_prior_uses_all_valid_surface_pixels() -> None:
+    direct_normal = torch.tensor(
+        [[[0.0, 0.0, 1.0], [1.0, 0.0, 0.0]]],
+        requires_grad=True,
+    )
+    depth_normal = torch.tensor([[[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]])
+    prior_normal = torch.tensor([[[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]])
+    prior_valid = torch.ones((1, 2, 1), dtype=torch.bool)
+    surface_valid = torch.ones_like(prior_valid)
+
+    result = compute_gaussurf_losses(
+        direct_normal_hw3=direct_normal,
+        depth_normal_hw3=depth_normal,
+        prior_normal_hw3=prior_normal,
+        prior_valid_hw1=prior_valid,
+        surface_valid_hw1=surface_valid,
+    )
+
+    torch.testing.assert_close(result.normal_prior_cosine, torch.tensor(1.0))
+    torch.testing.assert_close(result.depth_normal_cosine, torch.tensor(0.5))
+    torch.testing.assert_close(result.normal_prior_mask_fraction, torch.tensor(1.0))
+
+
+def test_neuris_gate_can_veto_prior_without_changing_depth_mask() -> None:
+    normals = torch.tensor([[[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]])
+    prior_valid = torch.ones((1, 2, 1), dtype=torch.bool)
+    contradiction_gate = torch.tensor([[[True], [False]]])
+
+    result = compute_gaussurf_losses(
+        direct_normal_hw3=normals,
+        depth_normal_hw3=normals,
+        prior_normal_hw3=normals,
+        prior_valid_hw1=prior_valid,
+        surface_valid_hw1=torch.ones_like(prior_valid),
+        normal_prior_gate_hw1=contradiction_gate,
+    )
+
+    torch.testing.assert_close(result.normal_prior_mask_fraction, torch.tensor(0.5))
+    torch.testing.assert_close(result.normal_prior_cosine, torch.tensor(0.0))
+
+
+def test_empty_masks_produce_finite_differentiable_zero_losses() -> None:
+    normal = torch.tensor(
+        [[[0.0, 0.0, 1.0]]], device="cpu", requires_grad=True
+    )
+    false_mask = torch.zeros((1, 1, 1), dtype=torch.bool, device="cpu")
+
+    result = compute_gaussurf_losses(
+        direct_normal_hw3=normal,
+        depth_normal_hw3=normal,
+        prior_normal_hw3=normal.detach(),
+        prior_valid_hw1=false_mask,
+        surface_valid_hw1=false_mask,
+    )
+    loss_terms: tuple[torch.Tensor, ...] = (
+        result.normal_prior_cosine,
+        result.depth_normal_cosine,
+    )
+    for loss_term in loss_terms:
+        assert torch.equal(loss_term, torch.zeros_like(loss_term))
+        assert torch.isfinite(loss_term)
+    total: torch.Tensor = torch.stack(loss_terms).sum()
+    total.backward()
+
+    assert torch.equal(total, torch.tensor(0.0, device="cpu"))
+    assert normal.grad is not None and torch.isfinite(normal.grad).all()
+
+
+def test_pgsr_edge_weights_keep_smooth_interiors_and_suppress_borders() -> None:
+    rgb = torch.full((5, 6, 3), 0.5, requires_grad=True)
+
+    weights = pgsr_edge_weights(rgb)
+
+    assert weights.shape == (5, 6, 1)
+    torch.testing.assert_close(weights[1:-1, 1:-1], torch.ones((3, 4, 1)))
+    assert weights[0].eq(0).all() and weights[-1].eq(0).all()
+    assert weights[:, 0].eq(0).all() and weights[:, -1].eq(0).all()
+    assert not weights.requires_grad
+
+
+def test_pgsr_edge_weights_suppress_a_vertical_rgb_step() -> None:
+    rgb = torch.zeros((5, 7, 3))
+    rgb[:, 3:] = 1.0
+
+    weights = pgsr_edge_weights(rgb)
+
+    assert weights[2, 2, 0].item() == 0.0
+    assert weights[2, 3, 0].item() == 0.0
+    assert weights[2, 1, 0].item() == 1.0
+    assert weights[2, 5, 0].item() == 1.0
+
+    floored = pgsr_edge_weights(rgb, minimum_weight=0.25)
+    assert floored[2, 2, 0].item() == 0.25
+    assert floored[2, 3, 0].item() == 0.25
+    assert floored[0].eq(0).all()
+
+
+def test_consistency_weights_normalize_by_active_weight() -> None:
+    direct = torch.tensor(
+        [[[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]], requires_grad=True
+    )
+    depth_normal = torch.tensor([[[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]])
+    false_mask = torch.zeros((1, 2, 1), dtype=torch.bool)
+
+    losses = compute_gaussurf_losses(
+        direct_normal_hw3=direct,
+        depth_normal_hw3=depth_normal,
+        prior_normal_hw3=depth_normal,
+        prior_valid_hw1=false_mask,
+        surface_valid_hw1=torch.ones_like(false_mask),
+        consistency_weight_hw1=torch.tensor([[[0.0], [0.25]]]),
+    )
+
+    torch.testing.assert_close(losses.depth_normal_cosine, torch.tensor(0.0))
+    torch.testing.assert_close(losses.consistency_weight_mean, torch.tensor(0.125))
+    torch.testing.assert_close(
+        losses.consistency_weight_below_half_fraction, torch.tensor(1.0)
+    )
+    losses.depth_normal_cosine.backward()
+    assert direct.grad is not None and torch.isfinite(direct.grad).all()
+
+
+def test_consistency_weights_can_match_pgsr_full_image_mean() -> None:
+    direct = torch.tensor(
+        [[[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]], requires_grad=True
+    )
+    depth_normal = torch.tensor([[[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]])
+    false_mask = torch.zeros((1, 2, 1), dtype=torch.bool)
+
+    losses = compute_gaussurf_losses(
+        direct_normal_hw3=direct,
+        depth_normal_hw3=depth_normal,
+        prior_normal_hw3=depth_normal,
+        prior_valid_hw1=false_mask,
+        surface_valid_hw1=torch.ones_like(false_mask),
+        consistency_weight_hw1=torch.full((1, 2, 1), 0.25),
+        normalize_consistency_weights=False,
+    )
+
+    torch.testing.assert_close(losses.depth_normal_cosine, torch.tensor(0.125))

--- a/packages/gauss-surf/tests/test_normals_encoding.py
+++ b/packages/gauss-surf/tests/test_normals_encoding.py
@@ -1,0 +1,44 @@
+"""Behavior checks for the lossless uint8 normal-map representation."""
+
+import numpy as np
+from jaxtyping import Float32
+from numpy import ndarray
+
+from gauss_surf.normals_encoding import decode_normals_png, encode_normals_png, to_away_from_camera
+
+
+def test_random_unit_normals_survive_png_with_sub_half_degree_error() -> None:
+    """Lossless PNG storage adds only the expected uint8 angular quantization."""
+    rng: np.random.Generator = np.random.default_rng(20260815)
+    raw_hw3: Float32[ndarray, "h=48 w=64 3"] = rng.normal(size=(48, 64, 3)).astype(np.float32)
+    normals_hw3: Float32[ndarray, "h=48 w=64 3"] = raw_hw3 / np.linalg.norm(raw_hw3, axis=-1, keepdims=True)
+
+    png_bytes: bytes = encode_normals_png(normals_hw3)
+    decoded_hw3: Float32[ndarray, "h=48 w=64 3"] = decode_normals_png(png_bytes)
+
+    cosine_hw: Float32[ndarray, "h=48 w=64"] = np.sum(normals_hw3 * decoded_hw3, axis=-1) / np.linalg.norm(decoded_hw3, axis=-1)
+    angular_error_hw: Float32[ndarray, "h=48 w=64"] = np.rad2deg(np.arccos(np.clip(cosine_hw, -1.0, 1.0)))
+    assert float(np.max(angular_error_hw)) < 0.5
+    assert float(np.mean(angular_error_hw)) < 0.2
+
+
+def test_signed_mapping_inverts_endpoints_and_zero_exactly() -> None:
+    """The three signed anchor values retain exact meanings after quantization."""
+    anchors_hw3: Float32[ndarray, "h=1 w=1 3"] = np.array([[[-1.0, 0.0, 1.0]]], dtype=np.float32)
+
+    decoded_hw3: Float32[ndarray, "h=1 w=1 3"] = decode_normals_png(encode_normals_png(anchors_hw3))
+
+    np.testing.assert_array_equal(decoded_hw3, anchors_hw3)
+
+
+def test_moge_toward_camera_normals_are_negated_for_gaussurf_training() -> None:
+    """Both normal layers store the away-from-camera RDF convention."""
+    toward_hw3: Float32[ndarray, "h=1 w=2 3"] = np.array(
+        [[[0.0, 0.0, -1.0], [0.6, 0.0, -0.8]]],
+        dtype=np.float32,
+    )
+
+    away_hw3: Float32[ndarray, "h=1 w=2 3"] = to_away_from_camera(toward_hw3)
+
+    np.testing.assert_array_equal(away_hw3, -toward_hw3)
+    assert float(np.mean(away_hw3[..., 2] > 0.0)) == 1.0

--- a/packages/gauss-surf/tests/test_package.py
+++ b/packages/gauss-surf/tests/test_package.py
@@ -1,0 +1,2 @@
+def test_package_imports() -> None:
+    import gauss_surf  # noqa: F401

--- a/packages/gauss-surf/tests/test_render_io.py
+++ b/packages/gauss-surf/tests/test_render_io.py
@@ -1,0 +1,76 @@
+"""Behavior contracts for the full-grid camera manifest."""
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from gauss_surf.render_io import RenderCamera, load_render_cameras
+
+
+def test_renderer_loads_image_free_full_grid_camera_manifest(tmp_path: Path) -> None:
+    cameras_path: Path = tmp_path / "cameras_all.json"
+    world_from_camera_44: np.ndarray = np.eye(4, dtype=np.float32)
+    world_from_camera_44[:3, 3] = np.asarray((2.0, 3.0, 4.0), dtype=np.float32)
+    frames: list[dict[str, object]] = [
+        {
+            "stem": "wide_all_000000",
+            "camera": "wide",
+            "timestamp_ns": 100,
+            "fl_x": 500.0,
+            "fl_y": 501.0,
+            "cx": 320.0,
+            "cy": 240.0,
+            "w": 640,
+            "h": 480,
+            "transform_matrix": world_from_camera_44.tolist(),
+        },
+        {
+            "stem": "uw_all_000000",
+            "camera": "uw",
+            "timestamp_ns": 100,
+            "fl_x": 400.0,
+            "fl_y": 401.0,
+            "cx": 319.0,
+            "cy": 239.0,
+            "w": 640,
+            "h": 480,
+            "transform_matrix": world_from_camera_44.tolist(),
+        },
+    ]
+    cameras_path.write_text(
+        json.dumps({"schema_version": 1, "camera_model": "OPENCV", "counts": {"wide": 1, "uw": 1, "total": 2}, "frames": frames}),
+        encoding="utf-8",
+    )
+
+    cameras: list[RenderCamera] = load_render_cameras(cameras_path)
+
+    assert [(camera.stem, camera.camera, camera.timestamp_ns) for camera in cameras] == [
+        ("wide_all_000000", "wide", 100),
+        ("uw_all_000000", "uw", 100),
+    ]
+    np.testing.assert_allclose(cameras[0].world_from_camera_34[:, 3], [2.0, 3.0, 4.0])
+
+
+def test_renderer_rejects_camera_manifest_count_mismatch(tmp_path: Path) -> None:
+    cameras_path: Path = tmp_path / "cameras_all.json"
+    frame: dict[str, object] = {
+        "stem": "wide_all_000000",
+        "camera": "wide",
+        "timestamp_ns": 0,
+        "fl_x": 500.0,
+        "fl_y": 501.0,
+        "cx": 320.0,
+        "cy": 240.0,
+        "w": 640,
+        "h": 480,
+        "transform_matrix": np.eye(4, dtype=np.float32).tolist(),
+    }
+    cameras_path.write_text(
+        json.dumps({"schema_version": 1, "camera_model": "OPENCV", "counts": {"wide": 2, "uw": 0, "total": 2}, "frames": [frame]}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="manifest counts"):
+        load_render_cameras(cameras_path)

--- a/packages/gauss-surf/tests/test_uw_geometry.py
+++ b/packages/gauss-surf/tests/test_uw_geometry.py
@@ -4,14 +4,12 @@ from io import BytesIO
 
 import numpy as np
 import open3d as o3d
-import pytest
 from arkitscenes_download.ingest.depth import encode_depth_png
 from jaxtyping import Float32, UInt8, UInt16
 from numpy import ndarray
 from PIL import Image
 
 from gauss_surf.uw_geometry import (
-    AppleRadialPolynomial,
     build_apple_undistortion,
     compose_world_from_ultrawide,
     depth_meters_to_uint16_mm,
@@ -24,24 +22,6 @@ REAL_ULTRAWIDE_COEFFICIENTS_8: Float32[ndarray, "8"] = np.array(
     [-0.08353952, -6.350463, 5.248554, -1.9897834, 0.5831521, -0.10259675, 0.009266047, -0.0003309832],
     dtype=np.float32,
 )
-
-
-def test_apple_even_percent_polynomial_round_trips_real_frame_radii() -> None:
-    """The empirically selected even-power forward model inverts within 0.1 px."""
-    model: AppleRadialPolynomial = AppleRadialPolynomial(REAL_ULTRAWIDE_COEFFICIENTS_8)
-    distorted_radii_n: Float32[ndarray, "n=5"] = np.array([0.0, 0.25, 0.5, 0.75, 1.0], dtype=np.float32)
-
-    rectified_radii_n: Float32[ndarray, "n=5"] = model.distorted_to_rectified_radius(distorted_radii_n)
-    recovered_radii_n: Float32[ndarray, "n=5"] = model.rectified_to_distorted_radius(rectified_radii_n)
-
-    np.testing.assert_allclose(
-        rectified_radii_n,
-        [0.0, 0.24992806, 0.49828497, 0.7403127, 0.97314256],
-        atol=2e-7,
-        rtol=0.0,
-    )
-    max_round_trip_error_px: float = float(np.max(np.abs(recovered_radii_n - distorted_radii_n)) * 2315.9016)
-    assert max_round_trip_error_px < 0.1
 
 
 def test_zero_apple_polynomial_builds_an_identity_remap() -> None:
@@ -192,43 +172,3 @@ def test_depth_png_preserves_zero_sentinel_and_clamps_uint16_overflow() -> None:
         decoded_mm_hw: UInt16[ndarray, "h=2 w=3"] = np.asarray(image, dtype=np.uint16)
 
     np.testing.assert_array_equal(decoded_mm_hw, [[0, 1234, 1235], [0, 0, 65535]])
-
-
-def test_opencv_rational_fit_matches_real_ultrawide_calibration_to_sub_millipixel() -> None:
-    """The interop fit reproduces segment 47115416's real Apple field almost exactly.
-
-    Golden values decoded from the segment's mebx stream 10 (see the distortion
-    research report, 2026-08-16): the rational model fit this lens at 9.2e-5 px
-    worst case against a ~10.8 px full-frame distortion.
-    """
-    from gauss_surf.uw_geometry import OpenCVRationalFit, opencv_rational_from_apple
-
-    forward_8 = np.array(
-        [-0.08353952318429947, -6.350462913513184, 5.24855375289917, -1.9897834062576294, 0.5831521153450012, -0.10259674489498138, 0.009266046807169914, -0.0003309831954538822],
-        dtype=np.float32,
-    )
-    center_reference_xy = np.array([1853.150634765625, 1371.03173828125], dtype=np.float32)
-    K_native_33 = np.array(
-        [[245.39100646972656, 0.0, 321.8739929199219], [0.0, 245.39100646972656, 238.02699279785156], [0.0, 0.0, 1.0]],
-        dtype=np.float32,
-    )
-
-    fit: OpenCVRationalFit = opencv_rational_from_apple(K_native_33, forward_8, center_reference_xy, (3680, 2760), (640, 480))
-
-    assert fit.max_residual_px < 1e-3
-    assert fit.K_33[0, 2] == pytest.approx(322.287066915761, abs=1e-3)
-    assert fit.K_33[1, 2] == pytest.approx(238.440302309783, abs=1e-3)
-    assert fit.K_33[0, 0] == pytest.approx(245.391006, abs=1e-3)
-    assert fit.distortion.k1 == pytest.approx(0.1423159406627, rel=1e-2)
-    assert fit.distortion.p1 == 0.0 and fit.distortion.p2 == 0.0
-
-
-def test_opencv_rational_fit_rejects_a_non_invertible_calibration() -> None:
-    """A pathological polynomial fails validation instead of returning a bad fit."""
-    from gauss_surf.uw_geometry import opencv_rational_from_apple
-
-    collapsing_8 = np.array([-200.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
-    K_native_33 = np.array([[245.0, 0.0, 320.0], [0.0, 245.0, 240.0], [0.0, 0.0, 1.0]], dtype=np.float32)
-
-    with pytest.raises(ValueError):
-        opencv_rational_from_apple(K_native_33, collapsing_8, np.array([1840.0, 1380.0], dtype=np.float32), (3680, 2760), (640, 480))

--- a/packages/gauss-surf/tests/test_uw_geometry.py
+++ b/packages/gauss-surf/tests/test_uw_geometry.py
@@ -4,6 +4,7 @@ from io import BytesIO
 
 import numpy as np
 import open3d as o3d
+import pytest
 from arkitscenes_download.ingest.depth import encode_depth_png
 from jaxtyping import Float32, UInt8, UInt16
 from numpy import ndarray
@@ -191,3 +192,43 @@ def test_depth_png_preserves_zero_sentinel_and_clamps_uint16_overflow() -> None:
         decoded_mm_hw: UInt16[ndarray, "h=2 w=3"] = np.asarray(image, dtype=np.uint16)
 
     np.testing.assert_array_equal(decoded_mm_hw, [[0, 1234, 1235], [0, 0, 65535]])
+
+
+def test_opencv_rational_fit_matches_real_ultrawide_calibration_to_sub_millipixel() -> None:
+    """The interop fit reproduces segment 47115416's real Apple field almost exactly.
+
+    Golden values decoded from the segment's mebx stream 10 (see the distortion
+    research report, 2026-08-16): the rational model fit this lens at 9.2e-5 px
+    worst case against a ~10.8 px full-frame distortion.
+    """
+    from gauss_surf.uw_geometry import OpenCVRationalFit, opencv_rational_from_apple
+
+    forward_8 = np.array(
+        [-0.08353952318429947, -6.350462913513184, 5.24855375289917, -1.9897834062576294, 0.5831521153450012, -0.10259674489498138, 0.009266046807169914, -0.0003309831954538822],
+        dtype=np.float32,
+    )
+    center_reference_xy = np.array([1853.150634765625, 1371.03173828125], dtype=np.float32)
+    K_native_33 = np.array(
+        [[245.39100646972656, 0.0, 321.8739929199219], [0.0, 245.39100646972656, 238.02699279785156], [0.0, 0.0, 1.0]],
+        dtype=np.float32,
+    )
+
+    fit: OpenCVRationalFit = opencv_rational_from_apple(K_native_33, forward_8, center_reference_xy, (3680, 2760), (640, 480))
+
+    assert fit.max_residual_px < 1e-3
+    assert fit.K_33[0, 2] == pytest.approx(322.287066915761, abs=1e-3)
+    assert fit.K_33[1, 2] == pytest.approx(238.440302309783, abs=1e-3)
+    assert fit.K_33[0, 0] == pytest.approx(245.391006, abs=1e-3)
+    assert fit.distortion.k1 == pytest.approx(0.1423159406627, rel=1e-2)
+    assert fit.distortion.p1 == 0.0 and fit.distortion.p2 == 0.0
+
+
+def test_opencv_rational_fit_rejects_a_non_invertible_calibration() -> None:
+    """A pathological polynomial fails validation instead of returning a bad fit."""
+    from gauss_surf.uw_geometry import opencv_rational_from_apple
+
+    collapsing_8 = np.array([-200.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+    K_native_33 = np.array([[245.0, 0.0, 320.0], [0.0, 245.0, 240.0], [0.0, 0.0, 1.0]], dtype=np.float32)
+
+    with pytest.raises(ValueError):
+        opencv_rational_from_apple(K_native_33, collapsing_8, np.array([1840.0, 1380.0], dtype=np.float32), (3680, 2760), (640, 480))

--- a/packages/gauss-surf/tests/test_uw_geometry.py
+++ b/packages/gauss-surf/tests/test_uw_geometry.py
@@ -10,7 +10,7 @@ from numpy import ndarray
 from PIL import Image
 
 from gauss_surf.uw_geometry import (
-    build_apple_undistortion,
+    build_brown_conrady_undistortion,
     compose_world_from_ultrawide,
     depth_meters_to_uint16_mm,
     pose_indices_at_or_before,
@@ -18,22 +18,37 @@ from gauss_surf.uw_geometry import (
     undistort_rgb,
 )
 
-REAL_ULTRAWIDE_COEFFICIENTS_8: Float32[ndarray, "8"] = np.array(
-    [-0.08353952, -6.350463, 5.248554, -1.9897834, 0.5831521, -0.10259675, 0.009266047, -0.0003309832],
+REAL_ULTRAWIDE_COEFFICIENTS_14: Float32[ndarray, "14"] = np.array(
+    [
+        0.14226905,
+        -0.03264365,
+        -1.7744861e-5,
+        -1.9211448e-5,
+        0.00754465,
+        0.14195952,
+        -0.04144133,
+        0.00897725,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+    ],
     dtype=np.float32,
 )
 
 
-def test_zero_apple_polynomial_builds_an_identity_remap() -> None:
-    """Zero Apple coefficients leave the pinhole and every source pixel unchanged."""
+def test_zero_brown_conrady_builds_an_identity_remap() -> None:
+    """Zero Brown-Conrady coefficients leave the pinhole and every source pixel unchanged."""
     K_33: Float32[ndarray, "3 3"] = np.array(
         [[8.0, 0.0, 3.0], [0.0, 8.0, 2.0], [0.0, 0.0, 1.0]],
         dtype=np.float32,
     )
 
-    undistortion = build_apple_undistortion(
+    undistortion = build_brown_conrady_undistortion(
         K_33,
-        np.zeros(8, dtype=np.float32),
+        np.zeros(14, dtype=np.float32),
         distortion_center_reference_xy=np.array([3.0, 2.0], dtype=np.float32),
         reference_dimensions_wh=(7, 5),
         image_wh=(7, 5),
@@ -46,16 +61,16 @@ def test_zero_apple_polynomial_builds_an_identity_remap() -> None:
     np.testing.assert_array_equal(undistortion.source_y_hw, expected_y_hw)
 
 
-def test_real_apple_remap_crops_only_enough_to_keep_every_sample_in_bounds() -> None:
-    """The real 640×480 remap has no invalid sampled source pixels."""
+def test_real_brown_conrady_remap_preserves_the_apple_exact_framing_contract() -> None:
+    """The standard fit stays within 0.006 px of the old remap and preserves its rectified pinhole."""
     K_uw_33: Float32[ndarray, "3 3"] = np.array(
         [[245.3910065, 0.0, 321.8739929], [0.0, 245.3910065, 238.0269928], [0.0, 0.0, 1.0]],
         dtype=np.float32,
     )
 
-    undistortion = build_apple_undistortion(
+    undistortion = build_brown_conrady_undistortion(
         K_uw_33,
-        REAL_ULTRAWIDE_COEFFICIENTS_8,
+        REAL_ULTRAWIDE_COEFFICIENTS_14,
         distortion_center_reference_xy=np.array([1853.1506, 1371.0317], dtype=np.float32),
         reference_dimensions_wh=(3680, 2760),
         image_wh=(640, 480),
@@ -63,8 +78,29 @@ def test_real_apple_remap_crops_only_enough_to_keep_every_sample_in_bounds() -> 
 
     assert np.all((undistortion.source_x_hw >= 0.0) & (undistortion.source_x_hw <= 639.0))
     assert np.all((undistortion.source_y_hw >= 0.0) & (undistortion.source_y_hw <= 479.0))
-    assert K_uw_33[0, 0] < undistortion.K_rect_33[0, 0] < 1.1 * K_uw_33[0, 0]
-    assert K_uw_33[1, 1] < undistortion.K_rect_33[1, 1] < 1.1 * K_uw_33[1, 1]
+    np.testing.assert_allclose(
+        undistortion.K_rect_33,
+        [[252.1431885, 0.0, 322.2870789], [0.0, 252.1431885, 238.4403076], [0.0, 0.0, 1.0]],
+        atol=1e-3,
+        rtol=0.0,
+    )
+    sample_yx_n2: ndarray = np.array([[0, 0], [0, 639], [479, 0], [479, 639], [240, 320], [100, 100], [300, 500]])
+    expected_source_n2: Float32[ndarray, "n=7 2"] = np.array(
+        [
+            [0.05831777, 0.04315982],
+            [638.737793, 0.19737177],
+            [0.00006369, 478.9999695],
+            [638.796814, 478.845703],
+            [320.0612183, 239.9582214],
+            [104.2524643, 102.6484451],
+            [495.6700134, 298.5000916],
+        ],
+        dtype=np.float32,
+    )
+    actual_source_n2: Float32[ndarray, "n=7 2"] = np.array(
+        [[undistortion.source_x_hw[y, x], undistortion.source_y_hw[y, x]] for y, x in sample_yx_n2], dtype=np.float32
+    )
+    assert float(np.max(np.linalg.norm(actual_source_n2 - expected_source_n2, axis=1))) <= 0.006
 
 
 def test_raycast_returns_camera_z_depth_at_oblique_pixels_and_zero_on_miss() -> None:
@@ -138,18 +174,18 @@ def test_pose_lookup_uses_nearest_sample_at_or_before_each_ultrawide_time() -> N
     assert np.all(pose_times_n[indices_n] <= ultrawide_times_n)
 
 
-def test_zero_apple_polynomial_rectification_is_pixel_exact() -> None:
-    """A zero Apple radial model leaves the RGB pixels unchanged."""
+def test_zero_brown_conrady_rectification_is_pixel_exact() -> None:
+    """A zero Brown-Conrady model leaves the RGB pixels unchanged."""
     rgb_hw3: UInt8[ndarray, "h=5 w=7 3"] = np.arange(5 * 7 * 3, dtype=np.uint8).reshape(5, 7, 3)
     K_33: Float32[ndarray, "3 3"] = np.array(
         [[8.0, 0.0, 3.0], [0.0, 8.0, 2.0], [0.0, 0.0, 1.0]],
         dtype=np.float32,
     )
-    coefficients_8: Float32[ndarray, "8"] = np.zeros(8, dtype=np.float32)
+    coefficients_14: Float32[ndarray, "14"] = np.zeros(14, dtype=np.float32)
 
-    undistortion = build_apple_undistortion(
+    undistortion = build_brown_conrady_undistortion(
         K_33,
-        coefficients_8,
+        coefficients_14,
         distortion_center_reference_xy=np.array([3.0, 2.0], dtype=np.float32),
         reference_dimensions_wh=(7, 5),
         image_wh=(7, 5),

--- a/packages/gauss-surf/tests/test_uw_geometry.py
+++ b/packages/gauss-surf/tests/test_uw_geometry.py
@@ -1,0 +1,193 @@
+"""Behavior checks for rectified ultrawide geometry and depth storage."""
+
+from io import BytesIO
+
+import numpy as np
+import open3d as o3d
+from arkitscenes_download.ingest.depth import encode_depth_png
+from jaxtyping import Float32, UInt8, UInt16
+from numpy import ndarray
+from PIL import Image
+
+from gauss_surf.uw_geometry import (
+    AppleRadialPolynomial,
+    build_apple_undistortion,
+    compose_world_from_ultrawide,
+    depth_meters_to_uint16_mm,
+    pose_indices_at_or_before,
+    raycast_z_depth,
+    undistort_rgb,
+)
+
+REAL_ULTRAWIDE_COEFFICIENTS_8: Float32[ndarray, "8"] = np.array(
+    [-0.08353952, -6.350463, 5.248554, -1.9897834, 0.5831521, -0.10259675, 0.009266047, -0.0003309832],
+    dtype=np.float32,
+)
+
+
+def test_apple_even_percent_polynomial_round_trips_real_frame_radii() -> None:
+    """The empirically selected even-power forward model inverts within 0.1 px."""
+    model: AppleRadialPolynomial = AppleRadialPolynomial(REAL_ULTRAWIDE_COEFFICIENTS_8)
+    distorted_radii_n: Float32[ndarray, "n=5"] = np.array([0.0, 0.25, 0.5, 0.75, 1.0], dtype=np.float32)
+
+    rectified_radii_n: Float32[ndarray, "n=5"] = model.distorted_to_rectified_radius(distorted_radii_n)
+    recovered_radii_n: Float32[ndarray, "n=5"] = model.rectified_to_distorted_radius(rectified_radii_n)
+
+    np.testing.assert_allclose(
+        rectified_radii_n,
+        [0.0, 0.24992806, 0.49828497, 0.7403127, 0.97314256],
+        atol=2e-7,
+        rtol=0.0,
+    )
+    max_round_trip_error_px: float = float(np.max(np.abs(recovered_radii_n - distorted_radii_n)) * 2315.9016)
+    assert max_round_trip_error_px < 0.1
+
+
+def test_zero_apple_polynomial_builds_an_identity_remap() -> None:
+    """Zero Apple coefficients leave the pinhole and every source pixel unchanged."""
+    K_33: Float32[ndarray, "3 3"] = np.array(
+        [[8.0, 0.0, 3.0], [0.0, 8.0, 2.0], [0.0, 0.0, 1.0]],
+        dtype=np.float32,
+    )
+
+    undistortion = build_apple_undistortion(
+        K_33,
+        np.zeros(8, dtype=np.float32),
+        distortion_center_reference_xy=np.array([3.0, 2.0], dtype=np.float32),
+        reference_dimensions_wh=(7, 5),
+        image_wh=(7, 5),
+    )
+
+    expected_x_hw: Float32[ndarray, "h=5 w=7"] = np.tile(np.arange(7, dtype=np.float32), (5, 1))
+    expected_y_hw: Float32[ndarray, "h=5 w=7"] = np.tile(np.arange(5, dtype=np.float32)[:, None], (1, 7))
+    np.testing.assert_array_equal(undistortion.K_rect_33, K_33)
+    np.testing.assert_array_equal(undistortion.source_x_hw, expected_x_hw)
+    np.testing.assert_array_equal(undistortion.source_y_hw, expected_y_hw)
+
+
+def test_real_apple_remap_crops_only_enough_to_keep_every_sample_in_bounds() -> None:
+    """The real 640×480 remap has no invalid sampled source pixels."""
+    K_uw_33: Float32[ndarray, "3 3"] = np.array(
+        [[245.3910065, 0.0, 321.8739929], [0.0, 245.3910065, 238.0269928], [0.0, 0.0, 1.0]],
+        dtype=np.float32,
+    )
+
+    undistortion = build_apple_undistortion(
+        K_uw_33,
+        REAL_ULTRAWIDE_COEFFICIENTS_8,
+        distortion_center_reference_xy=np.array([1853.1506, 1371.0317], dtype=np.float32),
+        reference_dimensions_wh=(3680, 2760),
+        image_wh=(640, 480),
+    )
+
+    assert np.all((undistortion.source_x_hw >= 0.0) & (undistortion.source_x_hw <= 639.0))
+    assert np.all((undistortion.source_y_hw >= 0.0) & (undistortion.source_y_hw <= 479.0))
+    assert K_uw_33[0, 0] < undistortion.K_rect_33[0, 0] < 1.1 * K_uw_33[0, 0]
+    assert K_uw_33[1, 1] < undistortion.K_rect_33[1, 1] < 1.1 * K_uw_33[1, 1]
+
+
+def test_raycast_returns_camera_z_depth_at_oblique_pixels_and_zero_on_miss() -> None:
+    """Open3D hit parameters become pinhole z-depth, not Euclidean ray length."""
+    vertices_n3: Float32[ndarray, "n=4 3"] = np.array(
+        [
+            [-1.1, -0.75, 2.0],
+            [1.1, -0.75, 2.0],
+            [1.1, 0.75, 2.0],
+            [-1.1, 0.75, 2.0],
+        ],
+        dtype=np.float32,
+    )
+    triangles_m3: ndarray = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.uint32)
+    mesh: o3d.t.geometry.TriangleMesh = o3d.t.geometry.TriangleMesh(
+        o3d.core.Tensor(vertices_n3),
+        o3d.core.Tensor(triangles_m3),
+    )
+    scene: o3d.t.geometry.RaycastingScene = o3d.t.geometry.RaycastingScene()
+    scene.add_triangles(mesh)
+    K_33: Float32[ndarray, "3 3"] = np.array(
+        [[2.0, 0.0, 1.5], [0.0, 2.0, 1.5], [0.0, 0.0, 1.0]],
+        dtype=np.float32,
+    )
+    world_from_camera_44: Float32[ndarray, "4 4"] = np.eye(4, dtype=np.float32)
+
+    depth_hw: Float32[ndarray, "h=4 w=4"] = raycast_z_depth(
+        scene,
+        K_33,
+        world_from_camera_44,
+        image_wh=(4, 4),
+    )
+
+    np.testing.assert_allclose(depth_hw[1, 1:3], 2.0, atol=1e-4, rtol=0.0)
+    assert depth_hw[0, 0] == 0.0
+
+
+def test_pose_composition_places_camera_ray_in_world_coordinates() -> None:
+    """The rig pose composes with wide-from-ultrawide before rays enter the world."""
+    world_from_rig_44: Float32[ndarray, "4 4"] = np.array(
+        [
+            [0.0, -1.0, 0.0, 1.0],
+            [1.0, 0.0, 0.0, 2.0],
+            [0.0, 0.0, 1.0, 3.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ],
+        dtype=np.float32,
+    )
+    wide_from_ultrawide_44: Float32[ndarray, "4 4"] = np.eye(4, dtype=np.float32)
+    wide_from_ultrawide_44[0, 3] = 0.012
+
+    world_from_ultrawide_44: Float32[ndarray, "4 4"] = compose_world_from_ultrawide(
+        world_from_rig_44[None],
+        wide_from_ultrawide_44,
+    )[0]
+    ray_origin_world_3: Float32[ndarray, "3"] = world_from_ultrawide_44[:3, 3]
+    ray_direction_world_3: Float32[ndarray, "3"] = world_from_ultrawide_44[:3, :3] @ np.array([1.0, 0.0, 1.0], dtype=np.float32)
+
+    np.testing.assert_allclose(ray_origin_world_3, [1.0, 2.012, 3.0], atol=1e-6, rtol=0.0)
+    np.testing.assert_allclose(ray_direction_world_3, [0.0, 1.0, 1.0], atol=1e-6, rtol=0.0)
+
+
+def test_pose_lookup_uses_nearest_sample_at_or_before_each_ultrawide_time() -> None:
+    """Jittered ultrawide times use causal 60 Hz poses and never a future sample."""
+    pose_times_n: ndarray = np.array([0, 16_666_667, 33_333_334, 50_000_001], dtype="timedelta64[ns]")
+    ultrawide_times_n: ndarray = np.array([1_000_000, 16_666_667, 32_900_000, 50_100_000], dtype="timedelta64[ns]")
+
+    indices_n: ndarray = pose_indices_at_or_before(pose_times_n, ultrawide_times_n)
+
+    np.testing.assert_array_equal(indices_n, [0, 1, 1, 3])
+    assert np.all(pose_times_n[indices_n] <= ultrawide_times_n)
+
+
+def test_zero_apple_polynomial_rectification_is_pixel_exact() -> None:
+    """A zero Apple radial model leaves the RGB pixels unchanged."""
+    rgb_hw3: UInt8[ndarray, "h=5 w=7 3"] = np.arange(5 * 7 * 3, dtype=np.uint8).reshape(5, 7, 3)
+    K_33: Float32[ndarray, "3 3"] = np.array(
+        [[8.0, 0.0, 3.0], [0.0, 8.0, 2.0], [0.0, 0.0, 1.0]],
+        dtype=np.float32,
+    )
+    coefficients_8: Float32[ndarray, "8"] = np.zeros(8, dtype=np.float32)
+
+    undistortion = build_apple_undistortion(
+        K_33,
+        coefficients_8,
+        distortion_center_reference_xy=np.array([3.0, 2.0], dtype=np.float32),
+        reference_dimensions_wh=(7, 5),
+        image_wh=(7, 5),
+    )
+    rectified_hw3: UInt8[ndarray, "h=5 w=7 3"] = undistort_rgb(rgb_hw3, undistortion)
+
+    np.testing.assert_array_equal(rectified_hw3, rgb_hw3)
+
+
+def test_depth_png_preserves_zero_sentinel_and_clamps_uint16_overflow() -> None:
+    """Metre depth rounds to millimetres while invalid and overflowing values stay safe."""
+    depth_m_hw: Float32[ndarray, "h=2 w=3"] = np.array(
+        [[0.0, 1.2344, 1.2346], [np.inf, -1.0, 70.0]],
+        dtype=np.float32,
+    )
+
+    depth_mm_hw: UInt16[ndarray, "h=2 w=3"] = depth_meters_to_uint16_mm(depth_m_hw)
+    png_bytes: bytes = encode_depth_png(depth_mm_hw)
+    with Image.open(BytesIO(png_bytes)) as image:
+        decoded_mm_hw: UInt16[ndarray, "h=2 w=3"] = np.asarray(image, dtype=np.uint16)
+
+    np.testing.assert_array_equal(decoded_mm_hw, [[0, 1234, 1235], [0, 0, 65535]])


### PR DESCRIPTION
New `gauss-surf` package, part 1: the foundations (stack 3/5). Pure library code + tests — **importable and reviewable standalone; runnable once the workspace wiring lands in #103** (the pixi envs arrive there).

The pipeline this serves: ARKitScenes segment → Rerun catalog → Gaussian-splat training with PGSR-style surface supervision (PromptDA metric depth + MoGe normals) → splat/depth/triage layers registered back to the catalog.

- **`contracts.py`** — single source for layer names + recovery paths, camera tags, the cross-stage catalog column schema, codec and render constants.
- **`catalog.py`** — `SegmentReader`: the per-segment opening moves every stage shares (row lookup, upstream-layer checks, chosen timestamps, pose reads, exact-timestamp NVDEC decode), Arrow cell decoders, typed `DatasetEntry`/`DatasetView` boundary.
- **`render_io.py`** — shared image/depth codecs (uint16-mm depth, JPEG/PNG RGB) and render-manifest validation.
- **`uw_geometry.py`** — ultrawide distortion/rectification, causal pose resolution (single home), mesh raycast depth; (the Apple polynomial + rational interop fit moved to arkitscenes-download `ingest/distortion.py`, which owns the mebx decode — see #100; gauss-surf consumes it from there, and the ultrawide rectifier consumes the recording's standard brown_conrady model via cv2.initUndistortRectifyMap — the bespoke Apple inversion machinery is deleted; unmigrated legacy segments fail with an explicit re-ingest instruction).
- **`gaussurf_geometry.py` / `gaussurf_losses.py`** — the PGSR plane-depth math (`offset/(normal·ray)` with validity gates) and losses; pinned by a hypothesis plane-depth oracle (exact ray-plane intersection) and a loss scaling-law property (the formal basis for metric-coordinate re-weighting).
- **`gsplat_schedule.py`** — refinement/downscale/SH schedules as pure-integer functions, testable without CUDA.
- **`frame_selection.py`** — per-10Hz-bin argmax-sharpness selection (no floor veto).

**Testing**: hypothesis property suites for every load-bearing contract above; part of the 102-passed package suite that runs under the #103 environment.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>



