### PR TITLE
gauss-surf: direct gsplat trainer with fused in-process publish (nerfstudio-free)

### DIFF
--- a/packages/gauss-surf/src/gauss_surf/apis/frame_selection.py
+++ b/packages/gauss-surf/src/gauss_surf/apis/frame_selection.py
@@ -1,0 +1,237 @@
+"""Select sharp ARKitScenes frames and publish a catalog layer."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypeAlias
+
+import numpy as np
+import rerun as rr
+import torch
+from arkitscenes_download.ingest.paths import (
+    FRAME_SELECTION_ULTRAWIDE,
+    FRAME_SELECTION_WIDE,
+    SHARPNESS_ULTRAWIDE,
+    SHARPNESS_WIDE,
+    TIMELINE,
+    VIDEO_ULTRAWIDE,
+    VIDEO_WIDE,
+)
+from arkitscenes_download.ingest.recording import atomic_recording
+from einops import rearrange
+from jaxtyping import Float32, UInt8
+from numpy import ndarray
+from rerun.catalog import DatasetEntry
+from rerun.experimental.dataloader import DataSource, Field, FixedRateSampling, NoShuffle, RerunIterableDataset
+from simplecv.rerun_dataloader import SegmentNvdecDecoder
+from torch import Tensor
+from torch.utils.data import DataLoader
+
+from gauss_surf.catalog import DEFAULT_CATALOG_URL, DEFAULT_DATASET_NAME, SegmentReader, register_layer
+from gauss_surf.contracts import FRAME_SELECTION_LAYER, ULTRAWIDE_FPS, WIDE_FPS
+from gauss_surf.frame_selection import FrameScores, SelectionResult, TimedeltaNs, score_frames, select_ultrawide_frames, select_wide_frames
+
+FETCH_SIZE: int = 1024
+"""Samples fetched per catalog request."""
+
+ScoreArrays: TypeAlias = tuple[Float32[ndarray, "n"], Float32[ndarray, "n"]]
+
+
+@dataclass(frozen=True, slots=True)
+class Config:
+    """Configuration for one segment's frame-selection layer."""
+
+    video_id: str
+    """ARKitScenes segment identifier to score."""
+    catalog_url: str = DEFAULT_CATALOG_URL
+    """URL of the gauss-surf development catalog server."""
+    dataset_name: str = DEFAULT_DATASET_NAME
+    """Catalog dataset to read and update."""
+    output_dir: Path = Path("data/frame_selection")
+    """Directory for generated per-segment frame-selection RRDs."""
+    window_size: int = 6
+    """Number of consecutive wide frames in each strict non-overlapping window."""
+    min_chosen: int = 200
+    """Minimum wide winners required to publish the segment layer."""
+    score_batch_size: int = 32
+    """Number of decoded CUDA frames scored together."""
+
+
+@dataclass(frozen=True, slots=True)
+class CameraMeasurements:
+    """Dense measurements decoded from one camera stream."""
+
+    timestamps: TimedeltaNs
+    """Packet timestamp per scored frame, as ``timedelta64[ns]``."""
+    sharpness: Float32[ndarray, "n_frames"]
+    """Normalized sharpness score per frame."""
+    texture: Float32[ndarray, "n_frames"]
+    """Grayscale standard deviation per frame."""
+
+
+def _camera_dataset(
+    dataset: DatasetEntry,
+    video_id: str,
+    entity_path: str,
+    fps: float,
+    device: torch.device,
+) -> tuple[RerunIterableDataset, SegmentNvdecDecoder]:
+    """Build one natural-order dataset for one camera's video packets."""
+    decoder: SegmentNvdecDecoder = SegmentNvdecDecoder(dataset, entity_path, TIMELINE, device, int(fps))
+    fields: dict[str, Field] = {"video": Field(f"/{entity_path}:VideoStream:sample", decode=decoder)}
+    samples: RerunIterableDataset = RerunIterableDataset(
+        DataSource(dataset=dataset, segments=[video_id]),
+        index=TIMELINE,
+        fields=fields,
+        timeline_sampling=FixedRateSampling(rate_hz=fps),
+        shuffle_strategy=NoShuffle(),  # pyrefly: ignore  # unexpected-keyword — gauss-surf runs the 0.36 prerelease API
+        fetch_size=FETCH_SIZE,
+    )
+    return samples, decoder
+
+
+def _score_frame_batch(frames_hwc: list[UInt8[Tensor, "h w 3"]]) -> ScoreArrays:
+    """Stack and score one same-resolution decoded frame batch."""
+    frames_bhw3: UInt8[Tensor, "b h w 3"] = torch.stack(frames_hwc)
+    scores: FrameScores = score_frames(frames_bhw3)
+    sharpness_b: Float32[ndarray, "b"] = scores.sharpness.detach().cpu().numpy().astype(np.float32, copy=False)
+    texture_b: Float32[ndarray, "b"] = scores.texture.detach().cpu().numpy().astype(np.float32, copy=False)
+    return sharpness_b, texture_b
+
+
+def _score_camera(
+    dataset: DatasetEntry,
+    video_id: str,
+    entity_path: str,
+    fps: float,
+    device: torch.device,
+    batch_size: int,
+) -> CameraMeasurements:
+    """Decode and score every packet from one camera entity in natural order."""
+    if batch_size < 1:
+        raise ValueError("score_batch_size must be positive")
+    samples: RerunIterableDataset
+    decoder: SegmentNvdecDecoder
+    samples, decoder = _camera_dataset(dataset, video_id, entity_path, fps, device)
+    loader: DataLoader = DataLoader(samples, batch_size=None, num_workers=0)
+    pending_frames_hwc: list[UInt8[Tensor, "h w 3"]] = []
+    sharpness_parts: list[Float32[ndarray, "batch"]] = []
+    texture_parts: list[Float32[ndarray, "batch"]] = []
+
+    row: dict[str, Tensor | None]
+    with torch.inference_mode():
+        for row in loader:
+            video: Tensor | None = row["video"]
+            if video is None:
+                continue
+            frame_chw: UInt8[Tensor, "3 h w"] = video
+            frame_hwc: UInt8[Tensor, "h w 3"] = rearrange(frame_chw, "c h w -> h w c")  # pyrefly: ignore  # bad-argument-type — einops stub
+            pending_frames_hwc.append(frame_hwc)
+            if len(pending_frames_hwc) < batch_size:
+                continue
+            batch_scores: ScoreArrays = _score_frame_batch(pending_frames_hwc)
+            sharpness_parts.append(batch_scores[0])
+            texture_parts.append(batch_scores[1])
+            pending_frames_hwc = []
+        if pending_frames_hwc:
+            final_scores: ScoreArrays = _score_frame_batch(pending_frames_hwc)
+            sharpness_parts.append(final_scores[0])
+            texture_parts.append(final_scores[1])
+
+    if not sharpness_parts:
+        raise RuntimeError(f"{entity_path} yielded no decodable frames for segment {video_id}")
+    sharpness_n: Float32[ndarray, "n_frames"] = np.concatenate(sharpness_parts).astype(np.float32, copy=False)
+    texture_n: Float32[ndarray, "n_frames"] = np.concatenate(texture_parts).astype(np.float32, copy=False)
+    timestamps_n: TimedeltaNs = np.asarray(decoder.times, dtype="timedelta64[ns]")
+    if len(sharpness_n) != len(timestamps_n):
+        raise RuntimeError(
+            f"{entity_path} decoded {len(sharpness_n)} frames but exposed {len(timestamps_n)} packet timestamps; "
+            "the native-rate sampling grid is not one-to-one"
+        )
+    return CameraMeasurements(timestamps=timestamps_n, sharpness=sharpness_n, texture=texture_n)
+
+
+def _send_camera_columns(
+    recording: rr.RecordingStream,
+    sharpness_entity: str,
+    chosen_entity: str,
+    result: SelectionResult,
+) -> None:
+    """Write one camera's dense scores and sparse selection rows."""
+    rr.send_columns(
+        sharpness_entity,
+        indexes=[rr.TimeColumn(TIMELINE, duration=result.timestamps)],
+        columns=rr.Scalars.columns(scalars=result.sharpness),
+        recording=recording,
+    )
+    chosen_sharpness_n: Float32[ndarray, "n_chosen"] = result.sharpness[result.chosen_indices]
+    rr.send_columns(
+        chosen_entity,
+        indexes=[rr.TimeColumn(TIMELINE, duration=result.chosen_timestamps)],
+        columns=rr.AnyValues.columns(
+            sharpness=chosen_sharpness_n,
+            window=result.windows,
+            rule=list(result.rules),
+        ),
+        recording=recording,
+    )
+
+
+def _print_summary(camera_name: str, result: SelectionResult) -> None:
+    """Print one camera's scored/chosen counts and sharpness distribution."""
+    score_min: float = float(np.min(result.sharpness))
+    score_median: float = float(np.median(result.sharpness))
+    score_max: float = float(np.max(result.sharpness))
+    print(
+        f"{camera_name}: scored={len(result.sharpness)} chosen={len(result.chosen_indices)} "
+        f"sharpness[min/median/max]={score_min:.2f}/{score_median:.2f}/{score_max:.2f}"
+    )
+
+
+def main(config: Config) -> None:
+    """Score both cameras, publish an accepted selection RRD, and register it."""
+    if not torch.cuda.is_available():
+        raise SystemExit("frame selection requires a CUDA device for whole-segment NVDEC decoding")
+    reader: SegmentReader = SegmentReader.open(config.catalog_url, config.dataset_name, config.video_id)
+    reader.row()
+    dataset: DatasetEntry = reader.dataset
+    device: torch.device = torch.device("cuda")
+
+    wide_measurements: CameraMeasurements = _score_camera(
+        dataset,
+        config.video_id,
+        VIDEO_WIDE,
+        WIDE_FPS,
+        device,
+        config.score_batch_size,
+    )
+    ultrawide_measurements: CameraMeasurements = _score_camera(
+        dataset,
+        config.video_id,
+        VIDEO_ULTRAWIDE,
+        ULTRAWIDE_FPS,
+        device,
+        config.score_batch_size,
+    )
+    wide_result: SelectionResult = select_wide_frames(
+        wide_measurements.sharpness,
+        wide_measurements.timestamps,
+        window_size=config.window_size,
+        min_chosen=config.min_chosen,
+    )
+    ultrawide_result: SelectionResult = select_ultrawide_frames(
+        ultrawide_measurements.sharpness,
+        ultrawide_measurements.timestamps,
+    )
+    _print_summary("wide", wide_result)
+    _print_summary("ultrawide", ultrawide_result)
+    if wide_result.rejected:
+        raise SystemExit(f"segment {config.video_id} rejected: {wide_result.rejection_reason}; no layer written")
+
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    rrd_path: Path = config.output_dir / f"{config.video_id}.rrd"
+    with atomic_recording(rrd_path, config.video_id, send_properties=False) as recording:
+        _send_camera_columns(recording, SHARPNESS_WIDE, FRAME_SELECTION_WIDE, wide_result)
+        _send_camera_columns(recording, SHARPNESS_ULTRAWIDE, FRAME_SELECTION_ULTRAWIDE, ultrawide_result)
+    register_layer(dataset, rrd_path, FRAME_SELECTION_LAYER)
+    print(f"rrd: {rrd_path}")
+    print(f"registered layer: {FRAME_SELECTION_LAYER}")

--- a/packages/gauss-surf/src/gauss_surf/apis/moge_normals.py
+++ b/packages/gauss-surf/src/gauss_surf/apis/moge_normals.py
@@ -1,0 +1,209 @@
+"""Infer MoGe v2 normals for chosen wide frames."""
+
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pyarrow as pa
+import rerun as rr
+import torch
+import torch.nn.functional as functional
+from arkitscenes_download.ingest.paths import NORMALS_MOGE, PINHOLE_MOGE, TIMELINE, VIDEO_WIDE
+from arkitscenes_download.ingest.recording import atomic_recording
+from einops import rearrange
+from jaxtyping import Float32, UInt8
+from monopriors.models.surface_normal.moge_v2_trt import DEFAULT_IMAGE_HW, MoGeV2NormalOutput, MoGeV2TrtNormalPredictor
+from numpy import ndarray
+from rerun.catalog import DatasetEntry
+from simplecv.camera_parameters import Intrinsics, rescale_intri
+from torch import Tensor
+
+from gauss_surf.catalog import (
+    DEFAULT_CATALOG_URL,
+    DEFAULT_DATASET_NAME,
+    SegmentReader,
+    TimedeltaNs,
+    _matrix_from_cell,
+    _resolution_from_cell,
+    register_layer,
+    table_timestamps,
+)
+from gauss_surf.contracts import (
+    FRAME_SELECTION_LAYER,
+    MOGE_INFERENCE_BATCH_SIZE,
+    MOGE_NORMALS_LAYER,
+    WIDE_CHOSEN_SHARPNESS_COLUMN,
+    WIDE_FPS,
+    WIDE_INTRINSICS_COLUMN,
+    WIDE_RESOLUTION_COLUMN,
+)
+from gauss_surf.normals_encoding import encode_normals_png, to_away_from_camera
+
+
+@dataclass(frozen=True, slots=True)
+class Config:
+    """Configuration for one segment's MoGe normal layer."""
+
+    video_id: str
+    """ARKitScenes segment identifier whose chosen frames are inferred."""
+    catalog_url: str = DEFAULT_CATALOG_URL
+    """URL of the gauss-surf development catalog server."""
+    dataset_name: str = DEFAULT_DATASET_NAME
+    """Catalog dataset to read and update."""
+    output_dir: Path = Path("data/moge_normals")
+    """Directory for generated per-segment MoGe normal RRDs."""
+
+
+@dataclass(frozen=True, slots=True)
+class ChosenFrameInputs:
+    """Chosen timestamps and their per-frame MoGe-resolution intrinsics."""
+
+    timestamps: TimedeltaNs
+    """Chosen wide packet times as ``timedelta64[ns]``."""
+    K_moge_n33: Float32[ndarray, "n_chosen 3 3"]
+    """Wide intrinsics rescaled per axis from native size to 1008×756."""
+
+
+def _load_chosen_frame_inputs(reader: SegmentReader) -> ChosenFrameInputs:
+    """Read chosen times and latest-at temporal wide intrinsics from the catalog."""
+    table: pa.Table = reader.chosen_table(
+        WIDE_CHOSEN_SHARPNESS_COLUMN,
+        (WIDE_INTRINSICS_COLUMN, WIDE_RESOLUTION_COLUMN),
+    )
+
+    timestamps_n: TimedeltaNs = table_timestamps(table)
+    k_values: list[Any] = table.column(WIDE_INTRINSICS_COLUMN).to_pylist()
+    resolution_values: list[Any] = table.column(WIDE_RESOLUTION_COLUMN).to_pylist()
+    K_moge_n33: Float32[ndarray, "n_chosen 3 3"] = np.empty((table.num_rows, 3, 3), dtype=np.float32)
+    for row_index, (k_value, resolution_value) in enumerate(zip(k_values, resolution_values, strict=True)):
+        try:
+            K_native_33: Float32[ndarray, "3 3"] = _matrix_from_cell(k_value, WIDE_INTRINSICS_COLUMN)
+        except (TypeError, ValueError) as error:
+            raise SystemExit(f"segment {reader.video_id} chosen row {row_index} has no unambiguous wide intrinsic matrix") from error
+        try:
+            native_width: int
+            native_height: int
+            native_width, native_height = _resolution_from_cell(resolution_value, WIDE_RESOLUTION_COLUMN)
+        except (TypeError, ValueError) as error:
+            raise SystemExit(f"segment {reader.video_id} chosen row {row_index} has no unambiguous wide resolution") from error
+        native_intrinsics: Intrinsics = Intrinsics.from_k_matrix(
+            camera_conventions="RDF",
+            k_matrix=K_native_33,
+            width=native_width,
+            height=native_height,
+        )
+        moge_intrinsics: Intrinsics = rescale_intri(
+            native_intrinsics,
+            target_width=DEFAULT_IMAGE_HW[1],
+            target_height=DEFAULT_IMAGE_HW[0],
+        )
+        assert moge_intrinsics.k_matrix is not None
+        K_moge_n33[row_index] = moge_intrinsics.k_matrix.astype(np.float32, copy=False)
+    return ChosenFrameInputs(timestamps=timestamps_n, K_moge_n33=K_moge_n33)
+
+
+def _send_pinhole_columns(recording: rr.RecordingStream, inputs: ChosenFrameInputs) -> None:
+    """Write one temporal MoGe-resolution pinhole per chosen frame."""
+    frame_count: int = len(inputs.timestamps)
+    resolutions_n2: Float32[ndarray, "n_chosen 2"] = np.tile(
+        np.array([[DEFAULT_IMAGE_HW[1], DEFAULT_IMAGE_HW[0]]], dtype=np.float32),
+        (frame_count, 1),
+    )
+    rr.send_columns(
+        PINHOLE_MOGE,
+        indexes=[rr.TimeColumn(TIMELINE, duration=inputs.timestamps)],
+        columns=rr.Pinhole.columns(
+            image_from_camera=inputs.K_moge_n33,
+            resolution=resolutions_n2,
+            camera_xyz=[rr.ViewCoordinates.RDF] * frame_count,
+        ),
+        recording=recording,
+    )
+
+
+def _infer_and_write_normals(
+    reader: SegmentReader,
+    inputs: ChosenFrameInputs,
+    predictor: MoGeV2TrtNormalPredictor,
+    recording: rr.RecordingStream,
+) -> int:
+    """Decode exact chosen frames, infer batches, and stream PNG columns."""
+    decoded_frames: Iterator[UInt8[Tensor, "3 h w"]] = reader.decode_frames(
+        VIDEO_WIDE,
+        inputs.timestamps,
+        fps=WIDE_FPS,
+        device=torch.device("cuda"),
+    )
+    inferred_frames: int = 0
+    with torch.inference_mode():
+        for start in range(0, len(inputs.timestamps), MOGE_INFERENCE_BATCH_SIZE):
+            batch_timestamps_n: TimedeltaNs = inputs.timestamps[start : start + MOGE_INFERENCE_BATCH_SIZE]
+            frames_hwc: list[UInt8[Tensor, "h w 3"]] = []
+            for _timestamp in batch_timestamps_n:
+                frame_chw: UInt8[Tensor, "3 h w"] = next(decoded_frames)
+                frame_hwc: UInt8[Tensor, "h w 3"] = rearrange(frame_chw, "c h w -> h w c")  # pyrefly: ignore  # bad-argument-type — einops stub
+                frames_hwc.append(frame_hwc)
+
+            frames_bhw3: UInt8[Tensor, "batch h w 3"] = torch.stack(frames_hwc)
+            frames_b3hw: Float32[Tensor, "batch 3 h w"] = rearrange(frames_bhw3, "b h w c -> b c h w").to(torch.float32)  # pyrefly: ignore  # bad-argument-type — einops stub
+            resized_b3hw: Float32[Tensor, "batch 3 net_h=756 net_w=1008"] = functional.interpolate(
+                frames_b3hw,
+                size=DEFAULT_IMAGE_HW,
+                mode="bilinear",
+                antialias=True,
+            )
+            resized_bhw3: UInt8[Tensor, "batch net_h=756 net_w=1008 3"] = rearrange(
+                resized_b3hw.round().clamp(0.0, 255.0).to(torch.uint8),
+                "b c h w -> b h w c",
+            )  # pyrefly: ignore  # bad-argument-type — einops stub
+            prediction: MoGeV2NormalOutput = predictor(resized_bhw3)
+            # MoGe emits toward-camera RDF normals; the layer stores the negated
+            # away-from-camera convention — the gaussurf training target and the
+            # colorization the mvsanywhere fork's figures use.
+            normals_toward_bhw3: Float32[ndarray, "batch net_h=756 net_w=1008 3"] = (
+                prediction.normals_bhw3.detach().cpu().numpy().astype(np.float32, copy=False)
+            )
+            normals_bhw3: Float32[ndarray, "batch net_h=756 net_w=1008 3"] = np.stack(
+                [to_away_from_camera(normals_toward_hw3) for normals_toward_hw3 in normals_toward_bhw3]
+            )
+            png_blobs: list[bytes] = [encode_normals_png(normals_hw3) for normals_hw3 in normals_bhw3]
+            batch_count: int = len(png_blobs)
+            rr.send_columns(
+                NORMALS_MOGE,
+                indexes=[rr.TimeColumn(TIMELINE, duration=batch_timestamps_n)],
+                columns=rr.EncodedImage.columns(blob=png_blobs, media_type=["image/png"] * batch_count),
+                recording=recording,
+            )
+            inferred_frames += batch_count
+            print(f"inferred {inferred_frames}/{len(inputs.timestamps)} frames")
+    return inferred_frames
+
+
+def main(config: Config) -> None:
+    """Infer chosen wide frames, publish the MoGe normals RRD, and register it."""
+    started_at: float = time.perf_counter()
+    if not torch.cuda.is_available():
+        raise SystemExit("MoGe normal inference requires CUDA for NVDEC and TensorRT")
+    reader: SegmentReader = SegmentReader.open(config.catalog_url, config.dataset_name, config.video_id)
+    reader.require_layers((FRAME_SELECTION_LAYER,))
+    reader.require_zero_orientation("MoGe normal inference")
+    dataset: DatasetEntry = reader.dataset
+    inputs: ChosenFrameInputs = _load_chosen_frame_inputs(reader)
+    predictor: MoGeV2TrtNormalPredictor = MoGeV2TrtNormalPredictor(batch_size=MOGE_INFERENCE_BATCH_SIZE)
+
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    rrd_path: Path = config.output_dir / f"{config.video_id}.rrd"
+    with atomic_recording(rrd_path, config.video_id, send_properties=False) as recording:
+        _send_pinhole_columns(recording, inputs)
+        inferred_frames: int = _infer_and_write_normals(reader, inputs, predictor, recording)
+    if inferred_frames != len(inputs.timestamps):
+        raise RuntimeError(f"inferred {inferred_frames} normal maps for {len(inputs.timestamps)} chosen timestamps")
+    register_layer(dataset, rrd_path, MOGE_NORMALS_LAYER)
+    wall_seconds: float = time.perf_counter() - started_at
+    throughput: float = inferred_frames / wall_seconds
+    print(f"rrd: {rrd_path}")
+    print(f"registered layer: {MOGE_NORMALS_LAYER}")
+    print(f"inferred {inferred_frames} frames in {wall_seconds:.2f}s ({throughput:.2f} img/s)")

--- a/packages/gauss-surf/src/gauss_surf/apis/register_segment.py
+++ b/packages/gauss-surf/src/gauss_surf/apis/register_segment.py
@@ -1,0 +1,181 @@
+"""Seed a development catalog with one ARKitScenes segment."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+from arkitscenes_download.ingest.blueprint import MeshFraming, make_blueprint
+from arkitscenes_download.ingest.paths import PROMPTDA_MESH
+from arkitscenes_download.schema import ALL_LAYER_NAMES
+from jaxtyping import Float64
+from numpy import ndarray
+from rerun.catalog import CatalogClient, DatasetEntry
+from rerun.experimental import RrdReader
+from simplecv.rerun_log_utils import mesh_bounding_geometry
+
+from gauss_surf.catalog import DEFAULT_CATALOG_URL, DEFAULT_DATASET_NAME, connect_catalog, register_layer
+from gauss_surf.contracts import LAYERS, PROMPTDA_LAYER
+
+DEFAULT_DATASET_ROOT: Path = Path("/mnt/nas/datasets/arkitscenes/arkitscenes.2026.07.22")
+"""NAS root containing layer-major ARKitScenes RRDs."""
+V2_BLUEPRINT_FILENAMES: tuple[str, str] = ("arkitscenes-v2-landscape.rbl", "arkitscenes-v2-portrait.rbl")
+"""The two v2 dataset blueprints used by the development catalog."""
+EXTENDED_BLUEPRINT_FILENAMES: tuple[str, str] = (
+    "arkitscenes-v2-gauss-surf-landscape.rbl",
+    "arkitscenes-v2-gauss-surf-portrait.rbl",
+)
+"""Generated PromptDA + gauss-surf blueprint pair."""
+
+
+@dataclass(frozen=True, slots=True)
+class Config:
+    """Configuration for reseeding one development-catalog segment."""
+
+    video_id: str
+    """ARKitScenes segment identifier to register."""
+    catalog_url: str = DEFAULT_CATALOG_URL
+    """Target Rerun catalog server URL."""
+    dataset_name: str = DEFAULT_DATASET_NAME
+    """Target dataset, created when absent."""
+    dataset_root: Path = DEFAULT_DATASET_ROOT
+    """Layer-major root containing ``<layer>/<video_id>.rrd`` files."""
+    blueprint_dir: Path = DEFAULT_DATASET_ROOT / "blueprints"
+    """Directory containing the two NAS ``arkitscenes-v2`` blueprint files used when generation is disabled."""
+    build_extended_blueprints: bool = True
+    """Build and register the PromptDA + gauss-surf blueprint pair instead of the NAS pair."""
+    extended_blueprint_dir: Path = Path("data/blueprints")
+    """Local output directory for generated extended blueprint files."""
+    extra_rrds: list[Path] = field(default_factory=list)
+    """Optional derived-layer RRDs; each layer name is inferred from its parent directory."""
+    recover_derived_layers: bool = False
+    """Register the complete local derived-layer recovery list in addition to standard layers."""
+    default_orientation: Literal["landscape", "portrait"] = "landscape"
+    """Which blueprint of the pair opens by default; match the target segment's orientation."""
+
+
+def promptda_mesh_framing(promptda_rrd_path: Path) -> MeshFraming:
+    """Compute the scene's AABB center and bounding radius from the registered PromptDA mesh.
+
+    Args:
+        promptda_rrd_path: PromptDA layer RRD containing the TSDF-fused mesh.
+
+    Returns:
+        World-frame AABB center and bounding-sphere radius in metres.
+    """
+    reader: RrdReader = RrdReader(str(promptda_rrd_path))
+    for chunk in reader.stream():
+        if str(chunk.entity_path).lstrip("/") != PROMPTDA_MESH:
+            continue
+        batch = chunk.to_record_batch()
+        for column_name in batch.schema.names:
+            if "vertex_positions" not in column_name:
+                continue
+            cell = batch.column(column_name)[0]
+            flat = cell.values.flatten() if hasattr(cell.values, "flatten") else cell.values
+            vertices_n3: Float64[ndarray, "n 3"] = np.asarray(flat, dtype=np.float64).reshape(-1, 3)
+            center_3: Float64[ndarray, "3"]
+            radius_m: float
+            center_3, radius_m = mesh_bounding_geometry(vertices_n3)
+            return center_3, radius_m
+    raise ValueError(f"{promptda_rrd_path} has no {PROMPTDA_MESH} vertex positions to frame")
+
+
+def write_extended_blueprints(output_dir: Path, dataset_name: str, framing: MeshFraming | None = None) -> list[Path]:
+    """Write the landscape and portrait PromptDA + gauss-surf blueprint artifacts.
+
+    Args:
+        output_dir: Directory for the generated ``.rbl`` files.
+        dataset_name: Filename prefix and dataset identity.
+        framing: Optional scene AABB center and bounding radius for the 3D eye controls.
+
+    Returns:
+        Landscape path followed by portrait path.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    paths: list[Path] = []
+    for filename, portrait in zip(EXTENDED_BLUEPRINT_FILENAMES, (False, True), strict=True):
+        path: Path = output_dir / filename.replace("arkitscenes-v2", dataset_name, 1)
+        make_blueprint(portrait=portrait, framing=framing, include_promptda=True, include_gauss_surf=True).save("arkitscenes", path)
+        path.chmod(0o644)
+        paths.append(path)
+    return paths
+
+
+def recovery_rrds(video_id: str) -> list[Path]:
+    """Resolve the complete local derived-layer recovery list for one segment."""
+    return [Path(pattern.format(video_id=video_id)) for pattern in LAYERS.values()]
+
+
+def existing_recovery_rrds(video_id: str) -> list[Path]:
+    """Resolve the derived-layer recovery paths that have already been generated."""
+    return [path for path in recovery_rrds(video_id) if path.is_file()]
+
+
+def main(config: Config) -> None:
+    """Register ten standard layers, extras, and one replaceable blueprint pair."""
+    standard_paths: dict[str, Path] = {
+        layer_name: config.dataset_root / layer_name / f"{config.video_id}.rrd" for layer_name in ALL_LAYER_NAMES
+    }
+    missing_paths: list[Path] = [path for path in standard_paths.values() if not path.is_file()]
+    extra_rrds: list[Path] = list(
+        dict.fromkeys([*(existing_recovery_rrds(config.video_id) if config.recover_derived_layers else []), *config.extra_rrds])
+    )
+    missing_extras: list[Path] = [path for path in extra_rrds if not path.is_file()]
+    if missing_paths or missing_extras:
+        missing_lines: str = "\n".join(f"  {path}" for path in [*missing_paths, *missing_extras])
+        raise SystemExit(f"required RRD files are missing:\n{missing_lines}")
+    if config.build_extended_blueprints:
+        promptda_candidates: list[Path] = [
+            *[path for path in extra_rrds if path.parent.name == PROMPTDA_LAYER],
+            Path(LAYERS[PROMPTDA_LAYER].format(video_id=config.video_id)),
+        ]
+        framing: MeshFraming | None = next(
+            (promptda_mesh_framing(path) for path in promptda_candidates if path.is_file()),
+            None,
+        )
+        blueprint_paths: list[Path] = write_extended_blueprints(config.extended_blueprint_dir, config.dataset_name, framing)
+    else:
+        blueprint_paths = [config.blueprint_dir / filename for filename in V2_BLUEPRINT_FILENAMES]
+    missing_blueprints: list[Path] = [path for path in blueprint_paths if not path.is_file()]
+    if missing_blueprints:
+        missing_lines = "\n".join(f"  {path}" for path in missing_blueprints)
+        raise SystemExit(f"required blueprint files are missing:\n{missing_lines}")
+
+    extra_layers: dict[str, Path] = {}
+    extra_path: Path
+    for extra_path in extra_rrds:
+        # Layer-major trees name the parent after the layer; per-segment trees
+        # (data/ultrawide_signals/<video_id>/<layer>.rrd) name the file instead.
+        layer_name: str = extra_path.stem if extra_path.parent.name == config.video_id else extra_path.parent.name
+        if layer_name in standard_paths or layer_name in extra_layers:
+            raise SystemExit(f"duplicate or reserved extra layer name {layer_name!r} inferred from {extra_path}")
+        extra_layers[layer_name] = extra_path
+
+    client: CatalogClient = connect_catalog(config.catalog_url, config.dataset_name, create_missing=True)
+    dataset: DatasetEntry = client.get_dataset(config.dataset_name)
+    layer_name: str
+    rrd_path: Path
+    for layer_name, rrd_path in (*standard_paths.items(), *extra_layers.items()):
+        register_layer(dataset, rrd_path, layer_name)
+        print(f"registered {layer_name}: {rrd_path}")
+
+    existing_blueprints: list[str] = dataset.blueprints()
+    if existing_blueprints and len(existing_blueprints) != len(blueprint_paths):
+        raise RuntimeError(
+            f"dataset already has {len(existing_blueprints)} blueprints; expected zero or {len(blueprint_paths)}, refusing to add duplicates"
+        )
+    if existing_blueprints:
+        blueprint_dataset: DatasetEntry | None = dataset.blueprint_dataset()
+        if blueprint_dataset is None:
+            raise RuntimeError("dataset reports blueprints but has no blueprint dataset")
+        print(f"replacing blueprint ids: {', '.join(existing_blueprints)}")
+        blueprint_dataset.unregister(segments_to_drop=existing_blueprints, layers_to_drop=[]).wait()
+    landscape_is_default: bool = config.default_orientation == "landscape"
+    dataset.register_blueprint(blueprint_paths[0].resolve().as_uri(), set_default=landscape_is_default)
+    dataset.register_blueprint(blueprint_paths[1].resolve().as_uri(), set_default=not landscape_is_default)
+    print(f"registered blueprints: {blueprint_paths[0].name}, {blueprint_paths[1].name} (default: {config.default_orientation})")
+    print(
+        f"segment {config.video_id}: cleanly replaced {len(standard_paths) + len(extra_layers)} layers "
+        f"in dataset {config.dataset_name!r}"
+    )

--- a/packages/gauss-surf/src/gauss_surf/apis/train_gsplat.py
+++ b/packages/gauss-surf/src/gauss_surf/apis/train_gsplat.py
@@ -1,0 +1,128 @@
+"""CLI orchestration for direct gsplat training and fused publication."""
+
+import json
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import gsplat
+import torch
+
+from gauss_surf.catalog import DEFAULT_CATALOG_URL, DEFAULT_DATASET_NAME, SegmentReader
+from gauss_surf.contracts import LAYERS, SPLAT_DEPTH_LAYER, SPLAT_LAYER, SPLAT_TRIAGE_LAYER
+from gauss_surf.train_gsplat.cache import load_gpu_cache
+from gauss_surf.train_gsplat.evaluation import evaluate_holdout
+from gauss_surf.train_gsplat.metadata import MetadataStats, metadata_files_complete, prepare_training_metadata
+from gauss_surf.train_gsplat.publish import PublishStats, publish_in_process
+from gauss_surf.train_gsplat.trainer import ITERATIONS, metric_training_constants, train
+
+
+@dataclass(frozen=True, slots=True)
+class Config:
+    """Configuration for direct metric-world gsplat training."""
+
+    video_id: str
+    """Catalog segment identifier."""
+    catalog_url: str = DEFAULT_CATALOG_URL
+    """Existing Rerun catalog server URL."""
+    dataset_name: str = DEFAULT_DATASET_NAME
+    """Catalog dataset read by the cache and targeted by publication."""
+    bundle_dir: Path | None = None
+    """Camera/seed metadata directory; defaults to a fresh per-segment catalog-derived path."""
+    output_root: Path = Path("data/splat_runs")
+    """Root for direct metric-world runs."""
+    timestamp: str = "run"
+    """Unique training run name."""
+    splat_output_dir: Path = Path(LAYERS[SPLAT_LAYER]).parent
+    """Destination for the in-process static Gaussian-splat RRD."""
+    depth_output_dir: Path = Path(LAYERS[SPLAT_DEPTH_LAYER]).parent
+    """Destination for the in-process two-camera depth RRD."""
+    triage_output_dir: Path = Path(LAYERS[SPLAT_TRIAGE_LAYER]).parent
+    """Destination for the in-process normal, RGB, and diagnostic RRD."""
+    publish_batch_size: int = 8
+    """Full-grid products encoded and sent per bounded-memory batch."""
+    encoder_workers: int = 8
+    """CPU worker threads used for PNG and JPEG encoding."""
+    seed: int = 42
+    """Training and camera-sampling seed."""
+    opacity_reset_every: int = 1_000_000_000
+    """Opacity reset interval; 3000 selects the measured Stage 2 path."""
+    fused_training: bool = False
+    """Opt into fused plane gradients for a future quality round; publication is always fused."""
+
+
+def _run_dir(config: Config) -> Path:
+    return config.output_root / f"{config.video_id}-gaussurf" / "gsplat-direct" / config.timestamp
+
+
+def main(config: Config) -> None:
+    """Run metric-world training, fused evaluation, and direct RRD publication."""
+    if not torch.cuda.is_available():
+        raise SystemExit("direct gsplat training requires CUDA")
+    segment_started_at: float = time.perf_counter()
+    device: torch.device = torch.device("cuda")
+    reader: SegmentReader = SegmentReader.open(config.catalog_url, config.dataset_name, config.video_id)
+    bundle_dir: Path = config.bundle_dir if config.bundle_dir is not None else Path("data/training_metadata") / config.video_id
+    if not metadata_files_complete(bundle_dir, allow_legacy=config.bundle_dir is not None):
+        metadata_stats: MetadataStats = prepare_training_metadata(reader, bundle_dir)
+        print(
+            f"generated training metadata: {bundle_dir} wide={metadata_stats.wide_frames} "
+            f"ultrawide={metadata_stats.ultrawide_frames} holdout={metadata_stats.holdout_frames} "
+            f"render_wide={metadata_stats.render_wide_frames} "
+            f"render_ultrawide={metadata_stats.render_ultrawide_frames} "
+            f"seed_vertices={metadata_stats.seed_vertices}",
+            flush=True,
+        )
+    cache = load_gpu_cache(reader, bundle_dir, device)
+    result = train(
+        cache,
+        bundle_dir=bundle_dir,
+        run_dir=_run_dir(config),
+        seed=config.seed,
+        opacity_reset_every=config.opacity_reset_every,
+        fused_training=config.fused_training,
+    )
+    holdout_metrics: dict[str, float] = evaluate_holdout(result.splats, cache)
+    publish_stats: PublishStats = publish_in_process(
+        result.splats,
+        reader=reader,
+        video_id=config.video_id,
+        bundle_dir=bundle_dir,
+        splat_output_dir=config.splat_output_dir,
+        depth_output_dir=config.depth_output_dir,
+        triage_output_dir=config.triage_output_dir,
+        batch_size=config.publish_batch_size,
+        encoder_workers=config.encoder_workers,
+    )
+    segment_wall_seconds: float = time.perf_counter() - segment_started_at
+    summary: dict[str, Any] = {
+        "seed": config.seed,
+        "iterations": ITERATIONS,
+        "dataset_read": config.dataset_name,
+        "holdout_sha256": cache.holdout_sha256,
+        "holdout_count": len(cache.holdout_indices),
+        "train_camera_count": len(cache.train_indices),
+        "versions": {
+            "gsplat": gsplat.__version__,
+            "torch": torch.__version__,
+            "cuda_runtime": torch.version.cuda,
+        },
+        "scene_scale_m": cache.scene_scale,
+        "metric_training_constants": asdict(metric_training_constants(cache.scene_scale)),
+        "opacity_reset_every": config.opacity_reset_every,
+        "fused_training": config.fused_training,
+        "metrics": holdout_metrics,
+        "gaussian_count": result.gaussian_count,
+        "exported_gaussian_count": result.exported_gaussian_count,
+        "training_wall_seconds": result.training_wall_seconds,
+        "train_evaluate_publish_wall_seconds": result.training_wall_seconds + holdout_metrics["wall_seconds"] + publish_stats.wall_seconds,
+        "segment_command_internal_wall_seconds": segment_wall_seconds,
+        "publication": asdict(publish_stats),
+        "refinement_steps": result.refinement_steps,
+        "reset_steps": result.reset_steps,
+        "strategy_trajectory": [asdict(event) for event in result.strategy_trajectory],
+        "final_losses": result.final_losses,
+    }
+    (_run_dir(config) / "run_summary.json").write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"completed direct gsplat run: {_run_dir(config)}")

--- a/packages/gauss-surf/src/gauss_surf/apis/ultrawide_signals.py
+++ b/packages/gauss-surf/src/gauss_surf/apis/ultrawide_signals.py
@@ -1,0 +1,414 @@
+"""Generate rectified ultrawide RGB, mesh depth, and MoGe normal catalog layers."""
+
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import open3d as o3d
+import pyarrow as pa
+import rerun as rr
+import torch
+from arkitscenes_download.ingest.depth import encode_depth_png
+from arkitscenes_download.ingest.paths import (
+    DEPTH_ULTRAWIDE_RECT,
+    NORMALS_ULTRAWIDE_RECT,
+    PINHOLE_ULTRAWIDE,
+    PINHOLE_ULTRAWIDE_RECT,
+    PROMPTDA_MESH,
+    RGB_ULTRAWIDE_RECT,
+    TIMELINE,
+    VIDEO_ULTRAWIDE,
+)
+from arkitscenes_download.ingest.recording import atomic_recording
+from arkitscenes_download.schema import DEPTH_RANGE_MM
+from einops import rearrange
+from jaxtyping import Float32, UInt8, UInt32
+from monopriors.models.surface_normal.moge_v2_trt import MoGeV2NormalOutput, MoGeV2TrtNormalPredictor
+from numpy import ndarray
+from rerun.catalog import DatasetEntry, DatasetView
+from torch import Tensor
+
+from gauss_surf.catalog import (
+    DEFAULT_CATALOG_URL,
+    DEFAULT_DATASET_NAME,
+    SegmentReader,
+    TimedeltaNs,
+    _matrix_from_cell,
+    _resolution_from_cell,
+    _single_instance,
+    register_layer,
+    table_timestamps,
+)
+from gauss_surf.contracts import (
+    FRAME_SELECTION_LAYER,
+    MOGE_INFERENCE_BATCH_SIZE,
+    PROMPTDA_LAYER,
+    RIG_QUATERNION_COLUMN,
+    RIG_TRANSLATION_COLUMN,
+    ULTRAWIDE_CHOSEN_SHARPNESS_COLUMN,
+    ULTRAWIDE_DEPTH_LAYER,
+    ULTRAWIDE_FPS,
+    ULTRAWIDE_NORMALS_LAYER,
+    ULTRAWIDE_QUATERNION_COLUMN,
+    ULTRAWIDE_TRANSLATION_COLUMN,
+)
+from gauss_surf.normals_encoding import encode_normals_png, to_away_from_camera
+from gauss_surf.render_io import encode_rgb_jpeg
+from gauss_surf.uw_geometry import (
+    AppleUndistortion,
+    CameraPoses,
+    CameraPoseTrack,
+    build_apple_undistortion,
+    depth_meters_to_uint16_mm,
+    load_camera_pose_track,
+    raycast_z_depth,
+    resolve_camera_poses,
+    undistort_rgb,
+    world_from_pose,
+)
+
+ULTRAWIDE_IMAGE_HW: tuple[int, int] = (480, 640)
+"""Native and network ultrawide height and width."""
+
+UW_K_COLUMN: str = f"/{PINHOLE_ULTRAWIDE}:Pinhole:image_from_camera"
+UW_RESOLUTION_COLUMN: str = f"/{PINHOLE_ULTRAWIDE}:Pinhole:resolution"
+DISTORTION_COEFFICIENTS_COLUMN: str = f"/{PINHOLE_ULTRAWIDE}:simplecv.components.DistortionCoefficients"
+DISTORTION_CENTER_COLUMN: str = f"/{PINHOLE_ULTRAWIDE}:distortion_center_xy"
+DISTORTION_REFERENCE_COLUMN: str = f"/{PINHOLE_ULTRAWIDE}:reference_dimensions_wh"
+MESH_VERTICES_COLUMN: str = f"/{PROMPTDA_MESH}:Mesh3D:vertex_positions"
+MESH_TRIANGLES_COLUMN: str = f"/{PROMPTDA_MESH}:Mesh3D:triangle_indices"
+
+
+@dataclass(frozen=True, slots=True)
+class Config:
+    """Configuration for one segment's paired ultrawide signal layers."""
+
+    video_id: str
+    """ARKitScenes segment identifier whose chosen frames are processed."""
+    catalog_url: str = DEFAULT_CATALOG_URL
+    """URL of the gauss-surf development catalog server."""
+    dataset_name: str = DEFAULT_DATASET_NAME
+    """Catalog dataset to read and update."""
+    output_dir: Path = Path("data/ultrawide_signals")
+    """Directory for generated per-segment layer RRDs."""
+
+
+@dataclass(frozen=True, slots=True)
+class UltrawideInputs:
+    """Catalog inputs resolved onto the chosen ultrawide timeline."""
+
+    timestamps: TimedeltaNs
+    """Chosen ultrawide packet times as ``timedelta64[ns]``."""
+    undistortion: AppleUndistortion
+    """Apple radial remap and minimally cropped rectified pinhole at 640×480."""
+    world_from_ultrawide_n44: Float32[ndarray, "n 4 4"]
+    """Chosen camera-to-world transforms using causal rig poses."""
+    pose_staleness_ms_n: Float32[ndarray, "n"]
+    """Age of each selected rig pose in milliseconds."""
+    mesh_vertices_n3: Float32[ndarray, "n_vertices 3"]
+    """PromptDA TSDF mesh vertices in world coordinates."""
+    mesh_triangles_m3: UInt32[ndarray, "n_triangles 3"]
+    """PromptDA TSDF mesh triangle vertex indices."""
+
+
+@dataclass(frozen=True, slots=True)
+class SignalStats:
+    """Counts and valid-depth coverage from the shared processing pass."""
+
+    frame_count: int
+    """Number of frames written to each layer."""
+    coverage_fraction_n: Float32[ndarray, "n"]
+    """Per-frame fraction of pixels with nonzero mesh z-depth."""
+
+
+def _single_instance_or_exit(value: Any, component_name: str) -> Any:
+    """Preserve this CLI stage's clean-exit behavior for malformed cells."""
+    try:
+        return _single_instance(value, component_name)
+    except ValueError as error:
+        raise SystemExit(str(error)) from error
+
+
+def _load_inputs(reader: SegmentReader) -> UltrawideInputs:
+    """Read chosen times, calibration, causal poses, and the static PromptDA mesh."""
+    segment_view: DatasetView = reader.segment_view()
+    available_columns: set[str] = set(segment_view.arrow_schema().names)
+    required_columns: tuple[str, ...] = (
+        ULTRAWIDE_CHOSEN_SHARPNESS_COLUMN,
+        UW_K_COLUMN,
+        UW_RESOLUTION_COLUMN,
+        DISTORTION_COEFFICIENTS_COLUMN,
+        DISTORTION_CENTER_COLUMN,
+        DISTORTION_REFERENCE_COLUMN,
+        ULTRAWIDE_TRANSLATION_COLUMN,
+        ULTRAWIDE_QUATERNION_COLUMN,
+        RIG_TRANSLATION_COLUMN,
+        RIG_QUATERNION_COLUMN,
+        MESH_VERTICES_COLUMN,
+        MESH_TRIANGLES_COLUMN,
+    )
+    missing_columns: list[str] = [name for name in required_columns if name not in available_columns]
+    if missing_columns:
+        raise SystemExit(f"segment {reader.video_id} is missing required ultrawide columns: {missing_columns}")
+
+    chosen_table: pa.Table = reader.chosen_table(ULTRAWIDE_CHOSEN_SHARPNESS_COLUMN, (UW_K_COLUMN, UW_RESOLUTION_COLUMN))
+    timestamps_n: TimedeltaNs = table_timestamps(chosen_table)
+
+    K_values: list[Any] = chosen_table.column(UW_K_COLUMN).to_pylist()
+    try:
+        K_uw_n33: Float32[ndarray, "n 3 3"] = np.stack([_matrix_from_cell(value, UW_K_COLUMN) for value in K_values])
+    except ValueError as error:
+        raise SystemExit(str(error)) from error
+    K_uw_33: Float32[ndarray, "3 3"] = K_uw_n33[0]
+    if not np.allclose(K_uw_n33, K_uw_33[None], atol=1e-5, rtol=0.0):
+        raise SystemExit(f"segment {reader.video_id} has varying ultrawide intrinsics; v1 requires one rectified pinhole")
+    resolution_values: list[Any] = chosen_table.column(UW_RESOLUTION_COLUMN).to_pylist()
+    try:
+        image_wh: tuple[int, int] = _resolution_from_cell(resolution_values[0], UW_RESOLUTION_COLUMN)
+    except ValueError as error:
+        raise SystemExit(str(error)) from error
+    if image_wh != (ULTRAWIDE_IMAGE_HW[1], ULTRAWIDE_IMAGE_HW[0]):
+        raise SystemExit(f"segment {reader.video_id} ultrawide resolution is {image_wh}, expected (640, 480)")
+
+    static_columns: tuple[str, ...] = (
+        DISTORTION_COEFFICIENTS_COLUMN,
+        DISTORTION_CENTER_COLUMN,
+        DISTORTION_REFERENCE_COLUMN,
+        ULTRAWIDE_TRANSLATION_COLUMN,
+        ULTRAWIDE_QUATERNION_COLUMN,
+    )
+    static_table: pa.Table = segment_view.reader(index=TIMELINE, fill_latest_at=True).select(TIMELINE, *static_columns).limit(1).to_arrow_table()
+    if static_table.num_rows != 1:
+        raise SystemExit(f"segment {reader.video_id} has no ultrawide static calibration row")
+    static_row: dict[str, Any] = static_table.to_pylist()[0]
+    # The existing corpus mislabeled this Apple forward polynomial as
+    # brown_conrady and omitted its inverse. Read the coefficient component
+    # regardless of that stale label so Part 5b does not require a corpus reseed.
+    distortion_coefficients_8: Float32[ndarray, "8"] = np.asarray(
+        _single_instance_or_exit(static_row[DISTORTION_COEFFICIENTS_COLUMN], DISTORTION_COEFFICIENTS_COLUMN),
+        dtype=np.float32,
+    )
+    distortion_center_reference_xy: Float32[ndarray, "2"] = np.asarray(static_row[DISTORTION_CENTER_COLUMN], dtype=np.float32)
+    reference_values_wh: list[int] = [int(value) for value in static_row[DISTORTION_REFERENCE_COLUMN]]
+    reference_dimensions_wh: tuple[int, int] = (reference_values_wh[0], reference_values_wh[1])
+    wide_from_ultrawide_44: Float32[ndarray, "4 4"] = world_from_pose(
+        np.asarray(_single_instance_or_exit(static_row[ULTRAWIDE_TRANSLATION_COLUMN], ULTRAWIDE_TRANSLATION_COLUMN), dtype=np.float32),
+        np.asarray(_single_instance_or_exit(static_row[ULTRAWIDE_QUATERNION_COLUMN], ULTRAWIDE_QUATERNION_COLUMN), dtype=np.float32),
+    )
+    undistortion: AppleUndistortion = build_apple_undistortion(
+        K_uw_33,
+        distortion_coefficients_8,
+        distortion_center_reference_xy,
+        reference_dimensions_wh,
+        image_wh,
+    )
+
+    try:
+        pose_track: CameraPoseTrack = load_camera_pose_track(
+            reader,
+            wide_from_ultrawide_44=wide_from_ultrawide_44,
+        )
+    except ValueError as error:
+        raise SystemExit(str(error)) from error
+    no_wide_timestamps_n: TimedeltaNs = np.asarray([], dtype="timedelta64[ns]")
+    poses: CameraPoses = resolve_camera_poses(
+        pose_track,
+        no_wide_timestamps_n,
+        timestamps_n,
+        exact_wide=False,
+    )
+
+    mesh_table: pa.Table = (
+        segment_view.reader(index=TIMELINE, fill_latest_at=True)
+        .select(TIMELINE, MESH_VERTICES_COLUMN, MESH_TRIANGLES_COLUMN)
+        .limit(1)
+        .to_arrow_table()
+    )
+    if mesh_table.num_rows != 1:
+        raise SystemExit(f"segment {reader.video_id} has no static PromptDA mesh row")
+    mesh_row: dict[str, Any] = mesh_table.to_pylist()[0]
+    mesh_vertices_n3: Float32[ndarray, "n_vertices 3"] = np.asarray(mesh_row[MESH_VERTICES_COLUMN], dtype=np.float32)
+    mesh_triangles_m3: UInt32[ndarray, "n_triangles 3"] = np.asarray(mesh_row[MESH_TRIANGLES_COLUMN], dtype=np.uint32)
+    if mesh_vertices_n3.ndim != 2 or mesh_vertices_n3.shape[1] != 3 or mesh_triangles_m3.ndim != 2 or mesh_triangles_m3.shape[1] != 3:
+        raise SystemExit(f"segment {reader.video_id} PromptDA mesh has invalid vertex or triangle shapes")
+
+    return UltrawideInputs(
+        timestamps=timestamps_n,
+        undistortion=undistortion,
+        world_from_ultrawide_n44=poses.world_from_ultrawide_n44,
+        pose_staleness_ms_n=poses.ultrawide_staleness_ms_n,
+        mesh_vertices_n3=mesh_vertices_n3,
+        mesh_triangles_m3=mesh_triangles_m3,
+    )
+
+
+def _send_rectified_pinhole(recording: rr.RecordingStream, inputs: UltrawideInputs) -> None:
+    """Write the rectified pinhole at every chosen timestamp."""
+    frame_count: int = len(inputs.timestamps)
+    intrinsics_n33: Float32[ndarray, "n 3 3"] = np.repeat(inputs.undistortion.K_rect_33[None], frame_count, axis=0)
+    resolutions_n2: Float32[ndarray, "n 2"] = np.tile(np.array([[640.0, 480.0]], dtype=np.float32), (frame_count, 1))
+    rr.send_columns(
+        PINHOLE_ULTRAWIDE_RECT,
+        indexes=[rr.TimeColumn(TIMELINE, duration=inputs.timestamps)],
+        columns=rr.Pinhole.columns(
+            image_from_camera=intrinsics_n33,
+            resolution=resolutions_n2,
+            camera_xyz=[rr.ViewCoordinates.RDF] * frame_count,
+        ),
+        recording=recording,
+    )
+
+
+def _process_and_write(
+    reader: SegmentReader,
+    inputs: UltrawideInputs,
+    predictor: MoGeV2TrtNormalPredictor,
+    scene: o3d.t.geometry.RaycastingScene,
+    depth_recording: rr.RecordingStream,
+    normals_recording: rr.RecordingStream,
+) -> SignalStats:
+    """Decode and rectify once, then fan each batch into both output layers."""
+    decoded_frames: Iterator[UInt8[Tensor, "3 h w"]] = reader.decode_frames(
+        VIDEO_ULTRAWIDE,
+        inputs.timestamps,
+        fps=ULTRAWIDE_FPS,
+        device=torch.device("cuda"),
+    )
+    coverage_fractions: list[float] = []
+    processed_frames: int = 0
+    for start in range(0, len(inputs.timestamps), MOGE_INFERENCE_BATCH_SIZE):
+        batch_timestamps_n: TimedeltaNs = inputs.timestamps[start : start + MOGE_INFERENCE_BATCH_SIZE]
+        rectified_frames: list[UInt8[ndarray, "h=480 w=640 3"]] = []
+        rgb_jpeg_blobs: list[bytes] = []
+        depth_png_blobs: list[bytes] = []
+        for batch_offset, _timestamp in enumerate(batch_timestamps_n):
+            frame_chw: UInt8[Tensor, "3 h w"] = next(decoded_frames)
+            frame_hwc: UInt8[Tensor, "h w 3"] = rearrange(frame_chw, "c h w -> h w c")  # pyrefly: ignore  # bad-argument-type — einops stub
+            rgb_hw3: UInt8[ndarray, "h w 3"] = frame_hwc.cpu().numpy().astype(np.uint8, copy=False)
+            if rgb_hw3.shape != (ULTRAWIDE_IMAGE_HW[0], ULTRAWIDE_IMAGE_HW[1], 3):
+                raise RuntimeError(f"decoded ultrawide frame has shape {rgb_hw3.shape}, expected (480, 640, 3)")
+            rectified_hw3: UInt8[ndarray, "h=480 w=640 3"] = undistort_rgb(
+                rgb_hw3,
+                inputs.undistortion,
+            )
+            rectified_frames.append(rectified_hw3)
+            rgb_jpeg_blobs.append(encode_rgb_jpeg(rectified_hw3))
+
+            frame_index: int = start + batch_offset
+            depth_m_hw: Float32[ndarray, "h=480 w=640"] = raycast_z_depth(
+                scene,
+                inputs.undistortion.K_rect_33,
+                inputs.world_from_ultrawide_n44[frame_index],
+                image_wh=(ULTRAWIDE_IMAGE_HW[1], ULTRAWIDE_IMAGE_HW[0]),
+            )
+            coverage_fractions.append(float(np.count_nonzero(depth_m_hw) / depth_m_hw.size))
+            depth_mm_hw: ndarray = depth_meters_to_uint16_mm(depth_m_hw)
+            depth_png_blobs.append(encode_depth_png(depth_mm_hw, level=1))
+
+        frames_bhw3: UInt8[ndarray, "batch h=480 w=640 3"] = np.stack(rectified_frames)
+        frames_cuda_bhw3: UInt8[Tensor, "batch h=480 w=640 3"] = torch.from_numpy(frames_bhw3).to(device="cuda", dtype=torch.uint8)
+        prediction: MoGeV2NormalOutput = predictor(frames_cuda_bhw3)
+        normals_toward_bhw3: Float32[ndarray, "batch h=480 w=640 3"] = (
+            prediction.normals_bhw3.detach().cpu().numpy().astype(np.float32, copy=False)
+        )
+        normals_away_bhw3: Float32[ndarray, "batch h=480 w=640 3"] = np.stack(
+            [to_away_from_camera(normals_toward_hw3) for normals_toward_hw3 in normals_toward_bhw3]
+        )
+        normals_png_blobs: list[bytes] = [encode_normals_png(normals_hw3) for normals_hw3 in normals_away_bhw3]
+        batch_count: int = len(batch_timestamps_n)
+        rr.send_columns(
+            RGB_ULTRAWIDE_RECT,
+            indexes=[rr.TimeColumn(TIMELINE, duration=batch_timestamps_n)],
+            columns=rr.EncodedImage.columns(blob=rgb_jpeg_blobs, media_type=["image/jpeg"] * batch_count),
+            recording=depth_recording,
+        )
+        rr.send_columns(
+            DEPTH_ULTRAWIDE_RECT,
+            indexes=[rr.TimeColumn(TIMELINE, duration=batch_timestamps_n)],
+            columns=rr.EncodedDepthImage.columns(
+                blob=depth_png_blobs,
+                media_type=["image/png"] * batch_count,
+                meter=[1000.0] * batch_count,
+                depth_range=[DEPTH_RANGE_MM] * batch_count,
+            ),
+            recording=depth_recording,
+        )
+        rr.send_columns(
+            NORMALS_ULTRAWIDE_RECT,
+            indexes=[rr.TimeColumn(TIMELINE, duration=batch_timestamps_n)],
+            columns=rr.EncodedImage.columns(blob=normals_png_blobs, media_type=["image/png"] * batch_count),
+            recording=normals_recording,
+        )
+        processed_frames += batch_count
+        print(f"processed {processed_frames}/{len(inputs.timestamps)} ultrawide frames")
+
+    coverage_fraction_n: Float32[ndarray, "n"] = np.asarray(coverage_fractions, dtype=np.float32)
+    return SignalStats(frame_count=processed_frames, coverage_fraction_n=coverage_fraction_n)
+
+
+def main(config: Config) -> None:
+    """Generate, atomically publish, and replace both ultrawide signal layers."""
+    started_at: float = time.perf_counter()
+    if not torch.cuda.is_available():
+        raise SystemExit("ultrawide signal generation requires CUDA for NVDEC and TensorRT")
+    reader: SegmentReader = SegmentReader.open(config.catalog_url, config.dataset_name, config.video_id)
+    reader.require_layers((FRAME_SELECTION_LAYER, PROMPTDA_LAYER))
+    reader.require_zero_orientation("ultrawide rectification")
+    dataset: DatasetEntry = reader.dataset
+    inputs: UltrawideInputs = _load_inputs(reader)
+    predictor: MoGeV2TrtNormalPredictor = MoGeV2TrtNormalPredictor(
+        image_hw=ULTRAWIDE_IMAGE_HW,
+        batch_size=MOGE_INFERENCE_BATCH_SIZE,
+    )
+    mesh: o3d.t.geometry.TriangleMesh = o3d.t.geometry.TriangleMesh(
+        o3d.core.Tensor(inputs.mesh_vertices_n3),
+        o3d.core.Tensor(inputs.mesh_triangles_m3),
+    )
+    scene: o3d.t.geometry.RaycastingScene = o3d.t.geometry.RaycastingScene()
+    scene.add_triangles(mesh)
+
+    segment_output_dir: Path = config.output_dir / config.video_id
+    segment_output_dir.mkdir(parents=True, exist_ok=True)
+    depth_rrd_path: Path = segment_output_dir / f"{ULTRAWIDE_DEPTH_LAYER}.rrd"
+    normals_rrd_path: Path = segment_output_dir / f"{ULTRAWIDE_NORMALS_LAYER}.rrd"
+    with (
+        atomic_recording(depth_rrd_path, config.video_id, send_properties=False) as depth_recording,
+        atomic_recording(normals_rrd_path, config.video_id, send_properties=False) as normals_recording,
+    ):
+        _send_rectified_pinhole(depth_recording, inputs)
+        stats: SignalStats = _process_and_write(
+            reader,
+            inputs,
+            predictor,
+            scene,
+            depth_recording,
+            normals_recording,
+        )
+    if stats.frame_count != len(inputs.timestamps):
+        raise RuntimeError(f"processed {stats.frame_count} frames for {len(inputs.timestamps)} chosen timestamps")
+    register_layer(dataset, depth_rrd_path, ULTRAWIDE_DEPTH_LAYER)
+    register_layer(dataset, normals_rrd_path, ULTRAWIDE_NORMALS_LAYER)
+
+    coverage_mean: float = float(np.mean(stats.coverage_fraction_n))
+    coverage_min: float = float(np.min(stats.coverage_fraction_n))
+    coverage_max: float = float(np.max(stats.coverage_fraction_n))
+    wall_seconds: float = time.perf_counter() - started_at
+    print(f"K_rect: {inputs.undistortion.K_rect_33.tolist()}")
+    print(
+        "causal pose staleness: "
+        f"mean={float(np.mean(inputs.pose_staleness_ms_n)):.3f}ms "
+        f"min={float(np.min(inputs.pose_staleness_ms_n)):.3f}ms "
+        f"max={float(np.max(inputs.pose_staleness_ms_n)):.3f}ms (nearest 60 Hz sample at or before each frame; no interpolation)"
+    )
+    print(
+        f"{ULTRAWIDE_DEPTH_LAYER}: {stats.frame_count} frames registered from {depth_rrd_path}; "
+        f"valid-depth coverage mean={coverage_mean:.6f} min={coverage_min:.6f} max={coverage_max:.6f}"
+    )
+    print(
+        f"{ULTRAWIDE_NORMALS_LAYER}: {stats.frame_count} frames registered from {normals_rrd_path}; "
+        f"shared-pass depth coverage mean={coverage_mean:.6f}"
+    )
+    print(f"completed both ultrawide layers in {wall_seconds:.2f}s ({stats.frame_count / wall_seconds:.2f} frames/s)")

--- a/packages/gauss-surf/src/gauss_surf/apis/ultrawide_signals.py
+++ b/packages/gauss-surf/src/gauss_surf/apis/ultrawide_signals.py
@@ -43,12 +43,9 @@ from gauss_surf.catalog import (
     table_timestamps,
 )
 from gauss_surf.contracts import (
-    APPLE_FORWARD_DISTORTION_COLUMN,
-    APPLE_INVERSE_DISTORTION_COLUMN,
+    DISTORTION_COEFFICIENTS_COLUMN,
     DISTORTION_MODEL_COLUMN,
     FRAME_SELECTION_LAYER,
-    LEGACY_APPLE_DISTORTION_MODELS,
-    LEGACY_DISTORTION_COEFFICIENTS_COLUMN,
     MOGE_INFERENCE_BATCH_SIZE,
     PROMPTDA_LAYER,
     RIG_QUATERNION_COLUMN,
@@ -63,10 +60,10 @@ from gauss_surf.contracts import (
 from gauss_surf.normals_encoding import encode_normals_png, to_away_from_camera
 from gauss_surf.render_io import encode_rgb_jpeg
 from gauss_surf.uw_geometry import (
-    AppleUndistortion,
     CameraPoses,
     CameraPoseTrack,
-    build_apple_undistortion,
+    Undistortion,
+    build_brown_conrady_undistortion,
     depth_meters_to_uint16_mm,
     load_camera_pose_track,
     raycast_z_depth,
@@ -106,8 +103,8 @@ class UltrawideInputs:
 
     timestamps: TimedeltaNs
     """Chosen ultrawide packet times as ``timedelta64[ns]``."""
-    undistortion: AppleUndistortion
-    """Apple radial remap and minimally cropped rectified pinhole at 640×480."""
+    undistortion: Undistortion
+    """Brown-Conrady remap and minimally cropped rectified pinhole at 640×480."""
     world_from_ultrawide_n44: Float32[ndarray, "n 4 4"]
     """Chosen camera-to-world transforms using causal rig poses."""
     pose_staleness_ms_n: Float32[ndarray, "n"]
@@ -136,62 +133,57 @@ def _single_instance_or_exit(value: Any, component_name: str) -> Any:
         raise SystemExit(str(error)) from error
 
 
-def apple_distortion_coefficients(static_row: dict[str, Any]) -> Float32[ndarray, "8"]:
-    """Resolve exact Apple coefficients from the canonical or legacy schema.
-
-    New recordings must pair Apple provenance with the canonical
-    ``brown_conrady`` generic model. Legacy recordings stored the Apple vector
-    in the generic coefficient column under one of two known stale labels.
+def brown_conrady_coefficients(static_row: dict[str, Any], *, video_id: str) -> Float32[ndarray, "14"]:
+    """Read one standard Brown-Conrady model and coefficient vector.
 
     Args:
-        static_row: Catalog row containing one distortion model and either the
-            provenance or legacy coefficient component.
+        static_row: Catalog row containing the generic model and coefficients.
+        video_id: Segment identifier included in migration errors.
 
     Returns:
-        Exact float32 Apple forward coefficients shaped ``8``.
+        Standard float32 Brown-Conrady coefficients shaped ``14``.
     """
     model_value: Any = _single_instance_or_exit(static_row[DISTORTION_MODEL_COLUMN], DISTORTION_MODEL_COLUMN)
     if not isinstance(model_value, str):
         raise SystemExit(f"component {DISTORTION_MODEL_COLUMN!r} is not a string")
     model: str = model_value
-    coefficient_column: str
-    allowed_models: frozenset[str]
-    if APPLE_FORWARD_DISTORTION_COLUMN in static_row:
-        coefficient_column = APPLE_FORWARD_DISTORTION_COLUMN
-        allowed_models = frozenset({"brown_conrady"})
-    else:
-        coefficient_column = LEGACY_DISTORTION_COEFFICIENTS_COLUMN
-        allowed_models = LEGACY_APPLE_DISTORTION_MODELS
-    if model not in allowed_models:
-        raise SystemExit(
-            f"distortion model {model!r} is incompatible with Apple coefficient column {coefficient_column!r}; "
-            f"expected one of {sorted(allowed_models)}"
-        )
-    coefficients_8: Float32[ndarray, "8"] = np.asarray(
-        _single_instance_or_exit(static_row[coefficient_column], coefficient_column), dtype=np.float32
+    migration_instruction: str = (
+        f"re-ingest segment {video_id}'s calibration with arkitscenes-download-ingest "
+        f"(`tools/apps/ingest_sequence.py`), then reseed it with gauss-surf-register-segment"
     )
-    if coefficients_8.shape != (8,):
-        raise SystemExit(f"Apple distortion component {coefficient_column!r} has shape {coefficients_8.shape}, expected (8,)")
-    return coefficients_8
+    if model != "brown_conrady":
+        raise SystemExit(
+            f"segment {video_id} distortion model is {model!r}, not 'brown_conrady'; {migration_instruction}"
+        )
+    coefficients_n: Float32[ndarray, "n"] = np.asarray(
+        _single_instance_or_exit(static_row[DISTORTION_COEFFICIENTS_COLUMN], DISTORTION_COEFFICIENTS_COLUMN), dtype=np.float32
+    )
+    if coefficients_n.shape != (14,):
+        raise SystemExit(
+            f"segment {video_id} Brown-Conrady coefficients have shape {coefficients_n.shape}, expected (14,); {migration_instruction}"
+        )
+    return coefficients_n
 
 
 def _load_inputs(reader: SegmentReader) -> UltrawideInputs:
     """Read chosen times, calibration, causal poses, and the static PromptDA mesh."""
     segment_view: DatasetView = reader.segment_view()
     available_columns: set[str] = set(segment_view.arrow_schema().names)
-    has_apple_provenance: bool = APPLE_FORWARD_DISTORTION_COLUMN in available_columns
-    distortion_coefficient_column: str = (
-        APPLE_FORWARD_DISTORTION_COLUMN if has_apple_provenance else LEGACY_DISTORTION_COEFFICIENTS_COLUMN
-    )
-    provenance_required_columns: tuple[str, ...] = (
-        (APPLE_FORWARD_DISTORTION_COLUMN, APPLE_INVERSE_DISTORTION_COLUMN) if has_apple_provenance else (LEGACY_DISTORTION_COEFFICIENTS_COLUMN,)
-    )
+    missing_distortion_columns: list[str] = [
+        name for name in (DISTORTION_MODEL_COLUMN, DISTORTION_COEFFICIENTS_COLUMN) if name not in available_columns
+    ]
+    if missing_distortion_columns:
+        raise SystemExit(
+            f"segment {reader.video_id} lacks Brown-Conrady calibration columns {missing_distortion_columns}; "
+            f"re-ingest that segment's calibration with arkitscenes-download-ingest (`tools/apps/ingest_sequence.py`), "
+            f"then reseed it with gauss-surf-register-segment"
+        )
     required_columns: tuple[str, ...] = (
         ULTRAWIDE_CHOSEN_SHARPNESS_COLUMN,
         UW_K_COLUMN,
         UW_RESOLUTION_COLUMN,
         DISTORTION_MODEL_COLUMN,
-        *provenance_required_columns,
+        DISTORTION_COEFFICIENTS_COLUMN,
         DISTORTION_CENTER_COLUMN,
         DISTORTION_REFERENCE_COLUMN,
         ULTRAWIDE_TRANSLATION_COLUMN,
@@ -226,7 +218,7 @@ def _load_inputs(reader: SegmentReader) -> UltrawideInputs:
 
     static_columns: tuple[str, ...] = (
         DISTORTION_MODEL_COLUMN,
-        distortion_coefficient_column,
+        DISTORTION_COEFFICIENTS_COLUMN,
         DISTORTION_CENTER_COLUMN,
         DISTORTION_REFERENCE_COLUMN,
         ULTRAWIDE_TRANSLATION_COLUMN,
@@ -236,7 +228,7 @@ def _load_inputs(reader: SegmentReader) -> UltrawideInputs:
     if static_table.num_rows != 1:
         raise SystemExit(f"segment {reader.video_id} has no ultrawide static calibration row")
     static_row: dict[str, Any] = static_table.to_pylist()[0]
-    distortion_coefficients_8: Float32[ndarray, "8"] = apple_distortion_coefficients(static_row)
+    distortion_coefficients_14: Float32[ndarray, "14"] = brown_conrady_coefficients(static_row, video_id=reader.video_id)
     distortion_center_reference_xy: Float32[ndarray, "2"] = np.asarray(static_row[DISTORTION_CENTER_COLUMN], dtype=np.float32)
     reference_values_wh: list[int] = [int(value) for value in static_row[DISTORTION_REFERENCE_COLUMN]]
     reference_dimensions_wh: tuple[int, int] = (reference_values_wh[0], reference_values_wh[1])
@@ -244,9 +236,9 @@ def _load_inputs(reader: SegmentReader) -> UltrawideInputs:
         np.asarray(_single_instance_or_exit(static_row[ULTRAWIDE_TRANSLATION_COLUMN], ULTRAWIDE_TRANSLATION_COLUMN), dtype=np.float32),
         np.asarray(_single_instance_or_exit(static_row[ULTRAWIDE_QUATERNION_COLUMN], ULTRAWIDE_QUATERNION_COLUMN), dtype=np.float32),
     )
-    undistortion: AppleUndistortion = build_apple_undistortion(
+    undistortion: Undistortion = build_brown_conrady_undistortion(
         K_uw_33,
-        distortion_coefficients_8,
+        distortion_coefficients_14,
         distortion_center_reference_xy,
         reference_dimensions_wh,
         image_wh,

--- a/packages/gauss-surf/src/gauss_surf/apis/ultrawide_signals.py
+++ b/packages/gauss-surf/src/gauss_surf/apis/ultrawide_signals.py
@@ -43,7 +43,12 @@ from gauss_surf.catalog import (
     table_timestamps,
 )
 from gauss_surf.contracts import (
+    APPLE_FORWARD_DISTORTION_COLUMN,
+    APPLE_INVERSE_DISTORTION_COLUMN,
+    DISTORTION_MODEL_COLUMN,
     FRAME_SELECTION_LAYER,
+    LEGACY_APPLE_DISTORTION_MODELS,
+    LEGACY_DISTORTION_COEFFICIENTS_COLUMN,
     MOGE_INFERENCE_BATCH_SIZE,
     PROMPTDA_LAYER,
     RIG_QUATERNION_COLUMN,
@@ -75,7 +80,6 @@ ULTRAWIDE_IMAGE_HW: tuple[int, int] = (480, 640)
 
 UW_K_COLUMN: str = f"/{PINHOLE_ULTRAWIDE}:Pinhole:image_from_camera"
 UW_RESOLUTION_COLUMN: str = f"/{PINHOLE_ULTRAWIDE}:Pinhole:resolution"
-DISTORTION_COEFFICIENTS_COLUMN: str = f"/{PINHOLE_ULTRAWIDE}:simplecv.components.DistortionCoefficients"
 DISTORTION_CENTER_COLUMN: str = f"/{PINHOLE_ULTRAWIDE}:distortion_center_xy"
 DISTORTION_REFERENCE_COLUMN: str = f"/{PINHOLE_ULTRAWIDE}:reference_dimensions_wh"
 MESH_VERTICES_COLUMN: str = f"/{PROMPTDA_MESH}:Mesh3D:vertex_positions"
@@ -132,15 +136,62 @@ def _single_instance_or_exit(value: Any, component_name: str) -> Any:
         raise SystemExit(str(error)) from error
 
 
+def apple_distortion_coefficients(static_row: dict[str, Any]) -> Float32[ndarray, "8"]:
+    """Resolve exact Apple coefficients from the canonical or legacy schema.
+
+    New recordings must pair Apple provenance with the canonical
+    ``brown_conrady`` generic model. Legacy recordings stored the Apple vector
+    in the generic coefficient column under one of two known stale labels.
+
+    Args:
+        static_row: Catalog row containing one distortion model and either the
+            provenance or legacy coefficient component.
+
+    Returns:
+        Exact float32 Apple forward coefficients shaped ``8``.
+    """
+    model_value: Any = _single_instance_or_exit(static_row[DISTORTION_MODEL_COLUMN], DISTORTION_MODEL_COLUMN)
+    if not isinstance(model_value, str):
+        raise SystemExit(f"component {DISTORTION_MODEL_COLUMN!r} is not a string")
+    model: str = model_value
+    coefficient_column: str
+    allowed_models: frozenset[str]
+    if APPLE_FORWARD_DISTORTION_COLUMN in static_row:
+        coefficient_column = APPLE_FORWARD_DISTORTION_COLUMN
+        allowed_models = frozenset({"brown_conrady"})
+    else:
+        coefficient_column = LEGACY_DISTORTION_COEFFICIENTS_COLUMN
+        allowed_models = LEGACY_APPLE_DISTORTION_MODELS
+    if model not in allowed_models:
+        raise SystemExit(
+            f"distortion model {model!r} is incompatible with Apple coefficient column {coefficient_column!r}; "
+            f"expected one of {sorted(allowed_models)}"
+        )
+    coefficients_8: Float32[ndarray, "8"] = np.asarray(
+        _single_instance_or_exit(static_row[coefficient_column], coefficient_column), dtype=np.float32
+    )
+    if coefficients_8.shape != (8,):
+        raise SystemExit(f"Apple distortion component {coefficient_column!r} has shape {coefficients_8.shape}, expected (8,)")
+    return coefficients_8
+
+
 def _load_inputs(reader: SegmentReader) -> UltrawideInputs:
     """Read chosen times, calibration, causal poses, and the static PromptDA mesh."""
     segment_view: DatasetView = reader.segment_view()
     available_columns: set[str] = set(segment_view.arrow_schema().names)
+    has_apple_provenance: bool = APPLE_FORWARD_DISTORTION_COLUMN in available_columns
+    distortion_coefficient_column: str = (
+        APPLE_FORWARD_DISTORTION_COLUMN if has_apple_provenance else LEGACY_DISTORTION_COEFFICIENTS_COLUMN
+    )
+    provenance_required_columns: tuple[str, ...] = (
+        (APPLE_FORWARD_DISTORTION_COLUMN, APPLE_INVERSE_DISTORTION_COLUMN) if has_apple_provenance else (LEGACY_DISTORTION_COEFFICIENTS_COLUMN,)
+    )
     required_columns: tuple[str, ...] = (
         ULTRAWIDE_CHOSEN_SHARPNESS_COLUMN,
         UW_K_COLUMN,
         UW_RESOLUTION_COLUMN,
-        DISTORTION_COEFFICIENTS_COLUMN,
+        DISTORTION_MODEL_COLUMN,
+        *provenance_required_columns,
         DISTORTION_CENTER_COLUMN,
         DISTORTION_REFERENCE_COLUMN,
         ULTRAWIDE_TRANSLATION_COLUMN,
@@ -174,7 +225,8 @@ def _load_inputs(reader: SegmentReader) -> UltrawideInputs:
         raise SystemExit(f"segment {reader.video_id} ultrawide resolution is {image_wh}, expected (640, 480)")
 
     static_columns: tuple[str, ...] = (
-        DISTORTION_COEFFICIENTS_COLUMN,
+        DISTORTION_MODEL_COLUMN,
+        distortion_coefficient_column,
         DISTORTION_CENTER_COLUMN,
         DISTORTION_REFERENCE_COLUMN,
         ULTRAWIDE_TRANSLATION_COLUMN,
@@ -184,13 +236,7 @@ def _load_inputs(reader: SegmentReader) -> UltrawideInputs:
     if static_table.num_rows != 1:
         raise SystemExit(f"segment {reader.video_id} has no ultrawide static calibration row")
     static_row: dict[str, Any] = static_table.to_pylist()[0]
-    # The existing corpus mislabeled this Apple forward polynomial as
-    # brown_conrady and omitted its inverse. Read the coefficient component
-    # regardless of that stale label so Part 5b does not require a corpus reseed.
-    distortion_coefficients_8: Float32[ndarray, "8"] = np.asarray(
-        _single_instance_or_exit(static_row[DISTORTION_COEFFICIENTS_COLUMN], DISTORTION_COEFFICIENTS_COLUMN),
-        dtype=np.float32,
-    )
+    distortion_coefficients_8: Float32[ndarray, "8"] = apple_distortion_coefficients(static_row)
     distortion_center_reference_xy: Float32[ndarray, "2"] = np.asarray(static_row[DISTORTION_CENTER_COLUMN], dtype=np.float32)
     reference_values_wh: list[int] = [int(value) for value in static_row[DISTORTION_REFERENCE_COLUMN]]
     reference_dimensions_wh: tuple[int, int] = (reference_values_wh[0], reference_values_wh[1])

--- a/packages/gauss-surf/src/gauss_surf/train_gsplat/__init__.py
+++ b/packages/gauss-surf/src/gauss_surf/train_gsplat/__init__.py
@@ -1,0 +1,1 @@
+"""Direct gsplat training path for gauss-surf."""

--- a/packages/gauss-surf/src/gauss_surf/train_gsplat/cache.py
+++ b/packages/gauss-surf/src/gauss_surf/train_gsplat/cache.py
@@ -1,0 +1,404 @@
+"""GPU-resident training cache populated directly from one catalog segment."""
+
+import json
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pyarrow as pa
+import torch
+from arkitscenes_download.ingest.paths import (
+    DEPTH_ULTRAWIDE_RECT,
+    NORMALS_MOGE,
+    NORMALS_ULTRAWIDE_RECT,
+    RGB_ULTRAWIDE_RECT,
+    VIDEO_WIDE,
+)
+from einops import rearrange
+from jaxtyping import Float32
+from PIL import Image
+
+from gauss_surf.catalog import SegmentReader, TimedeltaNs, table_timestamps
+from gauss_surf.contracts import (
+    PROMPTDA_DEPTH_BLOB_COLUMN,
+    ULTRAWIDE_CHOSEN_SHARPNESS_COLUMN,
+    WIDE_CHOSEN_SHARPNESS_COLUMN,
+    WIDE_FPS,
+    CameraTag,
+)
+from gauss_surf.render_io import RenderCamera, blob_bytes, decode_rgb_image
+from gauss_surf.train_gsplat.core import decode_normal_uint8, holdout_hash
+
+WIDE_NORMAL_COLUMN: str = f"/{NORMALS_MOGE}:EncodedImage:blob"
+UW_RGB_COLUMN: str = f"/{RGB_ULTRAWIDE_RECT}:EncodedImage:blob"
+UW_DEPTH_COLUMN: str = f"/{DEPTH_ULTRAWIDE_RECT}:EncodedDepthImage:blob"
+UW_NORMAL_COLUMN: str = f"/{NORMALS_ULTRAWIDE_RECT}:EncodedImage:blob"
+
+
+@dataclass(frozen=True, slots=True)
+class RasterCamera:
+    """Minimal camera values consumed by the gsplat renderer."""
+
+    width: int
+    """Native camera width in pixels."""
+    height: int
+    """Native camera height in pixels."""
+    viewmat_44: torch.Tensor
+    """OpenCV world-to-camera transform."""
+    K_33: torch.Tensor
+    """Native camera intrinsic matrix."""
+
+
+@dataclass(frozen=True, slots=True)
+class TrainingCamera(RasterCamera):
+    """One metric-world training camera and its cache location."""
+
+    stem: str
+    """Stable chosen-frame stem."""
+    camera: CameraTag
+    """Wide or rectified-ultrawide tag."""
+    timestamp_ns: int
+    """Exact duration since recording start, in nanoseconds."""
+    cache_index: int
+    """Index within the corresponding resident camera-group tensors."""
+    holdout: bool
+    """Whether this camera belongs to the wide holdout split."""
+
+
+@dataclass(slots=True)
+class GpuTrainingCache:
+    """Quantized source signals and metric-world cameras resident on one GPU."""
+
+    wide_rgb_nhw3: torch.Tensor
+    wide_depth_nhw: torch.Tensor
+    wide_normal_nhw3: torch.Tensor
+    uw_rgb_nhw3: torch.Tensor
+    uw_depth_nhw: torch.Tensor
+    uw_normal_nhw3: torch.Tensor
+    cameras: tuple[TrainingCamera, ...]
+    train_indices: torch.Tensor
+    holdout_indices: tuple[int, ...]
+    holdout_sha256: str
+    scene_scale: float
+
+    def sample(self, training_index: int, downscale: int) -> tuple[TrainingCamera, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Dequantize one randomly selected resident frame on the GPU."""
+        camera_index: int = int(self.train_indices[training_index].item())
+        camera: TrainingCamera = self.cameras[camera_index]
+        if camera.camera == "wide":
+            rgb_hw3: torch.Tensor = self.wide_rgb_nhw3[camera.cache_index]
+            depth_hw: torch.Tensor = self.wide_depth_nhw[camera.cache_index]
+            normal_hw3: torch.Tensor = self.wide_normal_nhw3[camera.cache_index]
+        else:
+            rgb_hw3 = self.uw_rgb_nhw3[camera.cache_index]
+            depth_hw = self.uw_depth_nhw[camera.cache_index]
+            normal_hw3 = self.uw_normal_nhw3[camera.cache_index]
+        rgb_13hw: torch.Tensor = rgb_hw3.permute(2, 0, 1).unsqueeze(0).to(torch.float32) / 255.0
+        depth_11hw: torch.Tensor = depth_hw.unsqueeze(0).unsqueeze(0).to(torch.float32) / 1_000.0
+        normal_13hw: torch.Tensor = decode_normal_uint8(normal_hw3).permute(2, 0, 1).unsqueeze(0)
+        if downscale > 1:
+            output_size: tuple[int, int] = (camera.height // downscale, camera.width // downscale)
+            rgb_13hw = torch.nn.functional.interpolate(rgb_13hw, output_size, mode="bilinear", align_corners=False, antialias=True)
+            depth_11hw = torch.nn.functional.interpolate(depth_11hw, output_size, mode="bilinear", align_corners=False)
+            normal_13hw = torch.nn.functional.interpolate(normal_13hw, output_size, mode="bilinear", align_corners=False)
+        elif normal_13hw.shape[-2:] != rgb_13hw.shape[-2:]:
+            normal_13hw = torch.nn.functional.interpolate(normal_13hw, rgb_13hw.shape[-2:], mode="bilinear", align_corners=False)
+        return camera, rgb_13hw.squeeze(0).permute(1, 2, 0), depth_11hw.squeeze(0).permute(1, 2, 0), normal_13hw.squeeze(0)
+
+
+@dataclass(frozen=True, slots=True)
+class CacheParity:
+    """Pixel/component counts from a full cache-to-bundle comparison."""
+
+    compared_values: dict[str, int]
+    mismatched_values: dict[str, int]
+
+    @property
+    def mismatch_count(self) -> int:
+        """Return mismatches summed across all six modalities."""
+        return sum(self.mismatched_values.values())
+
+
+def _decode_png_uint16(encoded: bytes) -> np.ndarray:
+    """Decode one lossless uint16 depth PNG without dequantizing it."""
+    with Image.open(BytesIO(encoded)) as image:
+        depth: np.ndarray = np.asarray(image, dtype=np.uint16).copy()
+    if depth.ndim != 2:
+        raise ValueError(f"depth PNG must be two-dimensional, got {depth.shape}")
+    return depth
+
+
+def _metric_camera(
+    raw_frame: dict[str, Any],
+    *,
+    cache_index: int,
+) -> TrainingCamera:
+    """Convert a metric-world OpenGL camera to an OpenCV view matrix."""
+    world_from_camera_44: np.ndarray = np.asarray(raw_frame["transform_matrix"], dtype=np.float32)
+    world_from_opencv_44: np.ndarray = world_from_camera_44.copy()
+    world_from_opencv_44[:, 1:3] *= -1.0
+    viewmat_44: np.ndarray = np.linalg.inv(world_from_opencv_44).astype(np.float32)
+    K_33: np.ndarray = np.asarray(
+        [
+            [raw_frame["fl_x"], 0.0, raw_frame["cx"]],
+            [0.0, raw_frame["fl_y"], raw_frame["cy"]],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=np.float32,
+    )
+    return TrainingCamera(
+        stem=Path(str(raw_frame["file_path"])).stem,
+        camera=str(raw_frame["camera"]),  # pyrefly: ignore  # validated by bundle schema
+        timestamp_ns=int(raw_frame["timestamp_ns"]),
+        width=int(raw_frame["w"]),
+        height=int(raw_frame["h"]),
+        viewmat_44=torch.from_numpy(viewmat_44),
+        K_33=torch.from_numpy(K_33),
+        cache_index=cache_index,
+        holdout=bool(raw_frame["holdout"]),
+    )
+
+
+def raster_camera_from_render_camera(camera: RenderCamera) -> RasterCamera:
+    """Adapt one metric full-grid camera to the minimal renderer contract."""
+    world_from_camera_44: np.ndarray = np.eye(4, dtype=np.float32)
+    world_from_camera_44[:3] = camera.world_from_camera_34
+    world_from_opencv_44: np.ndarray = world_from_camera_44.copy()
+    world_from_opencv_44[:, 1:3] *= -1.0
+    K_33: np.ndarray = np.asarray(
+        [[camera.fx, 0.0, camera.cx], [0.0, camera.fy, camera.cy], [0.0, 0.0, 1.0]],
+        dtype=np.float32,
+    )
+    return RasterCamera(
+        width=camera.width,
+        height=camera.height,
+        viewmat_44=torch.from_numpy(np.linalg.inv(world_from_opencv_44).astype(np.float32)),
+        K_33=torch.from_numpy(K_33),
+    )
+
+
+def scene_scale_from_camera_poses(world_from_camera_n44: Float32[torch.Tensor, "n 4 4"]) -> float:
+    """Return the inverse of the applied automatic pose scale.
+
+    This reproduces the historical pose-centering rule in float32: translate
+    by the mean camera origin, rotate the mean camera-up direction onto +Z,
+    then take the largest absolute translation coordinate.
+
+    Args:
+        world_from_camera_n44: Float32 camera-to-world matrices with shape
+            ``(n, 4, 4)``.
+
+    Returns:
+        Positive scene scale in world units.
+    """
+    if world_from_camera_n44.ndim != 3 or world_from_camera_n44.shape[1:] != (4, 4) or len(world_from_camera_n44) == 0:
+        raise ValueError(f"camera poses must have non-empty shape (n, 4, 4), got {tuple(world_from_camera_n44.shape)}")
+    if not bool(torch.isfinite(world_from_camera_n44).all().item()):
+        raise ValueError("camera poses must be finite")
+    origins_n3: Float32[torch.Tensor, "n 3"] = world_from_camera_n44[:, :3, 3]
+    translation_3: Float32[torch.Tensor, "3"] = origins_n3.mean(dim=0)
+    up_3: Float32[torch.Tensor, "3"] = world_from_camera_n44[:, :3, 1].mean(dim=0)
+    up_norm: torch.Tensor = torch.linalg.vector_norm(up_3)
+    if not bool(torch.isfinite(up_norm).item()) or float(up_norm.item()) <= 0.0:
+        raise ValueError("mean camera-up direction must be finite and nonzero")
+    up_3 = up_3 / up_norm
+    target_up_3: Float32[torch.Tensor, "3"] = torch.tensor(
+        (0.0, 0.0, 1.0), dtype=world_from_camera_n44.dtype, device=world_from_camera_n44.device
+    )
+    up_3 = up_3 / torch.linalg.vector_norm(up_3)
+    target_up_3 = target_up_3 / torch.linalg.vector_norm(target_up_3)
+    rotation_axis_3: Float32[torch.Tensor, "3"] = torch.linalg.cross(up_3, target_up_3)
+    if float(torch.abs(rotation_axis_3).sum().item()) < 1e-6:
+        fallback_axis_3: Float32[torch.Tensor, "3"] = torch.tensor(
+            (1.0, 0.0, 0.0) if abs(float(up_3[0].item())) < 1e-6 else (0.0, 1.0, 0.0),
+            dtype=world_from_camera_n44.dtype,
+            device=world_from_camera_n44.device,
+        )
+        rotation_axis_3 = torch.linalg.cross(up_3, fallback_axis_3)
+    rotation_axis_3 = rotation_axis_3 / torch.linalg.vector_norm(rotation_axis_3)
+    axis_x: torch.Tensor = rotation_axis_3[0]
+    axis_y: torch.Tensor = rotation_axis_3[1]
+    axis_z: torch.Tensor = rotation_axis_3[2]
+    zero: torch.Tensor = torch.zeros((), dtype=world_from_camera_n44.dtype, device=world_from_camera_n44.device)
+    skew_33: Float32[torch.Tensor, "3 3"] = torch.stack(
+        (
+            torch.stack((zero, -axis_z, axis_y)),
+            torch.stack((axis_z, zero, -axis_x)),
+            torch.stack((-axis_y, axis_x, zero)),
+        )
+    )
+    angle: torch.Tensor = torch.acos(torch.clip(torch.dot(up_3, target_up_3), -1.0, 1.0))
+    identity_33: Float32[torch.Tensor, "3 3"] = torch.eye(
+        3, dtype=world_from_camera_n44.dtype, device=world_from_camera_n44.device
+    )
+    rotation_33: Float32[torch.Tensor, "3 3"] = (
+        identity_33 + torch.sin(angle) * skew_33 + (1.0 - torch.cos(angle)) * (skew_33 @ skew_33)
+    )
+    transform_34: Float32[torch.Tensor, "3 4"] = torch.cat(
+        (rotation_33, rotation_33 @ -translation_3[:, None]), dim=-1
+    )
+    oriented_poses_n34: Float32[torch.Tensor, "n 3 4"] = transform_34 @ world_from_camera_n44
+    scene_scale: float = float(torch.abs(oriented_poses_n34[:, :3, 3]).max().item())
+    if not np.isfinite(scene_scale) or scene_scale <= 0.0:
+        raise ValueError(f"camera scene scale must be positive and finite, got {scene_scale}")
+    return scene_scale
+
+
+def load_training_cameras(
+    bundle_dir: Path,
+) -> tuple[tuple[TrainingCamera, ...], float]:
+    """Read metric bundle cameras and reproduce their automatic scene scale."""
+    transforms: dict[str, Any] = json.loads((bundle_dir / "transforms.json").read_text(encoding="utf-8"))
+    raw_frames: list[dict[str, Any]] = list(transforms["frames"])
+    if len(raw_frames) == 0:
+        raise ValueError("training camera manifest is empty")
+    world_from_camera_n44: Float32[torch.Tensor, "n 4 4"] = torch.tensor(
+        [raw_frame["transform_matrix"] for raw_frame in raw_frames], dtype=torch.float32
+    )
+    scene_scale: float = scene_scale_from_camera_poses(world_from_camera_n44)
+    camera_counts: dict[str, int] = {"wide": 0, "uw": 0}
+    cameras: list[TrainingCamera] = []
+    for raw_frame in raw_frames:
+        camera_tag: str = str(raw_frame["camera"])
+        cache_index: int = camera_counts[camera_tag]
+        cameras.append(_metric_camera(raw_frame, cache_index=cache_index))
+        camera_counts[camera_tag] += 1
+    return tuple(cameras), scene_scale
+
+
+def load_gpu_cache(
+    reader: SegmentReader,
+    bundle_dir: Path,
+    device: torch.device,
+) -> GpuTrainingCache:
+    """Fill timeline-ordered quantized tensors from catalog source layers."""
+    cameras, scene_scale = load_training_cameras(bundle_dir)
+    wide_cameras: tuple[TrainingCamera, ...] = tuple(camera for camera in cameras if camera.camera == "wide")
+    uw_cameras: tuple[TrainingCamera, ...] = tuple(camera for camera in cameras if camera.camera == "uw")
+
+    wide_table: pa.Table = reader.chosen_table(
+        WIDE_CHOSEN_SHARPNESS_COLUMN,
+        (PROMPTDA_DEPTH_BLOB_COLUMN, WIDE_NORMAL_COLUMN),
+    )
+    uw_table: pa.Table = reader.chosen_table(
+        ULTRAWIDE_CHOSEN_SHARPNESS_COLUMN,
+        (UW_RGB_COLUMN, UW_DEPTH_COLUMN, UW_NORMAL_COLUMN),
+    )
+    if wide_table.num_rows != len(wide_cameras) or uw_table.num_rows != len(uw_cameras):
+        raise RuntimeError(
+            f"catalog/bundle counts differ: wide {wide_table.num_rows}/{len(wide_cameras)}, uw {uw_table.num_rows}/{len(uw_cameras)}"
+        )
+    wide_timestamps: TimedeltaNs = table_timestamps(wide_table)
+    uw_timestamps: TimedeltaNs = table_timestamps(uw_table)
+    expected_wide_ns: np.ndarray = np.asarray([camera.timestamp_ns for camera in wide_cameras], dtype=np.int64)
+    expected_uw_ns: np.ndarray = np.asarray([camera.timestamp_ns for camera in uw_cameras], dtype=np.int64)
+    if not np.array_equal(wide_timestamps.astype(np.int64), expected_wide_ns) or not np.array_equal(uw_timestamps.astype(np.int64), expected_uw_ns):
+        raise RuntimeError("catalog and Part 10 bundle timelines differ")
+
+    wide_rows: list[dict[str, Any]] = wide_table.to_pylist()
+    uw_rows: list[dict[str, Any]] = uw_table.to_pylist()
+    wide_resolutions: set[tuple[int, int]] = {(camera.height, camera.width) for camera in wide_cameras}
+    uw_resolutions: set[tuple[int, int]] = {(camera.height, camera.width) for camera in uw_cameras}
+    if len(wide_resolutions) != 1 or len(uw_resolutions) != 1:
+        raise RuntimeError(
+            f"training cameras must have one resolution per group, got wide={sorted(wide_resolutions)} uw={sorted(uw_resolutions)}"
+        )
+    wide_hw: tuple[int, int] = next(iter(wide_resolutions))
+    uw_hw: tuple[int, int] = next(iter(uw_resolutions))
+    first_wide_normal_hw3: np.ndarray = decode_rgb_image(blob_bytes(wide_rows[0][WIDE_NORMAL_COLUMN], WIDE_NORMAL_COLUMN))
+    wide_normal_hw3: tuple[int, int, int] = first_wide_normal_hw3.shape
+    if wide_normal_hw3[-1:] != (3,):
+        raise RuntimeError(f"wide normal layer must contain RGB images, got {wide_normal_hw3}")
+    wide_depth_nhw: torch.Tensor = torch.empty((len(wide_rows), *wide_hw), dtype=torch.uint16, device=device)
+    wide_normal_nhw3: torch.Tensor = torch.empty((len(wide_rows), *wide_normal_hw3), dtype=torch.uint8, device=device)
+    wide_rgb_nhw3: torch.Tensor = torch.empty((len(wide_rows), *wide_hw, 3), dtype=torch.uint8, device=device)
+    decoded_wide = reader.decode_frames(VIDEO_WIDE, wide_timestamps, fps=WIDE_FPS, device=device)
+    for index, (row, frame_chw) in enumerate(zip(wide_rows, decoded_wide, strict=True)):
+        decoded_rgb_hw3: torch.Tensor = rearrange(frame_chw, "c h w -> h w c")  # pyrefly: ignore  # einops stubs
+        depth_hw: np.ndarray = _decode_png_uint16(blob_bytes(row[PROMPTDA_DEPTH_BLOB_COLUMN], PROMPTDA_DEPTH_BLOB_COLUMN))
+        normal_hw3: np.ndarray = first_wide_normal_hw3 if index == 0 else decode_rgb_image(blob_bytes(row[WIDE_NORMAL_COLUMN], WIDE_NORMAL_COLUMN))
+        if tuple(decoded_rgb_hw3.shape) != (*wide_hw, 3) or depth_hw.shape != wide_hw or normal_hw3.shape != wide_normal_hw3:
+            raise RuntimeError(
+                f"wide cache signal shapes differ from contracts: rgb={tuple(decoded_rgb_hw3.shape)} depth={depth_hw.shape} "
+                f"normal={normal_hw3.shape}; expected rgb/depth={wide_hw} normal={wide_normal_hw3[:2]}"
+            )
+        wide_rgb_nhw3[index].copy_(decoded_rgb_hw3)
+        wide_depth_nhw[index].copy_(torch.from_numpy(depth_hw))
+        wide_normal_nhw3[index].copy_(torch.from_numpy(normal_hw3))
+        if (index + 1) % 25 == 0 or index + 1 == len(wide_rows):
+            print(f"cached {index + 1}/{len(wide_rows)} wide frames", flush=True)
+
+    uw_rgb_nhw3: torch.Tensor = torch.empty((len(uw_rows), *uw_hw, 3), dtype=torch.uint8, device=device)
+    uw_depth_nhw: torch.Tensor = torch.empty((len(uw_rows), *uw_hw), dtype=torch.uint16, device=device)
+    uw_normal_nhw3: torch.Tensor = torch.empty((len(uw_rows), *uw_hw, 3), dtype=torch.uint8, device=device)
+    for index, row in enumerate(uw_rows):
+        rgb_hw3 = decode_rgb_image(blob_bytes(row[UW_RGB_COLUMN], UW_RGB_COLUMN))
+        depth_hw = _decode_png_uint16(blob_bytes(row[UW_DEPTH_COLUMN], UW_DEPTH_COLUMN))
+        normal_hw3 = decode_rgb_image(blob_bytes(row[UW_NORMAL_COLUMN], UW_NORMAL_COLUMN))
+        if rgb_hw3.shape != (*uw_hw, 3) or depth_hw.shape != uw_hw or normal_hw3.shape != (*uw_hw, 3):
+            raise RuntimeError(
+                f"ultrawide cache signal shapes differ from camera resolution {uw_hw}: "
+                f"rgb={rgb_hw3.shape} depth={depth_hw.shape} normal={normal_hw3.shape}"
+            )
+        uw_rgb_nhw3[index].copy_(torch.from_numpy(rgb_hw3))
+        uw_depth_nhw[index].copy_(torch.from_numpy(depth_hw))
+        uw_normal_nhw3[index].copy_(torch.from_numpy(normal_hw3))
+        if (index + 1) % 50 == 0 or index + 1 == len(uw_rows):
+            print(f"cached {index + 1}/{len(uw_rows)} ultrawide frames", flush=True)
+
+    holdout_indices: tuple[int, ...] = tuple(index for index, camera in enumerate(cameras) if camera.holdout)
+    train_indices: torch.Tensor = torch.tensor(
+        [index for index, camera in enumerate(cameras) if not camera.holdout], dtype=torch.int64, device="cpu"
+    )
+    return GpuTrainingCache(
+        wide_rgb_nhw3=wide_rgb_nhw3,
+        wide_depth_nhw=wide_depth_nhw,
+        wide_normal_nhw3=wide_normal_nhw3,
+        uw_rgb_nhw3=uw_rgb_nhw3,
+        uw_depth_nhw=uw_depth_nhw,
+        uw_normal_nhw3=uw_normal_nhw3,
+        cameras=cameras,
+        train_indices=train_indices,
+        holdout_indices=holdout_indices,
+        holdout_sha256=holdout_hash(tuple(cameras[index].stem for index in holdout_indices)),
+        scene_scale=scene_scale,
+    )
+
+
+def compare_cache_to_bundle(cache: GpuTrainingCache, bundle_dir: Path) -> CacheParity:
+    """Compare all six cached modalities with the Part 10 bundle pixel-by-pixel."""
+    compared: dict[str, int] = {name: 0 for name in ("wide_rgb", "wide_depth", "wide_normal", "uw_rgb", "uw_depth", "uw_normal")}
+    mismatched: dict[str, int] = dict.fromkeys(compared, 0)
+    for camera in cache.cameras:
+        if camera.camera == "wide":
+            image_relative: Path = Path("images") / f"{camera.stem}.png"
+            rgb_actual: np.ndarray = cache.wide_rgb_nhw3[camera.cache_index].cpu().numpy()
+            depth_actual: np.ndarray = cache.wide_depth_nhw[camera.cache_index].cpu().numpy()
+            normal_actual: np.ndarray = cache.wide_normal_nhw3[camera.cache_index].cpu().numpy()
+            prefix: str = "wide"
+        else:
+            image_relative = Path("images_uw") / f"{camera.stem}.jpg"
+            rgb_actual = cache.uw_rgb_nhw3[camera.cache_index].cpu().numpy()
+            depth_actual = cache.uw_depth_nhw[camera.cache_index].cpu().numpy()
+            normal_actual = cache.uw_normal_nhw3[camera.cache_index].cpu().numpy()
+            prefix = "uw"
+        with Image.open(bundle_dir / image_relative) as image:
+            rgb_expected: np.ndarray = np.asarray(image.convert("RGB"), dtype=np.uint8)
+        with np.load(bundle_dir / "depth" / f"{camera.stem}.npz") as archive:
+            depth_expected: np.ndarray = np.rint(archive["depth"] * 1_000.0).astype(np.uint16)
+        with np.load(bundle_dir / "normals" / f"{camera.stem}.npz") as archive:
+            normal_float: np.ndarray = archive["normal"]
+            normal_expected: np.ndarray = np.rint((normal_float + 1.0) / 2.0 * 255.0).astype(np.uint8)
+        for suffix, actual, expected in (
+            ("rgb", rgb_actual, rgb_expected),
+            ("depth", depth_actual, depth_expected),
+            ("normal", normal_actual, normal_expected),
+        ):
+            name: str = f"{prefix}_{suffix}"
+            if actual.shape != expected.shape:
+                raise RuntimeError(f"cache parity shape mismatch for {camera.stem} {name}: {actual.shape} != {expected.shape}")
+            compared[name] += actual.size
+            mismatched[name] += int(np.count_nonzero(actual != expected))
+    return CacheParity(compared_values=compared, mismatched_values=mismatched)

--- a/packages/gauss-surf/src/gauss_surf/train_gsplat/core.py
+++ b/packages/gauss-surf/src/gauss_surf/train_gsplat/core.py
@@ -1,0 +1,79 @@
+"""Small, testable contracts used by direct gsplat training."""
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+
+def decode_normal_uint8(encoded: torch.Tensor) -> torch.Tensor:
+    """Decode normal components while mapping the central code to exact zero."""
+    if encoded.dtype != torch.uint8:
+        raise TypeError(f"encoded normals must be uint8, got {encoded.dtype}")
+    decoded: torch.Tensor = encoded.to(torch.float32) / 255.0 * 2.0 - 1.0
+    return torch.where(encoded == 128, torch.zeros_like(decoded), decoded)
+
+
+def per_frame_average_psnr(prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """Return the mean of independent frame PSNR values."""
+    if prediction.shape != target.shape or prediction.ndim < 2:
+        raise ValueError(f"prediction and target shapes must match by frame, got {prediction.shape} and {target.shape}")
+    frame_dimensions: tuple[int, ...] = tuple(range(1, prediction.ndim))
+    frame_mse: torch.Tensor = (prediction - target).square().mean(dim=frame_dimensions)
+    return (-10.0 * torch.log10(frame_mse)).mean()
+
+
+def holdout_hash(stems: tuple[str, ...]) -> str:
+    """Hash ordered holdout identities with an unambiguous trailing newline."""
+    return hashlib.sha256(("\n".join(stems) + "\n").encode()).hexdigest()
+
+
+def opacity_export_mask(opacity_logits: torch.Tensor) -> torch.Tensor:
+    """Select Gaussians whose opacity meets the required 1/255 floor."""
+    threshold: torch.Tensor = torch.logit(opacity_logits.new_tensor(1.0 / 255.0))
+    return opacity_logits >= threshold
+
+
+def median_scale_regularization(log_scales_n3: torch.Tensor, *, maximum_ratio: float) -> torch.Tensor:
+    """Return max-to-median loss with zero-volume duplicate seeds neutralized."""
+    if log_scales_n3.ndim != 2 or log_scales_n3.shape[1] != 3:
+        raise ValueError(f"log scales must have shape (N, 3), got {log_scales_n3.shape}")
+    if maximum_ratio <= 0.0:
+        raise ValueError("maximum ratio must be positive")
+    scales_n3: torch.Tensor = torch.exp(log_scales_n3)
+    threshold: torch.Tensor = scales_n3.new_tensor(maximum_ratio)
+    ratio_n: torch.Tensor = scales_n3.amax(dim=-1) / scales_n3.median(dim=-1).values
+    # A duplicated seed can have all three log-scales at -inf. It contributes
+    # no rendered support, so give its undefined 0/0 ratio zero excess loss.
+    ratio_n = torch.where(torch.isnan(ratio_n), threshold, ratio_n)
+    return (torch.maximum(ratio_n, threshold) - threshold).mean()
+
+
+def positive_neighbor_distances(average_distances_n1: np.ndarray) -> np.ndarray:
+    """Replace exact duplicate-seed zero distances by the smallest positive one."""
+    distances_n1: np.ndarray = np.asarray(average_distances_n1, dtype=np.float32)
+    positive: np.ndarray = distances_n1[distances_n1 > 0.0]
+    if positive.size == 0:
+        raise ValueError("nearest-neighbor initialization has no positive distances")
+    return np.where(distances_n1 > 0.0, distances_n1, positive.min()).astype(np.float32, copy=False)
+
+
+def save_checkpoint(
+    path: Path,
+    *,
+    step: int,
+    splats: torch.nn.ParameterDict,
+    metadata: dict[str, Any],
+) -> None:
+    """Save a tensor-and-primitives checkpoint compatible with weights-only loading."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, Any] = {
+        "step": step,
+        "splats": {name: parameter.detach().cpu() for name, parameter in splats.items()},
+        "metadata": metadata,
+    }
+    temporary_path: Path = path.with_suffix(path.suffix + ".tmp")
+    torch.save(payload, temporary_path)
+    temporary_path.replace(path)

--- a/packages/gauss-surf/src/gauss_surf/train_gsplat/evaluation.py
+++ b/packages/gauss-surf/src/gauss_surf/train_gsplat/evaluation.py
@@ -1,0 +1,50 @@
+"""Holdout metrics and schema-v3 product rendering for direct gsplat."""
+
+import time
+
+import numpy as np
+import torch
+from torchmetrics.functional.image import structural_similarity_index_measure
+
+from gauss_surf.contracts import RENDER_BACKGROUND
+from gauss_surf.train_gsplat.cache import GpuTrainingCache, TrainingCamera
+from gauss_surf.train_gsplat.core import per_frame_average_psnr
+from gauss_surf.train_gsplat.renderer import RenderOutput, render_splats
+
+
+def evaluate_holdout(
+    splats: torch.nn.ParameterDict | dict[str, torch.Tensor],
+    cache: GpuTrainingCache,
+) -> dict[str, float]:
+    """Render all wide holdouts at full resolution and average per-frame metrics."""
+    holdouts: tuple[TrainingCamera, ...] = tuple(cache.cameras[index] for index in cache.holdout_indices)
+    if not holdouts:
+        raise RuntimeError("training cache has no wide holdouts")
+    device: torch.device = splats["means"].device
+    background_3: torch.Tensor = torch.tensor(RENDER_BACKGROUND, dtype=torch.float32, device=device)
+    psnr_values: list[float] = []
+    ssim_values: list[float] = []
+    started_at: float = time.perf_counter()
+    with torch.inference_mode():
+        for index, camera in enumerate(holdouts):
+            output: RenderOutput = render_splats(
+                splats, camera, downscale=1, sh_degree=3, background_3=background_3, absgrad=False
+            )
+            target: torch.Tensor = cache.wide_rgb_nhw3[camera.cache_index].to(device=device, dtype=torch.float32) / 255.0
+            psnr: torch.Tensor = per_frame_average_psnr(output.rgb_hw3[None], target[None])
+            psnr_values.append(float(psnr.item()))
+            ssim_value = structural_similarity_index_measure(
+                output.rgb_hw3.permute(2, 0, 1).unsqueeze(0), target.permute(2, 0, 1).unsqueeze(0), data_range=1.0
+            )
+            if not isinstance(ssim_value, torch.Tensor):
+                raise RuntimeError("SSIM metric unexpectedly returned a full image")
+            ssim: torch.Tensor = ssim_value
+            ssim_values.append(float(ssim.item()))
+            if (index + 1) % 10 == 0 or index + 1 == len(holdouts):
+                print(f"evaluated {index + 1}/{len(holdouts)} holdout frames", flush=True)
+    torch.cuda.synchronize(device)
+    return {
+        "psnr": float(np.mean(psnr_values)),
+        "ssim": float(np.mean(ssim_values)),
+        "wall_seconds": time.perf_counter() - started_at,
+    }

--- a/packages/gauss-surf/src/gauss_surf/train_gsplat/layer_metrics.py
+++ b/packages/gauss-surf/src/gauss_surf/train_gsplat/layer_metrics.py
@@ -1,0 +1,307 @@
+"""Reference loading and metric definitions for fused layer publication."""
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import pyarrow as pa
+from arkitscenes_download.ingest.paths import (
+    DEPTH_ULTRAWIDE_RECT,
+    NORMALS_ULTRAWIDE_RECT,
+    RGB_ULTRAWIDE_RECT,
+    TIMELINE,
+)
+from datafusion import col
+from jaxtyping import Bool, Float32, UInt8
+from numpy import ndarray
+from rerun.catalog import DatasetView
+
+from gauss_surf.catalog import table_timestamps
+from gauss_surf.contracts import CameraTag
+from gauss_surf.render_io import blob_bytes
+
+RGB_ERROR_MAXIMUM: float = 0.5
+"""Maximum mean-absolute RGB error mapped to the top of the colormap."""
+DEPTH_ERROR_MAXIMUM_M: float = 0.5
+"""Maximum absolute depth error, in metres, mapped to the top of the colormap."""
+NORMAL_ERROR_MAXIMUM_DEGREES: float = 45.0
+"""Maximum angular normal error, in degrees, mapped to the top of the colormap."""
+ULTRAWIDE_REFERENCE_COLUMN: str = f"/{DEPTH_ULTRAWIDE_RECT}:EncodedDepthImage:blob"
+"""Mesh-raycast reference component used for rectified-ultrawide metrics."""
+RGB_REFERENCE_COLUMN: str = f"/{RGB_ULTRAWIDE_RECT}:EncodedImage:blob"
+"""Rectified-ultrawide RGB component used for triage metrics."""
+DEPTH_REFERENCE_COLUMN: str = f"/{DEPTH_ULTRAWIDE_RECT}:EncodedDepthImage:blob"
+"""Rectified-ultrawide mesh-depth component used for triage metrics."""
+NORMAL_REFERENCE_COLUMN: str = f"/{NORMALS_ULTRAWIDE_RECT}:EncodedImage:blob"
+"""Rectified-ultrawide normal component used for triage metrics."""
+
+
+@dataclass(frozen=True, slots=True)
+class CameraSummary:
+    """Coverage and depth-error summary for one camera."""
+
+    camera: CameraTag
+    """Wide or rectified-ultrawide camera tag."""
+    frame_count: int
+    """Number of full-grid product frames encoded."""
+    compared_frames: int
+    """Number of frames with an exact provenance-depth reference."""
+    coverage_min: float
+    """Minimum per-frame splat valid-pixel fraction."""
+    coverage_mean: float
+    """Mean per-frame splat valid-pixel fraction."""
+    coverage_max: float
+    """Maximum per-frame splat valid-pixel fraction."""
+    joint_valid_fraction: float
+    """Joint-valid splat/reference pixels divided by all compared pixels."""
+    joint_valid_pixels: int
+    """Number of jointly valid pixels contributing to MAE."""
+    total_pixels: int
+    """Total splat pixels considered for joint coverage."""
+    mae_m: float
+    """Mean absolute z-depth error over jointly valid pixels, in metres."""
+    resized_reference_frames: int
+    """Reference frames resized by nearest-neighbor sampling to splat resolution."""
+
+
+@dataclass(frozen=True, slots=True)
+class TriageReferenceBlobs:
+    """Source ultrawide signals at one exact chosen timestamp."""
+
+    timestamp_ns: int
+    """Exact duration since recording start, in nanoseconds."""
+    rgb_blob: bytes
+    """Stored rectified RGB image bytes."""
+    depth_blob: bytes
+    """Stored mesh-raycast depth PNG bytes."""
+    normal_blob: bytes
+    """Stored away-from-camera MoGe normal PNG bytes."""
+
+
+@dataclass(frozen=True, slots=True)
+class TriageErrors:
+    """Three error images plus their valid-pixel means."""
+
+    rgb_map_hw3: UInt8[ndarray, "h w 3"]
+    """Viridis-like mean-absolute RGB error, scaled from 0 to 0.5."""
+    depth_map_hw3: UInt8[ndarray, "h w 3"]
+    """Viridis-like absolute depth error, scaled from 0 to 0.5 metres."""
+    normal_map_hw3: UInt8[ndarray, "h w 3"]
+    """Viridis-like angular normal error, scaled from 0 to 45 degrees."""
+    rgb_mean: float
+    """Mean normalized RGB error over splat-valid pixels."""
+    depth_mean_m: float
+    """Mean absolute depth error over jointly valid pixels, in metres."""
+    normal_mean_degrees: float
+    """Mean normal angle over jointly valid pixels, in degrees."""
+
+
+@dataclass(frozen=True, slots=True)
+class MetricSummary:
+    """Distribution of per-frame means for one error signal."""
+
+    mean: float
+    """Mean of finite per-frame means."""
+    minimum: float
+    """Minimum finite per-frame mean."""
+    maximum: float
+    """Maximum finite per-frame mean."""
+
+
+@dataclass(frozen=True, slots=True)
+class TriageWriteStats:
+    """Product and diagnostic counts plus chosen-frame error summaries."""
+
+    product_frames: int
+    """Number of full-grid splat RGB and normal frames written."""
+    diagnostic_frames: int
+    """Number of chosen-frame error-map rows written."""
+    rgb: MetricSummary
+    """Per-frame mean RGB-error distribution on chosen frames."""
+    depth: MetricSummary
+    """Per-frame mean depth-error distribution on chosen frames."""
+    normal: MetricSummary
+    """Per-frame mean normal-error distribution on chosen frames."""
+
+
+@dataclass(frozen=True, slots=True)
+class SplatTriageWriteStats:
+    """Wide-normal and ultrawide triage counts from one recording write."""
+
+    wide_normal_frames: int
+    """Number of full-grid wide splat-normal frames written."""
+    ultrawide: TriageWriteStats
+    """Ultrawide product and chosen-diagnostic statistics."""
+
+
+def reference_blobs_at_component_timestamps(segment_view: DatasetView, component_name: str) -> dict[int, bytes]:
+    """Read encoded reference depth at every exact component timestamp."""
+    available_columns: set[str] = set(segment_view.arrow_schema().names)
+    if component_name not in available_columns:
+        raise ValueError(f"catalog segment has no required comparison component: {component_name}")
+    table: pa.Table = (
+        segment_view.reader(index=TIMELINE, fill_latest_at=False)
+        .filter(col(f'"{component_name}"').is_not_null())
+        .select(TIMELINE, component_name)
+        .sort(TIMELINE)
+        .to_arrow_table()
+    )
+    timestamps_ns_n: ndarray = table_timestamps(table).astype(np.int64)
+    component_values: list[Any] = table.column(component_name).to_pylist()
+    references: dict[int, bytes] = {}
+    for timestamp_ns, value in zip(timestamps_ns_n, component_values, strict=True):
+        timestamp: int = int(timestamp_ns)
+        if timestamp in references:
+            raise ValueError(f"reference component {component_name!r} has duplicate timestamp {timestamp}")
+        references[timestamp] = blob_bytes(value, component_name)
+    return references
+
+
+def resize_reference_nearest(
+    reference_m_hw: Float32[ndarray, "source_h source_w"], target_hw: tuple[int, int]
+) -> Float32[ndarray, "target_h target_w"]:
+    """Resize reference depth with nearest-neighbor sampling to preserve invalid zero pixels."""
+    target_height: int = target_hw[0]
+    target_width: int = target_hw[1]
+    if reference_m_hw.shape == target_hw:
+        return reference_m_hw
+    source_height: int = reference_m_hw.shape[0]
+    source_width: int = reference_m_hw.shape[1]
+    source_y_h: ndarray = np.minimum((np.arange(target_height) * source_height) // target_height, source_height - 1)
+    source_x_w: ndarray = np.minimum((np.arange(target_width) * source_width) // target_width, source_width - 1)
+    return reference_m_hw[np.ix_(source_y_h, source_x_w)].astype(np.float32, copy=False)
+
+
+def viridis_like(values: Float32[ndarray, "..."]) -> UInt8[ndarray, "... 3"]:
+    """Map normalized values to a small piecewise-linear viridis approximation."""
+    positions_n: Float32[ndarray, "n=6"] = np.asarray([0.0, 0.2, 0.4, 0.6, 0.8, 1.0], dtype=np.float32)
+    colors_n3: Float32[ndarray, "n=6 3"] = np.asarray(
+        [[68.0, 1.0, 84.0], [65.0, 68.0, 135.0], [42.0, 120.0, 142.0], [34.0, 168.0, 132.0], [122.0, 209.0, 81.0], [253.0, 231.0, 37.0]],
+        dtype=np.float32,
+    )
+    clipped: Float32[ndarray, "..."] = np.clip(values, 0.0, 1.0).astype(np.float32, copy=False)
+    rgb_float: Float32[ndarray, "... 3"] = np.empty((*clipped.shape, 3), dtype=np.float32)
+    for channel in range(3):
+        rgb_float[..., channel] = np.interp(clipped, positions_n, colors_n3[:, channel]).astype(np.float32)
+    return np.rint(rgb_float).astype(np.uint8)
+
+
+def angular_error_degrees(
+    first_hw3: Float32[ndarray, "h w 3"],
+    second_hw3: Float32[ndarray, "h w 3"],
+) -> tuple[Float32[ndarray, "h w"], Bool[ndarray, "h w"]]:
+    """Compute unsigned angles between two normal maps."""
+    if first_hw3.shape != second_hw3.shape or first_hw3.ndim != 3 or first_hw3.shape[-1] != 3:
+        raise ValueError(f"normal shapes must match as (H, W, 3), got {first_hw3.shape} and {second_hw3.shape}")
+    first_norm_hw: Float32[ndarray, "h w"] = np.linalg.norm(first_hw3, axis=-1).astype(np.float32)
+    second_norm_hw: Float32[ndarray, "h w"] = np.linalg.norm(second_hw3, axis=-1).astype(np.float32)
+    valid_hw: Bool[ndarray, "h w"] = (
+        np.all(np.isfinite(first_hw3), axis=-1)
+        & np.all(np.isfinite(second_hw3), axis=-1)
+        & (first_norm_hw > 1e-6)
+        & (second_norm_hw > 1e-6)
+    )
+    safe_first_norm_hw: Float32[ndarray, "h w"] = np.where(valid_hw, first_norm_hw, 1.0).astype(np.float32)
+    safe_second_norm_hw: Float32[ndarray, "h w"] = np.where(valid_hw, second_norm_hw, 1.0).astype(np.float32)
+    cosine_hw: Float32[ndarray, "h w"] = np.sum(first_hw3 * second_hw3, axis=-1) / (safe_first_norm_hw * safe_second_norm_hw)
+    angle_hw: Float32[ndarray, "h w"] = np.rad2deg(np.arccos(np.clip(cosine_hw, -1.0, 1.0))).astype(np.float32)
+    return np.where(valid_hw, angle_hw, 0.0).astype(np.float32), valid_hw
+
+
+def colorize_error(
+    error_hw: Float32[ndarray, "h w"], valid_hw: Bool[ndarray, "h w"], *, maximum: float
+) -> UInt8[ndarray, "h w 3"]:
+    """Colorize an error image and paint invalid pixels black."""
+    if error_hw.shape != valid_hw.shape:
+        raise ValueError(f"error and validity shapes differ: {error_hw.shape} != {valid_hw.shape}")
+    if maximum <= 0.0 or not np.isfinite(maximum):
+        raise ValueError(f"maximum must be positive and finite, got {maximum}")
+    normalized_hw: Float32[ndarray, "h w"] = (error_hw / maximum).astype(np.float32)
+    color_hw3: UInt8[ndarray, "h w 3"] = viridis_like(normalized_hw)
+    color_hw3[~valid_hw] = 0
+    return color_hw3
+
+
+def _masked_mean(values_hw: Float32[ndarray, "h w"], valid_hw: Bool[ndarray, "h w"]) -> float:
+    """Return one valid-pixel mean or NaN for an empty mask."""
+    return float(np.mean(values_hw[valid_hw], dtype=np.float64)) if np.any(valid_hw) else float("nan")
+
+
+def compute_triage_errors(
+    source_rgb_hw3: UInt8[ndarray, "h w 3"],
+    splat_rgb_hw3: UInt8[ndarray, "h w 3"],
+    mesh_depth_m_hw: Float32[ndarray, "h w"],
+    splat_depth_m_hw: Float32[ndarray, "h w"],
+    moge_normal_hw3: Float32[ndarray, "h w 3"],
+    splat_normal_hw3: Float32[ndarray, "h w 3"],
+) -> TriageErrors:
+    """Build RGB, depth, and normal error maps for one joined frame."""
+    expected_hw: tuple[int, int] = splat_depth_m_hw.shape
+    expected_hw3: tuple[int, int, int] = (*expected_hw, 3)
+    signal_shapes: tuple[tuple[int, ...], ...] = (
+        source_rgb_hw3.shape,
+        splat_rgb_hw3.shape,
+        mesh_depth_m_hw.shape,
+        moge_normal_hw3.shape,
+        splat_normal_hw3.shape,
+    )
+    if signal_shapes != (expected_hw3, expected_hw3, expected_hw, expected_hw3, expected_hw3):
+        raise ValueError(f"triage signal shapes do not align to splat depth {expected_hw}: {signal_shapes}")
+    splat_valid_hw: Bool[ndarray, "h w"] = np.isfinite(splat_depth_m_hw) & (splat_depth_m_hw > 0.0)
+    source_rgb_float_hw3: Float32[ndarray, "h w 3"] = source_rgb_hw3.astype(np.float32) / 255.0
+    splat_rgb_float_hw3: Float32[ndarray, "h w 3"] = splat_rgb_hw3.astype(np.float32) / 255.0
+    rgb_error_hw: Float32[ndarray, "h w"] = np.mean(np.abs(source_rgb_float_hw3 - splat_rgb_float_hw3), axis=-1).astype(np.float32)
+    mesh_valid_hw: Bool[ndarray, "h w"] = np.isfinite(mesh_depth_m_hw) & (mesh_depth_m_hw > 0.0)
+    depth_valid_hw: Bool[ndarray, "h w"] = splat_valid_hw & mesh_valid_hw
+    depth_error_m_hw: Float32[ndarray, "h w"] = np.abs(splat_depth_m_hw - mesh_depth_m_hw).astype(np.float32)
+    normal_error_degrees_hw: Float32[ndarray, "h w"]
+    normal_valid_hw: Bool[ndarray, "h w"]
+    normal_error_degrees_hw, normal_valid_hw = angular_error_degrees(splat_normal_hw3, moge_normal_hw3)
+    normal_valid_hw &= splat_valid_hw
+    return TriageErrors(
+        rgb_map_hw3=colorize_error(rgb_error_hw, splat_valid_hw, maximum=RGB_ERROR_MAXIMUM),
+        depth_map_hw3=colorize_error(depth_error_m_hw, depth_valid_hw, maximum=DEPTH_ERROR_MAXIMUM_M),
+        normal_map_hw3=colorize_error(normal_error_degrees_hw, normal_valid_hw, maximum=NORMAL_ERROR_MAXIMUM_DEGREES),
+        rgb_mean=_masked_mean(rgb_error_hw, splat_valid_hw),
+        depth_mean_m=_masked_mean(depth_error_m_hw, depth_valid_hw),
+        normal_mean_degrees=_masked_mean(normal_error_degrees_hw, normal_valid_hw),
+    )
+
+
+def load_reference_blobs(segment_view: DatasetView) -> list[TriageReferenceBlobs]:
+    """Load stored source images at every chosen ultrawide timestamp."""
+    required_columns: tuple[str, ...] = (RGB_REFERENCE_COLUMN, DEPTH_REFERENCE_COLUMN, NORMAL_REFERENCE_COLUMN)
+    available_columns: set[str] = set(segment_view.arrow_schema().names)
+    missing_columns: list[str] = [name for name in required_columns if name not in available_columns]
+    if missing_columns:
+        raise ValueError(f"catalog segment has no required triage components: {missing_columns}")
+    table: pa.Table = (
+        segment_view.reader(index=TIMELINE, fill_latest_at=False)
+        .filter(col(f'"{RGB_REFERENCE_COLUMN}"').is_not_null())
+        .select(TIMELINE, RGB_REFERENCE_COLUMN, DEPTH_REFERENCE_COLUMN, NORMAL_REFERENCE_COLUMN)
+        .sort(TIMELINE)
+        .to_arrow_table()
+    )
+    timestamps_ns_n: ndarray = table_timestamps(table).astype(np.int64)
+    rgb_values: list[Any] = table.column(RGB_REFERENCE_COLUMN).to_pylist()
+    depth_values: list[Any] = table.column(DEPTH_REFERENCE_COLUMN).to_pylist()
+    normal_values: list[Any] = table.column(NORMAL_REFERENCE_COLUMN).to_pylist()
+    return [
+        TriageReferenceBlobs(
+            timestamp_ns=int(timestamp_ns),
+            rgb_blob=blob_bytes(rgb_value, RGB_REFERENCE_COLUMN),
+            depth_blob=blob_bytes(depth_value, DEPTH_REFERENCE_COLUMN),
+            normal_blob=blob_bytes(normal_value, NORMAL_REFERENCE_COLUMN),
+        )
+        for timestamp_ns, rgb_value, depth_value, normal_value in zip(
+            timestamps_ns_n, rgb_values, depth_values, normal_values, strict=True
+        )
+    ]
+
+
+def summarize_metrics(values: list[float]) -> MetricSummary:
+    """Summarize finite per-frame means."""
+    finite_n: Float32[ndarray, "n"] = np.asarray([value for value in values if np.isfinite(value)], dtype=np.float32)
+    if finite_n.size == 0:
+        return MetricSummary(float("nan"), float("nan"), float("nan"))
+    return MetricSummary(float(np.mean(finite_n)), float(np.min(finite_n)), float(np.max(finite_n)))

--- a/packages/gauss-surf/src/gauss_surf/train_gsplat/metadata.py
+++ b/packages/gauss-surf/src/gauss_surf/train_gsplat/metadata.py
@@ -1,0 +1,327 @@
+"""Create the camera and seed metadata needed by direct gsplat training."""
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pyarrow as pa
+from arkitscenes_download.ingest.paths import (
+    PINHOLE_ULTRAWIDE_RECT,
+    PROMPTDA_MESH,
+    SHARPNESS_ULTRAWIDE,
+    TIMELINE,
+)
+from jaxtyping import Float32, UInt8
+from numpy import ndarray
+
+from gauss_surf.catalog import (
+    SegmentReader,
+    TimedeltaNs,
+    _matrix_from_cell,
+    _resolution_from_cell,
+    table_timestamps,
+)
+from gauss_surf.contracts import (
+    FRAME_SELECTION_LAYER,
+    MOGE_NORMALS_LAYER,
+    PROMPTDA_DEPTH_BLOB_COLUMN,
+    PROMPTDA_LAYER,
+    ULTRAWIDE_CHOSEN_SHARPNESS_COLUMN,
+    ULTRAWIDE_DEPTH_LAYER,
+    ULTRAWIDE_NORMALS_LAYER,
+    WIDE_CHOSEN_SHARPNESS_COLUMN,
+    WIDE_INTRINSICS_COLUMN,
+    WIDE_RESOLUTION_COLUMN,
+    CameraTag,
+)
+from gauss_surf.uw_geometry import CameraPoses, CameraPoseTrack, load_camera_pose_track, resolve_camera_poses
+
+UW_GRID_COLUMN: str = f"/{SHARPNESS_ULTRAWIDE}:Scalars:scalars"
+UW_K_COLUMN: str = f"/{PINHOLE_ULTRAWIDE_RECT}:Pinhole:image_from_camera"
+UW_RESOLUTION_COLUMN: str = f"/{PINHOLE_ULTRAWIDE_RECT}:Pinhole:resolution"
+MESH_VERTICES_COLUMN: str = f"/{PROMPTDA_MESH}:Mesh3D:vertex_positions"
+MESH_COLORS_COLUMN: str = f"/{PROMPTDA_MESH}:Mesh3D:vertex_colors"
+METADATA_FILENAMES: tuple[str, ...] = ("transforms.json", "cameras_all.json", "seed.ply")
+BUNDLE_MANIFEST_FILENAME: str = "bundle_manifest.json"
+BUNDLE_MANIFEST_SCHEMA_VERSION: int = 1
+
+
+@dataclass(frozen=True, slots=True)
+class MetadataStats:
+    """Counts written for one fresh segment's direct-training metadata."""
+
+    wide_frames: int
+    ultrawide_frames: int
+    holdout_frames: int
+    seed_vertices: int
+    render_wide_frames: int
+    render_ultrawide_frames: int
+
+
+def _sha256_file(path: Path) -> str:
+    """Return the SHA-256 digest of one metadata file."""
+    with path.open("rb") as input_file:
+        return hashlib.file_digest(input_file, "sha256").hexdigest()
+
+
+def metadata_files_complete(bundle_dir: Path, *, allow_legacy: bool = False) -> bool:
+    """Return whether a complete, internally consistent metadata generation exists."""
+    if not all((bundle_dir / name).is_file() for name in METADATA_FILENAMES):
+        return False
+    manifest_path: Path = bundle_dir / BUNDLE_MANIFEST_FILENAME
+    if not manifest_path.is_file():
+        return allow_legacy
+    try:
+        manifest: object = json.loads(manifest_path.read_text(encoding="utf-8"))
+        expected_manifest: dict[str, Any] = {
+            "schema_version": BUNDLE_MANIFEST_SCHEMA_VERSION,
+            "files": {name: {"sha256": _sha256_file(bundle_dir / name)} for name in METADATA_FILENAMES},
+        }
+    except (json.JSONDecodeError, OSError):
+        return False
+    return manifest == expected_manifest
+
+
+def holdout_wide_indices(frame_count: int, interval: int = 8) -> tuple[int, ...]:
+    """Return deterministic zero-based wide holdouts at a one-based cadence."""
+    if frame_count < 0:
+        raise ValueError("frame count must be non-negative")
+    if interval <= 0:
+        raise ValueError("holdout interval must be positive")
+    return tuple(range(interval - 1, frame_count, interval))
+
+
+def _opencv_to_opengl(world_from_camera_44: Float32[ndarray, "4 4"]) -> Float32[ndarray, "4 4"]:
+    """Convert an RDF OpenCV camera transform to the OpenGL convention."""
+    world_from_opengl_44: Float32[ndarray, "4 4"] = np.asarray(world_from_camera_44, dtype=np.float32).copy()
+    world_from_opengl_44[:, 1:3] *= -1.0
+    return world_from_opengl_44
+
+
+def _camera_entry(
+    *,
+    stem: str,
+    camera: CameraTag,
+    timestamp_ns: int,
+    K_33: Float32[ndarray, "3 3"],
+    image_wh: tuple[int, int],
+    world_from_camera_44: Float32[ndarray, "4 4"],
+) -> dict[str, Any]:
+    """Build one image-free direct-render camera record."""
+    return {
+        "stem": stem,
+        "camera": camera,
+        "timestamp_ns": timestamp_ns,
+        "fl_x": float(K_33[0, 0]),
+        "fl_y": float(K_33[1, 1]),
+        "cx": float(K_33[0, 2]),
+        "cy": float(K_33[1, 2]),
+        "w": image_wh[0],
+        "h": image_wh[1],
+        "transform_matrix": _opencv_to_opengl(world_from_camera_44).tolist(),
+    }
+
+
+def _load_seed_mesh(reader: SegmentReader) -> tuple[Float32[ndarray, "n 3"], ndarray | None]:
+    """Read PromptDA mesh positions and optional packed RGBA colors."""
+    mesh_table: pa.Table = (
+        reader.segment_view()
+        .reader(index=TIMELINE, fill_latest_at=True)
+        .select(TIMELINE, MESH_VERTICES_COLUMN, MESH_COLORS_COLUMN)
+        .limit(1)
+        .to_arrow_table()
+    )
+    if mesh_table.num_rows != 1:
+        raise SystemExit("catalog segment has no PromptDA TSDF mesh")
+    mesh_row: dict[str, Any] = mesh_table.to_pylist()[0]
+    vertices_n3: Float32[ndarray, "n 3"] = np.asarray(mesh_row[MESH_VERTICES_COLUMN], dtype=np.float32)
+    packed_colors_n: ndarray | None = None
+    if mesh_row[MESH_COLORS_COLUMN] is not None:
+        packed_colors_n = np.asarray(mesh_row[MESH_COLORS_COLUMN], dtype=np.uint32)
+    return vertices_n3, packed_colors_n
+
+
+def _write_seed_ply(path: Path, vertices_n3: Float32[ndarray, "n 3"], packed_rgba_n: ndarray | None) -> int:
+    """Write PromptDA vertices as a metric colored binary PLY."""
+    if vertices_n3.ndim != 2 or vertices_n3.shape[1] != 3:
+        raise ValueError(f"seed vertices must have shape (N, 3), got {vertices_n3.shape}")
+    vertex_count: int = len(vertices_n3)
+    colors_n3: UInt8[ndarray, "n 3"] = np.full((vertex_count, 3), 128, dtype=np.uint8)
+    if packed_rgba_n is not None:
+        packed_n: ndarray = np.asarray(packed_rgba_n, dtype=np.uint32).reshape(-1)
+        if len(packed_n) != vertex_count:
+            raise ValueError("seed vertex colors do not match the vertex count")
+        colors_n3[:, 0] = (packed_n >> 24).astype(np.uint8)
+        colors_n3[:, 1] = (packed_n >> 16).astype(np.uint8)
+        colors_n3[:, 2] = (packed_n >> 8).astype(np.uint8)
+    vertex_dtype: np.dtype = np.dtype(
+        [("x", "<f4"), ("y", "<f4"), ("z", "<f4"), ("red", "u1"), ("green", "u1"), ("blue", "u1")]
+    )
+    records_n: ndarray = np.empty(vertex_count, dtype=vertex_dtype)
+    records_n["x"], records_n["y"], records_n["z"] = vertices_n3[:, 0], vertices_n3[:, 1], vertices_n3[:, 2]
+    records_n["red"], records_n["green"], records_n["blue"] = colors_n3[:, 0], colors_n3[:, 1], colors_n3[:, 2]
+    header: str = (
+        "ply\nformat binary_little_endian 1.0\n"
+        f"element vertex {vertex_count}\n"
+        "property float x\nproperty float y\nproperty float z\n"
+        "property uchar red\nproperty uchar green\nproperty uchar blue\nend_header\n"
+    )
+    temporary_path: Path = path.with_suffix(path.suffix + ".tmp")
+    with temporary_path.open("wb") as output_file:
+        output_file.write(header.encode("ascii"))
+        records_n.tofile(output_file)
+    temporary_path.replace(path)
+    return vertex_count
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    """Atomically write one stable JSON metadata file."""
+    temporary_path: Path = path.with_suffix(path.suffix + ".tmp")
+    temporary_path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary_path.replace(path)
+
+
+def prepare_training_metadata(reader: SegmentReader, bundle_dir: Path) -> MetadataStats:
+    """Build camera manifests and a metric seed directly from one live segment."""
+    reader.require_layers(
+        (FRAME_SELECTION_LAYER, MOGE_NORMALS_LAYER, PROMPTDA_LAYER, ULTRAWIDE_DEPTH_LAYER, ULTRAWIDE_NORMALS_LAYER)
+    )
+    wide_table: pa.Table = reader.chosen_table(
+        WIDE_CHOSEN_SHARPNESS_COLUMN,
+        (WIDE_INTRINSICS_COLUMN, WIDE_RESOLUTION_COLUMN),
+    )
+    uw_table: pa.Table = reader.chosen_table(ULTRAWIDE_CHOSEN_SHARPNESS_COLUMN, (UW_K_COLUMN, UW_RESOLUTION_COLUMN))
+    wide_timestamps_n: TimedeltaNs = table_timestamps(wide_table)
+    uw_timestamps_n: TimedeltaNs = table_timestamps(uw_table)
+    pose_track: CameraPoseTrack = load_camera_pose_track(reader)
+    poses: CameraPoses = resolve_camera_poses(pose_track, wide_timestamps_n, uw_timestamps_n, exact_wide=True)
+    holdout_indices: set[int] = set(holdout_wide_indices(wide_table.num_rows))
+
+    training_frames: list[dict[str, Any]] = []
+    for frame_index, (timestamp, row) in enumerate(zip(wide_timestamps_n, wide_table.to_pylist(), strict=True)):
+        entry: dict[str, Any] = _camera_entry(
+            stem=f"wide_{frame_index:06d}",
+            camera="wide",
+            timestamp_ns=int(timestamp.astype(np.int64)),
+            K_33=_matrix_from_cell(row[WIDE_INTRINSICS_COLUMN], WIDE_INTRINSICS_COLUMN),
+            image_wh=_resolution_from_cell(row[WIDE_RESOLUTION_COLUMN], WIDE_RESOLUTION_COLUMN),
+            world_from_camera_44=poses.world_from_wide_n44[frame_index],
+        )
+        training_frames.append(
+            {
+                **entry,
+                "file_path": f"images/{entry['stem']}.png",
+                "holdout": frame_index in holdout_indices,
+            }
+        )
+    for frame_index, (timestamp, row) in enumerate(zip(uw_timestamps_n, uw_table.to_pylist(), strict=True)):
+        entry = _camera_entry(
+            stem=f"uw_{frame_index:06d}",
+            camera="uw",
+            timestamp_ns=int(timestamp.astype(np.int64)),
+            K_33=_matrix_from_cell(row[UW_K_COLUMN], UW_K_COLUMN),
+            image_wh=_resolution_from_cell(row[UW_RESOLUTION_COLUMN], UW_RESOLUTION_COLUMN),
+            world_from_camera_44=poses.world_from_ultrawide_n44[frame_index],
+        )
+        training_frames.append({**entry, "file_path": f"images_uw/{entry['stem']}.jpg", "holdout": False})
+
+    wide_render_table: pa.Table = reader.chosen_table(
+        PROMPTDA_DEPTH_BLOB_COLUMN,
+        (WIDE_INTRINSICS_COLUMN, WIDE_RESOLUTION_COLUMN),
+    )
+    uw_render_table: pa.Table = reader.chosen_table(UW_GRID_COLUMN, ())
+    wide_render_timestamps_n: TimedeltaNs = table_timestamps(wide_render_table)
+    uw_render_timestamps_n: TimedeltaNs = table_timestamps(uw_render_table)
+    render_poses: CameraPoses = resolve_camera_poses(
+        pose_track,
+        wide_render_timestamps_n,
+        uw_render_timestamps_n,
+        exact_wide=False,
+    )
+    uw_rows: list[dict[str, Any]] = uw_table.to_pylist()
+    uw_intrinsics_n33: Float32[ndarray, "n_uw 3 3"] = np.stack(
+        [_matrix_from_cell(row[UW_K_COLUMN], UW_K_COLUMN) for row in uw_rows]
+    )
+    uw_resolutions: list[tuple[int, int]] = [
+        _resolution_from_cell(row[UW_RESOLUTION_COLUMN], UW_RESOLUTION_COLUMN) for row in uw_rows
+    ]
+    if not np.allclose(uw_intrinsics_n33, uw_intrinsics_n33[0][None], atol=1e-5, rtol=0.0):
+        raise SystemExit("catalog segment has varying rectified-ultrawide intrinsics")
+    if any(resolution != uw_resolutions[0] for resolution in uw_resolutions):
+        raise SystemExit("catalog segment has varying rectified-ultrawide resolutions")
+
+    render_frames: list[dict[str, Any]] = []
+    for frame_index, (timestamp, row) in enumerate(
+        zip(wide_render_timestamps_n, wide_render_table.to_pylist(), strict=True)
+    ):
+        render_frames.append(
+            _camera_entry(
+                stem=f"wide_all_{frame_index:06d}",
+                camera="wide",
+                timestamp_ns=int(timestamp.astype(np.int64)),
+                K_33=_matrix_from_cell(row[WIDE_INTRINSICS_COLUMN], WIDE_INTRINSICS_COLUMN),
+                image_wh=_resolution_from_cell(row[WIDE_RESOLUTION_COLUMN], WIDE_RESOLUTION_COLUMN),
+                world_from_camera_44=render_poses.world_from_wide_n44[frame_index],
+            )
+        )
+    for frame_index, timestamp in enumerate(uw_render_timestamps_n):
+        render_frames.append(
+            _camera_entry(
+                stem=f"uw_all_{frame_index:06d}",
+                camera="uw",
+                timestamp_ns=int(timestamp.astype(np.int64)),
+                K_33=uw_intrinsics_n33[0],
+                image_wh=uw_resolutions[0],
+                world_from_camera_44=render_poses.world_from_ultrawide_n44[frame_index],
+            )
+        )
+
+    vertices_n3: Float32[ndarray, "n 3"]
+    packed_colors_n: ndarray | None
+    vertices_n3, packed_colors_n = _load_seed_mesh(reader)
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    seed_vertices: int = _write_seed_ply(bundle_dir / "seed.ply", vertices_n3, packed_colors_n)
+    _write_json(
+        bundle_dir / "transforms.json",
+        {
+            "camera_model": "OPENCV",
+            "ply_file_path": "seed.ply",
+            "frames": training_frames,
+        },
+    )
+    _write_json(
+        bundle_dir / "cameras_all.json",
+        {
+            "schema_version": 1,
+            "camera_model": "OPENCV",
+            "counts": {
+                "wide": wide_render_table.num_rows,
+                "uw": uw_render_table.num_rows,
+                "total": len(render_frames),
+            },
+            "ultrawide_pose_staleness_ms": {
+                "minimum": float(np.min(poses.ultrawide_staleness_ms_n)),
+                "mean": float(np.mean(poses.ultrawide_staleness_ms_n)),
+                "maximum": float(np.max(poses.ultrawide_staleness_ms_n)),
+            },
+            "frames": render_frames,
+        },
+    )
+    _write_json(
+        bundle_dir / BUNDLE_MANIFEST_FILENAME,
+        {
+            "schema_version": BUNDLE_MANIFEST_SCHEMA_VERSION,
+            "files": {name: {"sha256": _sha256_file(bundle_dir / name)} for name in METADATA_FILENAMES},
+        },
+    )
+    return MetadataStats(
+        wide_frames=wide_table.num_rows,
+        ultrawide_frames=uw_table.num_rows,
+        holdout_frames=len(holdout_indices),
+        seed_vertices=seed_vertices,
+        render_wide_frames=wide_render_table.num_rows,
+        render_ultrawide_frames=uw_render_table.num_rows,
+    )

--- a/packages/gauss-surf/src/gauss_surf/train_gsplat/publish.py
+++ b/packages/gauss-surf/src/gauss_surf/train_gsplat/publish.py
@@ -1,0 +1,622 @@
+"""In-process quantization and publication of trained gsplat products."""
+
+import time
+from collections.abc import Sequence
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TypeAlias
+
+import numpy as np
+import rerun as rr
+import torch
+from arkitscenes_download.ingest.depth import encode_depth_png
+from arkitscenes_download.ingest.paths import (
+    DEPTH_SPLAT_ULTRAWIDE,
+    DEPTH_SPLAT_WIDE,
+    ERROR_DEPTH_ULTRAWIDE_RECT,
+    ERROR_NORMAL_ULTRAWIDE_RECT,
+    ERROR_RGB_ULTRAWIDE_RECT,
+    NORMALS_SPLAT_ULTRAWIDE_RECT,
+    NORMALS_SPLAT_WIDE,
+    RGB_SPLAT_ULTRAWIDE_RECT,
+    TIMELINE,
+)
+from arkitscenes_download.ingest.recording import atomic_recording
+from arkitscenes_download.schema import DEPTH_RANGE_MM
+from jaxtyping import Float32, UInt8, UInt16
+from numpy import ndarray
+from rerun.catalog import DatasetEntry, DatasetView
+
+from gauss_surf.catalog import SegmentReader, register_layer
+from gauss_surf.contracts import (
+    PROMPTDA_DEPTH_BLOB_COLUMN,
+    PROMPTDA_LAYER,
+    RENDER_BACKGROUND,
+    RGB_JPEG_QUALITY,
+    SPLAT_DEPTH_LAYER,
+    SPLAT_LAYER,
+    SPLAT_TRIAGE_LAYER,
+    ULTRAWIDE_DEPTH_LAYER,
+    ULTRAWIDE_NORMALS_LAYER,
+    CameraTag,
+)
+from gauss_surf.normals_encoding import decode_normal_codes, decode_normals_png
+from gauss_surf.render_io import (
+    RenderCamera,
+    decode_rgb_image,
+    decode_splat_depth_png,
+    encode_rgb_jpeg,
+    encode_rgb_png,
+    load_render_cameras,
+)
+from gauss_surf.train_gsplat.cache import RasterCamera, raster_camera_from_render_camera
+from gauss_surf.train_gsplat.core import opacity_export_mask
+from gauss_surf.train_gsplat.layer_metrics import (
+    DEPTH_ERROR_MAXIMUM_M,
+    NORMAL_ERROR_MAXIMUM_DEGREES,
+    RGB_ERROR_MAXIMUM,
+    ULTRAWIDE_REFERENCE_COLUMN,
+    CameraSummary,
+    SplatTriageWriteStats,
+    TriageErrors,
+    TriageReferenceBlobs,
+    TriageWriteStats,
+    compute_triage_errors,
+    load_reference_blobs,
+    reference_blobs_at_component_timestamps,
+    resize_reference_nearest,
+    summarize_metrics,
+)
+from gauss_surf.train_gsplat.renderer import RenderOutput, render_splats
+from gauss_surf.train_gsplat.splat_values import GaussianSplats, inria_colors_rgba, inria_quaternions_xyzw
+
+
+def quantize_depth_m_to_mm(depth_m_hw: torch.Tensor) -> torch.Tensor:
+    """Quantize metre depth on-device to uint16 millimetres with zero invalid."""
+    valid_hw: torch.Tensor = torch.isfinite(depth_m_hw) & (depth_m_hw > 0.0)
+    safe_m_hw: torch.Tensor = torch.where(valid_hw, depth_m_hw, torch.zeros_like(depth_m_hw))
+    return torch.round((safe_m_hw * 1000.0).clamp(0.0, 65535.0)).to(dtype=torch.uint16)
+
+
+def quantize_normal_to_uint8(normal_hw3: torch.Tensor) -> torch.Tensor:
+    """Quantize signed normals on-device with round-to-nearest central code 128."""
+    return torch.round((normal_hw3.clamp(-1.0, 1.0) + 1.0) * 127.5).to(dtype=torch.uint8)
+
+
+@dataclass(frozen=True, slots=True)
+class WideQuantizedRender:
+    """One wide full-grid render after on-device storage quantization and D2H."""
+
+    camera: RenderCamera
+    """Camera identity, timestamp, pose, and intrinsics."""
+    depth_mm_hw: UInt16[ndarray, "h w"]
+    """Plane-pass z-depth in uint16 millimetres with zero invalid."""
+    normal_rgb_hw3: UInt8[ndarray, "h w 3"]
+    """Direct plane normal encoded to the lossless uint8 storage contract."""
+
+
+@dataclass(frozen=True, slots=True)
+class UltrawideQuantizedRender:
+    """One ultrawide full-grid render after on-device storage quantization and D2H."""
+
+    camera: RenderCamera
+    """Camera identity, timestamp, pose, and intrinsics."""
+    depth_mm_hw: UInt16[ndarray, "h w"]
+    """Plane-pass z-depth in uint16 millimetres with zero invalid."""
+    normal_rgb_hw3: UInt8[ndarray, "h w 3"]
+    """Direct plane normal encoded to the lossless uint8 storage contract."""
+    rgb_hw3: UInt8[ndarray, "h w 3"]
+    """Fitted ultrawide RGB quantized to uint8."""
+
+
+PublicationProduct: TypeAlias = WideQuantizedRender | UltrawideQuantizedRender
+QuantizedDepthNormal: TypeAlias = tuple[
+    RenderOutput,
+    UInt16[ndarray, "h w"],
+    UInt8[ndarray, "h w 3"],
+]
+
+
+@dataclass(frozen=True, slots=True)
+class PublishStats:
+    """In-process render, metric, recording, and registration outcomes."""
+
+    wall_seconds: float
+    """Complete in-process publication wall, including RRD writes and registration."""
+    render_wall_seconds: float
+    """Accumulated GPU render, quantization, and D2H wall."""
+    frame_count: int
+    """Number of full-grid cameras rendered."""
+    frames_per_second: float
+    """Full-grid product count divided by render wall."""
+    gaussian_count: int
+    """Opacity-filtered Gaussian count written to the splat layer."""
+    d2h_transfers: dict[str, int]
+    """D2H call counts by product signal."""
+    wide_depth: CameraSummary
+    """Wide plane-depth coverage and PromptDA comparison."""
+    ultrawide_depth: CameraSummary
+    """Ultrawide plane-depth coverage and mesh-depth comparison."""
+    triage: SplatTriageWriteStats
+    """Wide-normal counts plus ultrawide fit-error summaries."""
+    rrd_paths: dict[str, str]
+    """Registered layer names mapped to local RRD paths."""
+
+
+@dataclass(slots=True)
+class _DepthMetrics:
+    """Streaming depth metric accumulator for one camera."""
+
+    camera: CameraTag
+    """Camera summarized by this accumulator."""
+    reference_blobs: dict[int, bytes]
+    """Reference depth PNGs keyed by exact timestamp."""
+    coverage_fractions: list[float] = field(default_factory=list)
+    """Per-frame valid fractions."""
+    seen_timestamps: set[int] = field(default_factory=set)
+    """Rendered timestamps used to audit reference completeness."""
+    absolute_error_sum: float = 0.0
+    """Float64-accumulated absolute depth error in metres."""
+    joint_valid_pixels: int = 0
+    """Joint-valid pixel count."""
+    total_pixels: int = 0
+    """All pixels in compared frames."""
+    resized_reference_frames: int = 0
+    """References resized to the rendered shape."""
+    compared_frames: int = 0
+    """Frames with an exact reference."""
+
+    def add(self, timestamp_ns: int, splat_m_hw: Float32[ndarray, "h w"]) -> None:
+        """Accumulate one quantized splat-depth product."""
+        self.seen_timestamps.add(timestamp_ns)
+        splat_valid_hw: ndarray = np.isfinite(splat_m_hw) & (splat_m_hw > 0.0)
+        self.coverage_fractions.append(float(np.count_nonzero(splat_valid_hw) / splat_m_hw.size))
+        reference_blob: bytes | None = self.reference_blobs.get(timestamp_ns)
+        if reference_blob is None:
+            return
+        reference_m_hw: Float32[ndarray, "reference_h reference_w"] = decode_splat_depth_png(reference_blob)
+        if reference_m_hw.shape != splat_m_hw.shape:
+            self.resized_reference_frames += 1
+            reference_m_hw = resize_reference_nearest(reference_m_hw, splat_m_hw.shape)
+        reference_valid_hw: ndarray = np.isfinite(reference_m_hw) & (reference_m_hw > 0.0)
+        joint_valid_hw: ndarray = splat_valid_hw & reference_valid_hw
+        frame_joint_pixels: int = int(np.count_nonzero(joint_valid_hw))
+        if frame_joint_pixels:
+            errors_m: ndarray = np.abs(
+                splat_m_hw[joint_valid_hw].astype(np.float64) - reference_m_hw[joint_valid_hw].astype(np.float64)
+            )
+            self.absolute_error_sum += float(np.sum(errors_m, dtype=np.float64))
+        self.joint_valid_pixels += frame_joint_pixels
+        self.total_pixels += splat_m_hw.size
+        self.compared_frames += 1
+
+    def summary(self) -> CameraSummary:
+        """Validate completeness and return the final camera summary."""
+        missing_timestamps: list[int] = [timestamp for timestamp in self.reference_blobs if timestamp not in self.seen_timestamps]
+        if missing_timestamps:
+            raise ValueError(f"{self.camera} reference has no exact render timestamp for {missing_timestamps[0]}")
+        if not self.coverage_fractions:
+            raise ValueError(f"no {self.camera} depth frames were rendered")
+        coverage_n: Float32[ndarray, "n"] = np.asarray(self.coverage_fractions, dtype=np.float32)
+        mae_m: float = self.absolute_error_sum / self.joint_valid_pixels if self.joint_valid_pixels else float("nan")
+        joint_valid_fraction: float = self.joint_valid_pixels / self.total_pixels if self.total_pixels else float("nan")
+        return CameraSummary(
+            camera=self.camera,
+            frame_count=len(self.coverage_fractions),
+            compared_frames=self.compared_frames,
+            coverage_min=float(np.min(coverage_n)),
+            coverage_mean=float(np.mean(coverage_n)),
+            coverage_max=float(np.max(coverage_n)),
+            joint_valid_fraction=joint_valid_fraction,
+            joint_valid_pixels=self.joint_valid_pixels,
+            total_pixels=self.total_pixels,
+            mae_m=mae_m,
+            resized_reference_frames=self.resized_reference_frames,
+        )
+
+
+def _send_depth_batch(
+    recording: rr.RecordingStream,
+    entity_path: str,
+    products: Sequence[PublicationProduct],
+    blobs: list[bytes],
+) -> None:
+    """Send one encoded depth batch on the duration timeline."""
+    timestamps_n: ndarray = np.asarray([product.camera.timestamp_ns for product in products], dtype=np.int64).astype("timedelta64[ns]")
+    count: int = len(products)
+    rr.send_columns(
+        entity_path,
+        indexes=[rr.TimeColumn(TIMELINE, duration=timestamps_n)],
+        columns=rr.EncodedDepthImage.columns(
+            blob=blobs,
+            media_type=["image/png"] * count,
+            meter=[1000.0] * count,
+            depth_range=[DEPTH_RANGE_MM] * count,
+        ),
+        recording=recording,
+    )
+
+
+def _send_image_batch(
+    recording: rr.RecordingStream,
+    entity_path: str,
+    products: Sequence[PublicationProduct],
+    blobs: list[bytes],
+    media_type: str,
+) -> None:
+    """Send one encoded image batch on the duration timeline."""
+    timestamps_n: ndarray = np.asarray([product.camera.timestamp_ns for product in products], dtype=np.int64).astype("timedelta64[ns]")
+    rr.send_columns(
+        entity_path,
+        indexes=[rr.TimeColumn(TIMELINE, duration=timestamps_n)],
+        columns=rr.EncodedImage.columns(blob=blobs, media_type=[media_type] * len(products)),
+        recording=recording,
+    )
+
+
+def metric_splats_from_live(splats: torch.nn.ParameterDict | dict[str, torch.Tensor]) -> GaussianSplats:
+    """Convert opacity-filtered live metric tensors directly to Rerun values."""
+    keep_n: torch.Tensor = opacity_export_mask(splats["opacities"].squeeze(-1))
+    centers_n3: Float32[ndarray, "n 3"] = splats["means"][keep_n].detach().cpu().numpy().astype(np.float32, copy=False)
+    log_scales_n3: Float32[ndarray, "n 3"] = splats["scales"][keep_n].detach().cpu().numpy().astype(np.float32, copy=False)
+    quaternions_wxyz_n4: Float32[ndarray, "n 4"] = splats["quats"][keep_n].detach().cpu().numpy().astype(np.float32, copy=False)
+    f_dc_n3: Float32[ndarray, "n 3"] = splats["sh0"][keep_n, 0].detach().cpu().numpy().astype(np.float32, copy=False)
+    opacity_logits_n: Float32[ndarray, "n"] = splats["opacities"][keep_n, 0].detach().cpu().numpy().astype(np.float32, copy=False)
+    sh_coefficients_n153: Float32[ndarray, "n 15 3"] = np.ascontiguousarray(
+        splats["shN"][keep_n].detach().cpu().numpy(), dtype=np.float32
+    )
+    return GaussianSplats(
+        centers_n3=centers_n3,
+        scales_n3=np.exp(log_scales_n3).astype(np.float32, copy=False),
+        quaternions_xyzw_n4=inria_quaternions_xyzw(quaternions_wxyz_n4),
+        colors_rgba_n4=inria_colors_rgba(f_dc_n3, opacity_logits_n),
+        sh_coefficients_n153=sh_coefficients_n153,
+    )
+
+
+def _write_metric_splats(rrd_path: Path, video_id: str, splats: GaussianSplats) -> None:
+    """Write live metric-world Gaussian tensors as one static layer recording."""
+    rrd_path.parent.mkdir(parents=True, exist_ok=True)
+    with atomic_recording(rrd_path, video_id, send_properties=False) as recording:
+        rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True, recording=recording)
+        rr.log("world/splats", splats.as_archetype(), static=True, recording=recording)
+
+
+def _quantized_depth_normal_render(
+    splats: torch.nn.ParameterDict | dict[str, torch.Tensor],
+    render_camera: RenderCamera,
+    background_3: torch.Tensor,
+) -> QuantizedDepthNormal:
+    """Render fused publication channels and transfer quantized depth and normal."""
+    camera: RasterCamera = raster_camera_from_render_camera(render_camera)
+    output: RenderOutput = render_splats(
+        splats,
+        camera,
+        downscale=1,
+        sh_degree=3,
+        background_3=background_3,
+        absgrad=False,
+    )
+    valid_hw1: torch.Tensor = output.surface_valid_hw1 & torch.isfinite(output.surface_depth_hw1) & (output.surface_depth_hw1 > 0.0)
+    depth_m_hw: torch.Tensor = torch.where(
+        valid_hw1.squeeze(-1), output.surface_depth_hw1.squeeze(-1), torch.zeros_like(output.surface_depth_hw1.squeeze(-1))
+    )
+    normal_hw3: torch.Tensor = torch.where(
+        valid_hw1.expand_as(output.direct_normal_hw3), output.direct_normal_hw3, torch.zeros_like(output.direct_normal_hw3)
+    )
+    depth_mm_hw: UInt16[ndarray, "h w"] = quantize_depth_m_to_mm(depth_m_hw).cpu().numpy()
+    normal_rgb_hw3: UInt8[ndarray, "h w 3"] = quantize_normal_to_uint8(normal_hw3).cpu().numpy()
+    return output, depth_mm_hw, normal_rgb_hw3
+
+
+def _quantized_wide_render(
+    splats: torch.nn.ParameterDict | dict[str, torch.Tensor],
+    render_camera: RenderCamera,
+    background_3: torch.Tensor,
+) -> WideQuantizedRender:
+    """Build one required depth-and-normal wide product."""
+    rendered: QuantizedDepthNormal = _quantized_depth_normal_render(splats, render_camera, background_3)
+    return WideQuantizedRender(camera=render_camera, depth_mm_hw=rendered[1], normal_rgb_hw3=rendered[2])
+
+
+def _quantized_ultrawide_render(
+    splats: torch.nn.ParameterDict | dict[str, torch.Tensor],
+    render_camera: RenderCamera,
+    background_3: torch.Tensor,
+) -> UltrawideQuantizedRender:
+    """Build one required depth, normal, and RGB ultrawide product."""
+    rendered: QuantizedDepthNormal = _quantized_depth_normal_render(splats, render_camera, background_3)
+    rgb_hw3: UInt8[ndarray, "h w 3"] = (
+        torch.round(rendered[0].rgb_hw3.clamp(0.0, 1.0) * 255.0).to(dtype=torch.uint8).cpu().numpy()
+    )
+    return UltrawideQuantizedRender(
+        camera=render_camera,
+        depth_mm_hw=rendered[1],
+        normal_rgb_hw3=rendered[2],
+        rgb_hw3=rgb_hw3,
+    )
+
+
+def _initialize_triage_recording(recording: rr.RecordingStream) -> None:
+    """Write static product and fixed-scale diagnostic metadata."""
+    recording.log(
+        NORMALS_SPLAT_WIDE,
+        rr.AnyValues(normal_convention="camera-space RDF, away-from-camera; direct Gaussian plane pass, no sign flip"),
+        static=True,
+    )
+    recording.log(RGB_SPLAT_ULTRAWIDE_RECT, rr.AnyValues(jpeg_quality=RGB_JPEG_QUALITY), static=True)
+    recording.log(
+        NORMALS_SPLAT_ULTRAWIDE_RECT,
+        rr.AnyValues(normal_convention="camera-space RDF, away-from-camera; direct Gaussian plane pass, no sign flip"),
+        static=True,
+    )
+    for entity_path, quantity, maximum, unit in (
+        (ERROR_RGB_ULTRAWIDE_RECT, "per-pixel mean absolute RGB error", RGB_ERROR_MAXIMUM, "normalized RGB [0,1]"),
+        (ERROR_DEPTH_ULTRAWIDE_RECT, "absolute z-depth error", DEPTH_ERROR_MAXIMUM_M, "metres"),
+        (ERROR_NORMAL_ULTRAWIDE_RECT, "normal angular error", NORMAL_ERROR_MAXIMUM_DEGREES, "degrees"),
+    ):
+        recording.log(
+            entity_path,
+            rr.AnyValues(
+                colormap="viridis-like",
+                error_quantity=quantity,
+                error_range=[0.0, maximum],
+                error_unit=unit,
+                invalid_color="black",
+            ),
+            static=True,
+        )
+
+
+def _future_results(futures: list[Future[bytes]]) -> list[bytes]:
+    """Collect encoded images in submission order."""
+    return [future.result() for future in futures]
+
+
+def publish_in_process(
+    splats: torch.nn.ParameterDict | dict[str, torch.Tensor],
+    *,
+    reader: SegmentReader,
+    bundle_dir: Path,
+    video_id: str,
+    splat_output_dir: Path,
+    depth_output_dir: Path,
+    triage_output_dir: Path,
+    batch_size: int = 8,
+    encoder_workers: int = 8,
+) -> PublishStats:
+    """Render the full grid, write three RRDs, and register them from the training process."""
+    if batch_size <= 0 or encoder_workers <= 0:
+        raise ValueError("batch size and encoder worker count must be positive")
+    cameras: list[RenderCamera] = load_render_cameras(bundle_dir / "cameras_all.json")
+    wide_cameras: list[RenderCamera] = [camera for camera in cameras if camera.camera == "wide"]
+    ultrawide_cameras: list[RenderCamera] = [camera for camera in cameras if camera.camera == "uw"]
+    if not wide_cameras or not ultrawide_cameras:
+        raise RuntimeError(
+            f"full-grid manifest needs both cameras, got {len(wide_cameras)} wide and {len(ultrawide_cameras)} ultrawide"
+        )
+    reader.require_layers((PROMPTDA_LAYER, ULTRAWIDE_DEPTH_LAYER, ULTRAWIDE_NORMALS_LAYER))
+    segment_view: DatasetView = reader.segment_view()
+    wide_depth_references: dict[int, bytes] = reference_blobs_at_component_timestamps(
+        segment_view,
+        PROMPTDA_DEPTH_BLOB_COLUMN,
+    )
+    ultrawide_depth_references: dict[int, bytes] = reference_blobs_at_component_timestamps(segment_view, ULTRAWIDE_REFERENCE_COLUMN)
+    triage_references: list[TriageReferenceBlobs] = load_reference_blobs(segment_view)
+    triage_reference_by_timestamp: dict[int, TriageReferenceBlobs] = {
+        reference.timestamp_ns: reference for reference in triage_references
+    }
+    if len(triage_reference_by_timestamp) != len(triage_references):
+        raise ValueError("triage references contain duplicate timestamps")
+
+    splat_output_dir.mkdir(parents=True, exist_ok=True)
+    depth_output_dir.mkdir(parents=True, exist_ok=True)
+    triage_output_dir.mkdir(parents=True, exist_ok=True)
+    splat_rrd_path: Path = splat_output_dir / f"{video_id}.rrd"
+    depth_rrd_path: Path = depth_output_dir / f"{video_id}.rrd"
+    triage_rrd_path: Path = triage_output_dir / f"{video_id}.rrd"
+
+    started_at: float = time.perf_counter()
+    rerun_splats: GaussianSplats = metric_splats_from_live(splats)
+    _write_metric_splats(splat_rrd_path, video_id, rerun_splats)
+    wide_depth_metrics = _DepthMetrics(camera="wide", reference_blobs=wide_depth_references)
+    ultrawide_depth_metrics = _DepthMetrics(camera="uw", reference_blobs=ultrawide_depth_references)
+    rgb_means: list[float] = []
+    depth_means_m: list[float] = []
+    normal_means_degrees: list[float] = []
+    diagnostic_frames: int = 0
+    render_wall_seconds: float = 0.0
+    device: torch.device = splats["means"].device
+    background_3: torch.Tensor = torch.tensor(RENDER_BACKGROUND, dtype=torch.float32, device=device)
+    d2h_transfers: dict[str, int] = {"depth": 0, "normal": 0, "rgb": 0}
+
+    with (
+        atomic_recording(depth_rrd_path, video_id, send_properties=False) as depth_recording,
+        atomic_recording(triage_rrd_path, video_id, send_properties=False) as triage_recording,
+        ThreadPoolExecutor(max_workers=encoder_workers, thread_name_prefix="gauss-surf-png") as executor,
+        torch.inference_mode(),
+    ):
+        _initialize_triage_recording(triage_recording)
+        rendered_count: int = 0
+        for batch_start in range(0, len(wide_cameras), batch_size):
+            wide_batch: list[RenderCamera] = wide_cameras[batch_start : batch_start + batch_size]
+            render_started_at: float = time.perf_counter()
+            wide_products: list[WideQuantizedRender] = [
+                _quantized_wide_render(splats, camera, background_3) for camera in wide_batch
+            ]
+            render_wall_seconds += time.perf_counter() - render_started_at
+            d2h_transfers["depth"] += len(wide_products)
+            d2h_transfers["normal"] += len(wide_products)
+
+            wide_depth_futures: list[Future[bytes]] = [
+                executor.submit(encode_depth_png, product.depth_mm_hw, level=1) for product in wide_products
+            ]
+            wide_normal_futures: list[Future[bytes]] = [
+                executor.submit(encode_rgb_png, product.normal_rgb_hw3) for product in wide_products
+            ]
+            for product in wide_products:
+                splat_depth_m_hw: Float32[ndarray, "h w"] = (
+                    product.depth_mm_hw.astype(np.float32) / 1000.0
+                ).astype(np.float32, copy=False)
+                wide_depth_metrics.add(product.camera.timestamp_ns, splat_depth_m_hw)
+            _send_depth_batch(
+                depth_recording,
+                DEPTH_SPLAT_WIDE,
+                wide_products,
+                _future_results(wide_depth_futures),
+            )
+            _send_image_batch(
+                triage_recording,
+                NORMALS_SPLAT_WIDE,
+                wide_products,
+                _future_results(wide_normal_futures),
+                "image/png",
+            )
+            rendered_count += len(wide_products)
+            elapsed: float = time.perf_counter() - started_at
+            print(
+                f"published {rendered_count}/{len(cameras)} full-grid frames "
+                f"({rendered_count / elapsed:.2f} end-to-end frames/s)",
+                flush=True,
+            )
+
+        for batch_start in range(0, len(ultrawide_cameras), batch_size):
+            ultrawide_batch: list[RenderCamera] = ultrawide_cameras[batch_start : batch_start + batch_size]
+            render_started_at = time.perf_counter()
+            ultrawide_products: list[UltrawideQuantizedRender] = [
+                _quantized_ultrawide_render(splats, camera, background_3) for camera in ultrawide_batch
+            ]
+            render_wall_seconds += time.perf_counter() - render_started_at
+            d2h_transfers["depth"] += len(ultrawide_products)
+            d2h_transfers["normal"] += len(ultrawide_products)
+            d2h_transfers["rgb"] += len(ultrawide_products)
+
+            ultrawide_depth_futures: list[Future[bytes]] = [
+                executor.submit(encode_depth_png, product.depth_mm_hw, level=1) for product in ultrawide_products
+            ]
+            ultrawide_normal_futures: list[Future[bytes]] = [
+                executor.submit(encode_rgb_png, product.normal_rgb_hw3) for product in ultrawide_products
+            ]
+            rgb_futures: list[Future[bytes]] = [
+                executor.submit(encode_rgb_jpeg, product.rgb_hw3) for product in ultrawide_products
+            ]
+            rgb_error_futures: list[Future[bytes]] = []
+            depth_error_futures: list[Future[bytes]] = []
+            normal_error_futures: list[Future[bytes]] = []
+            diagnostic_products: list[UltrawideQuantizedRender] = []
+            for product in ultrawide_products:
+                splat_depth_m_hw = (product.depth_mm_hw.astype(np.float32) / 1000.0).astype(np.float32, copy=False)
+                ultrawide_depth_metrics.add(product.camera.timestamp_ns, splat_depth_m_hw)
+                reference: TriageReferenceBlobs | None = triage_reference_by_timestamp.get(product.camera.timestamp_ns)
+                if reference is None:
+                    continue
+                splat_normal_hw3: Float32[ndarray, "h w 3"] = decode_normal_codes(product.normal_rgb_hw3)
+                source_rgb_hw3: UInt8[ndarray, "h w 3"] = decode_rgb_image(reference.rgb_blob)
+                mesh_depth_m_hw: Float32[ndarray, "h w"] = decode_splat_depth_png(reference.depth_blob)
+                moge_normal_hw3: Float32[ndarray, "h w 3"] = decode_normals_png(reference.normal_blob)
+                errors: TriageErrors = compute_triage_errors(
+                    source_rgb_hw3,
+                    product.rgb_hw3,
+                    mesh_depth_m_hw,
+                    splat_depth_m_hw,
+                    moge_normal_hw3,
+                    splat_normal_hw3,
+                )
+                diagnostic_products.append(product)
+                rgb_error_futures.append(executor.submit(encode_rgb_png, errors.rgb_map_hw3))
+                depth_error_futures.append(executor.submit(encode_rgb_png, errors.depth_map_hw3))
+                normal_error_futures.append(executor.submit(encode_rgb_png, errors.normal_map_hw3))
+                rgb_means.append(errors.rgb_mean)
+                depth_means_m.append(errors.depth_mean_m)
+                normal_means_degrees.append(errors.normal_mean_degrees)
+            _send_depth_batch(
+                depth_recording,
+                DEPTH_SPLAT_ULTRAWIDE,
+                ultrawide_products,
+                _future_results(ultrawide_depth_futures),
+            )
+            _send_image_batch(
+                triage_recording,
+                RGB_SPLAT_ULTRAWIDE_RECT,
+                ultrawide_products,
+                _future_results(rgb_futures),
+                "image/jpeg",
+            )
+            _send_image_batch(
+                triage_recording,
+                NORMALS_SPLAT_ULTRAWIDE_RECT,
+                ultrawide_products,
+                _future_results(ultrawide_normal_futures),
+                "image/png",
+            )
+            if diagnostic_products:
+                _send_image_batch(
+                    triage_recording,
+                    ERROR_RGB_ULTRAWIDE_RECT,
+                    diagnostic_products,
+                    _future_results(rgb_error_futures),
+                    "image/png",
+                )
+                _send_image_batch(
+                    triage_recording,
+                    ERROR_DEPTH_ULTRAWIDE_RECT,
+                    diagnostic_products,
+                    _future_results(depth_error_futures),
+                    "image/png",
+                )
+                _send_image_batch(
+                    triage_recording,
+                    ERROR_NORMAL_ULTRAWIDE_RECT,
+                    diagnostic_products,
+                    _future_results(normal_error_futures),
+                    "image/png",
+                )
+                diagnostic_frames += len(diagnostic_products)
+            rendered_count += len(ultrawide_products)
+            elapsed = time.perf_counter() - started_at
+            print(
+                f"published {rendered_count}/{len(cameras)} full-grid frames "
+                f"({rendered_count / elapsed:.2f} end-to-end frames/s)",
+                flush=True,
+            )
+
+    wide_summary: CameraSummary = wide_depth_metrics.summary()
+    ultrawide_summary: CameraSummary = ultrawide_depth_metrics.summary()
+    if diagnostic_frames != len(triage_references):
+        raise RuntimeError(f"published {diagnostic_frames} triage frames for {len(triage_references)} references")
+    triage_stats = SplatTriageWriteStats(
+        wide_normal_frames=len(wide_cameras),
+        ultrawide=TriageWriteStats(
+            product_frames=len(ultrawide_cameras),
+            diagnostic_frames=diagnostic_frames,
+            rgb=summarize_metrics(rgb_means),
+            depth=summarize_metrics(depth_means_m),
+            normal=summarize_metrics(normal_means_degrees),
+        ),
+    )
+    dataset: DatasetEntry = reader.dataset
+    for rrd_path, layer_name in (
+        (splat_rrd_path, SPLAT_LAYER),
+        (depth_rrd_path, SPLAT_DEPTH_LAYER),
+        (triage_rrd_path, SPLAT_TRIAGE_LAYER),
+    ):
+        register_layer(dataset, rrd_path, layer_name)
+        print(f"registered layer: {layer_name} (REPLACE)", flush=True)
+    wall_seconds: float = time.perf_counter() - started_at
+    return PublishStats(
+        wall_seconds=wall_seconds,
+        render_wall_seconds=render_wall_seconds,
+        frame_count=len(cameras),
+        frames_per_second=len(cameras) / render_wall_seconds,
+        gaussian_count=rerun_splats.count,
+        d2h_transfers=d2h_transfers,
+        wide_depth=wide_summary,
+        ultrawide_depth=ultrawide_summary,
+        triage=triage_stats,
+        rrd_paths={
+            SPLAT_LAYER: str(splat_rrd_path),
+            SPLAT_DEPTH_LAYER: str(depth_rrd_path),
+            SPLAT_TRIAGE_LAYER: str(triage_rrd_path),
+        },
+    )

--- a/packages/gauss-surf/src/gauss_surf/train_gsplat/renderer.py
+++ b/packages/gauss-surf/src/gauss_surf/train_gsplat/renderer.py
@@ -1,0 +1,216 @@
+"""Fused gsplat renderer and its retained two-call parity reference."""
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from gsplat import rasterization
+
+from gauss_surf.gaussurf_geometry import gaussian_plane_features, plane_depth_from_rendered_features
+from gauss_surf.train_gsplat.cache import RasterCamera
+
+
+@dataclass(frozen=True, slots=True)
+class RenderOutput:
+    """Appearance and plane-intersection signals from one camera."""
+
+    rgb_hw3: torch.Tensor
+    alpha_hw1: torch.Tensor
+    center_depth_hw1: torch.Tensor
+    plane_features_hw4: torch.Tensor
+    surface_depth_hw1: torch.Tensor
+    surface_valid_hw1: torch.Tensor
+    direct_normal_hw3: torch.Tensor
+    depth_normal_hw3: torch.Tensor
+    background_3: torch.Tensor
+    appearance_info: dict[str, Any]
+
+
+def fill_depth_holes(depth_hw1: torch.Tensor, alpha_hw1: torch.Tensor) -> torch.Tensor:
+    """Fill auxiliary expected-depth holes with Splatfacto's detached maximum."""
+    if depth_hw1.shape != alpha_hw1.shape:
+        raise ValueError("depth and alpha must have identical [H,W,1] shapes")
+    return torch.where(alpha_hw1 > 0.0, depth_hw1, depth_hw1.detach().max())
+
+
+def normal_from_depth(depth_hw1: torch.Tensor, intrinsics_33: torch.Tensor, valid_hw1: torch.Tensor) -> torch.Tensor:
+    """Derive RDF away-from-camera normals with the historical Sobel operator."""
+    height: int = depth_hw1.shape[0]
+    width: int = depth_hw1.shape[1]
+    dtype: torch.dtype = depth_hw1.dtype
+    device: torch.device = depth_hw1.device
+    pixel_x_hw: torch.Tensor
+    pixel_y_hw: torch.Tensor
+    pixel_x_hw, pixel_y_hw = torch.meshgrid(
+        torch.arange(width, dtype=dtype, device=device) + 0.5,
+        torch.arange(height, dtype=dtype, device=device) + 0.5,
+        indexing="xy",
+    )
+    pixels_hw3: torch.Tensor = torch.stack((pixel_x_hw, pixel_y_hw, torch.ones_like(pixel_x_hw)), dim=-1)
+    rays_hw3: torch.Tensor = pixels_hw3 @ torch.linalg.inv(intrinsics_33).T
+    points_13hw: torch.Tensor = (rays_hw3 * depth_hw1).movedim(-1, 0).unsqueeze(0)
+    sobel_x_1133: torch.Tensor = torch.tensor(
+        [[[-1.0, 0.0, 1.0], [-2.0, 0.0, 2.0], [-1.0, 0.0, 1.0]]], dtype=dtype, device=device
+    ).unsqueeze(0)
+    sobel_y_1133: torch.Tensor = sobel_x_1133.transpose(-1, -2)
+    padded_13hw: torch.Tensor = F.pad(points_13hw, (1, 1, 1, 1), mode="replicate")
+    gradient_x_13hw: torch.Tensor = F.conv2d(padded_13hw, sobel_x_1133.repeat(3, 1, 1, 1), groups=3)
+    gradient_y_13hw: torch.Tensor = F.conv2d(padded_13hw, sobel_y_1133.repeat(3, 1, 1, 1), groups=3)
+    normal_13hw: torch.Tensor = F.normalize(torch.cross(gradient_x_13hw, gradient_y_13hw, dim=1), dim=1, eps=1e-6)
+    normal_hw3: torch.Tensor = normal_13hw.squeeze(0).movedim(0, -1)
+    return torch.where(valid_hw1.expand_as(normal_hw3), normal_hw3, torch.zeros_like(normal_hw3))
+
+
+def _render_splats(
+    splats: torch.nn.ParameterDict | dict[str, torch.Tensor],
+    camera: RasterCamera,
+    *,
+    downscale: int,
+    sh_degree: int,
+    background_3: torch.Tensor,
+    absgrad: bool,
+    fused: bool,
+) -> RenderOutput:
+    """Render shared outputs with either fused or reference rasterization calls."""
+    device: torch.device = splats["means"].device
+    viewmat_144: torch.Tensor = camera.viewmat_44.to(device).unsqueeze(0)
+    intrinsics_133: torch.Tensor = camera.K_33.to(device).unsqueeze(0).clone()
+    intrinsics_133[:, :2] /= downscale
+    width: int = camera.width // downscale
+    height: int = camera.height // downscale
+    quats_n4: torch.Tensor = F.normalize(splats["quats"], dim=-1)
+    scales_n3: torch.Tensor = torch.exp(splats["scales"])
+    opacity_n: torch.Tensor = torch.sigmoid(splats["opacities"]).squeeze(-1)
+    colors_nk3: torch.Tensor = torch.cat((splats["sh0"], splats["shN"]), dim=1)
+    plane_features_n4: torch.Tensor = gaussian_plane_features(
+        splats["means"], splats["scales"], quats_n4, viewmat_144.squeeze(0)
+    )
+
+    rendered_appearance_1hw4: torch.Tensor
+    appearance_alpha_1hw1: torch.Tensor
+    appearance_info: dict[str, Any]
+    rendered_plane_1hw4: torch.Tensor
+    plane_alpha_1hw1: torch.Tensor
+    if fused:
+        rendered_appearance_1hw4, appearance_alpha_1hw1, appearance_info = rasterization(
+            means=splats["means"],
+            quats=quats_n4,
+            scales=scales_n3,
+            opacities=opacity_n,
+            colors=colors_nk3,
+            viewmats=viewmat_144,
+            Ks=intrinsics_133,
+            width=width,
+            height=height,
+            packed=False,
+            render_mode="RGB+ED",
+            sh_degree=sh_degree,
+            sparse_grad=False,
+            absgrad=absgrad,
+            rasterize_mode="classic",
+            extra_signals=plane_features_n4,
+            extra_signals_sh_degree=None,
+        )
+        rendered_plane_1hw4 = appearance_info["render_extra_signals"]
+        plane_alpha_1hw1 = appearance_alpha_1hw1
+    else:
+        rendered_appearance_1hw4, appearance_alpha_1hw1, appearance_info = rasterization(
+            means=splats["means"],
+            quats=quats_n4,
+            scales=scales_n3,
+            opacities=opacity_n,
+            colors=colors_nk3,
+            viewmats=viewmat_144,
+            Ks=intrinsics_133,
+            width=width,
+            height=height,
+            packed=False,
+            render_mode="RGB+ED",
+            sh_degree=sh_degree,
+            sparse_grad=False,
+            absgrad=absgrad,
+            rasterize_mode="classic",
+        )
+        rendered_plane_1hw4, plane_alpha_1hw1, _plane_info = rasterization(
+            means=splats["means"],
+            quats=quats_n4,
+            scales=scales_n3,
+            opacities=opacity_n,
+            colors=plane_features_n4,
+            viewmats=viewmat_144,
+            Ks=intrinsics_133,
+            width=width,
+            height=height,
+            packed=False,
+            render_mode="RGB",
+            sh_degree=None,
+            sparse_grad=False,
+            absgrad=False,
+            rasterize_mode="classic",
+        )
+    rgb_hw3: torch.Tensor = rendered_appearance_1hw4[0, ..., :3] + (1.0 - appearance_alpha_1hw1[0]) * background_3
+    rgb_hw3 = rgb_hw3.clamp(0.0, 1.0)
+    center_depth_hw1: torch.Tensor = fill_depth_holes(rendered_appearance_1hw4[0, ..., 3:4], appearance_alpha_1hw1[0])
+    surface = plane_depth_from_rendered_features(
+        rendered_plane_1hw4.squeeze(0),
+        plane_alpha_1hw1.squeeze(0),
+        intrinsics_133.squeeze(0),
+        min_alpha=0.01,
+        min_denominator=1e-4,
+    )
+    depth_normal_hw3: torch.Tensor = normal_from_depth(surface.depth_hw1, intrinsics_133.squeeze(0), surface.valid_hw1)
+    return RenderOutput(
+        rgb_hw3=rgb_hw3,
+        alpha_hw1=appearance_alpha_1hw1.squeeze(0),
+        center_depth_hw1=center_depth_hw1,
+        plane_features_hw4=rendered_plane_1hw4.squeeze(0),
+        surface_depth_hw1=surface.depth_hw1,
+        surface_valid_hw1=surface.valid_hw1,
+        direct_normal_hw3=surface.normal_hw3,
+        depth_normal_hw3=depth_normal_hw3,
+        background_3=background_3,
+        appearance_info=appearance_info,
+    )
+
+
+def render_splats_two_call(
+    splats: torch.nn.ParameterDict | dict[str, torch.Tensor],
+    camera: RasterCamera,
+    *,
+    downscale: int,
+    sh_degree: int,
+    background_3: torch.Tensor,
+    absgrad: bool,
+) -> RenderOutput:
+    """Render appearance and plane features with the retained two-call reference."""
+    return _render_splats(
+        splats,
+        camera,
+        downscale=downscale,
+        sh_degree=sh_degree,
+        background_3=background_3,
+        absgrad=absgrad,
+        fused=False,
+    )
+
+
+def render_splats(
+    splats: torch.nn.ParameterDict | dict[str, torch.Tensor],
+    camera: RasterCamera,
+    *,
+    downscale: int,
+    sh_degree: int,
+    background_3: torch.Tensor,
+    absgrad: bool,
+) -> RenderOutput:
+    """Render RGB, expected center depth, and four plane channels in one 8-channel pass."""
+    return _render_splats(
+        splats,
+        camera,
+        downscale=downscale,
+        sh_degree=sh_degree,
+        background_3=background_3,
+        absgrad=absgrad,
+        fused=True,
+    )

--- a/packages/gauss-surf/src/gauss_surf/train_gsplat/splat_values.py
+++ b/packages/gauss-surf/src/gauss_surf/train_gsplat/splat_values.py
@@ -1,0 +1,86 @@
+"""Natural-form Gaussian values used by direct Rerun publication."""
+
+from dataclasses import dataclass
+from math import pi, sqrt
+
+import numpy as np
+import rerun as rr
+from jaxtyping import Float32, UInt8
+from numpy import ndarray
+
+SH_C0: float = 0.5 * sqrt(1.0 / pi)
+"""Degree-zero real spherical-harmonic basis constant used by INRIA 3DGS."""
+
+
+@dataclass(frozen=True, slots=True)
+class GaussianSplats:
+    """Natural-form values accepted by ``rr.GaussianSplats3D``."""
+
+    centers_n3: Float32[ndarray, "n 3"]
+    """Gaussian centers in metric world coordinates."""
+    scales_n3: Float32[ndarray, "n 3"]
+    """Linear per-axis standard deviations in metres."""
+    quaternions_xyzw_n4: Float32[ndarray, "n 4"]
+    """Normalized Rerun-layout quaternions."""
+    colors_rgba_n4: UInt8[ndarray, "n 4"]
+    """Unmultiplied base RGB and peak opacity."""
+    sh_coefficients_n153: Float32[ndarray, "n 15 3"]
+    """Coefficient-major RGB spherical harmonics of degrees one through three."""
+
+    @property
+    def count(self) -> int:
+        """Return the number of Gaussian splats."""
+        return len(self.centers_n3)
+
+    def as_archetype(self) -> rr.GaussianSplats3D:
+        """Build the unstable Rerun Gaussian-splat archetype."""
+        return rr.GaussianSplats3D(
+            centers=self.centers_n3,
+            scales=self.scales_n3,
+            quaternions=self.quaternions_xyzw_n4,
+            colors=self.colors_rgba_n4,
+            sh_coefficients=self.sh_coefficients_n153,
+            spherical_harmonics_degree=3,
+        )
+
+
+def inria_quaternions_xyzw(quaternions_wxyz_n4: Float32[ndarray, "n 4"]) -> Float32[ndarray, "n 4"]:
+    """Normalize INRIA-layout quaternions and reorder them for Rerun.
+
+    Args:
+        quaternions_wxyz_n4: Float32 unnormalized INRIA quaternions shaped ``n 4``.
+
+    Returns:
+        Float32 normalized Rerun ``xyzw`` quaternions shaped ``n 4``. A zero quaternion becomes identity.
+    """
+    norms_n: Float32[ndarray, "n"] = np.linalg.norm(quaternions_wxyz_n4, axis=1).astype(np.float32, copy=False)
+    nonzero_n: ndarray = norms_n > 0.0
+    quaternions_xyzw_n4: Float32[ndarray, "n 4"] = np.zeros_like(quaternions_wxyz_n4, dtype=np.float32)
+    quaternions_xyzw_n4[:, 3] = 1.0
+    quaternions_xyzw_n4[nonzero_n] = quaternions_wxyz_n4[nonzero_n][:, [1, 2, 3, 0]] / norms_n[nonzero_n, None]
+    return quaternions_xyzw_n4
+
+
+def inria_colors_rgba(
+    f_dc_n3: Float32[ndarray, "n 3"],
+    opacity_logits_n: Float32[ndarray, "n"],
+) -> UInt8[ndarray, "n 4"]:
+    """Convert INRIA DC coefficients and opacity logits to unmultiplied RGBA.
+
+    Args:
+        f_dc_n3: Float32 degree-zero spherical-harmonic coefficients shaped ``n 3``.
+        opacity_logits_n: Float32 opacity logits shaped ``n``.
+
+    Returns:
+        Uint8 unmultiplied RGBA colors shaped ``n 4``.
+    """
+    if len(f_dc_n3) != len(opacity_logits_n):
+        raise ValueError(f"DC/color row count {len(f_dc_n3)} does not match opacity row count {len(opacity_logits_n)}")
+    rgb_01_n3: Float32[ndarray, "n 3"] = np.clip(0.5 + SH_C0 * f_dc_n3, 0.0, 1.0).astype(np.float32, copy=False)
+    alpha_01_n: Float32[ndarray, "n"] = np.empty_like(opacity_logits_n, dtype=np.float32)
+    nonnegative_n: ndarray = opacity_logits_n >= 0.0
+    alpha_01_n[nonnegative_n] = 1.0 / (1.0 + np.exp(-opacity_logits_n[nonnegative_n]))
+    exp_logits_n: Float32[ndarray, "n_negative"] = np.exp(opacity_logits_n[~nonnegative_n])
+    alpha_01_n[~nonnegative_n] = exp_logits_n / (1.0 + exp_logits_n)
+    rgba_01_n4: Float32[ndarray, "n 4"] = np.column_stack((rgb_01_n3, alpha_01_n)).astype(np.float32, copy=False)
+    return np.clip(rgba_01_n4 * 255.0 + 0.5, 0.0, 255.0).astype(np.uint8)

--- a/packages/gauss-surf/src/gauss_surf/train_gsplat/trainer.py
+++ b/packages/gauss-surf/src/gauss_surf/train_gsplat/trainer.py
@@ -1,0 +1,441 @@
+"""Direct 7,000-step gsplat trainer with the settled GausSurf losses."""
+
+import math
+import random
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, TypeAlias
+
+import numpy as np
+import torch
+from gsplat import export_splats
+from gsplat.strategy import DefaultStrategy
+from plyfile import PlyData
+from torchmetrics.functional.image import structural_similarity_index_measure
+
+from gauss_surf.gaussurf_losses import (
+    GausSurfLosses,
+    GausSurfTargets,
+    compute_gaussurf_losses,
+    linear_ramp_weight,
+    normal_contradiction_gate,
+    prepare_gaussurf_targets,
+)
+from gauss_surf.gsplat_schedule import downscale_factor, opacity_reset_callback_step, sh_degree, should_refine, should_reset_opacity
+from gauss_surf.train_gsplat.cache import GpuTrainingCache
+from gauss_surf.train_gsplat.core import median_scale_regularization, opacity_export_mask, positive_neighbor_distances, save_checkpoint
+from gauss_surf.train_gsplat.renderer import RenderOutput, render_splats, render_splats_two_call
+
+ITERATIONS: int = 7_000
+BASE_MEANS_LR: float = 1.6e-4
+BASE_MEANS_LR_FINAL: float = 1.6e-6
+BASE_DEPTH_REGULARIZATION_WEIGHT: float = 3.2
+BASE_FLAT_REGULARIZATION_WEIGHT: float = 1.0
+TrainingRenderer: TypeAlias = Callable[..., RenderOutput]
+
+
+def select_training_renderer(*, fused_training: bool) -> TrainingRenderer:
+    """Select the default two-call path or the explicit fused quality-round path."""
+    return render_splats if fused_training else render_splats_two_call
+
+
+@dataclass(frozen=True, slots=True)
+class MetricTrainingConstants:
+    """The four scale-dependent constants for metric-world training."""
+
+    means_lr: float
+    """Initial Gaussian-mean learning rate in metres."""
+    means_lr_final: float
+    """Final Gaussian-mean learning rate in metres."""
+    depth_regularization_weight: float
+    """Dense metric-depth loss weight."""
+    flat_regularization_weight: float
+    """Metric Gaussian-flatness loss weight."""
+
+
+def metric_training_constants(scene_scale: float) -> MetricTrainingConstants:
+    """Scale exactly the four dimensional training constants."""
+    if not math.isfinite(scene_scale) or scene_scale <= 0.0:
+        raise ValueError(f"scene scale must be positive and finite, got {scene_scale}")
+    return MetricTrainingConstants(
+        means_lr=BASE_MEANS_LR * scene_scale,
+        means_lr_final=BASE_MEANS_LR_FINAL * scene_scale,
+        depth_regularization_weight=BASE_DEPTH_REGULARIZATION_WEIGHT / scene_scale,
+        flat_regularization_weight=BASE_FLAT_REGULARIZATION_WEIGHT / scene_scale,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class TrainingResult:
+    """Direct training artifacts and scalar outcomes."""
+
+    splats: torch.nn.ParameterDict
+    """Final live Gaussian parameters."""
+    training_wall_seconds: float
+    """Synchronized training-loop wall time."""
+    gaussian_count: int
+    """Final in-memory Gaussian count."""
+    exported_gaussian_count: int
+    """Gaussian count after the opacity export filter."""
+    refinement_steps: tuple[int, ...]
+    """Iterations at which refinement ran."""
+    reset_steps: tuple[int, ...]
+    """Iterations at which opacity reset ran."""
+    strategy_trajectory: tuple["StrategyEvent", ...]
+    """Pre/post counts and opacity maxima for every strategy event."""
+    final_losses: dict[str, float]
+    """Final iteration loss terms."""
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyEvent:
+    """One observed refinement or opacity-reset event."""
+
+    step: int
+    """Zero-based training iteration."""
+    kind: Literal["refine", "reset"]
+    """Strategy operation that ran at this iteration."""
+    gaussian_count_before: int
+    """Gaussian count before the strategy callback."""
+    gaussian_count_after: int
+    """Gaussian count after the strategy callback."""
+    opacity_max_before: float
+    """Maximum post-sigmoid opacity before the callback."""
+    opacity_max_after: float
+    """Maximum post-sigmoid opacity after the callback."""
+
+
+def camera_sample_indices(*, num_train_data: int, iteration_count: int, seed: int) -> tuple[int, ...]:
+    """Return the accepted seeded, shuffled, without-replacement camera stream."""
+    if num_train_data <= 0 or iteration_count < 0:
+        raise ValueError("training camera count must be positive and iteration count non-negative")
+    sample_random: random.Random = random.Random(seed)
+    sampled_indices: list[int] = []
+    while len(sampled_indices) < iteration_count:
+        epoch_indices: list[int] = list(range(num_train_data))
+        sample_random.shuffle(epoch_indices)
+        sampled_indices.extend(epoch_indices[: iteration_count - len(sampled_indices)])
+    return tuple(sampled_indices)
+
+
+def read_metric_seed(seed_path: Path) -> tuple[np.ndarray, np.ndarray]:
+    """Read metric-world seed vertices and colors without normalization."""
+    ply_data: PlyData = PlyData.read(str(seed_path), mmap="r")
+    vertex: Any = ply_data["vertex"]
+    points_n3: np.ndarray = np.stack((vertex["x"], vertex["y"], vertex["z"]), axis=-1).astype(np.float32)
+    colors_n3: np.ndarray = np.stack((vertex["red"], vertex["green"], vertex["blue"]), axis=-1).astype(np.float32) / 255.0
+    return points_n3, colors_n3
+
+
+def _random_quaternions(count: int) -> torch.Tensor:
+    """Match the accepted uniform random quaternion initialization."""
+    u: torch.Tensor = torch.rand(count)
+    v: torch.Tensor = torch.rand(count)
+    w: torch.Tensor = torch.rand(count)
+    return torch.stack(
+        (
+            torch.sqrt(1.0 - u) * torch.sin(2.0 * math.pi * v),
+            torch.sqrt(1.0 - u) * torch.cos(2.0 * math.pi * v),
+            torch.sqrt(u) * torch.sin(2.0 * math.pi * w),
+            torch.sqrt(u) * torch.cos(2.0 * math.pi * w),
+        ),
+        dim=-1,
+    )
+
+
+def initialize_splats(
+    seed_path: Path,
+    device: torch.device,
+    constants: MetricTrainingConstants,
+) -> tuple[torch.nn.ParameterDict, dict[str, torch.optim.Optimizer]]:
+    """Initialize seeds with sklearn three-neighbor mean scales."""
+    from sklearn.neighbors import NearestNeighbors  # pyrefly: ignore  # copied runtime package; see Part 8 report
+
+    points_n3, colors_n3 = read_metric_seed(seed_path)
+    neighbor_model = NearestNeighbors(n_neighbors=4, algorithm="auto", metric="euclidean").fit(points_n3)
+    distances_n4: np.ndarray
+    distances_n4, _indices_n4 = neighbor_model.kneighbors(points_n3)
+    average_distance_n1: np.ndarray = distances_n4[:, 1:].astype(np.float32).mean(axis=-1, keepdims=True)
+    average_distance_n1 = positive_neighbor_distances(average_distance_n1)
+    count: int = len(points_n3)
+    colors_n16x3: torch.Tensor = torch.zeros((count, 16, 3), dtype=torch.float32)
+    colors_n16x3[:, 0] = (torch.from_numpy(colors_n3) - 0.5) / 0.28209479177387814
+    parameter_values: dict[str, torch.Tensor] = {
+        "means": torch.from_numpy(points_n3),
+        "scales": torch.from_numpy(np.log(average_distance_n1).repeat(3, axis=1)),
+        "quats": _random_quaternions(count),
+        "opacities": torch.logit(torch.full((count, 1), 0.1)),
+        "sh0": colors_n16x3[:, :1],
+        "shN": colors_n16x3[:, 1:],
+    }
+    splats = torch.nn.ParameterDict(
+        {name: torch.nn.Parameter(value.to(device)) for name, value in parameter_values.items()}
+    )
+    learning_rates: dict[str, float] = {
+        "means": constants.means_lr,
+        "scales": 0.005,
+        "quats": 0.001,
+        "opacities": 0.05,
+        "sh0": 0.0025,
+        "shN": 0.0025 / 20.0,
+    }
+    optimizers: dict[str, torch.optim.Optimizer] = {
+        name: torch.optim.Adam([{"params": splats[name], "lr": learning_rate, "name": name}], eps=1e-15)
+        for name, learning_rate in learning_rates.items()
+    }
+    return splats, optimizers
+
+
+def _losses(
+    *,
+    step: int,
+    splats: torch.nn.ParameterDict,
+    output: RenderOutput,
+    target_rgb_hw3: torch.Tensor,
+    target_depth_hw1: torch.Tensor,
+    target_normal_3hw: torch.Tensor,
+    constants: MetricTrainingConstants,
+) -> dict[str, torch.Tensor]:
+    """Compute the unchanged appearance, depth, plane, and normal recipe."""
+    target_rgb_hw3 = target_rgb_hw3[..., :3]
+    l1: torch.Tensor = (target_rgb_hw3 - output.rgb_hw3).abs().mean()
+    ssim_value = structural_similarity_index_measure(
+        target_rgb_hw3.permute(2, 0, 1).unsqueeze(0),
+        output.rgb_hw3.permute(2, 0, 1).unsqueeze(0),
+        data_range=1.0,
+    )
+    if not isinstance(ssim_value, torch.Tensor):
+        raise RuntimeError("SSIM metric unexpectedly returned a full image")
+    ssim: torch.Tensor = ssim_value
+    valid_depth_hw1: torch.Tensor = target_depth_hw1 > 0.0
+    depth_error_hw1: torch.Tensor = (output.surface_depth_hw1 - target_depth_hw1).abs()
+    depth_loss: torch.Tensor = (depth_error_hw1 * valid_depth_hw1).sum() / valid_depth_hw1.sum().clamp_min(1)
+    result: dict[str, torch.Tensor] = {
+        "main_loss": 0.8 * l1 + 0.2 * (1.0 - ssim),
+        "depth_loss": constants.depth_regularization_weight * depth_loss,
+    }
+    if step < 1_400:
+        return result
+
+    target_normal_valid_1hw: torch.Tensor = torch.linalg.vector_norm(target_normal_3hw, dim=0, keepdim=True) > 0.5
+    targets: GausSurfTargets = prepare_gaussurf_targets(
+        prior_normal_3hw=target_normal_3hw,
+        prior_valid_1hw=target_normal_valid_1hw,
+        height=output.rgb_hw3.shape[0],
+        width=output.rgb_hw3.shape[1],
+    )
+    normal_gate_hw1: torch.Tensor | None = None
+    if step >= 2_625:
+        normal_gate_hw1 = normal_contradiction_gate(
+            output.direct_normal_hw3,
+            targets.prior_normal_hw3,
+            targets.prior_valid_hw1,
+            maximum_angle_degrees=30.0,
+        )
+    normal_losses: GausSurfLosses = compute_gaussurf_losses(
+        direct_normal_hw3=output.direct_normal_hw3,
+        depth_normal_hw3=output.depth_normal_hw3,
+        prior_normal_hw3=targets.prior_normal_hw3,
+        prior_valid_hw1=targets.prior_valid_hw1,
+        surface_valid_hw1=output.surface_valid_hw1.bool(),
+        normal_prior_gate_hw1=normal_gate_hw1,
+    )
+    normal_ramp: float = linear_ramp_weight(step=step, start_step=1_400, ramp_steps=875)
+    final_consistency_ramp: float = linear_ramp_weight(step=step, start_step=5_500, ramp_steps=500)
+    consistency_weight: float = 0.5 + (0.55 - 0.5) * final_consistency_ramp
+    scale_exp_n3: torch.Tensor = torch.exp(splats["scales"])
+    result.update(
+        {
+            "gaussurf_normal_prior_loss": normal_losses.normal_prior_cosine * normal_ramp,
+            "gaussurf_normal_consistency_loss": normal_losses.depth_normal_cosine * consistency_weight * normal_ramp,
+            "flat_loss": constants.flat_regularization_weight * scale_exp_n3.amin(dim=-1).mean(),
+        }
+    )
+    if step % 10 == 0:
+        result["scale_reg"] = 0.1 * median_scale_regularization(splats["scales"], maximum_ratio=2.0)
+    return result
+
+
+def train(
+    cache: GpuTrainingCache,
+    *,
+    bundle_dir: Path,
+    run_dir: Path,
+    seed: int,
+    opacity_reset_every: int,
+    fused_training: bool = False,
+) -> TrainingResult:
+    """Train the structural-parity recipe and write checkpoint/PLY artifacts."""
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    device: torch.device = cache.wide_rgb_nhw3.device
+    constants: MetricTrainingConstants = metric_training_constants(cache.scene_scale)
+    splats, optimizers = initialize_splats(bundle_dir / "seed.ply", device, constants)
+    means_scheduler = torch.optim.lr_scheduler.ExponentialLR(
+        optimizers["means"], gamma=(constants.means_lr_final / constants.means_lr) ** (1.0 / ITERATIONS)
+    )
+    num_train_data: int = len(cache.train_indices)
+    strategy = DefaultStrategy(
+        prune_opa=0.1,
+        grow_grad2d=0.0008,
+        grow_scale3d=0.01,
+        grow_scale2d=0.05,
+        prune_scale3d=0.5,
+        prune_scale2d=0.15,
+        refine_scale2d_stop_iter=5_500,
+        refine_start_iter=500,
+        refine_stop_iter=5_500,
+        reset_every=3_000,
+        refine_every=100,
+        pause_refine_after_reset=num_train_data + 100,
+        absgrad=True,
+        revised_opacity=False,
+        verbose=True,
+    )
+    strategy.check_sanity(splats, optimizers)
+    strategy_state: dict[str, Any] = strategy.initialize_state(scene_scale=cache.scene_scale)
+    sample_indices: tuple[int, ...] = camera_sample_indices(
+        num_train_data=num_train_data,
+        iteration_count=ITERATIONS,
+        seed=seed,
+    )
+    training_renderer: TrainingRenderer = select_training_renderer(fused_training=fused_training)
+    training_log_path: Path = run_dir / "training.log"
+    run_dir.mkdir(parents=True, exist_ok=False)
+    refinement_steps: list[int] = []
+    reset_steps: list[int] = []
+    strategy_trajectory: list[StrategyEvent] = []
+    final_losses: dict[str, float] = {}
+    torch.cuda.synchronize(device)
+    started_at: float = time.perf_counter()
+    with training_log_path.open("w", encoding="utf-8", buffering=1) as training_log:
+        for step in range(ITERATIONS):
+            sample_index: int = sample_indices[step]
+            factor: int = downscale_factor(step)
+            camera, target_rgb_hw3, target_depth_hw1, target_normal_3hw = cache.sample(sample_index, factor)
+            background_3: torch.Tensor = torch.rand(3, dtype=torch.float32, device=device)
+            output: RenderOutput = training_renderer(
+                splats,
+                camera,
+                downscale=factor,
+                sh_degree=sh_degree(step),
+                background_3=background_3,
+                absgrad=True,
+            )
+            strategy.step_pre_backward(splats, optimizers, strategy_state, step, output.appearance_info)
+            loss_terms: dict[str, torch.Tensor] = _losses(
+                step=step,
+                splats=splats,
+                output=output,
+                target_rgb_hw3=target_rgb_hw3,
+                target_depth_hw1=target_depth_hw1,
+                target_normal_3hw=target_normal_3hw,
+                constants=constants,
+            )
+            stacked_loss_terms: torch.Tensor = torch.stack(tuple(loss_terms.values()))
+            if not bool(torch.isfinite(stacked_loss_terms).all().item()):
+                nonfinite_terms: dict[str, float] = {
+                    name: float(value.detach().item()) for name, value in loss_terms.items() if not bool(torch.isfinite(value).item())
+                }
+                all_terms: dict[str, float] = {name: float(value.detach().item()) for name, value in loss_terms.items()}
+                message = f"step={step} nonfinite_loss_terms={nonfinite_terms} all_loss_terms={all_terms}"
+                print(message, flush=True)
+                training_log.write(message + "\n")
+                raise FloatingPointError(message)
+            total_loss: torch.Tensor = stacked_loss_terms.sum()
+            total_loss.backward()
+            for optimizer in optimizers.values():
+                optimizer.step()
+                optimizer.zero_grad(set_to_none=True)
+            means_scheduler.step()
+            scheduled_refinement: bool = should_refine(
+                step=step,
+                num_train_frames=num_train_data,
+                refine_every=strategy.refine_every,
+                reset_every=strategy.reset_every,
+                refine_start=strategy.refine_start_iter,
+                refine_stop=strategy.refine_stop_iter,
+            )
+            scheduled_reset: bool = should_reset_opacity(
+                step=step,
+                reset_every=opacity_reset_every,
+                refine_stop=strategy.refine_stop_iter,
+            )
+            gaussian_count_before: int = len(splats["means"])
+            opacity_max_before: float | None = None
+            if scheduled_refinement or scheduled_reset:
+                opacity_max_before = float(torch.sigmoid(splats["opacities"]).max().item())
+            strategy_callback_step: int = opacity_reset_callback_step(
+                step=step,
+                refinement_cycle_every=strategy.reset_every,
+                opacity_reset_every=opacity_reset_every,
+            )
+            strategy.step_post_backward(splats, optimizers, strategy_state, strategy_callback_step, output.appearance_info, packed=False)
+            if scheduled_refinement or scheduled_reset:
+                if opacity_max_before is None:
+                    raise RuntimeError("strategy event opacity was not sampled")
+                event_kind: Literal["refine", "reset"] = "reset" if scheduled_reset else "refine"
+                event = StrategyEvent(
+                    step=step,
+                    kind=event_kind,
+                    gaussian_count_before=gaussian_count_before,
+                    gaussian_count_after=len(splats["means"]),
+                    opacity_max_before=opacity_max_before,
+                    opacity_max_after=float(torch.sigmoid(splats["opacities"]).max().item()),
+                )
+                strategy_trajectory.append(event)
+                message: str = (
+                    f"Step {step}: {event_kind} completed; "
+                    f"gaussians={event.gaussian_count_before}->{event.gaussian_count_after}; "
+                    f"opacity_max={event.opacity_max_before:.9f}->{event.opacity_max_after:.9f}."
+                )
+                print(message, flush=True)
+                training_log.write(message + "\n")
+            if scheduled_refinement:
+                refinement_steps.append(step)
+            if scheduled_reset:
+                reset_steps.append(step)
+            if step + 1 == ITERATIONS:
+                final_losses = {name: float(value.detach().item()) for name, value in loss_terms.items()}
+            if step % 100 == 0 or step + 1 == ITERATIONS:
+                elapsed: float = time.perf_counter() - started_at
+                message = (
+                    f"step={step} loss={float(total_loss.detach().item()):.6f} "
+                    f"gaussians={len(splats['means'])} factor={factor} sh={sh_degree(step)} wall={elapsed:.3f}"
+                )
+                print(message, flush=True)
+                training_log.write(message + "\n")
+    torch.cuda.synchronize(device)
+    training_wall_seconds: float = time.perf_counter() - started_at
+    checkpoint_path: Path = run_dir / "checkpoints" / "step-000006999.pt"
+    save_checkpoint(
+        checkpoint_path,
+        step=ITERATIONS - 1,
+        splats=splats,
+        metadata={"seed": seed, "holdout_sha256": cache.holdout_sha256, "iterations": ITERATIONS},
+    )
+    keep_n: torch.Tensor = opacity_export_mask(splats["opacities"].squeeze(-1))
+    export_splats(
+        means=splats["means"][keep_n],
+        scales=splats["scales"][keep_n],
+        quats=splats["quats"][keep_n],
+        opacities=splats["opacities"][keep_n].squeeze(-1),
+        sh0=splats["sh0"][keep_n],
+        shN=splats["shN"][keep_n],
+        format="ply",
+        save_to=str(run_dir / "splat.ply"),
+    )
+    return TrainingResult(
+        splats=splats,
+        training_wall_seconds=training_wall_seconds,
+        gaussian_count=len(splats["means"]),
+        exported_gaussian_count=int(keep_n.sum().item()),
+        refinement_steps=tuple(refinement_steps),
+        reset_steps=tuple(reset_steps),
+        strategy_trajectory=tuple(strategy_trajectory),
+        final_losses=final_losses,
+    )

--- a/packages/gauss-surf/tests/test_fresh_segment_portability.py
+++ b/packages/gauss-surf/tests/test_fresh_segment_portability.py
@@ -1,0 +1,128 @@
+"""Contracts that let the direct trainer accept a fresh catalog segment."""
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+from gauss_surf.train_gsplat.cache import GpuTrainingCache, TrainingCamera
+from gauss_surf.train_gsplat.evaluation import evaluate_holdout
+from gauss_surf.train_gsplat.metadata import holdout_wide_indices, metadata_files_complete
+from gauss_surf.train_gsplat.renderer import RenderOutput
+
+
+def _camera(index: int) -> TrainingCamera:
+    """Build one tiny wide holdout camera."""
+    return TrainingCamera(
+        stem=f"wide_{index:06d}",
+        camera="wide",
+        timestamp_ns=index,
+        width=16,
+        height=16,
+        viewmat_44=torch.eye(4),
+        K_33=torch.eye(3),
+        cache_index=index,
+        holdout=True,
+    )
+
+
+def test_fresh_metadata_contract_uses_segment_length(tmp_path: Path) -> None:
+    """Fresh metadata uses a dynamic holdout cadence."""
+    assert holdout_wide_indices(663) == tuple(range(7, 663, 8))
+    assert len(holdout_wide_indices(663)) == 82
+    assert metadata_files_complete(tmp_path) is False
+
+
+def test_generated_metadata_rejects_an_interrupted_mixed_generation(tmp_path: Path) -> None:
+    """An auto-generated bundle is invalid when one file differs from its completed generation."""
+    file_contents: dict[str, bytes] = {
+        "transforms.json": b"generation-a transforms\n",
+        "cameras_all.json": b"generation-a cameras\n",
+        "seed.ply": b"generation-a seed\n",
+    }
+    for name, content in file_contents.items():
+        (tmp_path / name).write_bytes(content)
+    (tmp_path / "bundle_manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "files": {name: {"sha256": hashlib.sha256(content).hexdigest()} for name, content in file_contents.items()},
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert metadata_files_complete(tmp_path) is True
+
+    (tmp_path / "cameras_all.json").write_bytes(b"stale cameras from generation-b\n")
+
+    assert metadata_files_complete(tmp_path) is False
+
+
+def test_explicit_legacy_metadata_bundle_remains_readable(tmp_path: Path) -> None:
+    """An explicit legacy bundle may omit the generation manifest."""
+    for name in ("transforms.json", "cameras_all.json", "seed.ply"):
+        (tmp_path / name).touch()
+
+    assert metadata_files_complete(tmp_path) is False
+    assert metadata_files_complete(tmp_path, allow_legacy=True) is True
+
+
+def test_holdout_evaluation_reads_dynamic_targets_from_gpu_cache(monkeypatch: Any) -> None:
+    """Evaluation neither reads bundle images nor requires exactly 81 holdouts."""
+    cameras: tuple[TrainingCamera, ...] = (_camera(0), _camera(1))
+    wide_rgb_nhw3: torch.Tensor = torch.stack(
+        (
+            torch.full((16, 16, 3), 64, dtype=torch.uint8),
+            torch.full((16, 16, 3), 192, dtype=torch.uint8),
+        )
+    )
+    cache = GpuTrainingCache(
+        wide_rgb_nhw3=wide_rgb_nhw3,
+        wide_depth_nhw=torch.empty((2, 16, 16), dtype=torch.uint16),
+        wide_normal_nhw3=torch.empty((2, 16, 16, 3), dtype=torch.uint8),
+        uw_rgb_nhw3=torch.empty((0, 16, 16, 3), dtype=torch.uint8),
+        uw_depth_nhw=torch.empty((0, 16, 16), dtype=torch.uint16),
+        uw_normal_nhw3=torch.empty((0, 16, 16, 3), dtype=torch.uint8),
+        cameras=cameras,
+        train_indices=torch.empty(0, dtype=torch.int64),
+        holdout_indices=(0, 1),
+        holdout_sha256="test",
+        scene_scale=1.0,
+    )
+
+    def fake_render(
+        _splats: torch.nn.ParameterDict | dict[str, torch.Tensor],
+        camera: TrainingCamera,
+        **_kwargs: Any,
+    ) -> RenderOutput:
+        target: torch.Tensor = cache.wide_rgb_nhw3[camera.cache_index].to(torch.float32) / 255.0
+        rgb_hw3: torch.Tensor = (target - 0.1).clamp(0.0, 1.0)
+        scalar_hw1: torch.Tensor = torch.ones((16, 16, 1))
+        normal_hw3: torch.Tensor = torch.zeros((16, 16, 3))
+        return RenderOutput(
+            rgb_hw3=rgb_hw3,
+            alpha_hw1=scalar_hw1,
+            center_depth_hw1=scalar_hw1,
+            plane_features_hw4=torch.zeros((16, 16, 4)),
+            surface_depth_hw1=scalar_hw1,
+            surface_valid_hw1=scalar_hw1.to(torch.bool),
+            direct_normal_hw3=normal_hw3,
+            depth_normal_hw3=normal_hw3,
+            background_3=torch.zeros(3),
+            appearance_info={},
+        )
+
+    monkeypatch.setattr("gauss_surf.train_gsplat.evaluation.render_splats", fake_render)
+    monkeypatch.setattr(
+        "gauss_surf.train_gsplat.evaluation.structural_similarity_index_measure",
+        lambda *_args, **_kwargs: torch.tensor(0.75),
+    )
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda _device: None)
+
+    metrics: dict[str, float] = evaluate_holdout({"means": torch.zeros((1, 3))}, cache)
+
+    assert np.isfinite(metrics["psnr"])
+    assert metrics["ssim"] == 0.75

--- a/packages/gauss-surf/tests/test_gsplat_cache_parity.py
+++ b/packages/gauss-surf/tests/test_gsplat_cache_parity.py
@@ -1,0 +1,27 @@
+"""One-off full catalog-cache parity gate for the direct trainer."""
+
+import os
+from pathlib import Path
+
+import pytest
+import torch
+
+from gauss_surf.catalog import SegmentReader
+from gauss_surf.train_gsplat.cache import compare_cache_to_bundle, load_gpu_cache
+
+
+@pytest.mark.skipif(os.environ.get("GAUSS_SURF_RUN_CACHE_PARITY") != "1", reason="requires the live catalog and a large CUDA cache")
+def test_catalog_gpu_cache_is_pixel_identical_to_part10_bundle() -> None:
+    """Compare every RGB, depth, and normal value for both camera streams."""
+    root: Path = Path(__file__).parents[1]
+    bundle_dir: Path = root / "data/training_bundle_part10/47115416"
+    reader: SegmentReader = SegmentReader.open("rerun+http://127.0.0.1:51236", "part8-band", "47115416")
+
+    cache = load_gpu_cache(reader, bundle_dir, torch.device("cuda"))
+    parity = compare_cache_to_bundle(cache, bundle_dir)
+
+    assert len(cache.cameras) == 1_302
+    assert len(cache.holdout_indices) == 81
+    assert len(cache.train_indices) == 1_221
+    assert parity.mismatch_count == 0, parity.mismatched_values
+    print({"compared_values": parity.compared_values, "mismatched_values": parity.mismatched_values})

--- a/packages/gauss-surf/tests/test_gsplat_port_contracts.py
+++ b/packages/gauss-surf/tests/test_gsplat_port_contracts.py
@@ -1,0 +1,211 @@
+"""CPU-only recipe and metric oracles for the direct-gsplat port."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from pathlib import Path
+
+import torch
+
+from gauss_surf.train_gsplat.core import per_frame_average_psnr
+
+PART6_REFINE_STEPS: tuple[int, ...] = (
+    1_000,
+    1_100,
+    1_200,
+    1_300,
+    1_400,
+    1_500,
+    1_600,
+    1_700,
+    1_800,
+    1_900,
+    2_000,
+    2_100,
+    2_200,
+    2_300,
+    2_400,
+    2_500,
+    2_600,
+    2_700,
+    2_800,
+    2_900,
+    4_000,
+    4_100,
+    4_200,
+    4_300,
+    4_400,
+    4_500,
+    4_600,
+    4_700,
+    4_800,
+    4_900,
+    5_000,
+    5_100,
+    5_200,
+    5_300,
+    5_400,
+)
+"""All 35 actual split/duplicate steps printed by the Part 6 run."""
+
+PART10_REFINE_STEPS: tuple[int, ...] = (
+    1_400,
+    1_500,
+    1_600,
+    1_700,
+    1_800,
+    1_900,
+    2_000,
+    2_100,
+    2_200,
+    2_300,
+    2_400,
+    2_500,
+    2_600,
+    2_700,
+    2_800,
+    2_900,
+    4_400,
+    4_500,
+    4_600,
+    4_700,
+    4_800,
+    4_900,
+    5_000,
+    5_100,
+    5_200,
+    5_300,
+    5_400,
+)
+"""The 27 refinements printed by both real 1,221-image reference runs."""
+
+
+def _part10_should_refine(step: int, *, num_train_data: int) -> bool:
+    """Return the integer-only Part 10 refinement predicate."""
+    warmup_length: int = 500
+    refine_every: int = 100
+    reset_every: int = 3_000
+    refine_stop: int = 5_500
+    pause_refine_after_reset: int = num_train_data + refine_every
+    return (
+        step > warmup_length
+        and step < refine_stop
+        and step % refine_every == 0
+        and step % reset_every >= pause_refine_after_reset
+    )
+
+
+def _downscale_factor(step: int) -> int:
+    """Return the historical quarter-to-half-to-full resolution factor."""
+    return 2 ** max(2 - step // 3_000, 0)
+
+
+def _sh_degree(step: int) -> int:
+    """Return the historical progressive spherical-harmonic degree."""
+    return min(step // 1_000, 3)
+
+
+def test_part6_training_log_contains_the_exact_35_refinement_steps() -> None:
+    """The checked-in real run, not a reconstructed config, owns this golden."""
+    training_log: Path = (
+        Path(__file__).parents[1]
+        / "data/splat_runs/47115416-gaussurf/gaussurf-arkit/part6/training.log"
+    )
+    refine_pattern: re.Pattern[str] = re.compile(
+        r"^Step (\d+): \d+ GSs duplicated, \d+ GSs split\.", re.MULTILINE
+    )
+
+    parsed_steps: tuple[int, ...] = tuple(
+        int(match) for match in refine_pattern.findall(training_log.read_text())
+    )
+
+    assert parsed_steps == PART6_REFINE_STEPS
+    assert len(parsed_steps) == 35
+
+
+def test_part10_and_part8_0b_logs_contain_the_same_27_refinement_steps() -> None:
+    """The two real reference runs, not reconstructed config, own the golden."""
+    run_root: Path = Path(__file__).parents[1] / "data/splat_runs/47115416-gaussurf/gaussurf-arkit"
+    refine_pattern: re.Pattern[str] = re.compile(
+        r"^Step (\d+): \d+ GSs duplicated, \d+ GSs split\.", re.MULTILINE
+    )
+
+    parsed_by_run: dict[str, tuple[int, ...]] = {
+        run_name: tuple(int(match) for match in refine_pattern.findall((run_root / run_name / "training.log").read_text()))
+        for run_name in ("part10", "part8-0b")
+    }
+
+    assert parsed_by_run == {"part10": PART10_REFINE_STEPS, "part8-0b": PART10_REFINE_STEPS}
+
+
+def test_part10_pause_after_reset_is_derived_from_train_frame_count() -> None:
+    """Use all train images, correcting the old wide-only 570-image contract.
+
+    Both `part10/training.log` and `part8-0b/training.log` print the same 27
+    refinement events at 1400–2900 and 4400–5400. The prior 670-step pause
+    predicted 41 events and therefore contradicted both empirical logs.
+    """
+    transforms_path: Path = Path(__file__).parents[1] / "data/training_bundle_part10/47115416/transforms.json"
+    transforms: dict[str, object] = json.loads(transforms_path.read_text(encoding="utf-8"))
+    frames: list[dict[str, object]] = transforms["frames"]  # type: ignore[assignment]
+    chosen_frames: int = len(frames)
+    holdout_frames: int = sum(bool(frame["holdout"]) for frame in frames)
+    num_train_data: int = chosen_frames - holdout_frames
+    refine_every: int = 100
+    pause_refine_after_reset: int = num_train_data + refine_every
+
+    assert chosen_frames == 1_302
+    assert holdout_frames == 81
+    assert num_train_data == 1_221
+    assert pause_refine_after_reset == 1_321
+    assert pause_refine_after_reset != 0
+    assert tuple(step for step in range(7_000) if _part10_should_refine(step, num_train_data=num_train_data)) == PART10_REFINE_STEPS
+
+
+def test_progressive_resolution_boundaries_are_exact() -> None:
+    """Training is quarter scale before 3000, half before 6000, then full."""
+    boundary_steps: tuple[int, ...] = (0, 2_999, 3_000, 5_999, 6_000, 6_999)
+
+    factors: tuple[int, ...] = tuple(_downscale_factor(step) for step in boundary_steps)
+
+    assert factors == (4, 4, 2, 2, 1, 1)
+
+
+def test_spherical_harmonic_degree_progression_boundaries_are_exact() -> None:
+    """SH degree rises at 1000, 2000, and 3000, then remains at degree three."""
+    boundary_steps: tuple[int, ...] = (0, 999, 1_000, 1_999, 2_000, 2_999, 3_000, 6_999)
+
+    degrees: tuple[int, ...] = tuple(_sh_degree(step) for step in boundary_steps)
+
+    assert degrees == (0, 0, 1, 1, 2, 2, 3, 3)
+
+
+def test_psnr_is_averaged_per_frame_not_computed_from_pooled_mse() -> None:
+    """Pin the accepted metric definition on synthetic images.
+
+    Full checkpoint parity against ``evaluation.json`` belongs to migration
+    stage 1. This pre-port oracle pins only the formula, including a case where
+    averaging frame PSNR and converting pooled MSE differ by much more than
+    0.1 dB.
+    """
+    prediction_nchw: torch.Tensor = torch.zeros(
+        (2, 1, 2, 2), dtype=torch.float64, device="cpu"
+    )
+    target_nchw: torch.Tensor = torch.stack(
+        (
+            torch.full((1, 2, 2), 0.1, dtype=torch.float64, device="cpu"),
+            torch.full((1, 2, 2), 0.5, dtype=torch.float64, device="cpu"),
+        )
+    )
+
+    per_frame_psnr: torch.Tensor = per_frame_average_psnr(
+        prediction_nchw, target_nchw
+    )
+    pooled_mse: torch.Tensor = (prediction_nchw - target_nchw).square().mean()
+    pooled_psnr: torch.Tensor = -10.0 * torch.log10(pooled_mse)
+
+    assert math.isclose(per_frame_psnr.item(), 13.010299956639813, abs_tol=1e-12)
+    assert math.isclose(pooled_psnr.item(), 8.860566476931632, abs_tol=1e-12)
+    assert abs(per_frame_psnr.item() - pooled_psnr.item()) >= 0.1

--- a/packages/gauss-surf/tests/test_gsplat_port_schedules.py
+++ b/packages/gauss-surf/tests/test_gsplat_port_schedules.py
@@ -1,0 +1,96 @@
+"""Schedule tests shared by the version-control and direct-gsplat stages."""
+
+from gauss_surf.apis.train_gsplat import Config
+from gauss_surf.gsplat_schedule import (
+    downscale_factor,
+    opacity_reset_callback_step,
+    sh_degree,
+    should_refine,
+    should_reset_opacity,
+)
+
+EXPECTED_REFINE_STEPS: tuple[int, ...] = (
+    1_400,
+    1_500,
+    1_600,
+    1_700,
+    1_800,
+    1_900,
+    2_000,
+    2_100,
+    2_200,
+    2_300,
+    2_400,
+    2_500,
+    2_600,
+    2_700,
+    2_800,
+    2_900,
+    4_400,
+    4_500,
+    4_600,
+    4_700,
+    4_800,
+    4_900,
+    5_000,
+    5_100,
+    5_200,
+    5_300,
+    5_400,
+)
+
+
+def test_production_trainer_keeps_opacity_reset_gated_off() -> None:
+    """Stage 2 remains selectable, but the production port keeps reset off."""
+    assert Config(video_id="segment").opacity_reset_every == 1_000_000_000
+
+
+def test_opacity_reset_gate_preserves_the_refinement_cycle() -> None:
+    """Only the fixed gsplat reset branch is bypassed at historical reset steps."""
+    callback_steps: tuple[int, ...] = tuple(
+        opacity_reset_callback_step(
+            step=step,
+            refinement_cycle_every=3_000,
+            opacity_reset_every=1_000_000_000,
+        )
+        for step in (2_999, 3_000, 3_001, 6_000)
+    )
+
+    assert callback_steps == (2_999, 3_001, 3_001, 6_001)
+
+
+def test_direct_trainer_refinement_steps_match_the_golden() -> None:
+    """The public predicate derives its pause from all 1,221 training images."""
+    actual_steps: tuple[int, ...] = tuple(
+        step
+        for step in range(7_000)
+        if should_refine(
+            step=step,
+            num_train_frames=1_221,
+            refine_every=100,
+            reset_every=3_000,
+            refine_start=500,
+            refine_stop=5_500,
+        )
+    )
+
+    assert actual_steps == EXPECTED_REFINE_STEPS
+
+
+def test_fixed_opacity_reset_stops_with_refinement() -> None:
+    """Match installed gsplat 1.6: step 3000 resets, but step 6000 is past refine stop."""
+    actual_steps: tuple[int, ...] = tuple(
+        step
+        for step in range(7_000)
+        if should_reset_opacity(step=step, reset_every=3_000, refine_stop=5_500)
+    )
+
+    assert actual_steps == (3_000,)
+
+
+def test_direct_trainer_resolution_and_sh_boundaries_match_the_goldens() -> None:
+    """Progressive resolution and SH degree change at exact iteration boundaries."""
+    boundary_steps: tuple[int, ...] = (0, 999, 1_000, 1_999, 2_000, 2_999, 3_000, 5_999, 6_000, 6_999)
+
+    assert tuple(downscale_factor(step) for step in boundary_steps) == (4, 4, 4, 4, 4, 4, 2, 2, 1, 1)
+    assert tuple(sh_degree(step) for step in boundary_steps) == (0, 0, 1, 1, 2, 2, 3, 3, 3, 3)

--- a/packages/gauss-surf/tests/test_gsplat_trainer.py
+++ b/packages/gauss-surf/tests/test_gsplat_trainer.py
@@ -1,0 +1,319 @@
+"""CPU contracts for the direct gsplat trainer."""
+
+import json
+import os
+from pathlib import Path
+from typing import cast
+
+import numpy as np
+import pytest
+import torch
+from hypothesis import given
+from hypothesis import strategies as st
+
+from gauss_surf.apis.train_gsplat import Config
+from gauss_surf.train_gsplat.cache import load_training_cameras, scene_scale_from_camera_poses
+from gauss_surf.train_gsplat.core import (
+    decode_normal_uint8,
+    holdout_hash,
+    median_scale_regularization,
+    opacity_export_mask,
+    per_frame_average_psnr,
+    positive_neighbor_distances,
+    save_checkpoint,
+)
+from gauss_surf.train_gsplat.publish import metric_splats_from_live, quantize_depth_m_to_mm, quantize_normal_to_uint8
+from gauss_surf.train_gsplat.renderer import fill_depth_holes, render_splats, render_splats_two_call
+from gauss_surf.train_gsplat.trainer import camera_sample_indices, metric_training_constants, read_metric_seed, select_training_renderer
+
+
+def test_training_renderer_defaults_to_accepted_two_call_path() -> None:
+    """Fused training needs an explicit quality-round opt-in."""
+    config = Config(video_id="segment")
+
+    assert config.dataset_name == "arkitscenes-v2"
+    assert config.bundle_dir is None
+    assert config.timestamp == "run"
+    assert (config.splat_output_dir, config.depth_output_dir, config.triage_output_dir) == (
+        Path("data/splat"),
+        Path("data/splat_depth"),
+        Path("data/splat_triage"),
+    )
+    assert config.fused_training is False
+    assert select_training_renderer(fused_training=config.fused_training) is render_splats_two_call
+    assert select_training_renderer(fused_training=True) is render_splats
+
+
+@given(scene_scale=st.sampled_from((0.25, 0.5, 1.0, 2.0, 4.0, 8.0)))
+def test_metric_training_constants_preserve_weighted_depth_scale(scene_scale: float) -> None:
+    """Metric depth scales by S, so dividing its weight by S preserves loss."""
+    constants = metric_training_constants(scene_scale)
+    normalized_depth_error: torch.Tensor = torch.tensor(0.375, dtype=torch.float64)
+    metric_depth_error: torch.Tensor = normalized_depth_error * scene_scale
+
+    assert constants.means_lr == 1.6e-4 * scene_scale
+    assert constants.means_lr_final == 1.6e-6 * scene_scale
+    assert constants.depth_regularization_weight == 3.2 / scene_scale
+    assert constants.flat_regularization_weight == 1.0 / scene_scale
+    assert torch.equal(
+        metric_depth_error * constants.depth_regularization_weight,
+        normalized_depth_error * 3.2,
+    )
+
+
+def test_training_cameras_keep_metric_centers_and_reproduce_applied_scale(tmp_path: Path) -> None:
+    """Metric cameras stay unchanged while scale follows centered pose axes."""
+    centers_n3: np.ndarray = np.asarray(((0.0, 0.0, 0.0), (2.0, 0.0, 0.0), (0.0, 4.0, 0.0)), dtype=np.float32)
+    frames: list[dict[str, object]] = []
+    for index, center_3 in enumerate(centers_n3):
+        world_from_camera_44: np.ndarray = np.eye(4, dtype=np.float32)
+        world_from_camera_44[:3, 3] = center_3
+        frames.append(
+            {
+                "file_path": f"images/wide_{index:06d}.png",
+                "camera": "wide",
+                "holdout": index == 2,
+                "timestamp_ns": index,
+                "fl_x": 100.0,
+                "fl_y": 100.0,
+                "cx": 10.0,
+                "cy": 10.0,
+                "w": 20,
+                "h": 20,
+                "transform_matrix": world_from_camera_44.tolist(),
+            }
+        )
+    (tmp_path / "transforms.json").write_text(json.dumps({"frames": frames}), encoding="utf-8")
+
+    cameras, scene_scale = load_training_cameras(tmp_path)
+    recovered_centers_n3: torch.Tensor = torch.stack(
+        tuple(torch.linalg.inv(camera.viewmat_44)[:3, 3] for camera in cameras)
+    )
+
+    torch.testing.assert_close(recovered_centers_n3, torch.from_numpy(centers_n3))
+    np.testing.assert_allclose(scene_scale, np.float32(8.0 / 3.0), rtol=0.0, atol=2.0 * np.finfo(np.float32).eps)
+
+
+def test_part10_scene_scale_is_inverse_of_saved_applied_scale() -> None:
+    """The local formula reproduces the historical float32 parser artifact."""
+    package_root: Path = Path(__file__).parents[1]
+    bundle_dir: Path = package_root / "data/training_bundle_part10/47115416"
+    transform_path: Path = package_root / "data/splat_runs/47115416-gaussurf/gaussurf-arkit/part10/dataparser_transforms.json"
+    artifact: dict[str, object] = json.loads(transform_path.read_text(encoding="utf-8"))
+
+    _cameras, scene_scale = load_training_cameras(bundle_dir)
+    expected_scene_scale: float = 1.0 / float(artifact["scale"])
+
+    assert np.float32(scene_scale) == np.float32(expected_scene_scale)
+
+
+def test_scene_scale_is_translation_invariant() -> None:
+    """A common world translation cannot change the automatic scene scale."""
+    poses_n44: torch.Tensor = torch.eye(4, dtype=torch.float32).repeat(3, 1, 1)
+    poses_n44[:, :3, 3] = torch.tensor(((0.0, 0.0, 0.0), (2.0, 0.0, 0.0), (0.0, 4.0, 0.0)))
+    translated_poses_n44: torch.Tensor = poses_n44.clone()
+    translated_poses_n44[:, :3, 3] += torch.tensor((17.0, -11.0, 5.0))
+
+    np.testing.assert_allclose(
+        scene_scale_from_camera_poses(poses_n44),
+        scene_scale_from_camera_poses(translated_poses_n44),
+        rtol=0.0,
+        atol=4.0 * np.finfo(np.float32).eps,
+    )
+
+
+def test_metric_seed_loader_preserves_world_coordinates(tmp_path: Path) -> None:
+    """Seed vertices are already metric and need no dataparser transform."""
+    seed_path: Path = tmp_path / "seed.ply"
+    seed_path.write_text(
+        "ply\n"
+        "format ascii 1.0\n"
+        "element vertex 2\n"
+        "property float x\nproperty float y\nproperty float z\n"
+        "property uchar red\nproperty uchar green\nproperty uchar blue\n"
+        "end_header\n"
+        "1.0 2.0 3.0 255 0 128\n"
+        "-4.0 5.0 6.0 0 255 64\n",
+        encoding="ascii",
+    )
+
+    points_n3, colors_n3 = read_metric_seed(seed_path)
+
+    assert np.array_equal(points_n3, np.asarray(((1.0, 2.0, 3.0), (-4.0, 5.0, 6.0)), dtype=np.float32))
+    assert np.array_equal(colors_n3, np.asarray(((1.0, 0.0, 128.0 / 255.0), (0.0, 1.0, 64.0 / 255.0)), dtype=np.float32))
+
+
+def test_camera_sample_indices_match_accepted_seeded_shuffled_epochs() -> None:
+    """Every camera appears once per epoch in the accepted seed-42 order."""
+    sampled_indices: tuple[int, ...] = camera_sample_indices(num_train_data=5, iteration_count=12, seed=42)
+
+    assert sampled_indices == (3, 1, 2, 4, 0, 3, 2, 0, 4, 1, 3, 1)
+    assert sorted(sampled_indices[:5]) == list(range(5))
+    assert sorted(sampled_indices[5:10]) == list(range(5))
+
+
+def test_normal_dequantization_restores_central_code_to_exact_zero() -> None:
+    """Code 128 denotes signed zero, not the affine inverse 1/255."""
+    encoded: torch.Tensor = torch.tensor([0, 127, 128, 129, 255], dtype=torch.uint8)
+
+    decoded: torch.Tensor = decode_normal_uint8(encoded)
+
+    assert torch.equal(decoded[2], torch.tensor(0.0))
+    assert torch.allclose(decoded, torch.tensor([-1.0, -1.0 / 255.0, 0.0, 3.0 / 255.0, 1.0]))
+
+
+def test_psnr_averages_frame_scores_instead_of_pooling_mse() -> None:
+    """Match the accepted evaluation on unequal per-frame errors."""
+    prediction: torch.Tensor = torch.zeros((2, 2, 2, 1), dtype=torch.float64)
+    target: torch.Tensor = torch.stack(
+        (
+            torch.full((2, 2, 1), 0.1, dtype=torch.float64),
+            torch.full((2, 2, 1), 0.5, dtype=torch.float64),
+        )
+    )
+
+    psnr: torch.Tensor = per_frame_average_psnr(prediction, target)
+
+    assert torch.isclose(psnr, torch.tensor(13.010299956639813, dtype=torch.float64), atol=1e-12, rtol=0.0)
+
+
+def test_holdout_hash_is_order_sensitive_and_stable() -> None:
+    """The split fingerprint changes if frame identity or order changes."""
+    assert holdout_hash(("wide_000007", "wide_000015")) == "10447155eb2b0d40b728e256bcabfb9c918c7fea9741587e91248c30de8cdcde"
+    assert holdout_hash(("wide_000015", "wide_000007")) != holdout_hash(("wide_000007", "wide_000015"))
+
+
+def test_export_filter_uses_the_required_one_over_255_threshold() -> None:
+    """The exporter keeps exact-threshold opacity and drops only lower values."""
+    threshold: float = torch.logit(torch.tensor(1.0 / 255.0)).item()
+    logits: torch.Tensor = torch.tensor([threshold - 1e-4, threshold, threshold + 1e-4])
+
+    assert torch.equal(opacity_export_mask(logits), torch.tensor([False, True, True]))
+
+
+def test_checkpoint_loads_with_weights_only(tmp_path: Path) -> None:
+    """Direct checkpoints contain tensors and primitive metadata only."""
+    checkpoint_path: Path = tmp_path / "step-000000001.pt"
+    splats = torch.nn.ParameterDict({"means": torch.nn.Parameter(torch.ones((2, 3)))})
+
+    save_checkpoint(checkpoint_path, step=1, splats=splats, metadata={"seed": 42})
+    payload: dict[str, object] = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
+
+    assert payload["step"] == 1
+    assert payload["metadata"] == {"seed": 42}
+    assert torch.equal(payload["splats"]["means"], torch.ones((2, 3)))  # type: ignore[index]
+
+
+def test_scale_regularization_ignores_only_all_zero_duplicate_seeds() -> None:
+    """Four duplicate mesh seeds must not turn the first geometry step into NaN."""
+    log_scales: torch.Tensor = torch.tensor(
+        [[float("-inf"), float("-inf"), float("-inf")], [0.0, 0.0, torch.log(torch.tensor(3.0)).item()]]
+    )
+
+    loss: torch.Tensor = median_scale_regularization(log_scales, maximum_ratio=2.0)
+
+    assert torch.isfinite(loss)
+    assert torch.equal(loss, torch.tensor(0.5))
+
+
+def test_duplicate_seed_neighbor_distance_uses_smallest_observed_positive_value() -> None:
+    """Duplicate mesh vertices keep finite log-scales without changing seed count."""
+    distances: np.ndarray = np.asarray([[0.0], [2e-7], [5e-7]], dtype=np.float32)
+
+    repaired: np.ndarray = positive_neighbor_distances(distances)
+
+    assert np.array_equal(repaired, np.asarray([[2e-7], [2e-7], [5e-7]], dtype=np.float32))
+
+
+def test_auxiliary_center_depth_fills_zero_alpha_holes_with_detached_maximum() -> None:
+    """Keep Splatfacto's ED postprocessing without using ED as surface depth."""
+    depth: torch.Tensor = torch.tensor([[[1.0], [2.0]], [[3.0], [4.0]]], requires_grad=True)
+    alpha: torch.Tensor = torch.tensor([[[1.0], [0.0]], [[0.5], [0.0]]])
+
+    filled: torch.Tensor = fill_depth_holes(depth, alpha)
+    filled.sum().backward()
+
+    assert torch.equal(filled, torch.tensor([[[1.0], [4.0]], [[3.0], [4.0]]]))
+    assert torch.equal(depth.grad, torch.tensor([[[1.0], [0.0]], [[1.0], [0.0]]]))
+
+
+def test_publish_quantization_matches_depth_and_normal_storage_contracts() -> None:
+    """GPU-side product quantization preserves sentinels, rounding, and saturation."""
+    depth_m_hw: torch.Tensor = torch.tensor(
+        [[float("nan"), -1.0, 0.0, 1.2344, 1.2346, 70.0]], dtype=torch.float32
+    )
+    normals_hw3: torch.Tensor = torch.tensor(
+        [[[-1.0, -1.0 / 255.0, 0.0], [3.0 / 255.0, 1.0, 0.0]]], dtype=torch.float32
+    )
+
+    depth_mm_hw: torch.Tensor = quantize_depth_m_to_mm(depth_m_hw)
+    normal_rgb_hw3: torch.Tensor = quantize_normal_to_uint8(normals_hw3)
+
+    assert depth_mm_hw.dtype == torch.uint16
+    assert torch.equal(depth_mm_hw, torch.tensor([[0, 0, 0, 1234, 1235, 65535]], dtype=torch.uint16))
+    assert normal_rgb_hw3.dtype == torch.uint8
+    assert torch.equal(normal_rgb_hw3, torch.tensor([[[0, 127, 128], [129, 255, 128]]], dtype=torch.uint8))
+
+
+def test_live_metric_splats_need_no_parent_coordinate_transform() -> None:
+    """In-process splat publication preserves metric centers and natural values."""
+    splats: dict[str, torch.Tensor] = {
+        "means": torch.tensor([[1.0, 2.0, 3.0]]),
+        "scales": torch.log(torch.tensor([[1.0, 2.0, 3.0]])),
+        "quats": torch.tensor([[1.0, 0.0, 0.0, 0.0]]),
+        "opacities": torch.tensor([[0.0]]),
+        "sh0": torch.zeros((1, 1, 3)),
+        "shN": torch.zeros((1, 15, 3)),
+    }
+
+    published = metric_splats_from_live(splats)
+
+    assert np.array_equal(published.centers_n3, np.asarray([[1.0, 2.0, 3.0]], dtype=np.float32))
+    assert np.array_equal(published.scales_n3, np.asarray([[1.0, 2.0, 3.0]], dtype=np.float32))
+    assert np.array_equal(published.quaternions_xyzw_n4, np.asarray([[0.0, 0.0, 0.0, 1.0]], dtype=np.float32))
+    assert np.array_equal(published.colors_rgba_n4, np.asarray([[128, 128, 128, 128]], dtype=np.uint8))
+
+
+@pytest.mark.skipif(
+    os.environ.get("GAUSS_SURF_RUN_FUSED_PARITY") != "1" or not torch.cuda.is_available(),
+    reason="requires CUDA and the accepted Stage-3b checkpoint",
+)
+def test_fused_raster_matches_two_call_reference_on_trained_scene() -> None:
+    """One 8-channel pass preserves RGB and raw plane channels within atomics noise."""
+    package_root: Path = Path(__file__).parents[1]
+    bundle_dir: Path = package_root / "data/training_bundle_part10/47115416"
+    checkpoint_path: Path = (
+        package_root
+        / "data/splat_runs/47115416-gaussurf/gsplat-direct/part8-stage3b/checkpoints/step-000006999.pt"
+    )
+    checkpoint: dict[str, object] = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
+    saved_splats: dict[str, torch.Tensor] = cast(dict[str, torch.Tensor], checkpoint["splats"])
+    device: torch.device = torch.device("cuda")
+    splats: dict[str, torch.Tensor] = {name: value.to(device) for name, value in saved_splats.items()}
+    cameras, _scene_scale = load_training_cameras(bundle_dir)
+    camera = cameras[len(cameras) // 2]
+    background_3: torch.Tensor = torch.tensor((0.1490, 0.1647, 0.2157), dtype=torch.float32, device=device)
+
+    with torch.inference_mode():
+        reference = render_splats_two_call(
+            splats,
+            camera,
+            downscale=4,
+            sh_degree=2,
+            background_3=background_3,
+            absgrad=False,
+        )
+        fused = render_splats(
+            splats,
+            camera,
+            downscale=4,
+            sh_degree=2,
+            background_3=background_3,
+            absgrad=False,
+        )
+
+    rgb_max_abs: float = float((fused.rgb_hw3 - reference.rgb_hw3).abs().max().item())
+    plane_max_abs: float = float((fused.plane_features_hw4 - reference.plane_features_hw4).abs().max().item())
+    print({"rgb_max_abs": rgb_max_abs, "plane_max_abs": plane_max_abs})
+    torch.testing.assert_close(fused.rgb_hw3, reference.rgb_hw3, rtol=2e-5, atol=2e-5)
+    torch.testing.assert_close(fused.plane_features_hw4, reference.plane_features_hw4, rtol=2e-5, atol=2e-5)

--- a/packages/gauss-surf/tests/test_layer_metrics.py
+++ b/packages/gauss-surf/tests/test_layer_metrics.py
@@ -1,0 +1,59 @@
+"""Behavior contracts for fused-publication error metrics."""
+
+import numpy as np
+from jaxtyping import Bool, Float32, UInt8
+from numpy import ndarray
+
+from gauss_surf.train_gsplat.layer_metrics import TriageErrors, angular_error_degrees, colorize_error, compute_triage_errors, viridis_like
+
+
+def test_viridis_like_has_stable_endpoints() -> None:
+    values_n: Float32[ndarray, "n=2"] = np.asarray([0.0, 1.0], dtype=np.float32)
+
+    colors_n3: UInt8[ndarray, "n=2 3"] = viridis_like(values_n)
+
+    np.testing.assert_array_equal(colors_n3[0], [68, 1, 84])
+    np.testing.assert_array_equal(colors_n3[1], [253, 231, 37])
+
+
+def test_angular_error_is_zero_for_identical_and_ninety_for_orthogonal() -> None:
+    first_hw3: Float32[ndarray, "h=1 w=2 3"] = np.asarray([[[0.0, 0.0, 1.0], [1.0, 0.0, 0.0]]], dtype=np.float32)
+    second_hw3: Float32[ndarray, "h=1 w=2 3"] = np.asarray([[[0.0, 0.0, 1.0], [0.0, 1.0, 0.0]]], dtype=np.float32)
+
+    result: tuple[Float32[ndarray, "h=1 w=2"], Bool[ndarray, "h=1 w=2"]] = angular_error_degrees(first_hw3, second_hw3)
+    error_degrees_hw: Float32[ndarray, "h=1 w=2"] = result[0]
+    valid_hw: Bool[ndarray, "h=1 w=2"] = result[1]
+
+    np.testing.assert_allclose(error_degrees_hw, [[0.0, 90.0]], atol=1e-5)
+    np.testing.assert_array_equal(valid_hw, True)
+
+
+def test_error_maps_are_black_outside_each_validity_mask() -> None:
+    source_rgb_hw3: UInt8[ndarray, "h=1 w=2 3"] = np.asarray([[[255, 255, 255], [255, 255, 255]]], dtype=np.uint8)
+    splat_rgb_hw3: UInt8[ndarray, "h=1 w=2 3"] = np.zeros((1, 2, 3), dtype=np.uint8)
+    splat_depth_m_hw: Float32[ndarray, "h=1 w=2"] = np.asarray([[1.0, 0.0]], dtype=np.float32)
+    mesh_depth_m_hw: Float32[ndarray, "h=1 w=2"] = np.asarray([[1.5, 1.0]], dtype=np.float32)
+    splat_normal_hw3: Float32[ndarray, "h=1 w=2 3"] = np.asarray([[[0.0, 0.0, 1.0], [0.0, 0.0, 0.0]]], dtype=np.float32)
+    moge_normal_hw3: Float32[ndarray, "h=1 w=2 3"] = np.asarray([[[0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], dtype=np.float32)
+
+    errors: TriageErrors = compute_triage_errors(
+        source_rgb_hw3, splat_rgb_hw3, mesh_depth_m_hw, splat_depth_m_hw, moge_normal_hw3, splat_normal_hw3
+    )
+
+    for error_map_hw3 in (errors.rgb_map_hw3, errors.depth_map_hw3, errors.normal_map_hw3):
+        np.testing.assert_array_equal(error_map_hw3[0, 1], [0, 0, 0])
+        assert np.any(error_map_hw3[0, 0] != 0)
+    assert errors.rgb_mean == 1.0
+    assert errors.depth_mean_m == 0.5
+    assert errors.normal_mean_degrees == 90.0
+
+
+def test_colorize_error_clips_scale_and_masks_invalid_pixels() -> None:
+    error_hw: Float32[ndarray, "h=1 w=3"] = np.asarray([[0.0, 0.5, 2.0]], dtype=np.float32)
+    valid_hw: Bool[ndarray, "h=1 w=3"] = np.asarray([[True, False, True]], dtype=np.bool_)
+
+    color_hw3: UInt8[ndarray, "h=1 w=3 3"] = colorize_error(error_hw, valid_hw, maximum=1.0)
+
+    np.testing.assert_array_equal(color_hw3[0, 0], [68, 1, 84])
+    np.testing.assert_array_equal(color_hw3[0, 1], [0, 0, 0])
+    np.testing.assert_array_equal(color_hw3[0, 2], [253, 231, 37])

--- a/packages/gauss-surf/tests/test_moge_normals.py
+++ b/packages/gauss-surf/tests/test_moge_normals.py
@@ -1,0 +1,182 @@
+"""Behavior checks for chosen-frame MoGe normal inference."""
+
+import numpy as np
+import pytest
+import torch
+from arkitscenes_download.ingest.paths import FRAME_SELECTION_WIDE
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from hypothesis.strategies import DrawFn
+from jaxtyping import Float32, Int64, UInt8
+from numpy import ndarray
+from torch import Tensor
+
+from gauss_surf.catalog import match_exact_timestamps
+from gauss_surf.contracts import WIDE_CHOSEN_SHARPNESS_COLUMN
+from gauss_surf.normals_encoding import decode_normals_png, encode_normals_png
+
+requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+
+@st.composite
+def exact_timestamp_cases(
+    draw: DrawFn,
+) -> tuple[ndarray, ndarray, ndarray]:
+    """Generate a sorted packet timeline and a permuted exact target subset."""
+    packet_values: list[int] = sorted(
+        draw(
+            st.lists(
+                st.integers(-1_000_000_000, 1_000_000_000),
+                min_size=1,
+                max_size=20,
+                unique=True,
+            )
+        )
+    )
+    target_indices: list[int] = draw(
+        st.lists(
+            st.integers(0, len(packet_values) - 1),
+            min_size=1,
+            max_size=len(packet_values),
+            unique=True,
+        )
+    )
+    permuted_indices: list[int] = list(draw(st.permutations(target_indices)))
+    packet_times_n: ndarray = np.asarray(packet_values, dtype=np.int64).astype(
+        "timedelta64[ns]"
+    )
+    target_times_n: ndarray = packet_times_n[permuted_indices]
+    expected_indices_n: ndarray = np.asarray(permuted_indices, dtype=np.int64)
+    return packet_times_n, target_times_n, expected_indices_n
+
+
+@st.composite
+def drift_timestamp_cases(draw: DrawFn) -> tuple[ndarray, ndarray, ndarray]:
+    """Generate one exact timestamp and an absent one-nanosecond neighbor."""
+    start: int = draw(st.integers(-1_000_000_000, 1_000_000_000))
+    gaps: list[int] = draw(
+        st.lists(st.integers(3, 1_000_000), min_size=1, max_size=16)
+    )
+    packet_values: list[int] = [start]
+    for gap in gaps:
+        packet_values.append(packet_values[-1] + gap)
+    chosen_index: int = draw(st.integers(0, len(packet_values) - 1))
+    drift_ns: int = draw(st.sampled_from((-1, 1)))
+    packet_times_n: ndarray = np.asarray(packet_values, dtype=np.int64).astype(
+        "timedelta64[ns]"
+    )
+    target_times_n: ndarray = packet_times_n[[chosen_index]]
+    drifted_times_n: ndarray = (
+        target_times_n.astype(np.int64) + drift_ns
+    ).astype("timedelta64[ns]")
+    return packet_times_n, target_times_n, drifted_times_n
+
+
+@settings(max_examples=64, deadline=None)
+@given(case=exact_timestamp_cases())
+def test_exact_timestamp_matching_is_invariant_to_target_permutation(
+    case: tuple[ndarray, ndarray, ndarray],
+) -> None:
+    """Target order changes output order only; packet identities remain exact."""
+    packet_times_n: ndarray = case[0]
+    target_times_n: ndarray = case[1]
+    expected_indices_n: ndarray = case[2]
+
+    matched_indices_n: ndarray = match_exact_timestamps(
+        packet_times_n, target_times_n
+    )
+
+    np.testing.assert_array_equal(matched_indices_n, expected_indices_n)
+
+
+@settings(max_examples=32, deadline=None)
+@given(
+    packet_values=st.lists(
+        st.integers(-1_000_000_000, 1_000_000_000),
+        min_size=2,
+        max_size=20,
+        unique=True,
+    )
+)
+def test_exact_timestamp_matching_rejects_an_unsorted_packet_timeline(
+    packet_values: list[int],
+) -> None:
+    """Binary-search matching refuses packet timelines that are not sorted."""
+    descending_values: list[int] = sorted(packet_values, reverse=True)
+    packet_times_n: ndarray = np.asarray(
+        descending_values, dtype=np.int64
+    ).astype("timedelta64[ns]")
+    target_times_n: ndarray = packet_times_n[:1]
+
+    with pytest.raises(ValueError, match="Packet timestamps must be sorted"):
+        match_exact_timestamps(packet_times_n, target_times_n)
+
+
+@settings(max_examples=48, deadline=None)
+@given(case=drift_timestamp_cases())
+def test_exact_timestamp_matching_refuses_plus_or_minus_one_nanosecond_drift(
+    case: tuple[ndarray, ndarray, ndarray],
+) -> None:
+    """An exact hit succeeds, but either one-nanosecond neighbor is absent."""
+    packet_times_n: ndarray = case[0]
+    target_times_n: ndarray = case[1]
+    drifted_times_n: ndarray = case[2]
+    chosen_index: int = int(np.searchsorted(packet_times_n, target_times_n[0]))
+
+    matched_indices_n: ndarray = match_exact_timestamps(
+        packet_times_n, target_times_n
+    )
+    np.testing.assert_array_equal(
+        matched_indices_n, np.asarray([chosen_index], dtype=np.int64)
+    )
+    with pytest.raises(ValueError, match="no exact video-packet match"):
+        match_exact_timestamps(packet_times_n, drifted_times_n)
+
+
+def test_moge_inference_is_anchored_to_chosen_wide_rows() -> None:
+    """The provenance stage reads frame-selection rows, not the dense PromptDA grid."""
+    assert f"/{FRAME_SELECTION_WIDE}:sharpness" == WIDE_CHOSEN_SHARPNESS_COLUMN
+
+
+def test_chosen_timestamps_match_exact_packet_times_despite_jitter() -> None:
+    """Exact packet identities survive irregular inter-frame timing."""
+    packet_times_n: ndarray = np.array([0, 16_666_667, 33_333_333, 50_000_001, 66_666_669], dtype="timedelta64[ns]")
+    chosen_times_n: ndarray = np.array([0, 33_333_333, 66_666_669], dtype="timedelta64[ns]")
+
+    matched_indices_n: Int64[ndarray, "n_chosen=3"] = match_exact_timestamps(packet_times_n, chosen_times_n)
+
+    np.testing.assert_array_equal(matched_indices_n, np.array([0, 2, 4], dtype=np.int64))
+
+
+def test_chosen_timestamp_matching_refuses_one_nanosecond_drift() -> None:
+    """A nearby packet never substitutes for a missing chosen timestamp."""
+    packet_times_n: ndarray = np.array([0, 16_666_667, 33_333_333], dtype="timedelta64[ns]")
+    drifted_chosen_n: ndarray = np.array([33_333_334], dtype="timedelta64[ns]")
+
+    with pytest.raises(ValueError, match="no exact video-packet match"):
+        match_exact_timestamps(packet_times_n, drifted_chosen_n)
+
+
+@requires_cuda
+def test_trt_front_facing_normals_keep_unit_length_and_positive_z_after_png() -> None:
+    """The catalog representation stores away-from-camera RDF normals (the gaussurf training convention)."""
+    from monopriors.models.surface_normal.moge_v2_trt import DEFAULT_IMAGE_HW, MoGeV2NormalOutput, MoGeV2TrtNormalPredictor
+
+    height: int = DEFAULT_IMAGE_HW[0]
+    width: int = DEFAULT_IMAGE_HW[1]
+    x_w: Float32[Tensor, "w"] = torch.linspace(0.0, 255.0, width, dtype=torch.float32, device="cuda")
+    y_h: Float32[Tensor, "h"] = torch.linspace(0.0, 255.0, height, dtype=torch.float32, device="cuda")
+    red_hw: Float32[Tensor, "h w"] = x_w[None, :].expand(height, width)
+    green_hw: Float32[Tensor, "h w"] = y_h[:, None].expand(height, width)
+    blue_hw: Float32[Tensor, "h w"] = (red_hw + green_hw) / 2.0
+    rgb_bhw3: UInt8[Tensor, "b=1 h=756 w=1008 3"] = torch.stack((red_hw, green_hw, blue_hw), dim=-1).to(torch.uint8)[None]
+    predictor: MoGeV2TrtNormalPredictor = MoGeV2TrtNormalPredictor(batch_size=8)
+
+    prediction: MoGeV2NormalOutput = predictor(rgb_bhw3)
+    # Mirror the layer path: MoGe's toward-camera output is negated before encoding.
+    normals_hw3: Float32[ndarray, "h=756 w=1008 3"] = (-prediction.normals_bhw3[0]).detach().cpu().numpy()
+    decoded_hw3: Float32[ndarray, "h=756 w=1008 3"] = decode_normals_png(encode_normals_png(normals_hw3))
+    lengths_hw: Float32[ndarray, "h=756 w=1008"] = np.linalg.norm(decoded_hw3, axis=-1)
+
+    np.testing.assert_allclose(lengths_hw, 1.0, atol=0.007, rtol=0.0)
+    assert float(np.mean(decoded_hw3[..., 2] > 0.0)) > 0.9

--- a/packages/gauss-surf/tests/test_publish_replacement.py
+++ b/packages/gauss-surf/tests/test_publish_replacement.py
@@ -1,0 +1,108 @@
+"""Republish contracts for fused direct-gsplat publication."""
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from jaxtyping import UInt8, UInt16
+from numpy import ndarray
+from rerun.catalog import DatasetEntry, DatasetView
+
+from gauss_surf.catalog import SegmentReader
+from gauss_surf.render_io import RenderCamera
+from gauss_surf.train_gsplat.publish import (
+    PublishStats,
+    UltrawideQuantizedRender,
+    WideQuantizedRender,
+    publish_in_process,
+)
+
+
+def _camera(camera: str, index: int) -> RenderCamera:
+    """Build one tiny synthetic full-grid camera."""
+    world_from_camera_34: ndarray = np.eye(4, dtype=np.float32)[:3]
+    return RenderCamera(
+        stem=f"{camera}_{index:06d}",
+        camera=camera,  # pyrefly: ignore  # validated fixture literal
+        timestamp_ns=index if camera == "wide" else 1_000 + index,
+        width=1,
+        height=1,
+        fx=1.0,
+        fy=1.0,
+        cx=0.5,
+        cy=0.5,
+        world_from_camera_34=world_from_camera_34,
+    )
+
+
+def test_publish_replaces_existing_canonical_rrds(tmp_path: Path, monkeypatch: Any) -> None:
+    """A rerun atomically replaces all three existing canonical layer files."""
+    cameras: list[RenderCamera] = [
+        *[_camera("wide", index) for index in range(2)],
+        *[_camera("uw", index) for index in range(3)],
+    ]
+    registered_layers: list[str] = []
+
+    def fake_quantized_wide_render(
+        _splats: torch.nn.ParameterDict | dict[str, torch.Tensor],
+        camera: RenderCamera,
+        _background_3: torch.Tensor,
+    ) -> WideQuantizedRender:
+        depth_mm_hw: UInt16[ndarray, "h=1 w=1"] = np.ones((1, 1), dtype=np.uint16)
+        normal_rgb_hw3: UInt8[ndarray, "h=1 w=1 3"] = np.full((1, 1, 3), 128, dtype=np.uint8)
+        return WideQuantizedRender(camera, depth_mm_hw, normal_rgb_hw3)
+
+    def fake_quantized_ultrawide_render(
+        _splats: torch.nn.ParameterDict | dict[str, torch.Tensor],
+        camera: RenderCamera,
+        _background_3: torch.Tensor,
+    ) -> UltrawideQuantizedRender:
+        depth_mm_hw: UInt16[ndarray, "h=1 w=1"] = np.ones((1, 1), dtype=np.uint16)
+        normal_rgb_hw3: UInt8[ndarray, "h=1 w=1 3"] = np.full((1, 1, 3), 128, dtype=np.uint8)
+        rgb_hw3: UInt8[ndarray, "h=1 w=1 3"] = np.zeros((1, 1, 3), dtype=np.uint8)
+        return UltrawideQuantizedRender(camera, depth_mm_hw, normal_rgb_hw3, rgb_hw3)
+
+    monkeypatch.setattr("gauss_surf.train_gsplat.publish.load_render_cameras", lambda _path: cameras)
+    monkeypatch.setattr("gauss_surf.train_gsplat.publish.reference_blobs_at_component_timestamps", lambda _view, _column: {})
+    monkeypatch.setattr("gauss_surf.train_gsplat.publish.load_reference_blobs", lambda _view: [])
+    monkeypatch.setattr("gauss_surf.train_gsplat.publish._quantized_wide_render", fake_quantized_wide_render)
+    monkeypatch.setattr("gauss_surf.train_gsplat.publish._quantized_ultrawide_render", fake_quantized_ultrawide_render)
+    monkeypatch.setattr(SegmentReader, "require_layers", lambda _reader, _layers: None)
+    segment_view: DatasetView = object.__new__(DatasetView)
+    monkeypatch.setattr(SegmentReader, "segment_view", lambda _reader: segment_view)
+    monkeypatch.setattr(
+        "gauss_surf.train_gsplat.publish.register_layer",
+        lambda _dataset, _path, layer_name: registered_layers.append(layer_name),
+    )
+
+    splats: dict[str, torch.Tensor] = {
+        "means": torch.tensor([[0.0, 0.0, 1.0]]),
+        "scales": torch.log(torch.tensor([[0.1, 0.1, 0.1]])),
+        "quats": torch.tensor([[1.0, 0.0, 0.0, 0.0]]),
+        "opacities": torch.tensor([[0.0]]),
+        "sh0": torch.zeros((1, 1, 3)),
+        "shN": torch.zeros((1, 15, 3)),
+    }
+    output_dirs: tuple[Path, Path, Path] = tuple(tmp_path / name for name in ("splat", "splat_depth", "splat_triage"))
+    for output_dir in output_dirs:
+        output_dir.mkdir()
+        (output_dir / "segment.rrd").write_bytes(b"old canonical layer")
+
+    dataset: DatasetEntry = object.__new__(DatasetEntry)
+    reader: SegmentReader = SegmentReader(dataset=dataset, video_id="segment")
+    stats: PublishStats = publish_in_process(
+        splats,
+        reader=reader,
+        bundle_dir=tmp_path,
+        video_id="segment",
+        splat_output_dir=output_dirs[0],
+        depth_output_dir=output_dirs[1],
+        triage_output_dir=output_dirs[2],
+        batch_size=3,
+        encoder_workers=1,
+    )
+
+    assert registered_layers == ["splat", "splat_depth", "splat_triage"]
+    assert stats.frame_count == 5
+    assert all((output_dir / "segment.rrd").read_bytes() != b"old canonical layer" for output_dir in output_dirs)

--- a/packages/gauss-surf/tests/test_register_segment.py
+++ b/packages/gauss-surf/tests/test_register_segment.py
@@ -1,0 +1,35 @@
+"""Extended gauss-surf catalog blueprint artifact tests."""
+
+from pathlib import Path
+from typing import Any
+
+from gauss_surf.apis.register_segment import existing_recovery_rrds, recovery_rrds, write_extended_blueprints
+
+
+def test_write_extended_blueprints_writes_both_orientations(tmp_path: Path) -> None:
+    blueprint_paths: list[Path] = write_extended_blueprints(tmp_path, "arkitscenes-v2")
+
+    assert [path.name for path in blueprint_paths] == [
+        "arkitscenes-v2-gauss-surf-landscape.rbl",
+        "arkitscenes-v2-gauss-surf-portrait.rbl",
+    ]
+    assert all(path.is_file() and path.stat().st_size > 0 for path in blueprint_paths)
+
+
+def test_recovery_rrds_include_the_independent_splat_layers() -> None:
+    paths: list[Path] = recovery_rrds("47115416")
+
+    assert Path("data/splat_depth/47115416.rrd") in paths
+    assert Path("data/splat_triage/47115416.rrd") in paths
+
+
+def test_existing_recovery_rrds_skip_outputs_not_generated_yet(tmp_path: Path, monkeypatch: Any) -> None:
+    """Fresh onboarding recovers PromptDA without requiring future pipeline layers."""
+    monkeypatch.chdir(tmp_path)
+    promptda_path: Path = Path("data/promptda/segment.rrd")
+    promptda_path.parent.mkdir(parents=True)
+    promptda_path.write_bytes(b"promptda")
+
+    paths: list[Path] = existing_recovery_rrds("segment")
+
+    assert paths == [promptda_path]

--- a/packages/gauss-surf/tests/test_splat_values.py
+++ b/packages/gauss-surf/tests/test_splat_values.py
@@ -1,0 +1,29 @@
+"""Natural-form Gaussian conversion contracts for fused publication."""
+
+import numpy as np
+from jaxtyping import Float32, UInt8
+from numpy import ndarray
+
+from gauss_surf.train_gsplat.splat_values import SH_C0, inria_colors_rgba, inria_quaternions_xyzw
+
+
+def test_inria_colors_match_rerun_ply_conversion() -> None:
+    """Match the Gaussian archetype conversion, including u8 rounding and sigmoid endpoints."""
+    source_rgb_n3: UInt8[ndarray, "n=3 3"] = np.asarray([[0, 128, 255], [128, 128, 128], [255, 128, 0]], dtype=np.uint8)
+    dc_n3: Float32[ndarray, "n=3 3"] = ((source_rgb_n3.astype(np.float32) / 255.0 - 0.5) / SH_C0).astype(np.float32)
+    opacity_logits_n: Float32[ndarray, "n=3"] = np.asarray([-100.0, 0.0, 100.0], dtype=np.float32)
+
+    colors_rgba_n4: UInt8[ndarray, "n=3 4"] = inria_colors_rgba(dc_n3, opacity_logits_n)
+
+    np.testing.assert_array_equal(colors_rgba_n4[:, :3], source_rgb_n3)
+    np.testing.assert_array_equal(colors_rgba_n4[:, 3], np.asarray([0, 128, 255], dtype=np.uint8))
+
+
+def test_inria_wxyz_quaternions_become_normalized_xyzw() -> None:
+    quaternions_wxyz_n4: Float32[ndarray, "n=3 4"] = np.asarray(
+        [[2.0, 0.0, 0.0, 0.0], [0.0, 3.0, 0.0, 4.0], [0.0, 0.0, 0.0, 0.0]], dtype=np.float32
+    )
+
+    quaternions_xyzw_n4: Float32[ndarray, "n=3 4"] = inria_quaternions_xyzw(quaternions_wxyz_n4)
+
+    np.testing.assert_allclose(quaternions_xyzw_n4, [[0.0, 0.0, 0.0, 1.0], [0.6, 0.0, 0.8, 0.0], [0.0, 0.0, 0.0, 1.0]])

--- a/packages/gauss-surf/tests/test_ultrawide_signals.py
+++ b/packages/gauss-surf/tests/test_ultrawide_signals.py
@@ -1,0 +1,45 @@
+"""Behavior checks for ultrawide-resolution MoGe normal inference."""
+
+import numpy as np
+import pytest
+import torch
+from arkitscenes_download.ingest.paths import FRAME_SELECTION_ULTRAWIDE
+from jaxtyping import Float32, UInt8
+from monopriors.models.surface_normal.moge_v2_trt import MoGeV2NormalOutput, MoGeV2TrtNormalPredictor
+from numpy import ndarray
+from torch import Tensor
+
+from gauss_surf.apis.ultrawide_signals import ULTRAWIDE_IMAGE_HW
+from gauss_surf.contracts import MOGE_INFERENCE_BATCH_SIZE, ULTRAWIDE_CHOSEN_SHARPNESS_COLUMN
+from gauss_surf.normals_encoding import decode_normals_png, encode_normals_png, to_away_from_camera
+
+requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA and TensorRT required")
+
+
+def test_ultrawide_provenance_is_anchored_to_chosen_rows() -> None:
+    """Rectified RGB, raycast depth, and MoGe normals share the chosen timeline."""
+    assert f"/{FRAME_SELECTION_ULTRAWIDE}:sharpness" == ULTRAWIDE_CHOSEN_SHARPNESS_COLUMN
+
+
+@requires_cuda
+def test_ultrawide_trt_normals_store_away_from_camera_positive_z() -> None:
+    """The 480×640 engine keeps the same signed gaussurf convention as Part 4."""
+    height: int = ULTRAWIDE_IMAGE_HW[0]
+    width: int = ULTRAWIDE_IMAGE_HW[1]
+    x_w: Float32[Tensor, "w"] = torch.linspace(0.0, 255.0, width, dtype=torch.float32, device="cuda")
+    y_h: Float32[Tensor, "h"] = torch.linspace(0.0, 255.0, height, dtype=torch.float32, device="cuda")
+    red_hw: Float32[Tensor, "h w"] = x_w[None, :].expand(height, width)
+    green_hw: Float32[Tensor, "h w"] = y_h[:, None].expand(height, width)
+    blue_hw: Float32[Tensor, "h w"] = (red_hw + green_hw) / 2.0
+    rgb_bhw3: UInt8[Tensor, "b=1 h=480 w=640 3"] = torch.stack((red_hw, green_hw, blue_hw), dim=-1).to(torch.uint8)[None]
+    predictor: MoGeV2TrtNormalPredictor = MoGeV2TrtNormalPredictor(
+        image_hw=ULTRAWIDE_IMAGE_HW,
+        batch_size=MOGE_INFERENCE_BATCH_SIZE,
+    )
+
+    prediction: MoGeV2NormalOutput = predictor(rgb_bhw3)
+    toward_hw3: Float32[ndarray, "h=480 w=640 3"] = prediction.normals_bhw3[0].detach().cpu().numpy().astype(np.float32, copy=False)
+    away_hw3: Float32[ndarray, "h=480 w=640 3"] = to_away_from_camera(toward_hw3)
+    decoded_hw3: Float32[ndarray, "h=480 w=640 3"] = decode_normals_png(encode_normals_png(away_hw3))
+
+    assert float(np.mean(decoded_hw3[..., 2] > 0.0)) > 0.9

--- a/packages/gauss-surf/tests/test_ultrawide_signals.py
+++ b/packages/gauss-surf/tests/test_ultrawide_signals.py
@@ -9,11 +9,10 @@ from monopriors.models.surface_normal.moge_v2_trt import MoGeV2NormalOutput, MoG
 from numpy import ndarray
 from torch import Tensor
 
-from gauss_surf.apis.ultrawide_signals import ULTRAWIDE_IMAGE_HW, apple_distortion_coefficients
+from gauss_surf.apis.ultrawide_signals import ULTRAWIDE_IMAGE_HW, brown_conrady_coefficients
 from gauss_surf.contracts import (
-    APPLE_FORWARD_DISTORTION_COLUMN,
+    DISTORTION_COEFFICIENTS_COLUMN,
     DISTORTION_MODEL_COLUMN,
-    LEGACY_DISTORTION_COEFFICIENTS_COLUMN,
     MOGE_INFERENCE_BATCH_SIZE,
     ULTRAWIDE_CHOSEN_SHARPNESS_COLUMN,
 )
@@ -27,41 +26,49 @@ def test_ultrawide_provenance_is_anchored_to_chosen_rows() -> None:
     assert f"/{FRAME_SELECTION_ULTRAWIDE}:sharpness" == ULTRAWIDE_CHOSEN_SHARPNESS_COLUMN
 
 
-def test_canonical_distortion_reads_apple_provenance_under_a_brown_label() -> None:
-    """New recordings use exact Apple provenance while generic components stay standard."""
+def test_canonical_distortion_reads_the_standard_fourteen_vector() -> None:
+    """The reader consumes the standard Brown-Conrady coefficient component."""
     static_row: dict[str, object] = {
         DISTORTION_MODEL_COLUMN: ["brown_conrady"],
-        APPLE_FORWARD_DISTORTION_COLUMN: [[float(index) for index in range(8)]],
-        LEGACY_DISTORTION_COEFFICIENTS_COLUMN: [[99.0] * 14],
+        DISTORTION_COEFFICIENTS_COLUMN: [[float(index) for index in range(14)]],
     }
 
-    coefficients_8: Float32[ndarray, "8"] = apple_distortion_coefficients(static_row)
+    coefficients_14: Float32[ndarray, "14"] = brown_conrady_coefficients(static_row, video_id="47115416")
 
-    np.testing.assert_array_equal(coefficients_8, np.arange(8, dtype=np.float32))
+    np.testing.assert_array_equal(coefficients_14, np.arange(14, dtype=np.float32))
 
 
-@pytest.mark.parametrize("legacy_model", ["brown_conrady", "apple_radial_poly"])
-def test_legacy_distortion_fallback_accepts_only_documented_stale_labels(legacy_model: str) -> None:
-    """Old corpus rows may carry Apple coefficients under either known stale model label."""
+def test_unmigrated_apple_distortion_requires_calibration_reingest() -> None:
+    """An old Apple-model row fails with the exact migration tools to run."""
     static_row: dict[str, object] = {
-        DISTORTION_MODEL_COLUMN: [legacy_model],
-        LEGACY_DISTORTION_COEFFICIENTS_COLUMN: [[float(index) for index in range(8)]],
+        DISTORTION_MODEL_COLUMN: ["apple_radial_poly"],
+        DISTORTION_COEFFICIENTS_COLUMN: [[float(index) for index in range(8)]],
     }
 
-    coefficients_8: Float32[ndarray, "8"] = apple_distortion_coefficients(static_row)
+    with pytest.raises(SystemExit, match="arkitscenes-download-ingest.*gauss-surf-register-segment"):
+        brown_conrady_coefficients(static_row, video_id="47115416")
 
-    np.testing.assert_array_equal(coefficients_8, np.arange(8, dtype=np.float32))
+
+def test_brown_conrady_distortion_requires_fourteen_coefficients() -> None:
+    """A stale eight-vector under a Brown label also receives the migration instruction."""
+    static_row: dict[str, object] = {
+        DISTORTION_MODEL_COLUMN: ["brown_conrady"],
+        DISTORTION_COEFFICIENTS_COLUMN: [[float(index) for index in range(8)]],
+    }
+
+    with pytest.raises(SystemExit, match="arkitscenes-download-ingest.*gauss-surf-register-segment"):
+        brown_conrady_coefficients(static_row, video_id="47115416")
 
 
 def test_distortion_reader_rejects_an_unrecognized_model_label() -> None:
-    """The fallback never ignores an unknown generic distortion label."""
+    """An unknown generic label cannot bypass the standard-only contract."""
     static_row: dict[str, object] = {
         DISTORTION_MODEL_COLUMN: ["mystery_model"],
-        LEGACY_DISTORTION_COEFFICIENTS_COLUMN: [[float(index) for index in range(8)]],
+        DISTORTION_COEFFICIENTS_COLUMN: [[float(index) for index in range(14)]],
     }
 
-    with pytest.raises(SystemExit, match="mystery_model"):
-        apple_distortion_coefficients(static_row)
+    with pytest.raises(SystemExit, match="mystery_model.*arkitscenes-download-ingest"):
+        brown_conrady_coefficients(static_row, video_id="47115416")
 
 
 @requires_cuda

--- a/packages/gauss-surf/tests/test_ultrawide_signals.py
+++ b/packages/gauss-surf/tests/test_ultrawide_signals.py
@@ -9,8 +9,14 @@ from monopriors.models.surface_normal.moge_v2_trt import MoGeV2NormalOutput, MoG
 from numpy import ndarray
 from torch import Tensor
 
-from gauss_surf.apis.ultrawide_signals import ULTRAWIDE_IMAGE_HW
-from gauss_surf.contracts import MOGE_INFERENCE_BATCH_SIZE, ULTRAWIDE_CHOSEN_SHARPNESS_COLUMN
+from gauss_surf.apis.ultrawide_signals import ULTRAWIDE_IMAGE_HW, apple_distortion_coefficients
+from gauss_surf.contracts import (
+    APPLE_FORWARD_DISTORTION_COLUMN,
+    DISTORTION_MODEL_COLUMN,
+    LEGACY_DISTORTION_COEFFICIENTS_COLUMN,
+    MOGE_INFERENCE_BATCH_SIZE,
+    ULTRAWIDE_CHOSEN_SHARPNESS_COLUMN,
+)
 from gauss_surf.normals_encoding import decode_normals_png, encode_normals_png, to_away_from_camera
 
 requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA and TensorRT required")
@@ -19,6 +25,43 @@ requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA a
 def test_ultrawide_provenance_is_anchored_to_chosen_rows() -> None:
     """Rectified RGB, raycast depth, and MoGe normals share the chosen timeline."""
     assert f"/{FRAME_SELECTION_ULTRAWIDE}:sharpness" == ULTRAWIDE_CHOSEN_SHARPNESS_COLUMN
+
+
+def test_canonical_distortion_reads_apple_provenance_under_a_brown_label() -> None:
+    """New recordings use exact Apple provenance while generic components stay standard."""
+    static_row: dict[str, object] = {
+        DISTORTION_MODEL_COLUMN: ["brown_conrady"],
+        APPLE_FORWARD_DISTORTION_COLUMN: [[float(index) for index in range(8)]],
+        LEGACY_DISTORTION_COEFFICIENTS_COLUMN: [[99.0] * 14],
+    }
+
+    coefficients_8: Float32[ndarray, "8"] = apple_distortion_coefficients(static_row)
+
+    np.testing.assert_array_equal(coefficients_8, np.arange(8, dtype=np.float32))
+
+
+@pytest.mark.parametrize("legacy_model", ["brown_conrady", "apple_radial_poly"])
+def test_legacy_distortion_fallback_accepts_only_documented_stale_labels(legacy_model: str) -> None:
+    """Old corpus rows may carry Apple coefficients under either known stale model label."""
+    static_row: dict[str, object] = {
+        DISTORTION_MODEL_COLUMN: [legacy_model],
+        LEGACY_DISTORTION_COEFFICIENTS_COLUMN: [[float(index) for index in range(8)]],
+    }
+
+    coefficients_8: Float32[ndarray, "8"] = apple_distortion_coefficients(static_row)
+
+    np.testing.assert_array_equal(coefficients_8, np.arange(8, dtype=np.float32))
+
+
+def test_distortion_reader_rejects_an_unrecognized_model_label() -> None:
+    """The fallback never ignores an unknown generic distortion label."""
+    static_row: dict[str, object] = {
+        DISTORTION_MODEL_COLUMN: ["mystery_model"],
+        LEGACY_DISTORTION_COEFFICIENTS_COLUMN: [[float(index) for index in range(8)]],
+    }
+
+    with pytest.raises(SystemExit, match="mystery_model"):
+        apple_distortion_coefficients(static_row)
 
 
 @requires_cuda

--- a/packages/gauss-surf/tools/apps/frame_selection.py
+++ b/packages/gauss-surf/tools/apps/frame_selection.py
@@ -1,0 +1,8 @@
+"""CLI shim for the catalog frame-selection stage."""
+
+import tyro
+
+from gauss_surf.apis.frame_selection import Config, main
+
+if __name__ == "__main__":
+    main(tyro.cli(Config))

--- a/packages/gauss-surf/tools/apps/moge_normals.py
+++ b/packages/gauss-surf/tools/apps/moge_normals.py
@@ -1,0 +1,8 @@
+"""CLI shim for chosen-frame MoGe normal inference."""
+
+import tyro
+
+from gauss_surf.apis.moge_normals import Config, main
+
+if __name__ == "__main__":
+    main(tyro.cli(Config))

--- a/packages/gauss-surf/tools/apps/register_segment.py
+++ b/packages/gauss-surf/tools/apps/register_segment.py
@@ -1,0 +1,8 @@
+"""CLI shim for reseeding one development-catalog segment."""
+
+import tyro
+
+from gauss_surf.apis.register_segment import Config, main
+
+if __name__ == "__main__":
+    main(tyro.cli(Config))

--- a/packages/gauss-surf/tools/apps/train_gsplat.py
+++ b/packages/gauss-surf/tools/apps/train_gsplat.py
@@ -1,0 +1,8 @@
+"""Thin Tyro shim for direct gsplat training."""
+
+import tyro
+
+from gauss_surf.apis.train_gsplat import Config, main
+
+if __name__ == "__main__":
+    main(tyro.cli(Config))

--- a/packages/gauss-surf/tools/apps/ultrawide_signals.py
+++ b/packages/gauss-surf/tools/apps/ultrawide_signals.py
@@ -1,0 +1,8 @@
+"""CLI shim for rectified ultrawide depth and normal generation."""
+
+import tyro
+
+from gauss_surf.apis.ultrawide_signals import Config, main
+
+if __name__ == "__main__":
+    main(tyro.cli(Config))


### PR DESCRIPTION
New `gauss-surf` package, part 2: the trainer and pipeline stages (stack 4/5). Direct gsplat 1.6.0 — no nerfstudio anywhere. Same caveat as #101: runnable once #103 lands.

- **`train_gsplat/`** — GPU-resident quantized cache (NVDEC decodes wide RGB straight to VRAM; uint16-mm depth; uint8 normals with the exact 128→0 rule), two-call training renderer + fused 8-channel `extra_signals` publish renderer (parity-tested against each other at 0.0 max delta), 7k-step trainer replicating splatfacto's schedule exactly (shuffled-epoch camera sampling, `pause_refine_after_reset` derived from the real train-image count), holdout evaluation, and fused in-process publication (render → GPU quantize → one D2H → threaded PNG encode → RRD layers → catalog registration) with hash-manifest bundle atomicity.
- **`apis/` + `tools/`** — the five stage Configs (frame selection, MoGe normals, ultrawide signals, train+publish, register segment) with thin Tyro shims.

**Why trust it** — the port ran as staged, gated parity migration against the nerfstudio baseline, with empirical 3-seed variance bands as gates:
- All one-sided quality gates pass: PSNR 20.375 vs 20.380 baseline (band ±0.022), wide/uw depth MAE at-or-better, triage metrics within band.
- Schedule goldens exact (27 refine events parsed from real baseline logs); metric-definition parity +0.0003 dB against the baseline's evaluation.json.
- Cache proven pixel-identical to the historical training bundle (opt-in test, ~10B values, 0 mismatches).
- Two real parity bugs found and fixed by these gates along the way: wide-only train-image count in the schedule derivation, and IID-with-replacement camera sampling silently starving densification.

**Performance**: per-segment lane 1,489 s → **265 s** (training 112→100 s; the 651+651-frame publish renders at ~200 fps vs the old 1.5 fps offline pass; zero NPZ intermediates). Fresh-segment onboarding is three commands (~10 min) — validated end-to-end on a second, unseen segment.

Deliberate flags (measured, off by default): `fused_training` (couples plane gradients into densification: +0.06 dB PSNR, ~1 mm depth cost), opacity reset (−0.05 dB PSNR, better geometry, −17% gaussians). Both documented quality-round levers.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
