### PR TITLE
dataforge: contracts (identity, paths, schema, writing, transports)

### DIFF
--- a/packages/dataforge/dataforge/identity.py
+++ b/packages/dataforge/dataforge/identity.py
@@ -1,0 +1,52 @@
+"""Stable sequence identity: one value derives key, recording_id, and filename.
+
+Borrowed from simplecv's exoego ``sequence_identity.py``; dataforge keeps the
+"id = filename = key = segment" rule, so the recording_id doubles as the rrd
+filename stem (see ``dataforge.paths.rrd_path``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+def _normalize_part(value: object) -> tuple[str, ...]:
+    raw: str = str(value).strip().replace("\\", "/")
+    parts: tuple[str, ...] = tuple(part for part in raw.split("/") if part)
+    if any(part in {".", ".."} for part in parts):
+        raise ValueError(f"Invalid sequence identity part: {value!r}")
+    if any("__" in part for part in parts):
+        raise ValueError(f"Sequence identity parts cannot contain '__': {value!r}")
+    return parts
+
+
+@dataclass(frozen=True)
+class SequenceIdentity:
+    """Stable identity for one dataset sequence (= one recording, one base rrd)."""
+
+    dataset: str
+    """Dataset name, a single path part (e.g. ``robocap``)."""
+    parts: tuple[str, ...]
+    """Sequence parts within the dataset (e.g. ``(device, session, segment)``)."""
+
+    def __post_init__(self) -> None:
+        dataset_parts: tuple[str, ...] = _normalize_part(self.dataset)
+        if len(dataset_parts) != 1:
+            raise ValueError(f"Dataset identity must be one path part, got {self.dataset!r}")
+
+        normalized_parts: tuple[str, ...] = tuple(part for value in self.parts for part in _normalize_part(value))
+        if not normalized_parts:
+            raise ValueError("Sequence identity needs at least one part")
+
+        object.__setattr__(self, "dataset", dataset_parts[0])
+        object.__setattr__(self, "parts", normalized_parts)
+
+    @property
+    def sequence_key(self) -> str:
+        """Human-readable identity within the dataset."""
+        return "/".join(self.parts)
+
+    @property
+    def recording_id(self) -> str:
+        """Stable Rerun recording/segment ID; includes dataset to avoid cross-dataset collisions."""
+        return "__".join((self.dataset, *self.parts))

--- a/packages/dataforge/dataforge/paths.py
+++ b/packages/dataforge/dataforge/paths.py
@@ -1,0 +1,30 @@
+"""On-disk layout: layer-major rrd tree plus raw-download tree. Stdlib-only.
+
+Layout (relative to the overridable roots; defaults are package-local because
+pixi tasks run with ``cwd = packages/dataforge``):
+
+    data/raw/<dataset>/...            upstream layout, untouched
+    data/dataforge/rrd/<layer>/<recording_id>.rrd
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from dataforge.identity import SequenceIdentity
+
+
+def output_root() -> Path:
+    """Root of the converted rrd tree; override with ``DATAFORGE_OUTPUT_ROOT``."""
+    return Path(os.environ.get("DATAFORGE_OUTPUT_ROOT", "data/dataforge/rrd"))
+
+
+def raw_root() -> Path:
+    """Root of raw dataset downloads; override with ``DATAFORGE_RAW_ROOT``."""
+    return Path(os.environ.get("DATAFORGE_RAW_ROOT", "data/raw"))
+
+
+def rrd_path(root: Path, *, layer: str, identity: SequenceIdentity) -> Path:
+    """Layer-major rrd location: ``<root>/<layer>/<recording_id>.rrd``."""
+    return root / layer / f"{identity.recording_id}.rrd"

--- a/packages/dataforge/dataforge/schema.py
+++ b/packages/dataforge/dataforge/schema.py
@@ -1,0 +1,65 @@
+"""dataforge:v1 logging schema — the exoego:v2 conventions, as code. Stdlib-only.
+
+The authoritative prose spec is ``packages/simplecv/docs/exoego_schema.md``:
+one ``video_time`` timestamp timeline everywhere, world-anchored rigs at
+``/world/rig_NN``, cameras at ``.../cam_MM/pinhole/video``, and IMUs at the
+(previously reserved) ``.../imu_MM/{gyro,accel}``. dataforge is the first
+emitter of the IMU section.
+"""
+
+from __future__ import annotations
+
+TIMELINE: str = "video_time"
+"""The single timestamp timeline every dataforge stream logs on."""
+
+EXOEGO_SCHEMA_VERSION: str = "exoego:v2"
+"""Value of the ``schema_version`` AnyValue on every rig node."""
+
+DATAFORGE_SCHEMA_VERSION: str = "dataforge:v1"
+"""Value of the ``property:capture:schema`` recording property."""
+
+
+def _index(value: int, kind: str) -> str:
+    if value < 0:
+        raise ValueError(f"{kind} index must be non-negative, got {value}")
+    return f"{value:02d}"
+
+
+def rig_path(rig: int) -> str:
+    """``/world/rig_NN`` — a static exo rig or the moving ego rig."""
+    return f"/world/rig_{_index(rig, 'rig')}"
+
+
+def cam_path(rig: int, cam: int) -> str:
+    """``/world/rig_NN/cam_MM`` — carries the static ``rig_T_cam`` transform."""
+    return f"{rig_path(rig)}/cam_{_index(cam, 'cam')}"
+
+
+def pinhole_path(rig: int, cam: int) -> str:
+    """``.../cam_MM/pinhole`` — the (distorted) pinhole projection node."""
+    return f"{cam_path(rig, cam)}/pinhole"
+
+
+def video_path(rig: int, cam: int) -> str:
+    """``.../pinhole/video`` — the VideoStream entity on ``video_time``."""
+    return f"{pinhole_path(rig, cam)}/video"
+
+
+def imu_path(rig: int, imu: int) -> str:
+    """``/world/rig_NN/imu_MM`` — carries the static ``rig_T_imu`` transform."""
+    return f"{rig_path(rig)}/imu_{_index(imu, 'imu')}"
+
+
+def gyro_path(rig: int, imu: int) -> str:
+    """``.../imu_MM/gyro`` — rad/s Scalars on ``video_time``."""
+    return f"{imu_path(rig, imu)}/gyro"
+
+
+def accel_path(rig: int, imu: int) -> str:
+    """``.../imu_MM/accel`` — m/s^2 Scalars on ``video_time``."""
+    return f"{imu_path(rig, imu)}/accel"
+
+
+def capture_property(name: str) -> str:
+    """``property:capture:<name>`` — recording-level capture metadata key."""
+    return f"property:capture:{name}"

--- a/packages/dataforge/dataforge/transports.py
+++ b/packages/dataforge/dataforge/transports.py
@@ -1,0 +1,31 @@
+"""Download transports. v1 ships ``local_verify``; the fetchers land with HOCap.
+
+Planned surface (from the design report): ``hf_fetch`` (HuggingFace snapshots),
+``http_fetch``, ``gdrive_fetch``, ``api_fetch``, and ``local_verify`` for
+datasets that are already on disk (robocap's download verb is verify-only).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+
+def local_verify(root: Path, *, required: Iterable[str]) -> list[str]:
+    """Return the ``required`` glob patterns (relative to ``root``) with no match."""
+    return [pattern for pattern in required if not any(root.glob(pattern))]
+
+
+def hf_fetch() -> None:
+    """HuggingFace snapshot fetch — lands with the HOCap dataset (next PR)."""
+    raise NotImplementedError("hf_fetch lands with the HOCap dataset")
+
+
+def http_fetch() -> None:
+    """Plain HTTP fetch — not needed by any v1 dataset yet."""
+    raise NotImplementedError("http_fetch is not needed by any v1 dataset")
+
+
+def gdrive_fetch() -> None:
+    """Google Drive fetch — not needed by any v1 dataset yet."""
+    raise NotImplementedError("gdrive_fetch is not needed by any v1 dataset")

--- a/packages/dataforge/dataforge/writing.py
+++ b/packages/dataforge/dataforge/writing.py
@@ -1,0 +1,47 @@
+"""Atomic publication of layer rrds: tmp file → ``os.replace``.
+
+Half-written files poison batch runs and the catalog server, so a target rrd
+either exists complete or not at all ("exists = done"). Never save over an
+rrd that a catalog server has registered — truncation poisons the server;
+re-runs write a fresh tmp and atomically replace, and the catalog re-registers.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import rerun as rr
+import rerun.blueprint as rrb
+
+
+def should_skip(target: Path, *, force: bool) -> bool:
+    """Idempotency check: an existing target is done unless ``--force``."""
+    return target.exists() and not force
+
+
+@contextmanager
+def atomic_recording(
+    target: Path,
+    *,
+    application_id: str,
+    recording_id: str,
+    default_blueprint: rrb.Blueprint | None = None,
+) -> Iterator[rr.RecordingStream]:
+    """Yield a recording saved to a temp file that replaces ``target`` on success."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temp_name = tempfile.mkstemp(dir=target.parent, suffix=".rrd.tmp")
+    os.close(descriptor)
+    temp_path: Path = Path(temp_name)
+    try:
+        with rr.RecordingStream(application_id=application_id, recording_id=recording_id, send_properties=True) as recording:
+            recording.save(temp_path, default_blueprint=default_blueprint)
+            yield recording
+        temp_path.chmod(0o644)  # mkstemp temps are 0600; NFS mounts and the catalog server need world-readable files
+        os.replace(temp_path, target)
+    except BaseException:
+        temp_path.unlink(missing_ok=True)
+        raise

--- a/packages/dataforge/pyproject.toml
+++ b/packages/dataforge/pyproject.toml
@@ -28,6 +28,8 @@ ignore = [
 
 [tool.vulture]
 paths = ["dataforge", "tests"]
+# Contract constant consumed by the robocap converter (next PR in the stack).
+ignore_names = ["DATAFORGE_SCHEMA_VERSION"]
 exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modules/*"]
 sort_by_size = true
 min_confidence = 60

--- a/packages/dataforge/tests/test_identity.py
+++ b/packages/dataforge/tests/test_identity.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import pytest
+
+from dataforge.identity import SequenceIdentity
+from dataforge.paths import rrd_path
+
+
+def test_recording_id_joins_dataset_and_parts() -> None:
+    identity: SequenceIdentity = SequenceIdentity(dataset="robocap", parts=("f408193e6447b3b0", "s1", "seg1"))
+    assert identity.recording_id == "robocap__f408193e6447b3b0__s1__seg1"
+
+
+def test_sequence_key_is_slash_joined() -> None:
+    identity: SequenceIdentity = SequenceIdentity(dataset="hocap", parts=("subject_1", "seq01"))
+    assert identity.sequence_key == "subject_1/seq01"
+
+
+def test_parts_reject_double_underscore() -> None:
+    with pytest.raises(ValueError, match="__"):
+        SequenceIdentity(dataset="robocap", parts=("bad__part",))
+
+
+def test_parts_reject_traversal() -> None:
+    with pytest.raises(ValueError, match="Invalid"):
+        SequenceIdentity(dataset="robocap", parts=("..",))
+
+
+def test_dataset_must_be_single_part() -> None:
+    with pytest.raises(ValueError, match="one path part"):
+        SequenceIdentity(dataset="a/b", parts=("x",))
+
+
+def test_rrd_path_is_layer_major_with_recording_id_filename() -> None:
+    identity: SequenceIdentity = SequenceIdentity(dataset="robocap", parts=("f408193e6447b3b0", "s1", "seg1"))
+    path: Path = rrd_path(Path("/out"), layer="base", identity=identity)
+    assert path == Path("/out/base/robocap__f408193e6447b3b0__s1__seg1.rrd")

--- a/packages/dataforge/tests/test_paths.py
+++ b/packages/dataforge/tests/test_paths.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from dataforge.paths import output_root, raw_root
+
+
+def test_output_root_defaults_to_package_local_data(monkeypatch) -> None:
+    monkeypatch.delenv("DATAFORGE_OUTPUT_ROOT", raising=False)
+    root: Path = output_root()
+    assert root == Path("data/dataforge/rrd")
+
+
+def test_output_root_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("DATAFORGE_OUTPUT_ROOT", "/mnt/nas/datasets/dataforge/rrd")
+    assert output_root() == Path("/mnt/nas/datasets/dataforge/rrd")
+
+
+def test_raw_root_defaults_and_overrides(monkeypatch) -> None:
+    monkeypatch.delenv("DATAFORGE_RAW_ROOT", raising=False)
+    assert raw_root() == Path("data/raw")
+    monkeypatch.setenv("DATAFORGE_RAW_ROOT", "/mnt/nas/datasets")
+    assert raw_root() == Path("/mnt/nas/datasets")

--- a/packages/dataforge/tests/test_schema.py
+++ b/packages/dataforge/tests/test_schema.py
@@ -1,0 +1,39 @@
+import pytest
+
+from dataforge.schema import (
+    EXOEGO_SCHEMA_VERSION,
+    TIMELINE,
+    accel_path,
+    cam_path,
+    capture_property,
+    gyro_path,
+    imu_path,
+    pinhole_path,
+    rig_path,
+    video_path,
+)
+
+
+def test_timeline_and_schema_version_match_exoego_v2() -> None:
+    assert TIMELINE == "video_time"
+    assert EXOEGO_SCHEMA_VERSION == "exoego:v2"
+
+
+def test_entity_paths_are_zero_padded_exoego_v2() -> None:
+    assert rig_path(0) == "/world/rig_00"
+    assert cam_path(0, 3) == "/world/rig_00/cam_03"
+    assert pinhole_path(1, 0) == "/world/rig_01/cam_00/pinhole"
+    assert video_path(1, 0) == "/world/rig_01/cam_00/pinhole/video"
+    assert imu_path(0, 0) == "/world/rig_00/imu_00"
+    assert gyro_path(0, 0) == "/world/rig_00/imu_00/gyro"
+    assert accel_path(0, 0) == "/world/rig_00/imu_00/accel"
+
+
+def test_indices_must_be_nonnegative() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        rig_path(-1)
+
+
+def test_capture_property_keys() -> None:
+    assert capture_property("num_frames") == "property:capture:num_frames"
+    assert capture_property("schema") == "property:capture:schema"

--- a/packages/dataforge/tests/test_transports.py
+++ b/packages/dataforge/tests/test_transports.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import pytest
+
+from dataforge.transports import gdrive_fetch, hf_fetch, http_fetch, local_verify
+
+
+def test_local_verify_reports_missing_globs(tmp_path: Path) -> None:
+    (tmp_path / "sess").mkdir()
+    (tmp_path / "sess" / "video_dev0.mp4").write_bytes(b"x")
+    missing: list[str] = local_verify(tmp_path, required=("sess/video_*.mp4", "sess/IMUWriter_*.db"))
+    assert missing == ["sess/IMUWriter_*.db"]
+
+
+def test_local_verify_ok_when_all_present(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_bytes(b"x")
+    assert local_verify(tmp_path, required=("a.txt",)) == []
+
+
+def test_local_verify_missing_root(tmp_path: Path) -> None:
+    missing: list[str] = local_verify(tmp_path / "nope", required=("a.txt",))
+    assert missing == ["a.txt"]
+
+
+def test_unbuilt_transports_raise() -> None:
+    for fetch in (hf_fetch, http_fetch, gdrive_fetch):
+        with pytest.raises(NotImplementedError):
+            fetch()

--- a/packages/dataforge/tests/test_writing.py
+++ b/packages/dataforge/tests/test_writing.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import pytest
+import rerun as rr
+
+from dataforge.writing import atomic_recording, should_skip
+
+
+def test_should_skip_existing_unless_forced(tmp_path: Path) -> None:
+    target: Path = tmp_path / "base" / "x.rrd"
+    assert not should_skip(target, force=False)
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"done")
+    assert should_skip(target, force=False)
+    assert not should_skip(target, force=True)
+
+
+def test_atomic_recording_publishes_only_on_success(tmp_path: Path) -> None:
+    target: Path = tmp_path / "robocap__a__b.rrd"
+    with atomic_recording(target, application_id="dataforge", recording_id="robocap__a__b") as recording:
+        recording.log("/world", rr.Points3D([[0.0, 0.0, 0.0]]), static=True)
+    assert target.exists()
+    assert target.stat().st_size > 0
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_atomic_recording_leaves_no_target_or_tmp_on_failure(tmp_path: Path) -> None:
+    target: Path = tmp_path / "robocap__a__c.rrd"
+    with pytest.raises(RuntimeError, match="boom"), atomic_recording(target, application_id="dataforge", recording_id="robocap__a__c"):
+        raise RuntimeError("boom")
+    assert not target.exists()
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_atomic_recording_creates_parent_dirs(tmp_path: Path) -> None:
+    target: Path = tmp_path / "rrd" / "base" / "robocap__a__d.rrd"
+    with atomic_recording(target, application_id="dataforge", recording_id="robocap__a__d") as recording:
+        recording.log("/world", rr.Points3D([[0.0, 0.0, 0.0]]), static=True)
+    assert target.exists()


### PR DESCRIPTION
First step of the dataforge work plan (design report in packages/dataforge/docs): the stdlib-only contracts, unit-tested without data.

- **identity.py** — `SequenceIdentity` (borrowed from simplecv's exoego `sequence_identity.py`): one value derives `sequence_key`, `recording_id`, and — per the "id = filename = key = segment" rule — the rrd filename stem.
- **paths.py** — layer-major on-disk layout `data/dataforge/rrd/<layer>/<recording_id>.rrd`, raw tree `data/raw/<dataset>/…`; roots overridable via `DATAFORGE_OUTPUT_ROOT` / `DATAFORGE_RAW_ROOT` (defaults package-local; batch runs point them at the NAS).
- **schema.py** — the exoego:v2 conventions as code: `video_time` timeline, `/world/rig_NN/cam_MM/pinhole/video`, the (until now reserved) `/world/rig_NN/imu_MM/{gyro,accel}`, `property:capture:*` keys.
- **writing.py** — atomic tmp → `os.replace` rrd publication (pattern from arkitscenes-download), `should_skip` (exists = done, `--force`).
- **transports.py** — `local_verify` (robocap's download is verify-only) plus typed `NotImplementedError` stubs for `hf_fetch`/`http_fetch`/`gdrive_fetch` (land with HOCap).

All dev gates green: `pixi run -e dataforge-dev {tests,lint,typecheck,deadcode}` (22 tests).

Next PR in the stack: the robocap end-to-end slice (convert one segment: 6-cam video + Kalibr fisheye62 calib + dev0 IMU from the SQLite `.db`, register + view).