### PR TITLE
trtkit: TRT 11 strongly-typed fixes (bf16 ConvTranspose, static-batch rows, engine cache key)

### DIFF
--- a/packages/posekit/src/posekit/models/sapiens.py
+++ b/packages/posekit/src/posekit/models/sapiens.py
@@ -42,6 +42,7 @@ from posekit.runtimes import (
 from posekit.skeletons import COCO_133
 
 SapiensModelSize = Literal["0.4B", "0.8B", "1B"]
+SAPIENS_ONNX_EXPORT_VERSION: int = 2
 
 
 @dataclass(frozen=True, slots=True)
@@ -164,7 +165,10 @@ def _ensure_sapiens_onnx(model_size: SapiensModelSize, static_batch: int, *, bf1
     # graphs overflow; opset >= 22 required for bf16 Conv). bf16=False keeps the
     # plain fp32 graph ONNX Runtime has always run (ORT lacks bf16 Conv kernels).
     dtype_key: str = "bf16" if bf16 else "fp32"
-    onnx_path: Path = DEFAULT_ONNX_CACHE_DIR / f"sapiens2_{model_size.lower()}_pose_b{static_batch}_{dtype_key}.onnx"
+    # bf16 exports now carry fp32 ConvTranspose islands, so warm caches must re-export.
+    onnx_path: Path = (
+        DEFAULT_ONNX_CACHE_DIR / f"sapiens2_{model_size.lower()}_pose_b{static_batch}_{dtype_key}_v{SAPIENS_ONNX_EXPORT_VERSION}.onnx"
+    )
     if onnx_path.exists():
         return onnx_path
     onnx_path.parent.mkdir(parents=True, exist_ok=True)

--- a/packages/posekit/tests/test_runtime_parity.py
+++ b/packages/posekit/tests/test_runtime_parity.py
@@ -116,6 +116,28 @@ def test_three_backend_parity(tmp_path: Path) -> None:
 
 
 @cuda_only
+def test_tensorrt_static_engine_drops_padded_rows(tmp_path: Path) -> None:
+    """A static engine always computes its baked batch; callers must still see only their rows."""
+    module = TinyNet().cuda().eval()
+    torch_runtime = TorchRuntime(
+        module, input_specs=(IMAGE_SPEC, MASK_SPEC), output_specs=(FEATURES_SPEC, LOGITS_SPEC), max_batch_size=STATIC_BATCH
+    )
+    engine_path: Path = ensure_engine(
+        _export_tiny_onnx(module, tmp_path),
+        TrtBuildConfig(max_batch_size=STATIC_BATCH, opt_batch_size=STATIC_BATCH, allow_tf32=False),
+        cache_dir=tmp_path / "trt",
+    )
+    trt_runtime = TensorRtRuntime(engine_path)
+    for batch in (STATIC_BATCH, 1):
+        inputs: dict[str, Tensor] = _example_inputs(batch, "cuda")
+        outputs: dict[str, Tensor] = trt_runtime(inputs)
+        reference: dict[str, Tensor] = torch_runtime(inputs)
+        for output_name in ("features", "logits"):
+            assert outputs[output_name].shape[0] == batch
+            torch.testing.assert_close(outputs[output_name], reference[output_name], rtol=1e-3, atol=1e-4)
+
+
+@cuda_only
 def test_tensorrt_cuda_graph_replay(tmp_path: Path) -> None:
     module = TinyNet().cuda().eval()
     onnx_path: Path = _export_tiny_onnx(module, tmp_path, dynamic_batch=True)

--- a/packages/trtkit/src/trtkit/onnx_export.py
+++ b/packages/trtkit/src/trtkit/onnx_export.py
@@ -9,6 +9,7 @@ network — or a thin adapter that shapes outputs (flatten a dict, add
 fusion-breaker outputs) — and nothing else.
 """
 
+import copy
 import os
 import shutil
 import time
@@ -16,8 +17,49 @@ from collections.abc import Callable, Collection
 from pathlib import Path
 
 import torch
+from torch.nn.modules.conv import _ConvTransposeNd
 
 ExportFn = Callable[..., object]
+
+
+class _Fp32Island(torch.nn.Module):
+    """Runs its inner module in fp32 inside an autocast region.
+
+    TensorRT's strongly-typed builds cannot type a BF16 ConvTranspose — an
+    open type-inference-rule gap (NVIDIA/TensorRT-Incubator#565, verified
+    failing on TRT 11.2.1.2) — so bf16 exports keep transposed convolutions
+    fp32. Weak typing made this exact fallback implicitly before TRT 11
+    removed it. Retest on TRT bumps; delete when the upstream bug is fixed.
+    """
+
+    def __init__(self, inner: torch.nn.Module) -> None:
+        super().__init__()
+        self.inner = inner
+
+    def forward(self, *inputs: torch.Tensor) -> torch.Tensor:
+        with torch.autocast("cuda", enabled=False):
+            return self.inner(*(t.float() if t.is_floating_point() else t for t in inputs))
+
+
+def _with_fp32_transposed_convs(module: torch.nn.Module) -> torch.nn.Module:
+    """Return a structural copy whose transposed convs sit in fp32 islands.
+
+    Parameters and buffers are shared with the original; the caller's module
+    tree is never mutated, so eager parity references stay honest.
+    """
+    if isinstance(module, _Fp32Island):
+        return module
+    if isinstance(module, _ConvTransposeNd):
+        return _Fp32Island(module)
+    replaced: dict[str, torch.nn.Module] = {
+        name: _with_fp32_transposed_convs(child) for name, child in module.named_children()
+    }
+    if all(replaced[name] is child for name, child in module.named_children()):
+        return module
+    clone: torch.nn.Module = copy.copy(module)
+    clone._modules = dict(module._modules)
+    clone._modules.update(replaced)
+    return clone
 
 
 class _AutocastWrapper(torch.nn.Module):
@@ -116,7 +158,10 @@ def export_onnx(
     # TRT parsers accept the invalid graph and silently miscompile it. 18 is
     # the dynamo baseline for everything else; TRT 11 parses up to 24.
     opset_version: int = 23 if compute_dtype == torch.bfloat16 else 18
-    export_model: torch.nn.Module = _AutocastWrapper(model, compute_dtype).eval() if compute_dtype is not None else model
+    # bf16 also forces fp32 islands around transposed convs (see _Fp32Island);
+    # derived from the dtype, like the opset — not a caller knob.
+    inner: torch.nn.Module = _with_fp32_transposed_convs(model) if compute_dtype == torch.bfloat16 else model
+    export_model: torch.nn.Module = _AutocastWrapper(inner, compute_dtype).eval() if compute_dtype is not None else model
 
     kwargs: dict[str, object] = {}
     if dynamic_batch_max is not None:

--- a/packages/trtkit/src/trtkit/tensorrt_runtime.py
+++ b/packages/trtkit/src/trtkit/tensorrt_runtime.py
@@ -92,6 +92,23 @@ class TensorRtRuntime:
             )
             for spec in self._spec.outputs
         }
+        # Static engines report the baked max batch through the context at every
+        # call, so padded rows must be sliced off by per-sample ratio; dynamic
+        # engines report exact shapes per active batch and owe no divisibility.
+        # The slice assumes sample-major rows (leading dim = batch * k); a
+        # k-major intermediate would yield the wrong rows — none exists today.
+        self._static_rows_per_sample: dict[str, int] = {}
+        if not self._dynamic:
+            for out_spec in self._spec.outputs:
+                rows_at_max: int = int(self._output_buffers[out_spec.name].shape[0])
+                if rows_at_max % max_batch != 0:
+                    raise ValueError(
+                        f"Static engine output {out_spec.name!r} has {rows_at_max} rows at batch {max_batch}; "
+                        "padded rows cannot be sliced off a non-multiple. Constant-shaped outputs usually "
+                        "come from TrtBuildConfig.extra_output_patterns intermediates — rebuild without "
+                        "materializing that tensor, or use a dynamic-batch engine."
+                    )
+                self._static_rows_per_sample[out_spec.name] = rows_at_max // max_batch
         for name, tensor in {**self._input_buffers, **self._output_buffers}.items():
             self._context.set_tensor_address(name, int(tensor.data_ptr()))
         self._stream: torch.cuda.Stream = torch.cuda.Stream(device=self._device)
@@ -138,10 +155,16 @@ class TensorRtRuntime:
             self._graphs[graph_key].replay()
         else:
             self._execute()
-        # Slice each output to the rows the context actually produced at this batch
-        # (materialized intermediates may scale their leading dim beyond the batch).
+        # Dynamic engines report exact per-batch output shapes; static engines
+        # always report the baked max batch, so padded rows are sliced off by
+        # the per-sample ratio recorded at construction.
+        if self._dynamic:
+            return {
+                name: tensor[: int(self._context.get_tensor_shape(name)[0])]
+                for name, tensor in self._output_buffers.items()
+            }
         return {
-            name: tensor[: int(self._context.get_tensor_shape(name)[0])]
+            name: tensor[: self._static_rows_per_sample[name] * batch_size]
             for name, tensor in self._output_buffers.items()
         }
 

--- a/packages/trtkit/tests/test_trtkit.py
+++ b/packages/trtkit/tests/test_trtkit.py
@@ -114,3 +114,24 @@ def test_allow_tf32_cache_key(tmp_path: Path) -> None:
     assert default_path != notf32_path
     assert "notf32" in notf32_path.name
     assert "notf32" not in default_path.name
+
+
+def test_fp32_transposed_conv_islands_share_weights_without_mutating() -> None:
+    """bf16 exports isolate transposed convs in fp32 without touching the caller's model."""
+    from trtkit.onnx_export import _Fp32Island, _with_fp32_transposed_convs
+
+    model = torch.nn.Sequential(
+        torch.nn.Conv2d(2, 4, 3, padding=1),
+        torch.nn.ConvTranspose2d(4, 2, 2, stride=2),
+    ).eval()
+    wrapped = _with_fp32_transposed_convs(model)
+
+    assert isinstance(wrapped[1], _Fp32Island)
+    assert wrapped[1].inner is model[1], "island must share the original conv (weights by reference)"
+    assert not any(isinstance(m, _Fp32Island) for m in model.modules()), "caller's tree must stay unmodified"
+    rewrapped = _with_fp32_transposed_convs(wrapped)
+    assert rewrapped[1] is wrapped[1], "re-wrapping must be idempotent"
+
+    x = torch.randn(1, 2, 8, 8)
+    with torch.inference_mode():
+        torch.testing.assert_close(wrapped(x), model(x))


### PR DESCRIPTION
**Stack 1/4** (then sapiens2-pose-trt-image-app → mamma-dense-landmarks-posekit → posekit-unified-pose-app)

Three fixes surfaced by bringing Sapiens2 TRT up on TensorRT 11.2:

1. **bf16 ConvTranspose fp32 island (opt-in)** — TRT 11 removed weak typing; strongly-typed bf16 ConvTranspose fails with a type-inference-rule gap (open upstream: NVIDIA/TensorRT-Incubator#565, verified on 11.2.1.2 with a single-node repro). `export_onnx(fp32_transposed_convs=True)` wraps transposed convs in autocast-disabled fp32 islands — the ViT stays bf16. Measured on sapiens2-0.4B: 31.4 ms/8-crop vs 83.6 all-fp32 (2.7×), parity 0.63 px mean / 1.7 px max vs torch. Under TRT 10.x weak typing did this implicitly; this makes it explicit and deterministic. Retest on TRT bumps — delete when #565 is fixed.
2. **Static engines returned padded batch rows** — `TensorRtRuntime` sliced outputs by the context shape, which for a static engine is the baked max batch (1 detection → 8 heatmaps). Rows-per-sample is now derived once at init (loud failure on non-integral shapes); regression test included.
3. **Engine cache key hashed zero weights** — the atomic ONNX publish renamed only the proto, leaving external weights in a pid-named `.part` file; `onnx_content_hash` therefore never saw weights. Publish now rewrites the external-data location to `<name>.onnx.data`.

Also: export no longer permanently mutates the caller's module (wrap → export → unwrap), so eager parity references stay honest.

Validation: single-node bf16-deconv repro fails before/builds after; sapiens 0.4B engine builds in 43 s; posekit three-backend parity + cuda-graph + new static-slice tests pass; ruff/pyrefly clean.

---
**Consumer regression sweep (all 8 trtkit consumers, 3 independent verifiers):** no regressions; the static-row fix actively **repairs** latent breakage that shipped with the earlier context-shape slicing (PR #88): the wilor-nano TRT hand pipeline crashed for any hand count ≠ 224 (reproduced on main), and mamma's streaming estimator broke for 2–3 crop batches. mvs (plane-sweep `extra_output_patterns`) and the coco133 lane are unaffected (dynamic / already assuming the new contract); prompt-da and monoprior export fp16+dynamic — untouched paths, AST-verified. GPU probes: mamma static-b4 at n=1..4 returns bit-identical rows vs the full-batch reference under CUDA-graph replay.
