### PR TITLE
mamma: posekit-role TensorRT backend, approximate 2D skeleton, example assets

### DIFF
--- a/packages/mamma/src/mamma/landmarks/estimator.py
+++ b/packages/mamma/src/mamma/landmarks/estimator.py
@@ -14,6 +14,7 @@ from mamma.engine.types import CameraTracks
 from mamma.landmarks.config import DEFAULT_MAMMANET_CONFIG, MammaNetConfig
 from mamma.landmarks.crops import box_geometry, gpu_crop_batch, gpu_mask_crop_batch, unproject_joints2d
 from mamma.landmarks.mammanet import MammaNet, load_mammanet
+from mamma.landmarks.tensorrt_backend import INPUT_NAMES, OUTPUT_NAMES
 
 
 @dataclass(slots=True)
@@ -41,7 +42,7 @@ class LandmarkEstimator:
 
     def __init__(
         self,
-        weights_path: Path,
+        weights_path: Path | None = None,
         device: str = "cuda",
         config: MammaNetConfig = DEFAULT_MAMMANET_CONFIG,
         compile_model: bool = False,
@@ -117,15 +118,15 @@ class LandmarkEstimator:
         img_crops, _ = gpu_crop_batch(frames_batch, centers * s, sizes * s, None, self.config)
         mask_crops = gpu_mask_crop_batch(masks_batch, centers, sizes, self.config)
         if self.runner is not None and img_crops.shape[0] <= 4:
-            out: dict[str, torch.Tensor | None] = dict(self.runner({"crops": img_crops, "masks": mask_crops}))
+            out: dict[str, torch.Tensor | None] = dict(self.runner({INPUT_NAMES[0]: img_crops, INPUT_NAMES[1]: mask_crops}))
         else:
             with torch.no_grad(), torch.autocast("cuda", dtype=torch.float16, enabled="cuda" in self.device):
                 out = self.model(img_crops, mask_crops)
 
-        joints2d_raw = out["joints2d"]
-        visibility_raw = out["visibility"]
-        contact_raw = out["contact"]
-        floor_raw = out["floor_contact"]
+        joints2d_raw = out[OUTPUT_NAMES[0]]
+        visibility_raw = out[OUTPUT_NAMES[1]]
+        contact_raw = out[OUTPUT_NAMES[2]]
+        floor_raw = out[OUTPUT_NAMES[3]]
         assert joints2d_raw is not None and visibility_raw is not None and contact_raw is not None and floor_raw is not None
         joints2d_px: Float32[torch.Tensor, "n j 3"] = unproject_joints2d(joints2d_raw.float(), centers, sizes, self.config)
         visibility: Float32[torch.Tensor, "n j"] = torch.sigmoid(visibility_raw.squeeze(-1).float())

--- a/packages/mamma/src/mamma/landmarks/mammanet.py
+++ b/packages/mamma/src/mamma/landmarks/mammanet.py
@@ -25,6 +25,8 @@ DEFAULT_MEAN: Float32[ndarray, "3"] = (255.0 * np.array([0.485, 0.456, 0.406])).
 """Per-channel RGB mean (0..255 scale) used to normalize crops."""
 DEFAULT_STD: Float32[ndarray, "3"] = (255.0 * np.array([0.229, 0.224, 0.225])).astype(np.float32)
 """Per-channel RGB std (0..255 scale) used to normalize crops."""
+MAMMANET_WEIGHTS_REPO: str = "pablovela5620/mamma-streaming-data"
+MAMMANET_WEIGHTS_FILE: str = "weights/ma_2d/mamma_mask_full_cvpr.safetensors"
 
 
 class MammaNet(nn.Module):
@@ -72,11 +74,38 @@ class MammaNet(nn.Module):
         return self.decoder(features, self.backbone.pos_embed)
 
 
-def load_mammanet(weights_path: Path, device: str = "cuda", config: MammaNetConfig = DEFAULT_MAMMANET_CONFIG) -> MammaNet:
-    """Load MammaNet from the converted safetensors state dict (strict)."""
+def resolve_mammanet_weights_path(weights_path: Path | None = None) -> Path:
+    """Resolve an explicit checkpoint or download the published MammaNet weights."""
+    if weights_path is None:
+        from huggingface_hub import hf_hub_download
+
+        weights_path = Path(hf_hub_download(repo_id=MAMMANET_WEIGHTS_REPO, repo_type="dataset", filename=MAMMANET_WEIGHTS_FILE))
+    resolved_path: Path = weights_path.expanduser().resolve()
+    if not resolved_path.is_file():
+        raise FileNotFoundError(f"MammaNet weights not found: {resolved_path}")
+    return resolved_path
+
+
+def load_mammanet(
+    weights_path: Path | None = None,
+    device: str = "cuda",
+    config: MammaNetConfig = DEFAULT_MAMMANET_CONFIG,
+) -> MammaNet:
+    """Load MammaNet from the converted safetensors state dict.
+
+    Args:
+        weights_path: Local checkpoint path. ``None`` downloads the published
+            MammaNet weights from Hugging Face.
+        device: Device receiving the loaded model.
+        config: MammaNet architecture configuration.
+
+    Returns:
+        The strictly loaded evaluation model.
+    """
+    resolved_path: Path = resolve_mammanet_weights_path(weights_path)
     from safetensors.torch import load_file
 
     model: MammaNet = MammaNet(config)
-    state_dict: dict[str, torch.Tensor] = load_file(str(weights_path))
+    state_dict: dict[str, torch.Tensor] = load_file(str(resolved_path))
     model.load_state_dict(state_dict, strict=True)
     return model.to(device).eval()

--- a/packages/mamma/src/mamma/landmarks/posekit_role.py
+++ b/packages/mamma/src/mamma/landmarks/posekit_role.py
@@ -1,4 +1,4 @@
-"""MammaNet behind posekit's ``TopDownDenseLandmarks2d`` role.
+"""Posekit adapter for MammaNet's ``TopDownDenseLandmarks2d`` role.
 
 The adapter that lets mamma's dense-landmark net slot into any posekit
 pipeline (posekit docs/design.md §6): detections with masks in — the tracker's
@@ -7,7 +7,7 @@ visibility / contact heads out, all GPU tensors. Crop math, normalization, and
 precision match ``LandmarkEstimator.estimate`` exactly (same mamma ops).
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import numpy as np
@@ -17,23 +17,35 @@ from numpy import ndarray
 from posekit.models import TopDownDenseLandmarks2d
 from posekit.predictions import BoxDetections, DenseLandmarks2d, validate_frames_rgb
 from torch import Tensor
+from trtkit import (
+    TensorRtBackendConfig,
+    TensorRuntime,
+    TensorSpec,
+    TorchBackendConfig,
+    TorchRuntime,
+    create_runtime_from_onnx,
+    run_chunked,
+)
 
 from mamma.landmarks.config import DEFAULT_MAMMANET_CONFIG, MammaNetConfig
 from mamma.landmarks.crops import box_geometry, gpu_crop_batch, gpu_mask_crop_batch, unproject_joints2d
-from mamma.landmarks.mammanet import MammaNet, load_mammanet
-
-MAMMANET_WEIGHTS_REPO: str = "pablovela5620/mamma-streaming-data"
-MAMMANET_WEIGHTS_FILE: str = "weights/ma_2d/mamma_mask_full_cvpr.safetensors"
+from mamma.landmarks.mammanet import MammaNet, load_mammanet, resolve_mammanet_weights_path
+from mamma.landmarks.tensorrt_backend import INPUT_NAMES, OUTPUT_NAMES, FlattenOutputs, ensure_mammanet_onnx
 
 
 @dataclass(frozen=True, slots=True)
 class MammaNetLandmarksConfig:
-    """MammaNet dense-landmark estimator configuration (torch backend)."""
+    """MammaNet dense-landmark estimator configuration."""
 
     weights_path: Path | None = None
-    """Local safetensors checkpoint; ``None`` downloads mamma's HF weights."""
+    """Checkpoint used by the torch backend and by one-time ONNX export; ``None`` downloads the published weights."""
     device: str = "cuda"
     """Inference device."""
+    backend: TorchBackendConfig | TensorRtBackendConfig = field(default_factory=TorchBackendConfig)
+    """Backend running the loaded model or its cached dynamic ONNX export.
+
+    ``OnnxBackendConfig`` is excluded because the fp16-compute graph uses kernels not covered by ONNX Runtime's CUDA provider.
+    """
 
     def setup(self) -> "MammaNetLandmarks":
         """Load weights and return a ready estimator."""
@@ -47,18 +59,35 @@ class MammaNetLandmarks(TopDownDenseLandmarks2d):
         """Load the checkpoint.
 
         Args:
-            config: Weights source and device.
+            config: Weights source, runtime backend, and device.
         """
-        from huggingface_hub import hf_hub_download
-
+        if not isinstance(config.backend, TorchBackendConfig) and config.device != "cuda":
+            raise ValueError("MammaNet accelerated backends require device='cuda'.")
         self.config: MammaNetLandmarksConfig = config
-        weights_path: Path = (
-            config.weights_path
-            if config.weights_path is not None
-            else Path(hf_hub_download(repo_id=MAMMANET_WEIGHTS_REPO, repo_type="dataset", filename=MAMMANET_WEIGHTS_FILE))
-        )
         self.mamma_config: MammaNetConfig = DEFAULT_MAMMANET_CONFIG
-        self.model: MammaNet = load_mammanet(weights_path, device=config.device, config=self.mamma_config)
+        weights_path: Path = resolve_mammanet_weights_path(config.weights_path)
+        model: MammaNet = load_mammanet(weights_path, device=config.device, config=self.mamma_config)
+        input_specs: tuple[TensorSpec, TensorSpec] = (
+            TensorSpec(INPUT_NAMES[0], (3, self.mamma_config.crop_height, self.mamma_config.crop_width), torch.float32),
+            TensorSpec(INPUT_NAMES[1], (1, self.mamma_config.crop_height, self.mamma_config.crop_width), torch.float32),
+        )
+        output_specs: tuple[TensorSpec, TensorSpec, TensorSpec, TensorSpec] = (
+            TensorSpec(OUTPUT_NAMES[0], (self.mamma_config.num_landmarks, 3), torch.float32),
+            TensorSpec(OUTPUT_NAMES[1], (self.mamma_config.num_landmarks, 1), torch.float32),
+            TensorSpec(OUTPUT_NAMES[2], (self.mamma_config.num_landmarks, 1), torch.float32),
+            TensorSpec(OUTPUT_NAMES[3], (self.mamma_config.num_landmarks, 1), torch.float32),
+        )
+        if isinstance(config.backend, TorchBackendConfig):
+            autocast_dtype: torch.dtype | None = config.backend.autocast_dtype if "cuda" in config.device else None
+            self.runtime: TensorRuntime = TorchRuntime(
+                FlattenOutputs(model),
+                input_specs=input_specs,
+                output_specs=output_specs,
+                max_batch_size=config.backend.max_batch_size,
+                autocast_dtype=autocast_dtype,
+            )
+        else:
+            self.runtime = create_runtime_from_onnx(ensure_mammanet_onnx(model, weights_path), config.backend)
         self.num_landmarks = int(self.mamma_config.num_landmarks)
 
     @torch.no_grad()
@@ -86,7 +115,7 @@ class MammaNetLandmarks(TopDownDenseLandmarks2d):
             empty_p: Float32[Tensor, "0 p"] = torch.empty((0, self.num_landmarks), dtype=torch.float32, device=device)
             return DenseLandmarks2d(empty_xy, empty_p, empty_p, empty_p, empty_p, detections.frame_indices)
 
-        boxes_np: Float32[ndarray, "n 4"] = detections.xyxy.detach().cpu().numpy().astype(np.float32, copy=False)
+        boxes_np: Float32[ndarray, "n 4"] = detections.xyxy_numpy()
         geometry: list[tuple[Float64[ndarray, "2"], Float64[ndarray, "2"]]] = [
             box_geometry(boxes_np[row], self.mamma_config) for row in range(num_instances)
         ]
@@ -98,13 +127,11 @@ class MammaNetLandmarks(TopDownDenseLandmarks2d):
         masks_batch: Float[Tensor, "n 1 h w"] = detections.masks.unsqueeze(1).float() * 255.0
         img_crops, _ = gpu_crop_batch(gathered, centers, sizes, None, self.mamma_config)
         mask_crops = gpu_mask_crop_batch(masks_batch, centers, sizes, self.mamma_config)
-        with torch.autocast("cuda", dtype=torch.float16, enabled="cuda" in self.config.device):
-            out: dict[str, Tensor | None] = self.model(img_crops, mask_crops)
-        joints2d_raw = out["joints2d"]
-        visibility_raw = out["visibility"]
-        contact_raw = out["contact"]
-        floor_raw = out["floor_contact"]
-        assert joints2d_raw is not None and visibility_raw is not None and contact_raw is not None and floor_raw is not None
+        out: dict[str, Tensor] = run_chunked(self.runtime, {INPUT_NAMES[0]: img_crops, INPUT_NAMES[1]: mask_crops})
+        joints2d_raw: Tensor = out[OUTPUT_NAMES[0]]
+        visibility_raw: Tensor = out[OUTPUT_NAMES[1]]
+        contact_raw: Tensor = out[OUTPUT_NAMES[2]]
+        floor_raw: Tensor = out[OUTPUT_NAMES[3]]
         joints2d_px: Float32[Tensor, "n p 3"] = unproject_joints2d(joints2d_raw.float(), centers, sizes, self.mamma_config)
         return DenseLandmarks2d(
             xy=joints2d_px[:, :, 0:2].contiguous(),
@@ -116,4 +143,7 @@ class MammaNetLandmarks(TopDownDenseLandmarks2d):
         )
 
 
-__all__ = ("MammaNetLandmarks", "MammaNetLandmarksConfig")
+__all__ = (
+    "MammaNetLandmarks",
+    "MammaNetLandmarksConfig",
+)

--- a/packages/mamma/src/mamma/landmarks/skeleton.py
+++ b/packages/mamma/src/mamma/landmarks/skeleton.py
@@ -1,0 +1,141 @@
+"""Approximate 2D SMPL-X skeleton from the 512 dense surface landmarks.
+
+Each of the 512 landmarks is a fixed SMPL-X surface vertex, so every joint can
+be estimated as a fixed weighted average of nearby landmarks. Weights are
+k-nearest-neighbor gaussians built in rest pose (joint -> surface distances).
+Restricting SMPL-X's own ``J_regressor`` to the 512 sampled vertices was
+measured and rejected: most rows keep <5% of their mass (pelvis 0.2%), giving
+12.5 cm mean body-joint error on posed bodies vs 3.3 cm for the kNN weights.
+No SMPL-X fitting happens here — this is a linear map, exact articulation is
+not preserved, and the output is a display skeleton, not a measurement.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import torch
+from jaxtyping import Float32, Int
+from numpy import ndarray
+
+KNN_NEIGHBORS: int = 8
+"""Landmarks averaged per joint."""
+SIGMA_NEIGHBORS: int = 4
+"""Nearest neighbors whose mean distance sets each joint's gaussian sigma."""
+DEFAULT_BODY_MODELS_DIR: Path = Path(
+    os.environ.get("MAMMA_BODY_MODELS_DIR", str(Path(__file__).resolve().parents[3] / "data" / "body_models"))
+).expanduser()
+"""Package-relative body-model root populated by ``_download-mamma-body-models``."""
+
+
+@dataclass(frozen=True, slots=True)
+class SkeletonRegressor:
+    """Fixed linear map from dense landmarks to 2D SMPL-X joints."""
+
+    weights: Float32[ndarray, "j landmarks"]
+    """Per-joint landmark weights, rows sum to 1."""
+    parents: tuple[int, ...]
+    """SMPL-X kinematic tree; ``parents[0] == -1``."""
+    bones: Int[ndarray, "b 2"]
+    """Child-parent joint indices for every non-root bone."""
+
+
+def body_models_available(body_models_dir: Path | None = None) -> bool:
+    """Return whether the downloaded SMPL-X model directory is present."""
+    resolved_dir: Path = DEFAULT_BODY_MODELS_DIR if body_models_dir is None else body_models_dir
+    return (resolved_dir / "smplx").exists()
+
+
+@functools.lru_cache(maxsize=1)
+def load_skeleton_regressor(body_models_dir: Path | None = None) -> SkeletonRegressor:
+    """Load the display skeleton regressor from the package's body-model assets.
+
+    Raises:
+        RuntimeError: If the body-model download task has not populated the assets.
+    """
+    resolved_dir: Path = DEFAULT_BODY_MODELS_DIR if body_models_dir is None else body_models_dir
+    if not body_models_available(resolved_dir):
+        raise RuntimeError("SMPL-X body models not found. Run the pixi task _download-mamma-body-models in packages/mamma.")
+    return build_skeleton_regressor(resolved_dir)
+
+
+def skeleton_strips(
+    joints_xy: Float32[ndarray, "j 2"],
+    regressor: SkeletonRegressor,
+) -> Float32[ndarray, "b 2 2"]:
+    """Build child-parent line strips from one person's regressed joints.
+
+    Args:
+        joints_xy: Display skeleton joints in image pixels.
+        regressor: Regressor carrying the SMPL-X kinematic tree.
+
+    Returns:
+        One two-point strip for every non-root joint.
+    """
+    return joints_xy[regressor.bones]
+
+
+def build_skeleton_regressor(body_models_dir: Path) -> SkeletonRegressor:
+    """Build the kNN joint regressor from the SMPL-X neutral model in rest pose.
+
+    Args:
+        body_models_dir: Root containing ``smplx/SMPLX_NEUTRAL.npz`` and
+            ``downsampled_verts/verts_512.pkl`` (the ``_download-mamma-body-models``
+            pixi task layout).
+
+    Returns:
+        The regressor over the joints exposed by the loaded SMPL-X model.
+    """
+    import pickle
+
+    from mamma.fitting.smplx_wrapper import build_smplx_neutral
+
+    model = build_smplx_neutral(body_models_dir, device="cpu")
+    with open(body_models_dir / "downsampled_verts" / "verts_512.pkl", "rb") as f:
+        sampling: Float32[torch.Tensor, "n v"] = pickle.load(f).float()
+
+    v_rest: Float32[torch.Tensor, "v 3"] = model.v_template.float()
+    landmarks_rest: Float32[torch.Tensor, "n 3"] = sampling @ v_rest
+    joints_rest: Float32[torch.Tensor, "j 3"] = model.J_regressor.float() @ v_rest
+
+    distances: Float32[torch.Tensor, "j n"] = torch.cdist(joints_rest, landmarks_rest)
+    knn_dist, knn_idx = distances.topk(KNN_NEIGHBORS, largest=False)
+    sigma: Float32[torch.Tensor, "j 1"] = knn_dist[:, :SIGMA_NEIGHBORS].mean(dim=1, keepdim=True).clamp_min(1e-4)
+    gaussians: Float32[torch.Tensor, "j k"] = torch.exp(-0.5 * (knn_dist / sigma) ** 2)
+    weights: Float32[torch.Tensor, "j n"] = torch.zeros(joints_rest.shape[0], landmarks_rest.shape[0])
+    weights.scatter_(1, knn_idx, gaussians)
+    weights = weights / weights.sum(dim=1, keepdim=True)
+
+    parents: tuple[int, ...] = tuple(int(parent) for parent in model.parents.tolist())
+    bones: Int[ndarray, "b 2"] = np.asarray(
+        [(joint_idx, parent_idx) for joint_idx, parent_idx in enumerate(parents) if parent_idx >= 0], dtype=np.int64
+    )
+    return SkeletonRegressor(weights=weights.numpy().astype(np.float32), parents=parents, bones=bones)
+
+
+def joints_from_landmarks(
+    landmarks_xy: Float32[ndarray, "n landmarks 2"],
+    regressor: SkeletonRegressor,
+) -> Float32[ndarray, "n j 2"]:
+    """Estimate 2D joints per person as fixed weighted landmark averages.
+
+    All 512 landmarks participate regardless of visibility: MammaNet predicts
+    xy for occluded landmarks too (the fitting pipeline consumes all of them),
+    and in 2D projection a back-surface landmark lands at nearly the same pixel
+    as a front one — visibility reweighting would only bias joints toward the
+    visible side (SMPL-X spine joints sit near the back surface and would
+    otherwise lose all their support).
+
+    Args:
+        landmarks_xy: Predicted landmark positions in image pixels.
+        regressor: Fixed landmark->joint weights.
+
+    Returns:
+        2D joints per person.
+    """
+    joints: Float32[ndarray, "n j 2"] = np.einsum("jl,nlc->njc", regressor.weights, landmarks_xy)
+    return joints.astype(np.float32)

--- a/packages/mamma/src/mamma/landmarks/tensorrt_backend.py
+++ b/packages/mamma/src/mamma/landmarks/tensorrt_backend.py
@@ -1,57 +1,76 @@
 """TensorRT backend for MammaNet (ONNX export + trtkit engine build).
 
-Inference runs directly on :class:`trtkit.TensorRtRuntime` with
-``use_cuda_graph=True`` (inputs ``crops``/``masks``, outputs ``joints2d``/
-``visibility``/``contact``/``floor_contact`` — see ``export_mammanet_onnx``).
+The static streaming path runs directly on :class:`trtkit.TensorRtRuntime`
+with ``use_cuda_graph=True`` (inputs ``crops``/``masks``, outputs
+``joints2d``/``visibility``/``contact``/``floor_contact`` — see
+``export_mammanet_onnx``).
 
 Follows the shared trtkit pattern: the `tensorrt-cu13` python API (not
-torch-tensorrt), static batch, a strongly-typed engine whose fp16 compute is
-baked into the ONNX graph (fp32 I/O boundary casts in the export wrapper), and
-one captured ``execute_async_v3`` launch replayed per call — which composes
-cleanly with the fitter's manual CUDA graph.
+torch-tensorrt) and a strongly-typed engine whose fp16 compute is baked into
+the ONNX graph (fp32 I/O boundary casts in the export wrapper). The streaming
+path retains its static-batch CUDA graph; posekit exports one cached dynamic
+ONNX graph and lets trtkit build and cache engines by content hash.
 
-Engines are machine-local artifacts (sm-specific): built once into
-``.trt_cache/`` by ``tools/build_trt_engine.py``, never committed.
+Engines are machine-local artifacts and are never committed. The static
+streaming engine is built into ``.trt_cache/`` by
+``tools/build_trt_engine.py``; posekit's dynamic engine uses trtkit's cache.
 """
 
 from __future__ import annotations
 
+import hashlib
+from os import stat_result
 from pathlib import Path
 
 import torch
+from jaxtyping import Float32
 
 from mamma.landmarks.config import DEFAULT_MAMMANET_CONFIG, MammaNetConfig
 from mamma.landmarks.mammanet import MammaNet
 
 ENGINE_BATCH: int = 4
 """Static batch baked into the engine (cameras x persons rounded up)."""
+INPUT_NAMES: tuple[str, str] = ("crops", "masks")
+"""MammaNet ONNX input bindings in graph order."""
+OUTPUT_NAMES: tuple[str, str, str, str] = ("joints2d", "visibility", "contact", "floor_contact")
+"""MammaNet ONNX output bindings in graph order."""
 
 
-class _FlattenOutputs(torch.nn.Module):
+class FlattenOutputs(torch.nn.Module):
     """Adapter shaping MammaNet's dict output into the flat ONNX output tuple."""
 
     def __init__(self, model: MammaNet) -> None:
         super().__init__()
         self.model = model
 
-    def forward(self, x: torch.Tensor, masks: torch.Tensor):
-        out = self.model(x, masks)
-        return out["joints2d"], out["visibility"], out["contact"], out["floor_contact"]
+    def forward(
+        self, crops: Float32[torch.Tensor, "b 3 h w"], masks: Float32[torch.Tensor, "b 1 h w"]
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+        outputs: dict[str, torch.Tensor | None] = self.model(crops, masks)
+        return outputs[OUTPUT_NAMES[0]], outputs[OUTPUT_NAMES[1]], outputs[OUTPUT_NAMES[2]], outputs[OUTPUT_NAMES[3]]
 
 
-def export_mammanet_onnx(model: MammaNet, onnx_path: Path, config: MammaNetConfig = DEFAULT_MAMMANET_CONFIG) -> None:
-    """Export MammaNet to a static-batch, fp16-compute ONNX graph via trtkit."""
+def export_mammanet_onnx(
+    model: MammaNet,
+    onnx_path: Path,
+    *,
+    batch: int = ENGINE_BATCH,
+    dynamic_batch_max: int | None = None,
+    config: MammaNetConfig = DEFAULT_MAMMANET_CONFIG,
+) -> None:
+    """Export MammaNet to one static- or dynamic-batch fp16-compute ONNX graph via trtkit."""
     from trtkit import export_onnx
 
-    x = torch.randn(ENGINE_BATCH, 3, config.crop_height, config.crop_width, device="cuda")
-    masks = torch.rand(ENGINE_BATCH, 1, config.crop_height, config.crop_width, device="cuda")
+    crops: Float32[torch.Tensor, "b 3 h w"] = torch.randn(batch, 3, config.crop_height, config.crop_width, device="cuda")
+    masks: Float32[torch.Tensor, "b 1 h w"] = torch.rand(batch, 1, config.crop_height, config.crop_width, device="cuda")
     export_onnx(
-        _FlattenOutputs(model).eval().cuda(),
-        (x, masks),
+        FlattenOutputs(model).eval().cuda(),
+        (crops, masks),
         onnx_path,
-        input_names=["crops", "masks"],
-        output_names=["joints2d", "visibility", "contact", "floor_contact"],
+        input_names=list(INPUT_NAMES),
+        output_names=list(OUTPUT_NAMES),
         compute_dtype=torch.float16,
+        dynamic_batch_max=dynamic_batch_max,
     )
 
 
@@ -61,3 +80,21 @@ def build_engine(onnx_path: Path, engine_path: Path) -> None:
     from trtkit import build_engine as trtkit_build_engine
 
     trtkit_build_engine(onnx_path, engine_path, TrtBuildConfig(max_batch_size=ENGINE_BATCH, opt_batch_size=ENGINE_BATCH))
+
+
+def ensure_mammanet_onnx(model: MammaNet, weights_path: Path, config: MammaNetConfig = DEFAULT_MAMMANET_CONFIG) -> Path:
+    """Return MammaNet's cached dynamic-batch fp16 ONNX export."""
+    from posekit.artifacts import DEFAULT_ONNX_CACHE_DIR
+
+    checkpoint_stat: stat_result = weights_path.stat()
+    # Metadata identity avoids hashing the 1.5 GB checkpoint on every setup.
+    checkpoint_id: str = hashlib.sha1(
+        f"{weights_path}:{checkpoint_stat.st_size}:{checkpoint_stat.st_mtime_ns}".encode()
+    ).hexdigest()[:10]
+    onnx_path: Path = DEFAULT_ONNX_CACHE_DIR / f"mammanet_dense512_dynamic_b32_fp16_{checkpoint_id}.onnx"
+    if onnx_path.exists():
+        return onnx_path
+    onnx_path.parent.mkdir(parents=True, exist_ok=True)
+    print(f"[mamma] exporting MammaNet to ONNX (one-time): {onnx_path.name}")
+    export_mammanet_onnx(model, onnx_path, batch=8, dynamic_batch_max=32, config=config)
+    return onnx_path

--- a/packages/mamma/tests/test_posekit_role.py
+++ b/packages/mamma/tests/test_posekit_role.py
@@ -1,0 +1,86 @@
+"""Public-contract tests for MammaNet's posekit landmark role."""
+
+from pathlib import Path
+
+import pytest
+import torch
+from posekit.predictions import BoxDetections
+from posekit.runtimes import TensorRtBackendConfig
+from torch import Tensor
+from trtkit import RuntimeSpec, TensorSpec
+
+from mamma.landmarks.mammanet import MammaNet
+from mamma.landmarks.posekit_role import MammaNetLandmarksConfig
+
+
+def test_accelerated_role_requires_cuda_before_loading_weights() -> None:
+    with pytest.raises(ValueError, match="require device='cuda'"):
+        MammaNetLandmarksConfig(device="cpu", backend=TensorRtBackendConfig()).setup()
+
+
+def test_tensorrt_role_builds_from_weights_and_returns_dense_landmark_heads(monkeypatch, tmp_path: Path) -> None:
+    """The TensorRT role resolves weights and preserves MammaNet's image-space output contract."""
+
+    class FakeTensorRtRuntime:
+        def __init__(self) -> None:
+            self.spec = RuntimeSpec(
+                inputs=(
+                    TensorSpec("crops", (3, 512, 384), torch.float32),
+                    TensorSpec("masks", (1, 512, 384), torch.float32),
+                ),
+                outputs=(
+                    TensorSpec("joints2d", (512, 3), torch.float32),
+                    TensorSpec("visibility", (512, 1), torch.float32),
+                    TensorSpec("contact", (512, 1), torch.float32),
+                    TensorSpec("floor_contact", (512, 1), torch.float32),
+                ),
+                max_batch_size=32,
+            )
+
+        def __call__(self, inputs: dict[str, Tensor]) -> dict[str, Tensor]:
+            batch_size: int = int(inputs["crops"].shape[0])
+            device: torch.device = inputs["crops"].device
+            return {
+                "joints2d": torch.zeros((batch_size, 512, 3), device=device),
+                "visibility": torch.zeros((batch_size, 512, 1), device=device),
+                "contact": torch.zeros((batch_size, 512, 1), device=device),
+                "floor_contact": torch.zeros((batch_size, 512, 1), device=device),
+            }
+
+    weights_path: Path = tmp_path / "mammanet.safetensors"
+    weights_path.touch()
+    onnx_path: Path = tmp_path / "mammanet.onnx"
+    model: MammaNet = MammaNet.__new__(MammaNet)
+
+    def fake_load_mammanet(path: Path | None, *, device: str, config: object) -> MammaNet:
+        del path, device, config
+        return model
+
+    def fake_ensure_mammanet_onnx(loaded_model: MammaNet, resolved_weights_path: Path) -> Path:
+        del loaded_model, resolved_weights_path
+        return onnx_path
+
+    def fake_create_runtime(path: Path, backend: TensorRtBackendConfig) -> FakeTensorRtRuntime:
+        del path, backend
+        return FakeTensorRtRuntime()
+
+    monkeypatch.setattr("mamma.landmarks.posekit_role.load_mammanet", fake_load_mammanet)
+    monkeypatch.setattr("mamma.landmarks.posekit_role.ensure_mammanet_onnx", fake_ensure_mammanet_onnx)
+    monkeypatch.setattr("mamma.landmarks.posekit_role.create_runtime_from_onnx", fake_create_runtime)
+    backend = TensorRtBackendConfig()
+    role = MammaNetLandmarksConfig(weights_path=weights_path, device="cuda", backend=backend).setup()
+    frames_rgb: Tensor = torch.zeros((1, 18, 12, 3), dtype=torch.uint8)
+    detections = BoxDetections(
+        xyxy=torch.tensor([[2.0, 3.0, 10.0, 15.0]], dtype=torch.float32),
+        scores=torch.ones((1,), dtype=torch.float32),
+        frame_indices=torch.zeros((1,), dtype=torch.long),
+        masks=torch.ones((1, 18, 12), dtype=torch.bool),
+    )
+
+    result = role(frames_rgb, detections)
+
+    torch.testing.assert_close(result.xy, torch.tensor([6.0, 9.0]).expand(1, 512, 2))
+    torch.testing.assert_close(result.log_variance, torch.zeros((1, 512)))
+    torch.testing.assert_close(result.visibility, torch.full((1, 512), 0.5))
+    torch.testing.assert_close(result.contact, torch.full((1, 512), 0.5))
+    torch.testing.assert_close(result.floor_contact, torch.full((1, 512), 0.5))

--- a/packages/mamma/tests/test_skeleton.py
+++ b/packages/mamma/tests/test_skeleton.py
@@ -1,0 +1,32 @@
+"""Public-contract tests for MammaNet display skeleton helpers."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from mamma.landmarks.skeleton import SkeletonRegressor, body_models_available, load_skeleton_regressor, skeleton_strips
+
+
+def test_body_model_loader_owns_missing_asset_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The skeleton seam reports the Pixi recovery task when SMPL-X assets are absent."""
+    monkeypatch.setattr("mamma.landmarks.skeleton.DEFAULT_BODY_MODELS_DIR", tmp_path)
+    load_skeleton_regressor.cache_clear()
+
+    assert not body_models_available()
+    with pytest.raises(RuntimeError, match="_download-mamma-body-models"):
+        load_skeleton_regressor()
+
+
+def test_skeleton_strips_follow_regressor_bones() -> None:
+    """Display strips contain the child-parent pairs stored by the regressor."""
+    joints_xy = np.asarray([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
+    regressor = SkeletonRegressor(
+        weights=np.zeros((3, 512), dtype=np.float32),
+        parents=(-1, 0, 1),
+        bones=np.asarray([[1, 0], [2, 1]], dtype=np.int64),
+    )
+
+    strips = skeleton_strips(joints_xy, regressor)
+
+    np.testing.assert_array_equal(strips, [[[3.0, 4.0], [1.0, 2.0]], [[5.0, 6.0], [3.0, 4.0]]])

--- a/packages/mamma/tools/build_trt_engine.py
+++ b/packages/mamma/tools/build_trt_engine.py
@@ -20,8 +20,8 @@ from mamma.landmarks.tensorrt_backend import ENGINE_BATCH, build_engine, export_
 
 @dataclass
 class BuildConfig:
-    mammanet_weights: Path = Path("data/weights/ma_2d/mamma_mask_full_cvpr.safetensors")
-    """Converted MammaNet state dict."""
+    mammanet_weights: Path | None = None
+    """Converted MammaNet state dict; ``None`` downloads the published weights."""
     cache_dir: Path = Path(".trt_cache")
     """Machine-local engine cache."""
     force: bool = False

--- a/packages/posekit/src/posekit/models/sapiens.py
+++ b/packages/posekit/src/posekit/models/sapiens.py
@@ -42,6 +42,7 @@ from posekit.runtimes import (
 from posekit.skeletons import COCO_133
 
 SapiensModelSize = Literal["0.4B", "0.8B", "1B"]
+SAPIENS_ONNX_EXPORT_VERSION: int = 2
 
 
 @dataclass(frozen=True, slots=True)
@@ -164,7 +165,10 @@ def _ensure_sapiens_onnx(model_size: SapiensModelSize, static_batch: int, *, bf1
     # graphs overflow; opset >= 22 required for bf16 Conv). bf16=False keeps the
     # plain fp32 graph ONNX Runtime has always run (ORT lacks bf16 Conv kernels).
     dtype_key: str = "bf16" if bf16 else "fp32"
-    onnx_path: Path = DEFAULT_ONNX_CACHE_DIR / f"sapiens2_{model_size.lower()}_pose_b{static_batch}_{dtype_key}.onnx"
+    # bf16 exports now carry fp32 ConvTranspose islands, so warm caches must re-export.
+    onnx_path: Path = (
+        DEFAULT_ONNX_CACHE_DIR / f"sapiens2_{model_size.lower()}_pose_b{static_batch}_{dtype_key}_v{SAPIENS_ONNX_EXPORT_VERSION}.onnx"
+    )
     if onnx_path.exists():
         return onnx_path
     onnx_path.parent.mkdir(parents=True, exist_ok=True)

--- a/packages/posekit/src/posekit/predictions.py
+++ b/packages/posekit/src/posekit/predictions.py
@@ -60,6 +60,10 @@ class BoxDetections:
         """Number of detections across the whole frame batch."""
         return int(self.xyxy.shape[0])
 
+    def xyxy_numpy(self) -> Float32[ndarray, "n 4"]:
+        """Copy boxes to CPU for logging/serialization."""
+        return self.xyxy.detach().cpu().numpy().astype(np.float32, copy=False)
+
     @classmethod
     def empty(cls, device: torch.device | str, *, mask_hw: tuple[int, int] | None = None, with_track_ids: bool = False) -> "BoxDetections":
         """Build a zero-detection result on the given device.
@@ -160,6 +164,22 @@ class DenseLandmarks2d:
     def num_instances(self) -> int:
         """Number of landmark instances across the whole frame batch."""
         return int(self.xy.shape[0])
+
+    def xy_numpy(self) -> Float32[ndarray, "n p 2"]:
+        """Copy landmarks to CPU for logging/serialization."""
+        return self.xy.detach().cpu().numpy().astype(np.float32, copy=False)
+
+    def visibility_numpy(self) -> Float32[ndarray, "n p"]:
+        """Copy visibility scores to CPU for logging/serialization."""
+        return self.visibility.detach().cpu().numpy().astype(np.float32, copy=False)
+
+    def contact_numpy(self) -> Float32[ndarray, "n p"]:
+        """Copy contact scores to CPU for logging/serialization."""
+        return self.contact.detach().cpu().numpy().astype(np.float32, copy=False)
+
+    def floor_contact_numpy(self) -> Float32[ndarray, "n p"]:
+        """Copy floor-contact scores to CPU for logging/serialization."""
+        return self.floor_contact.detach().cpu().numpy().astype(np.float32, copy=False)
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/posekit/tests/test_predictions.py
+++ b/packages/posekit/tests/test_predictions.py
@@ -1,0 +1,51 @@
+"""Public boundary tests for posekit prediction containers."""
+
+import numpy as np
+import torch
+
+from posekit.predictions import BoxDetections, DenseLandmarks2d, Keypoints2d
+from posekit.skeletons import COCO_17
+
+
+def test_numpy_helpers_detach_as_float32_arrays() -> None:
+    """Box and dense-landmark arrays cross the serialization boundary as float32 NumPy arrays."""
+    xyxy = torch.tensor([[1.0, 2.0, 3.0, 4.0]], dtype=torch.float32, requires_grad=True)
+    detections = BoxDetections(
+        xyxy=xyxy,
+        scores=torch.ones((1,), dtype=torch.float32),
+        frame_indices=torch.zeros((1,), dtype=torch.long),
+    )
+    dense = DenseLandmarks2d(
+        xy=torch.tensor([[[5.0, 6.0]]], dtype=torch.float32, requires_grad=True),
+        log_variance=torch.zeros((1, 1), dtype=torch.float32),
+        visibility=torch.tensor([[0.7]], dtype=torch.float32, requires_grad=True),
+        contact=torch.tensor([[0.4]], dtype=torch.float32, requires_grad=True),
+        floor_contact=torch.tensor([[0.2]], dtype=torch.float32, requires_grad=True),
+        frame_indices=torch.zeros((1,), dtype=torch.long),
+    )
+    keypoints = Keypoints2d(
+        xy=torch.tensor([[[7.0, 8.0]]], dtype=torch.float32, requires_grad=True),
+        scores=torch.tensor([[0.9]], dtype=torch.float32, requires_grad=True),
+        frame_indices=torch.zeros((1,), dtype=torch.long),
+        skeleton=COCO_17,
+    )
+
+    arrays: tuple[np.ndarray, ...] = (
+        detections.xyxy_numpy(),
+        dense.xy_numpy(),
+        dense.visibility_numpy(),
+        dense.contact_numpy(),
+        dense.floor_contact_numpy(),
+        keypoints.xy_numpy(),
+        keypoints.scores_numpy(),
+    )
+    boxes_array, dense_xy_array, visibility_array, contact_array, floor_contact_array, keypoints_xy_array, keypoint_scores_array = arrays
+
+    assert all(array.dtype == np.float32 for array in arrays)
+    np.testing.assert_array_equal(boxes_array, [[1.0, 2.0, 3.0, 4.0]])
+    np.testing.assert_array_equal(dense_xy_array, [[[5.0, 6.0]]])
+    np.testing.assert_allclose(visibility_array, [[0.7]])
+    np.testing.assert_allclose(contact_array, [[0.4]])
+    np.testing.assert_allclose(floor_contact_array, [[0.2]])
+    np.testing.assert_array_equal(keypoints_xy_array, [[[7.0, 8.0]]])
+    np.testing.assert_allclose(keypoint_scores_array, [[0.9]])

--- a/packages/posekit/tests/test_runtime_parity.py
+++ b/packages/posekit/tests/test_runtime_parity.py
@@ -116,6 +116,28 @@ def test_three_backend_parity(tmp_path: Path) -> None:
 
 
 @cuda_only
+def test_tensorrt_static_engine_drops_padded_rows(tmp_path: Path) -> None:
+    """A static engine always computes its baked batch; callers must still see only their rows."""
+    module = TinyNet().cuda().eval()
+    torch_runtime = TorchRuntime(
+        module, input_specs=(IMAGE_SPEC, MASK_SPEC), output_specs=(FEATURES_SPEC, LOGITS_SPEC), max_batch_size=STATIC_BATCH
+    )
+    engine_path: Path = ensure_engine(
+        _export_tiny_onnx(module, tmp_path),
+        TrtBuildConfig(max_batch_size=STATIC_BATCH, opt_batch_size=STATIC_BATCH, allow_tf32=False),
+        cache_dir=tmp_path / "trt",
+    )
+    trt_runtime = TensorRtRuntime(engine_path)
+    for batch in (STATIC_BATCH, 1):
+        inputs: dict[str, Tensor] = _example_inputs(batch, "cuda")
+        outputs: dict[str, Tensor] = trt_runtime(inputs)
+        reference: dict[str, Tensor] = torch_runtime(inputs)
+        for output_name in ("features", "logits"):
+            assert outputs[output_name].shape[0] == batch
+            torch.testing.assert_close(outputs[output_name], reference[output_name], rtol=1e-3, atol=1e-4)
+
+
+@cuda_only
 def test_tensorrt_cuda_graph_replay(tmp_path: Path) -> None:
     module = TinyNet().cuda().eval()
     onnx_path: Path = _export_tiny_onnx(module, tmp_path, dynamic_batch=True)

--- a/packages/sapiens2-pose/pyproject.toml
+++ b/packages/sapiens2-pose/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     # cuda: pytorch-gpu, torchvision
     "safetensors",
     "timm",
-    "spaces>=0.43.0",
     "tyro>=0.9.1",
 ]
 

--- a/packages/sapiens2-pose/src/sapiens2_pose/api/tensorrt_pose.py
+++ b/packages/sapiens2-pose/src/sapiens2_pose/api/tensorrt_pose.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -42,12 +43,24 @@ TensorRtPrecision = Literal["bf16"]
 
 STATIC_B1_PROFILE: tuple[int, int, int] = (1, 1, 1)
 """Static batch-1 profile used by the retained fastest engine."""
+DEFAULT_TENSORRT_ENGINE_ENV_VAR: str = "SAPIENS2_POSE_TENSORRT_ENGINE_PATH"
+DEFAULT_TENSORRT_ENGINE_FILENAME: str = "sapiens2_0_4b_pose_static_b1_bf16_current_static_graph.trt"
 
 PoseHeatmapRunner = Callable[[torch.Tensor], torch.Tensor | Float32[ndarray, "n k h w"]]
 """Callable backend that maps preprocessed Sapiens pose tensors to heatmaps."""
 
 ModelLoader = Callable[[str, str | Path, str], torch.nn.Module]
 ExportFn = Callable[..., object]
+
+
+def default_tensorrt_engine_path() -> str:
+    """Return the configured or stable cached Sapiens2 pose engine path."""
+    explicit_engine_path: str | None = os.environ.get(DEFAULT_TENSORRT_ENGINE_ENV_VAR)
+    if explicit_engine_path is not None:
+        return explicit_engine_path
+    xdg_cache_home: str | None = os.environ.get("XDG_CACHE_HOME")
+    cache_root: Path = Path(xdg_cache_home).expanduser() if xdg_cache_home is not None else Path.home() / ".cache"
+    return str(cache_root / "sapiens2-pose" / "tensorrt" / DEFAULT_TENSORRT_ENGINE_FILENAME)
 
 
 class ExportableRMSNorm(torch.nn.Module):
@@ -416,47 +429,54 @@ class TensorRtPoseHeatmapRunner:
         self._output_name: str = self._runtime.spec.outputs[0].name
 
     def __call__(self, inputs: torch.Tensor) -> torch.Tensor:
-        """Run TensorRT heatmap inference for one normalized static batch-1 input."""
+        """Run TensorRT heatmap inference, chunking full batches for the static batch-1 engine."""
         if inputs.device.type != "cuda":
             inputs = inputs.to("cuda")
-        return self._runtime({self._input_name: inputs})[self._output_name]
+        from trtkit import run_chunked
+
+        outputs: dict[str, torch.Tensor] = run_chunked(self._runtime, {self._input_name: inputs})
+        return outputs[self._output_name]
 
 
 def estimate_sapiens_pose_tensorrt(
     image_rgb: UInt8[ndarray, "h w 3"],
     bboxes: Float32[ndarray, "n 4"],
     *,
-    engine_path: Path,
+    engine_path: Path | None = None,
     model_size: ModelSize = "0.4B",
     device: DeviceChoice = "cuda",
     heatmap_runner: PoseHeatmapRunner | None = None,
 ) -> PosePredictionArtifact:
-    """Estimate Sapiens2 pose by running each person crop through the static batch-1 TensorRT engine."""
-    bboxes_f32: Float32[ndarray, "n 4"] = np.asarray(bboxes, dtype=np.float32).reshape(-1, 4)
-    spec: Any = MODEL_SPECS[model_size]
-    if bboxes_f32.shape[0] == 0:
-        empty_keypoints: Float32[ndarray, "0 308 2"] = np.empty((0, spec.num_keypoints, 2), dtype=np.float32)
-        empty_scores: Float32[ndarray, "0 308"] = np.empty((0, spec.num_keypoints), dtype=np.float32)
-        return PosePredictionArtifact(bboxes=bboxes_f32, keypoints=empty_keypoints, scores=empty_scores)
+    """Estimate Sapiens2 pose with a TensorRT or supplied heatmap runner.
 
-    runner: PoseHeatmapRunner = heatmap_runner or TensorRtPoseHeatmapRunner(engine_path, device=device)
-    keypoints_list: list[Float32[ndarray, "sapiens_k 2"]] = []
-    scores_list: list[Float32[ndarray, "sapiens_k"]] = []
-    for bbox in bboxes_f32:
-        one_bbox: Float32[ndarray, "1 4"] = np.asarray(bbox, dtype=np.float32).reshape(1, 4)
-        artifact: PosePredictionArtifact = estimate_sapiens_pose_with_heatmap_runner(
-            image_rgb,
-            one_bbox,
-            model_size=model_size,
-            device=device,
-            heatmap_runner=runner,
-        )
-        keypoints_list.append(np.asarray(artifact.keypoints[0], dtype=np.float32))
-        scores_list.append(np.asarray(artifact.scores[0], dtype=np.float32).reshape(-1))
+    Args:
+        image_rgb: Source image in uint8 RGB order.
+        bboxes: Person boxes in XYXY image coordinates.
+        engine_path: TensorRT engine path. May be ``None`` when
+            ``heatmap_runner`` is supplied.
+        model_size: Sapiens2 model size represented by the runner.
+        device: Inference device.
+        heatmap_runner: Optional ready heatmap backend.
 
-    keypoints: Float32[ndarray, "n sapiens_k 2"] = np.stack(keypoints_list, axis=0).astype(np.float32, copy=False)
-    scores: Float32[ndarray, "n sapiens_k"] = np.stack(scores_list, axis=0).astype(np.float32, copy=False)
-    return PosePredictionArtifact(bboxes=bboxes_f32, keypoints=keypoints, scores=scores)
+    Returns:
+        Dense Sapiens2 keypoints and scores for each box.
+
+    Raises:
+        ValueError: If neither an engine path nor a ready runner is supplied.
+    """
+    if heatmap_runner is None:
+        if engine_path is None:
+            raise ValueError("engine_path is required when heatmap_runner is not provided.")
+        runner: PoseHeatmapRunner = TensorRtPoseHeatmapRunner(engine_path, device=device)
+    else:
+        runner = heatmap_runner
+    return estimate_sapiens_pose_with_heatmap_runner(
+        image_rgb,
+        bboxes,
+        model_size=model_size,
+        device=device,
+        heatmap_runner=runner,
+    )
 
 
 def run_tensorrt_image_pose(config: TensorRtImagePoseConfig) -> ImagePoseSummary:

--- a/packages/sapiens2-pose/src/sapiens2_pose/gradio_ui.py
+++ b/packages/sapiens2-pose/src/sapiens2_pose/gradio_ui.py
@@ -11,14 +11,17 @@ import gradio as gr
 import numpy as np
 import rerun as rr
 import rerun.blueprint as rrb
-import spaces
 import torch
 from gradio_rerun import Rerun
 from huggingface_hub import hf_hub_download
+from jaxtyping import Float32
+from numpy import ndarray
 from PIL import Image
 from transformers import DetrForObjectDetection, DetrImageProcessor
 
-from .sapiens_lite.pose import estimate_pose, init_pose_model, nms, parse_pose_metainfo
+from sapiens2_pose.api.pose_artifact import PosePredictionArtifact
+from sapiens2_pose.api.tensorrt_pose import default_tensorrt_engine_path
+from sapiens2_pose.sapiens_lite.pose import estimate_pose, init_pose_model, nms, parse_pose_metainfo
 
 PACKAGE_DIR = Path(__file__).resolve().parent
 ASSETS_DIR = PACKAGE_DIR / "assets"
@@ -50,6 +53,8 @@ DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 BBOX_THR = 0.3
 NMS_THR = 0.3
 
+TENSORRT_MODEL_SIZE = "0.4B"
+
 
 def _env_flag(name: str, default: bool) -> bool:
     value = os.environ.get(name)
@@ -75,8 +80,25 @@ def _server_port() -> int:
 
 _pose_model_cache: dict[str, Any] = {}
 _detector_cache: dict[str, Any] = {}
+_trt_runner_cache: dict[str, Any] = {}
 _metainfo_cache: dict[str, Any] | None = None
 _skeleton_cache: dict[str, Any] | None = None
+
+
+def _get_trt_runner(engine_path: str) -> Any:
+    cache_key: str = str(Path(engine_path).expanduser().resolve())
+    if cache_key not in _trt_runner_cache:
+        if not Path(cache_key).is_file():
+            raise gr.Error(f"TensorRT engine not found at {cache_key}. Build it with the sapiens2-pose-build-trt task.")
+        from sapiens2_pose.api.tensorrt_pose import TensorRtPoseHeatmapRunner
+
+        _trt_runner_cache[cache_key] = TensorRtPoseHeatmapRunner(Path(cache_key))
+        if len(_trt_runner_cache) > 1:
+            oldest_key: str = next(iter(_trt_runner_cache))
+            evicted: Any = _trt_runner_cache.pop(oldest_key)
+            # TensorRT allocates outside Torch's caching allocator; del drops the last reference.
+            del evicted
+    return _trt_runner_cache[cache_key]
 
 
 def _get_metainfo() -> dict[str, Any]:
@@ -195,8 +217,8 @@ def _log_annotation_context() -> None:
 def _log_pose_recording(
     image_rgb: np.ndarray,
     bboxes: np.ndarray,
-    keypoints: list[np.ndarray],
-    scores: list[np.ndarray],
+    keypoints: Float32[ndarray, "n k 2"],
+    scores: Float32[ndarray, "n k"],
     kpt_thr: float,
 ) -> None:
     skeleton = _get_sapiens_skeleton()
@@ -217,7 +239,7 @@ def _log_pose_recording(
         rr.log(
             f"image/person_{idx}/bbox",
             rr.Boxes2D(
-                array=np.asarray(bbox, dtype=np.float32).reshape(1, 4),
+                array=bbox.reshape(1, 4),
                 array_format=rr.Box2DFormat.XYXY,
                 class_ids=0,
                 labels=f"person_{idx}",
@@ -225,8 +247,8 @@ def _log_pose_recording(
             ),
         )
 
-        kpts_arr = np.asarray(kpts, dtype=np.float32).copy()
-        scores_arr = np.asarray(scr, dtype=np.float32).reshape(-1)
+        kpts_arr = kpts.copy()
+        scores_arr = scr.reshape(-1)
         kpts_arr[scores_arr < kpt_thr] = np.nan
         rr.log(
             f"image/person_{idx}/keypoints",
@@ -244,6 +266,7 @@ def _predict_impl(
     image: Image.Image,
     size: str,
     kpt_thr: float,
+    use_tensorrt: bool,
     recording_id: uuid.UUID | str | None,
 ):
     if image is None:
@@ -251,17 +274,35 @@ def _predict_impl(
 
     image_pil = image.convert("RGB")
     image_rgb = np.array(image_pil)
-    image_bgr = cv2.cvtColor(image_rgb, cv2.COLOR_RGB2BGR)
 
     bboxes = _detect_persons(image_rgb)
-    model = _get_pose_model(size)
-    keypoints, scores = estimate_pose(image_bgr, bboxes, model)
+    if use_tensorrt:
+        if size != TENSORRT_MODEL_SIZE:
+            raise gr.Error(f"The TensorRT engine is a static {TENSORRT_MODEL_SIZE} build; select the {TENSORRT_MODEL_SIZE} model.")
+        engine_path: str = default_tensorrt_engine_path()
+        from sapiens2_pose.api.tensorrt_pose import estimate_sapiens_pose_tensorrt
+
+        artifact: PosePredictionArtifact = estimate_sapiens_pose_tensorrt(
+            image_rgb,
+            np.asarray(bboxes, dtype=np.float32),
+            engine_path=Path(engine_path),
+            model_size=TENSORRT_MODEL_SIZE,
+            heatmap_runner=_get_trt_runner(engine_path),
+        )
+        keypoints: Float32[ndarray, "n k 2"] = artifact.keypoints
+        scores: Float32[ndarray, "n k"] = artifact.scores
+    else:
+        image_bgr = cv2.cvtColor(image_rgb, cv2.COLOR_RGB2BGR)
+        model = _get_pose_model(size)
+        pose_result: tuple[list[np.ndarray], list[np.ndarray]] = estimate_pose(image_bgr, bboxes, model)
+        keypoints = np.stack(pose_result[0], axis=0).astype(np.float32, copy=False)
+        scores = np.stack(pose_result[1], axis=0).astype(np.float32, copy=False)
 
     instances = [
         {
-            "bbox": [float(v) for v in np.asarray(bbox).reshape(-1)[:4]],
-            "keypoints": np.asarray(kpts, dtype=float).tolist(),
-            "keypoint_scores": np.asarray(s, dtype=float).reshape(-1).tolist(),
+            "bbox": bbox.reshape(-1)[:4].tolist(),
+            "keypoints": kpts.tolist(),
+            "keypoint_scores": s.reshape(-1).tolist(),
         }
         for bbox, kpts, s in zip(bboxes, keypoints, scores, strict=False)
     ]
@@ -275,22 +316,18 @@ def _predict_impl(
     yield stream.read(), payload
 
 
-@spaces.GPU(duration=120)
-def predict(image: Image.Image, size: str, kpt_thr: float, recording_id: uuid.UUID | str | None):
-    yield from _predict_impl(image, size, kpt_thr, recording_id)
-
-
-@spaces.GPU(duration=120)
 def predict_ui(
     image: Image.Image,
     size: str,
     kpt_thr: float,
+    use_tensorrt: bool,
     recording_id: uuid.UUID | str | None,
 ):
-    for stream, payload in _predict_impl(image, size, kpt_thr, recording_id):
+    backend_label = "TensorRT" if use_tensorrt else "PyTorch"
+    for stream, payload in _predict_impl(image, size, kpt_thr, use_tensorrt, recording_id):
         count = len(payload["instances"])
         suffix = "" if count == 1 else "s"
-        yield stream, payload, f"Complete: {count} person{suffix} detected with Sapiens2 {size}."
+        yield stream, payload, f"Complete: {count} person{suffix} detected with Sapiens2 {size} ({backend_label})."
 
 
 def _switch_to_outputs():
@@ -362,6 +399,9 @@ HEADER_HTML = """
 </div>
 """
 
+# The viewer stream (crypto.randomUUID) and the image "Paste from clipboard"
+# button (navigator.clipboard.read) need a secure context. Serve over HTTPS —
+# on the tailnet: `tailscale serve --bg --https=7860 http://127.0.0.1:7860`.
 with gr.Blocks(title="Sapiens2 Pose") as demo:
     gr.HTML(HEADER_HTML)
     recording_id = gr.State(str(uuid.uuid4()))
@@ -386,6 +426,10 @@ with gr.Blocks(title="Sapiens2 Pose") as demo:
                             choices=list(POSE_MODELS.keys()),
                             value=DEFAULT_SIZE,
                             label="Model",
+                        )
+                        use_trt = gr.Checkbox(
+                            value=False,
+                            label=f"Use TensorRT Backend ({TENSORRT_MODEL_SIZE} only)",
                         )
 
                     examples = gr.Examples(
@@ -435,7 +479,7 @@ with gr.Blocks(title="Sapiens2 Pose") as demo:
         api_visibility="private",
     ).then(
         fn=predict_ui,
-        inputs=[inp, size, thr, recording_id],
+        inputs=[inp, size, thr, use_trt, recording_id],
         outputs=[viewer, out_json, status_text],
     )
 

--- a/packages/sapiens2-pose/src/sapiens2_pose/video_gradio_ui.py
+++ b/packages/sapiens2-pose/src/sapiens2_pose/video_gradio_ui.py
@@ -13,7 +13,6 @@ from typing import cast
 
 import gradio as gr
 import rerun as rr
-import spaces
 import torch
 from gradio.data_classes import FileData
 from gradio_rerun import Rerun
@@ -21,13 +20,12 @@ from gradio_rerun import Rerun
 from .api.metadata import KeypointSchemaName
 from .api.runtime import DEFAULT_BBOX_THR, DEFAULT_MODEL_SIZE, DEFAULT_NMS_THR, POSE_MODELS, ModelSize
 from .api.sam3_tracking import DEFAULT_SAM3_MEMORY_RETENTION_FRAMES, DEFAULT_SAM3_MIN_MASK_AREA_PX
+from .api.tensorrt_pose import DEFAULT_TENSORRT_ENGINE_ENV_VAR, default_tensorrt_engine_path
 from .api.video import PoseBackend, SapiensVideoPoseConfig, TrackingBackend, run_video_pose_pipeline
 
 DEFAULT_SIZE: ModelSize = DEFAULT_MODEL_SIZE
 DEFAULT_SCHEMA: KeypointSchemaName = "coco133"
 DEFAULT_TRACKING_BACKEND: TrackingBackend = "sam3_tracking"
-DEFAULT_TENSORRT_ENGINE_ENV_VAR: str = "SAPIENS2_POSE_TENSORRT_ENGINE_PATH"
-DEFAULT_TENSORRT_ENGINE_FILENAME: str = "sapiens2_0_4b_pose_static_b1_bf16_current_static_graph.trt"
 
 
 def _server_port() -> int:
@@ -79,18 +77,6 @@ def _remux_mov_for_rerun(video_path: Path, output_dir: Path) -> Path:
     return remuxed_path
 
 
-def _default_tensorrt_engine_path() -> str:
-    """Return the app's default TensorRT engine path."""
-    explicit_engine_path: str | None = os.environ.get(DEFAULT_TENSORRT_ENGINE_ENV_VAR)
-    if explicit_engine_path is not None:
-        return explicit_engine_path
-
-    xdg_cache_home: str | None = os.environ.get("XDG_CACHE_HOME")
-    cache_root: Path = Path(xdg_cache_home).expanduser() if xdg_cache_home is not None else Path.home() / ".cache"
-    engine_path: Path = cache_root / "sapiens2-pose" / "tensorrt" / DEFAULT_TENSORRT_ENGINE_FILENAME
-    return str(engine_path)
-
-
 def _format_video_inference_status(*, status: str, backend_label: str, elapsed_seconds: float) -> str:
     """Append whole-video inference timing to a completion status."""
     return f"{status} {backend_label} inference took {elapsed_seconds:.2f}s for the whole video."
@@ -106,7 +92,6 @@ def predict_video_ui(
     nms_thr: float,
     kpt_thr: float,
     use_tensorrt: bool,
-    tensorrt_engine_path: str | None,
     sam3_min_mask_area_px: float | int | None,
     sam3_memory_retention_frames: float | int | None,
     max_frames: float | int | None,
@@ -128,7 +113,7 @@ def predict_video_ui(
     if use_tensorrt:
         if model_size != "0.4B":
             raise gr.Error("TensorRT video mode currently expects a 0.4B pose engine.")
-        engine_path_text: str = str(tensorrt_engine_path or _default_tensorrt_engine_path()).strip()
+        engine_path_text: str = default_tensorrt_engine_path().strip()
         if engine_path_text == "":
             raise gr.Error(f"TensorRT video mode requires an engine path or {DEFAULT_TENSORRT_ENGINE_ENV_VAR}.")
         resolved_tensorrt_engine_path = Path(engine_path_text).expanduser()
@@ -173,9 +158,6 @@ def predict_video_ui(
                 elapsed_seconds=elapsed_seconds,
             )
         yield stream.read(), status_with_note
-
-
-predict_video_ui = spaces.GPU(duration=120)(predict_video_ui)
 
 
 def _reset_video_outputs() -> tuple[None, str]:
@@ -225,11 +207,6 @@ with gr.Blocks(title="Sapiens2 Video Pose") as demo:
                 use_tensorrt = gr.Checkbox(
                     value=False,
                     label="Use TensorRT Backend",
-                )
-                tensorrt_engine_path = gr.Textbox(
-                    value=_default_tensorrt_engine_path(),
-                    label="TensorRT Engine Path",
-                    placeholder=f"Set {DEFAULT_TENSORRT_ENGINE_ENV_VAR} or paste a .trt path",
                 )
                 tracking_backend = gr.Radio(
                     choices=["sam3_tracking", "detr_per_frame"],
@@ -303,7 +280,6 @@ with gr.Blocks(title="Sapiens2 Video Pose") as demo:
             nms_thr,
             kpt_thr,
             use_tensorrt,
-            tensorrt_engine_path,
             sam3_min_mask_area_px,
             sam3_memory_retention_frames,
             max_frames,

--- a/packages/sapiens2-pose/tests/test_gradio_video.py
+++ b/packages/sapiens2-pose/tests/test_gradio_video.py
@@ -8,12 +8,9 @@ from jaxtyping import Float32, UInt8
 from numpy import ndarray
 
 from sapiens2_pose.api.runtime import PoseEstimation
+from sapiens2_pose.api.tensorrt_pose import DEFAULT_TENSORRT_ENGINE_ENV_VAR, default_tensorrt_engine_path
 from sapiens2_pose.api.video import SapiensVideoPoseConfig, _make_effective_bbox_pose_fn, run_video_pose_pipeline
-from sapiens2_pose.video_gradio_ui import (
-    DEFAULT_TENSORRT_ENGINE_ENV_VAR,
-    _default_tensorrt_engine_path,
-    _format_video_inference_status,
-)
+from sapiens2_pose.video_gradio_ui import _format_video_inference_status
 
 
 def test_video_pipeline_tensorrt_backend_detects_boxes_then_runs_bbox_pose(tmp_path: Path) -> None:
@@ -121,12 +118,12 @@ def test_default_tensorrt_engine_path_uses_stable_cache(monkeypatch: Any, tmp_pa
     monkeypatch.delenv(DEFAULT_TENSORRT_ENGINE_ENV_VAR, raising=False)
     monkeypatch.setenv("XDG_CACHE_HOME", str(cache_root))
 
-    engine_path: Path = Path(_default_tensorrt_engine_path())
+    engine_path: Path = Path(default_tensorrt_engine_path())
 
     assert engine_path == cache_root / "sapiens2-pose" / "tensorrt" / "sapiens2_0_4b_pose_static_b1_bf16_current_static_graph.trt"
 
     monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
-    home_engine_path: Path = Path(_default_tensorrt_engine_path())
+    home_engine_path: Path = Path(default_tensorrt_engine_path())
 
     assert home_engine_path == Path.home() / ".cache" / "sapiens2-pose" / "tensorrt" / "sapiens2_0_4b_pose_static_b1_bf16_current_static_graph.trt"
 
@@ -135,7 +132,7 @@ def test_default_tensorrt_engine_path_honors_explicit_env_var(monkeypatch: Any, 
     engine_path: Path = tmp_path / "custom.trt"
     monkeypatch.setenv(DEFAULT_TENSORRT_ENGINE_ENV_VAR, str(engine_path))
 
-    assert _default_tensorrt_engine_path() == str(engine_path)
+    assert default_tensorrt_engine_path() == str(engine_path)
 
 
 def test_format_video_inference_status_reports_backend_and_elapsed_time() -> None:

--- a/packages/sapiens2-pose/tests/test_tensorrt_pose.py
+++ b/packages/sapiens2-pose/tests/test_tensorrt_pose.py
@@ -60,8 +60,12 @@ def test_export_sapiens_pose_onnx_uses_static_batch_one_graph(tmp_path: Path) ->
     assert export_summary.onnx_path == onnx_path
     assert export_summary.input_shape == (1, 3, 1024, 768)
     assert export_summary.output_shape == (1, 308, 256, 192)
-    assert calls[0]["path"].parent == onnx_path.parent
-    assert calls[0]["path"].name.startswith(onnx_path.name + ".part")
+    # trtkit exports into a pid-unique temp DIRECTORY under the final
+    # filename, so the external-data sidecar is born with the name the
+    # published protobuf references.
+    assert calls[0]["path"].name == onnx_path.name
+    assert calls[0]["path"].parent.parent == onnx_path.parent
+    assert calls[0]["path"].parent.name.startswith(onnx_path.name + ".part")
     assert onnx_path.exists()
     assert calls[0]["dummy_inputs"].shape == (1, 3, 1024, 768)
     assert calls[0]["input_names"] == ["inputs"]
@@ -159,27 +163,32 @@ def test_estimate_sapiens_pose_with_heatmap_runner_uses_common_decode_path() -> 
     assert np.all(artifact.scores > 0.0)
 
 
-def test_estimate_sapiens_pose_tensorrt_runs_multiple_boxes_as_static_batch_one_calls() -> None:
+def test_estimate_sapiens_pose_tensorrt_matches_common_heatmap_runner_path() -> None:
     image_rgb: UInt8[ndarray, "h w 3"] = np.zeros((64, 48, 3), dtype=np.uint8)
     bboxes: Float32[ndarray, "n 4"] = np.asarray([[0.0, 0.0, 47.0, 63.0], [4.0, 5.0, 40.0, 55.0]], dtype=np.float32)
     captured_shapes: list[tuple[int, ...]] = []
 
     def fake_heatmap_runner(inputs: torch.Tensor) -> Float32[ndarray, "n k h w"]:
         captured_shapes.append(tuple(int(dim) for dim in inputs.shape))
-        heatmaps: Float32[ndarray, "n k h w"] = np.zeros((1, 308, 256, 192), dtype=np.float32)
+        heatmaps: Float32[ndarray, "n k h w"] = np.zeros((inputs.shape[0], 308, 256, 192), dtype=np.float32)
         heatmaps[:, :, 128, 96] = 1.0
         return heatmaps
 
-    artifact: PosePredictionArtifact = estimate_sapiens_pose_tensorrt(
+    common_artifact: PosePredictionArtifact = estimate_sapiens_pose_with_heatmap_runner(
         image_rgb,
         bboxes,
-        engine_path=Path("/tmp/static-b1.trt"),
+        model_size="0.4B",
+        device="cpu",
+        heatmap_runner=fake_heatmap_runner,
+    )
+    tensorrt_artifact: PosePredictionArtifact = estimate_sapiens_pose_tensorrt(
+        image_rgb,
+        bboxes,
         model_size="0.4B",
         device="cpu",
         heatmap_runner=fake_heatmap_runner,
     )
 
-    assert captured_shapes == [(1, 3, 1024, 768), (1, 3, 1024, 768)]
-    assert artifact.bboxes.shape == (2, 4)
-    assert artifact.keypoints.shape == (2, 308, 2)
-    assert artifact.scores.shape == (2, 308)
+    assert captured_shapes == [(2, 3, 1024, 768), (2, 3, 1024, 768)]
+    np.testing.assert_allclose(tensorrt_artifact.keypoints, common_artifact.keypoints)
+    np.testing.assert_allclose(tensorrt_artifact.scores, common_artifact.scores)

--- a/packages/trtkit/src/trtkit/onnx_export.py
+++ b/packages/trtkit/src/trtkit/onnx_export.py
@@ -9,6 +9,7 @@ network — or a thin adapter that shapes outputs (flatten a dict, add
 fusion-breaker outputs) — and nothing else.
 """
 
+import copy
 import os
 import shutil
 import time
@@ -16,8 +17,49 @@ from collections.abc import Callable, Collection
 from pathlib import Path
 
 import torch
+from torch.nn.modules.conv import _ConvTransposeNd
 
 ExportFn = Callable[..., object]
+
+
+class _Fp32Island(torch.nn.Module):
+    """Runs its inner module in fp32 inside an autocast region.
+
+    TensorRT's strongly-typed builds cannot type a BF16 ConvTranspose — an
+    open type-inference-rule gap (NVIDIA/TensorRT-Incubator#565, verified
+    failing on TRT 11.2.1.2) — so bf16 exports keep transposed convolutions
+    fp32. Weak typing made this exact fallback implicitly before TRT 11
+    removed it. Retest on TRT bumps; delete when the upstream bug is fixed.
+    """
+
+    def __init__(self, inner: torch.nn.Module) -> None:
+        super().__init__()
+        self.inner = inner
+
+    def forward(self, *inputs: torch.Tensor) -> torch.Tensor:
+        with torch.autocast("cuda", enabled=False):
+            return self.inner(*(t.float() if t.is_floating_point() else t for t in inputs))
+
+
+def _with_fp32_transposed_convs(module: torch.nn.Module) -> torch.nn.Module:
+    """Return a structural copy whose transposed convs sit in fp32 islands.
+
+    Parameters and buffers are shared with the original; the caller's module
+    tree is never mutated, so eager parity references stay honest.
+    """
+    if isinstance(module, _Fp32Island):
+        return module
+    if isinstance(module, _ConvTransposeNd):
+        return _Fp32Island(module)
+    replaced: dict[str, torch.nn.Module] = {
+        name: _with_fp32_transposed_convs(child) for name, child in module.named_children()
+    }
+    if all(replaced[name] is child for name, child in module.named_children()):
+        return module
+    clone: torch.nn.Module = copy.copy(module)
+    clone._modules = dict(module._modules)
+    clone._modules.update(replaced)
+    return clone
 
 
 class _AutocastWrapper(torch.nn.Module):
@@ -116,7 +158,10 @@ def export_onnx(
     # TRT parsers accept the invalid graph and silently miscompile it. 18 is
     # the dynamo baseline for everything else; TRT 11 parses up to 24.
     opset_version: int = 23 if compute_dtype == torch.bfloat16 else 18
-    export_model: torch.nn.Module = _AutocastWrapper(model, compute_dtype).eval() if compute_dtype is not None else model
+    # bf16 also forces fp32 islands around transposed convs (see _Fp32Island);
+    # derived from the dtype, like the opset — not a caller knob.
+    inner: torch.nn.Module = _with_fp32_transposed_convs(model) if compute_dtype == torch.bfloat16 else model
+    export_model: torch.nn.Module = _AutocastWrapper(inner, compute_dtype).eval() if compute_dtype is not None else model
 
     kwargs: dict[str, object] = {}
     if dynamic_batch_max is not None:

--- a/packages/trtkit/src/trtkit/tensorrt_runtime.py
+++ b/packages/trtkit/src/trtkit/tensorrt_runtime.py
@@ -92,6 +92,23 @@ class TensorRtRuntime:
             )
             for spec in self._spec.outputs
         }
+        # Static engines report the baked max batch through the context at every
+        # call, so padded rows must be sliced off by per-sample ratio; dynamic
+        # engines report exact shapes per active batch and owe no divisibility.
+        # The slice assumes sample-major rows (leading dim = batch * k); a
+        # k-major intermediate would yield the wrong rows — none exists today.
+        self._static_rows_per_sample: dict[str, int] = {}
+        if not self._dynamic:
+            for out_spec in self._spec.outputs:
+                rows_at_max: int = int(self._output_buffers[out_spec.name].shape[0])
+                if rows_at_max % max_batch != 0:
+                    raise ValueError(
+                        f"Static engine output {out_spec.name!r} has {rows_at_max} rows at batch {max_batch}; "
+                        "padded rows cannot be sliced off a non-multiple. Constant-shaped outputs usually "
+                        "come from TrtBuildConfig.extra_output_patterns intermediates — rebuild without "
+                        "materializing that tensor, or use a dynamic-batch engine."
+                    )
+                self._static_rows_per_sample[out_spec.name] = rows_at_max // max_batch
         for name, tensor in {**self._input_buffers, **self._output_buffers}.items():
             self._context.set_tensor_address(name, int(tensor.data_ptr()))
         self._stream: torch.cuda.Stream = torch.cuda.Stream(device=self._device)
@@ -138,10 +155,16 @@ class TensorRtRuntime:
             self._graphs[graph_key].replay()
         else:
             self._execute()
-        # Slice each output to the rows the context actually produced at this batch
-        # (materialized intermediates may scale their leading dim beyond the batch).
+        # Dynamic engines report exact per-batch output shapes; static engines
+        # always report the baked max batch, so padded rows are sliced off by
+        # the per-sample ratio recorded at construction.
+        if self._dynamic:
+            return {
+                name: tensor[: int(self._context.get_tensor_shape(name)[0])]
+                for name, tensor in self._output_buffers.items()
+            }
         return {
-            name: tensor[: int(self._context.get_tensor_shape(name)[0])]
+            name: tensor[: self._static_rows_per_sample[name] * batch_size]
             for name, tensor in self._output_buffers.items()
         }
 

--- a/packages/trtkit/tests/test_trtkit.py
+++ b/packages/trtkit/tests/test_trtkit.py
@@ -114,3 +114,24 @@ def test_allow_tf32_cache_key(tmp_path: Path) -> None:
     assert default_path != notf32_path
     assert "notf32" in notf32_path.name
     assert "notf32" not in default_path.name
+
+
+def test_fp32_transposed_conv_islands_share_weights_without_mutating() -> None:
+    """bf16 exports isolate transposed convs in fp32 without touching the caller's model."""
+    from trtkit.onnx_export import _Fp32Island, _with_fp32_transposed_convs
+
+    model = torch.nn.Sequential(
+        torch.nn.Conv2d(2, 4, 3, padding=1),
+        torch.nn.ConvTranspose2d(4, 2, 2, stride=2),
+    ).eval()
+    wrapped = _with_fp32_transposed_convs(model)
+
+    assert isinstance(wrapped[1], _Fp32Island)
+    assert wrapped[1].inner is model[1], "island must share the original conv (weights by reference)"
+    assert not any(isinstance(m, _Fp32Island) for m in model.modules()), "caller's tree must stay unmodified"
+    rewrapped = _with_fp32_transposed_convs(wrapped)
+    assert rewrapped[1] is wrapped[1], "re-wrapping must be idempotent"
+
+    x = torch.randn(1, 2, 8, 8)
+    with torch.inference_mode():
+        torch.testing.assert_close(wrapped(x), model(x))


### PR DESCRIPTION
**Stack 3/4** — base: #107 (see run of stack in #106)

- `MammaNetLandmarksConfig` now takes `backend: Torch|TensorRt BackendConfig` like every posekit estimator: the TRT path exports a cached dynamic-batch (1-8-32) fp16 ONNX and auto-builds through trtkit's content-hashed engine cache on first use — no manual build task, env var, or engine path. 7.25 ms per 8-crop call vs 15.8 eager, max joints2d diff 0.006 (normalized) vs eager. The golden-validated streaming static-b4 path is untouched.
- `load_mammanet` gains the HF-weights download fallback (single home).
- `landmarks/skeleton.py`: display-only approximate 2D SMPL-X skeleton from the 512 surface landmarks (each landmark is a fixed SMPL-X vertex) via rest-pose kNN-gaussian joint weights — measured 3.3 cm mean body-joint error on posed bodies (restricting `J_regressor` to the 512 verts measured 12.5 cm and was rejected). Deliberately no visibility gating: spine joints' nearest surface vertices are on the back, and MammaNet predicts xy for occluded landmarks too.
- Example images for demo apps.

GPU-smoked end-to-end (auto-build 34 s then 1.1 s cache hits; finite 512×2 output). Tests + ruff/pyrefly clean.