### PR TITLE
sapiens2-pose: TensorRT backend in the image Gradio app

### DIFF
--- a/packages/posekit/src/posekit/models/sapiens.py
+++ b/packages/posekit/src/posekit/models/sapiens.py
@@ -42,6 +42,7 @@ from posekit.runtimes import (
 from posekit.skeletons import COCO_133
 
 SapiensModelSize = Literal["0.4B", "0.8B", "1B"]
+SAPIENS_ONNX_EXPORT_VERSION: int = 2
 
 
 @dataclass(frozen=True, slots=True)
@@ -164,7 +165,10 @@ def _ensure_sapiens_onnx(model_size: SapiensModelSize, static_batch: int, *, bf1
     # graphs overflow; opset >= 22 required for bf16 Conv). bf16=False keeps the
     # plain fp32 graph ONNX Runtime has always run (ORT lacks bf16 Conv kernels).
     dtype_key: str = "bf16" if bf16 else "fp32"
-    onnx_path: Path = DEFAULT_ONNX_CACHE_DIR / f"sapiens2_{model_size.lower()}_pose_b{static_batch}_{dtype_key}.onnx"
+    # bf16 exports now carry fp32 ConvTranspose islands, so warm caches must re-export.
+    onnx_path: Path = (
+        DEFAULT_ONNX_CACHE_DIR / f"sapiens2_{model_size.lower()}_pose_b{static_batch}_{dtype_key}_v{SAPIENS_ONNX_EXPORT_VERSION}.onnx"
+    )
     if onnx_path.exists():
         return onnx_path
     onnx_path.parent.mkdir(parents=True, exist_ok=True)

--- a/packages/posekit/tests/test_runtime_parity.py
+++ b/packages/posekit/tests/test_runtime_parity.py
@@ -116,6 +116,28 @@ def test_three_backend_parity(tmp_path: Path) -> None:
 
 
 @cuda_only
+def test_tensorrt_static_engine_drops_padded_rows(tmp_path: Path) -> None:
+    """A static engine always computes its baked batch; callers must still see only their rows."""
+    module = TinyNet().cuda().eval()
+    torch_runtime = TorchRuntime(
+        module, input_specs=(IMAGE_SPEC, MASK_SPEC), output_specs=(FEATURES_SPEC, LOGITS_SPEC), max_batch_size=STATIC_BATCH
+    )
+    engine_path: Path = ensure_engine(
+        _export_tiny_onnx(module, tmp_path),
+        TrtBuildConfig(max_batch_size=STATIC_BATCH, opt_batch_size=STATIC_BATCH, allow_tf32=False),
+        cache_dir=tmp_path / "trt",
+    )
+    trt_runtime = TensorRtRuntime(engine_path)
+    for batch in (STATIC_BATCH, 1):
+        inputs: dict[str, Tensor] = _example_inputs(batch, "cuda")
+        outputs: dict[str, Tensor] = trt_runtime(inputs)
+        reference: dict[str, Tensor] = torch_runtime(inputs)
+        for output_name in ("features", "logits"):
+            assert outputs[output_name].shape[0] == batch
+            torch.testing.assert_close(outputs[output_name], reference[output_name], rtol=1e-3, atol=1e-4)
+
+
+@cuda_only
 def test_tensorrt_cuda_graph_replay(tmp_path: Path) -> None:
     module = TinyNet().cuda().eval()
     onnx_path: Path = _export_tiny_onnx(module, tmp_path, dynamic_batch=True)

--- a/packages/sapiens2-pose/pyproject.toml
+++ b/packages/sapiens2-pose/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     # cuda: pytorch-gpu, torchvision
     "safetensors",
     "timm",
-    "spaces>=0.43.0",
     "tyro>=0.9.1",
 ]
 

--- a/packages/sapiens2-pose/src/sapiens2_pose/api/tensorrt_pose.py
+++ b/packages/sapiens2-pose/src/sapiens2_pose/api/tensorrt_pose.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -42,12 +43,24 @@ TensorRtPrecision = Literal["bf16"]
 
 STATIC_B1_PROFILE: tuple[int, int, int] = (1, 1, 1)
 """Static batch-1 profile used by the retained fastest engine."""
+DEFAULT_TENSORRT_ENGINE_ENV_VAR: str = "SAPIENS2_POSE_TENSORRT_ENGINE_PATH"
+DEFAULT_TENSORRT_ENGINE_FILENAME: str = "sapiens2_0_4b_pose_static_b1_bf16_current_static_graph.trt"
 
 PoseHeatmapRunner = Callable[[torch.Tensor], torch.Tensor | Float32[ndarray, "n k h w"]]
 """Callable backend that maps preprocessed Sapiens pose tensors to heatmaps."""
 
 ModelLoader = Callable[[str, str | Path, str], torch.nn.Module]
 ExportFn = Callable[..., object]
+
+
+def default_tensorrt_engine_path() -> str:
+    """Return the configured or stable cached Sapiens2 pose engine path."""
+    explicit_engine_path: str | None = os.environ.get(DEFAULT_TENSORRT_ENGINE_ENV_VAR)
+    if explicit_engine_path is not None:
+        return explicit_engine_path
+    xdg_cache_home: str | None = os.environ.get("XDG_CACHE_HOME")
+    cache_root: Path = Path(xdg_cache_home).expanduser() if xdg_cache_home is not None else Path.home() / ".cache"
+    return str(cache_root / "sapiens2-pose" / "tensorrt" / DEFAULT_TENSORRT_ENGINE_FILENAME)
 
 
 class ExportableRMSNorm(torch.nn.Module):
@@ -416,47 +429,54 @@ class TensorRtPoseHeatmapRunner:
         self._output_name: str = self._runtime.spec.outputs[0].name
 
     def __call__(self, inputs: torch.Tensor) -> torch.Tensor:
-        """Run TensorRT heatmap inference for one normalized static batch-1 input."""
+        """Run TensorRT heatmap inference, chunking full batches for the static batch-1 engine."""
         if inputs.device.type != "cuda":
             inputs = inputs.to("cuda")
-        return self._runtime({self._input_name: inputs})[self._output_name]
+        from trtkit import run_chunked
+
+        outputs: dict[str, torch.Tensor] = run_chunked(self._runtime, {self._input_name: inputs})
+        return outputs[self._output_name]
 
 
 def estimate_sapiens_pose_tensorrt(
     image_rgb: UInt8[ndarray, "h w 3"],
     bboxes: Float32[ndarray, "n 4"],
     *,
-    engine_path: Path,
+    engine_path: Path | None = None,
     model_size: ModelSize = "0.4B",
     device: DeviceChoice = "cuda",
     heatmap_runner: PoseHeatmapRunner | None = None,
 ) -> PosePredictionArtifact:
-    """Estimate Sapiens2 pose by running each person crop through the static batch-1 TensorRT engine."""
-    bboxes_f32: Float32[ndarray, "n 4"] = np.asarray(bboxes, dtype=np.float32).reshape(-1, 4)
-    spec: Any = MODEL_SPECS[model_size]
-    if bboxes_f32.shape[0] == 0:
-        empty_keypoints: Float32[ndarray, "0 308 2"] = np.empty((0, spec.num_keypoints, 2), dtype=np.float32)
-        empty_scores: Float32[ndarray, "0 308"] = np.empty((0, spec.num_keypoints), dtype=np.float32)
-        return PosePredictionArtifact(bboxes=bboxes_f32, keypoints=empty_keypoints, scores=empty_scores)
+    """Estimate Sapiens2 pose with a TensorRT or supplied heatmap runner.
 
-    runner: PoseHeatmapRunner = heatmap_runner or TensorRtPoseHeatmapRunner(engine_path, device=device)
-    keypoints_list: list[Float32[ndarray, "sapiens_k 2"]] = []
-    scores_list: list[Float32[ndarray, "sapiens_k"]] = []
-    for bbox in bboxes_f32:
-        one_bbox: Float32[ndarray, "1 4"] = np.asarray(bbox, dtype=np.float32).reshape(1, 4)
-        artifact: PosePredictionArtifact = estimate_sapiens_pose_with_heatmap_runner(
-            image_rgb,
-            one_bbox,
-            model_size=model_size,
-            device=device,
-            heatmap_runner=runner,
-        )
-        keypoints_list.append(np.asarray(artifact.keypoints[0], dtype=np.float32))
-        scores_list.append(np.asarray(artifact.scores[0], dtype=np.float32).reshape(-1))
+    Args:
+        image_rgb: Source image in uint8 RGB order.
+        bboxes: Person boxes in XYXY image coordinates.
+        engine_path: TensorRT engine path. May be ``None`` when
+            ``heatmap_runner`` is supplied.
+        model_size: Sapiens2 model size represented by the runner.
+        device: Inference device.
+        heatmap_runner: Optional ready heatmap backend.
 
-    keypoints: Float32[ndarray, "n sapiens_k 2"] = np.stack(keypoints_list, axis=0).astype(np.float32, copy=False)
-    scores: Float32[ndarray, "n sapiens_k"] = np.stack(scores_list, axis=0).astype(np.float32, copy=False)
-    return PosePredictionArtifact(bboxes=bboxes_f32, keypoints=keypoints, scores=scores)
+    Returns:
+        Dense Sapiens2 keypoints and scores for each box.
+
+    Raises:
+        ValueError: If neither an engine path nor a ready runner is supplied.
+    """
+    if heatmap_runner is None:
+        if engine_path is None:
+            raise ValueError("engine_path is required when heatmap_runner is not provided.")
+        runner: PoseHeatmapRunner = TensorRtPoseHeatmapRunner(engine_path, device=device)
+    else:
+        runner = heatmap_runner
+    return estimate_sapiens_pose_with_heatmap_runner(
+        image_rgb,
+        bboxes,
+        model_size=model_size,
+        device=device,
+        heatmap_runner=runner,
+    )
 
 
 def run_tensorrt_image_pose(config: TensorRtImagePoseConfig) -> ImagePoseSummary:

--- a/packages/sapiens2-pose/src/sapiens2_pose/gradio_ui.py
+++ b/packages/sapiens2-pose/src/sapiens2_pose/gradio_ui.py
@@ -11,14 +11,17 @@ import gradio as gr
 import numpy as np
 import rerun as rr
 import rerun.blueprint as rrb
-import spaces
 import torch
 from gradio_rerun import Rerun
 from huggingface_hub import hf_hub_download
+from jaxtyping import Float32
+from numpy import ndarray
 from PIL import Image
 from transformers import DetrForObjectDetection, DetrImageProcessor
 
-from .sapiens_lite.pose import estimate_pose, init_pose_model, nms, parse_pose_metainfo
+from sapiens2_pose.api.pose_artifact import PosePredictionArtifact
+from sapiens2_pose.api.tensorrt_pose import default_tensorrt_engine_path
+from sapiens2_pose.sapiens_lite.pose import estimate_pose, init_pose_model, nms, parse_pose_metainfo
 
 PACKAGE_DIR = Path(__file__).resolve().parent
 ASSETS_DIR = PACKAGE_DIR / "assets"
@@ -50,6 +53,8 @@ DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 BBOX_THR = 0.3
 NMS_THR = 0.3
 
+TENSORRT_MODEL_SIZE = "0.4B"
+
 
 def _env_flag(name: str, default: bool) -> bool:
     value = os.environ.get(name)
@@ -75,8 +80,25 @@ def _server_port() -> int:
 
 _pose_model_cache: dict[str, Any] = {}
 _detector_cache: dict[str, Any] = {}
+_trt_runner_cache: dict[str, Any] = {}
 _metainfo_cache: dict[str, Any] | None = None
 _skeleton_cache: dict[str, Any] | None = None
+
+
+def _get_trt_runner(engine_path: str) -> Any:
+    cache_key: str = str(Path(engine_path).expanduser().resolve())
+    if cache_key not in _trt_runner_cache:
+        if not Path(cache_key).is_file():
+            raise gr.Error(f"TensorRT engine not found at {cache_key}. Build it with the sapiens2-pose-build-trt task.")
+        from sapiens2_pose.api.tensorrt_pose import TensorRtPoseHeatmapRunner
+
+        _trt_runner_cache[cache_key] = TensorRtPoseHeatmapRunner(Path(cache_key))
+        if len(_trt_runner_cache) > 1:
+            oldest_key: str = next(iter(_trt_runner_cache))
+            evicted: Any = _trt_runner_cache.pop(oldest_key)
+            # TensorRT allocates outside Torch's caching allocator; del drops the last reference.
+            del evicted
+    return _trt_runner_cache[cache_key]
 
 
 def _get_metainfo() -> dict[str, Any]:
@@ -195,8 +217,8 @@ def _log_annotation_context() -> None:
 def _log_pose_recording(
     image_rgb: np.ndarray,
     bboxes: np.ndarray,
-    keypoints: list[np.ndarray],
-    scores: list[np.ndarray],
+    keypoints: Float32[ndarray, "n k 2"],
+    scores: Float32[ndarray, "n k"],
     kpt_thr: float,
 ) -> None:
     skeleton = _get_sapiens_skeleton()
@@ -217,7 +239,7 @@ def _log_pose_recording(
         rr.log(
             f"image/person_{idx}/bbox",
             rr.Boxes2D(
-                array=np.asarray(bbox, dtype=np.float32).reshape(1, 4),
+                array=bbox.reshape(1, 4),
                 array_format=rr.Box2DFormat.XYXY,
                 class_ids=0,
                 labels=f"person_{idx}",
@@ -225,8 +247,8 @@ def _log_pose_recording(
             ),
         )
 
-        kpts_arr = np.asarray(kpts, dtype=np.float32).copy()
-        scores_arr = np.asarray(scr, dtype=np.float32).reshape(-1)
+        kpts_arr = kpts.copy()
+        scores_arr = scr.reshape(-1)
         kpts_arr[scores_arr < kpt_thr] = np.nan
         rr.log(
             f"image/person_{idx}/keypoints",
@@ -244,6 +266,7 @@ def _predict_impl(
     image: Image.Image,
     size: str,
     kpt_thr: float,
+    use_tensorrt: bool,
     recording_id: uuid.UUID | str | None,
 ):
     if image is None:
@@ -251,17 +274,35 @@ def _predict_impl(
 
     image_pil = image.convert("RGB")
     image_rgb = np.array(image_pil)
-    image_bgr = cv2.cvtColor(image_rgb, cv2.COLOR_RGB2BGR)
 
     bboxes = _detect_persons(image_rgb)
-    model = _get_pose_model(size)
-    keypoints, scores = estimate_pose(image_bgr, bboxes, model)
+    if use_tensorrt:
+        if size != TENSORRT_MODEL_SIZE:
+            raise gr.Error(f"The TensorRT engine is a static {TENSORRT_MODEL_SIZE} build; select the {TENSORRT_MODEL_SIZE} model.")
+        engine_path: str = default_tensorrt_engine_path()
+        from sapiens2_pose.api.tensorrt_pose import estimate_sapiens_pose_tensorrt
+
+        artifact: PosePredictionArtifact = estimate_sapiens_pose_tensorrt(
+            image_rgb,
+            np.asarray(bboxes, dtype=np.float32),
+            engine_path=Path(engine_path),
+            model_size=TENSORRT_MODEL_SIZE,
+            heatmap_runner=_get_trt_runner(engine_path),
+        )
+        keypoints: Float32[ndarray, "n k 2"] = artifact.keypoints
+        scores: Float32[ndarray, "n k"] = artifact.scores
+    else:
+        image_bgr = cv2.cvtColor(image_rgb, cv2.COLOR_RGB2BGR)
+        model = _get_pose_model(size)
+        pose_result: tuple[list[np.ndarray], list[np.ndarray]] = estimate_pose(image_bgr, bboxes, model)
+        keypoints = np.stack(pose_result[0], axis=0).astype(np.float32, copy=False)
+        scores = np.stack(pose_result[1], axis=0).astype(np.float32, copy=False)
 
     instances = [
         {
-            "bbox": [float(v) for v in np.asarray(bbox).reshape(-1)[:4]],
-            "keypoints": np.asarray(kpts, dtype=float).tolist(),
-            "keypoint_scores": np.asarray(s, dtype=float).reshape(-1).tolist(),
+            "bbox": bbox.reshape(-1)[:4].tolist(),
+            "keypoints": kpts.tolist(),
+            "keypoint_scores": s.reshape(-1).tolist(),
         }
         for bbox, kpts, s in zip(bboxes, keypoints, scores, strict=False)
     ]
@@ -275,22 +316,18 @@ def _predict_impl(
     yield stream.read(), payload
 
 
-@spaces.GPU(duration=120)
-def predict(image: Image.Image, size: str, kpt_thr: float, recording_id: uuid.UUID | str | None):
-    yield from _predict_impl(image, size, kpt_thr, recording_id)
-
-
-@spaces.GPU(duration=120)
 def predict_ui(
     image: Image.Image,
     size: str,
     kpt_thr: float,
+    use_tensorrt: bool,
     recording_id: uuid.UUID | str | None,
 ):
-    for stream, payload in _predict_impl(image, size, kpt_thr, recording_id):
+    backend_label = "TensorRT" if use_tensorrt else "PyTorch"
+    for stream, payload in _predict_impl(image, size, kpt_thr, use_tensorrt, recording_id):
         count = len(payload["instances"])
         suffix = "" if count == 1 else "s"
-        yield stream, payload, f"Complete: {count} person{suffix} detected with Sapiens2 {size}."
+        yield stream, payload, f"Complete: {count} person{suffix} detected with Sapiens2 {size} ({backend_label})."
 
 
 def _switch_to_outputs():
@@ -362,6 +399,9 @@ HEADER_HTML = """
 </div>
 """
 
+# The viewer stream (crypto.randomUUID) and the image "Paste from clipboard"
+# button (navigator.clipboard.read) need a secure context. Serve over HTTPS —
+# on the tailnet: `tailscale serve --bg --https=7860 http://127.0.0.1:7860`.
 with gr.Blocks(title="Sapiens2 Pose") as demo:
     gr.HTML(HEADER_HTML)
     recording_id = gr.State(str(uuid.uuid4()))
@@ -386,6 +426,10 @@ with gr.Blocks(title="Sapiens2 Pose") as demo:
                             choices=list(POSE_MODELS.keys()),
                             value=DEFAULT_SIZE,
                             label="Model",
+                        )
+                        use_trt = gr.Checkbox(
+                            value=False,
+                            label=f"Use TensorRT Backend ({TENSORRT_MODEL_SIZE} only)",
                         )
 
                     examples = gr.Examples(
@@ -435,7 +479,7 @@ with gr.Blocks(title="Sapiens2 Pose") as demo:
         api_visibility="private",
     ).then(
         fn=predict_ui,
-        inputs=[inp, size, thr, recording_id],
+        inputs=[inp, size, thr, use_trt, recording_id],
         outputs=[viewer, out_json, status_text],
     )
 

--- a/packages/sapiens2-pose/src/sapiens2_pose/video_gradio_ui.py
+++ b/packages/sapiens2-pose/src/sapiens2_pose/video_gradio_ui.py
@@ -13,7 +13,6 @@ from typing import cast
 
 import gradio as gr
 import rerun as rr
-import spaces
 import torch
 from gradio.data_classes import FileData
 from gradio_rerun import Rerun
@@ -21,13 +20,12 @@ from gradio_rerun import Rerun
 from .api.metadata import KeypointSchemaName
 from .api.runtime import DEFAULT_BBOX_THR, DEFAULT_MODEL_SIZE, DEFAULT_NMS_THR, POSE_MODELS, ModelSize
 from .api.sam3_tracking import DEFAULT_SAM3_MEMORY_RETENTION_FRAMES, DEFAULT_SAM3_MIN_MASK_AREA_PX
+from .api.tensorrt_pose import DEFAULT_TENSORRT_ENGINE_ENV_VAR, default_tensorrt_engine_path
 from .api.video import PoseBackend, SapiensVideoPoseConfig, TrackingBackend, run_video_pose_pipeline
 
 DEFAULT_SIZE: ModelSize = DEFAULT_MODEL_SIZE
 DEFAULT_SCHEMA: KeypointSchemaName = "coco133"
 DEFAULT_TRACKING_BACKEND: TrackingBackend = "sam3_tracking"
-DEFAULT_TENSORRT_ENGINE_ENV_VAR: str = "SAPIENS2_POSE_TENSORRT_ENGINE_PATH"
-DEFAULT_TENSORRT_ENGINE_FILENAME: str = "sapiens2_0_4b_pose_static_b1_bf16_current_static_graph.trt"
 
 
 def _server_port() -> int:
@@ -79,18 +77,6 @@ def _remux_mov_for_rerun(video_path: Path, output_dir: Path) -> Path:
     return remuxed_path
 
 
-def _default_tensorrt_engine_path() -> str:
-    """Return the app's default TensorRT engine path."""
-    explicit_engine_path: str | None = os.environ.get(DEFAULT_TENSORRT_ENGINE_ENV_VAR)
-    if explicit_engine_path is not None:
-        return explicit_engine_path
-
-    xdg_cache_home: str | None = os.environ.get("XDG_CACHE_HOME")
-    cache_root: Path = Path(xdg_cache_home).expanduser() if xdg_cache_home is not None else Path.home() / ".cache"
-    engine_path: Path = cache_root / "sapiens2-pose" / "tensorrt" / DEFAULT_TENSORRT_ENGINE_FILENAME
-    return str(engine_path)
-
-
 def _format_video_inference_status(*, status: str, backend_label: str, elapsed_seconds: float) -> str:
     """Append whole-video inference timing to a completion status."""
     return f"{status} {backend_label} inference took {elapsed_seconds:.2f}s for the whole video."
@@ -106,7 +92,6 @@ def predict_video_ui(
     nms_thr: float,
     kpt_thr: float,
     use_tensorrt: bool,
-    tensorrt_engine_path: str | None,
     sam3_min_mask_area_px: float | int | None,
     sam3_memory_retention_frames: float | int | None,
     max_frames: float | int | None,
@@ -128,7 +113,7 @@ def predict_video_ui(
     if use_tensorrt:
         if model_size != "0.4B":
             raise gr.Error("TensorRT video mode currently expects a 0.4B pose engine.")
-        engine_path_text: str = str(tensorrt_engine_path or _default_tensorrt_engine_path()).strip()
+        engine_path_text: str = default_tensorrt_engine_path().strip()
         if engine_path_text == "":
             raise gr.Error(f"TensorRT video mode requires an engine path or {DEFAULT_TENSORRT_ENGINE_ENV_VAR}.")
         resolved_tensorrt_engine_path = Path(engine_path_text).expanduser()
@@ -173,9 +158,6 @@ def predict_video_ui(
                 elapsed_seconds=elapsed_seconds,
             )
         yield stream.read(), status_with_note
-
-
-predict_video_ui = spaces.GPU(duration=120)(predict_video_ui)
 
 
 def _reset_video_outputs() -> tuple[None, str]:
@@ -225,11 +207,6 @@ with gr.Blocks(title="Sapiens2 Video Pose") as demo:
                 use_tensorrt = gr.Checkbox(
                     value=False,
                     label="Use TensorRT Backend",
-                )
-                tensorrt_engine_path = gr.Textbox(
-                    value=_default_tensorrt_engine_path(),
-                    label="TensorRT Engine Path",
-                    placeholder=f"Set {DEFAULT_TENSORRT_ENGINE_ENV_VAR} or paste a .trt path",
                 )
                 tracking_backend = gr.Radio(
                     choices=["sam3_tracking", "detr_per_frame"],
@@ -303,7 +280,6 @@ with gr.Blocks(title="Sapiens2 Video Pose") as demo:
             nms_thr,
             kpt_thr,
             use_tensorrt,
-            tensorrt_engine_path,
             sam3_min_mask_area_px,
             sam3_memory_retention_frames,
             max_frames,

--- a/packages/sapiens2-pose/tests/test_gradio_video.py
+++ b/packages/sapiens2-pose/tests/test_gradio_video.py
@@ -8,12 +8,9 @@ from jaxtyping import Float32, UInt8
 from numpy import ndarray
 
 from sapiens2_pose.api.runtime import PoseEstimation
+from sapiens2_pose.api.tensorrt_pose import DEFAULT_TENSORRT_ENGINE_ENV_VAR, default_tensorrt_engine_path
 from sapiens2_pose.api.video import SapiensVideoPoseConfig, _make_effective_bbox_pose_fn, run_video_pose_pipeline
-from sapiens2_pose.video_gradio_ui import (
-    DEFAULT_TENSORRT_ENGINE_ENV_VAR,
-    _default_tensorrt_engine_path,
-    _format_video_inference_status,
-)
+from sapiens2_pose.video_gradio_ui import _format_video_inference_status
 
 
 def test_video_pipeline_tensorrt_backend_detects_boxes_then_runs_bbox_pose(tmp_path: Path) -> None:
@@ -121,12 +118,12 @@ def test_default_tensorrt_engine_path_uses_stable_cache(monkeypatch: Any, tmp_pa
     monkeypatch.delenv(DEFAULT_TENSORRT_ENGINE_ENV_VAR, raising=False)
     monkeypatch.setenv("XDG_CACHE_HOME", str(cache_root))
 
-    engine_path: Path = Path(_default_tensorrt_engine_path())
+    engine_path: Path = Path(default_tensorrt_engine_path())
 
     assert engine_path == cache_root / "sapiens2-pose" / "tensorrt" / "sapiens2_0_4b_pose_static_b1_bf16_current_static_graph.trt"
 
     monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
-    home_engine_path: Path = Path(_default_tensorrt_engine_path())
+    home_engine_path: Path = Path(default_tensorrt_engine_path())
 
     assert home_engine_path == Path.home() / ".cache" / "sapiens2-pose" / "tensorrt" / "sapiens2_0_4b_pose_static_b1_bf16_current_static_graph.trt"
 
@@ -135,7 +132,7 @@ def test_default_tensorrt_engine_path_honors_explicit_env_var(monkeypatch: Any, 
     engine_path: Path = tmp_path / "custom.trt"
     monkeypatch.setenv(DEFAULT_TENSORRT_ENGINE_ENV_VAR, str(engine_path))
 
-    assert _default_tensorrt_engine_path() == str(engine_path)
+    assert default_tensorrt_engine_path() == str(engine_path)
 
 
 def test_format_video_inference_status_reports_backend_and_elapsed_time() -> None:

--- a/packages/sapiens2-pose/tests/test_tensorrt_pose.py
+++ b/packages/sapiens2-pose/tests/test_tensorrt_pose.py
@@ -60,8 +60,12 @@ def test_export_sapiens_pose_onnx_uses_static_batch_one_graph(tmp_path: Path) ->
     assert export_summary.onnx_path == onnx_path
     assert export_summary.input_shape == (1, 3, 1024, 768)
     assert export_summary.output_shape == (1, 308, 256, 192)
-    assert calls[0]["path"].parent == onnx_path.parent
-    assert calls[0]["path"].name.startswith(onnx_path.name + ".part")
+    # trtkit exports into a pid-unique temp DIRECTORY under the final
+    # filename, so the external-data sidecar is born with the name the
+    # published protobuf references.
+    assert calls[0]["path"].name == onnx_path.name
+    assert calls[0]["path"].parent.parent == onnx_path.parent
+    assert calls[0]["path"].parent.name.startswith(onnx_path.name + ".part")
     assert onnx_path.exists()
     assert calls[0]["dummy_inputs"].shape == (1, 3, 1024, 768)
     assert calls[0]["input_names"] == ["inputs"]
@@ -159,27 +163,32 @@ def test_estimate_sapiens_pose_with_heatmap_runner_uses_common_decode_path() -> 
     assert np.all(artifact.scores > 0.0)
 
 
-def test_estimate_sapiens_pose_tensorrt_runs_multiple_boxes_as_static_batch_one_calls() -> None:
+def test_estimate_sapiens_pose_tensorrt_matches_common_heatmap_runner_path() -> None:
     image_rgb: UInt8[ndarray, "h w 3"] = np.zeros((64, 48, 3), dtype=np.uint8)
     bboxes: Float32[ndarray, "n 4"] = np.asarray([[0.0, 0.0, 47.0, 63.0], [4.0, 5.0, 40.0, 55.0]], dtype=np.float32)
     captured_shapes: list[tuple[int, ...]] = []
 
     def fake_heatmap_runner(inputs: torch.Tensor) -> Float32[ndarray, "n k h w"]:
         captured_shapes.append(tuple(int(dim) for dim in inputs.shape))
-        heatmaps: Float32[ndarray, "n k h w"] = np.zeros((1, 308, 256, 192), dtype=np.float32)
+        heatmaps: Float32[ndarray, "n k h w"] = np.zeros((inputs.shape[0], 308, 256, 192), dtype=np.float32)
         heatmaps[:, :, 128, 96] = 1.0
         return heatmaps
 
-    artifact: PosePredictionArtifact = estimate_sapiens_pose_tensorrt(
+    common_artifact: PosePredictionArtifact = estimate_sapiens_pose_with_heatmap_runner(
         image_rgb,
         bboxes,
-        engine_path=Path("/tmp/static-b1.trt"),
+        model_size="0.4B",
+        device="cpu",
+        heatmap_runner=fake_heatmap_runner,
+    )
+    tensorrt_artifact: PosePredictionArtifact = estimate_sapiens_pose_tensorrt(
+        image_rgb,
+        bboxes,
         model_size="0.4B",
         device="cpu",
         heatmap_runner=fake_heatmap_runner,
     )
 
-    assert captured_shapes == [(1, 3, 1024, 768), (1, 3, 1024, 768)]
-    assert artifact.bboxes.shape == (2, 4)
-    assert artifact.keypoints.shape == (2, 308, 2)
-    assert artifact.scores.shape == (2, 308)
+    assert captured_shapes == [(2, 3, 1024, 768), (2, 3, 1024, 768)]
+    np.testing.assert_allclose(tensorrt_artifact.keypoints, common_artifact.keypoints)
+    np.testing.assert_allclose(tensorrt_artifact.scores, common_artifact.scores)

--- a/packages/trtkit/src/trtkit/onnx_export.py
+++ b/packages/trtkit/src/trtkit/onnx_export.py
@@ -9,6 +9,7 @@ network — or a thin adapter that shapes outputs (flatten a dict, add
 fusion-breaker outputs) — and nothing else.
 """
 
+import copy
 import os
 import shutil
 import time
@@ -16,8 +17,49 @@ from collections.abc import Callable, Collection
 from pathlib import Path
 
 import torch
+from torch.nn.modules.conv import _ConvTransposeNd
 
 ExportFn = Callable[..., object]
+
+
+class _Fp32Island(torch.nn.Module):
+    """Runs its inner module in fp32 inside an autocast region.
+
+    TensorRT's strongly-typed builds cannot type a BF16 ConvTranspose — an
+    open type-inference-rule gap (NVIDIA/TensorRT-Incubator#565, verified
+    failing on TRT 11.2.1.2) — so bf16 exports keep transposed convolutions
+    fp32. Weak typing made this exact fallback implicitly before TRT 11
+    removed it. Retest on TRT bumps; delete when the upstream bug is fixed.
+    """
+
+    def __init__(self, inner: torch.nn.Module) -> None:
+        super().__init__()
+        self.inner = inner
+
+    def forward(self, *inputs: torch.Tensor) -> torch.Tensor:
+        with torch.autocast("cuda", enabled=False):
+            return self.inner(*(t.float() if t.is_floating_point() else t for t in inputs))
+
+
+def _with_fp32_transposed_convs(module: torch.nn.Module) -> torch.nn.Module:
+    """Return a structural copy whose transposed convs sit in fp32 islands.
+
+    Parameters and buffers are shared with the original; the caller's module
+    tree is never mutated, so eager parity references stay honest.
+    """
+    if isinstance(module, _Fp32Island):
+        return module
+    if isinstance(module, _ConvTransposeNd):
+        return _Fp32Island(module)
+    replaced: dict[str, torch.nn.Module] = {
+        name: _with_fp32_transposed_convs(child) for name, child in module.named_children()
+    }
+    if all(replaced[name] is child for name, child in module.named_children()):
+        return module
+    clone: torch.nn.Module = copy.copy(module)
+    clone._modules = dict(module._modules)
+    clone._modules.update(replaced)
+    return clone
 
 
 class _AutocastWrapper(torch.nn.Module):
@@ -116,7 +158,10 @@ def export_onnx(
     # TRT parsers accept the invalid graph and silently miscompile it. 18 is
     # the dynamo baseline for everything else; TRT 11 parses up to 24.
     opset_version: int = 23 if compute_dtype == torch.bfloat16 else 18
-    export_model: torch.nn.Module = _AutocastWrapper(model, compute_dtype).eval() if compute_dtype is not None else model
+    # bf16 also forces fp32 islands around transposed convs (see _Fp32Island);
+    # derived from the dtype, like the opset — not a caller knob.
+    inner: torch.nn.Module = _with_fp32_transposed_convs(model) if compute_dtype == torch.bfloat16 else model
+    export_model: torch.nn.Module = _AutocastWrapper(inner, compute_dtype).eval() if compute_dtype is not None else model
 
     kwargs: dict[str, object] = {}
     if dynamic_batch_max is not None:

--- a/packages/trtkit/src/trtkit/tensorrt_runtime.py
+++ b/packages/trtkit/src/trtkit/tensorrt_runtime.py
@@ -92,6 +92,23 @@ class TensorRtRuntime:
             )
             for spec in self._spec.outputs
         }
+        # Static engines report the baked max batch through the context at every
+        # call, so padded rows must be sliced off by per-sample ratio; dynamic
+        # engines report exact shapes per active batch and owe no divisibility.
+        # The slice assumes sample-major rows (leading dim = batch * k); a
+        # k-major intermediate would yield the wrong rows — none exists today.
+        self._static_rows_per_sample: dict[str, int] = {}
+        if not self._dynamic:
+            for out_spec in self._spec.outputs:
+                rows_at_max: int = int(self._output_buffers[out_spec.name].shape[0])
+                if rows_at_max % max_batch != 0:
+                    raise ValueError(
+                        f"Static engine output {out_spec.name!r} has {rows_at_max} rows at batch {max_batch}; "
+                        "padded rows cannot be sliced off a non-multiple. Constant-shaped outputs usually "
+                        "come from TrtBuildConfig.extra_output_patterns intermediates — rebuild without "
+                        "materializing that tensor, or use a dynamic-batch engine."
+                    )
+                self._static_rows_per_sample[out_spec.name] = rows_at_max // max_batch
         for name, tensor in {**self._input_buffers, **self._output_buffers}.items():
             self._context.set_tensor_address(name, int(tensor.data_ptr()))
         self._stream: torch.cuda.Stream = torch.cuda.Stream(device=self._device)
@@ -138,10 +155,16 @@ class TensorRtRuntime:
             self._graphs[graph_key].replay()
         else:
             self._execute()
-        # Slice each output to the rows the context actually produced at this batch
-        # (materialized intermediates may scale their leading dim beyond the batch).
+        # Dynamic engines report exact per-batch output shapes; static engines
+        # always report the baked max batch, so padded rows are sliced off by
+        # the per-sample ratio recorded at construction.
+        if self._dynamic:
+            return {
+                name: tensor[: int(self._context.get_tensor_shape(name)[0])]
+                for name, tensor in self._output_buffers.items()
+            }
         return {
-            name: tensor[: int(self._context.get_tensor_shape(name)[0])]
+            name: tensor[: self._static_rows_per_sample[name] * batch_size]
             for name, tensor in self._output_buffers.items()
         }
 

--- a/packages/trtkit/tests/test_trtkit.py
+++ b/packages/trtkit/tests/test_trtkit.py
@@ -114,3 +114,24 @@ def test_allow_tf32_cache_key(tmp_path: Path) -> None:
     assert default_path != notf32_path
     assert "notf32" in notf32_path.name
     assert "notf32" not in default_path.name
+
+
+def test_fp32_transposed_conv_islands_share_weights_without_mutating() -> None:
+    """bf16 exports isolate transposed convs in fp32 without touching the caller's model."""
+    from trtkit.onnx_export import _Fp32Island, _with_fp32_transposed_convs
+
+    model = torch.nn.Sequential(
+        torch.nn.Conv2d(2, 4, 3, padding=1),
+        torch.nn.ConvTranspose2d(4, 2, 2, stride=2),
+    ).eval()
+    wrapped = _with_fp32_transposed_convs(model)
+
+    assert isinstance(wrapped[1], _Fp32Island)
+    assert wrapped[1].inner is model[1], "island must share the original conv (weights by reference)"
+    assert not any(isinstance(m, _Fp32Island) for m in model.modules()), "caller's tree must stay unmodified"
+    rewrapped = _with_fp32_transposed_convs(wrapped)
+    assert rewrapped[1] is wrapped[1], "re-wrapping must be idempotent"
+
+    x = torch.randn(1, 2, 8, 8)
+    with torch.inference_mode():
+        torch.testing.assert_close(wrapped(x), model(x))


### PR DESCRIPTION
**Stack 2/4** — base: #106

Adds a 'Use TensorRT Backend (0.4B)' toggle to the image app, dispatching to `estimate_sapiens_pose_tensorrt` with a cached, path-normalized, bounded runner. One shared `default_tensorrt_engine_path()` in `api/tensorrt_pose.py` now serves both the image and video apps (bf16 static-b1 engine name — buildable again thanks to #106; the interim fp32 workaround engine name is gone). Per-bbox repeated BGR conversion + preprocessor construction hoisted out of the crop loop.

Validated in-browser over the tailnet HTTPS origin: TRT and PyTorch runs on the same example render visually identical keypoints; status reports the backend. Tests + ruff/pyrefly clean.