### PR TITLE
dataforge: selfcap dataset (exoego-self-collected)

### DIFF
--- a/packages/dataforge/README.md
+++ b/packages/dataforge/README.md
@@ -7,11 +7,41 @@ The full design — decisions, evidence from a 9-system study, and the ranked
 work plan — is in **[docs/dataforge-design-report.html](docs/dataforge-design-report.html)**
 (single self-contained file; open it in a browser).
 
-v1 scope: the simplecv **robocap** and **HOCap** datasets, nothing else.
+## What exists
 
-## Status
+**Contracts** (`dataforge/`): `identity.py` (one `SequenceIdentity` derives the
+sequence key, the Rerun recording id, and the rrd filename), `paths.py` (the
+layer-major output tree), `schema.py` (the `exoego:v2` entity paths and the
+single `video_time` timeline, as code), `writing.py` (atomic publication and the
+capture/convert recording properties), `logging_toolkit.py` (the shared rig-node,
+video-stream, and IMU writers), and `transports.py` (`local_verify`; the fetchers
+land with the next dataset).
 
-Skeleton only: packaging, envs, and tooling wiring exist; the package has no
-operational code yet. The remaining work is to implement the dataset verbs, dataset specs,
-and Tyro CLIs described in
-**[docs/dataforge-design-report.html](docs/dataforge-design-report.html)**.
+**Datasets** (`dataforge/datasets/`), one config + one dataset class each:
+
+| dataset | raw corpus | one sequence | rrd contents |
+| --- | --- | --- | --- |
+| `robocap` | `/mnt/nas/datasets/robocap` | one `(device, session, segment)` | 6 fisheye video streams, the dev0 IMU, the cap mesh |
+| `selfcap` | `/mnt/nas/datasets/exoego-self-collected/main` | one cut episode | 4 iPhone exo rigs + the OAK ego rig + the Quest (9 cameras), the OAK IMU, the Quest head-pose track |
+
+**Verbs**, each a thin `tools/apps/*.py` shim over `dataforge/apis/`:
+
+```bash
+pixi run -e dataforge --frozen dataforge-download selfcap        # fetch, or verify a local corpus
+pixi run -e dataforge --frozen dataforge-convert robocap --sequence f408193e6447b3b0/s1/seg1
+pixi run -e dataforge --frozen dataforge-register selfcap        # into a local `rerun server` catalog
+pixi run -e dataforge --frozen dataforge-view robocap --rr-config.headless
+```
+
+`convert` writes **one base-layer rrd per sequence**, layer-major, at
+`<DATAFORGE_OUTPUT_ROOT>/base/<recording_id>.rrd` — a temp file that atomically
+replaces the target, so "exists = done" and a re-run never truncates a file a
+catalog server holds open. Derived layers (slam, pose, labels) stack onto the
+same entities as sibling layers; v1 emits `base` only. Each rrd embeds a
+per-recording blueprint; `register` additionally sets the dataset-wide default
+blueprint on the catalog dataset.
+
+Conventions this package follows — beartype under `PIXI_DEV_MODE`, thin `tools/`
+shims, jaxtyping annotations, `pixi run -e dataforge-dev {lint,typecheck,deadcode,tests}` —
+are the monorepo ones in the root `AGENTS.md`. The logging schema is
+`packages/simplecv/docs/exoego_schema.md`.

--- a/packages/dataforge/dataforge/apis/convert.py
+++ b/packages/dataforge/dataforge/apis/convert.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from beartype.roar import BeartypeException
+
 from dataforge.datasets import AnnotatedDatasetUnion, RobocapConfig
 from dataforge.datasets.base import DataforgeDataset, DataforgeDatasetConfig
 from dataforge.identity import SequenceIdentity
@@ -35,12 +37,27 @@ def select(identities: list[SequenceIdentity], sequence: str | None) -> list[Seq
 
 
 def main(config: Config) -> None:
-    """Convert every selected sequence serially."""
+    """Convert every selected sequence serially, surviving individual failures.
+
+    One bad sequence must not throw away a batch that is hours in (a lesson from
+    robocap's malformed ``s10``), so failures are reported and the run continues;
+    the process still exits non-zero so a caller can tell a partial run apart
+    from a clean one.
+    """
     dataset_config: DataforgeDatasetConfig = config.dataset
     dataset: DataforgeDataset = dataset_config.setup()
     selected: list[SequenceIdentity] = select(dataset.sequences(), config.sequence)
     print(f"converting {len(selected)} sequence(s)")
+    failed: list[str] = []
     for identity in selected:
-        target: Path = dataset.convert(identity, force=config.force)
-        if not target.is_file():
-            raise RuntimeError(f"convert produced no recording for {identity.sequence_key}")
+        try:
+            target: Path = dataset.convert(identity, force=config.force)
+            if not target.is_file():
+                raise RuntimeError(f"convert produced no recording for {identity.sequence_key}")
+        except BeartypeException:
+            raise
+        except Exception as error:
+            print(f"FAILED {identity.sequence_key}: {type(error).__name__}: {error}")
+            failed.append(identity.sequence_key)
+    if failed:
+        raise SystemExit(f"{len(failed)} of {len(selected)} sequence(s) failed: {', '.join(failed)}")

--- a/packages/dataforge/dataforge/apis/convert.py
+++ b/packages/dataforge/dataforge/apis/convert.py
@@ -24,15 +24,17 @@ class Config:
     """Rewrite recordings that already exist instead of skipping them."""
 
 
-def select(identities: list[SequenceIdentity], sequence: str | None) -> list[SequenceIdentity]:
-    """Filter discovered identities by key, recording id, or a single part."""
+def select(discovered: list[tuple[SequenceIdentity, object]], sequence: str | None) -> list[tuple[SequenceIdentity, object]]:
+    """Filter discovered ``(identity, source)`` pairs by key, recording id, or a single part."""
     if sequence is None:
-        return identities
-    matches: list[SequenceIdentity] = [
-        identity for identity in identities if sequence in (identity.sequence_key, identity.recording_id) or sequence in identity.parts
+        return discovered
+    matches: list[tuple[SequenceIdentity, object]] = [
+        (identity, source)
+        for identity, source in discovered
+        if sequence in (identity.sequence_key, identity.recording_id) or sequence in identity.parts
     ]
     if not matches:
-        raise ValueError(f"No sequence matches {sequence!r} among {len(identities)} discovered sequences")
+        raise ValueError(f"No sequence matches {sequence!r} among {len(discovered)} discovered sequences")
     return matches
 
 
@@ -46,12 +48,12 @@ def main(config: Config) -> None:
     """
     dataset_config: DataforgeDatasetConfig = config.dataset
     dataset: DataforgeDataset = dataset_config.setup()
-    selected: list[SequenceIdentity] = select(dataset.sequences(), config.sequence)
+    selected: list[tuple[SequenceIdentity, object]] = select(dataset.discover(), config.sequence)
     print(f"converting {len(selected)} sequence(s)")
     failed: list[str] = []
-    for identity in selected:
+    for identity, source in selected:
         try:
-            target: Path = dataset.convert(identity, force=config.force)
+            target: Path = dataset.convert(identity, source, force=config.force)
             if not target.is_file():
                 raise RuntimeError(f"convert produced no recording for {identity.sequence_key}")
         except BeartypeException:

--- a/packages/dataforge/dataforge/apis/register.py
+++ b/packages/dataforge/dataforge/apis/register.py
@@ -8,12 +8,9 @@ from pathlib import Path
 import rerun.blueprint as rrb
 from rerun.catalog import CatalogClient, DatasetEntry, OnDuplicateSegmentLayer
 
-from dataforge import paths
-from dataforge.datasets import AnnotatedDatasetUnion, RobocapConfig, dataset_key
+from dataforge import paths, writing
+from dataforge.datasets import AnnotatedDatasetUnion, RobocapConfig
 from dataforge.datasets.base import DataforgeDatasetConfig
-
-LAYER: str = "base"
-"""Only layer dataforge v1 emits."""
 
 
 @dataclass
@@ -29,24 +26,25 @@ class Config:
 def main(config: Config) -> None:
     """Create the dataset if needed and register every base-layer rrd (idempotent)."""
     dataset_config: DataforgeDatasetConfig = config.dataset
-    name: str = dataset_key(dataset_config)
-    rrd_paths: list[Path] = sorted((paths.output_root() / LAYER).glob(f"{name}__*.rrd"))
+    name: str = dataset_config.name
+    layer_root: Path = paths.output_root() / paths.BASE_LAYER
+    rrd_paths: list[Path] = sorted(layer_root.glob(f"{name}__*.rrd"))
     if not rrd_paths:
-        raise FileNotFoundError(f"no {LAYER}-layer rrds for {name} under {paths.output_root() / LAYER}")
+        raise FileNotFoundError(f"no {paths.BASE_LAYER}-layer rrds for {name} under {layer_root}")
 
     client: CatalogClient = CatalogClient(config.catalog_url)
     dataset: DatasetEntry = client.create_dataset(name, exist_ok=True)
     dataset.register(
         [path.resolve().as_uri() for path in rrd_paths],
-        layer_name=LAYER,
+        layer_name=paths.BASE_LAYER,
         on_duplicate=OnDuplicateSegmentLayer.SKIP,
     ).wait()
 
     blueprint: rrb.Blueprint | None = dataset_config.setup().default_blueprint()
     if blueprint is not None:
         blueprint_path: Path = paths.output_root() / "blueprints" / f"{name}.rbl"
-        blueprint_path.parent.mkdir(parents=True, exist_ok=True)
-        blueprint.save(name, str(blueprint_path))
-        blueprint_path.chmod(0o644)  # uid-squashing NFS mounts can land fresh writes as mode 0000
+        # A re-register must never truncate the .rbl a live catalog server still holds open.
+        with writing.atomic_write(blueprint_path) as temp_path:
+            blueprint.save(name, str(temp_path))
         dataset.register_blueprint(blueprint_path.resolve().as_uri(), set_default=True)
-    print(f"registered {len(rrd_paths)} {LAYER}-layer rrds into '{name}' at {config.catalog_url}")
+    print(f"registered {len(rrd_paths)} {paths.BASE_LAYER}-layer rrds into '{name}' at {config.catalog_url}")

--- a/packages/dataforge/dataforge/apis/view.py
+++ b/packages/dataforge/dataforge/apis/view.py
@@ -9,11 +9,8 @@ import rerun as rr
 from simplecv.rerun_log_utils import RerunTyroConfig
 
 from dataforge import paths
-from dataforge.datasets import AnnotatedDatasetUnion, RobocapConfig, dataset_key
+from dataforge.datasets import AnnotatedDatasetUnion, RobocapConfig
 from dataforge.datasets.base import DataforgeDatasetConfig
-
-LAYER: str = "base"
-"""Layer whose recordings the viewer loads."""
 
 
 @dataclass
@@ -31,13 +28,14 @@ class Config:
 def main(config: Config) -> None:
     """Load the selected rrd into the recording stream configured by ``rr_config``."""
     dataset_config: DataforgeDatasetConfig = config.dataset
-    name: str = dataset_key(dataset_config)
-    candidates: list[Path] = sorted((paths.output_root() / LAYER).glob(f"{name}__*.rrd"))
+    name: str = dataset_config.name
+    layer_root: Path = paths.output_root() / paths.BASE_LAYER
+    candidates: list[Path] = sorted(layer_root.glob(f"{name}__*.rrd"))
     if config.sequence is not None:
         wanted: str = config.sequence.replace("/", "__")
         candidates = [path for path in candidates if wanted in path.stem]
     if not candidates:
-        raise FileNotFoundError(f"no {LAYER}-layer rrd for {name} (sequence={config.sequence}) under {paths.output_root() / LAYER}")
+        raise FileNotFoundError(f"no {paths.BASE_LAYER}-layer rrd for {name} (sequence={config.sequence}) under {layer_root}")
     rrd_path: Path = candidates[0]
     print(f"viewing {rrd_path}")
     rr.log_file_from_path(rrd_path)

--- a/packages/dataforge/dataforge/datasets/__init__.py
+++ b/packages/dataforge/dataforge/datasets/__init__.py
@@ -8,11 +8,8 @@ from dataforge.datasets.base import DataforgeDatasetConfig
 from dataforge.datasets.robocap import RobocapConfig
 from dataforge.datasets.selfcap import SelfcapConfig
 
-dataset_defaults: dict[str, DataforgeDatasetConfig] = {
-    "robocap": RobocapConfig(),
-    "selfcap": SelfcapConfig(),
-}
-"""Every dataset dataforge knows about, keyed by its CLI name."""
+dataset_defaults: dict[str, DataforgeDatasetConfig] = {config.name: config for config in (RobocapConfig(), SelfcapConfig())}
+"""Every dataset dataforge knows about, keyed by its own ``name`` (the single source of truth)."""
 
 DatasetUnion = tyro.extras.subcommand_type_from_defaults(dataset_defaults, prefix_names=False)
 """Config type every verb's ``Config.dataset`` field uses (one tyro subcommand per registry key).
@@ -25,11 +22,3 @@ pyrefly reject the call in an annotation position.
 
 AnnotatedDatasetUnion = tyro.conf.OmitSubcommandPrefixes[DatasetUnion]
 """``DatasetUnion`` without tyro's per-subcommand flag prefixes."""
-
-
-def dataset_key(config: DataforgeDatasetConfig) -> str:
-    """Registry key of a parsed dataset config (the catalog dataset name)."""
-    for key, default in dataset_defaults.items():
-        if isinstance(config, type(default)):
-            return key
-    raise ValueError(f"Config {type(config).__name__} is not in dataset_defaults")

--- a/packages/dataforge/dataforge/datasets/__init__.py
+++ b/packages/dataforge/dataforge/datasets/__init__.py
@@ -6,29 +6,22 @@ import tyro
 
 from dataforge.datasets.base import DataforgeDatasetConfig
 from dataforge.datasets.robocap import RobocapConfig
+from dataforge.datasets.selfcap import SelfcapConfig
 
 dataset_defaults: dict[str, DataforgeDatasetConfig] = {
     "robocap": RobocapConfig(),
+    "selfcap": SelfcapConfig(),
 }
 """Every dataset dataforge knows about, keyed by its CLI name."""
 
+DatasetUnion = tyro.extras.subcommand_type_from_defaults(dataset_defaults, prefix_names=False)
+"""Config type every verb's ``Config.dataset`` field uses (one tyro subcommand per registry key).
 
-def _build_dataset_union() -> type[DataforgeDatasetConfig]:
-    """Build the tyro subcommand union, tolerating a single-entry registry.
-
-    ``subcommand_type_from_defaults`` asserts ``len(defaults) >= 2`` in tyro
-    0.9.x (same workaround as ``robocap_slam.configs.track_dataset_configs``),
-    so with one dataset we hand tyro the concrete config type instead — no
-    placeholder subcommand shows up in ``--help``.
-    """
-    if len(dataset_defaults) >= 2:
-        return tyro.extras.subcommand_type_from_defaults(dataset_defaults, prefix_names=False)
-    only_default: DataforgeDatasetConfig = next(iter(dataset_defaults.values()))
-    return type(only_default)
-
-
-DatasetUnion: type[DataforgeDatasetConfig] = _build_dataset_union()
-"""Config type every verb's ``Config.dataset`` field uses."""
+Deliberately unannotated. The helper returns an ``Annotated[...] |
+Annotated[...]`` union, so a ``type[DataforgeDatasetConfig]`` annotation makes
+beartype's claw reject the global, while a ``TypeAlias`` annotation makes
+pyrefly reject the call in an annotation position.
+"""
 
 AnnotatedDatasetUnion = tyro.conf.OmitSubcommandPrefixes[DatasetUnion]
 """``DatasetUnion`` without tyro's per-subcommand flag prefixes."""

--- a/packages/dataforge/dataforge/datasets/base.py
+++ b/packages/dataforge/dataforge/datasets/base.py
@@ -2,9 +2,14 @@
 
 The config/``setup()`` split is simplecv's ``InstantiateConfig`` idiom (see
 ``simplecv/configs/base_config.py``): tyro parses the config, ``setup()``
-instantiates the dataset that owns the ``download`` / ``sequences`` /
+instantiates the dataset that owns the ``download`` / ``discover`` /
 ``convert`` verbs. dataforge keeps its own copy of the idiom so the dataset
 surface does not inherit simplecv's sequence-loader machinery.
+
+``discover()`` is the single traversal of the raw tree: it returns identity **and**
+the source location it was derived from, so ``convert`` never has to invert an
+identity back into a path. ``SourceT`` is whatever a dataset needs to carry from
+discovery to conversion (a directory, or a small record of parsed path parts).
 """
 
 from __future__ import annotations
@@ -12,7 +17,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Generic, TypeVar
+from typing import ClassVar, Generic, TypeVar
 
 import rerun.blueprint as rrb
 
@@ -23,20 +28,27 @@ from dataforge.identity import SequenceIdentity
 class DataforgeDatasetConfig:
     """Base config for a dataforge dataset; ``setup()`` builds the dataset."""
 
+    name: ClassVar[str]
+    """Registry key of the dataset: the CLI subcommand, the catalog dataset, and
+    the ``dataset`` part of every ``SequenceIdentity`` it produces."""
+
     _target: type
     """Dataset class instantiated by ``setup()``."""
 
-    def setup(self) -> DataforgeDataset[DataforgeDatasetConfig]:
+    def setup(self) -> DataforgeDataset:
         """Instantiate the dataset this config describes."""
-        dataset: DataforgeDataset[DataforgeDatasetConfig] = self._target(self)
+        dataset: DataforgeDataset = self._target(self)
         return dataset
 
 
 ConfigT = TypeVar("ConfigT", bound=DataforgeDatasetConfig)
 """Config type a concrete dataset is parameterized by (simplecv's sequence-loader idiom)."""
 
+SourceT = TypeVar("SourceT")
+"""Raw-tree handle ``discover()`` hands to ``convert()`` (an episode dir, a parsed segment record, …)."""
 
-class DataforgeDataset(Generic[ConfigT], ABC):
+
+class DataforgeDataset(Generic[ConfigT, SourceT], ABC):
     """A dataset dataforge can download, enumerate, and convert to base-layer rrds."""
 
     def __init__(self, config: ConfigT) -> None:
@@ -47,12 +59,16 @@ class DataforgeDataset(Generic[ConfigT], ABC):
         """Fetch (or verify) the raw corpus this dataset converts from."""
 
     @abstractmethod
+    def discover(self) -> list[tuple[SequenceIdentity, SourceT]]:
+        """Walk the raw tree once, pairing every convertible sequence with its source."""
+
     def sequences(self) -> list[SequenceIdentity]:
-        """Enumerate every convertible sequence found on disk."""
+        """Identities of every convertible sequence found on disk."""
+        return [identity for identity, _ in self.discover()]
 
     @abstractmethod
-    def convert(self, identity: SequenceIdentity, *, force: bool) -> Path:
-        """Write the base-layer rrd for one sequence and return its path."""
+    def convert(self, identity: SequenceIdentity, source: SourceT, *, force: bool) -> Path:
+        """Write the base-layer rrd for one discovered sequence and return its path."""
 
     def default_blueprint(self) -> rrb.Blueprint | None:
         """Dataset-wide default blueprint, registered on the catalog dataset.

--- a/packages/dataforge/dataforge/datasets/robocap.py
+++ b/packages/dataforge/dataforge/datasets/robocap.py
@@ -32,10 +32,10 @@ import sqlite3
 from contextlib import closing
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import ClassVar
 
 import av
 import numpy as np
-import pyarrow as pa
 import rerun as rr
 import rerun.blueprint as rrb
 from beartype.roar import BeartypeException
@@ -55,6 +55,7 @@ from simplecv.rerun_log_utils import log_pinhole
 from dataforge import paths, schema, transports, writing
 from dataforge.datasets.base import DataforgeDataset, DataforgeDatasetConfig
 from dataforge.identity import SequenceIdentity
+from dataforge.logging_toolkit import ImuChannel, log_imu, log_rig_node, log_video_stream
 
 GYRO_SCALE: float = 0.000266316
 """Raw gyro LSB → rad/s; measured in the basalt fork (``dataset_io_robocap.cpp``)."""
@@ -66,12 +67,13 @@ IMAGE_PLANE_DISTANCE: float = 0.025
 """Frustum length in metres, matching ``RobocapEgoSequence.image_plane_distance``."""
 RIG: int = 0
 """RoboCap is one rig; the whole device is ``rig_00``."""
+RIG_REFERENCE: str = "imu_00"
+"""The rig frame *is* dev0's IMU frame: every camera's Kalibr extrinsic is a ``T_imu_cam``,
+so the rig's reference sensor is the IMU node, not a camera."""
 IMU_DEVICE: int = 0
 """v1 logs the middle IMU (``dev0``) only. TODO(dataforge): also emit dev1/dev2."""
 SESSION_DIR_RE: re.Pattern[str] = re.compile(r"^(?P<device>[0-9a-f]+)_session_(?P<session>\d+)$")
 """Session directory names; the ``-old`` duplicates deliberately do not match."""
-IDENTITY_TRANSFORM: rr.Transform3D = rr.Transform3D(translation=[0.0, 0.0, 0.0], mat3x3=np.eye(3, dtype=np.float32))
-"""Explicit identity pose; an argument-less ``Transform3D`` logs no components at all."""
 MESH_RELATIVE_PATH: str = "robocap-mesh/3DModel.glb"
 """Cap scan location under the corpus root; the mesh is optional (skipped when unreadable)."""
 MESH_TRANSLATION: list[float] = [0.0, -0.15, 0.025]
@@ -88,18 +90,25 @@ VIDEO_NAME_RE: re.Pattern[str] = re.compile(r"^video_dev(?P<device>\d+)_session(
 
 
 @dataclass(frozen=True, slots=True)
-class ImuSamples:
-    """One raw IMU channel (gyro or accel) at its native sample rate."""
+class RobocapSource:
+    """One segment as discovery found it; ``convert`` needs nothing else from the tree."""
 
-    times_ns: Int64[ndarray, "n_samples"]
-    """Sample times on the ``video_time`` camera clock, in nanoseconds."""
-    values_xyz: Float64[ndarray, "n_samples 3"]
-    """Scaled samples (rad/s for gyro, m/s^2 for accel)."""
+    session_dir: Path
+    """``<root>/<device>_session_<S>`` directory holding the videos and IMU dbs."""
+    device: str
+    """Capture-device id, which also names the factory calibration directory."""
+    session: int
+    """Session number ``S`` (part of every filename in the directory)."""
+    segment: int
+    """Segment number ``G`` within the session."""
 
 
 @dataclass
 class RobocapConfig(DataforgeDatasetConfig):
     """RoboCap capture-rig recordings (6 fisheye cameras, 3 IMUs, no labels)."""
+
+    name: ClassVar[str] = "robocap"
+    """Registry key, catalog dataset name, and identity ``dataset`` part."""
 
     _target: type = field(default_factory=lambda: RobocapDataset)
     """Dataset class instantiated by ``setup()``."""
@@ -109,7 +118,7 @@ class RobocapConfig(DataforgeDatasetConfig):
     """Cap mesh glb; defaults to ``<root>/robocap-mesh/3DModel.glb`` when None."""
 
 
-def read_imu_channel(database: sqlite3.Connection, table: str, scale: float) -> ImuSamples:
+def read_imu_channel(database: sqlite3.Connection, table: str, scale: float) -> ImuChannel:
     """Read one raw IMU table and map it onto the camera clock.
 
     Args:
@@ -122,14 +131,14 @@ def read_imu_channel(database: sqlite3.Connection, table: str, scale: float) -> 
     """
     rows: list[tuple[int, int, int, int]] = database.execute(f"SELECT x, y, z, timestamp FROM {table} ORDER BY timestamp").fetchall()
     if not rows:
-        return ImuSamples(times_ns=np.zeros(0, dtype=np.int64), values_xyz=np.zeros((0, 3), dtype=np.float64))
+        return ImuChannel(times_ns=np.zeros(0, dtype=np.int64), values_xyz=np.zeros((0, 3), dtype=np.float64))
     raw: Int64[ndarray, "n_samples 4"] = np.asarray(rows, dtype=np.int64)
     times_ns: Int64[ndarray, "n_samples"] = raw[:, 3] - CAMERA_TO_IMU_OFFSET_NS
     values_xyz: Float64[ndarray, "n_samples 3"] = raw[:, :3].astype(np.float64) * scale
-    return ImuSamples(times_ns=times_ns, values_xyz=values_xyz)
+    return ImuChannel(times_ns=times_ns, values_xyz=values_xyz)
 
 
-def read_imu_database(db_path: Path) -> tuple[ImuSamples, ImuSamples] | None:
+def read_imu_database(db_path: Path) -> tuple[ImuChannel, ImuChannel] | None:
     """Read ``(gyro, accel)`` from one IMU db, or ``None`` when the file is unusable.
 
     Some segments ship a malformed db (session_1's ``dev2``), which must not
@@ -145,8 +154,8 @@ def read_imu_database(db_path: Path) -> tuple[ImuSamples, ImuSamples] | None:
         # contextlib.closing because sqlite3's own context manager only ends the
         # transaction; it leaves the connection (and its fd) open until GC.
         with closing(sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)) as database:
-            gyro: ImuSamples = read_imu_channel(database, "gyro_data", GYRO_SCALE)
-            accel: ImuSamples = read_imu_channel(database, "acc_data", ACCEL_SCALE)
+            gyro: ImuChannel = read_imu_channel(database, "gyro_data", GYRO_SCALE)
+            accel: ImuChannel = read_imu_channel(database, "acc_data", ACCEL_SCALE)
     except BeartypeException:
         raise
     except sqlite3.DatabaseError as error:
@@ -218,7 +227,7 @@ def build_blueprint(camera_names: list[str]) -> rrb.Blueprint:
     )
 
 
-class RobocapDataset(DataforgeDataset[RobocapConfig]):
+class RobocapDataset(DataforgeDataset[RobocapConfig, RobocapSource]):
     """Converts RoboCap segments into exoego:v2 base-layer recordings."""
 
     def default_blueprint(self) -> rrb.Blueprint:
@@ -238,9 +247,9 @@ class RobocapDataset(DataforgeDataset[RobocapConfig]):
         sessions: list[Path] = self.session_dirs()
         print(f"robocap: {self.config.root} — {len(sessions)} sessions, {len(self.sequences())} segments, calibration present")
 
-    def sequences(self) -> list[SequenceIdentity]:
-        """Discover every ``(device, session, segment)`` triple on disk."""
-        triples: set[tuple[str, int, int]] = set()
+    def discover(self) -> list[tuple[SequenceIdentity, RobocapSource]]:
+        """Pair every ``(device, session, segment)`` triple on disk with its session directory."""
+        sources: dict[tuple[str, int, int], Path] = {}
         for session_dir in self.session_dirs():
             match: re.Match[str] | None = SESSION_DIR_RE.match(session_dir.name)
             if match is None:
@@ -250,22 +259,14 @@ class RobocapDataset(DataforgeDataset[RobocapConfig]):
             for video_path in session_dir.glob(f"video_dev*_session{session}_segment*_*.mp4"):
                 video_match: re.Match[str] | None = VIDEO_NAME_RE.match(video_path.stem)
                 if video_match is not None:
-                    triples.add((device, session, int(video_match["segment"])))
+                    sources[(device, session, int(video_match["segment"]))] = session_dir
         return [
-            SequenceIdentity(dataset="robocap", parts=(device, f"s{session}", f"seg{segment}")) for device, session, segment in sorted(triples)
+            (
+                SequenceIdentity(dataset=self.config.name, parts=(device, f"s{session}", f"seg{segment}")),
+                RobocapSource(session_dir=session_dir, device=device, session=session, segment=segment),
+            )
+            for (device, session, segment), session_dir in sorted(sources.items())
         ]
-
-    def _locate(self, identity: SequenceIdentity) -> tuple[Path, str, int, int]:
-        """Resolve an identity back to ``(session_dir, device, session, segment)``."""
-        if len(identity.parts) != 3:
-            raise ValueError(f"RoboCap identities have three parts, got {identity.sequence_key!r}")
-        device: str = identity.parts[0]
-        session: int = int(identity.parts[1].removeprefix("s"))
-        segment: int = int(identity.parts[2].removeprefix("seg"))
-        session_dir: Path = self.config.root / f"{device}_session_{session}"
-        if not session_dir.is_dir():
-            raise FileNotFoundError(f"Session directory not found: {session_dir}")
-        return session_dir, device, session, segment
 
     def _videos(self, session_dir: Path, session: int, segment: int) -> dict[str, Path]:
         """Map canonical camera name → MP4 path, ordered by ``CAMERA_DISPLAY_ORDER``."""
@@ -296,21 +297,23 @@ class RobocapDataset(DataforgeDataset[RobocapConfig]):
         return cameras
 
     # ── conversion ────────────────────────────────────────────────────────
-    def convert(self, identity: SequenceIdentity, *, force: bool) -> Path:
+    def convert(self, identity: SequenceIdentity, source: RobocapSource, *, force: bool) -> Path:
         """Write one segment's base-layer rrd (cameras + video + dev0 IMU)."""
-        target: Path = paths.rrd_path(paths.output_root(), layer="base", identity=identity)
+        target: Path = paths.rrd_path(paths.output_root(), layer=paths.BASE_LAYER, identity=identity)
         if writing.should_skip(target, force=force):
             print(f"skip {identity.sequence_key} → {target}")
             return target
 
-        session_dir, device, session, segment = self._locate(identity)
-        videos: dict[str, Path] = self._videos(session_dir, session, segment)
+        videos: dict[str, Path] = self._videos(source.session_dir, source.session, source.segment)
         if not videos:
-            raise FileNotFoundError(f"No videos for {identity.sequence_key} in {session_dir}")
-        cameras: dict[str, Fisheye62Parameters] = self._calibration(device)
+            raise FileNotFoundError(f"No videos for {identity.sequence_key} in {source.session_dir}")
+        cameras: dict[str, Fisheye62Parameters] = self._calibration(source.device)
         camera_names: list[str] = [name for name in videos if name in cameras]
         if not camera_names:
             raise FileNotFoundError(f"No calibrated cameras for {identity.sequence_key}")
+        # Every MP4's container comment is parsed exactly once, before the recording opens:
+        # each stream is retimed by its own epoch, and the earliest doubles as start_time_ns.
+        epochs_ns: dict[str, int] = {name: video_epoch_ns(path) for name, path in videos.items()}
 
         with writing.atomic_recording(
             target,
@@ -318,17 +321,9 @@ class RobocapDataset(DataforgeDataset[RobocapConfig]):
             recording_id=identity.recording_id,
             default_blueprint=build_blueprint(camera_names),
         ) as recording:
-            # Deliberately NO static Transform3D on the rig node and NO ViewCoordinates at "/":
-            # per exoego:v2 a world-anchored rig carries no transform, and a static one would
-            # permanently shadow the temporal world_T_rig that a slam/pose layer stacks on this
-            # entity (verified: static components shadow temporal ones per component, silently).
-            # The pose layer owns the root ViewCoordinates (its world is gravity-aligned Z-up).
-            rr.log(
-                schema.rig_path(RIG),
-                rr.AnyValues(schema_version=schema.EXOEGO_SCHEMA_VERSION, reference="cam_00", num_cameras=len(camera_names)),
-                static=True,
-                recording=recording,
-            )
+            # Deliberately NO ViewCoordinates at "/": the pose layer owns the root
+            # ViewCoordinates (its world is gravity-aligned Z-up).
+            log_rig_node(recording, RIG, reference=RIG_REFERENCE, num_cameras=len(camera_names), name="robocap", kind="ego")
             self._log_mesh(recording)
 
             num_frames: int = 0
@@ -346,24 +341,22 @@ class RobocapDataset(DataforgeDataset[RobocapConfig]):
                     static=True,
                     recording=recording,
                 )
-                num_frames = max(num_frames, self._log_video(recording, videos[cam_name], schema.video_path(RIG, index)))
+                num_frames = max(
+                    num_frames,
+                    log_video_stream(recording, videos[cam_name], schema.video_path(RIG, index), shift_ns=epochs_ns[cam_name]),
+                )
 
-            self._log_imu(recording, session_dir, session, segment)
+            self._log_imu(recording, source)
 
-            recording.send_recording_name(identity.recording_id)
             # start_time_ns makes the device-clock origin queryable without scanning chunks
             # (e.g. for a consumer that wants a zero-based axis or cross-segment alignment).
-            start_time_ns: int = min(video_epoch_ns(path) for path in videos.values())
-            recording.send_property(
-                "capture",
-                rr.AnyValues(
-                    schema=schema.DATAFORGE_SCHEMA_VERSION,
-                    num_frames=num_frames,
-                    num_cameras=len(camera_names),
-                    start_time_ns=start_time_ns,
-                ),
+            writing.send_capture_properties(
+                recording,
+                identity,
+                num_cameras=len(camera_names),
+                num_frames=num_frames,
+                start_time_ns=min(epochs_ns.values()),
             )
-            recording.send_property("convert", rr.AnyValues(version="1"))
 
         print(f"done {identity.sequence_key} → {target} ({len(camera_names)} cameras, {num_frames} frames)")
         return target
@@ -382,70 +375,13 @@ class RobocapDataset(DataforgeDataset[RobocapConfig]):
         rr.log(mesh_entity, rr.Transform3D(translation=MESH_TRANSLATION, mat3x3=MESH_MAT3X3), static=True, recording=recording)
         rr.log(mesh_entity, rr.Asset3D(path=mesh_path), static=True, recording=recording)
 
-    def _log_video(self, recording: rr.RecordingStream, video_path: Path, entity_path: str) -> int:
-        """Remux one MP4 as a ``VideoStream``, retimed onto the camera clock.
-
-        ``Mp4Reader`` emits chunk timestamps as raw PTS (nanoseconds from the
-        start of the file), so every indexed chunk is shifted by the file's
-        absolute epoch before it reaches the recording.
-
-        Args:
-            recording: Destination recording stream.
-            video_path: RoboCap MP4 to remux (no decode, no re-encode).
-            entity_path: ``.../pinhole/video`` entity to log under.
-
-        Returns:
-            Number of video samples written.
-        """
-        epoch_ns: int = video_epoch_ns(video_path)
-        sample_count: int = 0
-
-        def retime(chunk: rr.experimental.Chunk) -> list[rr.experimental.Chunk]:
-            nonlocal sample_count
-            if schema.TIMELINE not in chunk.timeline_names:
-                return [chunk]  # the static codec chunk carries no index
-            record_batch: pa.RecordBatch = chunk.to_record_batch()
-            index: int = record_batch.schema.get_field_index(schema.TIMELINE)
-            shifted: pa.Array = pa.array(np.asarray(record_batch.column(index).cast(pa.int64())) + epoch_ns, type=pa.duration("ns"))
-            sample_count += record_batch.num_rows
-            retimed: pa.RecordBatch = record_batch.set_column(index, record_batch.schema.field(index), shifted)
-            # No index=/entity_path= overrides: the batch's rerun:* metadata already carries
-            # both, and passing either forces from_record_batch to mint fresh row/chunk ids.
-            return rr.experimental.Chunk.from_record_batch(retimed)
-
-        reader: rr.experimental.Mp4Reader = rr.experimental.Mp4Reader(
-            video_path,
-            mode="stream",
-            entity_path=entity_path,
-            timeline_name=schema.TIMELINE,
-        )
-        # send_chunks drives the lazy stream to completion, so sample_count is final here;
-        # anything short of a fully-consuming terminal would silently leave it at 0.
-        recording.send_chunks(reader.stream().flat_map(retime))
-        return sample_count
-
-    def _log_imu(self, recording: rr.RecordingStream, session_dir: Path, session: int, segment: int) -> None:
+    def _log_imu(self, recording: rr.RecordingStream, source: RobocapSource) -> None:
         """Log the dev0 IMU's raw gyro/accel samples columnar on ``video_time``."""
-        db_path: Path = session_dir / f"IMUWriter_dev{IMU_DEVICE}_session{session}_segment{segment}.db"
+        db_path: Path = source.session_dir / f"IMUWriter_dev{IMU_DEVICE}_session{source.session}_segment{source.segment}.db"
         if not db_path.is_file():
             print(f"  warning: no IMU database at {db_path}")
             return
-        channels: tuple[ImuSamples, ImuSamples] | None = read_imu_database(db_path)
+        channels: tuple[ImuChannel, ImuChannel] | None = read_imu_database(db_path)
         if channels is None:
             return
-        for samples, entity_path in ((channels[0], schema.gyro_path(RIG, IMU_DEVICE)), (channels[1], schema.accel_path(RIG, IMU_DEVICE))):
-            if samples.times_ns.size == 0:
-                continue
-            rr.send_columns(
-                entity_path,
-                indexes=[rr.TimeColumn(schema.TIMELINE, duration=samples.times_ns.astype("timedelta64[ns]"))],
-                columns=rr.Scalars.columns(scalars=samples.values_xyz),
-                recording=recording,
-            )
-        rr.log(schema.imu_path(RIG, IMU_DEVICE), IDENTITY_TRANSFORM, static=True, recording=recording)
-        rr.log(
-            schema.imu_path(RIG, IMU_DEVICE),
-            rr.AnyValues(name=f"dev{IMU_DEVICE}", kind="imu"),
-            static=True,
-            recording=recording,
-        )
+        log_imu(recording, RIG, IMU_DEVICE, gyro=channels[0], accel=channels[1], name=f"dev{IMU_DEVICE}")

--- a/packages/dataforge/dataforge/datasets/selfcap.py
+++ b/packages/dataforge/dataforge/datasets/selfcap.py
@@ -59,6 +59,7 @@ import re
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import ClassVar
 
 import numpy as np
 import rerun as rr
@@ -71,6 +72,7 @@ from simplecv.rerun_custom_types import CameraDistortion, PinholeWithDistortion
 from dataforge import paths, schema, transports, writing
 from dataforge.datasets.base import DataforgeDataset, DataforgeDatasetConfig
 from dataforge.identity import SequenceIdentity
+from dataforge.logging_toolkit import ImuChannel, log_imu, log_rig_node, log_video_stream
 
 DATE_DIR_RE: re.Pattern[str] = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 """Capture-day directories under the subset; the loose ``manifest.json`` siblings do not match."""
@@ -129,18 +131,6 @@ class CameraCalibration:
 
 
 @dataclass(frozen=True, slots=True)
-class ImuSamples:
-    """The OAK IMU's raw accelerometer and gyroscope channels at their native rate."""
-
-    times_ns: Int64[ndarray, "n_samples"]
-    """Sample times on the episode-relative ``video_time`` clock, in nanoseconds."""
-    accel_xyz: Float64[ndarray, "n_samples 3"]
-    """Linear acceleration in m/s^2 (gravity included)."""
-    gyro_xyz: Float64[ndarray, "n_samples 3"]
-    """Angular velocity in rad/s."""
-
-
-@dataclass(frozen=True, slots=True)
 class HeadPoses:
     """The Quest's left-eye track in its own Y-up world frame."""
 
@@ -169,9 +159,72 @@ class CameraPane:
     layout communicates has to travel with the pane list itself."""
 
 
+@dataclass(frozen=True, slots=True)
+class CameraPlan:
+    """One camera that *will* be logged: its slot, its media, and its metadata."""
+
+    rig: int
+    """Rig index owning the camera."""
+    cam: int
+    """Camera index within the rig."""
+    video_path: Path
+    """mp4 remuxed onto ``schema.video_path(rig, cam)``."""
+    calibration: CameraCalibration
+    """Intrinsics; a camera without them never reaches a plan."""
+    name: str
+    """``name`` AnyValue on the cam node (device name or stream label)."""
+    kind: str
+    """``kind`` AnyValue on the cam node: ``rgb`` or ``grayscale``."""
+    native_frames: int | None = None
+    """Rows in the ego stream's native-rate csv; None for cameras without one."""
+    native_duration_ns: int | None = None
+    """Last native-rate timestamp; None for cameras without a csv."""
+
+
+@dataclass(frozen=True, slots=True)
+class RigPlan:
+    """One rig node and the cameras that survived plan building."""
+
+    rig: int
+    """Rig index; the node is ``schema.rig_path(rig)``."""
+    reference: str
+    """Sensor child whose frame the rig frame coincides with."""
+    name: str
+    """Human device label (the exo device name, ``oak``, ``quest``)."""
+    kind: str
+    """Device role: ``exo`` / ``ego`` / ``quest``."""
+    cameras: tuple[CameraPlan, ...]
+    """Cameras actually logged under this rig; sets the node's ``num_cameras``."""
+
+
+@dataclass(frozen=True, slots=True)
+class EpisodePlan:
+    """Everything convert needs, decided *before* the recording opens.
+
+    Building the plan first is what keeps the embedded blueprint and the
+    ``num_cameras`` property honest: a camera that lacks intrinsics is warned
+    about and dropped here, so it can never appear as a pane describing an
+    entity the converter then never logs.
+    """
+
+    episode_dir: Path
+    """``episodes/episode-<NNN>`` directory the plan was built from."""
+    rigs: tuple[RigPlan, ...]
+    """Exo rigs in name order, then the OAK ego rig, then the Quest."""
+    ego_rig: int
+    """Rig index of the OAK, whose ``imu_00`` feeds the time-series views."""
+    quest_rig: int
+    """Rig index of the Quest, whose node carries the temporal ``world_T_rig``."""
+    panes: tuple[CameraPane, ...]
+    """Blueprint panes — exactly the cameras in ``rigs``, in rig-then-camera order."""
+
+
 @dataclass
 class SelfcapConfig(DataforgeDatasetConfig):
     """Self-collected exo/ego/Quest captures, cut into per-task episodes."""
+
+    name: ClassVar[str] = "selfcap"
+    """Registry key, catalog dataset name, and identity ``dataset`` part."""
 
     _target: type = field(default_factory=lambda: SelfcapDataset)
     """Dataset class instantiated by ``setup()``."""
@@ -219,22 +272,25 @@ def read_frame_times_ns(csv_path: Path) -> Int64[ndarray, "n_frames"]:
     return np.rint(columns["ts_ns"]).astype(np.int64)
 
 
-def read_imu_csv(csv_path: Path) -> ImuSamples:
-    """Read the OAK IMU csv, keeping only the accelerometer and gyroscope channels.
+def read_imu_csv(csv_path: Path) -> tuple[ImuChannel, ImuChannel]:
+    """Read the OAK IMU csv, keeping only the gyroscope and accelerometer channels.
+
+    Both channels share the csv's single ``ts_ns`` column: the OAK reports one
+    fused row per sample instant, unlike RoboCap's two independent tables.
 
     Args:
         csv_path: An ``ego/imu.csv``; also holds ``mag_*`` and ``rot_*`` columns.
 
     Returns:
-        Accel (m/s^2) and gyro (rad/s) samples at their native ~100 Hz rate.
+        The gyro (rad/s) and accel (m/s^2) channels at their native ~100 Hz rate.
         TODO(dataforge): the magnetometer and the ``rot_ijk`` device attitude are
         dropped; they want a magnetometer entity and a proper rotation component.
     """
     columns: dict[str, Float64[ndarray, "n_rows"]] = read_csv_columns(csv_path)
     times_ns: Int64[ndarray, "n_samples"] = np.rint(columns["ts_ns"]).astype(np.int64)
-    accel_xyz: Float64[ndarray, "n_samples 3"] = np.stack([columns["accel_x"], columns["accel_y"], columns["accel_z"]], axis=-1)
     gyro_xyz: Float64[ndarray, "n_samples 3"] = np.stack([columns["gyro_x"], columns["gyro_y"], columns["gyro_z"]], axis=-1)
-    return ImuSamples(times_ns=times_ns, accel_xyz=accel_xyz, gyro_xyz=gyro_xyz)
+    accel_xyz: Float64[ndarray, "n_samples 3"] = np.stack([columns["accel_x"], columns["accel_y"], columns["accel_z"]], axis=-1)
+    return ImuChannel(times_ns=times_ns, values_xyz=gyro_xyz), ImuChannel(times_ns=times_ns, values_xyz=accel_xyz)
 
 
 def read_head_poses(csv_path: Path) -> HeadPoses:
@@ -363,7 +419,97 @@ def episode_is_readable(episode_dir: Path) -> bool:
     return bool(exo_devices(episode_dir))
 
 
-def build_blueprint(panes: list[CameraPane], ego_rig: int) -> rrb.Blueprint:
+def build_episode_plan(episode_dir: Path) -> EpisodePlan:
+    """Decide the whole recording's shape from the raw tree, before anything is logged.
+
+    Every camera is vetted here — the device directory must be readable (already
+    checked by discovery) *and* its ``calibration.json`` must actually describe
+    the camera. A camera that fails is warned about and dropped, so the blueprint
+    panes and the ``num_cameras`` property describe exactly what gets logged.
+
+    Args:
+        episode_dir: A readable ``episodes/episode-<NNN>`` directory.
+
+    Returns:
+        The rig/camera/pane plan for this episode.
+    """
+    devices: list[str] = exo_devices(episode_dir)
+    ego_rig: int = len(devices)
+    quest_rig: int = ego_rig + 1
+    rigs: list[RigPlan] = []
+    panes: list[CameraPane] = []
+
+    for rig, device in enumerate(devices):
+        device_dir: Path = episode_dir / "exo" / device
+        cameras: dict[str, CameraCalibration] = read_calibration(device_dir / "calibration.json")
+        # iPhone calibration ships one entry whose positional_layout is always "center";
+        # fall back to the sole entry so a renamed layout does not lose the camera.
+        calibration: CameraCalibration | None = cameras.get("center") or next(iter(cameras.values()), None)
+        exo_cameras: list[CameraPlan] = []
+        if calibration is None:
+            print(f"  warning: no usable intrinsics in {device_dir / 'calibration.json'}, skipping {device}")
+        else:
+            exo_cameras.append(
+                CameraPlan(rig=rig, cam=0, video_path=device_dir / f"{device}.mp4", calibration=calibration, name=device, kind="rgb")
+            )
+            panes.append(CameraPane(name=device.split("-")[0], rig=rig, cam=0, kind="exo"))
+        # reference="cam_00": a single-camera rig's frame is its camera's frame by construction.
+        rigs.append(RigPlan(rig=rig, reference="cam_00", name=device, kind="exo", cameras=tuple(exo_cameras)))
+
+    ego_dir: Path = episode_dir / "ego"
+    ego_calibration: dict[str, CameraCalibration] = read_calibration(ego_dir / "calibration.json")
+    ego_cameras: list[CameraPlan] = []
+    for cam, (stream, layout) in enumerate(EGO_STREAM_LAYOUTS):
+        calibration = ego_calibration.get(layout)
+        if calibration is None:
+            print(f"  warning: no '{layout}' intrinsics in {ego_dir / 'calibration.json'}, skipping ego {stream}")
+            continue
+        # The mp4 is resampled onto the shared episode grid, so the csv's native-rate
+        # clock is surfaced as metadata rather than used to retime the samples.
+        frame_times_ns: Int64[ndarray, "n_frames"] = read_frame_times_ns(ego_dir / f"{stream}.csv")
+        ego_cameras.append(
+            CameraPlan(
+                rig=ego_rig,
+                cam=cam,
+                video_path=ego_dir / f"{stream}.mp4",
+                calibration=calibration,
+                name=stream,
+                kind="rgb" if stream == "rgb" else "grayscale",
+                native_frames=frame_times_ns.size,
+                native_duration_ns=int(frame_times_ns[-1]) if frame_times_ns.size else 0,
+            )
+        )
+        panes.append(CameraPane(name=f"ego {stream}", rig=ego_rig, cam=cam, kind="ego"))
+    # reference="cam_00": the OAK's rgb camera stands in for the rig frame while the
+    # stereo extrinsics stay unlogged (see read_calibration's TODO on their units).
+    rigs.append(RigPlan(rig=ego_rig, reference="cam_00", name="oak", kind="ego", cameras=tuple(ego_cameras)))
+
+    quest_dir: Path = episode_dir / "quest"
+    quest_calibration: dict[str, CameraCalibration] = read_calibration(quest_dir / "calibration.json")
+    quest_cameras: list[CameraPlan] = []
+    for cam, (stream, layout) in enumerate(QUEST_STREAM_LAYOUTS):
+        calibration = quest_calibration.get(layout)
+        if calibration is None:
+            print(f"  warning: no '{layout}' intrinsics in {quest_dir / 'calibration.json'}, skipping quest {stream}")
+            continue
+        quest_cameras.append(
+            CameraPlan(
+                rig=quest_rig,
+                cam=cam,
+                video_path=quest_dir / f"{stream}.mp4",
+                calibration=calibration,
+                name=stream,
+                kind="grayscale",
+            )
+        )
+        panes.append(CameraPane(name=f"quest {stream}", rig=quest_rig, cam=cam, kind="quest"))
+    # reference="cam_00": the head_pose track logged on the rig node *is* the left-eye pose.
+    rigs.append(RigPlan(rig=quest_rig, reference="cam_00", name="quest", kind="quest", cameras=tuple(quest_cameras)))
+
+    return EpisodePlan(episode_dir=episode_dir, rigs=tuple(rigs), ego_rig=ego_rig, quest_rig=quest_rig, panes=tuple(panes))
+
+
+def build_blueprint(panes: tuple[CameraPane, ...], ego_rig: int) -> rrb.Blueprint:
     """Default layout: the 3D scene plus a camera grid over the ego IMU plots.
 
     Args:
@@ -413,7 +559,7 @@ def build_blueprint(panes: list[CameraPane], ego_rig: int) -> rrb.Blueprint:
     )
 
 
-class SelfcapDataset(DataforgeDataset[SelfcapConfig]):
+class SelfcapDataset(DataforgeDataset[SelfcapConfig, Path]):
     """Converts SelfCap episodes into exoego:v2 base-layer recordings."""
 
     def default_blueprint(self) -> rrb.Blueprint:
@@ -425,7 +571,7 @@ class SelfcapDataset(DataforgeDataset[SelfcapConfig]):
         panes: list[CameraPane] = [CameraPane(name=f"exo {rig}", rig=rig, cam=0, kind="exo") for rig in range(DEFAULT_EXO_CAMERAS)]
         panes += [CameraPane(name=f"ego {stream}", rig=DEFAULT_EXO_CAMERAS, cam=index, kind="ego") for index, (stream, _) in enumerate(EGO_STREAM_LAYOUTS)]
         panes += [CameraPane(name=f"quest {stream}", rig=DEFAULT_EXO_CAMERAS + 1, cam=index, kind="quest") for index, (stream, _) in enumerate(QUEST_STREAM_LAYOUTS)]
-        return build_blueprint(panes, ego_rig=DEFAULT_EXO_CAMERAS)
+        return build_blueprint(tuple(panes), ego_rig=DEFAULT_EXO_CAMERAS)
 
     # ── raw-tree discovery ────────────────────────────────────────────────
     def subset_root(self) -> Path:
@@ -448,9 +594,9 @@ class SelfcapDataset(DataforgeDataset[SelfcapConfig]):
         dates: set[str] = {date for date, _ in sessions}
         print(f"selfcap: {self.subset_root()} — {len(dates)} days, {len(sessions)} sessions, {len(self.sequences())} readable episodes")
 
-    def sequences(self) -> list[SequenceIdentity]:
-        """Discover every readable episode; unreadable ones are dropped, not raised on."""
-        identities: list[SequenceIdentity] = []
+    def discover(self) -> list[tuple[SequenceIdentity, Path]]:
+        """Pair every readable episode with its directory; unreadable ones are dropped, not raised on."""
+        pairs: list[tuple[SequenceIdentity, Path]] = []
         skipped: int = 0
         for date, session_dir in self.session_dirs():
             for episode_dir in sorted((session_dir / "episodes").iterdir()):
@@ -460,102 +606,93 @@ class SelfcapDataset(DataforgeDataset[SelfcapConfig]):
                 if not episode_is_readable(episode_dir):
                     skipped += 1
                     continue
-                identities.append(
-                    SequenceIdentity(
-                        dataset="selfcap",
-                        parts=(date, session_dir.name[:SESSION_KEY_LENGTH], f"ep{int(match['number']):03d}"),
-                    )
+                identity: SequenceIdentity = SequenceIdentity(
+                    dataset=self.config.name,
+                    parts=(date, session_dir.name[:SESSION_KEY_LENGTH], f"ep{int(match['number']):03d}"),
                 )
+                pairs.append((identity, episode_dir))
         if skipped:
             print(f"  warning: skipped {skipped} episode(s) with unreadable files (corpus chmod pending)")
-        return identities
-
-    def _locate(self, identity: SequenceIdentity) -> Path:
-        """Resolve an identity back to its ``episodes/episode-<NNN>`` directory."""
-        if len(identity.parts) != 3:
-            raise ValueError(f"SelfCap identities have three parts, got {identity.sequence_key!r}")
-        date: str = identity.parts[0]
-        session_prefix: str = identity.parts[1]
-        episode_number: int = int(identity.parts[2].removeprefix("ep"))
-        candidates: list[Path] = sorted(path for path in self.subset_root().glob(f"{date}/{session_prefix}*") if (path / "episodes").is_dir())
-        if len(candidates) != 1:
-            raise FileNotFoundError(f"Expected exactly one session for {identity.sequence_key!r}, found {len(candidates)}")
-        episode_dir: Path = candidates[0] / "episodes" / f"episode-{episode_number:03d}"
-        if not episode_dir.is_dir():
-            raise FileNotFoundError(f"Episode directory not found: {episode_dir}")
-        return episode_dir
+        return pairs
 
     # ── conversion ────────────────────────────────────────────────────────
-    def convert(self, identity: SequenceIdentity, *, force: bool) -> Path:
+    def convert(self, identity: SequenceIdentity, source: Path, *, force: bool) -> Path:
         """Write one episode's base-layer rrd (nine cameras, ego IMU, Quest pose)."""
-        target: Path = paths.rrd_path(paths.output_root(), layer="base", identity=identity)
+        target: Path = paths.rrd_path(paths.output_root(), layer=paths.BASE_LAYER, identity=identity)
         if writing.should_skip(target, force=force):
             print(f"skip {identity.sequence_key} → {target}")
             return target
 
-        episode_dir: Path = self._locate(identity)
-        if not episode_is_readable(episode_dir):
-            raise PermissionError(f"Episode {identity.sequence_key} has unreadable files: {episode_dir}")
-        devices: list[str] = exo_devices(episode_dir)
-        ego_rig: int = len(devices)
-        quest_rig: int = ego_rig + 1
-
-        panes: list[CameraPane] = [CameraPane(name=device.split("-")[0], rig=rig, cam=0, kind="exo") for rig, device in enumerate(devices)]
-        panes += [CameraPane(name=f"ego {stream}", rig=ego_rig, cam=index, kind="ego") for index, (stream, _) in enumerate(EGO_STREAM_LAYOUTS)]
-        panes += [CameraPane(name=f"quest {stream}", rig=quest_rig, cam=index, kind="quest") for index, (stream, _) in enumerate(QUEST_STREAM_LAYOUTS)]
+        # Plan first, log second: the blueprint panes and num_cameras below are the
+        # plan's, so they can only ever describe cameras that really get logged.
+        plan: EpisodePlan = build_episode_plan(source)
 
         with writing.atomic_recording(
             target,
             application_id="dataforge",
             recording_id=identity.recording_id,
-            default_blueprint=build_blueprint(panes, ego_rig=ego_rig),
+            default_blueprint=build_blueprint(plan.panes, ego_rig=plan.ego_rig),
         ) as recording:
             # The base layer owns the root ViewCoordinates because it already carries a real
-            # moving-rig pose: the Quest world is right-handed Y-up. Still NO static
-            # Transform3D on any rig node — a static component permanently shadows the
-            # temporal world_T_rig that a slam/pose layer stacks on the same entity.
+            # moving-rig pose: the Quest world is right-handed Y-up.
             rr.log("/", rr.ViewCoordinates.RIGHT_HAND_Y_UP, static=True, recording=recording)
 
             num_frames: int = 0
-            for rig, device in enumerate(devices):
-                num_frames = max(num_frames, self._log_exo(recording, episode_dir / "exo" / device, rig))
-            num_frames = max(num_frames, self._log_ego(recording, episode_dir / "ego", ego_rig))
-            num_frames = max(num_frames, self._log_quest(recording, episode_dir / "quest", quest_rig))
+            for rig_plan in plan.rigs:
+                log_rig_node(
+                    recording,
+                    rig_plan.rig,
+                    reference=rig_plan.reference,
+                    num_cameras=len(rig_plan.cameras),
+                    name=rig_plan.name,
+                    kind=rig_plan.kind,
+                )
+                for camera in rig_plan.cameras:
+                    num_frames = max(num_frames, self._log_camera(recording, camera))
+            self._log_ego_imu(recording, plan)
+            self._log_quest_pose(recording, plan)
 
-            recording.send_recording_name(identity.recording_id)
             # AnyValues drops None-valued kwargs, so an unreadable metadata.json simply
             # leaves task/collector off the property instead of writing empty strings.
-            session: dict[str, str] = read_session_task(episode_dir.parents[1] / "metadata.json")
-            recording.send_property(
-                "capture",
-                rr.AnyValues(
-                    schema=schema.DATAFORGE_SCHEMA_VERSION,
-                    num_cameras=len(panes),
-                    num_frames=num_frames,
-                    task=session.get("task"),
-                    collector=session.get("collector"),
-                ),
+            session: dict[str, str] = read_session_task(plan.episode_dir.parents[1] / "metadata.json")
+            writing.send_capture_properties(
+                recording,
+                identity,
+                num_cameras=len(plan.panes),
+                num_frames=num_frames,
+                task=session.get("task"),
+                collector=session.get("collector"),
             )
-            recording.send_property("convert", rr.AnyValues(version="1"))
 
-        print(f"done {identity.sequence_key} → {target} ({len(panes)} cameras, {num_frames} frames)")
+        print(f"done {identity.sequence_key} → {target} ({len(plan.panes)} cameras, {num_frames} frames)")
         return target
 
-    def _log_rig(self, recording: rr.RecordingStream, rig: int, *, name: str, kind: str) -> None:
-        """Tag a rig node with its schema version, device name, and role."""
+    def _log_camera(self, recording: rr.RecordingStream, camera: CameraPlan) -> int:
+        """Log one planned camera: node metadata, static pinhole, and its video stream.
+
+        No ``rig_T_cam`` transform is written: the raw exo calibration ships empty
+        extrinsics, and the ego/Quest ones are in unvalidated units. Brown-Conrady
+        coefficients ride along when the calibration declares them.
+
+        Args:
+            recording: Destination recording stream.
+            camera: The camera's slot, media, and metadata as planned.
+
+        Returns:
+            Number of video samples written for this camera.
+        """
         rr.log(
-            schema.rig_path(rig),
-            rr.AnyValues(schema_version=schema.EXOEGO_SCHEMA_VERSION, name=name, kind=kind),
+            schema.cam_path(camera.rig, camera.cam),
+            rr.AnyValues(
+                name=camera.name,
+                kind=camera.kind,
+                num_native_frames=camera.native_frames,
+                native_duration_ns=camera.native_duration_ns,
+            ),
             static=True,
             recording=recording,
         )
-
-    def _log_camera(self, recording: rr.RecordingStream, calibration: CameraCalibration, rig: int, cam: int) -> None:
-        """Log one camera's static pinhole (plus Brown-Conrady coefficients when known).
-
-        No ``rig_T_cam`` transform is written: the raw exo calibration ships empty
-        extrinsics, and the ego/Quest ones are in unvalidated units.
-        """
+        calibration: CameraCalibration = camera.calibration
         focal_length_xy: Float64[ndarray, "2"] = calibration.focal_length_xy
         principal_point_xy: Float64[ndarray, "2"] = calibration.principal_point_xy
         image_from_camera: Float32[ndarray, "3 3"] = np.array(
@@ -571,8 +708,11 @@ class SelfcapDataset(DataforgeDataset[SelfcapConfig]):
             if calibration.distortion_coefficients is None
             else CameraDistortion(model="brown_conrady", coefficients=calibration.distortion_coefficients.astype(np.float32))
         )
+        # TODO(dataforge): the Quest intrinsics describe the 1280x1280 sensor array while
+        # capture_resolution (and the mp4) is 1280x960, so cy lands ~160 px below the image
+        # centre. Confirm the crop origin against the device before shifting the principal point.
         rr.log(
-            schema.pinhole_path(rig, cam),
+            schema.pinhole_path(camera.rig, camera.cam),
             PinholeWithDistortion(
                 pinhole=rr.Pinhole(
                     image_from_camera=image_from_camera,
@@ -586,121 +726,25 @@ class SelfcapDataset(DataforgeDataset[SelfcapConfig]):
             static=True,
             recording=recording,
         )
+        # Raw PTS is already the shared episode clock (see the module docstring), so no shift.
+        return log_video_stream(recording, camera.video_path, schema.video_path(camera.rig, camera.cam))
 
-    def _log_video(self, recording: rr.RecordingStream, video_path: Path, entity_path: str) -> int:
-        """Remux one mp4 as a ``VideoStream`` on its own PTS, counting samples.
+    def _log_ego_imu(self, recording: rr.RecordingStream, plan: EpisodePlan) -> None:
+        """Log the OAK's single IMU on the ego rig, when its csv holds samples."""
+        channels: tuple[ImuChannel, ImuChannel] = read_imu_csv(plan.episode_dir / "ego" / "imu.csv")
+        if channels[0].times_ns.size:
+            log_imu(recording, plan.ego_rig, IMU_DEVICE, gyro=channels[0], accel=channels[1], name="oak-imu")
 
-        Raw PTS is already the shared episode clock (see the module docstring),
-        so chunks pass straight through; the tap only tallies samples so the
-        capture property can report a frame count.
-
-        Args:
-            recording: Destination recording stream.
-            video_path: SelfCap mp4 to remux (no decode, no re-encode).
-            entity_path: ``.../pinhole/video`` entity to log under.
-
-        Returns:
-            Number of video samples written.
-        """
-        sample_count: int = 0
-
-        def tally(chunk: rr.experimental.Chunk) -> list[rr.experimental.Chunk]:
-            nonlocal sample_count
-            if schema.TIMELINE in chunk.timeline_names:  # the static codec chunk carries no index
-                sample_count += chunk.num_rows
-            return [chunk]
-
-        reader: rr.experimental.Mp4Reader = rr.experimental.Mp4Reader(
-            video_path,
-            mode="stream",
-            entity_path=entity_path,
-            timeline_name=schema.TIMELINE,
+    def _log_quest_pose(self, recording: rr.RecordingStream, plan: EpisodePlan) -> None:
+        """Log the Quest's left-eye track as the temporal ``world_T_rig`` on its rig node."""
+        head_pose_path: Path = plan.episode_dir / "quest" / "head_pose.csv"
+        poses: HeadPoses = read_head_poses(head_pose_path)
+        if not poses.times_ns.size:
+            print(f"  warning: no head poses in {head_pose_path}; the quest rig stays unposed")
+            return
+        rr.send_columns(
+            schema.rig_path(plan.quest_rig),
+            indexes=[rr.TimeColumn(schema.TIMELINE, duration=poses.times_ns.astype("timedelta64[ns]"))],
+            columns=rr.Transform3D.columns(translation=poses.translations_xyz, quaternion=poses.quaternions_xyzw),
+            recording=recording,
         )
-        # send_chunks drives the lazy stream to completion, so sample_count is final here.
-        recording.send_chunks(reader.stream().flat_map(tally))
-        return sample_count
-
-    def _log_exo(self, recording: rr.RecordingStream, device_dir: Path, rig: int) -> int:
-        """Log one iPhone as a world-anchored-unknown rig with a single camera."""
-        self._log_rig(recording, rig, name=device_dir.name, kind="exo")
-        cameras: dict[str, CameraCalibration] = read_calibration(device_dir / "calibration.json")
-        # iPhone calibration ships one entry whose positional_layout is always "center";
-        # fall back to the sole entry so a renamed layout does not lose the camera.
-        calibration: CameraCalibration | None = cameras.get("center") or next(iter(cameras.values()), None)
-        if calibration is None:
-            print(f"  warning: no usable intrinsics in {device_dir / 'calibration.json'}, skipping {device_dir.name}")
-            return 0
-        rr.log(schema.cam_path(rig, 0), rr.AnyValues(name=device_dir.name, kind="rgb"), static=True, recording=recording)
-        self._log_camera(recording, calibration, rig, 0)
-        return self._log_video(recording, device_dir / f"{device_dir.name}.mp4", schema.video_path(rig, 0))
-
-    def _log_ego(self, recording: rr.RecordingStream, ego_dir: Path, rig: int) -> int:
-        """Log the OAK's three cameras and its IMU."""
-        self._log_rig(recording, rig, name="oak", kind="ego")
-        cameras: dict[str, CameraCalibration] = read_calibration(ego_dir / "calibration.json")
-        num_frames: int = 0
-        for cam, (stream, layout) in enumerate(EGO_STREAM_LAYOUTS):
-            calibration: CameraCalibration | None = cameras.get(layout)
-            if calibration is None:
-                print(f"  warning: no '{layout}' intrinsics in {ego_dir / 'calibration.json'}, skipping ego {stream}")
-                continue
-            # The mp4 is resampled onto the shared episode grid, so the csv's native-rate
-            # clock is surfaced as metadata rather than used to retime the samples.
-            frame_times_ns: Int64[ndarray, "n_frames"] = read_frame_times_ns(ego_dir / f"{stream}.csv")
-            rr.log(
-                schema.cam_path(rig, cam),
-                rr.AnyValues(
-                    name=stream,
-                    kind="rgb" if stream == "rgb" else "grayscale",
-                    num_native_frames=frame_times_ns.size,
-                    native_duration_ns=int(frame_times_ns[-1]) if frame_times_ns.size else 0,
-                ),
-                static=True,
-                recording=recording,
-            )
-            self._log_camera(recording, calibration, rig, cam)
-            num_frames = max(num_frames, self._log_video(recording, ego_dir / f"{stream}.mp4", schema.video_path(rig, cam)))
-
-        samples: ImuSamples = read_imu_csv(ego_dir / "imu.csv")
-        if samples.times_ns.size:
-            for values_xyz, entity_path in (
-                (samples.gyro_xyz, schema.gyro_path(rig, IMU_DEVICE)),
-                (samples.accel_xyz, schema.accel_path(rig, IMU_DEVICE)),
-            ):
-                rr.send_columns(
-                    entity_path,
-                    indexes=[rr.TimeColumn(schema.TIMELINE, duration=samples.times_ns.astype("timedelta64[ns]"))],
-                    columns=rr.Scalars.columns(scalars=values_xyz),
-                    recording=recording,
-                )
-            rr.log(schema.imu_path(rig, IMU_DEVICE), rr.AnyValues(name="oak-imu", kind="imu"), static=True, recording=recording)
-        return num_frames
-
-    def _log_quest(self, recording: rr.RecordingStream, quest_dir: Path, rig: int) -> int:
-        """Log the Quest's two eye cameras and its left-eye world pose track."""
-        self._log_rig(recording, rig, name="quest", kind="quest")
-        poses: HeadPoses = read_head_poses(quest_dir / "head_pose.csv")
-        if poses.times_ns.size:
-            rr.send_columns(
-                schema.rig_path(rig),
-                indexes=[rr.TimeColumn(schema.TIMELINE, duration=poses.times_ns.astype("timedelta64[ns]"))],
-                columns=rr.Transform3D.columns(translation=poses.translations_xyz, quaternion=poses.quaternions_xyzw),
-                recording=recording,
-            )
-        else:
-            print(f"  warning: no head poses in {quest_dir / 'head_pose.csv'}; the quest rig stays unposed")
-
-        cameras: dict[str, CameraCalibration] = read_calibration(quest_dir / "calibration.json")
-        num_frames: int = 0
-        for cam, (stream, layout) in enumerate(QUEST_STREAM_LAYOUTS):
-            calibration: CameraCalibration | None = cameras.get(layout)
-            if calibration is None:
-                print(f"  warning: no '{layout}' intrinsics in {quest_dir / 'calibration.json'}, skipping quest {stream}")
-                continue
-            rr.log(schema.cam_path(rig, cam), rr.AnyValues(name=stream, kind="grayscale"), static=True, recording=recording)
-            # TODO(dataforge): the Quest intrinsics describe the 1280x1280 sensor array while
-            # capture_resolution (and the mp4) is 1280x960, so cy lands ~160 px below the image
-            # centre. Confirm the crop origin against the device before shifting the principal point.
-            self._log_camera(recording, calibration, rig, cam)
-            num_frames = max(num_frames, self._log_video(recording, quest_dir / f"{stream}.mp4", schema.video_path(rig, cam)))
-        return num_frames

--- a/packages/dataforge/dataforge/datasets/selfcap.py
+++ b/packages/dataforge/dataforge/datasets/selfcap.py
@@ -381,21 +381,18 @@ def build_blueprint(panes: list[CameraPane], ego_rig: int) -> rrb.Blueprint:
         ]
 
     # The layout is grouped by device kind (blueprints cannot select on the rigs'
-    # `kind` AnyValues, so the grouping travels through the pane list instead):
-    # exo cameras as a grid, the OAK and Quest as labeled ego rows beneath it.
+    # `kind` AnyValues, so the grouping travels through the pane list instead) and
+    # mirrors simplecv's exoego ergonomics: a dominant 3D scene with the ego views
+    # (OAK + Quest) in a two-column grid beside it, the exo cameras as a bottom
+    # row, and the IMU strip beneath. Layout only — the logged schema is untouched.
     return rrb.Blueprint(
         rrb.Vertical(
             rrb.Horizontal(
                 rrb.Spatial3DView(name="Scene", origin="/", line_grid=True),
-                rrb.Vertical(
-                    rrb.Grid(*views("exo"), grid_columns=2, name="Exo"),
-                    rrb.Horizontal(*views("ego"), name="Ego · OAK"),
-                    rrb.Horizontal(*views("quest"), name="Ego · Quest"),
-                    row_shares=[2.0, 1.0, 1.0],
-                    name="Cameras",
-                ),
-                column_shares=[1.0, 1.0],
+                rrb.Grid(*views("ego"), *views("quest"), grid_columns=2, name="Ego"),
+                column_shares=[3.0, 1.0],
             ),
+            rrb.Horizontal(*views("exo"), name="Exo"),
             rrb.Horizontal(
                 rrb.TimeSeriesView(
                     name="Gyroscope",
@@ -410,7 +407,7 @@ def build_blueprint(panes: list[CameraPane], ego_rig: int) -> rrb.Blueprint:
                     plot_legend=rrb.PlotLegend(visible=True),
                 ),
             ),
-            row_shares=[3, 1],
+            row_shares=[4.0, 1.4, 1.0],
         ),
         collapse_panels=True,
     )

--- a/packages/dataforge/dataforge/datasets/selfcap.py
+++ b/packages/dataforge/dataforge/datasets/selfcap.py
@@ -1,0 +1,691 @@
+"""SelfCap: 4 iPhones + an OAK ego rig + a Quest → one exoego:v2 base rrd per episode.
+
+Raw layout on disk (already local; ``download`` only verifies it)::
+
+    <root>/<subset>/<YYYY-MM-DD>/<session-uuid>/
+        metadata.json                     task / collector / time (usually mode 000)
+        calibration_manifest.json         (usually mode 000)
+        episodes/episode-<NNN>/
+            ego/{rgb,left,right}.mp4      OAK, 1280x720
+            ego/{rgb,left,right}.csv      ts_ns,frame_idx at the OAK's native rate
+            ego/imu.csv                   ts_ns + accel/gyro/mag/rot, ~100 Hz
+            ego/calibration.json          3 cameras, 14-coeff Brown-Conrady
+            exo/<DeviceName>/<DeviceName>.mp4 + calibration.json
+            quest/{left,right}.mp4 + head_pose.csv + body/hand poses + calibration.json
+            episode-<NNN>.rrd             prior art; deliberately ignored
+
+Clocks (verified on disk, 2026-08-20, over four days x one episode each plus
+three episodes of ``2025-12-20/25aeb66a``). Every ``ts_ns`` column — ego frame
+csvs, ``imu.csv``, ``head_pose.csv`` — is **episode-relative** and starts at 0,
+so ``video_time`` is a duration timeline anchored at the episode start.
+
+The nine videos are *not* the raw device streams: the cutting pipeline
+re-encoded all of them to AV1 on one shared, near-CFR grid. Within an episode
+every stream carries the same frame count and the same ``start_pts`` (0, or a
+constant 16-20 ms), and the container duration matches the ego csv span to
+~40 ms; the ego mp4s additionally carry ~50% zero-cost duplicate packets (3
+bytes = ``show_existing_frame``) because the 24 fps OAK was resampled onto the
+iPhone grid. Consequences:
+
+* Raw PTS **is** the episode clock, for exo *and* ego *and* quest. Every video
+  therefore passes through ``Mp4Reader`` unmodified — no retime shift.
+* The ego frame csvs cannot index the ego mp4 samples (e.g. 322 csv rows vs 671
+  video samples). They stay the authoritative *native-rate* clock and are
+  surfaced as ``num_native_frames`` / ``native_duration_ns`` on each ego camera.
+  TODO(dataforge): a lens that drops the duplicate packets and retimes the ego
+  streams onto their native csv timestamps.
+
+Permissions. Large parts of the corpus are mode 000 (a NAS sync artifact; a
+corpus-wide chmod is pending). Discovery gates every required file behind
+``os.access(..., os.R_OK)`` and silently drops episodes that fail; convert warns
+and degrades instead of aborting. Session ``metadata.json`` is currently
+unreadable for **all** 692 ``cut`` sessions, so ``task`` / ``collector`` are
+absent from the capture property until the chmod lands.
+
+Rig topology. Exo devices sorted by name take ``rig_00..``, then the OAK ego rig,
+then the Quest — nine cameras and ``rig_00..rig_05`` in the usual 4-iPhone case.
+Only the Quest rig has a known pose (its left-eye track in the Quest's Y-up
+world frame), so the base layer owns the root ``ViewCoordinates``. Exo extrinsics
+are empty in the raw calibration: those rigs are world-anchored-unknown and carry
+no transform at all, waiting for a calibration/SLAM layer to localize them.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import rerun as rr
+import rerun.blueprint as rrb
+from beartype.roar import BeartypeException
+from jaxtyping import Float32, Float64, Int64
+from numpy import ndarray
+from simplecv.rerun_custom_types import CameraDistortion, PinholeWithDistortion
+
+from dataforge import paths, schema, transports, writing
+from dataforge.datasets.base import DataforgeDataset, DataforgeDatasetConfig
+from dataforge.identity import SequenceIdentity
+
+DATE_DIR_RE: re.Pattern[str] = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+"""Capture-day directories under the subset; the loose ``manifest.json`` siblings do not match."""
+EPISODE_DIR_RE: re.Pattern[str] = re.compile(r"^episode-(?P<number>\d+)$")
+"""Episode directory names, e.g. ``episode-009``."""
+SESSION_KEY_LENGTH: int = 8
+"""Prefix of the session uuid used in the sequence identity (uuid4 is unique well inside 8 hex chars)."""
+
+EGO_STREAM_LAYOUTS: tuple[tuple[str, str], ...] = (("rgb", "center"), ("left", "left"), ("right", "right"))
+"""OAK stream name → ``positional_layout`` in ``ego/calibration.json``, in cam_00..cam_02 order.
+
+Keying on ``positional_layout`` rather than ``camera_id`` because the OAK's
+``CAM_A``/``CAM_B``/``CAM_C`` lettering is device-firmware detail.
+"""
+QUEST_STREAM_LAYOUTS: tuple[tuple[str, str], ...] = (("left", "left"), ("right", "right"))
+"""Quest stream name → ``positional_layout``, in cam_00..cam_01 order."""
+
+BROWN_CONRADY_COEFFICIENTS: int = 14
+"""OpenCV's ``[k1 k2 p1 p2 k3 k4 k5 k6 s1 s2 s3 s4 tau_x tau_y]`` — exactly simplecv's ``BrownConradyDistortion``."""
+IMAGE_PLANE_DISTANCE: float = 0.1
+"""Frustum length in metres; the Quest world is metric, so this reads as 10 cm."""
+IMU_DEVICE: int = 0
+"""The OAK ships one IMU, so the ego rig has a single ``imu_00``."""
+DEFAULT_EXO_CAMERAS: int = 4
+"""Exo device count in 2937 of the 3085 readable ``cut`` episodes; shapes the dataset-wide blueprint."""
+
+EGO_CORE_FILES: tuple[str, ...] = (
+    "ego/rgb.mp4",
+    "ego/left.mp4",
+    "ego/right.mp4",
+    "ego/rgb.csv",
+    "ego/left.csv",
+    "ego/right.csv",
+    "ego/imu.csv",
+    "ego/calibration.json",
+)
+"""Files an episode must expose readably for its ego rig to be convertible."""
+QUEST_CORE_FILES: tuple[str, ...] = ("quest/left.mp4", "quest/right.mp4", "quest/head_pose.csv", "quest/calibration.json")
+"""Files an episode must expose readably for its Quest rig to be convertible."""
+
+
+@dataclass(frozen=True, slots=True)
+class CameraCalibration:
+    """One camera's intrinsics as the raw calibration states them."""
+
+    width: int
+    """Image width in pixels, from ``capture_resolution`` (the encoded video's width)."""
+    height: int
+    """Image height in pixels, from ``capture_resolution``."""
+    focal_length_xy: Float64[ndarray, "2"]
+    """``(fx, fy)`` in pixels."""
+    principal_point_xy: Float64[ndarray, "2"]
+    """``(cx, cy)`` in pixels."""
+    distortion_coefficients: Float64[ndarray, "14"] | None
+    """Brown-Conrady coefficients, or None when the raw calibration declares none."""
+
+
+@dataclass(frozen=True, slots=True)
+class ImuSamples:
+    """The OAK IMU's raw accelerometer and gyroscope channels at their native rate."""
+
+    times_ns: Int64[ndarray, "n_samples"]
+    """Sample times on the episode-relative ``video_time`` clock, in nanoseconds."""
+    accel_xyz: Float64[ndarray, "n_samples 3"]
+    """Linear acceleration in m/s^2 (gravity included)."""
+    gyro_xyz: Float64[ndarray, "n_samples 3"]
+    """Angular velocity in rad/s."""
+
+
+@dataclass(frozen=True, slots=True)
+class HeadPoses:
+    """The Quest's left-eye track in its own Y-up world frame."""
+
+    times_ns: Int64[ndarray, "n_samples"]
+    """Sample times on the episode-relative ``video_time`` clock, in nanoseconds."""
+    translations_xyz: Float32[ndarray, "n_samples 3"]
+    """Left-eye positions in metres."""
+    quaternions_xyzw: Float32[ndarray, "n_samples 4"]
+    """Left-eye orientations as xyzw quaternions (Rerun's component layout)."""
+
+
+@dataclass(frozen=True, slots=True)
+class CameraPane:
+    """One camera's identity in the blueprint: where it lives and what to call it."""
+
+    name: str
+    """Human label shown on the 2D view."""
+    rig: int
+    """Rig index owning the camera."""
+    cam: int
+    """Camera index within the rig."""
+
+
+@dataclass
+class SelfcapConfig(DataforgeDatasetConfig):
+    """Self-collected exo/ego/Quest captures, cut into per-task episodes."""
+
+    _target: type = field(default_factory=lambda: SelfcapDataset)
+    """Dataset class instantiated by ``setup()``."""
+    root: Path = Path("/mnt/nas/datasets/exoego-self-collected/main")
+    """Corpus root holding the ``cut`` / ``good`` / ``sample`` subsets."""
+    subset: str = "cut"
+    """Subset directory to convert; only ``cut`` holds per-episode captures."""
+
+
+def read_csv_columns(csv_path: Path) -> dict[str, Float64[ndarray, "n_rows"]]:
+    """Read a fully numeric csv into one float64 column per header name.
+
+    Column *order* differs between corpus revisions, so every caller indexes by
+    name. ``ts_ns`` survives the float64 round trip exactly: episode-relative
+    times stay below 1e12 ns, far inside float64's 2^53 integer range.
+
+    Args:
+        csv_path: A csv whose first row is a header and whose body is numeric.
+
+    Returns:
+        Header name → column values; empty arrays when the file holds only a header.
+    """
+    with csv_path.open(newline="") as handle:
+        reader: Iterator[list[str]] = csv.reader(handle)
+        header: list[str] = next(reader)
+        rows: list[list[str]] = list(reader)
+    if not rows:
+        return {name: np.zeros(0, dtype=np.float64) for name in header}
+    values: Float64[ndarray, "n_rows n_columns"] = np.array(rows, dtype=np.float64)
+    return {name: values[:, index] for index, name in enumerate(header)}
+
+
+def read_frame_times_ns(csv_path: Path) -> Int64[ndarray, "n_frames"]:
+    """Native-rate capture times of one ego video stream, in row (frame) order.
+
+    Args:
+        csv_path: An ``ego/{rgb,left,right}.csv`` with ``ts_ns,frame_idx`` columns.
+
+    Returns:
+        The ``ts_ns`` column as nanoseconds on the episode-relative clock. The
+        companion ``frame_idx`` is a *session*-global counter, not an index into
+        the episode's mp4, so it is deliberately dropped.
+    """
+    columns: dict[str, Float64[ndarray, "n_rows"]] = read_csv_columns(csv_path)
+    return np.rint(columns["ts_ns"]).astype(np.int64)
+
+
+def read_imu_csv(csv_path: Path) -> ImuSamples:
+    """Read the OAK IMU csv, keeping only the accelerometer and gyroscope channels.
+
+    Args:
+        csv_path: An ``ego/imu.csv``; also holds ``mag_*`` and ``rot_*`` columns.
+
+    Returns:
+        Accel (m/s^2) and gyro (rad/s) samples at their native ~100 Hz rate.
+        TODO(dataforge): the magnetometer and the ``rot_ijk`` device attitude are
+        dropped; they want a magnetometer entity and a proper rotation component.
+    """
+    columns: dict[str, Float64[ndarray, "n_rows"]] = read_csv_columns(csv_path)
+    times_ns: Int64[ndarray, "n_samples"] = np.rint(columns["ts_ns"]).astype(np.int64)
+    accel_xyz: Float64[ndarray, "n_samples 3"] = np.stack([columns["accel_x"], columns["accel_y"], columns["accel_z"]], axis=-1)
+    gyro_xyz: Float64[ndarray, "n_samples 3"] = np.stack([columns["gyro_x"], columns["gyro_y"], columns["gyro_z"]], axis=-1)
+    return ImuSamples(times_ns=times_ns, accel_xyz=accel_xyz, gyro_xyz=gyro_xyz)
+
+
+def read_head_poses(csv_path: Path) -> HeadPoses:
+    """Read the Quest head-pose csv, keeping the left-eye track.
+
+    Args:
+        csv_path: A ``quest/head_pose.csv`` holding both eye poses per row.
+
+    Returns:
+        The left-eye poses, which stand in for the Quest rig pose.
+        TODO(dataforge): the right eye's offset relative to the left is
+        recoverable from ``quest/calibration.json`` (``device_to_left`` /
+        ``device_to_right`` / ``left_to_right`` extrinsics); once validated it
+        becomes the static ``rig_T_cam`` of both Quest cameras.
+    """
+    columns: dict[str, Float64[ndarray, "n_rows"]] = read_csv_columns(csv_path)
+    times_ns: Int64[ndarray, "n_samples"] = np.rint(columns["ts_ns"]).astype(np.int64)
+    translations_xyz: Float32[ndarray, "n_samples 3"] = np.stack(
+        [columns["left_pos_x"], columns["left_pos_y"], columns["left_pos_z"]], axis=-1
+    ).astype(np.float32)
+    quaternions_xyzw: Float32[ndarray, "n_samples 4"] = np.stack(
+        [columns["left_quat_x"], columns["left_quat_y"], columns["left_quat_z"], columns["left_quat_w"]], axis=-1
+    ).astype(np.float32)
+    return HeadPoses(times_ns=times_ns, translations_xyz=translations_xyz, quaternions_xyzw=quaternions_xyzw)
+
+
+def read_calibration(calibration_path: Path) -> dict[str, CameraCalibration]:
+    """Read a device ``calibration.json`` into intrinsics keyed by ``positional_layout``.
+
+    Extrinsics are deliberately not read: exo files ship an empty list, and the
+    ego/Quest ones are in unvalidated units (the OAK baseline reads as 7.5,
+    i.e. centimetres). TODO(dataforge): validate and log them as ``rig_T_cam``.
+
+    Args:
+        calibration_path: A ``calibration.json`` from ``ego/``, ``exo/<Device>/``, or ``quest/``.
+
+    Returns:
+        ``positional_layout`` → intrinsics for every camera the file describes.
+    """
+    document: dict = json.loads(calibration_path.read_text())
+    cameras: dict[str, CameraCalibration] = {}
+    for entry in document.get("intrinsics", []):
+        lens: dict = entry.get("lens_intrinsics") or {}
+        resolution: dict = entry.get("capture_resolution") or {}
+        if lens.get("focal_length_x") is None or resolution.get("width") is None:
+            continue
+        raw_coefficients: list[float] | None = (entry.get("distortion") or {}).get("coefficients")
+        distortion: Float64[ndarray, "14"] | None = (
+            np.asarray(raw_coefficients, dtype=np.float64) if raw_coefficients is not None and len(raw_coefficients) == BROWN_CONRADY_COEFFICIENTS else None
+        )
+        cameras[str(entry.get("positional_layout"))] = CameraCalibration(
+            width=int(resolution["width"]),
+            height=int(resolution["height"]),
+            focal_length_xy=np.asarray([lens["focal_length_x"], lens["focal_length_y"]], dtype=np.float64),
+            principal_point_xy=np.asarray([lens["principal_point_x"], lens["principal_point_y"]], dtype=np.float64),
+            distortion_coefficients=distortion,
+        )
+    return cameras
+
+
+def read_session_task(metadata_path: Path) -> dict[str, str]:
+    """Task and collector of a session, or ``{}`` when its metadata is unreadable.
+
+    Every ``cut`` session's ``metadata.json`` is mode 000 as of 2026-08-20, so
+    this returns ``{}`` corpus-wide until the pending chmod lands.
+
+    Args:
+        metadata_path: Session-level ``metadata.json``.
+
+    Returns:
+        The ``task`` and ``collector`` keys that were present and non-empty.
+    """
+    if not os.access(metadata_path, os.R_OK):
+        return {}
+    try:
+        document: dict = json.loads(metadata_path.read_text())
+    except BeartypeException:
+        raise
+    except (OSError, json.JSONDecodeError) as error:
+        print(f"  warning: unreadable session metadata {metadata_path}: {error}")
+        return {}
+    values: dict[str, str] = {}
+    for key, source in (("task", "task"), ("collector", "collector_name")):
+        value: object = document.get(source)
+        if isinstance(value, str) and value:
+            values[key] = value
+    return values
+
+
+def exo_devices(episode_dir: Path) -> list[str]:
+    """Exo device names with a readable video *and* calibration, sorted by name.
+
+    Five episodes ship a split-brain ``exo/`` tree (bare ``<Device>/`` holding
+    only calibration next to ``multiCam-<Device>._multicam._tcp.local./`` holding
+    only the mp4); requiring both files in one directory drops those halves.
+
+    Args:
+        episode_dir: An ``episodes/episode-<NNN>`` directory.
+
+    Returns:
+        Device directory names, which double as the video stems.
+    """
+    exo_dir: Path = episode_dir / "exo"
+    if not exo_dir.is_dir():
+        return []
+    return sorted(
+        device_dir.name
+        for device_dir in exo_dir.iterdir()
+        if device_dir.is_dir()
+        and os.access(device_dir / f"{device_dir.name}.mp4", os.R_OK)
+        and os.access(device_dir / "calibration.json", os.R_OK)
+    )
+
+
+def episode_is_readable(episode_dir: Path) -> bool:
+    """Whether every file the converter needs is present and readable.
+
+    Args:
+        episode_dir: An ``episodes/episode-<NNN>`` directory.
+
+    Returns:
+        True when the ego and Quest cores plus at least one exo device are readable.
+    """
+    if not all(os.access(episode_dir / relative, os.R_OK) for relative in EGO_CORE_FILES + QUEST_CORE_FILES):
+        return False
+    return bool(exo_devices(episode_dir))
+
+
+def build_blueprint(panes: list[CameraPane], ego_rig: int) -> rrb.Blueprint:
+    """Default layout: the 3D scene plus a camera grid over the ego IMU plots.
+
+    Args:
+        panes: Camera labels and indices, in rig-then-camera order.
+        ego_rig: Rig index of the OAK, whose ``imu_00`` feeds the time-series views.
+
+    Returns:
+        The blueprint embedded in every SelfCap base-layer rrd.
+    """
+    camera_views: list[rrb.Spatial2DView] = [
+        rrb.Spatial2DView(name=pane.name, origin=schema.pinhole_path(pane.rig, pane.cam), contents=f"{schema.pinhole_path(pane.rig, pane.cam)}/**")
+        for pane in panes
+    ]
+    return rrb.Blueprint(
+        rrb.Vertical(
+            rrb.Horizontal(
+                rrb.Spatial3DView(name="Scene", origin="/", line_grid=True),
+                rrb.Grid(*camera_views, grid_columns=3, name="Synchronized cameras"),
+            ),
+            rrb.Horizontal(
+                rrb.TimeSeriesView(
+                    name="Gyroscope",
+                    origin=schema.imu_path(ego_rig, IMU_DEVICE),
+                    contents=schema.gyro_path(ego_rig, IMU_DEVICE),
+                    plot_legend=rrb.PlotLegend(visible=True),
+                ),
+                rrb.TimeSeriesView(
+                    name="Accelerometer",
+                    origin=schema.imu_path(ego_rig, IMU_DEVICE),
+                    contents=schema.accel_path(ego_rig, IMU_DEVICE),
+                    plot_legend=rrb.PlotLegend(visible=True),
+                ),
+            ),
+            row_shares=[3, 1],
+        ),
+        collapse_panels=True,
+    )
+
+
+class SelfcapDataset(DataforgeDataset[SelfcapConfig]):
+    """Converts SelfCap episodes into exoego:v2 base-layer recordings."""
+
+    def default_blueprint(self) -> rrb.Blueprint:
+        """Corpus-wide layout for the modal four-iPhone rig.
+
+        Exo device names vary per session, so the dataset default labels them by
+        index; the per-recording blueprint embedded at convert uses real names.
+        """
+        panes: list[CameraPane] = [CameraPane(name=f"exo {rig}", rig=rig, cam=0) for rig in range(DEFAULT_EXO_CAMERAS)]
+        panes += [CameraPane(name=f"ego {stream}", rig=DEFAULT_EXO_CAMERAS, cam=index) for index, (stream, _) in enumerate(EGO_STREAM_LAYOUTS)]
+        panes += [CameraPane(name=f"quest {stream}", rig=DEFAULT_EXO_CAMERAS + 1, cam=index) for index, (stream, _) in enumerate(QUEST_STREAM_LAYOUTS)]
+        return build_blueprint(panes, ego_rig=DEFAULT_EXO_CAMERAS)
+
+    # ── raw-tree discovery ────────────────────────────────────────────────
+    def subset_root(self) -> Path:
+        """Root of the configured subset, e.g. ``<root>/cut``."""
+        return self.config.root / self.config.subset
+
+    def session_dirs(self) -> list[tuple[str, Path]]:
+        """Every ``(capture_date, session_dir)`` pair holding an ``episodes/`` tree."""
+        pairs: list[tuple[str, Path]] = []
+        for date_dir in sorted(path for path in self.subset_root().glob("*") if path.is_dir() and DATE_DIR_RE.match(path.name)):
+            pairs += [(date_dir.name, session_dir) for session_dir in sorted(date_dir.iterdir()) if (session_dir / "episodes").is_dir()]
+        return pairs
+
+    def download(self) -> None:
+        """Verify the local corpus; SelfCap has no upstream fetch."""
+        missing: list[str] = transports.local_verify(self.config.root, required=[f"{self.config.subset}/*/*/episodes"])
+        if missing:
+            raise FileNotFoundError(f"SelfCap corpus at {self.config.root} is missing: {', '.join(missing)}")
+        sessions: list[tuple[str, Path]] = self.session_dirs()
+        dates: set[str] = {date for date, _ in sessions}
+        print(f"selfcap: {self.subset_root()} — {len(dates)} days, {len(sessions)} sessions, {len(self.sequences())} readable episodes")
+
+    def sequences(self) -> list[SequenceIdentity]:
+        """Discover every readable episode; unreadable ones are dropped, not raised on."""
+        identities: list[SequenceIdentity] = []
+        skipped: int = 0
+        for date, session_dir in self.session_dirs():
+            for episode_dir in sorted((session_dir / "episodes").iterdir()):
+                match: re.Match[str] | None = EPISODE_DIR_RE.match(episode_dir.name)
+                if match is None or not episode_dir.is_dir():
+                    continue
+                if not episode_is_readable(episode_dir):
+                    skipped += 1
+                    continue
+                identities.append(
+                    SequenceIdentity(
+                        dataset="selfcap",
+                        parts=(date, session_dir.name[:SESSION_KEY_LENGTH], f"ep{int(match['number']):03d}"),
+                    )
+                )
+        if skipped:
+            print(f"  warning: skipped {skipped} episode(s) with unreadable files (corpus chmod pending)")
+        return identities
+
+    def _locate(self, identity: SequenceIdentity) -> Path:
+        """Resolve an identity back to its ``episodes/episode-<NNN>`` directory."""
+        if len(identity.parts) != 3:
+            raise ValueError(f"SelfCap identities have three parts, got {identity.sequence_key!r}")
+        date: str = identity.parts[0]
+        session_prefix: str = identity.parts[1]
+        episode_number: int = int(identity.parts[2].removeprefix("ep"))
+        candidates: list[Path] = sorted(path for path in self.subset_root().glob(f"{date}/{session_prefix}*") if (path / "episodes").is_dir())
+        if len(candidates) != 1:
+            raise FileNotFoundError(f"Expected exactly one session for {identity.sequence_key!r}, found {len(candidates)}")
+        episode_dir: Path = candidates[0] / "episodes" / f"episode-{episode_number:03d}"
+        if not episode_dir.is_dir():
+            raise FileNotFoundError(f"Episode directory not found: {episode_dir}")
+        return episode_dir
+
+    # ── conversion ────────────────────────────────────────────────────────
+    def convert(self, identity: SequenceIdentity, *, force: bool) -> Path:
+        """Write one episode's base-layer rrd (nine cameras, ego IMU, Quest pose)."""
+        target: Path = paths.rrd_path(paths.output_root(), layer="base", identity=identity)
+        if writing.should_skip(target, force=force):
+            print(f"skip {identity.sequence_key} → {target}")
+            return target
+
+        episode_dir: Path = self._locate(identity)
+        if not episode_is_readable(episode_dir):
+            raise PermissionError(f"Episode {identity.sequence_key} has unreadable files: {episode_dir}")
+        devices: list[str] = exo_devices(episode_dir)
+        ego_rig: int = len(devices)
+        quest_rig: int = ego_rig + 1
+
+        panes: list[CameraPane] = [CameraPane(name=device.split("-")[0], rig=rig, cam=0) for rig, device in enumerate(devices)]
+        panes += [CameraPane(name=f"ego {stream}", rig=ego_rig, cam=index) for index, (stream, _) in enumerate(EGO_STREAM_LAYOUTS)]
+        panes += [CameraPane(name=f"quest {stream}", rig=quest_rig, cam=index) for index, (stream, _) in enumerate(QUEST_STREAM_LAYOUTS)]
+
+        with writing.atomic_recording(
+            target,
+            application_id="dataforge",
+            recording_id=identity.recording_id,
+            default_blueprint=build_blueprint(panes, ego_rig=ego_rig),
+        ) as recording:
+            # The base layer owns the root ViewCoordinates because it already carries a real
+            # moving-rig pose: the Quest world is right-handed Y-up. Still NO static
+            # Transform3D on any rig node — a static component permanently shadows the
+            # temporal world_T_rig that a slam/pose layer stacks on the same entity.
+            rr.log("/", rr.ViewCoordinates.RIGHT_HAND_Y_UP, static=True, recording=recording)
+
+            num_frames: int = 0
+            for rig, device in enumerate(devices):
+                num_frames = max(num_frames, self._log_exo(recording, episode_dir / "exo" / device, rig))
+            num_frames = max(num_frames, self._log_ego(recording, episode_dir / "ego", ego_rig))
+            num_frames = max(num_frames, self._log_quest(recording, episode_dir / "quest", quest_rig))
+
+            recording.send_recording_name(identity.recording_id)
+            # AnyValues drops None-valued kwargs, so an unreadable metadata.json simply
+            # leaves task/collector off the property instead of writing empty strings.
+            session: dict[str, str] = read_session_task(episode_dir.parents[1] / "metadata.json")
+            recording.send_property(
+                "capture",
+                rr.AnyValues(
+                    schema=schema.DATAFORGE_SCHEMA_VERSION,
+                    num_cameras=len(panes),
+                    num_frames=num_frames,
+                    task=session.get("task"),
+                    collector=session.get("collector"),
+                ),
+            )
+            recording.send_property("convert", rr.AnyValues(version="1"))
+
+        print(f"done {identity.sequence_key} → {target} ({len(panes)} cameras, {num_frames} frames)")
+        return target
+
+    def _log_rig(self, recording: rr.RecordingStream, rig: int, *, name: str, kind: str) -> None:
+        """Tag a rig node with its schema version, device name, and role."""
+        rr.log(
+            schema.rig_path(rig),
+            rr.AnyValues(schema_version=schema.EXOEGO_SCHEMA_VERSION, name=name, kind=kind),
+            static=True,
+            recording=recording,
+        )
+
+    def _log_camera(self, recording: rr.RecordingStream, calibration: CameraCalibration, rig: int, cam: int) -> None:
+        """Log one camera's static pinhole (plus Brown-Conrady coefficients when known).
+
+        No ``rig_T_cam`` transform is written: the raw exo calibration ships empty
+        extrinsics, and the ego/Quest ones are in unvalidated units.
+        """
+        focal_length_xy: Float64[ndarray, "2"] = calibration.focal_length_xy
+        principal_point_xy: Float64[ndarray, "2"] = calibration.principal_point_xy
+        image_from_camera: Float32[ndarray, "3 3"] = np.array(
+            [
+                [focal_length_xy[0], 0.0, principal_point_xy[0]],
+                [0.0, focal_length_xy[1], principal_point_xy[1]],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=np.float32,
+        )
+        distortion: CameraDistortion | None = (
+            None
+            if calibration.distortion_coefficients is None
+            else CameraDistortion(model="brown_conrady", coefficients=calibration.distortion_coefficients.astype(np.float32))
+        )
+        rr.log(
+            schema.pinhole_path(rig, cam),
+            PinholeWithDistortion(
+                pinhole=rr.Pinhole(
+                    image_from_camera=image_from_camera,
+                    width=calibration.width,
+                    height=calibration.height,
+                    camera_xyz=rr.ViewCoordinates.RDF,
+                    image_plane_distance=IMAGE_PLANE_DISTANCE,
+                ),
+                distortion=distortion,
+            ),
+            static=True,
+            recording=recording,
+        )
+
+    def _log_video(self, recording: rr.RecordingStream, video_path: Path, entity_path: str) -> int:
+        """Remux one mp4 as a ``VideoStream`` on its own PTS, counting samples.
+
+        Raw PTS is already the shared episode clock (see the module docstring),
+        so chunks pass straight through; the tap only tallies samples so the
+        capture property can report a frame count.
+
+        Args:
+            recording: Destination recording stream.
+            video_path: SelfCap mp4 to remux (no decode, no re-encode).
+            entity_path: ``.../pinhole/video`` entity to log under.
+
+        Returns:
+            Number of video samples written.
+        """
+        sample_count: int = 0
+
+        def tally(chunk: rr.experimental.Chunk) -> list[rr.experimental.Chunk]:
+            nonlocal sample_count
+            if schema.TIMELINE in chunk.timeline_names:  # the static codec chunk carries no index
+                sample_count += chunk.num_rows
+            return [chunk]
+
+        reader: rr.experimental.Mp4Reader = rr.experimental.Mp4Reader(
+            video_path,
+            mode="stream",
+            entity_path=entity_path,
+            timeline_name=schema.TIMELINE,
+        )
+        # send_chunks drives the lazy stream to completion, so sample_count is final here.
+        recording.send_chunks(reader.stream().flat_map(tally))
+        return sample_count
+
+    def _log_exo(self, recording: rr.RecordingStream, device_dir: Path, rig: int) -> int:
+        """Log one iPhone as a world-anchored-unknown rig with a single camera."""
+        self._log_rig(recording, rig, name=device_dir.name, kind="exo")
+        cameras: dict[str, CameraCalibration] = read_calibration(device_dir / "calibration.json")
+        # iPhone calibration ships one entry whose positional_layout is always "center";
+        # fall back to the sole entry so a renamed layout does not lose the camera.
+        calibration: CameraCalibration | None = cameras.get("center") or next(iter(cameras.values()), None)
+        if calibration is None:
+            print(f"  warning: no usable intrinsics in {device_dir / 'calibration.json'}, skipping {device_dir.name}")
+            return 0
+        rr.log(schema.cam_path(rig, 0), rr.AnyValues(name=device_dir.name, kind="rgb"), static=True, recording=recording)
+        self._log_camera(recording, calibration, rig, 0)
+        return self._log_video(recording, device_dir / f"{device_dir.name}.mp4", schema.video_path(rig, 0))
+
+    def _log_ego(self, recording: rr.RecordingStream, ego_dir: Path, rig: int) -> int:
+        """Log the OAK's three cameras and its IMU."""
+        self._log_rig(recording, rig, name="oak", kind="ego")
+        cameras: dict[str, CameraCalibration] = read_calibration(ego_dir / "calibration.json")
+        num_frames: int = 0
+        for cam, (stream, layout) in enumerate(EGO_STREAM_LAYOUTS):
+            calibration: CameraCalibration | None = cameras.get(layout)
+            if calibration is None:
+                print(f"  warning: no '{layout}' intrinsics in {ego_dir / 'calibration.json'}, skipping ego {stream}")
+                continue
+            # The mp4 is resampled onto the shared episode grid, so the csv's native-rate
+            # clock is surfaced as metadata rather than used to retime the samples.
+            frame_times_ns: Int64[ndarray, "n_frames"] = read_frame_times_ns(ego_dir / f"{stream}.csv")
+            rr.log(
+                schema.cam_path(rig, cam),
+                rr.AnyValues(
+                    name=stream,
+                    kind="rgb" if stream == "rgb" else "grayscale",
+                    num_native_frames=frame_times_ns.size,
+                    native_duration_ns=int(frame_times_ns[-1]) if frame_times_ns.size else 0,
+                ),
+                static=True,
+                recording=recording,
+            )
+            self._log_camera(recording, calibration, rig, cam)
+            num_frames = max(num_frames, self._log_video(recording, ego_dir / f"{stream}.mp4", schema.video_path(rig, cam)))
+
+        samples: ImuSamples = read_imu_csv(ego_dir / "imu.csv")
+        if samples.times_ns.size:
+            for values_xyz, entity_path in (
+                (samples.gyro_xyz, schema.gyro_path(rig, IMU_DEVICE)),
+                (samples.accel_xyz, schema.accel_path(rig, IMU_DEVICE)),
+            ):
+                rr.send_columns(
+                    entity_path,
+                    indexes=[rr.TimeColumn(schema.TIMELINE, duration=samples.times_ns.astype("timedelta64[ns]"))],
+                    columns=rr.Scalars.columns(scalars=values_xyz),
+                    recording=recording,
+                )
+            rr.log(schema.imu_path(rig, IMU_DEVICE), rr.AnyValues(name="oak-imu", kind="imu"), static=True, recording=recording)
+        return num_frames
+
+    def _log_quest(self, recording: rr.RecordingStream, quest_dir: Path, rig: int) -> int:
+        """Log the Quest's two eye cameras and its left-eye world pose track."""
+        self._log_rig(recording, rig, name="quest", kind="quest")
+        poses: HeadPoses = read_head_poses(quest_dir / "head_pose.csv")
+        if poses.times_ns.size:
+            rr.send_columns(
+                schema.rig_path(rig),
+                indexes=[rr.TimeColumn(schema.TIMELINE, duration=poses.times_ns.astype("timedelta64[ns]"))],
+                columns=rr.Transform3D.columns(translation=poses.translations_xyz, quaternion=poses.quaternions_xyzw),
+                recording=recording,
+            )
+        else:
+            print(f"  warning: no head poses in {quest_dir / 'head_pose.csv'}; the quest rig stays unposed")
+
+        cameras: dict[str, CameraCalibration] = read_calibration(quest_dir / "calibration.json")
+        num_frames: int = 0
+        for cam, (stream, layout) in enumerate(QUEST_STREAM_LAYOUTS):
+            calibration: CameraCalibration | None = cameras.get(layout)
+            if calibration is None:
+                print(f"  warning: no '{layout}' intrinsics in {quest_dir / 'calibration.json'}, skipping quest {stream}")
+                continue
+            rr.log(schema.cam_path(rig, cam), rr.AnyValues(name=stream, kind="grayscale"), static=True, recording=recording)
+            # TODO(dataforge): the Quest intrinsics describe the 1280x1280 sensor array while
+            # capture_resolution (and the mp4) is 1280x960, so cy lands ~160 px below the image
+            # centre. Confirm the crop origin against the device before shifting the principal point.
+            self._log_camera(recording, calibration, rig, cam)
+            num_frames = max(num_frames, self._log_video(recording, quest_dir / f"{stream}.mp4", schema.video_path(rig, cam)))
+        return num_frames

--- a/packages/dataforge/dataforge/datasets/selfcap.py
+++ b/packages/dataforge/dataforge/datasets/selfcap.py
@@ -162,6 +162,11 @@ class CameraPane:
     """Rig index owning the camera."""
     cam: int
     """Camera index within the rig."""
+    kind: str
+    """Device group the pane belongs to: ``exo``, ``ego``, or ``quest``.
+
+    Blueprints cannot select entities by AnyValues, so the exo/ego grouping the
+    layout communicates has to travel with the pane list itself."""
 
 
 @dataclass
@@ -368,15 +373,28 @@ def build_blueprint(panes: list[CameraPane], ego_rig: int) -> rrb.Blueprint:
     Returns:
         The blueprint embedded in every SelfCap base-layer rrd.
     """
-    camera_views: list[rrb.Spatial2DView] = [
-        rrb.Spatial2DView(name=pane.name, origin=schema.pinhole_path(pane.rig, pane.cam), contents=f"{schema.pinhole_path(pane.rig, pane.cam)}/**")
-        for pane in panes
-    ]
+    def views(kind: str) -> list[rrb.Spatial2DView]:
+        return [
+            rrb.Spatial2DView(name=pane.name, origin=schema.pinhole_path(pane.rig, pane.cam), contents=f"{schema.pinhole_path(pane.rig, pane.cam)}/**")
+            for pane in panes
+            if pane.kind == kind
+        ]
+
+    # The layout is grouped by device kind (blueprints cannot select on the rigs'
+    # `kind` AnyValues, so the grouping travels through the pane list instead):
+    # exo cameras as a grid, the OAK and Quest as labeled ego rows beneath it.
     return rrb.Blueprint(
         rrb.Vertical(
             rrb.Horizontal(
                 rrb.Spatial3DView(name="Scene", origin="/", line_grid=True),
-                rrb.Grid(*camera_views, grid_columns=3, name="Synchronized cameras"),
+                rrb.Vertical(
+                    rrb.Grid(*views("exo"), grid_columns=2, name="Exo"),
+                    rrb.Horizontal(*views("ego"), name="Ego · OAK"),
+                    rrb.Horizontal(*views("quest"), name="Ego · Quest"),
+                    row_shares=[2.0, 1.0, 1.0],
+                    name="Cameras",
+                ),
+                column_shares=[1.0, 1.0],
             ),
             rrb.Horizontal(
                 rrb.TimeSeriesView(
@@ -407,9 +425,9 @@ class SelfcapDataset(DataforgeDataset[SelfcapConfig]):
         Exo device names vary per session, so the dataset default labels them by
         index; the per-recording blueprint embedded at convert uses real names.
         """
-        panes: list[CameraPane] = [CameraPane(name=f"exo {rig}", rig=rig, cam=0) for rig in range(DEFAULT_EXO_CAMERAS)]
-        panes += [CameraPane(name=f"ego {stream}", rig=DEFAULT_EXO_CAMERAS, cam=index) for index, (stream, _) in enumerate(EGO_STREAM_LAYOUTS)]
-        panes += [CameraPane(name=f"quest {stream}", rig=DEFAULT_EXO_CAMERAS + 1, cam=index) for index, (stream, _) in enumerate(QUEST_STREAM_LAYOUTS)]
+        panes: list[CameraPane] = [CameraPane(name=f"exo {rig}", rig=rig, cam=0, kind="exo") for rig in range(DEFAULT_EXO_CAMERAS)]
+        panes += [CameraPane(name=f"ego {stream}", rig=DEFAULT_EXO_CAMERAS, cam=index, kind="ego") for index, (stream, _) in enumerate(EGO_STREAM_LAYOUTS)]
+        panes += [CameraPane(name=f"quest {stream}", rig=DEFAULT_EXO_CAMERAS + 1, cam=index, kind="quest") for index, (stream, _) in enumerate(QUEST_STREAM_LAYOUTS)]
         return build_blueprint(panes, ego_rig=DEFAULT_EXO_CAMERAS)
 
     # ── raw-tree discovery ────────────────────────────────────────────────
@@ -485,9 +503,9 @@ class SelfcapDataset(DataforgeDataset[SelfcapConfig]):
         ego_rig: int = len(devices)
         quest_rig: int = ego_rig + 1
 
-        panes: list[CameraPane] = [CameraPane(name=device.split("-")[0], rig=rig, cam=0) for rig, device in enumerate(devices)]
-        panes += [CameraPane(name=f"ego {stream}", rig=ego_rig, cam=index) for index, (stream, _) in enumerate(EGO_STREAM_LAYOUTS)]
-        panes += [CameraPane(name=f"quest {stream}", rig=quest_rig, cam=index) for index, (stream, _) in enumerate(QUEST_STREAM_LAYOUTS)]
+        panes: list[CameraPane] = [CameraPane(name=device.split("-")[0], rig=rig, cam=0, kind="exo") for rig, device in enumerate(devices)]
+        panes += [CameraPane(name=f"ego {stream}", rig=ego_rig, cam=index, kind="ego") for index, (stream, _) in enumerate(EGO_STREAM_LAYOUTS)]
+        panes += [CameraPane(name=f"quest {stream}", rig=quest_rig, cam=index, kind="quest") for index, (stream, _) in enumerate(QUEST_STREAM_LAYOUTS)]
 
         with writing.atomic_recording(
             target,

--- a/packages/dataforge/dataforge/logging_toolkit.py
+++ b/packages/dataforge/dataforge/logging_toolkit.py
@@ -1,0 +1,150 @@
+"""Shared exoego:v2 writers every dataforge converter reuses: rig node, video, IMU.
+
+These three taps live together because both datasets need them *identically* and
+each one hides an invariant that is easy to break silently: the rig node's honest
+key set, the ``Mp4Reader`` → ``send_chunks`` pass-through (which must not mint
+fresh row ids), and the IMU node's mandatory static ``rig_T_imu``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+import rerun as rr
+from jaxtyping import Float64, Int64
+from numpy import ndarray
+
+from dataforge import schema
+
+IDENTITY_TRANSFORM: rr.Transform3D = rr.Transform3D(translation=[0.0, 0.0, 0.0], mat3x3=np.eye(3, dtype=np.float32))
+"""Explicit identity pose; an argument-less ``Transform3D`` logs no components at all."""
+
+
+def log_rig_node(
+    recording: rr.RecordingStream,
+    rig: int,
+    *,
+    reference: str,
+    num_cameras: int,
+    name: str | None = None,
+    kind: str | None = None,
+) -> None:
+    """Tag one ``/world/rig_NN`` node with the static metadata exoego:v2 requires.
+
+    Deliberately NO static ``Transform3D`` on the rig node: per exoego:v2 a
+    world-anchored rig carries no transform, and a static one would permanently
+    shadow the temporal ``world_T_rig`` a slam/pose layer stacks on the same
+    entity (verified: static components shadow temporal ones per component,
+    silently).
+
+    Args:
+        recording: Destination recording stream.
+        rig: Rig index; the node is ``schema.rig_path(rig)``.
+        reference: Id of the sensor child whose frame the rig frame coincides
+            with — usually ``"cam_00"``, but an inertially-referenced rig names
+            its ``imu_MM`` instead.
+        num_cameras: Number of cameras actually logged under this rig.
+        name: Optional human device label (``"robocap"``, ``"oak"``, an iPhone name).
+        kind: Optional device role (``"exo"`` / ``"ego"`` / ``"quest"``).
+    """
+    # AnyValues drops None-valued kwargs, so name/kind simply stay off the node
+    # when a dataset has nothing meaningful to say.
+    rr.log(
+        schema.rig_path(rig),
+        rr.AnyValues(schema_version=schema.EXOEGO_SCHEMA_VERSION, reference=reference, num_cameras=num_cameras, name=name, kind=kind),
+        static=True,
+        recording=recording,
+    )
+
+
+def log_video_stream(recording: rr.RecordingStream, video_path: Path, entity_path: str, *, shift_ns: int = 0) -> int:
+    """Remux one mp4 as a ``VideoStream``, optionally retimed, and count its samples.
+
+    Four invariants ride along, in the order they bite:
+
+    1. ``Mp4Reader`` emits one **static** codec chunk that carries no index; it
+       must pass through untouched (its ``timeline_names`` is empty).
+    2. ``send_chunks`` drives the lazy stream to completion, so ``sample_count``
+       is final on return — anything short of a fully-consuming terminal would
+       silently leave it at 0.
+    3. ``Chunk.from_record_batch`` is called **bare**: the batch's ``rerun:*``
+       metadata already carries index and entity path, and passing either
+       override forces fresh row/chunk ids.
+    4. Raw sample PTS is wall clock only when ``shift_ns == 0``. A non-zero
+       shift means the file's PTS are offsets from a capture epoch, and the
+       ``video_time`` column is rewritten to the absolute clock.
+
+    Args:
+        recording: Destination recording stream.
+        video_path: mp4 to remux (no decode, no re-encode).
+        entity_path: ``.../pinhole/video`` entity to log under.
+        shift_ns: Nanoseconds added to every indexed chunk's ``video_time``.
+
+    Returns:
+        Number of video samples written.
+    """
+    sample_count: int = 0
+
+    def tap(chunk: rr.experimental.Chunk) -> list[rr.experimental.Chunk]:
+        nonlocal sample_count
+        if schema.TIMELINE not in chunk.timeline_names:
+            return [chunk]  # invariant 1: the static codec chunk carries no index
+        if shift_ns == 0:
+            sample_count += chunk.num_rows
+            return [chunk]
+        record_batch: pa.RecordBatch = chunk.to_record_batch()
+        index: int = record_batch.schema.get_field_index(schema.TIMELINE)
+        shifted: pa.Array = pa.array(np.asarray(record_batch.column(index).cast(pa.int64())) + shift_ns, type=pa.duration("ns"))
+        sample_count += record_batch.num_rows
+        retimed: pa.RecordBatch = record_batch.set_column(index, record_batch.schema.field(index), shifted)
+        return rr.experimental.Chunk.from_record_batch(retimed)  # invariant 3
+
+    reader: rr.experimental.Mp4Reader = rr.experimental.Mp4Reader(
+        video_path,
+        mode="stream",
+        entity_path=entity_path,
+        timeline_name=schema.TIMELINE,
+    )
+    recording.send_chunks(reader.stream().flat_map(tap))  # invariant 2
+    return sample_count
+
+
+@dataclass(frozen=True, slots=True)
+class ImuChannel:
+    """One raw IMU channel (gyro or accel) at its native sample rate."""
+
+    times_ns: Int64[ndarray, "n_samples"]
+    """Sample times on the ``video_time`` clock, in nanoseconds."""
+    values_xyz: Float64[ndarray, "n_samples 3"]
+    """Scaled samples (rad/s for gyro, m/s^2 for accel)."""
+
+
+def log_imu(recording: rr.RecordingStream, rig: int, imu: int, *, gyro: ImuChannel, accel: ImuChannel, name: str) -> None:
+    """Log one IMU node: both channels columnar, plus the static node metadata.
+
+    The static identity ``rig_T_imu`` is **not** optional — exoego:v2 §8 makes
+    ``Transform3D`` part of the IMU node, so a reader can resolve the sensor's
+    place in the rig frame without special-casing the writer.
+
+    Args:
+        recording: Destination recording stream.
+        rig: Rig index owning the IMU.
+        imu: IMU index within the rig.
+        gyro: Angular-velocity samples in rad/s; an empty channel is skipped.
+        accel: Linear-acceleration samples in m/s^2; an empty channel is skipped.
+        name: Human label for the device (e.g. ``"dev0"``, ``"oak-imu"``).
+    """
+    for channel, entity_path in ((gyro, schema.gyro_path(rig, imu)), (accel, schema.accel_path(rig, imu))):
+        if channel.times_ns.size == 0:
+            continue
+        rr.send_columns(
+            entity_path,
+            indexes=[rr.TimeColumn(schema.TIMELINE, duration=channel.times_ns.astype("timedelta64[ns]"))],
+            columns=rr.Scalars.columns(scalars=channel.values_xyz),
+            recording=recording,
+        )
+    rr.log(schema.imu_path(rig, imu), IDENTITY_TRANSFORM, static=True, recording=recording)
+    rr.log(schema.imu_path(rig, imu), rr.AnyValues(name=name, kind="imu"), static=True, recording=recording)

--- a/packages/dataforge/dataforge/paths.py
+++ b/packages/dataforge/dataforge/paths.py
@@ -14,6 +14,9 @@ from pathlib import Path
 
 from dataforge.identity import SequenceIdentity
 
+BASE_LAYER: str = "base"
+"""The only layer dataforge v1 emits; the first path component under ``output_root()``."""
+
 
 def output_root() -> Path:
     """Root of the converted rrd tree; override with ``DATAFORGE_OUTPUT_ROOT``."""

--- a/packages/dataforge/dataforge/writing.py
+++ b/packages/dataforge/dataforge/writing.py
@@ -1,8 +1,8 @@
-"""Atomic publication of layer rrds: tmp file → ``os.replace``.
+"""Atomic publication of layer artifacts: tmp file → ``os.replace``.
 
-Half-written files poison batch runs and the catalog server, so a target rrd
-either exists complete or not at all ("exists = done"). Never save over an
-rrd that a catalog server has registered — truncation poisons the server;
+Half-written files poison batch runs and the catalog server, so a target either
+exists complete or not at all ("exists = done"). Never save over an rrd (or an
+``.rbl``) that a catalog server has registered — truncation poisons the server;
 re-runs write a fresh tmp and atomically replace, and the catalog re-registers.
 """
 
@@ -13,14 +13,41 @@ import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Any
 
 import rerun as rr
 import rerun.blueprint as rrb
+
+from dataforge import schema
+from dataforge.identity import SequenceIdentity
 
 
 def should_skip(target: Path, *, force: bool) -> bool:
     """Idempotency check: an existing target is done unless ``--force``."""
     return target.exists() and not force
+
+
+@contextmanager
+def atomic_write(target: Path) -> Iterator[Path]:
+    """Yield a temp path beside ``target`` that replaces it only on clean exit.
+
+    Args:
+        target: Final location; its parent directory is created if missing.
+
+    Yields:
+        A temp path in ``target.parent`` for the caller to write into.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temp_name = tempfile.mkstemp(dir=target.parent, suffix=f"{target.suffix}.tmp")
+    os.close(descriptor)
+    temp_path: Path = Path(temp_name)
+    try:
+        yield temp_path
+        temp_path.chmod(0o644)  # mkstemp temps are 0600; NFS mounts and the catalog server need world-readable files
+        os.replace(temp_path, target)
+    except BaseException:
+        temp_path.unlink(missing_ok=True)
+        raise
 
 
 @contextmanager
@@ -32,16 +59,38 @@ def atomic_recording(
     default_blueprint: rrb.Blueprint | None = None,
 ) -> Iterator[rr.RecordingStream]:
     """Yield a recording saved to a temp file that replaces ``target`` on success."""
-    target.parent.mkdir(parents=True, exist_ok=True)
-    descriptor, temp_name = tempfile.mkstemp(dir=target.parent, suffix=".rrd.tmp")
-    os.close(descriptor)
-    temp_path: Path = Path(temp_name)
-    try:
-        with rr.RecordingStream(application_id=application_id, recording_id=recording_id, send_properties=True) as recording:
-            recording.save(temp_path, default_blueprint=default_blueprint)
-            yield recording
-        temp_path.chmod(0o644)  # mkstemp temps are 0600; NFS mounts and the catalog server need world-readable files
-        os.replace(temp_path, target)
-    except BaseException:
-        temp_path.unlink(missing_ok=True)
-        raise
+    # The recording stream is the inner context on purpose: it flushes and closes
+    # before atomic_write reaches its os.replace.
+    with (
+        atomic_write(target) as temp_path,
+        rr.RecordingStream(application_id=application_id, recording_id=recording_id, send_properties=True) as recording,
+    ):
+        recording.save(temp_path, default_blueprint=default_blueprint)
+        yield recording
+
+
+def send_capture_properties(
+    recording: rr.RecordingStream,
+    identity: SequenceIdentity,
+    *,
+    num_cameras: int,
+    num_frames: int,
+    **extra: Any,
+) -> None:
+    """Name the recording and stamp it with the dataforge capture/convert properties.
+
+    Args:
+        recording: Destination recording stream.
+        identity: Sequence identity; its ``recording_id`` becomes the recording name.
+        num_cameras: Cameras actually logged in this recording.
+        num_frames: Longest per-camera video sample count.
+        **extra: Dataset-specific capture keys (``start_time_ns``, ``task``, …);
+            ``None`` values are dropped rather than written as empty values.
+    """
+    recording.send_recording_name(identity.recording_id)
+    present: dict[str, Any] = {key: value for key, value in extra.items() if value is not None}
+    recording.send_property(
+        "capture",
+        rr.AnyValues(schema=schema.DATAFORGE_SCHEMA_VERSION, num_frames=num_frames, num_cameras=num_cameras, **present),
+    )
+    recording.send_property("convert", rr.AnyValues(version="1"))

--- a/packages/dataforge/tests/test_robocap.py
+++ b/packages/dataforge/tests/test_robocap.py
@@ -14,12 +14,13 @@ from dataforge.datasets.robocap import (
     ACCEL_SCALE,
     CAMERA_TO_IMU_OFFSET_NS,
     GYRO_SCALE,
-    ImuSamples,
     RobocapConfig,
     RobocapDataset,
+    RobocapSource,
     read_imu_database,
 )
 from dataforge.identity import SequenceIdentity
+from dataforge.logging_toolkit import ImuChannel
 
 DEVICE: str = "f408193e6447b3b0"
 """Device id used by every fake session directory in these tests."""
@@ -47,15 +48,19 @@ def corpus(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def test_sequences_discovers_every_segment_and_skips_old_dirs(corpus: Path) -> None:
+def test_discover_pairs_every_segment_with_its_session_dir_and_skips_old_dirs(corpus: Path) -> None:
     dataset: RobocapDataset = RobocapDataset(RobocapConfig(root=corpus))
-    identities: list[SequenceIdentity] = dataset.sequences()
-    assert [identity.sequence_key for identity in identities] == [
+    discovered: list[tuple[SequenceIdentity, RobocapSource]] = dataset.discover()
+    assert [identity.sequence_key for identity, _ in discovered] == [
         f"{DEVICE}/s1/seg1",
         f"{DEVICE}/s1/seg2",
         f"{DEVICE}/s10/seg1",
     ]
-    assert identities[0].recording_id == f"robocap__{DEVICE}__s1__seg1"
+    assert discovered[0][0].recording_id == f"robocap__{DEVICE}__s1__seg1"
+    assert discovered[0][1] == RobocapSource(session_dir=corpus / f"{DEVICE}_session_1", device=DEVICE, session=1, segment=1)
+    assert discovered[2][1].session == 10
+    # sequences() is derived from discover(), so the two can never disagree.
+    assert dataset.sequences() == [identity for identity, _ in discovered]
 
 
 def test_download_verifies_local_corpus(corpus: Path, tmp_path: Path) -> None:
@@ -79,10 +84,10 @@ def write_imu_db(db_path: Path) -> None:
 def test_imu_parsing_scales_values_and_shifts_onto_camera_clock(tmp_path: Path) -> None:
     db_path: Path = tmp_path / "IMUWriter_dev0_session1_segment1.db"
     write_imu_db(db_path)
-    channels: tuple[ImuSamples, ImuSamples] | None = read_imu_database(db_path)
+    channels: tuple[ImuChannel, ImuChannel] | None = read_imu_database(db_path)
     assert channels is not None
-    gyro: ImuSamples = channels[0]
-    accel: ImuSamples = channels[1]
+    gyro: ImuChannel = channels[0]
+    accel: ImuChannel = channels[1]
 
     expected_gyro_times: Int64[ndarray, "2"] = np.array([1000000000, 1002000000], dtype=np.int64) - CAMERA_TO_IMU_OFFSET_NS
     np.testing.assert_array_equal(gyro.times_ns, expected_gyro_times)

--- a/packages/dataforge/tests/test_selfcap.py
+++ b/packages/dataforge/tests/test_selfcap.py
@@ -12,10 +12,11 @@ from numpy import ndarray
 
 from dataforge.datasets.selfcap import (
     CameraCalibration,
+    EpisodePlan,
     HeadPoses,
-    ImuSamples,
     SelfcapConfig,
     SelfcapDataset,
+    build_episode_plan,
     exo_devices,
     read_calibration,
     read_frame_times_ns,
@@ -24,6 +25,7 @@ from dataforge.datasets.selfcap import (
     read_session_task,
 )
 from dataforge.identity import SequenceIdentity
+from dataforge.logging_toolkit import ImuChannel
 
 SESSION_A: str = "25aeb66a-cf5a-44a3-845f-62606cefabe7"
 """Session uuid whose first eight characters become the identity's middle part."""
@@ -81,22 +83,24 @@ def corpus(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def test_sequences_skips_episodes_with_unreadable_files(corpus: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_discover_skips_episodes_with_unreadable_files(corpus: Path, capsys: pytest.CaptureFixture[str]) -> None:
     dataset: SelfcapDataset = SelfcapDataset(SelfcapConfig(root=corpus))
-    identities: list[SequenceIdentity] = dataset.sequences()
-    assert [identity.sequence_key for identity in identities] == [
+    discovered: list[tuple[SequenceIdentity, Path]] = dataset.discover()
+    assert [identity.sequence_key for identity, _ in discovered] == [
         f"2025-12-20/{SESSION_A[:8]}/ep001",
         f"2025-12-20/{SESSION_A[:8]}/ep009",
         f"2025-12-21/{SESSION_B[:8]}/ep002",
     ]
     assert "skipped 1 episode" in capsys.readouterr().out
+    # sequences() is derived from discover(), so the two can never disagree.
+    assert dataset.sequences() == [identity for identity, _ in discovered]
 
 
-def test_identity_maps_to_recording_id_and_back_to_the_episode_directory(corpus: Path) -> None:
+def test_discover_pairs_each_identity_with_its_episode_directory(corpus: Path) -> None:
     dataset: SelfcapDataset = SelfcapDataset(SelfcapConfig(root=corpus))
-    identity: SequenceIdentity = dataset.sequences()[1]
-    assert identity.recording_id == f"selfcap__2025-12-20__{SESSION_A[:8]}__ep009"
-    assert dataset._locate(identity) == corpus / "cut" / "2025-12-20" / SESSION_A / "episodes" / "episode-009"
+    pair: tuple[SequenceIdentity, Path] = dataset.discover()[1]
+    assert pair[0].recording_id == f"selfcap__2025-12-20__{SESSION_A[:8]}__ep009"
+    assert pair[1] == corpus / "cut" / "2025-12-20" / SESSION_A / "episodes" / "episode-009"
 
 
 def test_download_verifies_the_local_corpus(corpus: Path, tmp_path: Path) -> None:
@@ -146,12 +150,15 @@ def test_imu_csv_keeps_accel_and_gyro_and_drops_mag_and_rot(tmp_path: Path) -> N
         "0,0.71875,-4.95703125,-8.796875,-0.13671875,-0.15625,-0.07421875,19.25,10.1875,73.0625,-0.85,-0.45,0.068\n"
         "10035000,0.76953125,-5.01171875,-8.88671875,-0.111328125,-0.154296875,-0.0703125,20.3125,4.8125,69.75,-0.851,-0.455,0.068\n"
     )
-    samples: ImuSamples = read_imu_csv(csv_path)
-    np.testing.assert_array_equal(samples.times_ns, np.array([0, 10035000], dtype=np.int64))
-    expected_accel: Float64[ndarray, "2 3"] = np.array([[0.71875, -4.95703125, -8.796875], [0.76953125, -5.01171875, -8.88671875]])
-    np.testing.assert_allclose(samples.accel_xyz, expected_accel)
+    channels: tuple[ImuChannel, ImuChannel] = read_imu_csv(csv_path)
+    gyro: ImuChannel = channels[0]
+    accel: ImuChannel = channels[1]
+    np.testing.assert_array_equal(gyro.times_ns, np.array([0, 10035000], dtype=np.int64))
+    np.testing.assert_array_equal(accel.times_ns, np.array([0, 10035000], dtype=np.int64))
     expected_gyro: Float64[ndarray, "2 3"] = np.array([[-0.13671875, -0.15625, -0.07421875], [-0.111328125, -0.154296875, -0.0703125]])
-    np.testing.assert_allclose(samples.gyro_xyz, expected_gyro)
+    np.testing.assert_allclose(gyro.values_xyz, expected_gyro)
+    expected_accel: Float64[ndarray, "2 3"] = np.array([[0.71875, -4.95703125, -8.796875], [0.76953125, -5.01171875, -8.88671875]])
+    np.testing.assert_allclose(accel.values_xyz, expected_accel)
 
 
 def test_head_poses_take_the_left_eye_track_as_xyzw_quaternions(tmp_path: Path) -> None:
@@ -212,3 +219,54 @@ def test_calibration_keys_on_positional_layout_and_maps_14_coefficients(tmp_path
 def test_default_blueprint_covers_nine_cameras() -> None:
     blueprint = SelfcapConfig().setup().default_blueprint()
     assert blueprint is not None
+
+
+def calibration_document(layouts: tuple[str, ...]) -> str:
+    """A minimal ``calibration.json`` describing one usable camera per positional layout."""
+    return json.dumps(
+        {
+            "intrinsics": [
+                {
+                    "positional_layout": layout,
+                    "lens_intrinsics": {"focal_length_x": 700.0, "focal_length_y": 700.0, "principal_point_x": 640.0, "principal_point_y": 360.0},
+                    "capture_resolution": {"width": 1280, "height": 720},
+                }
+                for layout in layouts
+            ],
+            "extrinsics": [],
+        }
+    )
+
+
+def test_episode_plan_drops_cameras_without_intrinsics(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    # The bug this guards: panes built from readability alone described cameras the
+    # converter then skipped, so the blueprint and num_cameras over-reported.
+    episode_dir: Path = tmp_path / "episode-001"
+    make_episode(episode_dir)
+    for device in EXO_DEVICES[:-1]:
+        (episode_dir / "exo" / device / "calibration.json").write_text(calibration_document(("center",)))
+    (episode_dir / "exo" / EXO_DEVICES[-1] / "calibration.json").write_text(calibration_document(()))
+    (episode_dir / "ego" / "calibration.json").write_text(calibration_document(("center", "left")))  # no "right"
+    (episode_dir / "quest" / "calibration.json").write_text(calibration_document(("left", "right")))
+
+    plan: EpisodePlan = build_episode_plan(episode_dir)
+    assert (plan.ego_rig, plan.quest_rig) == (4, 5)
+    assert [(pane.rig, pane.cam, pane.kind) for pane in plan.panes] == [
+        (0, 0, "exo"),
+        (1, 0, "exo"),
+        (2, 0, "exo"),
+        (4, 0, "ego"),
+        (4, 1, "ego"),
+        (5, 0, "quest"),
+        (5, 1, "quest"),
+    ]
+    # The intrinsics-less exo device keeps its rig node, honestly declaring zero cameras.
+    assert [len(rig.cameras) for rig in plan.rigs] == [1, 1, 1, 0, 2, 2]
+    assert len(plan.panes) == sum(len(rig.cameras) for rig in plan.rigs)
+    assert {rig.reference for rig in plan.rigs} == {"cam_00"}
+    warnings: str = capsys.readouterr().out
+    assert "skipping Wolf-387E89E1" in warnings
+    assert "skipping ego right" in warnings
+    # Ego cameras carry the native-rate csv metadata; exo/quest leave it off entirely.
+    assert [(camera.native_frames, camera.native_duration_ns) for camera in plan.rigs[4].cameras] == [(1, 0), (1, 0)]
+    assert plan.rigs[0].cameras[0].native_frames is None

--- a/packages/dataforge/tests/test_selfcap.py
+++ b/packages/dataforge/tests/test_selfcap.py
@@ -1,0 +1,214 @@
+"""SelfCap discovery and raw-csv parsing against synthetic fixtures (no corpus needed)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+from jaxtyping import Float32, Float64, Int64
+from numpy import ndarray
+
+from dataforge.datasets.selfcap import (
+    CameraCalibration,
+    HeadPoses,
+    ImuSamples,
+    SelfcapConfig,
+    SelfcapDataset,
+    exo_devices,
+    read_calibration,
+    read_frame_times_ns,
+    read_head_poses,
+    read_imu_csv,
+    read_session_task,
+)
+from dataforge.identity import SequenceIdentity
+
+SESSION_A: str = "25aeb66a-cf5a-44a3-845f-62606cefabe7"
+"""Session uuid whose first eight characters become the identity's middle part."""
+SESSION_B: str = "1dbe8c49-5f09-4b58-875e-b0a3315d9d4a"
+"""Second session, on a different capture day."""
+EXO_DEVICES: tuple[str, ...] = ("Dragon-413A7CC1", "Tiger-FE57138F", "Titanium-B00700F9", "Wolf-387E89E1")
+"""Exo device directory names, which also form the video stems."""
+UNREADABLE: int = 0o000
+"""The mode the NAS sync leaves on much of the corpus."""
+
+
+def make_episode(episode_dir: Path, *, unreadable: str | None = None) -> None:
+    """Create every file the converter requires, optionally crippling one of them.
+
+    Args:
+        episode_dir: Target ``episodes/episode-<NNN>`` directory.
+        unreadable: Path relative to ``episode_dir`` to chmod 000, mimicking the NAS sync.
+    """
+    (episode_dir / "ego").mkdir(parents=True)
+    for stream in ("rgb", "left", "right"):
+        (episode_dir / "ego" / f"{stream}.mp4").touch()
+        (episode_dir / "ego" / f"{stream}.csv").write_text("ts_ns,frame_idx\n0,10\n")
+    (episode_dir / "ego" / "imu.csv").touch()
+    (episode_dir / "ego" / "calibration.json").touch()
+    (episode_dir / "quest").mkdir()
+    for stream in ("left", "right"):
+        (episode_dir / "quest" / f"{stream}.mp4").touch()
+    (episode_dir / "quest" / "head_pose.csv").touch()
+    (episode_dir / "quest" / "calibration.json").touch()
+    for device in EXO_DEVICES:
+        (episode_dir / "exo" / device).mkdir(parents=True)
+        (episode_dir / "exo" / device / f"{device}.mp4").touch()
+        (episode_dir / "exo" / device / "calibration.json").touch()
+    # The prior-art recording that dataforge deliberately rebuilds from raw.
+    (episode_dir / f"{episode_dir.name}.rrd").touch()
+    if unreadable is not None:
+        (episode_dir / unreadable).chmod(UNREADABLE)
+
+
+@pytest.fixture
+def corpus(tmp_path: Path) -> Path:
+    """A fake SelfCap root: two days, one session each, one crippled episode."""
+    session_a: Path = tmp_path / "cut" / "2025-12-20" / SESSION_A
+    make_episode(session_a / "episodes" / "episode-001")
+    make_episode(session_a / "episodes" / "episode-009")
+    (session_a / "metadata.json").write_text(json.dumps({"task": "hotdog_in_ricecooker", "collector_name": "Adil", "location": {}}))
+
+    session_b: Path = tmp_path / "cut" / "2025-12-21" / SESSION_B
+    make_episode(session_b / "episodes" / "episode-002")
+    make_episode(session_b / "episodes" / "episode-003", unreadable="quest/head_pose.csv")
+    (session_b / "metadata.json").write_text("{}")
+
+    # Loose files beside the day directories (the corpus keeps manifests there).
+    (tmp_path / "cut" / "manifest.json").write_text("{}")
+    return tmp_path
+
+
+def test_sequences_skips_episodes_with_unreadable_files(corpus: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    dataset: SelfcapDataset = SelfcapDataset(SelfcapConfig(root=corpus))
+    identities: list[SequenceIdentity] = dataset.sequences()
+    assert [identity.sequence_key for identity in identities] == [
+        f"2025-12-20/{SESSION_A[:8]}/ep001",
+        f"2025-12-20/{SESSION_A[:8]}/ep009",
+        f"2025-12-21/{SESSION_B[:8]}/ep002",
+    ]
+    assert "skipped 1 episode" in capsys.readouterr().out
+
+
+def test_identity_maps_to_recording_id_and_back_to_the_episode_directory(corpus: Path) -> None:
+    dataset: SelfcapDataset = SelfcapDataset(SelfcapConfig(root=corpus))
+    identity: SequenceIdentity = dataset.sequences()[1]
+    assert identity.recording_id == f"selfcap__2025-12-20__{SESSION_A[:8]}__ep009"
+    assert dataset._locate(identity) == corpus / "cut" / "2025-12-20" / SESSION_A / "episodes" / "episode-009"
+
+
+def test_download_verifies_the_local_corpus(corpus: Path, tmp_path: Path) -> None:
+    SelfcapConfig(root=corpus).setup().download()
+    empty_root: Path = tmp_path / "empty"
+    empty_root.mkdir()
+    with pytest.raises(FileNotFoundError, match="missing"):
+        SelfcapConfig(root=empty_root).setup().download()
+
+
+def test_exo_devices_requires_video_and_calibration_in_one_directory(tmp_path: Path) -> None:
+    make_episode(tmp_path / "episode-001")
+    split_brain: Path = tmp_path / "episode-001" / "exo" / "multiCam-Ghost-1._multicam._tcp.local."
+    split_brain.mkdir()
+    (split_brain / f"{split_brain.name}.mp4").touch()  # no calibration.json beside it
+    (tmp_path / "episode-001" / "exo" / EXO_DEVICES[0] / "calibration.json").chmod(UNREADABLE)
+    assert exo_devices(tmp_path / "episode-001") == list(EXO_DEVICES[1:])
+
+
+def test_session_task_degrades_to_empty_when_metadata_is_unreadable(corpus: Path) -> None:
+    metadata_path: Path = corpus / "cut" / "2025-12-20" / SESSION_A / "metadata.json"
+    assert read_session_task(metadata_path) == {"task": "hotdog_in_ricecooker", "collector": "Adil"}
+    metadata_path.chmod(UNREADABLE)
+    assert read_session_task(metadata_path) == {}
+    assert read_session_task(corpus / "cut" / "2025-12-21" / SESSION_B / "metadata.json") == {}
+
+
+def test_frame_times_come_from_ts_ns_in_row_order(tmp_path: Path) -> None:
+    # frame_idx is a session-global counter, so it must not be used as a row index.
+    csv_path: Path = tmp_path / "rgb.csv"
+    csv_path.write_text("ts_ns,frame_idx\n0,2019\n41653000,2020\n83306000,2021\n")
+    times_ns: Int64[ndarray, "3"] = read_frame_times_ns(csv_path)
+    np.testing.assert_array_equal(times_ns, np.array([0, 41653000, 83306000], dtype=np.int64))
+    assert times_ns.dtype == np.int64
+
+
+def test_frame_times_of_a_header_only_csv_are_empty(tmp_path: Path) -> None:
+    csv_path: Path = tmp_path / "rgb.csv"
+    csv_path.write_text("ts_ns,frame_idx\n")
+    assert read_frame_times_ns(csv_path).size == 0
+
+
+def test_imu_csv_keeps_accel_and_gyro_and_drops_mag_and_rot(tmp_path: Path) -> None:
+    csv_path: Path = tmp_path / "imu.csv"
+    csv_path.write_text(
+        "ts_ns,accel_x,accel_y,accel_z,gyro_x,gyro_y,gyro_z,mag_x,mag_y,mag_z,rot_i,rot_j,rot_k\n"
+        "0,0.71875,-4.95703125,-8.796875,-0.13671875,-0.15625,-0.07421875,19.25,10.1875,73.0625,-0.85,-0.45,0.068\n"
+        "10035000,0.76953125,-5.01171875,-8.88671875,-0.111328125,-0.154296875,-0.0703125,20.3125,4.8125,69.75,-0.851,-0.455,0.068\n"
+    )
+    samples: ImuSamples = read_imu_csv(csv_path)
+    np.testing.assert_array_equal(samples.times_ns, np.array([0, 10035000], dtype=np.int64))
+    expected_accel: Float64[ndarray, "2 3"] = np.array([[0.71875, -4.95703125, -8.796875], [0.76953125, -5.01171875, -8.88671875]])
+    np.testing.assert_allclose(samples.accel_xyz, expected_accel)
+    expected_gyro: Float64[ndarray, "2 3"] = np.array([[-0.13671875, -0.15625, -0.07421875], [-0.111328125, -0.154296875, -0.0703125]])
+    np.testing.assert_allclose(samples.gyro_xyz, expected_gyro)
+
+
+def test_head_poses_take_the_left_eye_track_as_xyzw_quaternions(tmp_path: Path) -> None:
+    csv_path: Path = tmp_path / "head_pose.csv"
+    csv_path.write_text(
+        "ts_ns,left_pos_x,left_pos_y,left_pos_z,left_quat_x,left_quat_y,left_quat_z,left_quat_w,"
+        "right_pos_x,right_pos_y,right_pos_z,right_quat_x,right_quat_y,right_quat_z,right_quat_w\n"
+        "0,-0.224171,1.953459,0.502586,0.448053,0.358166,-0.794444,0.199559,-0.257063,1.953081,0.448476,0.446841,0.35412,-0.793884,0.211378\n"
+        "17181303,-0.224091,1.953531,0.502348,0.448075,0.358003,-0.794497,0.199592,-0.256979,1.95314,0.448235,0.44686,0.353958,-0.793937,0.211411\n"
+    )
+    poses: HeadPoses = read_head_poses(csv_path)
+    np.testing.assert_array_equal(poses.times_ns, np.array([0, 17181303], dtype=np.int64))
+    expected_translations: Float32[ndarray, "2 3"] = np.array([[-0.224171, 1.953459, 0.502586], [-0.224091, 1.953531, 0.502348]], dtype=np.float32)
+    np.testing.assert_allclose(poses.translations_xyz, expected_translations)
+    # xyzw, not the wxyz the csv header might suggest to a careless reader.
+    np.testing.assert_allclose(poses.quaternions_xyzw[0], np.array([0.448053, 0.358166, -0.794444, 0.199559], dtype=np.float32))
+    assert np.isclose(np.linalg.norm(poses.quaternions_xyzw, axis=-1), 1.0, atol=1e-3).all()
+
+
+def test_calibration_keys_on_positional_layout_and_maps_14_coefficients(tmp_path: Path) -> None:
+    coefficients: list[float] = [5.53, 1.66, 8.6e-05, 1.9e-04, 0.0259, 5.9, 3.36, 0.226, 0.0, 0.0, 0.0, 0.0, -0.00158, 0.0067]
+    calibration_path: Path = tmp_path / "calibration.json"
+    calibration_path.write_text(
+        json.dumps(
+            {
+                "intrinsics": [
+                    {
+                        "camera_id": "CAM_C",
+                        "positional_layout": "left",
+                        "lens_intrinsics": {"focal_length_x": 572.2, "focal_length_y": 572.1, "principal_point_x": 648.4, "principal_point_y": 356.7},
+                        "distortion": {"coefficients": coefficients, "available": True},
+                        "capture_resolution": {"width": 1280, "height": 720},
+                    },
+                    {
+                        "camera_id": "avcapturedevice:5",
+                        "positional_layout": "center",
+                        "lens_intrinsics": {"focal_length_x": 700.0, "focal_length_y": 700.0, "principal_point_x": 960.0, "principal_point_y": 540.0},
+                        "distortion": {"available": False},
+                        "capture_resolution": {"width": 1920, "height": 1080},
+                    },
+                    {"camera_id": "broken", "positional_layout": "right", "lens_intrinsics": {"available": False}},
+                ],
+                "extrinsics": [],
+            }
+        )
+    )
+    cameras: dict[str, CameraCalibration] = read_calibration(calibration_path)
+    assert sorted(cameras) == ["center", "left"]  # the intrinsics-free entry is dropped
+    left: CameraCalibration = cameras["left"]
+    assert (left.width, left.height) == (1280, 720)
+    np.testing.assert_allclose(left.focal_length_xy, np.array([572.2, 572.1]))
+    np.testing.assert_allclose(left.principal_point_xy, np.array([648.4, 356.7]))
+    assert left.distortion_coefficients is not None
+    np.testing.assert_allclose(left.distortion_coefficients, np.asarray(coefficients))
+    assert cameras["center"].distortion_coefficients is None
+
+
+def test_default_blueprint_covers_nine_cameras() -> None:
+    blueprint = SelfcapConfig().setup().default_blueprint()
+    assert blueprint is not None

--- a/packages/dataforge/tests/test_writing.py
+++ b/packages/dataforge/tests/test_writing.py
@@ -3,7 +3,27 @@ from pathlib import Path
 import pytest
 import rerun as rr
 
-from dataforge.writing import atomic_recording, should_skip
+from dataforge.writing import atomic_recording, atomic_write, should_skip
+
+
+def test_atomic_write_replaces_the_target_only_on_success(tmp_path: Path) -> None:
+    target: Path = tmp_path / "blueprints" / "robocap.rbl"
+    with atomic_write(target) as temp_path:
+        assert temp_path.parent == target.parent  # same filesystem, so os.replace is atomic
+        temp_path.write_bytes(b"blueprint")
+    assert target.read_bytes() == b"blueprint"
+    assert target.stat().st_mode & 0o777 == 0o644  # mkstemp's 0600 would hide it from the catalog server
+    assert not list(target.parent.glob("*.tmp"))
+
+
+def test_atomic_write_leaves_a_previous_target_intact_on_failure(tmp_path: Path) -> None:
+    target: Path = tmp_path / "robocap.rbl"
+    target.write_bytes(b"old")
+    with pytest.raises(RuntimeError, match="boom"), atomic_write(target) as temp_path:
+        temp_path.write_bytes(b"half")
+        raise RuntimeError("boom")
+    assert target.read_bytes() == b"old"
+    assert not list(tmp_path.glob("*.tmp"))
 
 
 def test_should_skip_existing_unless_forced(tmp_path: Path) -> None:

--- a/packages/simplecv/docs/exoego_schema.md
+++ b/packages/simplecv/docs/exoego_schema.md
@@ -88,6 +88,16 @@ world_T_cam  = world_T_rig @ rig_T_cam           # composes along the entity tre
 - `reference` = the reference camera's id (e.g. `"cam_00"`),
 - `num_cameras`.
 
+Those three keys are the **required** set. A writer may add the two optional
+rig-level keys `name` (human device label, e.g. `"robocap"`, `"oak"`, an iPhone's
+advertised name) and `kind` (device role: `"exo"` / `"ego"` / `"quest"`) — dataforge
+emits both, because a capture with several unlike rigs is unreadable without them
+and blueprints cannot select entities by their `AnyValues`. Readers must treat them
+as optional. Note also that `reference` names a **sensor child**, not necessarily a
+camera: a rig whose extrinsics are all expressed in its inertial frame states
+`reference = "imu_00"` (dataforge's RoboCap rig does), and a single-camera rig
+trivially states `"cam_00"`.
+
 Per camera, on `/world/rig_NN/cam_MM`: `name` (human stream label) and `kind`
 (`"rgb"` / `"grayscale"`, a best-effort content hint). The reference camera of a
 **multi-camera** rig gets a green frustum tint; single-camera rigs are untinted.


### PR DESCRIPTION
Stacked on #112. The second dataforge dataset: `main/cut` of the self-collected exo+ego corpus (41 days, 692 sessions, 4,168 episodes — 3,085 currently readable pending a NAS chmod).

**Per episode, one base rrd with nine synchronized streams** on an episode-relative `video_time`:
- 4 exo iPhones — `rig_00..03`, plain Pinhole (upstream intrinsics are placeholders: `available: false`, fx=fy=700), **no transforms** (extrinsics empty upstream; a calibration/SLAM layer localizes them later).
- OAK ego — `rig_04` rgb + stereo with real `brown_conrady` distortion (`PinholeWithDistortion`), IMU gyro/accel columnar.
- Quest — `rig_05` with its **head pose as temporal `world_T_rig`** (base has a live 3D view; base owns root ViewCoordinates, Y-up). Body/hand poses deferred as TODOs.

Key finding baked into the design: the cut step re-encoded every stream onto one shared PTS grid (ego 24 fps content resampled, ~50% duplicate frames), so the ego per-frame csvs **cannot** retime the mp4s — all streams trust PTS, and the csvs surface as `num_native_frames`/`native_duration_ns` metadata with a de-dup-lens TODO.

Also fixes the convert verb's batch loop to survive per-sequence failures (the robocap s10 lesson).

Validated: 3 episodes (different days, frame-rate regimes 25/50/59.7 fps, and exo device sets) converted and registered into a `selfcap` catalog dataset; pixel-verified from the catalog URI — all 9 panes decoding, quest frustum animating under its head pose, IMU plots live. Gates green (37 tests).