### PR TITLE
dataforge: robocap end-to-end slice (download/convert/register/view)

### DIFF
--- a/packages/dataforge/dataforge/apis/__init__.py
+++ b/packages/dataforge/dataforge/apis/__init__.py
@@ -1,0 +1,1 @@
+"""Verb entry points: download, convert, register, view (one module each)."""

--- a/packages/dataforge/dataforge/apis/convert.py
+++ b/packages/dataforge/dataforge/apis/convert.py
@@ -1,0 +1,46 @@
+"""``dataforge-convert``: write the base-layer rrd for one or every sequence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from dataforge.datasets import AnnotatedDatasetUnion, RobocapConfig
+from dataforge.datasets.base import DataforgeDataset, DataforgeDatasetConfig
+from dataforge.identity import SequenceIdentity
+
+
+@dataclass
+class Config:
+    """Convert discovered sequences into base-layer recordings."""
+
+    dataset: AnnotatedDatasetUnion = field(default_factory=RobocapConfig)
+    """Dataset to convert; the raw-tree location lives on the dataset config."""
+    sequence: str | None = None
+    """Convert only this sequence (its ``sequence_key``, ``recording_id``, or any part)."""
+    force: bool = False
+    """Rewrite recordings that already exist instead of skipping them."""
+
+
+def select(identities: list[SequenceIdentity], sequence: str | None) -> list[SequenceIdentity]:
+    """Filter discovered identities by key, recording id, or a single part."""
+    if sequence is None:
+        return identities
+    matches: list[SequenceIdentity] = [
+        identity for identity in identities if sequence in (identity.sequence_key, identity.recording_id) or sequence in identity.parts
+    ]
+    if not matches:
+        raise ValueError(f"No sequence matches {sequence!r} among {len(identities)} discovered sequences")
+    return matches
+
+
+def main(config: Config) -> None:
+    """Convert every selected sequence serially."""
+    dataset_config: DataforgeDatasetConfig = config.dataset
+    dataset: DataforgeDataset = dataset_config.setup()
+    selected: list[SequenceIdentity] = select(dataset.sequences(), config.sequence)
+    print(f"converting {len(selected)} sequence(s)")
+    for identity in selected:
+        target: Path = dataset.convert(identity, force=config.force)
+        if not target.is_file():
+            raise RuntimeError(f"convert produced no recording for {identity.sequence_key}")

--- a/packages/dataforge/dataforge/apis/download.py
+++ b/packages/dataforge/dataforge/apis/download.py
@@ -1,0 +1,22 @@
+"""``dataforge-download``: fetch (or, for local corpora, verify) a dataset's raw tree."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from dataforge.datasets import AnnotatedDatasetUnion, RobocapConfig
+from dataforge.datasets.base import DataforgeDatasetConfig
+
+
+@dataclass
+class Config:
+    """Download/verify one dataset's raw corpus."""
+
+    dataset: AnnotatedDatasetUnion = field(default_factory=RobocapConfig)
+    """Dataset to download; the raw-tree location lives on the dataset config."""
+
+
+def main(config: Config) -> None:
+    """Run the dataset's download verb."""
+    dataset_config: DataforgeDatasetConfig = config.dataset
+    dataset_config.setup().download()

--- a/packages/dataforge/dataforge/apis/register.py
+++ b/packages/dataforge/dataforge/apis/register.py
@@ -1,0 +1,52 @@
+"""``dataforge-register``: register base-layer rrds into a local Rerun catalog."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import rerun.blueprint as rrb
+from rerun.catalog import CatalogClient, DatasetEntry, OnDuplicateSegmentLayer
+
+from dataforge import paths
+from dataforge.datasets import AnnotatedDatasetUnion, RobocapConfig, dataset_key
+from dataforge.datasets.base import DataforgeDatasetConfig
+
+LAYER: str = "base"
+"""Only layer dataforge v1 emits."""
+
+
+@dataclass
+class Config:
+    """Register a dataset's converted recordings into a catalog."""
+
+    dataset: AnnotatedDatasetUnion = field(default_factory=RobocapConfig)
+    """Dataset whose rrds get registered; its registry key is the catalog dataset name."""
+    catalog_url: str = "rerun+http://127.0.0.1:51235"
+    """gRPC URL of a locally running ``rerun server`` catalog."""
+
+
+def main(config: Config) -> None:
+    """Create the dataset if needed and register every base-layer rrd (idempotent)."""
+    dataset_config: DataforgeDatasetConfig = config.dataset
+    name: str = dataset_key(dataset_config)
+    rrd_paths: list[Path] = sorted((paths.output_root() / LAYER).glob(f"{name}__*.rrd"))
+    if not rrd_paths:
+        raise FileNotFoundError(f"no {LAYER}-layer rrds for {name} under {paths.output_root() / LAYER}")
+
+    client: CatalogClient = CatalogClient(config.catalog_url)
+    dataset: DatasetEntry = client.create_dataset(name, exist_ok=True)
+    dataset.register(
+        [path.resolve().as_uri() for path in rrd_paths],
+        layer_name=LAYER,
+        on_duplicate=OnDuplicateSegmentLayer.SKIP,
+    ).wait()
+
+    blueprint: rrb.Blueprint | None = dataset_config.setup().default_blueprint()
+    if blueprint is not None:
+        blueprint_path: Path = paths.output_root() / "blueprints" / f"{name}.rbl"
+        blueprint_path.parent.mkdir(parents=True, exist_ok=True)
+        blueprint.save(name, str(blueprint_path))
+        blueprint_path.chmod(0o644)  # uid-squashing NFS mounts can land fresh writes as mode 0000
+        dataset.register_blueprint(blueprint_path.resolve().as_uri(), set_default=True)
+    print(f"registered {len(rrd_paths)} {LAYER}-layer rrds into '{name}' at {config.catalog_url}")

--- a/packages/dataforge/dataforge/apis/view.py
+++ b/packages/dataforge/dataforge/apis/view.py
@@ -1,0 +1,43 @@
+"""``dataforge-view``: open one converted recording (and its embedded blueprint)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import rerun as rr
+from simplecv.rerun_log_utils import RerunTyroConfig
+
+from dataforge import paths
+from dataforge.datasets import AnnotatedDatasetUnion, RobocapConfig, dataset_key
+from dataforge.datasets.base import DataforgeDatasetConfig
+
+LAYER: str = "base"
+"""Layer whose recordings the viewer loads."""
+
+
+@dataclass
+class Config:
+    """View one converted base-layer recording."""
+
+    rr_config: RerunTyroConfig = field(default_factory=RerunTyroConfig)
+    """Viewer/save/connect behaviour; pass ``--rr-config.headless`` without a display."""
+    dataset: AnnotatedDatasetUnion = field(default_factory=RobocapConfig)
+    """Dataset to view; its registry key prefixes the recording filenames."""
+    sequence: str | None = None
+    """Recording id or sequence key to open; defaults to the first one found."""
+
+
+def main(config: Config) -> None:
+    """Load the selected rrd into the recording stream configured by ``rr_config``."""
+    dataset_config: DataforgeDatasetConfig = config.dataset
+    name: str = dataset_key(dataset_config)
+    candidates: list[Path] = sorted((paths.output_root() / LAYER).glob(f"{name}__*.rrd"))
+    if config.sequence is not None:
+        wanted: str = config.sequence.replace("/", "__")
+        candidates = [path for path in candidates if wanted in path.stem]
+    if not candidates:
+        raise FileNotFoundError(f"no {LAYER}-layer rrd for {name} (sequence={config.sequence}) under {paths.output_root() / LAYER}")
+    rrd_path: Path = candidates[0]
+    print(f"viewing {rrd_path}")
+    rr.log_file_from_path(rrd_path)

--- a/packages/dataforge/dataforge/datasets/__init__.py
+++ b/packages/dataforge/dataforge/datasets/__init__.py
@@ -1,0 +1,42 @@
+"""Dataset registry: the keys become tyro subcommands on every dataforge verb."""
+
+from __future__ import annotations
+
+import tyro
+
+from dataforge.datasets.base import DataforgeDatasetConfig
+from dataforge.datasets.robocap import RobocapConfig
+
+dataset_defaults: dict[str, DataforgeDatasetConfig] = {
+    "robocap": RobocapConfig(),
+}
+"""Every dataset dataforge knows about, keyed by its CLI name."""
+
+
+def _build_dataset_union() -> type[DataforgeDatasetConfig]:
+    """Build the tyro subcommand union, tolerating a single-entry registry.
+
+    ``subcommand_type_from_defaults`` asserts ``len(defaults) >= 2`` in tyro
+    0.9.x (same workaround as ``robocap_slam.configs.track_dataset_configs``),
+    so with one dataset we hand tyro the concrete config type instead — no
+    placeholder subcommand shows up in ``--help``.
+    """
+    if len(dataset_defaults) >= 2:
+        return tyro.extras.subcommand_type_from_defaults(dataset_defaults, prefix_names=False)
+    only_default: DataforgeDatasetConfig = next(iter(dataset_defaults.values()))
+    return type(only_default)
+
+
+DatasetUnion: type[DataforgeDatasetConfig] = _build_dataset_union()
+"""Config type every verb's ``Config.dataset`` field uses."""
+
+AnnotatedDatasetUnion = tyro.conf.OmitSubcommandPrefixes[DatasetUnion]
+"""``DatasetUnion`` without tyro's per-subcommand flag prefixes."""
+
+
+def dataset_key(config: DataforgeDatasetConfig) -> str:
+    """Registry key of a parsed dataset config (the catalog dataset name)."""
+    for key, default in dataset_defaults.items():
+        if isinstance(config, type(default)):
+            return key
+    raise ValueError(f"Config {type(config).__name__} is not in dataset_defaults")

--- a/packages/dataforge/dataforge/datasets/base.py
+++ b/packages/dataforge/dataforge/datasets/base.py
@@ -1,0 +1,64 @@
+"""Dataset plugin surface: one config dataclass + one dataset class per dataset.
+
+The config/``setup()`` split is simplecv's ``InstantiateConfig`` idiom (see
+``simplecv/configs/base_config.py``): tyro parses the config, ``setup()``
+instantiates the dataset that owns the ``download`` / ``sequences`` /
+``convert`` verbs. dataforge keeps its own copy of the idiom so the dataset
+surface does not inherit simplecv's sequence-loader machinery.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Generic, TypeVar
+
+import rerun.blueprint as rrb
+
+from dataforge.identity import SequenceIdentity
+
+
+@dataclass
+class DataforgeDatasetConfig:
+    """Base config for a dataforge dataset; ``setup()`` builds the dataset."""
+
+    _target: type
+    """Dataset class instantiated by ``setup()``."""
+
+    def setup(self) -> DataforgeDataset[DataforgeDatasetConfig]:
+        """Instantiate the dataset this config describes."""
+        dataset: DataforgeDataset[DataforgeDatasetConfig] = self._target(self)
+        return dataset
+
+
+ConfigT = TypeVar("ConfigT", bound=DataforgeDatasetConfig)
+"""Config type a concrete dataset is parameterized by (simplecv's sequence-loader idiom)."""
+
+
+class DataforgeDataset(Generic[ConfigT], ABC):
+    """A dataset dataforge can download, enumerate, and convert to base-layer rrds."""
+
+    def __init__(self, config: ConfigT) -> None:
+        self.config: ConfigT = config
+
+    @abstractmethod
+    def download(self) -> None:
+        """Fetch (or verify) the raw corpus this dataset converts from."""
+
+    @abstractmethod
+    def sequences(self) -> list[SequenceIdentity]:
+        """Enumerate every convertible sequence found on disk."""
+
+    @abstractmethod
+    def convert(self, identity: SequenceIdentity, *, force: bool) -> Path:
+        """Write the base-layer rrd for one sequence and return its path."""
+
+    def default_blueprint(self) -> rrb.Blueprint | None:
+        """Dataset-wide default blueprint, registered on the catalog dataset.
+
+        Per-recording blueprints are embedded at convert; this is the "dataset
+        default at register" half of the design. ``None`` means the dataset has
+        no sensible corpus-wide layout.
+        """
+        return None

--- a/packages/dataforge/dataforge/datasets/robocap.py
+++ b/packages/dataforge/dataforge/datasets/robocap.py
@@ -1,0 +1,403 @@
+"""RoboCap: 6-camera + 3-IMU capture rig → one exoego:v2 base-layer rrd per segment.
+
+Raw layout on disk (already local; ``download`` only verifies it):
+
+    <root>/0factory-calibration-<device>/imus_cam_*_extrinsic/*-camchain-imucam.yaml
+    <root>/<device>_session_<S>/video_dev<D>_session<S>_segment<G>_<camname>.mp4
+    <root>/<device>_session_<S>/IMUWriter_dev<0|1|2>_session<S>_segment<G>.db
+
+Clocks. Both sensors share one nanosecond device clock, offset by a fixed
+constant: basalt's RoboCap loader (``src/io/dataset_io_robocap.cpp``) *adds*
+``kCameraToImuOffsetNs`` to camera timestamps to land on the IMU clock. We pick
+the **raw camera clock** for ``video_time`` — video times are
+``comment_us * 1000 + pts_ns`` (the MP4 format-level ``comment`` tag is an
+absolute epoch in microseconds), and IMU sample times are therefore
+``t_imu_ns - CAMERA_TO_IMU_OFFSET_NS``. Nothing is resampled: raw samples land
+at their native rate.
+
+Calibration comes from simplecv's RoboCap ego loader; the private helpers are
+imported deliberately (the donor is scheduled for deletion once the dataset
+lives here).
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import av
+import numpy as np
+import pyarrow as pa
+import rerun as rr
+import rerun.blueprint as rrb
+from beartype.roar import BeartypeException
+from jaxtyping import Float64, Int64
+from numpy import ndarray
+from simplecv.camera_parameters import Fisheye62Parameters
+from simplecv.data.ego.robocap_ego import (
+    CAM_TO_CALIB_INFO,
+    CAMERA_DISPLAY_ORDER,
+    VIDEO_SUFFIX_TO_CAM_NAME,
+    KalibrCamWithExtrinsic,
+    _kalibr_cam_to_fisheye62,
+    _load_kalibr_camchain_imucam,
+)
+from simplecv.rerun_log_utils import log_pinhole
+
+from dataforge import paths, schema, transports, writing
+from dataforge.datasets.base import DataforgeDataset, DataforgeDatasetConfig
+from dataforge.identity import SequenceIdentity
+
+GYRO_SCALE: float = 0.000266316
+"""Raw gyro LSB → rad/s; measured in the basalt fork (``dataset_io_robocap.cpp``)."""
+ACCEL_SCALE: float = 0.001197101
+"""Raw accel LSB → m/s^2; measured in the basalt fork (``dataset_io_robocap.cpp``)."""
+CAMERA_TO_IMU_OFFSET_NS: int = 14_902_432
+"""basalt's ``kCameraToImuOffsetNs``: camera_ns + offset = imu_ns, so imu_ns - offset = camera_ns."""
+IMAGE_PLANE_DISTANCE: float = 0.025
+"""Frustum length in metres, matching ``RobocapEgoSequence.image_plane_distance``."""
+RIG: int = 0
+"""RoboCap is one rig; the whole device is ``rig_00``."""
+IMU_DEVICE: int = 0
+"""v1 logs the middle IMU (``dev0``) only. TODO(dataforge): also emit dev1/dev2."""
+SESSION_DIR_RE: re.Pattern[str] = re.compile(r"^(?P<device>[0-9a-f]+)_session_(?P<session>\d+)$")
+"""Session directory names; the ``-old`` duplicates deliberately do not match."""
+IDENTITY_TRANSFORM: rr.Transform3D = rr.Transform3D(translation=[0.0, 0.0, 0.0], mat3x3=np.eye(3, dtype=np.float32))
+"""Explicit identity pose; an argument-less ``Transform3D`` logs no components at all."""
+VIDEO_NAME_RE: re.Pattern[str] = re.compile(r"^video_dev(?P<device>\d+)_session(?P<session>\d+)_segment(?P<segment>\d+)_(?P<camname>[a-z-]+)$")
+"""Per-camera MP4 stem, e.g. ``video_dev0_session1_segment1_right-eye``."""
+
+
+@dataclass(frozen=True, slots=True)
+class ImuSamples:
+    """One raw IMU channel (gyro or accel) at its native sample rate."""
+
+    times_ns: Int64[ndarray, "n_samples"]
+    """Sample times on the ``video_time`` camera clock, in nanoseconds."""
+    values_xyz: Float64[ndarray, "n_samples 3"]
+    """Scaled samples (rad/s for gyro, m/s^2 for accel)."""
+
+
+@dataclass
+class RobocapConfig(DataforgeDatasetConfig):
+    """RoboCap capture-rig recordings (6 fisheye cameras, 3 IMUs, no labels)."""
+
+    _target: type = field(default_factory=lambda: RobocapDataset)
+    """Dataset class instantiated by ``setup()``."""
+    root: Path = Path("/mnt/nas/datasets/robocap")
+    """Corpus root holding ``<device>_session_<N>/`` and the factory calibration."""
+
+
+def read_imu_channel(database: sqlite3.Connection, table: str, scale: float) -> ImuSamples:
+    """Read one raw IMU table and map it onto the camera clock.
+
+    Args:
+        database: Read-only connection to an ``IMUWriter_dev*.db``.
+        table: ``gyro_data`` or ``acc_data``; columns are ``(id, imuid_, x, y, z, timestamp)``.
+        scale: LSB scale factor (``GYRO_SCALE`` or ``ACCEL_SCALE``).
+
+    Returns:
+        The channel's samples, sorted by time, on the ``video_time`` clock.
+    """
+    rows: list[tuple[int, int, int, int]] = database.execute(f"SELECT x, y, z, timestamp FROM {table} ORDER BY timestamp").fetchall()
+    if not rows:
+        return ImuSamples(times_ns=np.zeros(0, dtype=np.int64), values_xyz=np.zeros((0, 3), dtype=np.float64))
+    raw: Int64[ndarray, "n_samples 4"] = np.asarray(rows, dtype=np.int64)
+    times_ns: Int64[ndarray, "n_samples"] = raw[:, 3] - CAMERA_TO_IMU_OFFSET_NS
+    values_xyz: Float64[ndarray, "n_samples 3"] = raw[:, :3].astype(np.float64) * scale
+    return ImuSamples(times_ns=times_ns, values_xyz=values_xyz)
+
+
+def read_imu_database(db_path: Path) -> tuple[ImuSamples, ImuSamples] | None:
+    """Read ``(gyro, accel)`` from one IMU db, or ``None`` when the file is unusable.
+
+    Some segments ship a malformed db (session_1's ``dev2``), which must not
+    abort a conversion — the stream is simply absent from the recording.
+
+    Args:
+        db_path: Path to an ``IMUWriter_dev<N>_session<S>_segment<G>.db``.
+
+    Returns:
+        The gyro and accel channels, or ``None`` if SQLite refused the file.
+    """
+    try:
+        with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as database:
+            gyro: ImuSamples = read_imu_channel(database, "gyro_data", GYRO_SCALE)
+            accel: ImuSamples = read_imu_channel(database, "acc_data", ACCEL_SCALE)
+    except BeartypeException:
+        raise
+    except sqlite3.DatabaseError as error:
+        print(f"  warning: skipping IMU {db_path.name}: {error}")
+        return None
+    return gyro, accel
+
+
+def video_epoch_ns(video_path: Path) -> int:
+    """Absolute start time of an MP4 from its format-level ``comment`` tag.
+
+    RoboCap writes the capture epoch in microseconds into the container
+    ``comment`` metadata; sample PTS are offsets from it.
+
+    Args:
+        video_path: Path to a RoboCap MP4.
+
+    Returns:
+        The capture epoch in nanoseconds on the camera clock.
+    """
+    with av.open(str(video_path)) as container:
+        comment: str | None = container.metadata.get("comment")
+        if comment is None:
+            comment = next((stream.metadata.get("comment") for stream in container.streams.video if stream.metadata.get("comment")), None)
+    if comment is None:
+        raise ValueError(f"Missing absolute timestamp comment metadata in {video_path}")
+    return int(comment) * 1_000
+
+
+def build_blueprint(camera_names: list[str]) -> rrb.Blueprint:
+    """Default layout: 3D rig + a grid of camera panes over gyro/accel plots.
+
+    Mirrors basalt's ``basalt_vio_blueprint.py`` layout, on exoego:v2 paths.
+
+    Args:
+        camera_names: Human camera labels in ``cam_00..cam_NN`` order.
+
+    Returns:
+        The blueprint embedded in every RoboCap base-layer rrd.
+    """
+    camera_views: list[rrb.Spatial2DView] = [
+        rrb.Spatial2DView(name=name, origin=schema.pinhole_path(RIG, index), contents=f"{schema.pinhole_path(RIG, index)}/**")
+        for index, name in enumerate(camera_names)
+    ]
+    # TODO(dataforge): once dev1/dev2 are emitted, fan the plots out to one pane pair per IMU.
+    return rrb.Blueprint(
+        rrb.Vertical(
+            rrb.Horizontal(
+                rrb.Spatial3DView(name="Rig", origin="/", line_grid=True),
+                rrb.Grid(*camera_views, grid_columns=3, name="Synchronized cameras"),
+            ),
+            rrb.Horizontal(
+                rrb.TimeSeriesView(
+                    name="Gyroscope",
+                    origin=schema.imu_path(RIG, IMU_DEVICE),
+                    contents=schema.gyro_path(RIG, IMU_DEVICE),
+                    plot_legend=rrb.PlotLegend(visible=True),
+                ),
+                rrb.TimeSeriesView(
+                    name="Accelerometer",
+                    origin=schema.imu_path(RIG, IMU_DEVICE),
+                    contents=schema.accel_path(RIG, IMU_DEVICE),
+                    plot_legend=rrb.PlotLegend(visible=True),
+                ),
+            ),
+            row_shares=[3, 1],
+        ),
+        collapse_panels=True,
+    )
+
+
+class RobocapDataset(DataforgeDataset[RobocapConfig]):
+    """Converts RoboCap segments into exoego:v2 base-layer recordings."""
+
+    def default_blueprint(self) -> rrb.Blueprint:
+        """Corpus-wide layout: every RoboCap rig has the same six cameras."""
+        return build_blueprint(list(CAMERA_DISPLAY_ORDER))
+
+    # ── raw-tree discovery ────────────────────────────────────────────────
+    def session_dirs(self) -> list[Path]:
+        """Every ``<device>_session_<N>`` directory, ``-old`` duplicates excluded."""
+        return sorted(path for path in self.config.root.glob("*_session_*") if path.is_dir() and SESSION_DIR_RE.match(path.name))
+
+    def download(self) -> None:
+        """Verify the local corpus; RoboCap has no upstream fetch."""
+        missing: list[str] = transports.local_verify(self.config.root, required=["*_session_*", "0factory-calibration-*"])
+        if missing:
+            raise FileNotFoundError(f"RoboCap corpus at {self.config.root} is missing: {', '.join(missing)}")
+        sessions: list[Path] = self.session_dirs()
+        print(f"robocap: {self.config.root} — {len(sessions)} sessions, {len(self.sequences())} segments, calibration present")
+
+    def sequences(self) -> list[SequenceIdentity]:
+        """Discover every ``(device, session, segment)`` triple on disk."""
+        triples: set[tuple[str, int, int]] = set()
+        for session_dir in self.session_dirs():
+            match: re.Match[str] | None = SESSION_DIR_RE.match(session_dir.name)
+            if match is None:
+                continue
+            device: str = match["device"]
+            session: int = int(match["session"])
+            for video_path in session_dir.glob(f"video_dev*_session{session}_segment*_*.mp4"):
+                video_match: re.Match[str] | None = VIDEO_NAME_RE.match(video_path.stem)
+                if video_match is not None:
+                    triples.add((device, session, int(video_match["segment"])))
+        return [
+            SequenceIdentity(dataset="robocap", parts=(device, f"s{session}", f"seg{segment}")) for device, session, segment in sorted(triples)
+        ]
+
+    def _locate(self, identity: SequenceIdentity) -> tuple[Path, str, int, int]:
+        """Resolve an identity back to ``(session_dir, device, session, segment)``."""
+        if len(identity.parts) != 3:
+            raise ValueError(f"RoboCap identities have three parts, got {identity.sequence_key!r}")
+        device: str = identity.parts[0]
+        session: int = int(identity.parts[1].removeprefix("s"))
+        segment: int = int(identity.parts[2].removeprefix("seg"))
+        session_dir: Path = self.config.root / f"{device}_session_{session}"
+        if not session_dir.is_dir():
+            raise FileNotFoundError(f"Session directory not found: {session_dir}")
+        return session_dir, device, session, segment
+
+    def _videos(self, session_dir: Path, session: int, segment: int) -> dict[str, Path]:
+        """Map canonical camera name → MP4 path, ordered by ``CAMERA_DISPLAY_ORDER``."""
+        by_name: dict[str, Path] = {}
+        for video_path in session_dir.glob(f"video_dev*_session{session}_segment{segment}_*.mp4"):
+            match: re.Match[str] | None = VIDEO_NAME_RE.match(video_path.stem)
+            if match is None:
+                continue
+            cam_name: str | None = VIDEO_SUFFIX_TO_CAM_NAME.get(match["camname"])
+            if cam_name is not None:
+                by_name[cam_name] = video_path
+        return {name: by_name[name] for name in CAMERA_DISPLAY_ORDER if name in by_name}
+
+    def _calibration(self, device: str) -> dict[str, Fisheye62Parameters]:
+        """Load the factory Kalibr calibration, keyed by canonical camera name."""
+        calib_dir: Path = self.config.root / f"0factory-calibration-{device}"
+        if not calib_dir.is_dir():
+            raise FileNotFoundError(f"Calibration directory not found: {calib_dir}")
+        cameras: dict[str, Fisheye62Parameters] = {}
+        for cam_name, (calib_folder, cam_index) in CAM_TO_CALIB_INFO.items():
+            imucam_files: list[Path] = sorted((calib_dir / calib_folder).glob("*-camchain-imucam.yaml"))
+            if not imucam_files:
+                continue
+            cam_dict: dict[str, KalibrCamWithExtrinsic] = _load_kalibr_camchain_imucam(imucam_files[0])
+            cam_data: KalibrCamWithExtrinsic | None = cam_dict.get(f"cam{cam_index}")
+            if cam_data is not None:
+                cameras[cam_name] = _kalibr_cam_to_fisheye62(cam_data, name=cam_name)
+        return cameras
+
+    # ── conversion ────────────────────────────────────────────────────────
+    def convert(self, identity: SequenceIdentity, *, force: bool) -> Path:
+        """Write one segment's base-layer rrd (cameras + video + dev0 IMU)."""
+        target: Path = paths.rrd_path(paths.output_root(), layer="base", identity=identity)
+        if writing.should_skip(target, force=force):
+            print(f"skip {identity.sequence_key} → {target}")
+            return target
+
+        session_dir, device, session, segment = self._locate(identity)
+        videos: dict[str, Path] = self._videos(session_dir, session, segment)
+        if not videos:
+            raise FileNotFoundError(f"No videos for {identity.sequence_key} in {session_dir}")
+        cameras: dict[str, Fisheye62Parameters] = self._calibration(device)
+        camera_names: list[str] = [name for name in videos if name in cameras]
+        if not camera_names:
+            raise FileNotFoundError(f"No calibrated cameras for {identity.sequence_key}")
+
+        with writing.atomic_recording(
+            target,
+            application_id="dataforge",
+            recording_id=identity.recording_id,
+            default_blueprint=build_blueprint(camera_names),
+        ) as recording:
+            rr.log("/", rr.ViewCoordinates.RDF, static=True, recording=recording)
+            # simplecv's RoboCap loader treats the dev0 IMU frame as world, so world_T_rig is
+            # identity and static for v1. TODO(dataforge): log the VIO trajectory as a temporal
+            # world_T_rig once a pose layer exists.
+            rr.log(schema.rig_path(RIG), IDENTITY_TRANSFORM, static=True, recording=recording)
+            rr.log(
+                schema.rig_path(RIG),
+                rr.AnyValues(schema_version=schema.EXOEGO_SCHEMA_VERSION, reference="cam_00", num_cameras=len(camera_names)),
+                static=True,
+                recording=recording,
+            )
+
+            num_frames: int = 0
+            for index, cam_name in enumerate(camera_names):
+                rr.log(
+                    schema.cam_path(RIG, index),
+                    rr.AnyValues(name=cam_name, kind="grayscale"),
+                    static=True,
+                    recording=recording,
+                )
+                log_pinhole(
+                    cameras[cam_name],
+                    cam_log_path=Path(schema.cam_path(RIG, index)),
+                    image_plane_distance=IMAGE_PLANE_DISTANCE,
+                    static=True,
+                    recording=recording,
+                )
+                num_frames = max(num_frames, self._log_video(recording, videos[cam_name], schema.video_path(RIG, index)))
+
+            self._log_imu(recording, session_dir, session, segment)
+
+            recording.send_recording_name(identity.recording_id)
+            recording.send_property(
+                "capture",
+                rr.AnyValues(schema=schema.DATAFORGE_SCHEMA_VERSION, num_frames=num_frames, num_cameras=len(camera_names)),
+            )
+            recording.send_property("convert", rr.AnyValues(version="1"))
+
+        print(f"done {identity.sequence_key} → {target} ({len(camera_names)} cameras, {num_frames} frames)")
+        return target
+
+    def _log_video(self, recording: rr.RecordingStream, video_path: Path, entity_path: str) -> int:
+        """Remux one MP4 as a ``VideoStream``, retimed onto the camera clock.
+
+        ``Mp4Reader`` emits chunk timestamps as raw PTS (nanoseconds from the
+        start of the file), so every indexed chunk is shifted by the file's
+        absolute epoch before it reaches the recording.
+
+        Args:
+            recording: Destination recording stream.
+            video_path: RoboCap MP4 to remux (no decode, no re-encode).
+            entity_path: ``.../pinhole/video`` entity to log under.
+
+        Returns:
+            Number of video samples written.
+        """
+        epoch_ns: int = video_epoch_ns(video_path)
+        sample_count: int = 0
+
+        def retime(chunk: rr.experimental.Chunk) -> list[rr.experimental.Chunk]:
+            nonlocal sample_count
+            if schema.TIMELINE not in chunk.timeline_names:
+                return [chunk]  # the static codec chunk carries no index
+            record_batch: pa.RecordBatch = chunk.to_record_batch()
+            index: int = record_batch.schema.get_field_index(schema.TIMELINE)
+            shifted: pa.Array = pa.array(np.asarray(record_batch.column(index).cast(pa.int64())) + epoch_ns, type=pa.duration("ns"))
+            sample_count += record_batch.num_rows
+            retimed: pa.RecordBatch = record_batch.set_column(index, record_batch.schema.field(index), shifted)
+            return rr.experimental.Chunk.from_record_batch(retimed, index=schema.TIMELINE, entity_path=chunk.entity_path)
+
+        reader: rr.experimental.Mp4Reader = rr.experimental.Mp4Reader(
+            video_path,
+            mode="stream",
+            entity_path=entity_path,
+            timeline_name=schema.TIMELINE,
+        )
+        recording.send_chunks(reader.stream().flat_map(retime))
+        return sample_count
+
+    def _log_imu(self, recording: rr.RecordingStream, session_dir: Path, session: int, segment: int) -> None:
+        """Log the dev0 IMU's raw gyro/accel samples columnar on ``video_time``."""
+        db_path: Path = session_dir / f"IMUWriter_dev{IMU_DEVICE}_session{session}_segment{segment}.db"
+        if not db_path.is_file():
+            print(f"  warning: no IMU database at {db_path}")
+            return
+        channels: tuple[ImuSamples, ImuSamples] | None = read_imu_database(db_path)
+        if channels is None:
+            return
+        for samples, entity_path in ((channels[0], schema.gyro_path(RIG, IMU_DEVICE)), (channels[1], schema.accel_path(RIG, IMU_DEVICE))):
+            if samples.times_ns.size == 0:
+                continue
+            rr.send_columns(
+                entity_path,
+                indexes=[rr.TimeColumn(schema.TIMELINE, duration=samples.times_ns.astype("timedelta64[ns]"))],
+                columns=rr.Scalars.columns(scalars=samples.values_xyz),
+                recording=recording,
+            )
+        rr.log(schema.imu_path(RIG, IMU_DEVICE), IDENTITY_TRANSFORM, static=True, recording=recording)
+        rr.log(
+            schema.imu_path(RIG, IMU_DEVICE),
+            rr.AnyValues(name=f"dev{IMU_DEVICE}", kind="imu"),
+            static=True,
+            recording=recording,
+        )

--- a/packages/dataforge/dataforge/datasets/robocap.py
+++ b/packages/dataforge/dataforge/datasets/robocap.py
@@ -26,6 +26,7 @@ lives here).
 
 from __future__ import annotations
 
+import os
 import re
 import sqlite3
 from contextlib import closing
@@ -71,6 +72,17 @@ SESSION_DIR_RE: re.Pattern[str] = re.compile(r"^(?P<device>[0-9a-f]+)_session_(?
 """Session directory names; the ``-old`` duplicates deliberately do not match."""
 IDENTITY_TRANSFORM: rr.Transform3D = rr.Transform3D(translation=[0.0, 0.0, 0.0], mat3x3=np.eye(3, dtype=np.float32))
 """Explicit identity pose; an argument-less ``Transform3D`` logs no components at all."""
+MESH_RELATIVE_PATH: str = "robocap-mesh/3DModel.glb"
+"""Cap scan location under the corpus root; the mesh is optional (skipped when unreadable)."""
+MESH_TRANSLATION: list[float] = [0.0, -0.15, 0.025]
+"""Hand-tuned alignment of the Y-up photogrammetry scan into the dev0 IMU (rig) frame,
+carried over from robocap-slam's visualization; eyeballed, not a CAD extrinsic."""
+MESH_MAT3X3: list[list[float]] = [
+    [0.17364818, 0.0, 0.98480775],
+    [-0.98480775, 0.0, 0.17364818],
+    [0.0, -1.0, 0.0],
+]
+"""Rz(-80deg) @ Rx(-90deg), the rotation half of the same hand-tuned alignment."""
 VIDEO_NAME_RE: re.Pattern[str] = re.compile(r"^video_dev(?P<device>\d+)_session(?P<session>\d+)_segment(?P<segment>\d+)_(?P<camname>[a-z-]+)$")
 """Per-camera MP4 stem, e.g. ``video_dev0_session1_segment1_right-eye``."""
 
@@ -93,6 +105,8 @@ class RobocapConfig(DataforgeDatasetConfig):
     """Dataset class instantiated by ``setup()``."""
     root: Path = Path("/mnt/nas/datasets/robocap")
     """Corpus root holding ``<device>_session_<N>/`` and the factory calibration."""
+    mesh_path: Path | None = None
+    """Cap mesh glb; defaults to ``<root>/robocap-mesh/3DModel.glb`` when None."""
 
 
 def read_imu_channel(database: sqlite3.Connection, table: str, scale: float) -> ImuSamples:
@@ -304,17 +318,18 @@ class RobocapDataset(DataforgeDataset[RobocapConfig]):
             recording_id=identity.recording_id,
             default_blueprint=build_blueprint(camera_names),
         ) as recording:
-            rr.log("/", rr.ViewCoordinates.RDF, static=True, recording=recording)
-            # simplecv's RoboCap loader treats the dev0 IMU frame as world, so world_T_rig is
-            # identity and static for v1. TODO(dataforge): log the VIO trajectory as a temporal
-            # world_T_rig once a pose layer exists.
-            rr.log(schema.rig_path(RIG), IDENTITY_TRANSFORM, static=True, recording=recording)
+            # Deliberately NO static Transform3D on the rig node and NO ViewCoordinates at "/":
+            # per exoego:v2 a world-anchored rig carries no transform, and a static one would
+            # permanently shadow the temporal world_T_rig that a slam/pose layer stacks on this
+            # entity (verified: static components shadow temporal ones per component, silently).
+            # The pose layer owns the root ViewCoordinates (its world is gravity-aligned Z-up).
             rr.log(
                 schema.rig_path(RIG),
                 rr.AnyValues(schema_version=schema.EXOEGO_SCHEMA_VERSION, reference="cam_00", num_cameras=len(camera_names)),
                 static=True,
                 recording=recording,
             )
+            self._log_mesh(recording)
 
             num_frames: int = 0
             for index, cam_name in enumerate(camera_names):
@@ -352,6 +367,20 @@ class RobocapDataset(DataforgeDataset[RobocapConfig]):
 
         print(f"done {identity.sequence_key} → {target} ({len(camera_names)} cameras, {num_frames} frames)")
         return target
+
+    def _log_mesh(self, recording: rr.RecordingStream) -> None:
+        """Log the textured cap scan as a static child of the rig, if the asset is readable.
+
+        The mesh makes the rig legible as a physical object (the pinholes attach to
+        its brim) and rides any temporal ``world_T_rig`` a pose layer adds later.
+        """
+        mesh_path: Path = self.config.mesh_path if self.config.mesh_path is not None else self.config.root / MESH_RELATIVE_PATH
+        if not os.access(mesh_path, os.R_OK):
+            print(f"  warning: cap mesh not readable, skipping: {mesh_path}")
+            return
+        mesh_entity: str = f"{schema.rig_path(RIG)}/mesh"
+        rr.log(mesh_entity, rr.Transform3D(translation=MESH_TRANSLATION, mat3x3=MESH_MAT3X3), static=True, recording=recording)
+        rr.log(mesh_entity, rr.Asset3D(path=mesh_path), static=True, recording=recording)
 
     def _log_video(self, recording: rr.RecordingStream, video_path: Path, entity_path: str) -> int:
         """Remux one MP4 as a ``VideoStream``, retimed onto the camera clock.

--- a/packages/dataforge/dataforge/datasets/robocap.py
+++ b/packages/dataforge/dataforge/datasets/robocap.py
@@ -6,14 +6,18 @@ Raw layout on disk (already local; ``download`` only verifies it):
     <root>/<device>_session_<S>/video_dev<D>_session<S>_segment<G>_<camname>.mp4
     <root>/<device>_session_<S>/IMUWriter_dev<0|1|2>_session<S>_segment<G>.db
 
-Clocks. Both sensors share one nanosecond device clock, offset by a fixed
-constant: basalt's RoboCap loader (``src/io/dataset_io_robocap.cpp``) *adds*
+Clocks. Both sensors share one nanosecond device clock (boot-relative, NOT a
+Unix epoch — values sit around tens of seconds), offset by a fixed constant:
+basalt's RoboCap loader (``src/io/dataset_io_robocap.cpp``) *adds*
 ``kCameraToImuOffsetNs`` to camera timestamps to land on the IMU clock. We pick
 the **raw camera clock** for ``video_time`` — video times are
-``comment_us * 1000 + pts_ns`` (the MP4 format-level ``comment`` tag is an
-absolute epoch in microseconds), and IMU sample times are therefore
-``t_imu_ns - CAMERA_TO_IMU_OFFSET_NS``. Nothing is resampled: raw samples land
-at their native rate.
+``comment_us * 1000 + pts_ns`` (the MP4 format-level ``comment`` tag is the
+capture start on that device clock, in microseconds), and IMU sample times are
+therefore ``t_imu_ns - CAMERA_TO_IMU_OFFSET_NS``. Nothing is resampled: raw
+samples land at their native rate. ``video_time`` is deliberately a *duration*
+timeline — retagging it as ``timestamp`` would render the boot clock as
+1970-01-01T00:00:25. Segments recorded within one boot share the axis, which
+is what makes a future multi-segment session view line up for free.
 
 Calibration comes from simplecv's RoboCap ego loader; the private helpers are
 imported deliberately (the donor is scheduled for deletion once the dataset
@@ -24,6 +28,7 @@ from __future__ import annotations
 
 import re
 import sqlite3
+from contextlib import closing
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -123,7 +128,9 @@ def read_imu_database(db_path: Path) -> tuple[ImuSamples, ImuSamples] | None:
         The gyro and accel channels, or ``None`` if SQLite refused the file.
     """
     try:
-        with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as database:
+        # contextlib.closing because sqlite3's own context manager only ends the
+        # transaction; it leaves the connection (and its fd) open until GC.
+        with closing(sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)) as database:
             gyro: ImuSamples = read_imu_channel(database, "gyro_data", GYRO_SCALE)
             accel: ImuSamples = read_imu_channel(database, "acc_data", ACCEL_SCALE)
     except BeartypeException:
@@ -135,16 +142,16 @@ def read_imu_database(db_path: Path) -> tuple[ImuSamples, ImuSamples] | None:
 
 
 def video_epoch_ns(video_path: Path) -> int:
-    """Absolute start time of an MP4 from its format-level ``comment`` tag.
+    """Start time of an MP4 on the device clock, from its format-level ``comment`` tag.
 
-    RoboCap writes the capture epoch in microseconds into the container
-    ``comment`` metadata; sample PTS are offsets from it.
+    RoboCap writes the capture start (boot-relative device clock, microseconds)
+    into the container ``comment`` metadata; sample PTS are offsets from it.
 
     Args:
         video_path: Path to a RoboCap MP4.
 
     Returns:
-        The capture epoch in nanoseconds on the camera clock.
+        The capture start in nanoseconds on the camera clock.
     """
     with av.open(str(video_path)) as container:
         comment: str | None = container.metadata.get("comment")
@@ -329,9 +336,17 @@ class RobocapDataset(DataforgeDataset[RobocapConfig]):
             self._log_imu(recording, session_dir, session, segment)
 
             recording.send_recording_name(identity.recording_id)
+            # start_time_ns makes the device-clock origin queryable without scanning chunks
+            # (e.g. for a consumer that wants a zero-based axis or cross-segment alignment).
+            start_time_ns: int = min(video_epoch_ns(path) for path in videos.values())
             recording.send_property(
                 "capture",
-                rr.AnyValues(schema=schema.DATAFORGE_SCHEMA_VERSION, num_frames=num_frames, num_cameras=len(camera_names)),
+                rr.AnyValues(
+                    schema=schema.DATAFORGE_SCHEMA_VERSION,
+                    num_frames=num_frames,
+                    num_cameras=len(camera_names),
+                    start_time_ns=start_time_ns,
+                ),
             )
             recording.send_property("convert", rr.AnyValues(version="1"))
 
@@ -365,7 +380,9 @@ class RobocapDataset(DataforgeDataset[RobocapConfig]):
             shifted: pa.Array = pa.array(np.asarray(record_batch.column(index).cast(pa.int64())) + epoch_ns, type=pa.duration("ns"))
             sample_count += record_batch.num_rows
             retimed: pa.RecordBatch = record_batch.set_column(index, record_batch.schema.field(index), shifted)
-            return rr.experimental.Chunk.from_record_batch(retimed, index=schema.TIMELINE, entity_path=chunk.entity_path)
+            # No index=/entity_path= overrides: the batch's rerun:* metadata already carries
+            # both, and passing either forces from_record_batch to mint fresh row/chunk ids.
+            return rr.experimental.Chunk.from_record_batch(retimed)
 
         reader: rr.experimental.Mp4Reader = rr.experimental.Mp4Reader(
             video_path,
@@ -373,6 +390,8 @@ class RobocapDataset(DataforgeDataset[RobocapConfig]):
             entity_path=entity_path,
             timeline_name=schema.TIMELINE,
         )
+        # send_chunks drives the lazy stream to completion, so sample_count is final here;
+        # anything short of a fully-consuming terminal would silently leave it at 0.
         recording.send_chunks(reader.stream().flat_map(retime))
         return sample_count
 

--- a/packages/dataforge/pyproject.toml
+++ b/packages/dataforge/pyproject.toml
@@ -24,12 +24,13 @@ ignore = [
     "F821",   # jaxtyping forward annotation false positive
     "UP037",  # Remove quotes false positive with jaxtyping
     "UP040",  # Beartype requires TypeAlias, not PEP 695 type
+    "UP046",  # Same reason: beartype needs Generic[TypeVar], not PEP 695 type params
 ]
 
 [tool.vulture]
 paths = ["dataforge", "tests"]
-# Contract constant consumed by the robocap converter (next PR in the stack).
-ignore_names = ["DATAFORGE_SCHEMA_VERSION"]
+# Tyro-facing verb entry points and config fields; the CLI shims call them.
+ignore_names = ["main", "rr_config", "sequence", "force", "catalog_url", "dataset", "root", "_target"]
 exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modules/*"]
 sort_by_size = true
 min_confidence = 60

--- a/packages/dataforge/tests/test_robocap.py
+++ b/packages/dataforge/tests/test_robocap.py
@@ -1,0 +1,99 @@
+"""RoboCap discovery and IMU parsing against synthetic fixtures (no corpus needed)."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import numpy as np
+import pytest
+from jaxtyping import Float64, Int64
+from numpy import ndarray
+
+from dataforge.datasets.robocap import (
+    ACCEL_SCALE,
+    CAMERA_TO_IMU_OFFSET_NS,
+    GYRO_SCALE,
+    ImuSamples,
+    RobocapConfig,
+    RobocapDataset,
+    read_imu_database,
+)
+from dataforge.identity import SequenceIdentity
+
+DEVICE: str = "f408193e6447b3b0"
+"""Device id used by every fake session directory in these tests."""
+CAM_NAMES: tuple[str, ...] = ("right-eye", "left-front", "left-eye", "right", "left", "right-front")
+"""Video filename suffixes in device order (dev0..dev5)."""
+
+
+def make_segment(session_dir: Path, session: int, segment: int) -> None:
+    """Create the six empty MP4s and three empty IMU dbs of one fake segment."""
+    session_dir.mkdir(parents=True, exist_ok=True)
+    for device_index, cam_name in enumerate(CAM_NAMES):
+        (session_dir / f"video_dev{device_index}_session{session}_segment{segment}_{cam_name}.mp4").touch()
+    for imu_index in range(3):
+        (session_dir / f"IMUWriter_dev{imu_index}_session{session}_segment{segment}.db").touch()
+
+
+@pytest.fixture
+def corpus(tmp_path: Path) -> Path:
+    """A fake RoboCap root: two sessions, three segments, one ``-old`` decoy."""
+    (tmp_path / f"0factory-calibration-{DEVICE}").mkdir()
+    make_segment(tmp_path / f"{DEVICE}_session_1", session=1, segment=1)
+    make_segment(tmp_path / f"{DEVICE}_session_1", session=1, segment=2)
+    make_segment(tmp_path / f"{DEVICE}_session_10", session=10, segment=1)
+    make_segment(tmp_path / f"{DEVICE}_session_10-old", session=10, segment=9)
+    return tmp_path
+
+
+def test_sequences_discovers_every_segment_and_skips_old_dirs(corpus: Path) -> None:
+    dataset: RobocapDataset = RobocapDataset(RobocapConfig(root=corpus))
+    identities: list[SequenceIdentity] = dataset.sequences()
+    assert [identity.sequence_key for identity in identities] == [
+        f"{DEVICE}/s1/seg1",
+        f"{DEVICE}/s1/seg2",
+        f"{DEVICE}/s10/seg1",
+    ]
+    assert identities[0].recording_id == f"robocap__{DEVICE}__s1__seg1"
+
+
+def test_download_verifies_local_corpus(corpus: Path, tmp_path: Path) -> None:
+    RobocapConfig(root=corpus).setup().download()
+    empty_root: Path = tmp_path / "empty"
+    empty_root.mkdir()
+    with pytest.raises(FileNotFoundError, match="missing"):
+        RobocapConfig(root=empty_root).setup().download()
+
+
+def write_imu_db(db_path: Path) -> None:
+    """Write a two-sample synthetic IMU db in the RoboCap writer's schema."""
+    with sqlite3.connect(db_path) as database:
+        for table in ("gyro_data", "acc_data"):
+            database.execute(f"CREATE TABLE {table} (id INTEGER PRIMARY KEY, imuid_ INTEGER, x INTEGER, y INTEGER, z INTEGER, timestamp INTEGER)")
+        database.execute("INSERT INTO gyro_data VALUES (1, 0, 10, -20, 30, 1000000000)")
+        database.execute("INSERT INTO gyro_data VALUES (2, 0, 11, -21, 31, 1002000000)")
+        database.execute("INSERT INTO acc_data VALUES (1, 0, 100, 200, -300, 1001000000)")
+
+
+def test_imu_parsing_scales_values_and_shifts_onto_camera_clock(tmp_path: Path) -> None:
+    db_path: Path = tmp_path / "IMUWriter_dev0_session1_segment1.db"
+    write_imu_db(db_path)
+    channels: tuple[ImuSamples, ImuSamples] | None = read_imu_database(db_path)
+    assert channels is not None
+    gyro: ImuSamples = channels[0]
+    accel: ImuSamples = channels[1]
+
+    expected_gyro_times: Int64[ndarray, "2"] = np.array([1000000000, 1002000000], dtype=np.int64) - CAMERA_TO_IMU_OFFSET_NS
+    np.testing.assert_array_equal(gyro.times_ns, expected_gyro_times)
+    expected_gyro_xyz: Float64[ndarray, "2 3"] = np.array([[10.0, -20.0, 30.0], [11.0, -21.0, 31.0]]) * GYRO_SCALE
+    np.testing.assert_allclose(gyro.values_xyz, expected_gyro_xyz)
+
+    np.testing.assert_array_equal(accel.times_ns, np.array([1001000000 - CAMERA_TO_IMU_OFFSET_NS], dtype=np.int64))
+    np.testing.assert_allclose(accel.values_xyz, np.array([[100.0, 200.0, -300.0]]) * ACCEL_SCALE)
+
+
+def test_malformed_imu_db_is_skipped_not_fatal(tmp_path: Path) -> None:
+    db_path: Path = tmp_path / "IMUWriter_dev2_session1_segment1.db"
+    db_path.write_bytes(b"SQLite format 3\x00 this is not a database")
+    assert read_imu_database(db_path) is None

--- a/packages/dataforge/tools/apps/convert.py
+++ b/packages/dataforge/tools/apps/convert.py
@@ -1,0 +1,6 @@
+import tyro
+
+from dataforge.apis.convert import Config, main
+
+if __name__ == "__main__":
+    main(tyro.cli(Config))

--- a/packages/dataforge/tools/apps/download.py
+++ b/packages/dataforge/tools/apps/download.py
@@ -1,0 +1,6 @@
+import tyro
+
+from dataforge.apis.download import Config, main
+
+if __name__ == "__main__":
+    main(tyro.cli(Config))

--- a/packages/dataforge/tools/apps/register.py
+++ b/packages/dataforge/tools/apps/register.py
@@ -1,0 +1,6 @@
+import tyro
+
+from dataforge.apis.register import Config, main
+
+if __name__ == "__main__":
+    main(tyro.cli(Config))

--- a/packages/dataforge/tools/apps/view.py
+++ b/packages/dataforge/tools/apps/view.py
@@ -1,0 +1,6 @@
+import tyro
+
+from dataforge.apis.view import Config, main
+
+if __name__ == "__main__":
+    main(tyro.cli(Config))

--- a/packages/simplecv/docs/exoego_schema.md
+++ b/packages/simplecv/docs/exoego_schema.md
@@ -70,7 +70,7 @@ world_T_cam  = world_T_rig @ rig_T_cam           # composes along the entity tre
       /pinhole/video, /pinhole/coco133_uv
     /cam_01                     fixed rig_T_cam offset (multi-camera ego devices)
       /pinhole/video, /pinhole/coco133_uv
-    /imu_00                     reserved peer sensor (IMU — see §8; not emitted yet)
+    /imu_00                     peer sensor (IMU — see §8; emitted by dataforge)
   /gt                           ground-truth annotations (UNCHANGED from v1, see §5)
 ```
 
@@ -144,16 +144,17 @@ from the normalized `exo_cam_list` / `exo_video_names` and `ego_cam_dict` /
       temporal `world_T_rig` on the ego rig, and `schema_version=exoego:v2`; no
       `/world/{exo,ego}/*` remain.
 
-## 8. Reserved / planned sensors: IMU *(not emitted yet)*
+## 8. IMU *(emitted — first writer: dataforge / RoboCap dev0)*
 
 The rig model treats **every sensor as a peer child of the rig**, so a non-camera
-sensor slots in alongside the cameras without nesting under one. The next one to add
-is the **IMU**: ego devices like **Project Aria** (RGB + SLAM cameras *and* IMUs) and
+sensor slots in alongside the cameras without nesting under one. The first such
+sensor is the **IMU**: ego devices like **Project Aria** (RGB + SLAM cameras *and* IMUs) and
 the **RoboCap** capture rigs carry inertial data, and `SensorKind` in
 `simplecv/rig.py` already reserves `"imu"` for exactly this.
 
-**Planned layout** (mirrors `slam-evals`' `-vi` inertial modalities — **reserved; the
-current writer does not emit it**):
+**Layout** (mirrors `slam-evals`' `-vi` inertial modalities). `dataforge`'s RoboCap
+converter (`packages/dataforge/dataforge/datasets/robocap.py`) is the first writer that
+actually emits it; simplecv's own exo/ego writer still does not.
 
 ```
 /world/rig_NN/imu_MM        Transform3D = rig_T_imu (static) + AnyValues{name, kind="imu"}
@@ -171,8 +172,17 @@ current writer does not emit it**):
 - On a **moving** ego rig the IMU rides the rig's `world_T_rig(t)` like every other
   sensor; its `gyro`/`accel` samples are logged on the shared `video_time` timeline,
   as `slam-evals` does.
+- Samples are logged **raw, at their native rate, without interpolation or
+  resampling**, as columnar `rr.Scalars` batches (three components per row:
+  x/y/z) on `video_time`. Readers must not assume IMU rows line up with video
+  frames.
 - Adding IMUs is **mechanical** — a new peer entity plus the already-reserved `"imu"`
-  kind, no new vocabulary. Per the rule below, the first writer that actually emits
-  IMU data should bump the schema version and update this section.
+  kind, no new vocabulary. Emitting IMU data did not change any existing path, so
+  the schema version stays `exoego:v2`.
+- **RoboCap status / TODO:** dataforge v1 emits the middle IMU (`dev0`) only, as
+  `imu_00`; `dev1`/`dev2` and a multi-IMU blueprint layout (one gyro/accel pane pair
+  per IMU) are still TODO. RoboCap's IMU and camera clocks differ by a fixed
+  14,902,432 ns offset (basalt's `kCameraToImuOffsetNs`); dataforge picks the raw
+  **camera** clock for `video_time` and subtracts the offset from IMU timestamps.
 
 Any change to the layout should increment the schema version and update this doc.

--- a/pixi.toml
+++ b/pixi.toml
@@ -2446,6 +2446,26 @@ dataforge = { path = "packages/dataforge", editable = true }
 [feature.dataforge.activation.env]
 PACKAGE_DIR = "packages/dataforge"
 
+[feature.dataforge.tasks.dataforge-download]
+cmd = "python tools/apps/download.py"
+cwd = "packages/dataforge"
+description = "Fetch (or verify, for local corpora) a dataset's raw tree"
+
+[feature.dataforge.tasks.dataforge-convert]
+cmd = "python tools/apps/convert.py"
+cwd = "packages/dataforge"
+description = "Convert discovered sequences into base-layer rrds (--sequence, --force)"
+
+[feature.dataforge.tasks.dataforge-register]
+cmd = "python tools/apps/register.py"
+cwd = "packages/dataforge"
+description = "Register base-layer rrds into a local Rerun catalog"
+
+[feature.dataforge.tasks.dataforge-view]
+cmd = "python tools/apps/view.py"
+cwd = "packages/dataforge"
+description = "Open one converted recording in the viewer (--rr-config.headless in a bare shell)"
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Environments
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Stacked on #111 (contracts). The walking skeleton every dataset copies: robocap → one exoego:v2 base-layer rrd per `(device, session, segment)`.

- **RobocapDataset** (`dataforge/datasets/robocap.py`): verify-only `download` (corpus lives on the NAS), sequence discovery (23 sessions / 88 segments, `-old` dirs excluded), and `convert`:
  - 6 fisheye62 cameras — Kalibr calibration reused from simplecv's private helpers (donor deleted in a later migration), `log_pinhole`, video **remuxed chunk-native** (`Mp4Reader` → `send_chunks`, retimed onto the absolute epoch from the MP4 `comment` tag).
  - **dev0 IMU** — first emitter of exoego:v2 §8's reserved `/world/rig_NN/imu_MM/{gyro,accel}`: raw native-rate samples from the SQLite db (stdlib `sqlite3`), basalt's measured scale constants and 14 902 432 ns camera↔IMU offset; `video_time` is the raw camera clock. dev1/dev2 + multi-IMU blueprint panes are TODO. Malformed dbs (session_1's dev2) degrade to a warning, never abort.
  - Blueprint (3D rig | six named camera panes | gyro+accel strip) **embedded at convert** and **registered as the catalog dataset default at register**.
- Four tyro verbs (`dataforge/apis/`) + thin `tools/apps/` shims + pixi tasks: `pixi run -e dataforge dataforge-{download,convert,register,view}`.
- `exoego_schema.md` §8: IMU flips from reserved → emitted.

**Validated end-to-end on real data**: session_1 seg1 converted in ~2 s (pure remux; 6 cams, 336 frames, 36 MiB), registered into a `robocap` dataset on a local `rerun server` catalog (port 51235), and pixel-verified headless from the catalog URI — video decode, frustums, IMU plots, `dataforge:v1` properties, and the default blueprint all render. Evidence: `/tmp/rerun-viewer-validation/20260819-dataforge-robocap/`.

Gates: `pixi run -e dataforge-dev {tests,lint,typecheck,deadcode}` all green (26 tests).

Next: HOCap + `hf_fetch` + the `gt` layer.