### PR TITLE
posekit: unified 2D pose Gradio playground (network × backend)

### DIFF
--- a/packages/mamma/src/mamma/landmarks/estimator.py
+++ b/packages/mamma/src/mamma/landmarks/estimator.py
@@ -14,6 +14,7 @@ from mamma.engine.types import CameraTracks
 from mamma.landmarks.config import DEFAULT_MAMMANET_CONFIG, MammaNetConfig
 from mamma.landmarks.crops import box_geometry, gpu_crop_batch, gpu_mask_crop_batch, unproject_joints2d
 from mamma.landmarks.mammanet import MammaNet, load_mammanet
+from mamma.landmarks.tensorrt_backend import INPUT_NAMES, OUTPUT_NAMES
 
 
 @dataclass(slots=True)
@@ -41,7 +42,7 @@ class LandmarkEstimator:
 
     def __init__(
         self,
-        weights_path: Path,
+        weights_path: Path | None = None,
         device: str = "cuda",
         config: MammaNetConfig = DEFAULT_MAMMANET_CONFIG,
         compile_model: bool = False,
@@ -117,15 +118,15 @@ class LandmarkEstimator:
         img_crops, _ = gpu_crop_batch(frames_batch, centers * s, sizes * s, None, self.config)
         mask_crops = gpu_mask_crop_batch(masks_batch, centers, sizes, self.config)
         if self.runner is not None and img_crops.shape[0] <= 4:
-            out: dict[str, torch.Tensor | None] = dict(self.runner({"crops": img_crops, "masks": mask_crops}))
+            out: dict[str, torch.Tensor | None] = dict(self.runner({INPUT_NAMES[0]: img_crops, INPUT_NAMES[1]: mask_crops}))
         else:
             with torch.no_grad(), torch.autocast("cuda", dtype=torch.float16, enabled="cuda" in self.device):
                 out = self.model(img_crops, mask_crops)
 
-        joints2d_raw = out["joints2d"]
-        visibility_raw = out["visibility"]
-        contact_raw = out["contact"]
-        floor_raw = out["floor_contact"]
+        joints2d_raw = out[OUTPUT_NAMES[0]]
+        visibility_raw = out[OUTPUT_NAMES[1]]
+        contact_raw = out[OUTPUT_NAMES[2]]
+        floor_raw = out[OUTPUT_NAMES[3]]
         assert joints2d_raw is not None and visibility_raw is not None and contact_raw is not None and floor_raw is not None
         joints2d_px: Float32[torch.Tensor, "n j 3"] = unproject_joints2d(joints2d_raw.float(), centers, sizes, self.config)
         visibility: Float32[torch.Tensor, "n j"] = torch.sigmoid(visibility_raw.squeeze(-1).float())

--- a/packages/mamma/src/mamma/landmarks/mammanet.py
+++ b/packages/mamma/src/mamma/landmarks/mammanet.py
@@ -25,6 +25,8 @@ DEFAULT_MEAN: Float32[ndarray, "3"] = (255.0 * np.array([0.485, 0.456, 0.406])).
 """Per-channel RGB mean (0..255 scale) used to normalize crops."""
 DEFAULT_STD: Float32[ndarray, "3"] = (255.0 * np.array([0.229, 0.224, 0.225])).astype(np.float32)
 """Per-channel RGB std (0..255 scale) used to normalize crops."""
+MAMMANET_WEIGHTS_REPO: str = "pablovela5620/mamma-streaming-data"
+MAMMANET_WEIGHTS_FILE: str = "weights/ma_2d/mamma_mask_full_cvpr.safetensors"
 
 
 class MammaNet(nn.Module):
@@ -72,11 +74,38 @@ class MammaNet(nn.Module):
         return self.decoder(features, self.backbone.pos_embed)
 
 
-def load_mammanet(weights_path: Path, device: str = "cuda", config: MammaNetConfig = DEFAULT_MAMMANET_CONFIG) -> MammaNet:
-    """Load MammaNet from the converted safetensors state dict (strict)."""
+def resolve_mammanet_weights_path(weights_path: Path | None = None) -> Path:
+    """Resolve an explicit checkpoint or download the published MammaNet weights."""
+    if weights_path is None:
+        from huggingface_hub import hf_hub_download
+
+        weights_path = Path(hf_hub_download(repo_id=MAMMANET_WEIGHTS_REPO, repo_type="dataset", filename=MAMMANET_WEIGHTS_FILE))
+    resolved_path: Path = weights_path.expanduser().resolve()
+    if not resolved_path.is_file():
+        raise FileNotFoundError(f"MammaNet weights not found: {resolved_path}")
+    return resolved_path
+
+
+def load_mammanet(
+    weights_path: Path | None = None,
+    device: str = "cuda",
+    config: MammaNetConfig = DEFAULT_MAMMANET_CONFIG,
+) -> MammaNet:
+    """Load MammaNet from the converted safetensors state dict.
+
+    Args:
+        weights_path: Local checkpoint path. ``None`` downloads the published
+            MammaNet weights from Hugging Face.
+        device: Device receiving the loaded model.
+        config: MammaNet architecture configuration.
+
+    Returns:
+        The strictly loaded evaluation model.
+    """
+    resolved_path: Path = resolve_mammanet_weights_path(weights_path)
     from safetensors.torch import load_file
 
     model: MammaNet = MammaNet(config)
-    state_dict: dict[str, torch.Tensor] = load_file(str(weights_path))
+    state_dict: dict[str, torch.Tensor] = load_file(str(resolved_path))
     model.load_state_dict(state_dict, strict=True)
     return model.to(device).eval()

--- a/packages/mamma/src/mamma/landmarks/posekit_role.py
+++ b/packages/mamma/src/mamma/landmarks/posekit_role.py
@@ -1,4 +1,4 @@
-"""MammaNet behind posekit's ``TopDownDenseLandmarks2d`` role.
+"""Posekit adapter for MammaNet's ``TopDownDenseLandmarks2d`` role.
 
 The adapter that lets mamma's dense-landmark net slot into any posekit
 pipeline (posekit docs/design.md §6): detections with masks in — the tracker's
@@ -7,7 +7,7 @@ visibility / contact heads out, all GPU tensors. Crop math, normalization, and
 precision match ``LandmarkEstimator.estimate`` exactly (same mamma ops).
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import numpy as np
@@ -17,23 +17,35 @@ from numpy import ndarray
 from posekit.models import TopDownDenseLandmarks2d
 from posekit.predictions import BoxDetections, DenseLandmarks2d, validate_frames_rgb
 from torch import Tensor
+from trtkit import (
+    TensorRtBackendConfig,
+    TensorRuntime,
+    TensorSpec,
+    TorchBackendConfig,
+    TorchRuntime,
+    create_runtime_from_onnx,
+    run_chunked,
+)
 
 from mamma.landmarks.config import DEFAULT_MAMMANET_CONFIG, MammaNetConfig
 from mamma.landmarks.crops import box_geometry, gpu_crop_batch, gpu_mask_crop_batch, unproject_joints2d
-from mamma.landmarks.mammanet import MammaNet, load_mammanet
-
-MAMMANET_WEIGHTS_REPO: str = "pablovela5620/mamma-streaming-data"
-MAMMANET_WEIGHTS_FILE: str = "weights/ma_2d/mamma_mask_full_cvpr.safetensors"
+from mamma.landmarks.mammanet import MammaNet, load_mammanet, resolve_mammanet_weights_path
+from mamma.landmarks.tensorrt_backend import INPUT_NAMES, OUTPUT_NAMES, FlattenOutputs, ensure_mammanet_onnx
 
 
 @dataclass(frozen=True, slots=True)
 class MammaNetLandmarksConfig:
-    """MammaNet dense-landmark estimator configuration (torch backend)."""
+    """MammaNet dense-landmark estimator configuration."""
 
     weights_path: Path | None = None
-    """Local safetensors checkpoint; ``None`` downloads mamma's HF weights."""
+    """Checkpoint used by the torch backend and by one-time ONNX export; ``None`` downloads the published weights."""
     device: str = "cuda"
     """Inference device."""
+    backend: TorchBackendConfig | TensorRtBackendConfig = field(default_factory=TorchBackendConfig)
+    """Backend running the loaded model or its cached dynamic ONNX export.
+
+    ``OnnxBackendConfig`` is excluded because the fp16-compute graph uses kernels not covered by ONNX Runtime's CUDA provider.
+    """
 
     def setup(self) -> "MammaNetLandmarks":
         """Load weights and return a ready estimator."""
@@ -47,18 +59,35 @@ class MammaNetLandmarks(TopDownDenseLandmarks2d):
         """Load the checkpoint.
 
         Args:
-            config: Weights source and device.
+            config: Weights source, runtime backend, and device.
         """
-        from huggingface_hub import hf_hub_download
-
+        if not isinstance(config.backend, TorchBackendConfig) and config.device != "cuda":
+            raise ValueError("MammaNet accelerated backends require device='cuda'.")
         self.config: MammaNetLandmarksConfig = config
-        weights_path: Path = (
-            config.weights_path
-            if config.weights_path is not None
-            else Path(hf_hub_download(repo_id=MAMMANET_WEIGHTS_REPO, repo_type="dataset", filename=MAMMANET_WEIGHTS_FILE))
-        )
         self.mamma_config: MammaNetConfig = DEFAULT_MAMMANET_CONFIG
-        self.model: MammaNet = load_mammanet(weights_path, device=config.device, config=self.mamma_config)
+        weights_path: Path = resolve_mammanet_weights_path(config.weights_path)
+        model: MammaNet = load_mammanet(weights_path, device=config.device, config=self.mamma_config)
+        input_specs: tuple[TensorSpec, TensorSpec] = (
+            TensorSpec(INPUT_NAMES[0], (3, self.mamma_config.crop_height, self.mamma_config.crop_width), torch.float32),
+            TensorSpec(INPUT_NAMES[1], (1, self.mamma_config.crop_height, self.mamma_config.crop_width), torch.float32),
+        )
+        output_specs: tuple[TensorSpec, TensorSpec, TensorSpec, TensorSpec] = (
+            TensorSpec(OUTPUT_NAMES[0], (self.mamma_config.num_landmarks, 3), torch.float32),
+            TensorSpec(OUTPUT_NAMES[1], (self.mamma_config.num_landmarks, 1), torch.float32),
+            TensorSpec(OUTPUT_NAMES[2], (self.mamma_config.num_landmarks, 1), torch.float32),
+            TensorSpec(OUTPUT_NAMES[3], (self.mamma_config.num_landmarks, 1), torch.float32),
+        )
+        if isinstance(config.backend, TorchBackendConfig):
+            autocast_dtype: torch.dtype | None = config.backend.autocast_dtype if "cuda" in config.device else None
+            self.runtime: TensorRuntime = TorchRuntime(
+                FlattenOutputs(model),
+                input_specs=input_specs,
+                output_specs=output_specs,
+                max_batch_size=config.backend.max_batch_size,
+                autocast_dtype=autocast_dtype,
+            )
+        else:
+            self.runtime = create_runtime_from_onnx(ensure_mammanet_onnx(model, weights_path), config.backend)
         self.num_landmarks = int(self.mamma_config.num_landmarks)
 
     @torch.no_grad()
@@ -86,7 +115,7 @@ class MammaNetLandmarks(TopDownDenseLandmarks2d):
             empty_p: Float32[Tensor, "0 p"] = torch.empty((0, self.num_landmarks), dtype=torch.float32, device=device)
             return DenseLandmarks2d(empty_xy, empty_p, empty_p, empty_p, empty_p, detections.frame_indices)
 
-        boxes_np: Float32[ndarray, "n 4"] = detections.xyxy.detach().cpu().numpy().astype(np.float32, copy=False)
+        boxes_np: Float32[ndarray, "n 4"] = detections.xyxy_numpy()
         geometry: list[tuple[Float64[ndarray, "2"], Float64[ndarray, "2"]]] = [
             box_geometry(boxes_np[row], self.mamma_config) for row in range(num_instances)
         ]
@@ -98,13 +127,11 @@ class MammaNetLandmarks(TopDownDenseLandmarks2d):
         masks_batch: Float[Tensor, "n 1 h w"] = detections.masks.unsqueeze(1).float() * 255.0
         img_crops, _ = gpu_crop_batch(gathered, centers, sizes, None, self.mamma_config)
         mask_crops = gpu_mask_crop_batch(masks_batch, centers, sizes, self.mamma_config)
-        with torch.autocast("cuda", dtype=torch.float16, enabled="cuda" in self.config.device):
-            out: dict[str, Tensor | None] = self.model(img_crops, mask_crops)
-        joints2d_raw = out["joints2d"]
-        visibility_raw = out["visibility"]
-        contact_raw = out["contact"]
-        floor_raw = out["floor_contact"]
-        assert joints2d_raw is not None and visibility_raw is not None and contact_raw is not None and floor_raw is not None
+        out: dict[str, Tensor] = run_chunked(self.runtime, {INPUT_NAMES[0]: img_crops, INPUT_NAMES[1]: mask_crops})
+        joints2d_raw: Tensor = out[OUTPUT_NAMES[0]]
+        visibility_raw: Tensor = out[OUTPUT_NAMES[1]]
+        contact_raw: Tensor = out[OUTPUT_NAMES[2]]
+        floor_raw: Tensor = out[OUTPUT_NAMES[3]]
         joints2d_px: Float32[Tensor, "n p 3"] = unproject_joints2d(joints2d_raw.float(), centers, sizes, self.mamma_config)
         return DenseLandmarks2d(
             xy=joints2d_px[:, :, 0:2].contiguous(),
@@ -116,4 +143,7 @@ class MammaNetLandmarks(TopDownDenseLandmarks2d):
         )
 
 
-__all__ = ("MammaNetLandmarks", "MammaNetLandmarksConfig")
+__all__ = (
+    "MammaNetLandmarks",
+    "MammaNetLandmarksConfig",
+)

--- a/packages/mamma/src/mamma/landmarks/skeleton.py
+++ b/packages/mamma/src/mamma/landmarks/skeleton.py
@@ -1,0 +1,141 @@
+"""Approximate 2D SMPL-X skeleton from the 512 dense surface landmarks.
+
+Each of the 512 landmarks is a fixed SMPL-X surface vertex, so every joint can
+be estimated as a fixed weighted average of nearby landmarks. Weights are
+k-nearest-neighbor gaussians built in rest pose (joint -> surface distances).
+Restricting SMPL-X's own ``J_regressor`` to the 512 sampled vertices was
+measured and rejected: most rows keep <5% of their mass (pelvis 0.2%), giving
+12.5 cm mean body-joint error on posed bodies vs 3.3 cm for the kNN weights.
+No SMPL-X fitting happens here — this is a linear map, exact articulation is
+not preserved, and the output is a display skeleton, not a measurement.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import torch
+from jaxtyping import Float32, Int
+from numpy import ndarray
+
+KNN_NEIGHBORS: int = 8
+"""Landmarks averaged per joint."""
+SIGMA_NEIGHBORS: int = 4
+"""Nearest neighbors whose mean distance sets each joint's gaussian sigma."""
+DEFAULT_BODY_MODELS_DIR: Path = Path(
+    os.environ.get("MAMMA_BODY_MODELS_DIR", str(Path(__file__).resolve().parents[3] / "data" / "body_models"))
+).expanduser()
+"""Package-relative body-model root populated by ``_download-mamma-body-models``."""
+
+
+@dataclass(frozen=True, slots=True)
+class SkeletonRegressor:
+    """Fixed linear map from dense landmarks to 2D SMPL-X joints."""
+
+    weights: Float32[ndarray, "j landmarks"]
+    """Per-joint landmark weights, rows sum to 1."""
+    parents: tuple[int, ...]
+    """SMPL-X kinematic tree; ``parents[0] == -1``."""
+    bones: Int[ndarray, "b 2"]
+    """Child-parent joint indices for every non-root bone."""
+
+
+def body_models_available(body_models_dir: Path | None = None) -> bool:
+    """Return whether the downloaded SMPL-X model directory is present."""
+    resolved_dir: Path = DEFAULT_BODY_MODELS_DIR if body_models_dir is None else body_models_dir
+    return (resolved_dir / "smplx").exists()
+
+
+@functools.lru_cache(maxsize=1)
+def load_skeleton_regressor(body_models_dir: Path | None = None) -> SkeletonRegressor:
+    """Load the display skeleton regressor from the package's body-model assets.
+
+    Raises:
+        RuntimeError: If the body-model download task has not populated the assets.
+    """
+    resolved_dir: Path = DEFAULT_BODY_MODELS_DIR if body_models_dir is None else body_models_dir
+    if not body_models_available(resolved_dir):
+        raise RuntimeError("SMPL-X body models not found. Run the pixi task _download-mamma-body-models in packages/mamma.")
+    return build_skeleton_regressor(resolved_dir)
+
+
+def skeleton_strips(
+    joints_xy: Float32[ndarray, "j 2"],
+    regressor: SkeletonRegressor,
+) -> Float32[ndarray, "b 2 2"]:
+    """Build child-parent line strips from one person's regressed joints.
+
+    Args:
+        joints_xy: Display skeleton joints in image pixels.
+        regressor: Regressor carrying the SMPL-X kinematic tree.
+
+    Returns:
+        One two-point strip for every non-root joint.
+    """
+    return joints_xy[regressor.bones]
+
+
+def build_skeleton_regressor(body_models_dir: Path) -> SkeletonRegressor:
+    """Build the kNN joint regressor from the SMPL-X neutral model in rest pose.
+
+    Args:
+        body_models_dir: Root containing ``smplx/SMPLX_NEUTRAL.npz`` and
+            ``downsampled_verts/verts_512.pkl`` (the ``_download-mamma-body-models``
+            pixi task layout).
+
+    Returns:
+        The regressor over the joints exposed by the loaded SMPL-X model.
+    """
+    import pickle
+
+    from mamma.fitting.smplx_wrapper import build_smplx_neutral
+
+    model = build_smplx_neutral(body_models_dir, device="cpu")
+    with open(body_models_dir / "downsampled_verts" / "verts_512.pkl", "rb") as f:
+        sampling: Float32[torch.Tensor, "n v"] = pickle.load(f).float()
+
+    v_rest: Float32[torch.Tensor, "v 3"] = model.v_template.float()
+    landmarks_rest: Float32[torch.Tensor, "n 3"] = sampling @ v_rest
+    joints_rest: Float32[torch.Tensor, "j 3"] = model.J_regressor.float() @ v_rest
+
+    distances: Float32[torch.Tensor, "j n"] = torch.cdist(joints_rest, landmarks_rest)
+    knn_dist, knn_idx = distances.topk(KNN_NEIGHBORS, largest=False)
+    sigma: Float32[torch.Tensor, "j 1"] = knn_dist[:, :SIGMA_NEIGHBORS].mean(dim=1, keepdim=True).clamp_min(1e-4)
+    gaussians: Float32[torch.Tensor, "j k"] = torch.exp(-0.5 * (knn_dist / sigma) ** 2)
+    weights: Float32[torch.Tensor, "j n"] = torch.zeros(joints_rest.shape[0], landmarks_rest.shape[0])
+    weights.scatter_(1, knn_idx, gaussians)
+    weights = weights / weights.sum(dim=1, keepdim=True)
+
+    parents: tuple[int, ...] = tuple(int(parent) for parent in model.parents.tolist())
+    bones: Int[ndarray, "b 2"] = np.asarray(
+        [(joint_idx, parent_idx) for joint_idx, parent_idx in enumerate(parents) if parent_idx >= 0], dtype=np.int64
+    )
+    return SkeletonRegressor(weights=weights.numpy().astype(np.float32), parents=parents, bones=bones)
+
+
+def joints_from_landmarks(
+    landmarks_xy: Float32[ndarray, "n landmarks 2"],
+    regressor: SkeletonRegressor,
+) -> Float32[ndarray, "n j 2"]:
+    """Estimate 2D joints per person as fixed weighted landmark averages.
+
+    All 512 landmarks participate regardless of visibility: MammaNet predicts
+    xy for occluded landmarks too (the fitting pipeline consumes all of them),
+    and in 2D projection a back-surface landmark lands at nearly the same pixel
+    as a front one — visibility reweighting would only bias joints toward the
+    visible side (SMPL-X spine joints sit near the back surface and would
+    otherwise lose all their support).
+
+    Args:
+        landmarks_xy: Predicted landmark positions in image pixels.
+        regressor: Fixed landmark->joint weights.
+
+    Returns:
+        2D joints per person.
+    """
+    joints: Float32[ndarray, "n j 2"] = np.einsum("jl,nlc->njc", regressor.weights, landmarks_xy)
+    return joints.astype(np.float32)

--- a/packages/mamma/src/mamma/landmarks/tensorrt_backend.py
+++ b/packages/mamma/src/mamma/landmarks/tensorrt_backend.py
@@ -1,57 +1,76 @@
 """TensorRT backend for MammaNet (ONNX export + trtkit engine build).
 
-Inference runs directly on :class:`trtkit.TensorRtRuntime` with
-``use_cuda_graph=True`` (inputs ``crops``/``masks``, outputs ``joints2d``/
-``visibility``/``contact``/``floor_contact`` — see ``export_mammanet_onnx``).
+The static streaming path runs directly on :class:`trtkit.TensorRtRuntime`
+with ``use_cuda_graph=True`` (inputs ``crops``/``masks``, outputs
+``joints2d``/``visibility``/``contact``/``floor_contact`` — see
+``export_mammanet_onnx``).
 
 Follows the shared trtkit pattern: the `tensorrt-cu13` python API (not
-torch-tensorrt), static batch, a strongly-typed engine whose fp16 compute is
-baked into the ONNX graph (fp32 I/O boundary casts in the export wrapper), and
-one captured ``execute_async_v3`` launch replayed per call — which composes
-cleanly with the fitter's manual CUDA graph.
+torch-tensorrt) and a strongly-typed engine whose fp16 compute is baked into
+the ONNX graph (fp32 I/O boundary casts in the export wrapper). The streaming
+path retains its static-batch CUDA graph; posekit exports one cached dynamic
+ONNX graph and lets trtkit build and cache engines by content hash.
 
-Engines are machine-local artifacts (sm-specific): built once into
-``.trt_cache/`` by ``tools/build_trt_engine.py``, never committed.
+Engines are machine-local artifacts and are never committed. The static
+streaming engine is built into ``.trt_cache/`` by
+``tools/build_trt_engine.py``; posekit's dynamic engine uses trtkit's cache.
 """
 
 from __future__ import annotations
 
+import hashlib
+from os import stat_result
 from pathlib import Path
 
 import torch
+from jaxtyping import Float32
 
 from mamma.landmarks.config import DEFAULT_MAMMANET_CONFIG, MammaNetConfig
 from mamma.landmarks.mammanet import MammaNet
 
 ENGINE_BATCH: int = 4
 """Static batch baked into the engine (cameras x persons rounded up)."""
+INPUT_NAMES: tuple[str, str] = ("crops", "masks")
+"""MammaNet ONNX input bindings in graph order."""
+OUTPUT_NAMES: tuple[str, str, str, str] = ("joints2d", "visibility", "contact", "floor_contact")
+"""MammaNet ONNX output bindings in graph order."""
 
 
-class _FlattenOutputs(torch.nn.Module):
+class FlattenOutputs(torch.nn.Module):
     """Adapter shaping MammaNet's dict output into the flat ONNX output tuple."""
 
     def __init__(self, model: MammaNet) -> None:
         super().__init__()
         self.model = model
 
-    def forward(self, x: torch.Tensor, masks: torch.Tensor):
-        out = self.model(x, masks)
-        return out["joints2d"], out["visibility"], out["contact"], out["floor_contact"]
+    def forward(
+        self, crops: Float32[torch.Tensor, "b 3 h w"], masks: Float32[torch.Tensor, "b 1 h w"]
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+        outputs: dict[str, torch.Tensor | None] = self.model(crops, masks)
+        return outputs[OUTPUT_NAMES[0]], outputs[OUTPUT_NAMES[1]], outputs[OUTPUT_NAMES[2]], outputs[OUTPUT_NAMES[3]]
 
 
-def export_mammanet_onnx(model: MammaNet, onnx_path: Path, config: MammaNetConfig = DEFAULT_MAMMANET_CONFIG) -> None:
-    """Export MammaNet to a static-batch, fp16-compute ONNX graph via trtkit."""
+def export_mammanet_onnx(
+    model: MammaNet,
+    onnx_path: Path,
+    *,
+    batch: int = ENGINE_BATCH,
+    dynamic_batch_max: int | None = None,
+    config: MammaNetConfig = DEFAULT_MAMMANET_CONFIG,
+) -> None:
+    """Export MammaNet to one static- or dynamic-batch fp16-compute ONNX graph via trtkit."""
     from trtkit import export_onnx
 
-    x = torch.randn(ENGINE_BATCH, 3, config.crop_height, config.crop_width, device="cuda")
-    masks = torch.rand(ENGINE_BATCH, 1, config.crop_height, config.crop_width, device="cuda")
+    crops: Float32[torch.Tensor, "b 3 h w"] = torch.randn(batch, 3, config.crop_height, config.crop_width, device="cuda")
+    masks: Float32[torch.Tensor, "b 1 h w"] = torch.rand(batch, 1, config.crop_height, config.crop_width, device="cuda")
     export_onnx(
-        _FlattenOutputs(model).eval().cuda(),
-        (x, masks),
+        FlattenOutputs(model).eval().cuda(),
+        (crops, masks),
         onnx_path,
-        input_names=["crops", "masks"],
-        output_names=["joints2d", "visibility", "contact", "floor_contact"],
+        input_names=list(INPUT_NAMES),
+        output_names=list(OUTPUT_NAMES),
         compute_dtype=torch.float16,
+        dynamic_batch_max=dynamic_batch_max,
     )
 
 
@@ -61,3 +80,21 @@ def build_engine(onnx_path: Path, engine_path: Path) -> None:
     from trtkit import build_engine as trtkit_build_engine
 
     trtkit_build_engine(onnx_path, engine_path, TrtBuildConfig(max_batch_size=ENGINE_BATCH, opt_batch_size=ENGINE_BATCH))
+
+
+def ensure_mammanet_onnx(model: MammaNet, weights_path: Path, config: MammaNetConfig = DEFAULT_MAMMANET_CONFIG) -> Path:
+    """Return MammaNet's cached dynamic-batch fp16 ONNX export."""
+    from posekit.artifacts import DEFAULT_ONNX_CACHE_DIR
+
+    checkpoint_stat: stat_result = weights_path.stat()
+    # Metadata identity avoids hashing the 1.5 GB checkpoint on every setup.
+    checkpoint_id: str = hashlib.sha1(
+        f"{weights_path}:{checkpoint_stat.st_size}:{checkpoint_stat.st_mtime_ns}".encode()
+    ).hexdigest()[:10]
+    onnx_path: Path = DEFAULT_ONNX_CACHE_DIR / f"mammanet_dense512_dynamic_b32_fp16_{checkpoint_id}.onnx"
+    if onnx_path.exists():
+        return onnx_path
+    onnx_path.parent.mkdir(parents=True, exist_ok=True)
+    print(f"[mamma] exporting MammaNet to ONNX (one-time): {onnx_path.name}")
+    export_mammanet_onnx(model, onnx_path, batch=8, dynamic_batch_max=32, config=config)
+    return onnx_path

--- a/packages/mamma/tests/test_posekit_role.py
+++ b/packages/mamma/tests/test_posekit_role.py
@@ -1,0 +1,86 @@
+"""Public-contract tests for MammaNet's posekit landmark role."""
+
+from pathlib import Path
+
+import pytest
+import torch
+from posekit.predictions import BoxDetections
+from posekit.runtimes import TensorRtBackendConfig
+from torch import Tensor
+from trtkit import RuntimeSpec, TensorSpec
+
+from mamma.landmarks.mammanet import MammaNet
+from mamma.landmarks.posekit_role import MammaNetLandmarksConfig
+
+
+def test_accelerated_role_requires_cuda_before_loading_weights() -> None:
+    with pytest.raises(ValueError, match="require device='cuda'"):
+        MammaNetLandmarksConfig(device="cpu", backend=TensorRtBackendConfig()).setup()
+
+
+def test_tensorrt_role_builds_from_weights_and_returns_dense_landmark_heads(monkeypatch, tmp_path: Path) -> None:
+    """The TensorRT role resolves weights and preserves MammaNet's image-space output contract."""
+
+    class FakeTensorRtRuntime:
+        def __init__(self) -> None:
+            self.spec = RuntimeSpec(
+                inputs=(
+                    TensorSpec("crops", (3, 512, 384), torch.float32),
+                    TensorSpec("masks", (1, 512, 384), torch.float32),
+                ),
+                outputs=(
+                    TensorSpec("joints2d", (512, 3), torch.float32),
+                    TensorSpec("visibility", (512, 1), torch.float32),
+                    TensorSpec("contact", (512, 1), torch.float32),
+                    TensorSpec("floor_contact", (512, 1), torch.float32),
+                ),
+                max_batch_size=32,
+            )
+
+        def __call__(self, inputs: dict[str, Tensor]) -> dict[str, Tensor]:
+            batch_size: int = int(inputs["crops"].shape[0])
+            device: torch.device = inputs["crops"].device
+            return {
+                "joints2d": torch.zeros((batch_size, 512, 3), device=device),
+                "visibility": torch.zeros((batch_size, 512, 1), device=device),
+                "contact": torch.zeros((batch_size, 512, 1), device=device),
+                "floor_contact": torch.zeros((batch_size, 512, 1), device=device),
+            }
+
+    weights_path: Path = tmp_path / "mammanet.safetensors"
+    weights_path.touch()
+    onnx_path: Path = tmp_path / "mammanet.onnx"
+    model: MammaNet = MammaNet.__new__(MammaNet)
+
+    def fake_load_mammanet(path: Path | None, *, device: str, config: object) -> MammaNet:
+        del path, device, config
+        return model
+
+    def fake_ensure_mammanet_onnx(loaded_model: MammaNet, resolved_weights_path: Path) -> Path:
+        del loaded_model, resolved_weights_path
+        return onnx_path
+
+    def fake_create_runtime(path: Path, backend: TensorRtBackendConfig) -> FakeTensorRtRuntime:
+        del path, backend
+        return FakeTensorRtRuntime()
+
+    monkeypatch.setattr("mamma.landmarks.posekit_role.load_mammanet", fake_load_mammanet)
+    monkeypatch.setattr("mamma.landmarks.posekit_role.ensure_mammanet_onnx", fake_ensure_mammanet_onnx)
+    monkeypatch.setattr("mamma.landmarks.posekit_role.create_runtime_from_onnx", fake_create_runtime)
+    backend = TensorRtBackendConfig()
+    role = MammaNetLandmarksConfig(weights_path=weights_path, device="cuda", backend=backend).setup()
+    frames_rgb: Tensor = torch.zeros((1, 18, 12, 3), dtype=torch.uint8)
+    detections = BoxDetections(
+        xyxy=torch.tensor([[2.0, 3.0, 10.0, 15.0]], dtype=torch.float32),
+        scores=torch.ones((1,), dtype=torch.float32),
+        frame_indices=torch.zeros((1,), dtype=torch.long),
+        masks=torch.ones((1, 18, 12), dtype=torch.bool),
+    )
+
+    result = role(frames_rgb, detections)
+
+    torch.testing.assert_close(result.xy, torch.tensor([6.0, 9.0]).expand(1, 512, 2))
+    torch.testing.assert_close(result.log_variance, torch.zeros((1, 512)))
+    torch.testing.assert_close(result.visibility, torch.full((1, 512), 0.5))
+    torch.testing.assert_close(result.contact, torch.full((1, 512), 0.5))
+    torch.testing.assert_close(result.floor_contact, torch.full((1, 512), 0.5))

--- a/packages/mamma/tests/test_skeleton.py
+++ b/packages/mamma/tests/test_skeleton.py
@@ -1,0 +1,32 @@
+"""Public-contract tests for MammaNet display skeleton helpers."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from mamma.landmarks.skeleton import SkeletonRegressor, body_models_available, load_skeleton_regressor, skeleton_strips
+
+
+def test_body_model_loader_owns_missing_asset_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The skeleton seam reports the Pixi recovery task when SMPL-X assets are absent."""
+    monkeypatch.setattr("mamma.landmarks.skeleton.DEFAULT_BODY_MODELS_DIR", tmp_path)
+    load_skeleton_regressor.cache_clear()
+
+    assert not body_models_available()
+    with pytest.raises(RuntimeError, match="_download-mamma-body-models"):
+        load_skeleton_regressor()
+
+
+def test_skeleton_strips_follow_regressor_bones() -> None:
+    """Display strips contain the child-parent pairs stored by the regressor."""
+    joints_xy = np.asarray([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
+    regressor = SkeletonRegressor(
+        weights=np.zeros((3, 512), dtype=np.float32),
+        parents=(-1, 0, 1),
+        bones=np.asarray([[1, 0], [2, 1]], dtype=np.int64),
+    )
+
+    strips = skeleton_strips(joints_xy, regressor)
+
+    np.testing.assert_array_equal(strips, [[[3.0, 4.0], [1.0, 2.0]], [[5.0, 6.0], [3.0, 4.0]]])

--- a/packages/mamma/tools/build_trt_engine.py
+++ b/packages/mamma/tools/build_trt_engine.py
@@ -20,8 +20,8 @@ from mamma.landmarks.tensorrt_backend import ENGINE_BATCH, build_engine, export_
 
 @dataclass
 class BuildConfig:
-    mammanet_weights: Path = Path("data/weights/ma_2d/mamma_mask_full_cvpr.safetensors")
-    """Converted MammaNet state dict."""
+    mammanet_weights: Path | None = None
+    """Converted MammaNet state dict; ``None`` downloads the published weights."""
     cache_dir: Path = Path(".trt_cache")
     """Machine-local engine cache."""
     force: bool = False

--- a/packages/posekit/src/posekit/apis/video_pose.py
+++ b/packages/posekit/src/posekit/apis/video_pose.py
@@ -19,7 +19,7 @@ from tqdm.auto import tqdm
 
 from posekit.models import AnnotatedDetectorConfig, AnnotatedPose2dConfig, Pose2dPipeline, RtmPoseConfig, YoloxDetectorConfig
 from posekit.predictions import BoxDetections, Keypoints2d
-from posekit.skeletons import KeypointSkeleton
+from posekit.rerun_logging import log_person_points2d, log_skeleton_annotation_context
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -48,28 +48,6 @@ class VideoPoseConfig:
         return Pose2dPipeline(self.detector.setup(), self.pose.setup())
 
 
-def log_skeleton_annotation_context(skeleton: KeypointSkeleton, *, entity_path: str = "video") -> None:
-    """Log a Rerun annotation context describing the skeleton's keypoints/links.
-
-    Args:
-        skeleton: Skeleton format of the predictions.
-        entity_path: Entity subtree the context applies to.
-    """
-    rr.log(
-        entity_path,
-        rr.AnnotationContext(
-            [
-                rr.ClassDescription(
-                    info=rr.AnnotationInfo(id=0, label=skeleton.name),
-                    keypoint_annotations=[rr.AnnotationInfo(id=idx, label=name) for idx, name in enumerate(skeleton.keypoint_names)],
-                    keypoint_connections=list(skeleton.links),
-                )
-            ]
-        ),
-        static=True,
-    )
-
-
 def log_frame_predictions(
     *,
     frame_indices: Int[ndarray, "chunk"],
@@ -94,7 +72,7 @@ def log_frame_predictions(
             entities are never created in the recording.
     """
     person_frames: Int[ndarray, "n"] = detections.frame_indices.cpu().numpy()
-    boxes: Float32[ndarray, "n 4"] = detections.xyxy.cpu().numpy().astype(np.float32, copy=False)
+    boxes: Float32[ndarray, "n 4"] = detections.xyxy_numpy()
     xy: Float32[ndarray, "n k 2"] = keypoints.xy_numpy()
     scores: Float32[ndarray, "n k"] = keypoints.scores_numpy()
     for local_idx, (frame_idx, timestamp_ns) in enumerate(zip(frame_indices, timestamps_ns, strict=True)):
@@ -112,16 +90,14 @@ def log_frame_predictions(
                 continue
             live_slots.add(slot)
             row: int = int(rows[slot])
-            visible_xy: Float32[ndarray, "k 2"] = xy[row].copy()
-            visible_xy[scores[row] < keypoint_threshold] = np.nan
             rr.log(bbox_path, rr.Boxes2D(array=boxes[row][None], array_format=rr.Box2DFormat.XYXY))
-            rr.log(
+            log_person_points2d(
                 keypoints_path,
-                rr.Points2D(
-                    positions=visible_xy,
-                    keypoint_ids=np.arange(visible_xy.shape[0], dtype=np.uint16),
-                    class_ids=0,
-                ),
+                xy[row],
+                scores[row],
+                keypoint_threshold,
+                keypoint_ids=np.arange(xy.shape[1], dtype=np.uint16),
+                class_ids=0,
             )
 
 

--- a/packages/posekit/src/posekit/apis/video_track.py
+++ b/packages/posekit/src/posekit/apis/video_track.py
@@ -20,11 +20,11 @@ from simplecv.rerun_log_utils import RerunTyroConfig, log_video
 from torch import Tensor
 from tqdm.auto import tqdm
 
-from posekit.apis.video_pose import log_skeleton_annotation_context
 from posekit.models import AnnotatedDetectorConfig, AnnotatedPose2dConfig, RtmPoseConfig, SegmentationPrompts, YoloxDetectorConfig
 from posekit.models.clip_identity import ClipIdentityConfig
 from posekit.models.sam2_video import Sam2VideoSegmenterConfig
 from posekit.predictions import BoxDetections, Keypoints2d
+from posekit.rerun_logging import log_skeleton_annotation_context
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -68,7 +68,7 @@ def _log_tracked_frame(
     rr.set_time("video_time", duration=1e-9 * float(timestamp_ns))
     assert tracks.masks is not None and tracks.track_ids is not None
     label_map: ndarray = np.zeros(frame_hw, dtype=np.uint8)
-    boxes: Float32[ndarray, "n 4"] = tracks.xyxy.cpu().numpy().astype(np.float32, copy=False)
+    boxes: Float32[ndarray, "n 4"] = tracks.xyxy_numpy()
     track_ids: Int[ndarray, "n"] = tracks.track_ids.cpu().numpy()
     masks: Bool[ndarray, "n h w"] = tracks.masks.cpu().numpy()
     xy: Float32[ndarray, "p k 2"] = keypoints.xy_numpy()

--- a/packages/posekit/src/posekit/gradio_ui.py
+++ b/packages/posekit/src/posekit/gradio_ui.py
@@ -1,0 +1,374 @@
+"""Unified single-image 2D pose inference in Gradio and Rerun."""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable, Iterator
+from importlib import resources
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal, TypeAlias, cast
+
+import gradio as gr
+import numpy as np
+import rerun as rr
+import rerun.blueprint as rrb
+import torch
+from gradio_rerun import Rerun
+from jaxtyping import Float32, UInt8
+from numpy import ndarray
+from PIL import Image
+from torch import Tensor
+
+from posekit.models import (
+    RtmPoseConfig,
+    SapiensPoseConfig,
+    SegmentationPrompts,
+    TopDownDenseLandmarks2d,
+    TopDownPose2d,
+    VitPoseConfig,
+)
+from posekit.models.sam3_segmenter import Sam3Segmenter, Sam3SegmenterConfig
+from posekit.models.sapiens import SapiensModelSize
+from posekit.predictions import BoxDetections, DenseLandmarks2d, Keypoints2d
+from posekit.rerun_logging import log_approximate_skeletons, log_dense_predictions, log_topdown_predictions
+from posekit.runtimes import (
+    BackendConfig,
+    OnnxBackendConfig,
+    TensorRtBackendConfig,
+    TorchBackendConfig,
+)
+
+if TYPE_CHECKING:
+    from mamma.landmarks.skeleton import SkeletonRegressor
+
+BackendName: TypeAlias = Literal["torch", "onnx", "tensorrt"]
+
+# The pose-app environment is CUDA-only; model setup reports host availability when a request loads a network.
+DEVICE: str = "cuda"
+IMAGE_SUFFIXES: frozenset[str] = frozenset({".jpg", ".jpeg", ".png"})
+
+
+NETWORKS: dict[str, list[BackendName]] = {
+    "rtmpose-m-coco17": ["onnx", "tensorrt"],
+    "rtmpose-x-coco17": ["onnx", "tensorrt"],
+    "rtmw-x-coco133": ["onnx", "tensorrt"],
+    "vitpose": ["torch"],
+    "sapiens2-0.4b": ["torch", "onnx", "tensorrt"],
+    "sapiens2-1b": ["torch", "onnx", "tensorrt"],
+    "mamma-dense512": ["torch", "tensorrt"],
+}
+# Backend lists are ordered least-to-most preferred, so defaults are derived once.
+DEFAULT_BACKENDS: dict[str, BackendName] = {network_name: backends[-1] for network_name, backends in NETWORKS.items()}
+BACKEND_CONFIGS: dict[BackendName, Callable[[], BackendConfig]] = {
+    "torch": TorchBackendConfig,
+    "onnx": OnnxBackendConfig,
+    "tensorrt": TensorRtBackendConfig,
+}
+
+
+def _build_estimator(network_name: str, backend_name: BackendName) -> TopDownPose2d | TopDownDenseLandmarks2d:
+    """Construct one network on one backend; NETWORKS already gated the pair."""
+    match network_name:
+        case "rtmpose-m-coco17" | "rtmpose-x-coco17" | "rtmw-x-coco133":
+            accelerated: OnnxBackendConfig | TensorRtBackendConfig = (
+                OnnxBackendConfig() if backend_name == "onnx" else TensorRtBackendConfig()
+            )
+            return RtmPoseConfig(variant=network_name, backend=accelerated).setup()
+        case "vitpose":
+            return VitPoseConfig(device=DEVICE).setup()
+        case "sapiens2-0.4b" | "sapiens2-1b":
+            model_size: SapiensModelSize = "0.4B" if network_name == "sapiens2-0.4b" else "1B"
+            backend: BackendConfig = BACKEND_CONFIGS[backend_name]()
+            return SapiensPoseConfig(model_size=model_size, backend=backend).setup()
+        case "mamma-dense512":
+            try:
+                from mamma.landmarks.posekit_role import MammaNetLandmarksConfig
+            except ImportError as error:
+                raise gr.Error("mamma is not installed in this environment") from error
+            mamma_backend: TorchBackendConfig | TensorRtBackendConfig = (
+                TorchBackendConfig() if backend_name == "torch" else TensorRtBackendConfig()
+            )
+            return MammaNetLandmarksConfig(device=DEVICE, backend=mamma_backend).setup()
+        case _:
+            raise gr.Error(f"No builder for {network_name!r}")
+
+
+_estimator_cache: dict[tuple[str, str], TopDownPose2d | TopDownDenseLandmarks2d] = {}
+
+
+@functools.cache
+def _get_segmenter() -> Sam3Segmenter:
+    """Load SAM3 once and reuse it across requests."""
+    return Sam3SegmenterConfig(device=DEVICE).setup()
+
+
+def _get_estimator(network_name: str, backend_name: str) -> TopDownPose2d | TopDownDenseLandmarks2d:
+    """Load and cache the selected network/backend pair; at most two stay resident on the GPU."""
+    allowed: list[BackendName] = NETWORKS[network_name]
+    if backend_name not in allowed:
+        raise gr.Error(f"Backend {backend_name!r} is not available for {network_name}.")
+
+    cache_key: tuple[str, str] = (network_name, backend_name)
+    if cache_key in _estimator_cache:
+        _estimator_cache[cache_key] = _estimator_cache.pop(cache_key)
+        return _estimator_cache[cache_key]
+    if len(_estimator_cache) >= 2:
+        evicted: TopDownPose2d | TopDownDenseLandmarks2d = _estimator_cache.pop(next(iter(_estimator_cache)))
+        # The local reference would keep the evicted weights alive through empty_cache().
+        del evicted
+        torch.cuda.empty_cache()
+    _estimator_cache[cache_key] = _build_estimator(network_name, cast(BackendName, backend_name))
+    return _estimator_cache[cache_key]
+
+
+@rr.thread_local_stream("posekit_2d_pose_playground")
+def predict_ui(
+    image: Image.Image | None,
+    prompt: str | None,
+    network_name: str,
+    backend_name: str,
+    keypoint_threshold: float,
+    show_skeleton: bool,
+) -> Iterator[tuple[bytes | None, dict[str, object], str]]:
+    """Run SAM3 and the selected pose estimator, then stream one recording."""
+    if image is None:
+        raise gr.Error("No image provided.")
+    if prompt is None or not prompt.strip():
+        raise gr.Error("No prompt provided.")
+    stream: rr.BinaryStream = rr.binary_stream()
+
+    image_rgb: UInt8[ndarray, "h w 3"] = np.asarray(image.convert("RGB"), dtype=np.uint8)
+    frames_rgb: UInt8[Tensor, "1 h w 3"] = torch.from_numpy(image_rgb).unsqueeze(0).to(device=DEVICE)
+    prompts: SegmentationPrompts = SegmentationPrompts(
+        frame_indices=torch.zeros((1,), dtype=torch.long, device=frames_rgb.device),
+        text=prompt.strip(),
+    )
+    detections: BoxDetections = _get_segmenter()(frames_rgb, prompts)
+    estimator: TopDownPose2d | TopDownDenseLandmarks2d = _get_estimator(network_name, backend_name)
+    boxes_xyxy: Float32[ndarray, "n 4"] = detections.xyxy_numpy()
+
+    rr.send_blueprint(rrb.Blueprint(rrb.Spatial2DView(name="2D Pose", origin="image"), collapse_panels=True))
+    rr.set_time("iteration", sequence=0)
+    rr.log("image", rr.Image(image_rgb, color_model=rr.ColorModel.RGB))
+    instances: list[dict[str, object]] = []
+    if isinstance(estimator, TopDownDenseLandmarks2d):
+        landmarks: DenseLandmarks2d = estimator(frames_rgb, detections)
+        landmarks_xy: Float32[ndarray, "n p 2"] = landmarks.xy_numpy()
+        visibility: Float32[ndarray, "n p"] = landmarks.visibility_numpy()
+        contact: Float32[ndarray, "n p"] = landmarks.contact_numpy()
+        floor_contact: Float32[ndarray, "n p"] = landmarks.floor_contact_numpy()
+        log_dense_predictions(boxes_xyxy, landmarks_xy, visibility, keypoint_threshold)
+        if show_skeleton:
+            try:
+                from mamma.landmarks.skeleton import joints_from_landmarks, load_skeleton_regressor, skeleton_strips
+            except ImportError as error:
+                raise gr.Error("mamma is not installed in this environment") from error
+            regressor: SkeletonRegressor = load_skeleton_regressor()
+            joints_xy: Float32[ndarray, "n j 2"] = joints_from_landmarks(landmarks_xy, regressor)
+            strips_by_person: list[Float32[ndarray, "b 2 2"]] = [
+                skeleton_strips(joints_xy[person_idx], regressor) for person_idx in range(boxes_xyxy.shape[0])
+            ]
+            log_approximate_skeletons(joints_xy, strips_by_person)
+        for person_idx in range(boxes_xyxy.shape[0]):
+            instances.append(
+                {
+                    "bbox": boxes_xyxy[person_idx].tolist(),
+                    "keypoints": landmarks_xy[person_idx].tolist(),
+                    "visibility": visibility[person_idx].tolist(),
+                    "contact": contact[person_idx].tolist(),
+                    "floor_contact": floor_contact[person_idx].tolist(),
+                }
+            )
+    else:
+        keypoints: Keypoints2d = estimator(frames_rgb, detections)
+        keypoints_xy: Float32[ndarray, "n k 2"] = keypoints.xy_numpy()
+        scores: Float32[ndarray, "n k"] = keypoints.scores_numpy()
+        log_topdown_predictions(boxes_xyxy, keypoints_xy, scores, keypoints.skeleton, keypoint_threshold)
+        for person_idx in range(boxes_xyxy.shape[0]):
+            instances.append(
+                {
+                    "bbox": boxes_xyxy[person_idx].tolist(),
+                    "keypoints": keypoints_xy[person_idx].tolist(),
+                    "scores": scores[person_idx].tolist(),
+                }
+            )
+
+    stream_bytes: bytes | None = stream.read()
+    yield stream_bytes, {"instances": instances}, f"Complete: {len(instances)} person(s) — {network_name} ({backend_name})"
+
+
+def _update_backend_choices(network_name: str) -> dict[str, object]:
+    """Update the backend dropdown when the selected network changes."""
+    choices: list[BackendName] | None = NETWORKS.get(network_name)
+    if choices is None:
+        raise gr.Error(f"Unknown network: {network_name}")
+    return gr.update(choices=choices, value=DEFAULT_BACKENDS[network_name])
+
+
+def _example_images() -> list[str]:
+    """Find MAMMA examples, falling back to the Sapiens2 assets."""
+    candidate_dirs: list[Path] = []
+    for package_name in ("mamma", "sapiens2_pose"):
+        try:
+            candidate_dirs.append(Path(str(resources.files(package_name))) / "assets" / "images")
+        except ImportError:
+            continue
+    for images_dir in candidate_dirs:
+        if images_dir.is_dir():
+            return sorted(str(path) for path in images_dir.iterdir() if path.suffix.lower() in IMAGE_SUFFIXES)
+    return []
+
+
+EXAMPLES: list[str] = _example_images()
+
+CUSTOM_CSS: str = """
+:root, body, .gradio-container, button, input, select, textarea,
+.gradio-container *:not(code):not(pre) {
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif !important;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+#title { text-align: center; font-size: 44px; font-weight: 700;
+         letter-spacing: -0.01em; margin: 28px 0 4px;
+         background: linear-gradient(90deg, #1d4ed8 0%, #6d28d9 50%, #be185d 100%);
+         -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+         background-clip: text; }
+#subtitle { text-align: center; font-size: 12px; color: #64748b;
+            letter-spacing: 0.18em; margin: 0 0 14px; text-transform: uppercase;
+            font-weight: 500; }
+#badges { display: flex; justify-content: center; flex-wrap: wrap;
+          gap: 8px; margin: 0 0 32px; }
+.pill { display: inline-flex; align-items: center; gap: 6px;
+        padding: 7px 14px; border-radius: 999px;
+        background: #f1f5f9; color: #0f172a !important;
+        font-size: 13px; font-weight: 500; letter-spacing: 0.01em;
+        text-decoration: none !important; border: 1px solid #e2e8f0;
+        transition: background 150ms ease, transform 150ms ease, border-color 150ms ease; }
+.pill:hover { background: #0f172a; color: #f8fafc !important;
+              border-color: #0f172a; transform: translateY(-1px); }
+.pill svg { width: 14px; height: 14px; }
+"""
+
+HEADER_HTML: str = """
+<div id="title">posekit: 2D Pose Playground</div>
+<div id="subtitle">One detector &middot; Seven networks &middot; Three runtimes</div>
+<div id="badges">
+  <a class="pill" href="https://github.com/rerun-io/examples-monorepo/tree/main/packages/posekit" target="_blank" rel="noopener">
+    <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .3a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2c-3.3.7-4-1.6-4-1.6-.6-1.4-1.4-1.8-1.4-1.8-1.1-.7.1-.7.1-.7 1.3.1 2 1.3 2 1.3 1.1 1.9 3 1.4 3.7 1 .1-.8.4-1.4.8-1.7-2.7-.3-5.5-1.3-5.5-5.9 0-1.3.5-2.4 1.3-3.2-.1-.4-.6-1.6.1-3.2 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.3-1.5 3.3-1.2 3.3-1.2.7 1.6.2 2.8.1 3.2.8.8 1.3 1.9 1.3 3.2 0 4.6-2.8 5.6-5.5 5.9.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0 0 12 .3"/></svg>
+    Code
+  </a>
+</div>
+"""
+
+DEFAULT_NETWORK: str = "rtmw-x-coco133"
+
+with gr.Blocks(title="posekit: 2D Pose Playground") as demo:
+    gr.HTML(HEADER_HTML)
+
+    with gr.Row():
+        with gr.Column(scale=1):
+            tabs: gr.Tabs = gr.Tabs(selected="inputs")
+            with tabs:
+                with gr.TabItem("Inputs", id="inputs"):
+                    inp: gr.Image = gr.Image(label="Input Image", type="pil", image_mode="RGB", height=360)
+                    run: gr.Button = gr.Button("Run Pose", variant="primary")
+
+                    with gr.Accordion("Config", open=False):
+                        prompt_text: gr.Textbox = gr.Textbox(label="Prompt", value="person")
+                        network_dropdown: gr.Dropdown = gr.Dropdown(
+                            choices=list(NETWORKS),
+                            value=DEFAULT_NETWORK,
+                            label="Network",
+                        )
+                        backend_dropdown: gr.Dropdown = gr.Dropdown(
+                            choices=NETWORKS[DEFAULT_NETWORK],
+                            value=DEFAULT_BACKENDS[DEFAULT_NETWORK],
+                            label="Backend",
+                        )
+                        keypoint_thr: gr.Slider = gr.Slider(
+                            0.0,
+                            1.0,
+                            value=0.3,
+                            step=0.05,
+                            label="Keypoint/Visibility Threshold",
+                        )
+                        show_skeleton: gr.Checkbox = gr.Checkbox(value=True, label="Show Approximate Skeleton")
+
+                    examples: gr.helpers.Examples = gr.Examples(
+                        examples=EXAMPLES,
+                        inputs=[inp],
+                        examples_per_page=4,
+                        cache_examples=False,
+                    )
+
+                with gr.TabItem("Outputs", id="outputs"):
+                    status_text: gr.Textbox = gr.Textbox(
+                        label="Status",
+                        value="Select an image to begin.",
+                        interactive=False,
+                    )
+                    out_json: gr.JSON = gr.JSON(label="Predictions", value={"instances": []})
+
+        with gr.Column(scale=5):
+            viewer: Rerun = Rerun(
+                label="2D Pose",
+                streaming=True,
+                panel_states={
+                    "time": "collapsed",
+                    "blueprint": "hidden",
+                    "selection": "hidden",
+                },
+                height=800,
+            )
+
+    network_dropdown.change(
+        fn=_update_backend_choices,
+        inputs=[network_dropdown],
+        outputs=[backend_dropdown],
+        api_visibility="private",
+    )
+
+    examples.load_input_event.then(
+        fn=lambda: gr.update(selected="inputs"),
+        inputs=None,
+        outputs=[tabs],
+        api_visibility="private",
+    )
+
+    run.click(
+        fn=lambda: gr.update(selected="outputs"),
+        inputs=None,
+        outputs=[tabs],
+        api_visibility="private",
+    ).then(
+        fn=lambda: (None, {"instances": []}, "Starting pose estimation..."),
+        inputs=None,
+        outputs=[viewer, out_json, status_text],
+        api_visibility="private",
+    ).then(
+        fn=predict_ui,
+        inputs=[inp, prompt_text, network_dropdown, backend_dropdown, keypoint_thr, show_skeleton],
+        outputs=[viewer, out_json, status_text],
+    )
+
+
+# The viewer stream (crypto.randomUUID) and the image "Paste from clipboard"
+# button (navigator.clipboard.read) need a secure context. Serve over HTTPS —
+# on the tailnet: `tailscale serve --bg --https=7860 http://127.0.0.1:7860`.
+def launch() -> None:
+    """Launch the unified pose Gradio app."""
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    demo.launch(
+        share=False,
+        theme=gr.themes.Soft(),
+        css=CUSTOM_CSS,
+        # The example images live in sibling packages (mamma/sapiens2-pose
+        # assets), outside this app's cwd — gradio blocks them otherwise.
+        allowed_paths=sorted({str(Path(example).parent) for example in EXAMPLES}),
+    )
+
+
+if __name__ == "__main__":
+    launch()

--- a/packages/posekit/src/posekit/models/sapiens.py
+++ b/packages/posekit/src/posekit/models/sapiens.py
@@ -42,6 +42,7 @@ from posekit.runtimes import (
 from posekit.skeletons import COCO_133
 
 SapiensModelSize = Literal["0.4B", "0.8B", "1B"]
+SAPIENS_ONNX_EXPORT_VERSION: int = 2
 
 
 @dataclass(frozen=True, slots=True)
@@ -164,7 +165,10 @@ def _ensure_sapiens_onnx(model_size: SapiensModelSize, static_batch: int, *, bf1
     # graphs overflow; opset >= 22 required for bf16 Conv). bf16=False keeps the
     # plain fp32 graph ONNX Runtime has always run (ORT lacks bf16 Conv kernels).
     dtype_key: str = "bf16" if bf16 else "fp32"
-    onnx_path: Path = DEFAULT_ONNX_CACHE_DIR / f"sapiens2_{model_size.lower()}_pose_b{static_batch}_{dtype_key}.onnx"
+    # bf16 exports now carry fp32 ConvTranspose islands, so warm caches must re-export.
+    onnx_path: Path = (
+        DEFAULT_ONNX_CACHE_DIR / f"sapiens2_{model_size.lower()}_pose_b{static_batch}_{dtype_key}_v{SAPIENS_ONNX_EXPORT_VERSION}.onnx"
+    )
     if onnx_path.exists():
         return onnx_path
     onnx_path.parent.mkdir(parents=True, exist_ok=True)

--- a/packages/posekit/src/posekit/predictions.py
+++ b/packages/posekit/src/posekit/predictions.py
@@ -60,6 +60,10 @@ class BoxDetections:
         """Number of detections across the whole frame batch."""
         return int(self.xyxy.shape[0])
 
+    def xyxy_numpy(self) -> Float32[ndarray, "n 4"]:
+        """Copy boxes to CPU for logging/serialization."""
+        return self.xyxy.detach().cpu().numpy().astype(np.float32, copy=False)
+
     @classmethod
     def empty(cls, device: torch.device | str, *, mask_hw: tuple[int, int] | None = None, with_track_ids: bool = False) -> "BoxDetections":
         """Build a zero-detection result on the given device.
@@ -160,6 +164,22 @@ class DenseLandmarks2d:
     def num_instances(self) -> int:
         """Number of landmark instances across the whole frame batch."""
         return int(self.xy.shape[0])
+
+    def xy_numpy(self) -> Float32[ndarray, "n p 2"]:
+        """Copy landmarks to CPU for logging/serialization."""
+        return self.xy.detach().cpu().numpy().astype(np.float32, copy=False)
+
+    def visibility_numpy(self) -> Float32[ndarray, "n p"]:
+        """Copy visibility scores to CPU for logging/serialization."""
+        return self.visibility.detach().cpu().numpy().astype(np.float32, copy=False)
+
+    def contact_numpy(self) -> Float32[ndarray, "n p"]:
+        """Copy contact scores to CPU for logging/serialization."""
+        return self.contact.detach().cpu().numpy().astype(np.float32, copy=False)
+
+    def floor_contact_numpy(self) -> Float32[ndarray, "n p"]:
+        """Copy floor-contact scores to CPU for logging/serialization."""
+        return self.floor_contact.detach().cpu().numpy().astype(np.float32, copy=False)
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/posekit/src/posekit/rerun_logging.py
+++ b/packages/posekit/src/posekit/rerun_logging.py
@@ -1,0 +1,138 @@
+"""Rerun logging helpers for posekit image and video predictions."""
+
+from __future__ import annotations
+
+import numpy as np
+import rerun as rr
+from jaxtyping import Float32, UInt8, UInt16
+from numpy import ndarray
+
+from posekit.skeletons import KeypointSkeleton
+
+PERSON_COLORS: UInt8[ndarray, "palette 3"] = np.asarray(
+    [
+        [31, 119, 180], [255, 127, 14], [44, 160, 44], [214, 39, 40],
+        [148, 103, 189], [140, 86, 75], [227, 119, 194], [23, 190, 207],
+    ],
+    dtype=np.uint8,
+)
+
+
+def person_color(person_idx: int) -> tuple[int, int, int]:
+    """Return the stable display color for one person index."""
+    color_rgb: UInt8[ndarray, "3"] = PERSON_COLORS[person_idx % PERSON_COLORS.shape[0]]
+    return int(color_rgb[0]), int(color_rgb[1]), int(color_rgb[2])
+
+
+def log_skeleton_annotation_context(skeleton: KeypointSkeleton, *, entity_path: str = "video") -> None:
+    """Log a Rerun annotation context describing the skeleton's keypoints and links."""
+    rr.log(
+        entity_path,
+        rr.AnnotationContext(
+            [
+                rr.ClassDescription(
+                    info=rr.AnnotationInfo(id=0, label=skeleton.name),
+                    keypoint_annotations=[rr.AnnotationInfo(id=idx, label=name) for idx, name in enumerate(skeleton.keypoint_names)],
+                    keypoint_connections=list(skeleton.links),
+                )
+            ]
+        ),
+        static=True,
+    )
+
+
+def log_person_bbox(box_xyxy: Float32[ndarray, "4"], person_idx: int) -> None:
+    """Log one person's box with its stable display color."""
+    rr.log(
+        f"image/person_{person_idx}/bbox",
+        rr.Boxes2D(
+            array=box_xyxy.reshape(1, 4),
+            array_format=rr.Box2DFormat.XYXY,
+            labels=f"person_{person_idx}",
+            colors=person_color(person_idx),
+        ),
+    )
+
+
+def log_person_points2d(
+    entity_path: str,
+    xy: Float32[ndarray, "p 2"],
+    confidence: Float32[ndarray, "p"],
+    threshold: float,
+    *,
+    color: tuple[int, int, int] | None = None,
+    keypoint_ids: UInt16[ndarray, "p"] | None = None,
+    class_ids: int | None = None,
+) -> None:
+    """Log one person's points after masking low-confidence positions."""
+    visible_xy: Float32[ndarray, "p 2"] = xy.copy()
+    visible_xy[confidence < threshold] = np.nan
+    rr.log(
+        entity_path,
+        rr.Points2D(
+            positions=visible_xy,
+            keypoint_ids=keypoint_ids,
+            class_ids=class_ids,
+            colors=color,
+            # Negative radii are screen-space UI points, so they stay visible at every zoom level.
+            radii=-2.5,
+            show_labels=False,
+        ),
+    )
+
+
+def log_topdown_predictions(
+    boxes_xyxy: Float32[ndarray, "n 4"],
+    keypoints_xy: Float32[ndarray, "n k 2"],
+    scores: Float32[ndarray, "n k"],
+    skeleton: KeypointSkeleton,
+    keypoint_threshold: float,
+) -> None:
+    """Log sparse keypoints with their skeleton annotation context."""
+    log_skeleton_annotation_context(skeleton, entity_path="image")
+    keypoint_ids: UInt16[ndarray, "k"] = np.arange(keypoints_xy.shape[1], dtype=np.uint16)
+    for person_idx in range(boxes_xyxy.shape[0]):
+        log_person_bbox(boxes_xyxy[person_idx], person_idx)
+        log_person_points2d(
+            f"image/person_{person_idx}/keypoints",
+            keypoints_xy[person_idx],
+            scores[person_idx],
+            keypoint_threshold,
+            color=person_color(person_idx),
+            keypoint_ids=keypoint_ids,
+            class_ids=0,
+        )
+
+
+def log_dense_predictions(
+    boxes_xyxy: Float32[ndarray, "n 4"],
+    landmarks_xy: Float32[ndarray, "n p 2"],
+    visibility: Float32[ndarray, "n p"],
+    visibility_threshold: float,
+) -> None:
+    """Log MAMMA dense landmarks for each person."""
+    for person_idx in range(boxes_xyxy.shape[0]):
+        log_person_bbox(boxes_xyxy[person_idx], person_idx)
+        log_person_points2d(
+            f"image/person_{person_idx}/landmarks",
+            landmarks_xy[person_idx],
+            visibility[person_idx],
+            visibility_threshold,
+            color=person_color(person_idx),
+        )
+
+
+def log_approximate_skeletons(
+    joints_xy: Float32[ndarray, "n j 2"],
+    strips_by_person: list[Float32[ndarray, "b 2 2"]],
+) -> None:
+    """Log approximate skeleton strips and joints for each person."""
+    for person_idx, strips in enumerate(strips_by_person):
+        rr.log(
+            f"image/person_{person_idx}/skeleton",
+            rr.LineStrips2D(strips=strips, colors=(255, 255, 255), radii=-1.5),
+        )
+        rr.log(
+            f"image/person_{person_idx}/joints",
+            rr.Points2D(positions=joints_xy[person_idx], colors=person_color(person_idx), radii=-4.0, show_labels=False),
+        )

--- a/packages/posekit/tests/test_predictions.py
+++ b/packages/posekit/tests/test_predictions.py
@@ -1,0 +1,51 @@
+"""Public boundary tests for posekit prediction containers."""
+
+import numpy as np
+import torch
+
+from posekit.predictions import BoxDetections, DenseLandmarks2d, Keypoints2d
+from posekit.skeletons import COCO_17
+
+
+def test_numpy_helpers_detach_as_float32_arrays() -> None:
+    """Box and dense-landmark arrays cross the serialization boundary as float32 NumPy arrays."""
+    xyxy = torch.tensor([[1.0, 2.0, 3.0, 4.0]], dtype=torch.float32, requires_grad=True)
+    detections = BoxDetections(
+        xyxy=xyxy,
+        scores=torch.ones((1,), dtype=torch.float32),
+        frame_indices=torch.zeros((1,), dtype=torch.long),
+    )
+    dense = DenseLandmarks2d(
+        xy=torch.tensor([[[5.0, 6.0]]], dtype=torch.float32, requires_grad=True),
+        log_variance=torch.zeros((1, 1), dtype=torch.float32),
+        visibility=torch.tensor([[0.7]], dtype=torch.float32, requires_grad=True),
+        contact=torch.tensor([[0.4]], dtype=torch.float32, requires_grad=True),
+        floor_contact=torch.tensor([[0.2]], dtype=torch.float32, requires_grad=True),
+        frame_indices=torch.zeros((1,), dtype=torch.long),
+    )
+    keypoints = Keypoints2d(
+        xy=torch.tensor([[[7.0, 8.0]]], dtype=torch.float32, requires_grad=True),
+        scores=torch.tensor([[0.9]], dtype=torch.float32, requires_grad=True),
+        frame_indices=torch.zeros((1,), dtype=torch.long),
+        skeleton=COCO_17,
+    )
+
+    arrays: tuple[np.ndarray, ...] = (
+        detections.xyxy_numpy(),
+        dense.xy_numpy(),
+        dense.visibility_numpy(),
+        dense.contact_numpy(),
+        dense.floor_contact_numpy(),
+        keypoints.xy_numpy(),
+        keypoints.scores_numpy(),
+    )
+    boxes_array, dense_xy_array, visibility_array, contact_array, floor_contact_array, keypoints_xy_array, keypoint_scores_array = arrays
+
+    assert all(array.dtype == np.float32 for array in arrays)
+    np.testing.assert_array_equal(boxes_array, [[1.0, 2.0, 3.0, 4.0]])
+    np.testing.assert_array_equal(dense_xy_array, [[[5.0, 6.0]]])
+    np.testing.assert_allclose(visibility_array, [[0.7]])
+    np.testing.assert_allclose(contact_array, [[0.4]])
+    np.testing.assert_allclose(floor_contact_array, [[0.2]])
+    np.testing.assert_array_equal(keypoints_xy_array, [[[7.0, 8.0]]])
+    np.testing.assert_allclose(keypoint_scores_array, [[0.9]])

--- a/packages/posekit/tests/test_runtime_parity.py
+++ b/packages/posekit/tests/test_runtime_parity.py
@@ -116,6 +116,28 @@ def test_three_backend_parity(tmp_path: Path) -> None:
 
 
 @cuda_only
+def test_tensorrt_static_engine_drops_padded_rows(tmp_path: Path) -> None:
+    """A static engine always computes its baked batch; callers must still see only their rows."""
+    module = TinyNet().cuda().eval()
+    torch_runtime = TorchRuntime(
+        module, input_specs=(IMAGE_SPEC, MASK_SPEC), output_specs=(FEATURES_SPEC, LOGITS_SPEC), max_batch_size=STATIC_BATCH
+    )
+    engine_path: Path = ensure_engine(
+        _export_tiny_onnx(module, tmp_path),
+        TrtBuildConfig(max_batch_size=STATIC_BATCH, opt_batch_size=STATIC_BATCH, allow_tf32=False),
+        cache_dir=tmp_path / "trt",
+    )
+    trt_runtime = TensorRtRuntime(engine_path)
+    for batch in (STATIC_BATCH, 1):
+        inputs: dict[str, Tensor] = _example_inputs(batch, "cuda")
+        outputs: dict[str, Tensor] = trt_runtime(inputs)
+        reference: dict[str, Tensor] = torch_runtime(inputs)
+        for output_name in ("features", "logits"):
+            assert outputs[output_name].shape[0] == batch
+            torch.testing.assert_close(outputs[output_name], reference[output_name], rtol=1e-3, atol=1e-4)
+
+
+@cuda_only
 def test_tensorrt_cuda_graph_replay(tmp_path: Path) -> None:
     module = TinyNet().cuda().eval()
     onnx_path: Path = _export_tiny_onnx(module, tmp_path, dynamic_batch=True)

--- a/packages/posekit/tools/apps/gradio_app.py
+++ b/packages/posekit/tools/apps/gradio_app.py
@@ -1,0 +1,4 @@
+from posekit.gradio_ui import launch
+
+if __name__ == "__main__":
+    launch()

--- a/packages/sapiens2-pose/pyproject.toml
+++ b/packages/sapiens2-pose/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     # cuda: pytorch-gpu, torchvision
     "safetensors",
     "timm",
-    "spaces>=0.43.0",
     "tyro>=0.9.1",
 ]
 

--- a/packages/sapiens2-pose/src/sapiens2_pose/api/tensorrt_pose.py
+++ b/packages/sapiens2-pose/src/sapiens2_pose/api/tensorrt_pose.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -42,12 +43,24 @@ TensorRtPrecision = Literal["bf16"]
 
 STATIC_B1_PROFILE: tuple[int, int, int] = (1, 1, 1)
 """Static batch-1 profile used by the retained fastest engine."""
+DEFAULT_TENSORRT_ENGINE_ENV_VAR: str = "SAPIENS2_POSE_TENSORRT_ENGINE_PATH"
+DEFAULT_TENSORRT_ENGINE_FILENAME: str = "sapiens2_0_4b_pose_static_b1_bf16_current_static_graph.trt"
 
 PoseHeatmapRunner = Callable[[torch.Tensor], torch.Tensor | Float32[ndarray, "n k h w"]]
 """Callable backend that maps preprocessed Sapiens pose tensors to heatmaps."""
 
 ModelLoader = Callable[[str, str | Path, str], torch.nn.Module]
 ExportFn = Callable[..., object]
+
+
+def default_tensorrt_engine_path() -> str:
+    """Return the configured or stable cached Sapiens2 pose engine path."""
+    explicit_engine_path: str | None = os.environ.get(DEFAULT_TENSORRT_ENGINE_ENV_VAR)
+    if explicit_engine_path is not None:
+        return explicit_engine_path
+    xdg_cache_home: str | None = os.environ.get("XDG_CACHE_HOME")
+    cache_root: Path = Path(xdg_cache_home).expanduser() if xdg_cache_home is not None else Path.home() / ".cache"
+    return str(cache_root / "sapiens2-pose" / "tensorrt" / DEFAULT_TENSORRT_ENGINE_FILENAME)
 
 
 class ExportableRMSNorm(torch.nn.Module):
@@ -416,47 +429,54 @@ class TensorRtPoseHeatmapRunner:
         self._output_name: str = self._runtime.spec.outputs[0].name
 
     def __call__(self, inputs: torch.Tensor) -> torch.Tensor:
-        """Run TensorRT heatmap inference for one normalized static batch-1 input."""
+        """Run TensorRT heatmap inference, chunking full batches for the static batch-1 engine."""
         if inputs.device.type != "cuda":
             inputs = inputs.to("cuda")
-        return self._runtime({self._input_name: inputs})[self._output_name]
+        from trtkit import run_chunked
+
+        outputs: dict[str, torch.Tensor] = run_chunked(self._runtime, {self._input_name: inputs})
+        return outputs[self._output_name]
 
 
 def estimate_sapiens_pose_tensorrt(
     image_rgb: UInt8[ndarray, "h w 3"],
     bboxes: Float32[ndarray, "n 4"],
     *,
-    engine_path: Path,
+    engine_path: Path | None = None,
     model_size: ModelSize = "0.4B",
     device: DeviceChoice = "cuda",
     heatmap_runner: PoseHeatmapRunner | None = None,
 ) -> PosePredictionArtifact:
-    """Estimate Sapiens2 pose by running each person crop through the static batch-1 TensorRT engine."""
-    bboxes_f32: Float32[ndarray, "n 4"] = np.asarray(bboxes, dtype=np.float32).reshape(-1, 4)
-    spec: Any = MODEL_SPECS[model_size]
-    if bboxes_f32.shape[0] == 0:
-        empty_keypoints: Float32[ndarray, "0 308 2"] = np.empty((0, spec.num_keypoints, 2), dtype=np.float32)
-        empty_scores: Float32[ndarray, "0 308"] = np.empty((0, spec.num_keypoints), dtype=np.float32)
-        return PosePredictionArtifact(bboxes=bboxes_f32, keypoints=empty_keypoints, scores=empty_scores)
+    """Estimate Sapiens2 pose with a TensorRT or supplied heatmap runner.
 
-    runner: PoseHeatmapRunner = heatmap_runner or TensorRtPoseHeatmapRunner(engine_path, device=device)
-    keypoints_list: list[Float32[ndarray, "sapiens_k 2"]] = []
-    scores_list: list[Float32[ndarray, "sapiens_k"]] = []
-    for bbox in bboxes_f32:
-        one_bbox: Float32[ndarray, "1 4"] = np.asarray(bbox, dtype=np.float32).reshape(1, 4)
-        artifact: PosePredictionArtifact = estimate_sapiens_pose_with_heatmap_runner(
-            image_rgb,
-            one_bbox,
-            model_size=model_size,
-            device=device,
-            heatmap_runner=runner,
-        )
-        keypoints_list.append(np.asarray(artifact.keypoints[0], dtype=np.float32))
-        scores_list.append(np.asarray(artifact.scores[0], dtype=np.float32).reshape(-1))
+    Args:
+        image_rgb: Source image in uint8 RGB order.
+        bboxes: Person boxes in XYXY image coordinates.
+        engine_path: TensorRT engine path. May be ``None`` when
+            ``heatmap_runner`` is supplied.
+        model_size: Sapiens2 model size represented by the runner.
+        device: Inference device.
+        heatmap_runner: Optional ready heatmap backend.
 
-    keypoints: Float32[ndarray, "n sapiens_k 2"] = np.stack(keypoints_list, axis=0).astype(np.float32, copy=False)
-    scores: Float32[ndarray, "n sapiens_k"] = np.stack(scores_list, axis=0).astype(np.float32, copy=False)
-    return PosePredictionArtifact(bboxes=bboxes_f32, keypoints=keypoints, scores=scores)
+    Returns:
+        Dense Sapiens2 keypoints and scores for each box.
+
+    Raises:
+        ValueError: If neither an engine path nor a ready runner is supplied.
+    """
+    if heatmap_runner is None:
+        if engine_path is None:
+            raise ValueError("engine_path is required when heatmap_runner is not provided.")
+        runner: PoseHeatmapRunner = TensorRtPoseHeatmapRunner(engine_path, device=device)
+    else:
+        runner = heatmap_runner
+    return estimate_sapiens_pose_with_heatmap_runner(
+        image_rgb,
+        bboxes,
+        model_size=model_size,
+        device=device,
+        heatmap_runner=runner,
+    )
 
 
 def run_tensorrt_image_pose(config: TensorRtImagePoseConfig) -> ImagePoseSummary:

--- a/packages/sapiens2-pose/src/sapiens2_pose/gradio_ui.py
+++ b/packages/sapiens2-pose/src/sapiens2_pose/gradio_ui.py
@@ -11,14 +11,17 @@ import gradio as gr
 import numpy as np
 import rerun as rr
 import rerun.blueprint as rrb
-import spaces
 import torch
 from gradio_rerun import Rerun
 from huggingface_hub import hf_hub_download
+from jaxtyping import Float32
+from numpy import ndarray
 from PIL import Image
 from transformers import DetrForObjectDetection, DetrImageProcessor
 
-from .sapiens_lite.pose import estimate_pose, init_pose_model, nms, parse_pose_metainfo
+from sapiens2_pose.api.pose_artifact import PosePredictionArtifact
+from sapiens2_pose.api.tensorrt_pose import default_tensorrt_engine_path
+from sapiens2_pose.sapiens_lite.pose import estimate_pose, init_pose_model, nms, parse_pose_metainfo
 
 PACKAGE_DIR = Path(__file__).resolve().parent
 ASSETS_DIR = PACKAGE_DIR / "assets"
@@ -50,6 +53,8 @@ DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 BBOX_THR = 0.3
 NMS_THR = 0.3
 
+TENSORRT_MODEL_SIZE = "0.4B"
+
 
 def _env_flag(name: str, default: bool) -> bool:
     value = os.environ.get(name)
@@ -75,8 +80,25 @@ def _server_port() -> int:
 
 _pose_model_cache: dict[str, Any] = {}
 _detector_cache: dict[str, Any] = {}
+_trt_runner_cache: dict[str, Any] = {}
 _metainfo_cache: dict[str, Any] | None = None
 _skeleton_cache: dict[str, Any] | None = None
+
+
+def _get_trt_runner(engine_path: str) -> Any:
+    cache_key: str = str(Path(engine_path).expanduser().resolve())
+    if cache_key not in _trt_runner_cache:
+        if not Path(cache_key).is_file():
+            raise gr.Error(f"TensorRT engine not found at {cache_key}. Build it with the sapiens2-pose-build-trt task.")
+        from sapiens2_pose.api.tensorrt_pose import TensorRtPoseHeatmapRunner
+
+        _trt_runner_cache[cache_key] = TensorRtPoseHeatmapRunner(Path(cache_key))
+        if len(_trt_runner_cache) > 1:
+            oldest_key: str = next(iter(_trt_runner_cache))
+            evicted: Any = _trt_runner_cache.pop(oldest_key)
+            # TensorRT allocates outside Torch's caching allocator; del drops the last reference.
+            del evicted
+    return _trt_runner_cache[cache_key]
 
 
 def _get_metainfo() -> dict[str, Any]:
@@ -195,8 +217,8 @@ def _log_annotation_context() -> None:
 def _log_pose_recording(
     image_rgb: np.ndarray,
     bboxes: np.ndarray,
-    keypoints: list[np.ndarray],
-    scores: list[np.ndarray],
+    keypoints: Float32[ndarray, "n k 2"],
+    scores: Float32[ndarray, "n k"],
     kpt_thr: float,
 ) -> None:
     skeleton = _get_sapiens_skeleton()
@@ -217,7 +239,7 @@ def _log_pose_recording(
         rr.log(
             f"image/person_{idx}/bbox",
             rr.Boxes2D(
-                array=np.asarray(bbox, dtype=np.float32).reshape(1, 4),
+                array=bbox.reshape(1, 4),
                 array_format=rr.Box2DFormat.XYXY,
                 class_ids=0,
                 labels=f"person_{idx}",
@@ -225,8 +247,8 @@ def _log_pose_recording(
             ),
         )
 
-        kpts_arr = np.asarray(kpts, dtype=np.float32).copy()
-        scores_arr = np.asarray(scr, dtype=np.float32).reshape(-1)
+        kpts_arr = kpts.copy()
+        scores_arr = scr.reshape(-1)
         kpts_arr[scores_arr < kpt_thr] = np.nan
         rr.log(
             f"image/person_{idx}/keypoints",
@@ -244,6 +266,7 @@ def _predict_impl(
     image: Image.Image,
     size: str,
     kpt_thr: float,
+    use_tensorrt: bool,
     recording_id: uuid.UUID | str | None,
 ):
     if image is None:
@@ -251,17 +274,35 @@ def _predict_impl(
 
     image_pil = image.convert("RGB")
     image_rgb = np.array(image_pil)
-    image_bgr = cv2.cvtColor(image_rgb, cv2.COLOR_RGB2BGR)
 
     bboxes = _detect_persons(image_rgb)
-    model = _get_pose_model(size)
-    keypoints, scores = estimate_pose(image_bgr, bboxes, model)
+    if use_tensorrt:
+        if size != TENSORRT_MODEL_SIZE:
+            raise gr.Error(f"The TensorRT engine is a static {TENSORRT_MODEL_SIZE} build; select the {TENSORRT_MODEL_SIZE} model.")
+        engine_path: str = default_tensorrt_engine_path()
+        from sapiens2_pose.api.tensorrt_pose import estimate_sapiens_pose_tensorrt
+
+        artifact: PosePredictionArtifact = estimate_sapiens_pose_tensorrt(
+            image_rgb,
+            np.asarray(bboxes, dtype=np.float32),
+            engine_path=Path(engine_path),
+            model_size=TENSORRT_MODEL_SIZE,
+            heatmap_runner=_get_trt_runner(engine_path),
+        )
+        keypoints: Float32[ndarray, "n k 2"] = artifact.keypoints
+        scores: Float32[ndarray, "n k"] = artifact.scores
+    else:
+        image_bgr = cv2.cvtColor(image_rgb, cv2.COLOR_RGB2BGR)
+        model = _get_pose_model(size)
+        pose_result: tuple[list[np.ndarray], list[np.ndarray]] = estimate_pose(image_bgr, bboxes, model)
+        keypoints = np.stack(pose_result[0], axis=0).astype(np.float32, copy=False)
+        scores = np.stack(pose_result[1], axis=0).astype(np.float32, copy=False)
 
     instances = [
         {
-            "bbox": [float(v) for v in np.asarray(bbox).reshape(-1)[:4]],
-            "keypoints": np.asarray(kpts, dtype=float).tolist(),
-            "keypoint_scores": np.asarray(s, dtype=float).reshape(-1).tolist(),
+            "bbox": bbox.reshape(-1)[:4].tolist(),
+            "keypoints": kpts.tolist(),
+            "keypoint_scores": s.reshape(-1).tolist(),
         }
         for bbox, kpts, s in zip(bboxes, keypoints, scores, strict=False)
     ]
@@ -275,22 +316,18 @@ def _predict_impl(
     yield stream.read(), payload
 
 
-@spaces.GPU(duration=120)
-def predict(image: Image.Image, size: str, kpt_thr: float, recording_id: uuid.UUID | str | None):
-    yield from _predict_impl(image, size, kpt_thr, recording_id)
-
-
-@spaces.GPU(duration=120)
 def predict_ui(
     image: Image.Image,
     size: str,
     kpt_thr: float,
+    use_tensorrt: bool,
     recording_id: uuid.UUID | str | None,
 ):
-    for stream, payload in _predict_impl(image, size, kpt_thr, recording_id):
+    backend_label = "TensorRT" if use_tensorrt else "PyTorch"
+    for stream, payload in _predict_impl(image, size, kpt_thr, use_tensorrt, recording_id):
         count = len(payload["instances"])
         suffix = "" if count == 1 else "s"
-        yield stream, payload, f"Complete: {count} person{suffix} detected with Sapiens2 {size}."
+        yield stream, payload, f"Complete: {count} person{suffix} detected with Sapiens2 {size} ({backend_label})."
 
 
 def _switch_to_outputs():
@@ -362,6 +399,9 @@ HEADER_HTML = """
 </div>
 """
 
+# The viewer stream (crypto.randomUUID) and the image "Paste from clipboard"
+# button (navigator.clipboard.read) need a secure context. Serve over HTTPS —
+# on the tailnet: `tailscale serve --bg --https=7860 http://127.0.0.1:7860`.
 with gr.Blocks(title="Sapiens2 Pose") as demo:
     gr.HTML(HEADER_HTML)
     recording_id = gr.State(str(uuid.uuid4()))
@@ -386,6 +426,10 @@ with gr.Blocks(title="Sapiens2 Pose") as demo:
                             choices=list(POSE_MODELS.keys()),
                             value=DEFAULT_SIZE,
                             label="Model",
+                        )
+                        use_trt = gr.Checkbox(
+                            value=False,
+                            label=f"Use TensorRT Backend ({TENSORRT_MODEL_SIZE} only)",
                         )
 
                     examples = gr.Examples(
@@ -435,7 +479,7 @@ with gr.Blocks(title="Sapiens2 Pose") as demo:
         api_visibility="private",
     ).then(
         fn=predict_ui,
-        inputs=[inp, size, thr, recording_id],
+        inputs=[inp, size, thr, use_trt, recording_id],
         outputs=[viewer, out_json, status_text],
     )
 

--- a/packages/sapiens2-pose/src/sapiens2_pose/video_gradio_ui.py
+++ b/packages/sapiens2-pose/src/sapiens2_pose/video_gradio_ui.py
@@ -13,7 +13,6 @@ from typing import cast
 
 import gradio as gr
 import rerun as rr
-import spaces
 import torch
 from gradio.data_classes import FileData
 from gradio_rerun import Rerun
@@ -21,13 +20,12 @@ from gradio_rerun import Rerun
 from .api.metadata import KeypointSchemaName
 from .api.runtime import DEFAULT_BBOX_THR, DEFAULT_MODEL_SIZE, DEFAULT_NMS_THR, POSE_MODELS, ModelSize
 from .api.sam3_tracking import DEFAULT_SAM3_MEMORY_RETENTION_FRAMES, DEFAULT_SAM3_MIN_MASK_AREA_PX
+from .api.tensorrt_pose import DEFAULT_TENSORRT_ENGINE_ENV_VAR, default_tensorrt_engine_path
 from .api.video import PoseBackend, SapiensVideoPoseConfig, TrackingBackend, run_video_pose_pipeline
 
 DEFAULT_SIZE: ModelSize = DEFAULT_MODEL_SIZE
 DEFAULT_SCHEMA: KeypointSchemaName = "coco133"
 DEFAULT_TRACKING_BACKEND: TrackingBackend = "sam3_tracking"
-DEFAULT_TENSORRT_ENGINE_ENV_VAR: str = "SAPIENS2_POSE_TENSORRT_ENGINE_PATH"
-DEFAULT_TENSORRT_ENGINE_FILENAME: str = "sapiens2_0_4b_pose_static_b1_bf16_current_static_graph.trt"
 
 
 def _server_port() -> int:
@@ -79,18 +77,6 @@ def _remux_mov_for_rerun(video_path: Path, output_dir: Path) -> Path:
     return remuxed_path
 
 
-def _default_tensorrt_engine_path() -> str:
-    """Return the app's default TensorRT engine path."""
-    explicit_engine_path: str | None = os.environ.get(DEFAULT_TENSORRT_ENGINE_ENV_VAR)
-    if explicit_engine_path is not None:
-        return explicit_engine_path
-
-    xdg_cache_home: str | None = os.environ.get("XDG_CACHE_HOME")
-    cache_root: Path = Path(xdg_cache_home).expanduser() if xdg_cache_home is not None else Path.home() / ".cache"
-    engine_path: Path = cache_root / "sapiens2-pose" / "tensorrt" / DEFAULT_TENSORRT_ENGINE_FILENAME
-    return str(engine_path)
-
-
 def _format_video_inference_status(*, status: str, backend_label: str, elapsed_seconds: float) -> str:
     """Append whole-video inference timing to a completion status."""
     return f"{status} {backend_label} inference took {elapsed_seconds:.2f}s for the whole video."
@@ -106,7 +92,6 @@ def predict_video_ui(
     nms_thr: float,
     kpt_thr: float,
     use_tensorrt: bool,
-    tensorrt_engine_path: str | None,
     sam3_min_mask_area_px: float | int | None,
     sam3_memory_retention_frames: float | int | None,
     max_frames: float | int | None,
@@ -128,7 +113,7 @@ def predict_video_ui(
     if use_tensorrt:
         if model_size != "0.4B":
             raise gr.Error("TensorRT video mode currently expects a 0.4B pose engine.")
-        engine_path_text: str = str(tensorrt_engine_path or _default_tensorrt_engine_path()).strip()
+        engine_path_text: str = default_tensorrt_engine_path().strip()
         if engine_path_text == "":
             raise gr.Error(f"TensorRT video mode requires an engine path or {DEFAULT_TENSORRT_ENGINE_ENV_VAR}.")
         resolved_tensorrt_engine_path = Path(engine_path_text).expanduser()
@@ -173,9 +158,6 @@ def predict_video_ui(
                 elapsed_seconds=elapsed_seconds,
             )
         yield stream.read(), status_with_note
-
-
-predict_video_ui = spaces.GPU(duration=120)(predict_video_ui)
 
 
 def _reset_video_outputs() -> tuple[None, str]:
@@ -225,11 +207,6 @@ with gr.Blocks(title="Sapiens2 Video Pose") as demo:
                 use_tensorrt = gr.Checkbox(
                     value=False,
                     label="Use TensorRT Backend",
-                )
-                tensorrt_engine_path = gr.Textbox(
-                    value=_default_tensorrt_engine_path(),
-                    label="TensorRT Engine Path",
-                    placeholder=f"Set {DEFAULT_TENSORRT_ENGINE_ENV_VAR} or paste a .trt path",
                 )
                 tracking_backend = gr.Radio(
                     choices=["sam3_tracking", "detr_per_frame"],
@@ -303,7 +280,6 @@ with gr.Blocks(title="Sapiens2 Video Pose") as demo:
             nms_thr,
             kpt_thr,
             use_tensorrt,
-            tensorrt_engine_path,
             sam3_min_mask_area_px,
             sam3_memory_retention_frames,
             max_frames,

--- a/packages/sapiens2-pose/tests/test_gradio_video.py
+++ b/packages/sapiens2-pose/tests/test_gradio_video.py
@@ -8,12 +8,9 @@ from jaxtyping import Float32, UInt8
 from numpy import ndarray
 
 from sapiens2_pose.api.runtime import PoseEstimation
+from sapiens2_pose.api.tensorrt_pose import DEFAULT_TENSORRT_ENGINE_ENV_VAR, default_tensorrt_engine_path
 from sapiens2_pose.api.video import SapiensVideoPoseConfig, _make_effective_bbox_pose_fn, run_video_pose_pipeline
-from sapiens2_pose.video_gradio_ui import (
-    DEFAULT_TENSORRT_ENGINE_ENV_VAR,
-    _default_tensorrt_engine_path,
-    _format_video_inference_status,
-)
+from sapiens2_pose.video_gradio_ui import _format_video_inference_status
 
 
 def test_video_pipeline_tensorrt_backend_detects_boxes_then_runs_bbox_pose(tmp_path: Path) -> None:
@@ -121,12 +118,12 @@ def test_default_tensorrt_engine_path_uses_stable_cache(monkeypatch: Any, tmp_pa
     monkeypatch.delenv(DEFAULT_TENSORRT_ENGINE_ENV_VAR, raising=False)
     monkeypatch.setenv("XDG_CACHE_HOME", str(cache_root))
 
-    engine_path: Path = Path(_default_tensorrt_engine_path())
+    engine_path: Path = Path(default_tensorrt_engine_path())
 
     assert engine_path == cache_root / "sapiens2-pose" / "tensorrt" / "sapiens2_0_4b_pose_static_b1_bf16_current_static_graph.trt"
 
     monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
-    home_engine_path: Path = Path(_default_tensorrt_engine_path())
+    home_engine_path: Path = Path(default_tensorrt_engine_path())
 
     assert home_engine_path == Path.home() / ".cache" / "sapiens2-pose" / "tensorrt" / "sapiens2_0_4b_pose_static_b1_bf16_current_static_graph.trt"
 
@@ -135,7 +132,7 @@ def test_default_tensorrt_engine_path_honors_explicit_env_var(monkeypatch: Any, 
     engine_path: Path = tmp_path / "custom.trt"
     monkeypatch.setenv(DEFAULT_TENSORRT_ENGINE_ENV_VAR, str(engine_path))
 
-    assert _default_tensorrt_engine_path() == str(engine_path)
+    assert default_tensorrt_engine_path() == str(engine_path)
 
 
 def test_format_video_inference_status_reports_backend_and_elapsed_time() -> None:

--- a/packages/sapiens2-pose/tests/test_tensorrt_pose.py
+++ b/packages/sapiens2-pose/tests/test_tensorrt_pose.py
@@ -60,8 +60,12 @@ def test_export_sapiens_pose_onnx_uses_static_batch_one_graph(tmp_path: Path) ->
     assert export_summary.onnx_path == onnx_path
     assert export_summary.input_shape == (1, 3, 1024, 768)
     assert export_summary.output_shape == (1, 308, 256, 192)
-    assert calls[0]["path"].parent == onnx_path.parent
-    assert calls[0]["path"].name.startswith(onnx_path.name + ".part")
+    # trtkit exports into a pid-unique temp DIRECTORY under the final
+    # filename, so the external-data sidecar is born with the name the
+    # published protobuf references.
+    assert calls[0]["path"].name == onnx_path.name
+    assert calls[0]["path"].parent.parent == onnx_path.parent
+    assert calls[0]["path"].parent.name.startswith(onnx_path.name + ".part")
     assert onnx_path.exists()
     assert calls[0]["dummy_inputs"].shape == (1, 3, 1024, 768)
     assert calls[0]["input_names"] == ["inputs"]
@@ -159,27 +163,32 @@ def test_estimate_sapiens_pose_with_heatmap_runner_uses_common_decode_path() -> 
     assert np.all(artifact.scores > 0.0)
 
 
-def test_estimate_sapiens_pose_tensorrt_runs_multiple_boxes_as_static_batch_one_calls() -> None:
+def test_estimate_sapiens_pose_tensorrt_matches_common_heatmap_runner_path() -> None:
     image_rgb: UInt8[ndarray, "h w 3"] = np.zeros((64, 48, 3), dtype=np.uint8)
     bboxes: Float32[ndarray, "n 4"] = np.asarray([[0.0, 0.0, 47.0, 63.0], [4.0, 5.0, 40.0, 55.0]], dtype=np.float32)
     captured_shapes: list[tuple[int, ...]] = []
 
     def fake_heatmap_runner(inputs: torch.Tensor) -> Float32[ndarray, "n k h w"]:
         captured_shapes.append(tuple(int(dim) for dim in inputs.shape))
-        heatmaps: Float32[ndarray, "n k h w"] = np.zeros((1, 308, 256, 192), dtype=np.float32)
+        heatmaps: Float32[ndarray, "n k h w"] = np.zeros((inputs.shape[0], 308, 256, 192), dtype=np.float32)
         heatmaps[:, :, 128, 96] = 1.0
         return heatmaps
 
-    artifact: PosePredictionArtifact = estimate_sapiens_pose_tensorrt(
+    common_artifact: PosePredictionArtifact = estimate_sapiens_pose_with_heatmap_runner(
         image_rgb,
         bboxes,
-        engine_path=Path("/tmp/static-b1.trt"),
+        model_size="0.4B",
+        device="cpu",
+        heatmap_runner=fake_heatmap_runner,
+    )
+    tensorrt_artifact: PosePredictionArtifact = estimate_sapiens_pose_tensorrt(
+        image_rgb,
+        bboxes,
         model_size="0.4B",
         device="cpu",
         heatmap_runner=fake_heatmap_runner,
     )
 
-    assert captured_shapes == [(1, 3, 1024, 768), (1, 3, 1024, 768)]
-    assert artifact.bboxes.shape == (2, 4)
-    assert artifact.keypoints.shape == (2, 308, 2)
-    assert artifact.scores.shape == (2, 308)
+    assert captured_shapes == [(2, 3, 1024, 768), (2, 3, 1024, 768)]
+    np.testing.assert_allclose(tensorrt_artifact.keypoints, common_artifact.keypoints)
+    np.testing.assert_allclose(tensorrt_artifact.scores, common_artifact.scores)

--- a/packages/trtkit/src/trtkit/onnx_export.py
+++ b/packages/trtkit/src/trtkit/onnx_export.py
@@ -9,6 +9,7 @@ network — or a thin adapter that shapes outputs (flatten a dict, add
 fusion-breaker outputs) — and nothing else.
 """
 
+import copy
 import os
 import shutil
 import time
@@ -16,8 +17,49 @@ from collections.abc import Callable, Collection
 from pathlib import Path
 
 import torch
+from torch.nn.modules.conv import _ConvTransposeNd
 
 ExportFn = Callable[..., object]
+
+
+class _Fp32Island(torch.nn.Module):
+    """Runs its inner module in fp32 inside an autocast region.
+
+    TensorRT's strongly-typed builds cannot type a BF16 ConvTranspose — an
+    open type-inference-rule gap (NVIDIA/TensorRT-Incubator#565, verified
+    failing on TRT 11.2.1.2) — so bf16 exports keep transposed convolutions
+    fp32. Weak typing made this exact fallback implicitly before TRT 11
+    removed it. Retest on TRT bumps; delete when the upstream bug is fixed.
+    """
+
+    def __init__(self, inner: torch.nn.Module) -> None:
+        super().__init__()
+        self.inner = inner
+
+    def forward(self, *inputs: torch.Tensor) -> torch.Tensor:
+        with torch.autocast("cuda", enabled=False):
+            return self.inner(*(t.float() if t.is_floating_point() else t for t in inputs))
+
+
+def _with_fp32_transposed_convs(module: torch.nn.Module) -> torch.nn.Module:
+    """Return a structural copy whose transposed convs sit in fp32 islands.
+
+    Parameters and buffers are shared with the original; the caller's module
+    tree is never mutated, so eager parity references stay honest.
+    """
+    if isinstance(module, _Fp32Island):
+        return module
+    if isinstance(module, _ConvTransposeNd):
+        return _Fp32Island(module)
+    replaced: dict[str, torch.nn.Module] = {
+        name: _with_fp32_transposed_convs(child) for name, child in module.named_children()
+    }
+    if all(replaced[name] is child for name, child in module.named_children()):
+        return module
+    clone: torch.nn.Module = copy.copy(module)
+    clone._modules = dict(module._modules)
+    clone._modules.update(replaced)
+    return clone
 
 
 class _AutocastWrapper(torch.nn.Module):
@@ -116,7 +158,10 @@ def export_onnx(
     # TRT parsers accept the invalid graph and silently miscompile it. 18 is
     # the dynamo baseline for everything else; TRT 11 parses up to 24.
     opset_version: int = 23 if compute_dtype == torch.bfloat16 else 18
-    export_model: torch.nn.Module = _AutocastWrapper(model, compute_dtype).eval() if compute_dtype is not None else model
+    # bf16 also forces fp32 islands around transposed convs (see _Fp32Island);
+    # derived from the dtype, like the opset — not a caller knob.
+    inner: torch.nn.Module = _with_fp32_transposed_convs(model) if compute_dtype == torch.bfloat16 else model
+    export_model: torch.nn.Module = _AutocastWrapper(inner, compute_dtype).eval() if compute_dtype is not None else model
 
     kwargs: dict[str, object] = {}
     if dynamic_batch_max is not None:

--- a/packages/trtkit/src/trtkit/tensorrt_runtime.py
+++ b/packages/trtkit/src/trtkit/tensorrt_runtime.py
@@ -92,6 +92,23 @@ class TensorRtRuntime:
             )
             for spec in self._spec.outputs
         }
+        # Static engines report the baked max batch through the context at every
+        # call, so padded rows must be sliced off by per-sample ratio; dynamic
+        # engines report exact shapes per active batch and owe no divisibility.
+        # The slice assumes sample-major rows (leading dim = batch * k); a
+        # k-major intermediate would yield the wrong rows — none exists today.
+        self._static_rows_per_sample: dict[str, int] = {}
+        if not self._dynamic:
+            for out_spec in self._spec.outputs:
+                rows_at_max: int = int(self._output_buffers[out_spec.name].shape[0])
+                if rows_at_max % max_batch != 0:
+                    raise ValueError(
+                        f"Static engine output {out_spec.name!r} has {rows_at_max} rows at batch {max_batch}; "
+                        "padded rows cannot be sliced off a non-multiple. Constant-shaped outputs usually "
+                        "come from TrtBuildConfig.extra_output_patterns intermediates — rebuild without "
+                        "materializing that tensor, or use a dynamic-batch engine."
+                    )
+                self._static_rows_per_sample[out_spec.name] = rows_at_max // max_batch
         for name, tensor in {**self._input_buffers, **self._output_buffers}.items():
             self._context.set_tensor_address(name, int(tensor.data_ptr()))
         self._stream: torch.cuda.Stream = torch.cuda.Stream(device=self._device)
@@ -138,10 +155,16 @@ class TensorRtRuntime:
             self._graphs[graph_key].replay()
         else:
             self._execute()
-        # Slice each output to the rows the context actually produced at this batch
-        # (materialized intermediates may scale their leading dim beyond the batch).
+        # Dynamic engines report exact per-batch output shapes; static engines
+        # always report the baked max batch, so padded rows are sliced off by
+        # the per-sample ratio recorded at construction.
+        if self._dynamic:
+            return {
+                name: tensor[: int(self._context.get_tensor_shape(name)[0])]
+                for name, tensor in self._output_buffers.items()
+            }
         return {
-            name: tensor[: int(self._context.get_tensor_shape(name)[0])]
+            name: tensor[: self._static_rows_per_sample[name] * batch_size]
             for name, tensor in self._output_buffers.items()
         }
 

--- a/packages/trtkit/tests/test_trtkit.py
+++ b/packages/trtkit/tests/test_trtkit.py
@@ -114,3 +114,24 @@ def test_allow_tf32_cache_key(tmp_path: Path) -> None:
     assert default_path != notf32_path
     assert "notf32" in notf32_path.name
     assert "notf32" not in default_path.name
+
+
+def test_fp32_transposed_conv_islands_share_weights_without_mutating() -> None:
+    """bf16 exports isolate transposed convs in fp32 without touching the caller's model."""
+    from trtkit.onnx_export import _Fp32Island, _with_fp32_transposed_convs
+
+    model = torch.nn.Sequential(
+        torch.nn.Conv2d(2, 4, 3, padding=1),
+        torch.nn.ConvTranspose2d(4, 2, 2, stride=2),
+    ).eval()
+    wrapped = _with_fp32_transposed_convs(model)
+
+    assert isinstance(wrapped[1], _Fp32Island)
+    assert wrapped[1].inner is model[1], "island must share the original conv (weights by reference)"
+    assert not any(isinstance(m, _Fp32Island) for m in model.modules()), "caller's tree must stay unmodified"
+    rewrapped = _with_fp32_transposed_convs(wrapped)
+    assert rewrapped[1] is wrapped[1], "re-wrapping must be idempotent"
+
+    x = torch.randn(1, 2, 8, 8)
+    with torch.inference_mode():
+        torch.testing.assert_close(wrapped(x), model(x))

--- a/pixi.lock
+++ b/pixi.lock
@@ -19105,6 +19105,1149 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fc/b4/d088047afe39827556df21118cac9ffd20cc3f968c99a7681494d1eb333c/cuda_pathfinder-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/80/c959c5933adedb9ac15152e4067c702a808ea183a8b64cf8f31af8ad3155/multidict-6.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-11.2.1.2.tar.gz
+  pose-app:
+    channels:
+    - url: https://prefix.dev/ai-demos/
+    - url: https://prefix.dev/conda-forge/
+    indexes:
+    - https://pypi.org/simple
+    packages:
+      p1:
+      - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/argon2-cffi-bindings-25.1.0-py312h4c3975b_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/av-18.0.0-py312h46547aa_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.4-h4610da3_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.15-h6bbde05_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.14.3-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-h01ee8f8_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.11.0-hbe094ff_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.27.5-h4f381ba_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.13.1-h7508075_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.7-h01ee8f8_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-h01ee8f8_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/backports.zstd-1.7.0-py312h3f22e6b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils_linux-64-2.46.1-default_h4852527_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/brotli-python-1.2.0-py312he9c40d5_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.8-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-compiler-2.0.0-ha29393d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cffi-2.1.1-py312h703531f_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/conda-gcc-specs-15.2.0-h53410ce_20.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-crt-13.0.88-h69a702a_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-crt-tools-13.0.88-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-ctadvisor-13.0.85-h676940d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-13.0.96-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-dev-13.0.96-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-static-13.0.96-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cuobjdump-13.0.85-hffce074_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cupti-13.0.85-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cuxxfilt-13.0.85-hffce074_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-driver-dev-13.0.96-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-13.0.88-hcdd1206_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-impl-13.0.88-h85509e4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-tools-13.0.88-he02047a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc_linux-64-13.0.88-hb2fc203_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvdisasm-13.0.85-hffce074_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvml-dev-13.0.87-hffce074_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvprune-13.0.85-hffce074_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvrtc-13.0.88-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvrtc-dev-13.0.88-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvtx-13.0.85-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvtx-dev-13.0.85-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvvm-impl-13.0.88-h4bc722e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvvm-tools-13.0.88-h4bc722e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-profiler-api-13.0.85-h7938cbb_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cudnn-9.25.0.15-h886f0b6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cusparselt-0.9.1.1-h7bcfba5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cxx-compiler-2.0.0-hdab9b82_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/debugpy-1.8.21-py312h8285ef7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-8.1.2-gpl_h95e667c_906.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fmt-12.1.0-h76c4fd7_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/freetype-2.14.3-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fribidi-1.0.16-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc-15.2.0-hc6a0c74_20.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-h8ddf172_20.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_28.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gdk-pixbuf-2.44.8-h68053f1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/giflib-5.2.2-ha257d8a_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/glslang-16.5.0-h718be3e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gmp-6.3.0-hfd2156b_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gmpy2-2.3.1-py312h04c1168_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/graphite2-1.3.15-h54a6638_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx-15.2.0-h834e499_7.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-he8f701c_20.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-15.2.0-h71fc77c_28.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-14.3.1-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.2.0-nompi_hc529623_100.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hf-transfer-0.1.9-py312h914ccca_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hf-xet-1.5.2-py310hb823017_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/imath-3.2.2-hde8ca8f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/intel-gmmlib-22.10.0-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/intel-media-driver-26.1.6-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lerc-4.2.0-hdb68285_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/level-zero-1.29.0-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20260526.0-cxx17_h7b12aa8_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libass-0.17.5-h434b012_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libavif16-1.4.2-h0ed3d04_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-9_h5875eb1_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcap-2.78-h084b8d7_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-9_hfef963f_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcublas-13.1.1.3-h676940d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcublas-dev-13.1.1.3-h676940d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudnn-9.25.0.15-ha4b6413_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudnn-dev-9.25.0.15-h7bcfba5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudss-0.8.0.10-h7bcfba5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudss-dev-0.8.0.10-h21fdb18_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufft-12.0.0.61-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufft-dev-12.0.0.61-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufile-1.15.1.6-hbc026e6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufile-dev-1.15.1.6-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurand-10.4.0.35-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurand-dev-10.4.0.35-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.21.0-heca4667_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusolver-12.0.4.66-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusolver-dev-12.0.4.66-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusparse-12.6.3.3-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusparse-dev-12.6.3.3-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdovi-3.4.0-ha23c83e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdrm-2.4.129-h7cc23a3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libfreetype6-2.14.3-h5e6c136_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-16.1.0-h69a702a_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran-16.1.0-h69a702a_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-16.1.0-h79bb938_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.88.3-h45c3219_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libharfbuzz-14.3.1-h23af247_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libharfbuzz-devel-14.3.1-h23af247_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhwloc-2.13.0-default_he001693_1000.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhwy-1.4.0-h3a9caae_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libidn2-2.3.8-hfac485b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libjxl-0.12.0-heb2dce7_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-9_h5e43f62_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-9_hdba1596_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmagma-2.10.0-hd93470c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmagma_sparse-2.10.0-hbc3fd83_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnl-3.11.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnpp-13.0.1.2-h676940d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvjitlink-13.3.33-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvjpeg-13.0.1.86-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvptxcompiler-dev-13.0.88-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopencv-5.0.0-qt6_h469fc51_605.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-2026.3.0-hb2f3c86_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-batch-plugin-2026.3.0-h9f30d58_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-plugin-2026.3.0-h9f30d58_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-hetero-plugin-2026.3.0-hfeb6f35_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2026.3.0-hb2f3c86_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2026.3.0-hb2f3c86_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-npu-plugin-2026.3.0-hb2f3c86_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-ir-frontend-2026.3.0-hfeb6f35_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-onnx-frontend-2026.3.0-h6c33c14_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-paddle-frontend-2026.3.0-h6c33c14_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-pytorch-frontend-2026.3.0-h0542e35_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-frontend-2026.3.0-h565fa1b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2026.3.0-h0542e35_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpciaccess-0.19-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libplacebo-7.360.1-hc50b9dd_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpng-1.6.58-h922cc85_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpq-18.6-h9d76c99_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libprotobuf-7.35.1-h2840a7c_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpsl-0.23.1-hd9e3e90_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/librsvg-2.62.3-h4c96295_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-15.2.0-h984fb3e_20.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsodium-1.0.22-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-h6154650_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsystemd0-261.2-h6f4a2f1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libtorch-2.12.1-cuda130_mkl_h5535f43_300.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libudev1-261.2-h6f4a2f1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liburing-2.14-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libva-2.24.1-he1eb515_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvpl-2.16.0-h54a6638_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvpx-1.15.2-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvulkan-loader-1.4.357.0-h5279c79_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxcb-1.17.0-hb83e432_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.13.2-hca5e8e5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/llvm-openmp-22.1.8-h4922eb0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mkl-2026.1.0-hecca717_244.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ml_dtypes-0.5.4-np2py312h0f77346_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpg123-1.32.9-h8142553_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/nccl-2.30.7.1-h1aa9b5a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.5.2-py312h33ff503_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ocl-icd-2.3.4-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/onednn-3.12-omp_h83de36e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/onnx-1.22.0-py312hbee568d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/onnxruntime-1.28.0-py312h99cb659_200_cuda130.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/opencl-headers-2025.06.13-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openexr-3.4.14-h6de6307_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openh264-2.6.0-h65dd3cf_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openjph-0.31.0-h8d634f6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/optree-0.19.1-py312hd9148b4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pango-1.58.2-hda50119_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pillow-12.3.0-py312h50c33e8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pixman-0.46.4-h54a6638_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/protobuf-7.35.1-py312h7bd0bee_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/psutil-7.2.2-py312h5253ce2_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pthread-stubs-0.4-hb03c661_1003.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/py-opencv-5.0.0-qt6_h6945e2d_605.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/python-3.12.13-h8ab3286_1_cpython.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pytorch-2.12.1-cuda130_mkl_py312_h24b5296_300.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pytorch-gpu-2.12.1-cuda129_mkl_h0d04637_300.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/qt6-main-6.11.2-pl5321h9df5c37_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/rav1e-0.8.1-h1fbca29_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/rdma-core-63.0-h192683f_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/regex-2026.7.19-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/rpds-py-2026.6.3-py312h192e038_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.6-h7e3ee7f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/safetensors-0.8.0-py312h868fb18_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/scipy-1.18.0-py312h54fa4ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sdl3-3.4.14-hdeec2a5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/shaderc-2026.3-h1b60276_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/spirv-tools-2026.3-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-4.2.0-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tokenizers-0.22.2-py312hf875000_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/torchcodec-0.14.0-cuda130_py312_h0ea267f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/torchvision-0.28.0-cuda130_py312_h2966ecb_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.8-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/triton-3.7.1-cuda130py312hc6dca4b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.26.0-h1964d1d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/wget-1.25.0-h653f8fd_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-h280c20c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libsm-1.2.6-h0d788c3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxext-1.3.7-h7cc23a3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxi-1.8.3-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrender-0.9.12-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-xorgproto-2025.1-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zeromq-4.3.5-h09e67af_11.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zlib-ng-2.3.3-hce19668_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+      - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/anyio-4.14.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/arrow-1.4.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/asttokens-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/async-lru-2.3.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/beartype-0.22.9-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/beautifulsoup4-4.15.0-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/bleach-6.4.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/bleach-with-css-6.4.0-hac0b51c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cached_property-1.5.2-pyha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/casefy-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.7.22-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cccl_linux-64-13.0.85-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-compiler-13.0.3-hbad6d8a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-crt-dev_linux-64-13.0.88-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart-dev_linux-64-13.0.96-h376f20c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart-static_linux-64-13.0.96-h376f20c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart_linux-64-13.0.96-h376f20c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-driver-dev_linux-64-13.0.96-h376f20c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-nvcc-dev_linux-64-13.0.88-he91c749_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-nvvm-dev_linux-64-13.0.88-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-version-13.0-hc7b4dd1_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/docstring_parser-0.18.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/einops-0.8.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/eval_type_backport-0.4.0-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/filelock-3.32.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/frozendict-2.4.7-pyh851646a_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/fsspec-2026.7.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h2-4.4.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/huggingface_hub-1.28.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/idna-3.19-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ipykernel-7.2.0-pyha191276_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ipython-9.16.1-pyh53cf698_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jaxtyping-0.2.36-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/json5-0.15.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jsonschema-with-format-nongpl-4.26.0-hcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter-builder-1.2.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter-lsp-2.3.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter_client-8.8.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter_events-0.12.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter_server-2.20.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter_server_terminals-0.5.4-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyterlab-4.6.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/kernel-headers_linux-64-5.14.0-he073ed8_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_120.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libnvptxcompiler-dev_linux-64-13.0.88-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_120.conda
+      - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mistune-3.3.4-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/natsort-8.4.0-pyhcf101f3_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/nbclient-0.11.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/nbformat-5.11.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/onnx-ir-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/onnxscript-0.7.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.11.3-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/plum-dispatch-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/prometheus_client-0.26.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/prompt-toolkit-3.0.53-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-3.0.4-pyh293190f_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-global-3.0.4-pyh648e204_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pygments-2.21.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pyserde-0.31.8-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-fastjsonschema-2.22.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-flatbuffers-25.12.19-pyh9d96877_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.12.13-hd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-json-logger-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-tzdata-2026.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://prefix.dev/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/send2trash-2.1.0-pyha191276_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/setuptools-81.0.0-pyh332efcf_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/shtab-1.11.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/soupsieve-2.9.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-64-2.34-h087de78_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/traitlets-5.16.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/transformers-5.15.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typeguard-2.13.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/typer-0.27.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tyro-0.9.1-pyhff2d567_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.49-hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wcwidth-0.8.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/webcolors-25.10.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/websocket-client-1.9.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - pypi: ./packages/mamma
+      - pypi: ./packages/posekit
+      - pypi: ./packages/sam2-streaming
+      - pypi: ./packages/sapiens2-pose
+      - pypi: ./packages/simplecv
+      - pypi: ./packages/trtkit
+      - pypi: https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0f/7b/39c34ca613b0b198cb866466651b26b045e2009864c5183c979a3b83f383/pytz-2026.3.post1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/98/e976540c1addf70442be7842a18cf70884a964abbf69442504f4d2939989/pandas-3.0.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/2f/c9c617f8556e3b6e8c24880d91b8e7a7b242f32b85cf23602b029d705c05/nvidia_cuda_runtime_cu13-0.0.0a0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/23/45/caa600acfab94560807a20a64b5830d2cd3c3202b7f1328644d70b7d6bd8/nvidia_ml_py-13.610.43-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/28/27/3d6dcadc8a3214d8522c1e7f6a19554e33659be44546d44a2f7572ac7d2a/groovy-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/28/7f/cfd9bc4b1f5e424eeea83d0493e43f3b1b02707ce8e50c47945873982bd5/wrapt-2.3.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/2b/fe/0888040a24e4504098b85d8ad486b14cb01cf6b030bbe479dfc2dcffc2ac/polars-1.43.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/5f/e315fbb8c4b7091e2a2b21bc50c764d4eef25196eb0897564e6809237729/tensorrt_cu13_libs-11.2.1.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/2e/a3/0f0b7d78e2f1eb9e8e1afbff1d2bff8d60144aee17aca51c065b516743dd/safehttpx-0.1.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/30/2d/afff2ee87e75d8eb85c92bb8cf0e15b05c23c2ebd8fd8dec781d8601ed7f/hf_gradio-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/30/c5/6290519dec32f3cdf6827e3bbcbf7a9f4fb29a55a9204199901fed69957b/aiobotocore-3.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/32/91/30151a39f7570f448ed84529390628a651d7f27c87d73c9b887f8189695e/docutils-0.23-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/34/80/b9f4889209af02f8d14bccb0e6f0519c329b072bc4d2595025a1303f144c/datafusion-53.0.0-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/37/b5/41c315ccd94ca332ead3e832e83eee343ab245005c3e43d9d3e75eae34eb/open_clip_torch-3.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/38/31/7ff3f7768eded7535c621abc2fecb9d181a34ea4cae3afe682feb796f242/cuda_python-13.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/39/56/684ae3e973f6fbf813714cb875eca1be09876cdfa34806e044f86b3844a1/ultralytics_platform-0.1.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d19459005ca000b6e7012f2f1ca597746cbcd1fbfe5e/antlr4-python3-runtime-4.9.3.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3f/95/0ad40fb92ba3e6fe36182f722f81d69842a1e93cab1d9c6171256ef55418/gradio-6.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/45/e4/19d92435fb102320ece532fc9df58f0e39deee675f5b5d204dfc667a4ed3/tensorrt_cu13_bindings-11.2.1.2-cp312-none-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/52/b7/7cd31f29d6055bd711ae6e669367fba6f5ae9de463910a793e30556a8db7/aiohttp-3.14.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/53/98/f1fa3d40d548c8a2a3eec33b7f856063bb6c7d51e16d5198b1f390b2c79d/ultralytics_thop-2.1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5b/67/314f6151bad77a93d751978a344033e1fc890822f05f0416079338e34231/nh3-0.3.6-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/5c/cd/86fe9e659e9699f62f8dd5ecd8c6725474334b23cab8aa71d82b5f56f1a4/botocore-1.43.56-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/60/c9/711ca85d79f1ec98f29a5eae2b051e25b4ecec5de3e3c0e2d5c5dcb15664/pyarrow-25.0.1-cp312-cp312-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/61/91/288c883303be067c1648f1e63ea38e5f8eb5ab7123fd3a9a7366148e58b7/portalocker-4.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/62/60/64deacb3abc70c52e2d88a808a052d1621c86a48fe9194f2c065579ab1cd/polars_runtime_32-1.43.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/68/7d/ac9997138d585b6715641d655fd7a53ddb46c205b66e2288d20f21a09165/gradio_rerun-0.35.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/70/bd/cb98519aa658b488710aef0d5bac1435e7b95756b7e28c8c97ca394f5260/lovely_numpy-0.2.24-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/72/73/b3d451dfc523756cf177d3ebb0af76dc7751b341c60e2a21871be400ae29/iopath-0.1.10.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/77/c7/2342da9830e3e9d4870305ca5d2091d2a83284f2953079b7bdd3b5e029d8/fonttools-4.63.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/78/81/0a861b8e1ff42960139c6cd4c7dd591292fa09ea1ae2d87677441cba4c00/gradio_client-2.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/82/9707c7b0336bca53b75f52fc350956a93da66eb6be632b370bc933216fb4/icecream-2.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/57/80b986ebfecd9c6a177ddf1c2319717f0cd8feffb2b78946595a18a2fc88/orjson-3.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/90/7f/f620a74444c19e82717eecd8bf5508cc9bc2a65cb663cbf450d1373a40d3/fastcore-2.2.13-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/92/71/15074f4c7d4f2960481ffac97a65f8d7697f7bd48aef5c5259d7952f9031/ultralytics-8.4.123-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/96/08/ddcdc06225eaad6de0e48e1002b06d919dbde20582d0662c7af51308e5d6/twine-7.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/1b/295bf2fa3e740131778065e5ffa2c481f0e7210182d408e9a2c244ff5b0c/readme_renderer-45.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/98/cc/bcde19a37952ecc58e7d9d67ecaa048e1e21b17d014ce0863a6a6101e606/s3fs-2026.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9c/97/f9d463a6f3c7d0955753eca5cbbf35b596ac471dd13fe357211a53fd37be/hydra_core-1.3.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/4d/603557ab3cb171cc2a61d3678a39cb4dae3fd21275078bfbd1c0b0b5230b/cuda_core-1.0.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/0e/152509871bf30df6fc38569f52a2db9b55dd41aae957adae50a053ac7778/omegaconf-2.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ab/6e/81d47999aebc1b155f81eca4477a616a70f238a2549848c38983f3c22a82/ftfy-6.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/29/c028a0731e202035f0e2e0bfbf1a3e46ad6c628cbb17f6f1cc9eea5d9ff1/pathlib_abc-0.5.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/b9/11971acb516a95d2729dc04c4d42b7a12c747d5edc88317e623d045c8d14/rerun_sdk-0.35.0-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/1f/73c53fcbfb0b5a78f91176df41945ca466e71e9d9d836e5c522abda39ee7/pydantic-2.11.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/76/de1bfac17d183c49c6d0887903d3064ced51cf1d9ba7a8d611c1a8808c4f/timm-1.0.28-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/13/680c54afe3e65767bed7ec1a15571e1a2f1257128733851ade24abcefbcc/kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c9/33/bd37416aec828e7465652d9e2525fe52de0a29a581f1519cc51a74485091/smplx-0.1.28-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c9/cf/b4ad2cc81b6672ea29ea04e64e350a9f9b493b0908ccd884c67eeff8f7b2/matplotlib-3.11.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/d0/d56c859b8222116f5d68459199f48359e0bf121b6f65a69bf329b3602ba0/yarl-1.24.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dd/1a/5d9a402b39ec892d856bbdd9db502ff73ce28cdf4aff72eb1ce1d6843506/universal_pathlib-0.3.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e3/1e/2942a0d6d52240d439f44384a40c65d359d9ca70325b65b265c020113121/cuda_pathfinder-1.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
+      - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-11.2.1.2.tar.gz
+  pose-app-dev:
+    channels:
+    - url: https://prefix.dev/ai-demos/
+    - url: https://prefix.dev/conda-forge/
+    indexes:
+    - https://pypi.org/simple
+    packages:
+      p1:
+      - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/argon2-cffi-bindings-25.1.0-py312h4c3975b_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/av-18.0.0-py312h46547aa_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.4-h4610da3_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.15-h6bbde05_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.14.3-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-h01ee8f8_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.11.0-hbe094ff_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.27.5-h4f381ba_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.13.1-h7508075_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.7-h01ee8f8_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-h01ee8f8_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/backports.zstd-1.7.0-py312h3f22e6b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils_linux-64-2.46.1-default_h4852527_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/brotli-python-1.2.0-py312he9c40d5_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.8-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-compiler-2.0.0-ha29393d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cffi-2.1.1-py312h703531f_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/conda-gcc-specs-15.2.0-h53410ce_20.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-crt-13.0.88-h69a702a_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-crt-tools-13.0.88-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-ctadvisor-13.0.85-h676940d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-13.0.96-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-dev-13.0.96-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-static-13.0.96-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cuobjdump-13.0.85-hffce074_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cupti-13.0.85-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cuxxfilt-13.0.85-hffce074_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-driver-dev-13.0.96-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-13.0.88-hcdd1206_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-impl-13.0.88-h85509e4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-tools-13.0.88-he02047a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc_linux-64-13.0.88-hb2fc203_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvdisasm-13.0.85-hffce074_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvml-dev-13.0.87-hffce074_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvprune-13.0.85-hffce074_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvrtc-13.0.88-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvrtc-dev-13.0.88-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvtx-13.0.85-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvtx-dev-13.0.85-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvvm-impl-13.0.88-h4bc722e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvvm-tools-13.0.88-h4bc722e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-profiler-api-13.0.85-h7938cbb_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cudnn-9.25.0.15-h886f0b6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cusparselt-0.9.1.1-h7bcfba5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cxx-compiler-2.0.0-hdab9b82_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/debugpy-1.8.21-py312h8285ef7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-8.1.2-gpl_h95e667c_906.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fmt-12.1.0-h76c4fd7_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/freetype-2.14.3-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fribidi-1.0.16-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc-15.2.0-hc6a0c74_20.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-h8ddf172_20.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_28.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gdk-pixbuf-2.44.8-h68053f1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/giflib-5.2.2-ha257d8a_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/glslang-16.5.0-h718be3e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gmp-6.3.0-hfd2156b_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gmpy2-2.3.1-py312h04c1168_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/graphite2-1.3.15-h54a6638_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx-15.2.0-h834e499_7.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-he8f701c_20.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-15.2.0-h71fc77c_28.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-14.3.1-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.2.0-nompi_hc529623_100.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hf-transfer-0.1.9-py312h914ccca_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hf-xet-1.5.2-py310hb823017_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hypothesis-6.165.10-py312hc767a74_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/imath-3.2.2-hde8ca8f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/intel-gmmlib-22.10.0-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/intel-media-driver-26.1.6-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lerc-4.2.0-hdb68285_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/level-zero-1.29.0-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20260526.0-cxx17_h7b12aa8_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libass-0.17.5-h434b012_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libavif16-1.4.2-h0ed3d04_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-9_h5875eb1_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcap-2.78-h084b8d7_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-9_hfef963f_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcublas-13.1.1.3-h676940d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcublas-dev-13.1.1.3-h676940d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudnn-9.25.0.15-ha4b6413_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudnn-dev-9.25.0.15-h7bcfba5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudss-0.8.0.10-h7bcfba5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudss-dev-0.8.0.10-h21fdb18_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufft-12.0.0.61-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufft-dev-12.0.0.61-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufile-1.15.1.6-hbc026e6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufile-dev-1.15.1.6-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurand-10.4.0.35-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurand-dev-10.4.0.35-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.21.0-heca4667_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusolver-12.0.4.66-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusolver-dev-12.0.4.66-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusparse-12.6.3.3-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusparse-dev-12.6.3.3-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdovi-3.4.0-ha23c83e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdrm-2.4.129-h7cc23a3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libfreetype6-2.14.3-h5e6c136_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-16.1.0-h69a702a_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran-16.1.0-h69a702a_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-16.1.0-h79bb938_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.88.3-h45c3219_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libharfbuzz-14.3.1-h23af247_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libharfbuzz-devel-14.3.1-h23af247_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhwloc-2.13.0-default_he001693_1000.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhwy-1.4.0-h3a9caae_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libidn2-2.3.8-hfac485b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libjxl-0.12.0-heb2dce7_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-9_h5e43f62_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-9_hdba1596_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmagma-2.10.0-hd93470c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmagma_sparse-2.10.0-hbc3fd83_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnl-3.11.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnpp-13.0.1.2-h676940d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvjitlink-13.3.33-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvjpeg-13.0.1.86-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvptxcompiler-dev-13.0.88-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopencv-5.0.0-qt6_h469fc51_605.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-2026.3.0-hb2f3c86_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-batch-plugin-2026.3.0-h9f30d58_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-plugin-2026.3.0-h9f30d58_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-hetero-plugin-2026.3.0-hfeb6f35_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2026.3.0-hb2f3c86_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2026.3.0-hb2f3c86_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-npu-plugin-2026.3.0-hb2f3c86_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-ir-frontend-2026.3.0-hfeb6f35_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-onnx-frontend-2026.3.0-h6c33c14_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-paddle-frontend-2026.3.0-h6c33c14_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-pytorch-frontend-2026.3.0-h0542e35_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-frontend-2026.3.0-h565fa1b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2026.3.0-h0542e35_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpciaccess-0.19-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libplacebo-7.360.1-hc50b9dd_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpng-1.6.58-h922cc85_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpq-18.6-h9d76c99_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libprotobuf-7.35.1-h2840a7c_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpsl-0.23.1-hd9e3e90_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/librsvg-2.62.3-h4c96295_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-15.2.0-h984fb3e_20.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsodium-1.0.22-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-h6154650_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsystemd0-261.2-h6f4a2f1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libtorch-2.12.1-cuda130_mkl_h5535f43_300.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libudev1-261.2-h6f4a2f1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liburing-2.14-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libva-2.24.1-he1eb515_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvpl-2.16.0-h54a6638_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvpx-1.15.2-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvulkan-loader-1.4.357.0-h5279c79_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxcb-1.17.0-hb83e432_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.13.2-hca5e8e5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/llvm-openmp-22.1.8-h4922eb0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mkl-2026.1.0-hecca717_244.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ml_dtypes-0.5.4-np2py312h0f77346_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpg123-1.32.9-h8142553_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/nccl-2.30.7.1-h1aa9b5a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.5.2-py312h33ff503_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ocl-icd-2.3.4-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/onednn-3.12-omp_h83de36e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/onnx-1.22.0-py312hbee568d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/onnxruntime-1.28.0-py312h99cb659_200_cuda130.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/opencl-headers-2025.06.13-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openexr-3.4.14-h6de6307_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openh264-2.6.0-h65dd3cf_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openjph-0.31.0-h8d634f6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/optree-0.19.1-py312hd9148b4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pango-1.58.2-hda50119_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pillow-12.3.0-py312h50c33e8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pixman-0.46.4-h54a6638_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/protobuf-7.35.1-py312h7bd0bee_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/psutil-7.2.2-py312h5253ce2_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pthread-stubs-0.4-hb03c661_1003.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/py-opencv-5.0.0-qt6_h6945e2d_605.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyrefly-1.2.0-hb17b654_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/python-3.12.13-h8ab3286_1_cpython.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pytorch-2.12.1-cuda130_mkl_py312_h24b5296_300.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pytorch-gpu-2.12.1-cuda129_mkl_h0d04637_300.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/qt6-main-6.11.2-pl5321h9df5c37_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/rav1e-0.8.1-h1fbca29_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/rdma-core-63.0-h192683f_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/regex-2026.7.19-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/rpds-py-2026.6.3-py312h192e038_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ruff-0.16.3-hc991c3d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.6-h7e3ee7f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/safetensors-0.8.0-py312h868fb18_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/scipy-1.18.0-py312h54fa4ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sdl3-3.4.14-hdeec2a5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/shaderc-2026.3-h1b60276_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/spirv-tools-2026.3-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-4.2.0-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tokenizers-0.22.2-py312hf875000_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/torchcodec-0.14.0-cuda130_py312_h0ea267f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/torchvision-0.28.0-cuda130_py312_h2966ecb_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.8-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/triton-3.7.1-cuda130py312hc6dca4b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.26.0-h1964d1d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/wget-1.25.0-h653f8fd_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-h280c20c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libsm-1.2.6-h0d788c3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxext-1.3.7-h7cc23a3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxi-1.8.3-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrender-0.9.12-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-xorgproto-2025.1-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zeromq-4.3.5-h09e67af_11.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zlib-ng-2.3.3-hce19668_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+      - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/anyio-4.14.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/arrow-1.4.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/asttokens-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/async-lru-2.3.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/beartype-0.22.9-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/beautifulsoup4-4.15.0-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/bleach-6.4.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/bleach-with-css-6.4.0-hac0b51c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cached_property-1.5.2-pyha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/casefy-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.7.22-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cccl_linux-64-13.0.85-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-compiler-13.0.3-hbad6d8a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-crt-dev_linux-64-13.0.88-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart-dev_linux-64-13.0.96-h376f20c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart-static_linux-64-13.0.96-h376f20c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart_linux-64-13.0.96-h376f20c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-driver-dev_linux-64-13.0.96-h376f20c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-nvcc-dev_linux-64-13.0.88-he91c749_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-nvvm-dev_linux-64-13.0.88-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-version-13.0-hc7b4dd1_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/docstring_parser-0.18.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/einops-0.8.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/eval_type_backport-0.4.0-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/filelock-3.32.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/frozendict-2.4.7-pyh851646a_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/fsspec-2026.7.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h2-4.4.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/huggingface_hub-1.28.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/idna-3.19-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ipykernel-7.2.0-pyha191276_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ipython-9.16.1-pyh53cf698_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jaxtyping-0.2.36-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/json5-0.15.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jsonschema-with-format-nongpl-4.26.0-hcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter-builder-1.2.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter-lsp-2.3.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter_client-8.8.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter_events-0.12.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter_server-2.20.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyter_server_terminals-0.5.4-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyterlab-4.6.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/kernel-headers_linux-64-5.14.0-he073ed8_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_120.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libnvptxcompiler-dev_linux-64-13.0.88-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_120.conda
+      - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mistune-3.3.4-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/natsort-8.4.0-pyhcf101f3_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/nbclient-0.11.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/nbformat-5.11.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/onnx-ir-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/onnxscript-0.7.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.11.3-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/plum-dispatch-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/prometheus_client-0.26.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/prompt-toolkit-3.0.53-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-3.0.4-pyh293190f_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-global-3.0.4-pyh648e204_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pygments-2.21.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pyserde-0.31.8-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-fastjsonschema-2.22.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-flatbuffers-25.12.19-pyh9d96877_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.12.13-hd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-json-logger-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-tzdata-2026.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://prefix.dev/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/send2trash-2.1.0-pyha191276_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/setuptools-81.0.0-pyh332efcf_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/shtab-1.11.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/soupsieve-2.9.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-64-2.34-h087de78_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/traitlets-5.16.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/transformers-5.15.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typeguard-2.13.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/typer-0.27.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tyro-0.9.1-pyhff2d567_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/vulture-2.16-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.49-hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wcwidth-0.8.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/webcolors-25.10.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/websocket-client-1.9.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - pypi: ./packages/mamma
+      - pypi: ./packages/posekit
+      - pypi: ./packages/sam2-streaming
+      - pypi: ./packages/sapiens2-pose
+      - pypi: ./packages/simplecv
+      - pypi: ./packages/trtkit
+      - pypi: https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0f/7b/39c34ca613b0b198cb866466651b26b045e2009864c5183c979a3b83f383/pytz-2026.3.post1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/98/e976540c1addf70442be7842a18cf70884a964abbf69442504f4d2939989/pandas-3.0.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/2f/c9c617f8556e3b6e8c24880d91b8e7a7b242f32b85cf23602b029d705c05/nvidia_cuda_runtime_cu13-0.0.0a0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/23/45/caa600acfab94560807a20a64b5830d2cd3c3202b7f1328644d70b7d6bd8/nvidia_ml_py-13.610.43-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/28/27/3d6dcadc8a3214d8522c1e7f6a19554e33659be44546d44a2f7572ac7d2a/groovy-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/28/7f/cfd9bc4b1f5e424eeea83d0493e43f3b1b02707ce8e50c47945873982bd5/wrapt-2.3.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/2b/fe/0888040a24e4504098b85d8ad486b14cb01cf6b030bbe479dfc2dcffc2ac/polars-1.43.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/5f/e315fbb8c4b7091e2a2b21bc50c764d4eef25196eb0897564e6809237729/tensorrt_cu13_libs-11.2.1.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/2e/a3/0f0b7d78e2f1eb9e8e1afbff1d2bff8d60144aee17aca51c065b516743dd/safehttpx-0.1.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/30/2d/afff2ee87e75d8eb85c92bb8cf0e15b05c23c2ebd8fd8dec781d8601ed7f/hf_gradio-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/30/c5/6290519dec32f3cdf6827e3bbcbf7a9f4fb29a55a9204199901fed69957b/aiobotocore-3.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/32/91/30151a39f7570f448ed84529390628a651d7f27c87d73c9b887f8189695e/docutils-0.23-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/34/80/b9f4889209af02f8d14bccb0e6f0519c329b072bc4d2595025a1303f144c/datafusion-53.0.0-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/37/b5/41c315ccd94ca332ead3e832e83eee343ab245005c3e43d9d3e75eae34eb/open_clip_torch-3.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/38/31/7ff3f7768eded7535c621abc2fecb9d181a34ea4cae3afe682feb796f242/cuda_python-13.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/39/56/684ae3e973f6fbf813714cb875eca1be09876cdfa34806e044f86b3844a1/ultralytics_platform-0.1.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d19459005ca000b6e7012f2f1ca597746cbcd1fbfe5e/antlr4-python3-runtime-4.9.3.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3f/95/0ad40fb92ba3e6fe36182f722f81d69842a1e93cab1d9c6171256ef55418/gradio-6.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/45/e4/19d92435fb102320ece532fc9df58f0e39deee675f5b5d204dfc667a4ed3/tensorrt_cu13_bindings-11.2.1.2-cp312-none-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/52/b7/7cd31f29d6055bd711ae6e669367fba6f5ae9de463910a793e30556a8db7/aiohttp-3.14.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/53/98/f1fa3d40d548c8a2a3eec33b7f856063bb6c7d51e16d5198b1f390b2c79d/ultralytics_thop-2.1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5b/67/314f6151bad77a93d751978a344033e1fc890822f05f0416079338e34231/nh3-0.3.6-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/5c/cd/86fe9e659e9699f62f8dd5ecd8c6725474334b23cab8aa71d82b5f56f1a4/botocore-1.43.56-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/60/c9/711ca85d79f1ec98f29a5eae2b051e25b4ecec5de3e3c0e2d5c5dcb15664/pyarrow-25.0.1-cp312-cp312-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/61/91/288c883303be067c1648f1e63ea38e5f8eb5ab7123fd3a9a7366148e58b7/portalocker-4.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/62/60/64deacb3abc70c52e2d88a808a052d1621c86a48fe9194f2c065579ab1cd/polars_runtime_32-1.43.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/68/7d/ac9997138d585b6715641d655fd7a53ddb46c205b66e2288d20f21a09165/gradio_rerun-0.35.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/70/bd/cb98519aa658b488710aef0d5bac1435e7b95756b7e28c8c97ca394f5260/lovely_numpy-0.2.24-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/72/73/b3d451dfc523756cf177d3ebb0af76dc7751b341c60e2a21871be400ae29/iopath-0.1.10.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/77/c7/2342da9830e3e9d4870305ca5d2091d2a83284f2953079b7bdd3b5e029d8/fonttools-4.63.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/78/81/0a861b8e1ff42960139c6cd4c7dd591292fa09ea1ae2d87677441cba4c00/gradio_client-2.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/82/9707c7b0336bca53b75f52fc350956a93da66eb6be632b370bc933216fb4/icecream-2.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/57/80b986ebfecd9c6a177ddf1c2319717f0cd8feffb2b78946595a18a2fc88/orjson-3.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/90/7f/f620a74444c19e82717eecd8bf5508cc9bc2a65cb663cbf450d1373a40d3/fastcore-2.2.13-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/92/71/15074f4c7d4f2960481ffac97a65f8d7697f7bd48aef5c5259d7952f9031/ultralytics-8.4.123-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/96/08/ddcdc06225eaad6de0e48e1002b06d919dbde20582d0662c7af51308e5d6/twine-7.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/1b/295bf2fa3e740131778065e5ffa2c481f0e7210182d408e9a2c244ff5b0c/readme_renderer-45.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/92/acbd53e79df923bca3881192558a3bc73a47b8b7bd6c94b3649ae45e8094/types_tqdm-4.70.0.20260805-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/98/cc/bcde19a37952ecc58e7d9d67ecaa048e1e21b17d014ce0863a6a6101e606/s3fs-2026.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9c/97/f9d463a6f3c7d0955753eca5cbbf35b596ac471dd13fe357211a53fd37be/hydra_core-1.3.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/4d/603557ab3cb171cc2a61d3678a39cb4dae3fd21275078bfbd1c0b0b5230b/cuda_core-1.0.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/0e/152509871bf30df6fc38569f52a2db9b55dd41aae957adae50a053ac7778/omegaconf-2.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ab/6e/81d47999aebc1b155f81eca4477a616a70f238a2549848c38983f3c22a82/ftfy-6.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/29/c028a0731e202035f0e2e0bfbf1a3e46ad6c628cbb17f6f1cc9eea5d9ff1/pathlib_abc-0.5.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/b9/11971acb516a95d2729dc04c4d42b7a12c747d5edc88317e623d045c8d14/rerun_sdk-0.35.0-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/1f/73c53fcbfb0b5a78f91176df41945ca466e71e9d9d836e5c522abda39ee7/pydantic-2.11.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/76/de1bfac17d183c49c6d0887903d3064ced51cf1d9ba7a8d611c1a8808c4f/timm-1.0.28-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/13/680c54afe3e65767bed7ec1a15571e1a2f1257128733851ade24abcefbcc/kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c9/33/bd37416aec828e7465652d9e2525fe52de0a29a581f1519cc51a74485091/smplx-0.1.28-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c9/cf/b4ad2cc81b6672ea29ea04e64e350a9f9b493b0908ccd884c67eeff8f7b2/matplotlib-3.11.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/d0/d56c859b8222116f5d68459199f48359e0bf121b6f65a69bf329b3602ba0/yarl-1.24.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dd/1a/5d9a402b39ec892d856bbdd9db502ff73ce28cdf4aff72eb1ce1d6843506/universal_pathlib-0.3.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e3/1e/2942a0d6d52240d439f44384a40c65d359d9ca70325b65b265c020113121/cuda_pathfinder-1.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
+      - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-11.2.1.2.tar.gz
   posekit:
     channels:
     - url: https://prefix.dev/ai-demos/
@@ -19577,7 +20720,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/c9c617f8556e3b6e8c24880d91b8e7a7b242f32b85cf23602b029d705c05/nvidia_cuda_runtime_cu13-0.0.0a0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/23/97/942432289883220d760b9c776c5cf503c554da96a9d420ef77b76f3efcaf/spaces-0.51.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/28/27/3d6dcadc8a3214d8522c1e7f6a19554e33659be44546d44a2f7572ac7d2a/groovy-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/5f/e315fbb8c4b7091e2a2b21bc50c764d4eef25196eb0897564e6809237729/tensorrt_cu13_libs-11.2.1.2.tar.gz
@@ -20131,7 +21273,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/c9c617f8556e3b6e8c24880d91b8e7a7b242f32b85cf23602b029d705c05/nvidia_cuda_runtime_cu13-0.0.0a0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/23/97/942432289883220d760b9c776c5cf503c554da96a9d420ef77b76f3efcaf/spaces-0.51.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/28/27/3d6dcadc8a3214d8522c1e7f6a19554e33659be44546d44a2f7572ac7d2a/groovy-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/5f/e315fbb8c4b7091e2a2b21bc50c764d4eef25196eb0897564e6809237729/tensorrt_cu13_libs-11.2.1.2.tar.gz
@@ -30087,7 +31228,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/c9c617f8556e3b6e8c24880d91b8e7a7b242f32b85cf23602b029d705c05/nvidia_cuda_runtime_cu13-0.0.0a0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/99/f5376b53e095d8fd4572cb05e75d7549a5a0b0861fbb01831fd94958d803/ultralytics-8.4.52-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/23/97/942432289883220d760b9c776c5cf503c554da96a9d420ef77b76f3efcaf/spaces-0.51.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/28/27/3d6dcadc8a3214d8522c1e7f6a19554e33659be44546d44a2f7572ac7d2a/groovy-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/5f/e315fbb8c4b7091e2a2b21bc50c764d4eef25196eb0897564e6809237729/tensorrt_cu13_libs-11.2.1.2.tar.gz
@@ -30654,7 +31794,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/c9c617f8556e3b6e8c24880d91b8e7a7b242f32b85cf23602b029d705c05/nvidia_cuda_runtime_cu13-0.0.0a0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/99/f5376b53e095d8fd4572cb05e75d7549a5a0b0861fbb01831fd94958d803/ultralytics-8.4.52-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/23/97/942432289883220d760b9c776c5cf503c554da96a9d420ef77b76f3efcaf/spaces-0.51.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/28/27/3d6dcadc8a3214d8522c1e7f6a19554e33659be44546d44a2f7572ac7d2a/groovy-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/5f/e315fbb8c4b7091e2a2b21bc50c764d4eef25196eb0897564e6809237729/tensorrt_cu13_libs-11.2.1.2.tar.gz
@@ -31201,7 +32340,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/c9c617f8556e3b6e8c24880d91b8e7a7b242f32b85cf23602b029d705c05/nvidia_cuda_runtime_cu13-0.0.0a0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/23/97/942432289883220d760b9c776c5cf503c554da96a9d420ef77b76f3efcaf/spaces-0.51.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/28/27/3d6dcadc8a3214d8522c1e7f6a19554e33659be44546d44a2f7572ac7d2a/groovy-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/5f/e315fbb8c4b7091e2a2b21bc50c764d4eef25196eb0897564e6809237729/tensorrt_cu13_libs-11.2.1.2.tar.gz
@@ -31749,7 +32887,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/c9c617f8556e3b6e8c24880d91b8e7a7b242f32b85cf23602b029d705c05/nvidia_cuda_runtime_cu13-0.0.0a0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/23/97/942432289883220d760b9c776c5cf503c554da96a9d420ef77b76f3efcaf/spaces-0.51.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/28/27/3d6dcadc8a3214d8522c1e7f6a19554e33659be44546d44a2f7572ac7d2a/groovy-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/5f/e315fbb8c4b7091e2a2b21bc50c764d4eef25196eb0897564e6809237729/tensorrt_cu13_libs-11.2.1.2.tar.gz
@@ -43030,6 +44167,21 @@ packages:
   run_exports: {}
   size: 239892
   timestamp: 1781450817988
+- conda: https://prefix.dev/conda-forge/linux-64/backports.zstd-1.7.0-py312h3f22e6b_0.conda
+  sha256: c10df0467f534472f0aa39013850d6dd9dd38ea5a6fb5c0812afb6f3fc768924
+  md5: e7eb25765bdf21397cc6e30828871625
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - python_abi 3.12.* *_cp312
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause AND MIT AND EPL-2.0
+  purls:
+  - pkg:pypi/backports-zstd?source=hash-mapping
+  run_exports: {}
+  size: 240967
+  timestamp: 1786861419155
 - conda: https://prefix.dev/conda-forge/linux-64/binutils-2.45.1-default_h4852527_102.conda
   sha256: 3c7c5580c1720206f28b7fa3d60d17986b3f32465e63009c14c9ae1ea64f926c
   md5: 212fe5f1067445544c99dc1c847d032c
@@ -43581,6 +44733,23 @@ packages:
   run_exports: {}
   size: 301815
   timestamp: 1785810903512
+- conda: https://prefix.dev/conda-forge/linux-64/cffi-2.1.1-py312h703531f_2.conda
+  sha256: b649eacfd07be8fb889ef609601436dff831b2e9d095ef029601f3f10946c7d6
+  md5: 3101547f7c22db267bd40988f67d7ab1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.7.0,<3.8.0a0
+  - libgcc >=15
+  - pycparser
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
+  run_exports: {}
+  size: 302100
+  timestamp: 1786775110054
 - conda: https://prefix.dev/conda-forge/linux-64/charls-2.4.4-hecca717_0.conda
   sha256: 285bb88f6229a1eb4772ab805fbc61ef786e27b5e9ca0b6434b13d2a728790bb
   md5: dc7072d888ba25c06d706d9dd4bd48ec
@@ -45165,6 +46334,7 @@ packages:
   - libuuid >=2.42.2,<3.0a0
   - libzlib >=1.3.2,<2.0a0
   license: MIT
+  license_family: MIT
   purls: []
   run_exports:
     weak:
@@ -45931,6 +47101,24 @@ packages:
   run_exports: {}
   size: 253171
   timestamp: 1773245116314
+- conda: https://prefix.dev/conda-forge/linux-64/gmpy2-2.3.1-py312h04c1168_0.conda
+  sha256: 8f1abde65e50bf2f30292442a5388bf962f8275bb1e23a0fe8fbdc83b8b5a241
+  md5: 96a25063461871ac66728ecfa645116c
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - mpfr >=4.2.2,<5.0a0
+  - gmp >=6.3.0,<7.0a0
+  - python_abi 3.12.* *_cp312
+  - mpc >=1.4.0,<2.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  purls:
+  - pkg:pypi/gmpy2?source=compressed-mapping
+  run_exports: {}
+  size: 327022
+  timestamp: 1787066358050
 - conda: https://prefix.dev/conda-forge/linux-64/graphite2-1.3.15-h54a6638_1.conda
   sha256: 7fa3b6a9c081fa3e545573152a788d061a0a0ba57df7251cc0f4f75225fc93e7
   md5: f9fe2984587fa8235a6af6004760cd18
@@ -46399,6 +47587,19 @@ packages:
     - libharfbuzz >=14.3.0
   size: 11045
   timestamp: 1785770087614
+- conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-14.3.1-ha770c72_0.conda
+  sha256: d2b22411323270acf8199070fe3377d72f36830f467f09fb2f5bcd4dc3ef77dd
+  md5: 15971d7910faa28aa5b0b2560b9a3bab
+  depends:
+  - libharfbuzz-devel 14.3.1 h23af247_0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libharfbuzz >=14.3.1
+  size: 11076
+  timestamp: 1786970900409
 - conda: https://prefix.dev/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
   sha256: 0d09b6dc1ce5c4005ae1c6a19dc10767932ef9a5e9c755cfdbb5189ac8fb0684
   md5: bd77f8da987968ec3927990495dc22e4
@@ -46712,6 +47913,25 @@ packages:
   run_exports: {}
   size: 1558415
   timestamp: 1785918202843
+- conda: https://prefix.dev/conda-forge/linux-64/hypothesis-6.165.10-py312hc767a74_0.conda
+  sha256: bfd94b5baa170d896adc5116bbbf3d1286ab29bfe6024491c95b5386f8899525
+  md5: 5337fb60edd0c80381147e6972547d88
+  depends:
+  - python
+  - exceptiongroup >=1.0.0
+  - sortedcontainers >=2.1.0,<3.0.0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __glibc >=2.17
+  license: MPL-2.0
+  license_family: MOZILLA
+  purls:
+  - pkg:pypi/hypothesis?source=hash-mapping
+  run_exports: {}
+  size: 1573949
+  timestamp: 1787003739534
 - conda: https://prefix.dev/conda-forge/linux-64/hypothesis-6.165.2-py312h868fb18_0.conda
   sha256: 80c628742b5366833ac0b64d9d59bd4a270147b19a5bb76e4bff7a6862fc7772
   md5: 211b8a71a6891e3a26878f2c45e16064
@@ -47172,6 +48392,25 @@ packages:
   run_exports: {}
   size: 2145505
   timestamp: 1774729622154
+- conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
+  sha256: 2a5c38c85e63df84c4e69ee71439841ce570d259ae3060627bb9a49a938d66f4
+  md5: 53318d715316929a574f83591308b1f8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - keyutils >=1.6.3,<2.0a0
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - libgcc >=15
+  - libstdcxx >=15
+  - openssl >=3.5.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - krb5 >=1.22.2,<1.23.0a0
+  size: 1394333
+  timestamp: 1786762112514
 - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
   sha256: 9b07046870772f28740e3f6149f09ff222843733087a33c5540b169c6289652d
   md5: 54157a1c8c0bb70f62dd0b17fba7e7f2
@@ -49575,6 +50814,27 @@ packages:
   run_exports: {}
   size: 1333436
   timestamp: 1785770053613
+- conda: https://prefix.dev/conda-forge/linux-64/libharfbuzz-14.3.1-h23af247_0.conda
+  sha256: a4eac5a21b84e0fc753b72de01781f634fc9ab70fd32a28d6a40a19700c9188a
+  md5: 29709e61096dd490fff9e833e4c869f6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - graphite2 >=1.3.15,<2.0a0
+  - icu >=78.3,<79.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=15
+  - libglib >=2.88.3,<3.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libstdcxx >=15
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 1353639
+  timestamp: 1786970872936
 - conda: https://prefix.dev/conda-forge/linux-64/libharfbuzz-devel-14.2.1-h17a8019_1.conda
   sha256: 6d8e793042affd18ca1784b7794fab14d16f54f984777ce6ab86bacaa465ab0d
   md5: 99cf21100441e51272f1cd6fe0632a20
@@ -49625,6 +50885,31 @@ packages:
     - libharfbuzz >=14.3.0
   size: 2081226
   timestamp: 1785770079548
+- conda: https://prefix.dev/conda-forge/linux-64/libharfbuzz-devel-14.3.1-h23af247_0.conda
+  sha256: 9d9d620141102dcb580d8f42d1a6c9e7e691a8dfa0284783e712679723067d15
+  md5: e0f17ce01589ffa7d773be573e97b36c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - freetype
+  - graphite2 >=1.3.15,<2.0a0
+  - icu >=78.3,<79.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=15
+  - libglib >=2.88.3,<3.0a0
+  - libharfbuzz 14.3.1 h23af247_0
+  - libpng >=1.6.58,<1.7.0a0
+  - libstdcxx >=15
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libharfbuzz >=14.3.1
+  size: 2114382
+  timestamp: 1786970892473
 - conda: https://prefix.dev/conda-forge/linux-64/libheif-1.23.0-gpl_hbd16bbc_100.conda
   sha256: edf7f0e3bda310d58a77274e614355dbd3f01fbb5b427dae646c3719b39d47c6
   md5: 42162bc47747c3ad60cffb29272ec22b
@@ -49690,6 +50975,19 @@ packages:
     - libhwy >=1.4.0,<1.5.0a0
   size: 1431901
   timestamp: 1784325535334
+- conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+  sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
+  md5: f92233bf33e24a25668bb2119e2c51f9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  license: LGPL-2.1-only
+  purls: []
+  run_exports:
+    weak:
+    - libiconv >=1.18,<2.0a0
+  size: 789471
+  timestamp: 1787033836207
 - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
   sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
   md5: 915f5995e94f60e9a4826e0b0920ee88
@@ -49810,6 +51108,7 @@ packages:
   - libbrotlienc >=1.2.0,<1.3.0a0
   - libbrotlidec >=1.2.0,<1.3.0a0
   license: BSD-3-Clause
+  license_family: BSD
   purls: []
   run_exports:
     weak:
@@ -50196,6 +51495,20 @@ packages:
     - libnghttp2 >=1.68.1,<2.0a0
   size: 663344
   timestamp: 1773854035739
+- conda: https://prefix.dev/conda-forge/linux-64/libnl-3.11.0-hb03c661_1.conda
+  sha256: d0f2fd77aad83641c11bc3686bac677e99869f1d62b99e5064c9d99af8bfde6a
+  md5: eeaf53e3c9593d63ffee5ad97182858e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  run_exports:
+    weak:
+    - libnl >=3.11.0,<4.0a0
+  size: 735004
+  timestamp: 1787038268022
 - conda: https://prefix.dev/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
   sha256: ba7c5d294e3d80f08ac5a39564217702d1a752e352e486210faff794ac5001b4
   md5: db63358239cbe1ff86242406d440e44a
@@ -52250,6 +53563,22 @@ packages:
     - libpsl >=0.23.0,<0.24.0a0
   size: 72585
   timestamp: 1785426713969
+- conda: https://prefix.dev/conda-forge/linux-64/libpsl-0.23.1-hd9e3e90_1.conda
+  sha256: 09e8effdc89bc5d021349318d32b85594f5b8d8e3ab8f90a85b81f8fe695a566
+  md5: 77be60417aa572afcb48cbe0f967401d
+  depends:
+  - libstdcxx >=15
+  - libgcc >=15
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libpsl >=0.23.1,<0.24.0a0
+  size: 72519
+  timestamp: 1786970753847
 - conda: https://prefix.dev/conda-forge/linux-64/libpsl-0.23.1-hf670292_0.conda
   sha256: 2e6405feb59e3f40a5a4641dfa73afda158046893aa73d478e23415e18997ece
   md5: c8217f5bdd5b018087bdea081912cda5
@@ -52554,6 +53883,21 @@ packages:
     - libsqlite >=3.53.3,<4.0a0
   size: 962119
   timestamp: 1782519076616
+- conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+  sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
+  md5: e72bbec309c2b0f37823ee7d4fabfcd3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=15
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  purls: []
+  run_exports:
+    weak:
+    - libsqlite >=3.53.4,<4.0a0
+  size: 974348
+  timestamp: 1787051145557
 - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
   sha256: 72023efc207fe681e26b65fc9d668062cf0b4f0eacf3431e6eb099b95c1f2efd
   md5: df088a279cd5e6fd2790b4c196434da1
@@ -53363,6 +54707,23 @@ packages:
     - libxcb >=1.17.0,<2.0a0
   size: 395888
   timestamp: 1727278577118
+- conda: https://prefix.dev/conda-forge/linux-64/libxcb-1.17.0-hb83e432_1.conda
+  sha256: ce25a1efa85a78a3ce3b16721d9c36153814adbf2fb004a15f72ec69894b4cb1
+  md5: 64e856c420205b009da26471d3ac161d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - pthread-stubs
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdmcp >=1.1.5,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libxcb >=1.17.0,<2.0a0
+  size: 397355
+  timestamp: 1787077466600
 - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
   sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
   md5: 5aa797f8787fe7a17d1b0821485b5adc
@@ -54491,6 +55852,26 @@ packages:
   run_exports: {}
   size: 39889
   timestamp: 1783700145236
+- conda: https://prefix.dev/conda-forge/linux-64/onnx-1.22.0-py312hbee568d_1.conda
+  sha256: 5641b3b1fc0393fc52d026e433a23d105d60b78d20f457208954cb8f1fb9680c
+  md5: e00e532491dd409cd49e678b0e1b4e1e
+  depends:
+  - python
+  - ml_dtypes
+  - protobuf
+  - typing_extensions
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libprotobuf >=7.35.1,<7.35.2.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/onnx?source=hash-mapping
+  run_exports: {}
+  size: 12606067
+  timestamp: 1782239595571
 - conda: https://prefix.dev/conda-forge/linux-64/onnx-1.22.0-py312he0a7d46_0.conda
   sha256: b40e4d1ae3ce4ff087624d49d50f30c7d1c1bcacc468776c2aef60df0d28b552
   md5: fd57449888172c7d7f0d49b2a741caa2
@@ -57260,6 +58641,82 @@ packages:
     - qt6-main >=6.11.1,<7.0a0
   size: 60185421
   timestamp: 1780593127053
+- conda: https://prefix.dev/conda-forge/linux-64/qt6-main-6.11.2-pl5321h9df5c37_0.conda
+  sha256: 00d9bc98d04aeeab6f698ca7fe9d666b157ab39b52cad1af0fa346522705668d
+  md5: 2ff98660281d1c6bfebda5bffa52cc89
+  depends:
+  - libxcb
+  - xcb-util
+  - xcb-util-wm
+  - xcb-util-keysyms
+  - xcb-util-image
+  - xcb-util-renderutil
+  - xcb-util-cursor
+  - libgl-devel
+  - libegl-devel
+  - libgcc >=15
+  - libstdcxx >=15
+  - __glibc >=2.17,<3.0.a0
+  - libglib >=2.88.3,<3.0a0
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libvulkan-loader >=1.4.357.0,<2.0a0
+  - wayland >=1.26.0,<2.0a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - libcups >=2.3.3,<2.4.0a0
+  - alsa-lib >=1.2.16.1,<1.3.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libtiff >=4.7.2,<4.8.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - dbus >=1.16.2,<2.0a0
+  - libegl >=1.7.0,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libxxf86vm >=1.1.7,<2.0a0
+  - double-conversion >=3.4.0,<3.5.0a0
+  - icu >=78.3,<79.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - openssl >=3.5.7,<4.0a0
+  - xorg-libxcomposite >=0.4.7,<1.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libpq >=18.6,<19.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - libharfbuzz >=14.3.1
+  - fontconfig >=2.18.3,<3.0a0
+  - fonts-conda-ecosystem
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libxrandr >=1.5.5,<2.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - xcb-util-cursor >=0.1.6,<0.2.0a0
+  - libxkbcommon >=1.13.2,<2.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libdrm >=2.4.129,<2.5.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - xorg-libxtst >=1.2.5,<2.0a0
+  constrains:
+  - qt ==6.11.2
+  license: LGPL-3.0-only
+  license_family: LGPL
+  purls: []
+  run_exports:
+    weak:
+    - qt6-main >=6.11.2,<7.0a0
+  size: 60888449
+  timestamp: 1787048975419
 - conda: https://prefix.dev/conda-forge/linux-64/rav1e-0.8.1-h1fbca29_0.conda
   sha256: cf550bbc8e5ebedb6dba9ccaead3e07bd1cb86b183644a4c853e06e4b3ad5ac7
   md5: d83958768626b3c8471ce032e28afcd3
@@ -57323,6 +58780,21 @@ packages:
     - readline >=8.3,<9.0a0
   size: 345073
   timestamp: 1765813471974
+- conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+  sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
+  md5: 69c01c781e7c8190bbdaf79e3848c5ca
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - ncurses >=6.6,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports:
+    weak:
+    - readline >=8.3,<9.0a0
+  size: 348899
+  timestamp: 1787033801506
 - conda: https://prefix.dev/conda-forge/linux-64/regex-2026.5.9-py311h49ec1c0_0.conda
   sha256: ed61badc6132a5b7e699afa8a05ab0fca5982f0ac3627c0760eecd3341f164f6
   md5: 37723df906affabc3e6ca942c7480744
@@ -57597,6 +59069,23 @@ packages:
   run_exports: {}
   size: 9481279
   timestamp: 1786151870074
+- conda: https://prefix.dev/conda-forge/linux-64/ruff-0.16.3-hc991c3d_0.conda
+  noarch: python
+  sha256: 55443cd08836d9cfc724f91deae05b6149ab59e8337610861b8fbe14bae1aaf4
+  md5: 6dbd251a93fae4650975dbe481644161
+  depends:
+  - python
+  - libgcc >=15
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ruff?source=hash-mapping
+  run_exports: {}
+  size: 9549002
+  timestamp: 1786872517294
 - conda: https://prefix.dev/conda-forge/linux-64/rust-1.97.1-h53717f1_0.conda
   sha256: 66f7e7d46602a4fdc20769ef33cb30229983b3cfe8fb447bb2d2081e895383ef
   md5: f0d36652f4d8bbe4a51de53414f15db2
@@ -58155,6 +59644,23 @@ packages:
     - spirv-tools >=2026,<2027.0a0
   size: 2405017
   timestamp: 1785688937831
+- conda: https://prefix.dev/conda-forge/linux-64/spirv-tools-2026.3-hb700be7_0.conda
+  sha256: 863058fea246a08b348e010462dd5637cac9a15964012ae6c174f0f89978705f
+  md5: 471eb0afe44e7546d26209ed45b58ec9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - spirv-headers >=1.4.357.0,<1.4.357.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - spirv-tools >=2026,<2027.0a0
+  size: 2753273
+  timestamp: 1786908115068
 - conda: https://prefix.dev/conda-forge/linux-64/sqlite-3.53.2-hbc0de68_0.conda
   sha256: b7c3217b437f8aa531b4a18c89dc137b6066757f1e93146dc0d8d999ef55da09
   md5: 38d9bf35a4cc83094a327811e548b660
@@ -58613,6 +60119,21 @@ packages:
   run_exports: {}
   size: 864705
   timestamp: 1781006801632
+- conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.8-py312h4c3975b_0.conda
+  sha256: 2ea8f8b10e869b675d2fba157b387eaf4eed1696bfc924bb7b28e67d7aa0a947
+  md5: 5423c2b8f82d60320e65b9ff30babbdf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/tornado?source=compressed-mapping
+  run_exports: {}
+  size: 869730
+  timestamp: 1786226754702
 - conda: https://prefix.dev/conda-forge/linux-64/triton-3.7.0-cuda130py311h280606b_0.conda
   sha256: 566822dfa4ab58a2628488f16e77df801b6e1311bf854fbf135d52d6d2cf4e90
   md5: 1fa91ff164d0b6a10504bc5f4ada28b3
@@ -59265,6 +60786,21 @@ packages:
     - xorg-libx11 >=1.8.13,<2.0a0
   size: 839652
   timestamp: 1770819209719
+- conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_1.conda
+  sha256: 68053eebfa9f0d91666786c8fb5839d989aa9b869add92cb8815228bb2d7302c
+  md5: 8c282bbe4808a3cc80a5c98e9aec1cfc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libxcb >=1.17.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - xorg-libx11 >=1.8.13,<2.0a0
+  size: 839578
+  timestamp: 1787087012372
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
   sha256: 6bc6ab7a90a5d8ac94c7e300cc10beb0500eeba4b99822768ca2f2ef356f731b
   md5: b2895afaf55bf96a8c8282a2e47a5de0
@@ -59371,6 +60907,21 @@ packages:
     - xorg-libxdmcp >=1.1.5,<2.0a0
   size: 21120
   timestamp: 1786381006369
+- conda: https://prefix.dev/conda-forge/linux-64/xorg-libxext-1.3.7-h7cc23a3_1.conda
+  sha256: aa9bbe8b278aacc194e280ff5037f9f9a1f2c5b33ed97de8e7f01cfbe90dda43
+  md5: e5b6b28536b81b3f4cb20db4668a4642
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - xorg-libxext >=1.3.7,<2.0a0
+  size: 53124
+  timestamp: 1787100841900
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
   sha256: 79c60fc6acfd3d713d6340d3b4e296836a0f8c51602327b32794625826bd052f
   md5: 34e54f03dfea3e7a2dcf1453a85f1085
@@ -59452,6 +61003,21 @@ packages:
     - xorg-libxrandr >=1.5.5,<2.0a0
   size: 30456
   timestamp: 1769445263457
+- conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrender-0.9.12-hb03c661_1.conda
+  sha256: 6901f91d398811e4ec89d7e20a69abac02a7bfebfaf073338b7ea3d1a99685b7
+  md5: e470d224a7a5be1b1d021bded7abb536
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - xorg-libxrender >=0.9.12,<0.10.0a0
+  size: 34645
+  timestamp: 1787100191192
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
   sha256: 044c7b3153c224c6cedd4484dd91b389d2d7fd9c776ad0f4a34f099b3389f4a1
   md5: 96d57aba173e878a2089d5638016dc5e
@@ -70800,6 +72366,18 @@ packages:
   run_exports: {}
   size: 63942
   timestamp: 1786631964278
+- conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.5.1-pyhd8ed1ab_0.conda
+  sha256: cb60ef3e0631c8bacb4f7057196dee4496091a22baa3bb4b9bccb12c7e1c921b
+  md5: e0ac3accc64e23e40969d660e5f58ac8
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/charset-normalizer?source=compressed-mapping
+  run_exports: {}
+  size: 64487
+  timestamp: 1786835648298
 - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
   sha256: c253a41cdf898b651a0786cbb76c6d5fc101d0dbbe719f93a124bc4fde5cdd6a
   md5: 554304a07e581a85891b15e39ea9f268
@@ -71979,6 +73557,28 @@ packages:
   run_exports: {}
   size: 535131
   timestamp: 1786117980574
+- conda: https://prefix.dev/conda-forge/noarch/huggingface_hub-1.28.0-pyhcf101f3_0.conda
+  sha256: 4472980f8afbfcdd2ac4b23c64992cf83addcc80923b9b1a3c79a75ae4bf4f78
+  md5: c5a90c5c38ec7cb4fc010ae70c859c97
+  depends:
+  - python >=3.10
+  - click >=8.4.2,<9.0.0
+  - filelock >=3.10.0
+  - fsspec >=2023.5.0
+  - hf-xet >=1.5.2,<2.0.0
+  - httpx >=0.23.0,<1
+  - packaging >=20.9
+  - pyyaml >=5.1
+  - tqdm >=4.42.1
+  - typing_extensions >=4.1.0
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/huggingface-hub?source=hash-mapping
+  run_exports: {}
+  size: 541831
+  timestamp: 1787059786165
 - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
   sha256: 77af6f5fe8b62ca07d09ac60127a30d9069fdc3c68d6b256754d0ffb1f7779f8
   md5: 8e6923fc12f1fe8f8c4e5c9f343256ac
@@ -72051,6 +73651,19 @@ packages:
   run_exports: {}
   size: 163869
   timestamp: 1781620148226
+- conda: https://prefix.dev/conda-forge/noarch/idna-3.19-pyhcf101f3_0.conda
+  sha256: 1c35a59c1545ad0fdaddf1fbde7bcfa6ef41a8d68c3a2b0b4a291be00676163e
+  md5: a39ae05027e9b707742e41b30d296b75
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/idna?source=compressed-mapping
+  run_exports: {}
+  size: 177433
+  timestamp: 1787059857580
 - conda: https://prefix.dev/conda-forge/noarch/imageio-2.37.0-pyhfb79c49_0.conda
   sha256: 8ef69fa00c68fad34a3b7b260ea774fda9bd9274fd706d3baffb9519fd0063fe
   md5: b5577bc2212219566578fd5af9993af6
@@ -72529,6 +74142,23 @@ packages:
   run_exports: {}
   size: 862196
   timestamp: 1785596672766
+- conda: https://prefix.dev/conda-forge/noarch/jupyter-builder-1.2.2-pyhcf101f3_0.conda
+  sha256: 46777dd25ae623f960ec9ed9eae44cc7f96f371f3bc96f85d3ebf95737bd4e88
+  md5: 9672806e67ea8b09a61408597a418e20
+  depends:
+  - jupyter_core
+  - python >=3.10
+  - tomli
+  - traitlets
+  - python
+  constrains:
+  - nodejs >=22
+  license: BSD-3-Clause AND MIT AND ISC
+  purls:
+  - pkg:pypi/jupyter-builder?source=compressed-mapping
+  run_exports: {}
+  size: 862197
+  timestamp: 1786385602872
 - conda: https://prefix.dev/conda-forge/noarch/jupyter-lsp-2.3.1-pyhcf101f3_0.conda
   sha256: 3766e2ae59641c172cec8a821528bfa6bf9543ffaaeb8b358bfd5259dcf18e4e
   md5: 0c3b465ceee138b9c39279cc02e5c4a0
@@ -72771,6 +74401,33 @@ packages:
   run_exports: {}
   size: 14035048
   timestamp: 1784641255275
+- conda: https://prefix.dev/conda-forge/noarch/jupyterlab-4.6.3-pyhd8ed1ab_0.conda
+  sha256: dabfff705b000188a9f67c9af68bb607cdb2e46fd7c6283307a502994c2af46f
+  md5: e5527f195a1a1925b9207e9d47752480
+  depends:
+  - async-lru >=1.0.0
+  - httpx >=0.25.0,<1
+  - ipykernel >=6.5.0,!=6.30.0
+  - jinja2 >=3.0.3
+  - jupyter-builder >=1.0.2
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.19.0,<3
+  - jupyterlab_server >=2.28.0,<3
+  - notebook-shim >=0.2
+  - packaging >=23.2
+  - python >=3.10
+  - tomli >=1.2.2
+  - tornado >=6.2.0
+  - traitlets
+  - typing_extensions >=4.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/jupyterlab?source=compressed-mapping
+  run_exports: {}
+  size: 13178193
+  timestamp: 1786398793317
 - conda: https://prefix.dev/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
   sha256: dc24b900742fdaf1e077d9a3458fd865711de80bca95fe3c6d46610c532c6ef0
   md5: fd312693df06da3578383232528c468d
@@ -73373,6 +75030,22 @@ packages:
   run_exports: {}
   size: 100945
   timestamp: 1733402844974
+- conda: https://prefix.dev/conda-forge/noarch/nbformat-5.11.1-pyhcf101f3_0.conda
+  sha256: d85d76827ff732e1639f50f45e4d7d3387a27abd857b194dcbb5bb4166c2a7c2
+  md5: 2fbbf92e1173ae024f0b12759c1e64a1
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.10
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  - python
+  license: BSD-3-Clause
+  purls:
+  - pkg:pypi/nbformat?source=compressed-mapping
+  run_exports: {}
+  size: 107750
+  timestamp: 1787133512599
 - conda: https://prefix.dev/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
   sha256: bb7b21d7fd0445ddc0631f64e66d91a179de4ba920b8381f29b9d006a42788c0
   md5: 598fd7d4d0de2455fb74f56063969a97
@@ -73444,6 +75117,23 @@ packages:
   run_exports: {}
   size: 126994
   timestamp: 1781005937557
+- conda: https://prefix.dev/conda-forge/noarch/onnx-ir-1.0.0-pyhd8ed1ab_0.conda
+  sha256: 25fdaf0d8e7235b86809660b025454118fe4286d6faf1698bb4d74b68fc00318
+  md5: e9e38545188e55db89c2842bef9941ef
+  depends:
+  - ml_dtypes >=0.5.0
+  - numpy
+  - onnx >=1.16
+  - python >=3.10
+  - sympy >=1.13
+  - typing_extensions >=4.10
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/onnx-ir?source=hash-mapping
+  run_exports: {}
+  size: 144480
+  timestamp: 1786736802207
 - conda: https://prefix.dev/conda-forge/noarch/onnxscript-0.7.0-pyhd8ed1ab_0.conda
   sha256: 79a832eea2bbcaacb4d95701c6f444b798d0e72f28d8f445ec6959a4a43b8cb8
   md5: cefdd0235e6924a8ae6df2fb05601562
@@ -73462,6 +75152,24 @@ packages:
   run_exports: {}
   size: 380614
   timestamp: 1781046401884
+- conda: https://prefix.dev/conda-forge/noarch/onnxscript-0.7.1-pyhd8ed1ab_0.conda
+  sha256: 19f56173ee75eaf59837b1359082bda322a3df8e92aa904d5ff5db307315bd3e
+  md5: 95738f0a7f274499a3a92db089418485
+  depends:
+  - ml_dtypes
+  - numpy
+  - onnx >=1.17
+  - onnx-ir >=0.1.16,<2
+  - packaging
+  - python >=3.10
+  - typing_extensions >=4.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/onnxscript?source=hash-mapping
+  run_exports: {}
+  size: 385977
+  timestamp: 1784825483730
 - conda: https://prefix.dev/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
   sha256: 1840bd90d25d4930d60f57b4f38d4e0ae3f5b8db2819638709c36098c6ba770c
   md5: e51f1e4089cad105b6cac64bd8166587
@@ -73612,6 +75320,19 @@ packages:
   run_exports: {}
   size: 26632
   timestamp: 1784661349391
+- conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.11.3-pyhcf101f3_0.conda
+  sha256: 810511c90649ca59fa0174958a210fd5051c0a7848cfbd42c87054a6836726b5
+  md5: 31474b00d0ca5accac14eda09ba11216
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/platformdirs?source=compressed-mapping
+  run_exports: {}
+  size: 26956
+  timestamp: 1786708411066
 - conda: https://prefix.dev/conda-forge/noarch/plotly-6.8.0-pyhd8ed1ab_0.conda
   sha256: 4fb6cf23ca322b45f7dafb095bf42192f9ee85b18184fc4a1f82ae6a962dd1b0
   md5: 499b2e5cc7cf18761cfd20d6fb837f48
@@ -73957,6 +75678,19 @@ packages:
   run_exports: {}
   size: 893031
   timestamp: 1774796815820
+- conda: https://prefix.dev/conda-forge/noarch/pygments-2.21.0-pyhcf101f3_0.conda
+  sha256: f5f015ff1bc3e1b7fc08eee096b1865234189ae0b82bebdb86a5369116e42fa0
+  md5: 2882dee445dfa45b0c5afce3ffb7730a
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pygments?source=compressed-mapping
+  run_exports: {}
+  size: 959376
+  timestamp: 1786995678795
 - conda: https://prefix.dev/conda-forge/noarch/pyopengl-3.1.10-pyha804496_2.conda
   sha256: 0775255f81e2c6b49948b3656796823758e64938a15543302857d99da0e3d737
   md5: cce156023226a62044a8112bebf3d5e1
@@ -74157,6 +75891,19 @@ packages:
   run_exports: {}
   size: 252180
   timestamp: 1785242896823
+- conda: https://prefix.dev/conda-forge/noarch/python-fastjsonschema-2.22.2-pyhcf101f3_0.conda
+  sha256: fc4a704822df22defce49d0fb811fdc036a1fd3b579aeaa601228e9cfd198b3d
+  md5: aa75b7f096d17621bc307b3025b29461
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/fastjsonschema?source=compressed-mapping
+  run_exports: {}
+  size: 254446
+  timestamp: 1786892280524
 - conda: https://prefix.dev/conda-forge/noarch/python-flatbuffers-25.12.19-pyh9d96877_0.conda
   sha256: dff2f2fc462996f71686c05a0fba78a0dc919034ef8d879dd8366534ad64c0f1
   md5: 3a28cf4d2187c1dfb0c31aedbf275b8c
@@ -74226,6 +75973,19 @@ packages:
   run_exports: {}
   size: 19249
   timestamp: 1781036004580
+- conda: https://prefix.dev/conda-forge/noarch/python-json-logger-4.2.0-pyhd8ed1ab_0.conda
+  sha256: 4f8ecadbd9d282b0208d6e84640573fcb6ab462307d737eedd28341964e18cc6
+  md5: e5407c82510aab6a4baa31fcd4249655
+  depends:
+  - python >=3.10
+  - typing_extensions
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/python-json-logger?source=compressed-mapping
+  run_exports: {}
+  size: 19367
+  timestamp: 1786872772907
 - conda: https://prefix.dev/conda-forge/noarch/python-tzdata-2026.2-pyhd8ed1ab_0.conda
   sha256: e943f9c15a6bdba2e1b9f423ab913b3f6b02197b0ef9f8e6b7464d78b59965b9
   md5: f6ad7450fc21e00ecc23812baed6d2e4
@@ -74554,6 +76314,19 @@ packages:
   run_exports: {}
   size: 31368
   timestamp: 1786264158981
+- conda: https://prefix.dev/conda-forge/noarch/shtab-1.11.0-pyhcf101f3_0.conda
+  sha256: 62cb715e75e9cbd775f149840f0ee8e0bf5a6e1060bc42ee36e98a4e14501b35
+  md5: ddfc793776ac4c65b56e0f1b3ab41e7a
+  depends:
+  - python >=3.10
+  - python
+  license: MPL-2.0
+  license_family: MOZILLA
+  purls:
+  - pkg:pypi/shtab?source=hash-mapping
+  run_exports: {}
+  size: 32988
+  timestamp: 1786854255795
 - conda: https://prefix.dev/conda-forge/noarch/shtab-1.8.0-pyhd8ed1ab_0.conda
   sha256: 02567ec721dd5ff6e8942c1cf1db9bb12df64409ff48fc3571b212c122ef9006
   md5: 3b92b45edc5da4cbd603dd7a059f402a
@@ -74677,6 +76450,18 @@ packages:
   run_exports: {}
   size: 39457
   timestamp: 1784670700449
+- conda: https://prefix.dev/conda-forge/noarch/soupsieve-2.9.2-pyhd8ed1ab_0.conda
+  sha256: 056d7a2e91e303a9ee37e580f6dde0511fc3fb72476581cc337aacf2cc747613
+  md5: ba33e6c8a46ee373fdf6dd8665212778
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/soupsieve?source=compressed-mapping
+  run_exports: {}
+  size: 39439
+  timestamp: 1786202135509
 - conda: https://prefix.dev/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
   sha256: 570da295d421661af487f1595045760526964f41471021056e993e73089e9c41
   md5: b1b505328da7a6b246787df4b5a49fbc
@@ -75077,6 +76862,27 @@ packages:
   run_exports: {}
   size: 4457125
   timestamp: 1786399978103
+- conda: https://prefix.dev/conda-forge/noarch/transformers-5.15.1-pyhcf101f3_0.conda
+  sha256: 113f424b4389d2c970b7d6ab4aa06169e3b1b1c0708306112ed740288cdb1332
+  md5: e807bf3b1708682fb65831c6efd5fb82
+  depends:
+  - python >=3.10
+  - huggingface_hub >=1.5.0,<2.0
+  - numpy >=1.17
+  - packaging >=20.0
+  - pyyaml >=5.1
+  - regex >=2025.10.22
+  - tokenizers >=0.22.0,<=0.23.0
+  - typer
+  - safetensors >=0.8.0
+  - tqdm >=4.60
+  - python
+  license: Apache-2.0
+  purls:
+  - pkg:pypi/transformers?source=compressed-mapping
+  run_exports: {}
+  size: 4457831
+  timestamp: 1787140981122
 - conda: https://prefix.dev/conda-forge/noarch/trimesh-4.12.2-pyh7b2049a_0.conda
   sha256: ec8151a7211e7225f7d378f36a50b7f8336f114bd79935527e49bbd36e013c08
   md5: 1cc13d0d9f4f21cbcbf99b68f2f2a130
@@ -81045,7 +82851,6 @@ packages:
   requires_dist:
   - safetensors
   - timm
-  - spaces>=0.43.0
   - tyro>=0.9.1
   requires_python: '>=3.12'
 - pypi: ./packages/simplecv
@@ -82751,6 +84556,13 @@ packages:
   - cuda-toolkit==13.* ; extra == 'all'
   - nvidia-cudla==13.* ; platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'all'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/39/56/684ae3e973f6fbf813714cb875eca1be09876cdfa34806e044f86b3844a1/ultralytics_platform-0.1.5-py3-none-any.whl
+  name: ultralytics-platform
+  version: 0.1.5
+  sha256: 2e1b101b4b7a8a61757005c01101afa8cd535d653ab11f849653e17877bd14d9
+  requires_dist:
+  - httpx>=0.28,<1
+  requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/39/6e/899fed76dc1942b8a64193a4f059d7f1a2c7ef65085e8a9366ed8ec0d199/propcache-0.5.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: propcache
   version: 0.5.2
@@ -83605,6 +85417,24 @@ packages:
   name: pyarrow
   version: 25.0.1
   sha256: 5389cdf79447ed1515c9e31620e6e1e2302249564d603f2ad727d4f6d313e4c3
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/61/91/288c883303be067c1648f1e63ea38e5f8eb5ab7123fd3a9a7366148e58b7/portalocker-4.1.0-py3-none-any.whl
+  name: portalocker
+  version: 4.1.0
+  sha256: d985a430d265adf31adf12bc0bf3501aea59efc495e9104c057e5dfb7394c226
+  requires_dist:
+  - sphinx>=7 ; extra == 'docs'
+  - furo ; extra == 'docs'
+  - redis>=5.0 ; extra == 'redis'
+  - portalocker[redis] ; extra == 'tests'
+  - fakeredis>=2.31.0 ; extra == 'tests'
+  - pytest>=5.4.1 ; extra == 'tests'
+  - pytest-cov>=2.8.1 ; extra == 'tests'
+  - pytest-timeout>=2.1.0 ; extra == 'tests'
+  - pytest-rerunfailures>=15.1 ; extra == 'tests'
+  - coverage-conditional-plugin>=0.9 ; extra == 'tests'
+  - types-pywin32>=310.0.0.20250429 ; extra == 'tests'
+  - pywin32>=226 ; sys_platform == 'win32' and extra == 'win32'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/61/94/5961070353b97647917166b00cccf98773370e65b8716dedd14d99cf14dd/aiobotocore-3.0.0-py3-none-any.whl
   name: aiobotocore
@@ -84938,6 +86768,11 @@ packages:
   - plum-dispatch ; extra == 'dev'
   - toolslm ; extra == 'dev'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/8c/57/80b986ebfecd9c6a177ddf1c2319717f0cd8feffb2b78946595a18a2fc88/orjson-3.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: orjson
+  version: 3.12.0
+  sha256: 1192a7021b6d071aaf909864f6e924d6a2675ca360485b972b8401749311750b
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/8c/aa/7464ea7d4edfaf97e235f4c04389cdc67edbb11a808035168d3b51ee4227/tensorrt_cu13_bindings-11.2.1.2-cp312-none-manylinux_2_35_aarch64.whl
   name: tensorrt-cu13-bindings
   version: 11.2.1.2
@@ -85069,6 +86904,23 @@ packages:
   - wrapt>=1.10.10,<3.0.0
   - httpx>=0.25.1,<0.29 ; extra == 'httpx'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/90/7f/f620a74444c19e82717eecd8bf5508cc9bc2a65cb663cbf450d1373a40d3/fastcore-2.2.13-py3-none-any.whl
+  name: fastcore
+  version: 2.2.13
+  sha256: 3ba463020a19a43a5c3cc88104f78084a3d209fa5e7f4c94e5ae2557609a7dcf
+  requires_dist:
+  - numpy ; extra == 'dev'
+  - nbdev>=3.3.2 ; extra == 'dev'
+  - matplotlib ; extra == 'dev'
+  - pillow ; extra == 'dev'
+  - torch ; extra == 'dev'
+  - pandas ; extra == 'dev'
+  - nbclassic ; extra == 'dev'
+  - pysym2md>=0.0.6 ; extra == 'dev'
+  - llms-txt ; extra == 'dev'
+  - plum-dispatch ; extra == 'dev'
+  - remold ; extra == 'dev'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/90/8f/bdca24a84c81d56fffed052229cdcff368f6e05882e526f4558891481f65/fonttools-4.63.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
   name: fonttools
   version: 4.63.0
@@ -85119,6 +86971,86 @@ packages:
   - ml-dtypes>=0.5.0
   - sympy>=1.13
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/92/71/15074f4c7d4f2960481ffac97a65f8d7697f7bd48aef5c5259d7952f9031/ultralytics-8.4.123-py3-none-any.whl
+  name: ultralytics
+  version: 8.4.123
+  sha256: 07cc6cd099391555537ba459a1af6d00ade9ccd1f54447e54cad58ca9bd8517d
+  requires_dist:
+  - filelock>=3.16.1
+  - numpy>=1.23.0
+  - matplotlib>=3.3.0
+  - opencv-python>=4.7.0,!=4.13.0.90
+  - pillow>=7.1.2
+  - pyyaml>=5.3.1
+  - requests>=2.23.0
+  - torch>=1.8.0
+  - torch>=1.8.0,!=2.4.0 ; sys_platform == 'win32'
+  - torchvision>=0.9.0
+  - psutil>=5.8.0
+  - polars>=0.20.0
+  - nvidia-ml-py>=12.0.0
+  - ultralytics-thop>=2.1.6
+  - ultralytics-platform>=0.1.3 ; python_full_version >= '3.11'
+  - ipython ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  - pytest-cov ; extra == 'dev'
+  - pytest-xdist>=3.0.0 ; extra == 'dev'
+  - coverage[toml] ; extra == 'dev'
+  - zensical>=0.0.53 ; python_full_version >= '3.10' and extra == 'dev'
+  - minijinja>=2.0.0 ; extra == 'dev'
+  - onnx>=1.12.0 ; sys_platform != 'darwin' and extra == 'export-base'
+  - onnx>=1.12.0,<1.18.0 ; python_full_version < '3.13' and sys_platform == 'darwin' and extra == 'export-base'
+  - onnx>=1.20.0 ; python_full_version >= '3.13' and sys_platform == 'darwin' and extra == 'export-base'
+  - onnxslim>=0.1.82 ; extra == 'export-base'
+  - onnxruntime<1.20.0 ; (python_full_version < '3.11' and platform_machine != 'aarch64' and extra == 'export-base') or (python_full_version < '3.11' and sys_platform != 'linux' and extra == 'export-base')
+  - onnxruntime>=1.20.0 ; python_full_version >= '3.11' and extra == 'export-base'
+  - nncf>=2.14.0,<4.0.0 ; python_full_version >= '3.9' and extra == 'export-base'
+  - openvino>=2024.0.0 ; extra == 'export-base'
+  - packaging>=26.0 ; python_full_version >= '3.9' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'export-base'
+  - numpy<2 ; extra == 'export-legacy-torch'
+  - setuptools<81.0.0 ; python_full_version >= '3.9' and extra == 'export-legacy-torch'
+  - nncf<3.0.0 ; python_full_version >= '3.9' and extra == 'export-legacy-torch'
+  - numpy<2.0.0 ; python_full_version < '3.13' and extra == 'export-tensorflow'
+  - tensorflow>=2.0.0,<=2.19.0 ; python_full_version < '3.13' and extra == 'export-tensorflow'
+  - tensorflow>2.19.0 ; python_full_version >= '3.13' and extra == 'export-tensorflow'
+  - ydf<0.13.0 ; python_full_version < '3.13' and platform_machine != 'aarch64' and extra == 'export-tensorflow'
+  - googleapis-common-protos<1.74.0 ; python_full_version < '3.13' and extra == 'export-tensorflow'
+  - tensorstore>=0.1.63 ; python_full_version >= '3.9' and platform_machine == 'aarch64' and extra == 'export-tensorflow'
+  - h5py!=3.11.0 ; platform_machine == 'aarch64' and extra == 'export-tensorflow'
+  - numpy<=2.3.5 ; python_full_version < '3.14' and sys_platform != 'win32' and extra == 'export-coreml'
+  - coremltools>=9.0 ; python_full_version < '3.14' and sys_platform != 'win32' and extra == 'export-coreml'
+  - scikit-learn>=1.3.2 ; python_full_version < '3.14' and sys_platform != 'win32' and extra == 'export-coreml'
+  - executorch ; extra == 'export-executorch'
+  - torch>=2.12.0,<2.13.0 ; platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'export-executorch'
+  - numpy<=2.3.5 ; extra == 'export-executorch'
+  - dx-com ; extra == 'export-deepx'
+  - numpy<2 ; extra == 'export-deepx'
+  - litert-torch>=0.9.0 ; (sys_platform == 'darwin' and extra == 'export-litert') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'export-litert')
+  - ai-edge-litert>=2.1.4 ; (sys_platform == 'darwin' and extra == 'export-litert') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'export-litert')
+  - ai-edge-quantizer>=0.6.0 ; (sys_platform == 'darwin' and extra == 'export-litert') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'export-litert')
+  - ultralytics[export-base] ; extra == 'export'
+  - ultralytics[export-tensorflow] ; extra == 'export'
+  - ultralytics[export-coreml] ; extra == 'export'
+  - ultralytics[export-litert] ; extra == 'export'
+  - torch>=2.12.0,<2.13.0 ; python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'export'
+  - shapely>=2.0.0 ; extra == 'solutions'
+  - lap>=0.5.12 ; extra == 'solutions'
+  - streamlit>=1.51.0 ; python_full_version >= '3.10' and extra == 'solutions'
+  - streamlit>=1.29.0,<1.51.0 ; (python_full_version < '3.10' and platform_machine != 'aarch64' and extra == 'solutions') or (python_full_version < '3.10' and sys_platform != 'linux' and extra == 'solutions')
+  - flask>=3.0.1 ; extra == 'solutions'
+  - openai>=2.0.0 ; extra == 'llm'
+  - wandb ; extra == 'logging'
+  - tensorboard ; extra == 'logging'
+  - mlflow ; extra == 'logging'
+  - ipython ; extra == 'extra'
+  - albumentations>=1.4.6 ; extra == 'extra'
+  - faster-coco-eval>=1.6.7 ; extra == 'extra'
+  - types-pillow ; extra == 'typing'
+  - types-psutil ; extra == 'typing'
+  - types-pyyaml ; extra == 'typing'
+  - types-requests ; extra == 'typing'
+  - types-shapely ; extra == 'typing'
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl
   name: werkzeug
   version: 3.1.8
@@ -85426,6 +87358,15 @@ packages:
   - numpy<2.0 ; python_full_version < '3.9'
   - numpy>=2 ; python_full_version >= '3.9'
   requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/9c/97/f9d463a6f3c7d0955753eca5cbbf35b596ac471dd13fe357211a53fd37be/hydra_core-1.3.5-py3-none-any.whl
+  name: hydra-core
+  version: 1.3.5
+  sha256: a3ff35b4ea6794e4c83d993016f4bde4ac35797ebe7a08f30e83ed9341880331
+  requires_dist:
+  - omegaconf>=2.2,<2.4
+  - antlr4-python3-runtime==4.9.*
+  - importlib-resources ; python_full_version < '3.9'
+  - packaging
 - pypi: https://files.pythonhosted.org/packages/9e/bc/a6653249f6ee59ec85dcfec008d9cbc16586dad613963bb17a91b2b993a5/yarl-1.24.5-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: yarl
   version: 1.24.5
@@ -86435,6 +88376,20 @@ packages:
   version: 1.5.0
   sha256: b2af221f268f5af85e776a73d62b0845fc8baf8ef0abfae79d29c77d0e776aaf
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl
+  name: starlette
+  version: 1.6.0
+  sha256: a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c
+  requires_dist:
+  - anyio>=3.6.2,<5
+  - typing-extensions>=4.10.0 ; python_full_version < '3.13'
+  - httpx2>=2.0.0 ; extra == 'full'
+  - httpx>=0.27.0,<0.29.0 ; extra == 'full'
+  - itsdangerous ; extra == 'full'
+  - jinja2 ; extra == 'full'
+  - python-multipart>=0.0.18 ; extra == 'full'
+  - pyyaml ; extra == 'full'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/c8/e8/d381de4a3cc4e3682cba0338f43250893508aad0b310af1d0635f7b04413/tifffile-2026.7.14-py3-none-any.whl
   name: tifffile
   version: 2026.7.14
@@ -87151,6 +89106,11 @@ packages:
   version: 0.0.32
   sha256: ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/e3/1e/2942a0d6d52240d439f44384a40c65d359d9ca70325b65b265c020113121/cuda_pathfinder-1.6.1-py3-none-any.whl
+  name: cuda-pathfinder
+  version: 1.6.1
+  sha256: cc8ec4cb0881fa5bcbf96b6dd75d50e55352b74dd33d4f3d884e192e7c2b6ef8
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
   name: cycler
   version: 0.12.1
@@ -87343,6 +89303,21 @@ packages:
   version: 1.1.0
   sha256: a3dfcb14d85902d90702db1e9835760237f6a73ec0ae3b7e991ad767513a3cbc
   requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl
+  name: uvicorn
+  version: 0.52.4
+  sha256: f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1
+  requires_dist:
+  - click>=7.0
+  - h11>=0.8
+  - typing-extensions>=4.0 ; python_full_version < '3.11'
+  - httptools>=0.8.0 ; extra == 'standard'
+  - python-dotenv>=0.13 ; extra == 'standard'
+  - pyyaml>=5.1 ; extra == 'standard'
+  - uvloop>=0.15.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32' and extra == 'standard'
+  - watchfiles>=0.20 ; extra == 'standard'
+  - websockets>=13.0 ; extra == 'standard'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl
   name: jaraco-context
   version: 6.1.2

--- a/pixi.toml
+++ b/pixi.toml
@@ -2412,6 +2412,21 @@ depends-on = [
 ]
 description = "Run signal preparation, two-call gsplat training, and fused in-process publication"
 
+# ════════════════════════════════════════════════════════════════════════════
+# pose-app — unified SAM3 + 2D pose Gradio playground
+# ════════════════════════════════════════════════════════════════════════════
+[feature.pose-app]
+platforms = ["linux-64"]
+
+[feature.pose-app.activation.env]
+# This PACKAGE_DIR must win over posekit/mamma's bindings through feature order.
+PACKAGE_DIR = "packages/posekit"
+
+[feature.pose-app.tasks.pose-app]
+cmd = "python tools/apps/gradio_app.py"
+cwd = "packages/posekit"
+description = "Launch the unified SAM3 + 2D pose Gradio playground"
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Environments
 # ═══════════════════════════════════════════════════════════════════════════
@@ -2560,6 +2575,21 @@ trtkit-dev = { features = [
     "trtkit",
     "dev",
 ], solve-group = "trtkit", no-default-feature = true }
+pose-app = { features = [
+    "common",
+    "cuda",
+    "posekit",
+    "mamma",
+    "pose-app",
+], solve-group = "pose-app", no-default-feature = true }
+pose-app-dev = { features = [
+    "common",
+    "cuda",
+    "posekit",
+    "mamma",
+    "pose-app",
+    "dev",
+], solve-group = "pose-app", no-default-feature = true }
 posekit = { features = [
     "common",
     "cuda",


### PR DESCRIPTION
**Stack 4/4** — base: #108 (stack: #106 → #107 → #108 → this)

One app replacing the per-model demos: SAM3 text-prompted detection (default "person"; boxes for top-down nets, instance masks for MammaNet) feeding a **Network** dropdown — rtmpose-m/x (COCO-17), rtmw-x (COCO-133), ViTPose, Sapiens2 0.4b/1b, mamma-dense512 — and a per-network **Backend** dropdown (torch/onnx/tensorrt as each supports; choices update on network change). Top-down nets render their `KeypointSkeleton` links; mamma renders dense landmarks + the approximate skeleton. All TRT engines auto-build via trtkit's cache on first use. Estimator cache bounded to 2 MRU with eviction (model-switching demo ≠ unbounded VRAM).

New `pose-app` pixi env composes `common + cuda + posekit + mamma` (feature carries only the task).

Serve over HTTPS or secure-context APIs break (gradio-rerun's stream channel uses `crypto.randomUUID`; the clipboard-paste button uses `navigator.clipboard.read`): `tailscale serve --bg --https=7860 http://127.0.0.1:7860`.

Every network × backend combo browser-validated with pixel evidence over the tailnet HTTPS origin (incl. multi-person via SAM3 + dynamic-batch TRT).