### PR TITLE
pose logging: confidence-gradient keypoint colors by default

### DIFF
--- a/packages/mamma/src/mamma/viz/stream_logger.py
+++ b/packages/mamma/src/mamma/viz/stream_logger.py
@@ -17,6 +17,7 @@ import torch
 from jaxtyping import UInt8
 from numpy import ndarray
 from simplecv.camera_parameters import PinholeParameters
+from simplecv.rerun_custom_types import Points2DWithConfidence, confidence_scores_to_rgb
 from simplecv.rerun_log_utils import log_pinhole
 from simplecv.video_encoder import VideoCodecChoice, VideoEncoder
 
@@ -279,14 +280,11 @@ class StreamLogger:
             entity_base: str = pinhole_entity(cam_name)
             for obj_id, result in sorted(cam_landmarks.items()):
                 positions: ndarray = result.joints2d[:, :2].cpu().numpy()
-                vis: ndarray = result.visibility.cpu().numpy()
-                colors: ndarray = np.zeros((positions.shape[0], 4), dtype=np.uint8)
-                colors[:, 1] = (vis * 255).astype(np.uint8)
-                colors[:, 0] = ((1.0 - vis) * 255).astype(np.uint8)
-                colors[:, 3] = 255
+                vis: ndarray = result.visibility.cpu().numpy().astype(np.float32).reshape(-1)
+                colors: UInt8[ndarray, "p 3"] = confidence_scores_to_rgb(vis[None, :, None])[0]
                 rr.log(
                     f"{entity_base}/landmarks/person_{obj_id}",
-                    rr.Points2D(positions=positions, colors=colors, radii=1.5),
+                    Points2DWithConfidence(positions=positions, confidences=vis, colors=colors, radii=1.5),
                 )
 
     def log_tick_fit(

--- a/packages/mamma/src/mamma/viz/stream_logger.py
+++ b/packages/mamma/src/mamma/viz/stream_logger.py
@@ -14,10 +14,10 @@ from pathlib import Path
 import numpy as np
 import rerun as rr
 import torch
-from jaxtyping import UInt8
+from jaxtyping import Float32, UInt8
 from numpy import ndarray
 from simplecv.camera_parameters import PinholeParameters
-from simplecv.rerun_custom_types import Points2DWithConfidence, confidence_scores_to_rgb
+from simplecv.rerun_custom_types import Points2DWithConfidence
 from simplecv.rerun_log_utils import log_pinhole
 from simplecv.video_encoder import VideoCodecChoice, VideoEncoder
 
@@ -279,12 +279,11 @@ class StreamLogger:
         for cam_name, cam_landmarks in zip(self.sequence.camera_names, landmarks, strict=True):
             entity_base: str = pinhole_entity(cam_name)
             for obj_id, result in sorted(cam_landmarks.items()):
-                positions: ndarray = result.joints2d[:, :2].cpu().numpy()
-                vis: ndarray = result.visibility.cpu().numpy().astype(np.float32).reshape(-1)
-                colors: UInt8[ndarray, "p 3"] = confidence_scores_to_rgb(vis[None, :, None])[0]
+                positions_xy: Float32[ndarray, "p 2"] = result.joints2d[:, :2].cpu().numpy()
+                vis: Float32[ndarray, "p"] = result.visibility.cpu().numpy()
                 rr.log(
                     f"{entity_base}/landmarks/person_{obj_id}",
-                    Points2DWithConfidence(positions=positions, confidences=vis, colors=colors, radii=1.5),
+                    Points2DWithConfidence(positions=positions_xy, confidences=vis, radii=1.5),
                 )
 
     def log_tick_fit(

--- a/packages/mv-api/src/mv_api/api/full_exoego_pipeline.py
+++ b/packages/mv-api/src/mv_api/api/full_exoego_pipeline.py
@@ -40,7 +40,7 @@ from simplecv.data.skeleton.coco_133 import (
 from simplecv.ops.pc_utils import estimate_voxel_size
 from simplecv.ops.triangulate import proj_3d_vectorized
 from simplecv.ops.tsdf_depth_fuser import Open3DScaleInvariantFuser
-from simplecv.rerun_custom_types import Points2DWithConfidence, Points3DWithConfidence, confidence_scores_to_rgb
+from simplecv.rerun_custom_types import Points2DWithConfidence, Points3DWithConfidence
 from simplecv.rerun_log_utils import RerunTyroConfig, log_pinhole
 from simplecv.video_io import MultiVideoReader, TorchCodecMultiVideoReader, rgb_chw_tensor_to_bgr_hwc
 from tqdm import tqdm
@@ -548,10 +548,6 @@ def predict_kpts3d_from_calibrated_videos(
             vis_xyz[RIGHT_HAND_IDX, :] = np.nan
             vis_scores_3d[RIGHT_HAND_IDX] = np.nan
 
-        confidence_rgb_stack: UInt8[ndarray, "1 n_kpts 3"] = confidence_scores_to_rgb(
-            vis_scores_3d[np.newaxis, :, np.newaxis]
-        )
-        confidence_rgb: UInt8[ndarray, "n_kpts 3"] = confidence_rgb_stack[0]
         rr.log(
             str(parent_log_path / "gt" / "coco133_xyz"),
             Points3DWithConfidence(
@@ -560,7 +556,6 @@ def predict_kpts3d_from_calibrated_videos(
                 class_ids=triangulated_class_id,
                 keypoint_ids=COCO_133_IDS,
                 show_labels=False,
-                colors=confidence_rgb,
             ),
             recording=recording,
         )
@@ -590,10 +585,6 @@ def predict_kpts3d_from_calibrated_videos(
                 if exo_pinhole_log_paths is not None
                 else parent_log_path / "exo" / exo_cam.name / "pinhole"
             )
-            confidence_rgb_view_stack: UInt8[ndarray, "1 n_kpts 3"] = confidence_scores_to_rgb(
-                confidences_view[np.newaxis, :, np.newaxis]
-            )
-            confidence_rgb_view: UInt8[ndarray, "n_kpts 3"] = confidence_rgb_view_stack[0]
             rr.log(
                 str(pinhole_log_path / "gt" / "coco133_uv"),
                 Points2DWithConfidence(
@@ -602,7 +593,6 @@ def predict_kpts3d_from_calibrated_videos(
                     class_ids=triangulated_class_id,
                     keypoint_ids=COCO_133_IDS,
                     show_labels=False,
-                    colors=confidence_rgb_view,
                 ),
                 recording=recording,
             )
@@ -1019,10 +1009,6 @@ def run_model_backed_pipeline(
                 )
                 uv = masked_points.uv
                 confidences_view = masked_points.confidences
-                confidence_rgb_view_stack: UInt8[ndarray, "1 n_kpts 3"] = confidence_scores_to_rgb(
-                    confidences_view[np.newaxis, :, np.newaxis]
-                )
-                confidence_rgb_view: UInt8[ndarray, "n_kpts 3"] = confidence_rgb_view_stack[0]
                 rr.log(
                     str(pinhole_log_path / "pred" / "coco133_uv" / projected_variant),
                     Points2DWithConfidence(
@@ -1031,7 +1017,6 @@ def run_model_backed_pipeline(
                         class_ids=projected_class_id,
                         keypoint_ids=COCO_133_IDS,
                         show_labels=False,
-                        colors=confidence_rgb_view,
                     ),
                     recording=recording,
                 )

--- a/packages/mv-api/src/mv_api/multiview_pose_estimator.py
+++ b/packages/mv-api/src/mv_api/multiview_pose_estimator.py
@@ -15,7 +15,7 @@ from simplecv.camera_parameters import PinholeParameters
 from simplecv.data.skeleton.coco133_layers import COCO133_PREDICTION_LAYER_TO_PATH, Coco133AnnotationLayer
 from simplecv.data.skeleton.coco_133 import COCO_133_IDS, LEFT_HAND_IDX, RIGHT_HAND_IDX
 from simplecv.ops.triangulate import batch_triangulate, projectN3
-from simplecv.rerun_custom_types import Points2DWithConfidence, confidence_scores_to_rgb
+from simplecv.rerun_custom_types import Points2DWithConfidence
 from torch import Tensor
 from wilor_nano.hand_keypoints import (
     FinalWilorPred,
@@ -350,9 +350,6 @@ class MultiviewBodyTracker:
         )
         filtered_keypoints = np.where(finite_mask[:, None], filtered_keypoints, np.nan).astype(np.float32, copy=False)
         filtered_confidences = np.where(finite_mask, filtered_confidences, 0.0).astype(np.float32, copy=False)
-        confidence_rgb: UInt8[ndarray, "n_kpts 3"] = confidence_scores_to_rgb(
-            filtered_confidences[np.newaxis, :, np.newaxis]
-        )[0]
         layer_segment: str = COCO133_PREDICTION_LAYER_TO_PATH[layer]
         rr.log(
             f"{pinhole_path}/pred/coco133_uv/{layer_segment}",
@@ -362,7 +359,6 @@ class MultiviewBodyTracker:
                 class_ids=int(layer),
                 keypoint_ids=COCO_133_IDS,
                 show_labels=False,
-                colors=confidence_rgb,
             ),
             recording=recording,
         )

--- a/packages/posekit/src/posekit/apis/video_pose.py
+++ b/packages/posekit/src/posekit/apis/video_pose.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import numpy as np
 import rerun as rr
 import torch
-from jaxtyping import Float32, Int, UInt8
+from jaxtyping import Float32, Int, UInt8, UInt16
 from numpy import ndarray
 from simplecv.rerun_log_utils import RerunTyroConfig, log_video
 from torch import Tensor
@@ -75,6 +75,7 @@ def log_frame_predictions(
     boxes: Float32[ndarray, "n 4"] = detections.xyxy_numpy()
     xy: Float32[ndarray, "n k 2"] = keypoints.xy_numpy()
     scores: Float32[ndarray, "n k"] = keypoints.scores_numpy()
+    keypoint_ids: UInt16[ndarray, "k"] = np.arange(xy.shape[1], dtype=np.uint16)
     for local_idx, (frame_idx, timestamp_ns) in enumerate(zip(frame_indices, timestamps_ns, strict=True)):
         rr.set_time("frame", sequence=int(frame_idx))
         rr.set_time("video_time", duration=1e-9 * float(timestamp_ns))
@@ -96,7 +97,7 @@ def log_frame_predictions(
                 xy[row],
                 scores[row],
                 keypoint_threshold,
-                keypoint_ids=np.arange(xy.shape[1], dtype=np.uint16),
+                keypoint_ids=keypoint_ids,
                 class_ids=0,
             )
 

--- a/packages/posekit/src/posekit/apis/video_track.py
+++ b/packages/posekit/src/posekit/apis/video_track.py
@@ -24,7 +24,7 @@ from posekit.models import AnnotatedDetectorConfig, AnnotatedPose2dConfig, RtmPo
 from posekit.models.clip_identity import ClipIdentityConfig
 from posekit.models.sam2_video import Sam2VideoSegmenterConfig
 from posekit.predictions import BoxDetections, Keypoints2d
-from posekit.rerun_logging import log_skeleton_annotation_context
+from posekit.rerun_logging import log_person_points2d, log_skeleton_annotation_context
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -86,11 +86,13 @@ def _log_tracked_frame(
         rr.log(f"video/track_{track_id}/bbox", rr.Boxes2D(array=boxes[row][None], array_format=rr.Box2DFormat.XYXY, class_ids=track_id + 1))
         if row in row_to_pose:
             pose_idx: int = row_to_pose[row]
-            visible_xy: Float32[ndarray, "k 2"] = xy[pose_idx].copy()
-            visible_xy[scores[pose_idx] < keypoint_threshold] = np.nan
-            rr.log(
+            log_person_points2d(
                 f"video/track_{track_id}/keypoints",
-                rr.Points2D(positions=visible_xy, keypoint_ids=np.arange(visible_xy.shape[0], dtype=np.uint16), class_ids=0),
+                xy[pose_idx],
+                scores[pose_idx],
+                keypoint_threshold,
+                keypoint_ids=np.arange(xy.shape[1], dtype=np.uint16),
+                class_ids=0,
             )
         if track_id in identity_cosine:
             rr.log(f"identity/track_{track_id}", rr.Scalars(identity_cosine[track_id]))

--- a/packages/posekit/src/posekit/apis/video_track.py
+++ b/packages/posekit/src/posekit/apis/video_track.py
@@ -14,7 +14,7 @@ import numpy as np
 import rerun as rr
 import torch
 import torch.nn.functional as F
-from jaxtyping import Bool, Float32, Int, UInt8
+from jaxtyping import Bool, Float32, Int, UInt8, UInt16
 from numpy import ndarray
 from simplecv.rerun_log_utils import RerunTyroConfig, log_video
 from torch import Tensor
@@ -73,6 +73,7 @@ def _log_tracked_frame(
     masks: Bool[ndarray, "n h w"] = tracks.masks.cpu().numpy()
     xy: Float32[ndarray, "p k 2"] = keypoints.xy_numpy()
     scores: Float32[ndarray, "p k"] = keypoints.scores_numpy()
+    keypoint_ids: UInt16[ndarray, "k"] = np.arange(xy.shape[1], dtype=np.uint16)
     row_to_pose: dict[int, int] = {int(row): pose_idx for pose_idx, row in enumerate(pose_rows)}
     seen: set[int] = set()
     for row in range(tracks.num_detections):
@@ -91,7 +92,7 @@ def _log_tracked_frame(
                 xy[pose_idx],
                 scores[pose_idx],
                 keypoint_threshold,
-                keypoint_ids=np.arange(xy.shape[1], dtype=np.uint16),
+                keypoint_ids=keypoint_ids,
                 class_ids=0,
             )
         if track_id in identity_cosine:

--- a/packages/posekit/src/posekit/rerun_logging.py
+++ b/packages/posekit/src/posekit/rerun_logging.py
@@ -6,6 +6,7 @@ import numpy as np
 import rerun as rr
 from jaxtyping import Float32, UInt8, UInt16
 from numpy import ndarray
+from simplecv.rerun_custom_types import Points2DWithConfidence, confidence_scores_to_rgb
 
 from posekit.skeletons import KeypointSkeleton
 
@@ -60,23 +61,27 @@ def log_person_points2d(
     confidence: Float32[ndarray, "p"],
     threshold: float,
     *,
-    color: tuple[int, int, int] | None = None,
     keypoint_ids: UInt16[ndarray, "p"] | None = None,
     class_ids: int | None = None,
 ) -> None:
-    """Log one person's points after masking low-confidence positions."""
+    """Log one person's points colored by confidence, masking low-confidence positions.
+
+    Point colors follow the shared red -> yellow -> green confidence gradient and
+    the raw (unmasked) scores ride along as queryable confidence components.
+    """
     visible_xy: Float32[ndarray, "p 2"] = xy.copy()
     visible_xy[confidence < threshold] = np.nan
+    colors: UInt8[ndarray, "p 3"] = confidence_scores_to_rgb(confidence.astype(np.float32)[None, :, None])[0]
     rr.log(
         entity_path,
-        rr.Points2D(
+        Points2DWithConfidence(
             positions=visible_xy,
+            confidences=confidence,
             keypoint_ids=keypoint_ids,
             class_ids=class_ids,
-            colors=color,
+            colors=colors,
             # Negative radii are screen-space UI points, so they stay visible at every zoom level.
             radii=-2.5,
-            show_labels=False,
         ),
     )
 
@@ -98,7 +103,6 @@ def log_topdown_predictions(
             keypoints_xy[person_idx],
             scores[person_idx],
             keypoint_threshold,
-            color=person_color(person_idx),
             keypoint_ids=keypoint_ids,
             class_ids=0,
         )
@@ -118,7 +122,6 @@ def log_dense_predictions(
             landmarks_xy[person_idx],
             visibility[person_idx],
             visibility_threshold,
-            color=person_color(person_idx),
         )
 
 

--- a/packages/posekit/src/posekit/rerun_logging.py
+++ b/packages/posekit/src/posekit/rerun_logging.py
@@ -6,7 +6,7 @@ import numpy as np
 import rerun as rr
 from jaxtyping import Float32, UInt8, UInt16
 from numpy import ndarray
-from simplecv.rerun_custom_types import Points2DWithConfidence, confidence_scores_to_rgb
+from simplecv.rerun_custom_types import Points2DWithConfidence
 
 from posekit.skeletons import KeypointSkeleton
 
@@ -71,7 +71,6 @@ def log_person_points2d(
     """
     visible_xy: Float32[ndarray, "p 2"] = xy.copy()
     visible_xy[confidence < threshold] = np.nan
-    colors: UInt8[ndarray, "p 3"] = confidence_scores_to_rgb(confidence.astype(np.float32)[None, :, None])[0]
     rr.log(
         entity_path,
         Points2DWithConfidence(
@@ -79,7 +78,6 @@ def log_person_points2d(
             confidences=confidence,
             keypoint_ids=keypoint_ids,
             class_ids=class_ids,
-            colors=colors,
             # Negative radii are screen-space UI points, so they stay visible at every zoom level.
             radii=-2.5,
         ),

--- a/packages/posekit/tests/test_rerun_logging.py
+++ b/packages/posekit/tests/test_rerun_logging.py
@@ -1,0 +1,56 @@
+"""Behavior tests for the shared keypoint logging helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+import rerun as rr
+from jaxtyping import Float32
+from numpy import ndarray
+
+from posekit.rerun_logging import log_person_points2d
+
+
+def _batches_by_component(archetype: Any) -> dict[str, Any]:
+    return {batch.component_descriptor().component: batch for batch in archetype.as_component_batches()}
+
+
+def _unpack_rgba(packed: int) -> tuple[int, int, int]:
+    return (packed >> 24) & 0xFF, (packed >> 16) & 0xFF, (packed >> 8) & 0xFF
+
+
+def test_log_person_points2d_colors_by_confidence_and_keeps_raw_scores(monkeypatch: pytest.MonkeyPatch) -> None:
+    logged: list[tuple[str, Any]] = []
+    monkeypatch.setattr(rr, "log", lambda entity_path, archetype, **kwargs: logged.append((entity_path, archetype)))
+
+    xy: Float32[ndarray, "3 2"] = np.asarray([[10.0, 10.0], [20.0, 20.0], [30.0, 30.0]], dtype=np.float32)
+    confidence: Float32[ndarray, "3"] = np.asarray([0.0, 1.0, 0.1], dtype=np.float32)
+    log_person_points2d(
+        "image/person_0/keypoints",
+        xy,
+        confidence,
+        0.3,
+        keypoint_ids=np.arange(3, dtype=np.uint16),
+        class_ids=0,
+    )
+
+    assert len(logged) == 1
+    entity_path, archetype = logged[0]
+    assert entity_path == "image/person_0/keypoints"
+    batches: dict[str, Any] = _batches_by_component(archetype)
+
+    positions: Float32[ndarray, "3 2"] = np.asarray(batches["Points2D:positions"].as_arrow_array().to_pylist(), dtype=np.float32)
+    np.testing.assert_allclose(positions[1], xy[1])
+    assert np.isnan(positions[0]).all(), "below-threshold positions must be masked"
+    assert np.isnan(positions[2]).all(), "below-threshold positions must be masked"
+
+    packed_colors: list[int] = batches["Points2D:colors"].as_arrow_array().to_pylist()
+    assert _unpack_rgba(packed_colors[0]) == (255, 0, 0), "confidence 0.0 must render red"
+    assert _unpack_rgba(packed_colors[1]) == (0, 255, 0), "confidence 1.0 must render green"
+
+    raw_scores: Float32[ndarray, "3"] = np.asarray(
+        batches["simplecv.KeypointConfidence2D:confidences"].as_arrow_array().to_pylist(), dtype=np.float32
+    )
+    np.testing.assert_allclose(raw_scores, confidence, err_msg="raw confidence values must ride along unmasked")

--- a/packages/posekit/tests/test_rerun_logging.py
+++ b/packages/posekit/tests/test_rerun_logging.py
@@ -23,7 +23,7 @@ def _unpack_rgba(packed: int) -> tuple[int, int, int]:
 
 def test_log_person_points2d_colors_by_confidence_and_keeps_raw_scores(monkeypatch: pytest.MonkeyPatch) -> None:
     logged: list[tuple[str, Any]] = []
-    monkeypatch.setattr(rr, "log", lambda entity_path, archetype, **kwargs: logged.append((entity_path, archetype)))
+    monkeypatch.setattr(rr, "log", lambda entity_path, archetype, **_kwargs: logged.append((entity_path, archetype)))
 
     xy: Float32[ndarray, "3 2"] = np.asarray([[10.0, 10.0], [20.0, 20.0], [30.0, 30.0]], dtype=np.float32)
     confidence: Float32[ndarray, "3"] = np.asarray([0.0, 1.0, 0.1], dtype=np.float32)
@@ -46,9 +46,10 @@ def test_log_person_points2d_colors_by_confidence_and_keeps_raw_scores(monkeypat
     assert np.isnan(positions[0]).all(), "below-threshold positions must be masked"
     assert np.isnan(positions[2]).all(), "below-threshold positions must be masked"
 
+    # Exact hues are owned by simplecv's archetype tests; here we only assert
+    # that per-point colors vary with confidence at all.
     packed_colors: list[int] = batches["Points2D:colors"].as_arrow_array().to_pylist()
-    assert _unpack_rgba(packed_colors[0]) == (255, 0, 0), "confidence 0.0 must render red"
-    assert _unpack_rgba(packed_colors[1]) == (0, 255, 0), "confidence 1.0 must render green"
+    assert packed_colors[0] != packed_colors[1], "confidence 0.0 and 1.0 must render differently"
 
     raw_scores: Float32[ndarray, "3"] = np.asarray(
         batches["simplecv.KeypointConfidence2D:confidences"].as_arrow_array().to_pylist(), dtype=np.float32

--- a/packages/sapiens-coco133-pose/src/sapiens_coco133_pose/api/artifact.py
+++ b/packages/sapiens-coco133-pose/src/sapiens_coco133_pose/api/artifact.py
@@ -14,7 +14,7 @@ from numpy import ndarray
 from sapiens2_pose.api.metadata import get_pose_schema, log_annotation_context
 from sapiens2_pose.api.pose_artifact import PoseArtifactComparisonConfig, PoseArtifactComparisonMetrics, PosePredictionArtifact, compare_pose_prediction_artifacts
 from sapiens2_pose.api.rerun_pose_artifact import _load_one_recording_chunks
-from simplecv.rerun_custom_types import Points2DWithConfidence, confidence_scores_to_rgb
+from simplecv.rerun_custom_types import Points2DWithConfidence
 from simplecv.rerun_log_utils import log_video
 
 _LEGACY_POSE_ENTITY_PATTERN = re.compile(r"^/?video/frame_(?P<frame>\d+)/person_(?P<person>\d+)/(?P<kind>bbox|keypoints)$")
@@ -115,14 +115,14 @@ def coco133_points2d_with_confidence(
         class_id: Rerun class id for the person instance.
 
     Returns:
-        ``Points2DWithConfidence`` containing positions, confidence values, keypoint ids, class ids, and confidence colors.
+        ``Points2DWithConfidence`` containing positions, confidence values, keypoint ids, and class ids;
+        colors derive from the confidences inside the archetype.
     """
     keypoints_f32: Float32[ndarray, "133 2"] = np.asarray(keypoints, dtype=np.float32).reshape(133, 2).copy()
     scores_f32: Float32[ndarray, "133"] = np.asarray(scores, dtype=np.float32).reshape(133).copy()
     visible_mask: Bool[ndarray, "133"] = np.asarray(scores_f32 >= np.float32(keypoint_threshold), dtype=np.bool_)
     keypoints_f32[~visible_mask] = np.nan
-    confidence_rgb: UInt8[ndarray, "133 3"] = confidence_scores_to_rgb(scores_f32[np.newaxis, :, np.newaxis])[0]
-    return Points2DWithConfidence(positions=keypoints_f32, confidences=scores_f32, class_ids=class_id, keypoint_ids=keypoint_ids, colors=confidence_rgb, show_labels=False)
+    return Points2DWithConfidence(positions=keypoints_f32, confidences=scores_f32, class_ids=class_id, keypoint_ids=keypoint_ids, show_labels=False)
 
 
 def log_video_pose_frames(frames: list[Coco133PoseFrame], *, keypoint_threshold: float, recording: rr.RecordingStream, video_path: Path | None = None, video_log_path: Path = Path("video")) -> rr.RecordingStream:

--- a/packages/sapiens2-pose/src/sapiens2_pose/api/image_pose.py
+++ b/packages/sapiens2-pose/src/sapiens2_pose/api/image_pose.py
@@ -13,7 +13,7 @@ import rerun.blueprint as rrb
 from jaxtyping import Float32, UInt8
 from numpy import ndarray
 from PIL import Image
-from simplecv.rerun_custom_types import Points2DWithConfidence, confidence_scores_to_rgb
+from simplecv.rerun_custom_types import Points2DWithConfidence
 
 from sapiens2_pose.api.metadata import get_sapiens_metainfo
 from sapiens2_pose.api.pose_artifact import PosePredictionArtifact, save_pose_prediction_artifact
@@ -160,7 +160,6 @@ def _log_pose_recording(
         scores: Float32[ndarray, "k"] = np.asarray(artifact.scores[idx], dtype=np.float32).reshape(-1)
         low_confidence_indices: ndarray = np.flatnonzero(scores < kpt_thr)
         keypoints[low_confidence_indices] = np.nan
-        confidence_rgb: UInt8[ndarray, "k 3"] = confidence_scores_to_rgb(scores[None, :, None])[0]
         rr.log(
             f"image/person_{idx}/keypoints",
             Points2DWithConfidence(
@@ -168,7 +167,6 @@ def _log_pose_recording(
                 confidences=scores,
                 class_ids=0,
                 keypoint_ids=keypoint_ids,
-                colors=confidence_rgb,
             ),
         )
 

--- a/packages/sapiens2-pose/src/sapiens2_pose/api/image_pose.py
+++ b/packages/sapiens2-pose/src/sapiens2_pose/api/image_pose.py
@@ -13,6 +13,7 @@ import rerun.blueprint as rrb
 from jaxtyping import Float32, UInt8
 from numpy import ndarray
 from PIL import Image
+from simplecv.rerun_custom_types import Points2DWithConfidence, confidence_scores_to_rgb
 
 from sapiens2_pose.api.metadata import get_sapiens_metainfo
 from sapiens2_pose.api.pose_artifact import PosePredictionArtifact, save_pose_prediction_artifact
@@ -137,9 +138,7 @@ def _log_pose_recording(
 ) -> None:
     """Log one image pose artifact into the active Rerun recording."""
     keypoint_count: int = int(artifact.keypoints.shape[1]) if artifact.keypoints.ndim == 3 else 0
-    meta: dict[str, Any] = get_sapiens_metainfo()
     keypoint_ids: list[int] = list(range(keypoint_count))
-    keypoint_colors: UInt8[ndarray, "k 3"] = np.asarray(meta["keypoint_colors"], dtype=np.uint8)[:keypoint_count]
 
     rr.send_blueprint(rrb.Blueprint(rrb.Spatial2DView(name="Pose", origin="image"), collapse_panels=True))
     rr.set_time("iteration", sequence=0)
@@ -161,14 +160,15 @@ def _log_pose_recording(
         scores: Float32[ndarray, "k"] = np.asarray(artifact.scores[idx], dtype=np.float32).reshape(-1)
         low_confidence_indices: ndarray = np.flatnonzero(scores < kpt_thr)
         keypoints[low_confidence_indices] = np.nan
+        confidence_rgb: UInt8[ndarray, "k 3"] = confidence_scores_to_rgb(scores[None, :, None])[0]
         rr.log(
             f"image/person_{idx}/keypoints",
-            rr.Points2D(
+            Points2DWithConfidence(
                 positions=keypoints,
+                confidences=scores,
                 class_ids=0,
                 keypoint_ids=keypoint_ids,
-                colors=keypoint_colors,
-                show_labels=False,
+                colors=confidence_rgb,
             ),
         )
 

--- a/packages/sapiens2-pose/src/sapiens2_pose/api/metadata.py
+++ b/packages/sapiens2-pose/src/sapiens2_pose/api/metadata.py
@@ -9,7 +9,7 @@ from typing import Any, Literal
 
 import numpy as np
 import rerun as rr
-from jaxtyping import Float32, UInt8
+from jaxtyping import Float32
 from numpy import ndarray
 
 from sapiens2_pose.sapiens_lite.pose import parse_pose_metainfo
@@ -35,8 +35,6 @@ class PoseSchema:
     """Mapping from keypoint ID to display name."""
     keypoint_connections: list[tuple[int, int]]
     """Skeleton edges expressed in schema-local keypoint IDs."""
-    keypoint_colors: UInt8[ndarray, "k 3"]
-    """Per-keypoint RGB colors."""
 
 
 _keypoint_module_cache: Any | None = None
@@ -74,14 +72,12 @@ def _build_sapiens_schema() -> PoseSchema:
     keypoint_ids: list[int] = list(range(int(meta["num_keypoints"])))
     id2name: dict[int, str] = {int(idx): str(meta["keypoint_id2name"][idx]) for idx in keypoint_ids}
     keypoint_connections: list[tuple[int, int]] = [(int(a), int(b)) for a, b in meta["skeleton_links"]]
-    keypoint_colors: UInt8[ndarray, "k 3"] = np.asarray(meta["keypoint_colors"], dtype=np.uint8)
     return PoseSchema(
         name="sapiens308",
         class_label="Sapiens2 308",
         keypoint_ids=keypoint_ids,
         id2name=id2name,
         keypoint_connections=keypoint_connections,
-        keypoint_colors=keypoint_colors,
     )
 
 
@@ -94,10 +90,6 @@ def _build_coco133_schema() -> PoseSchema:
         int(idx): str(coco_info["keypoint_info"][idx]["name"])
         for idx in keypoint_ids
     }
-    keypoint_colors: UInt8[ndarray, "k 3"] = np.asarray(
-        [coco_info["keypoint_info"][idx].get("color", [255, 128, 0]) for idx in keypoint_ids],
-        dtype=np.uint8,
-    )
     name2id: dict[str, int] = {name: idx for idx, name in id2name.items()}
     keypoint_connections: list[tuple[int, int]] = []
     for skeleton_info in coco_info["skeleton_info"].values():
@@ -111,7 +103,6 @@ def _build_coco133_schema() -> PoseSchema:
         keypoint_ids=keypoint_ids,
         id2name=id2name,
         keypoint_connections=keypoint_connections,
-        keypoint_colors=keypoint_colors,
     )
 
 

--- a/packages/sapiens2-pose/src/sapiens2_pose/api/rerun_logging.py
+++ b/packages/sapiens2-pose/src/sapiens2_pose/api/rerun_logging.py
@@ -118,7 +118,9 @@ def _prepare_keypoints_for_logging(
     valid_count: int = min(keypoints_arr.shape[0], scores_arr.shape[0])
     if valid_count < keypoints_arr.shape[0]:
         keypoints_arr[valid_count:] = np.nan
-    reconciled_scores: Float32[ndarray, "k"] = np.zeros((keypoints_arr.shape[0],), dtype=np.float32)
+    # NaN (not 0.0) for missing tail scores: nanmean-based average_confidence
+    # skips NaN, and the gradient renders NaN as red either way.
+    reconciled_scores: Float32[ndarray, "k"] = np.full((keypoints_arr.shape[0],), np.nan, dtype=np.float32)
     reconciled_scores[:valid_count] = scores_arr[:valid_count]
     low_confidence_indices: Int[ndarray, "low_confidence"] = np.flatnonzero(scores_arr[:valid_count] < kpt_thr).astype(np.int32)
     keypoints_arr[low_confidence_indices] = np.nan

--- a/packages/sapiens2-pose/src/sapiens2_pose/api/rerun_logging.py
+++ b/packages/sapiens2-pose/src/sapiens2_pose/api/rerun_logging.py
@@ -9,6 +9,7 @@ import rerun as rr
 import rerun.blueprint as rrb
 from jaxtyping import Bool, Float32, Int, UInt8, UInt16
 from numpy import ndarray
+from simplecv.rerun_custom_types import Points2DWithConfidence, confidence_scores_to_rgb
 
 from sapiens2_pose.api.metadata import PoseSchema, log_annotation_context
 
@@ -135,7 +136,6 @@ def log_pose_instances(
 ) -> None:
     """Log per-person 2D boxes and keypoints below an entity root."""
     keypoint_ids: Int[ndarray, "k"] = np.asarray(schema.keypoint_ids, dtype=np.int32)
-    keypoint_colors: UInt8[ndarray, "k 3"] = np.asarray(schema.keypoint_colors, dtype=np.uint8)
     bboxes_f32: Float32[ndarray, "n 4"] = np.asarray(bboxes, dtype=np.float32).reshape(-1, 4)
     if track_ids is None:
         track_ids_arr: Int[ndarray, "n"] = np.arange(bboxes_f32.shape[0], dtype=np.int32)
@@ -161,14 +161,16 @@ def log_pose_instances(
         )
 
         keypoints_arr: Float32[ndarray, "k 2"] = _prepare_keypoints_for_logging(kpts, scr, kpt_thr)
+        scores_f32: Float32[ndarray, "k"] = np.asarray(scr, dtype=np.float32).reshape(-1)
+        confidence_rgb: UInt8[ndarray, "k 3"] = confidence_scores_to_rgb(scores_f32[None, :, None])[0]
         rr.log(
             f"{person_path}/keypoints",
-            rr.Points2D(
+            Points2DWithConfidence(
                 positions=keypoints_arr,
+                confidences=scores_f32,
                 class_ids=0,
                 keypoint_ids=keypoint_ids,
-                colors=keypoint_colors,
-                show_labels=False,
+                colors=confidence_rgb,
             ),
             recording=recording,
         )

--- a/packages/sapiens2-pose/src/sapiens2_pose/api/rerun_logging.py
+++ b/packages/sapiens2-pose/src/sapiens2_pose/api/rerun_logging.py
@@ -9,7 +9,7 @@ import rerun as rr
 import rerun.blueprint as rrb
 from jaxtyping import Bool, Float32, Int, UInt8, UInt16
 from numpy import ndarray
-from simplecv.rerun_custom_types import Points2DWithConfidence, confidence_scores_to_rgb
+from simplecv.rerun_custom_types import Points2DWithConfidence
 
 from sapiens2_pose.api.metadata import PoseSchema, log_annotation_context
 
@@ -111,16 +111,18 @@ def _prepare_keypoints_for_logging(
     keypoints: Float32[ndarray, "k 2"],
     scores: Float32[ndarray, "k"],
     kpt_thr: float,
-) -> Float32[ndarray, "k 2"]:
-    """Mask low-confidence keypoints with NaN so Rerun does not draw them."""
+) -> tuple[Float32[ndarray, "k 2"], Float32[ndarray, "k"]]:
+    """Mask low-confidence keypoints with NaN and return the length-reconciled scores."""
     keypoints_arr: Float32[ndarray, "k 2"] = np.asarray(keypoints, dtype=np.float32).copy()
     scores_arr: Float32[ndarray, "k"] = np.asarray(scores, dtype=np.float32).reshape(-1)
     valid_count: int = min(keypoints_arr.shape[0], scores_arr.shape[0])
     if valid_count < keypoints_arr.shape[0]:
         keypoints_arr[valid_count:] = np.nan
+    reconciled_scores: Float32[ndarray, "k"] = np.zeros((keypoints_arr.shape[0],), dtype=np.float32)
+    reconciled_scores[:valid_count] = scores_arr[:valid_count]
     low_confidence_indices: Int[ndarray, "low_confidence"] = np.flatnonzero(scores_arr[:valid_count] < kpt_thr).astype(np.int32)
     keypoints_arr[low_confidence_indices] = np.nan
-    return keypoints_arr
+    return keypoints_arr, reconciled_scores
 
 
 def log_pose_instances(
@@ -160,9 +162,9 @@ def log_pose_instances(
             recording=recording,
         )
 
-        keypoints_arr: Float32[ndarray, "k 2"] = _prepare_keypoints_for_logging(kpts, scr, kpt_thr)
-        scores_f32: Float32[ndarray, "k"] = np.asarray(scr, dtype=np.float32).reshape(-1)
-        confidence_rgb: UInt8[ndarray, "k 3"] = confidence_scores_to_rgb(scores_f32[None, :, None])[0]
+        prepared: tuple[Float32[ndarray, "k 2"], Float32[ndarray, "k"]] = _prepare_keypoints_for_logging(kpts, scr, kpt_thr)
+        keypoints_arr: Float32[ndarray, "k 2"] = prepared[0]
+        scores_f32: Float32[ndarray, "k"] = prepared[1]
         rr.log(
             f"{person_path}/keypoints",
             Points2DWithConfidence(
@@ -170,7 +172,6 @@ def log_pose_instances(
                 confidences=scores_f32,
                 class_ids=0,
                 keypoint_ids=keypoint_ids,
-                colors=confidence_rgb,
             ),
             recording=recording,
         )

--- a/packages/sapiens2-pose/src/sapiens2_pose/gradio_ui.py
+++ b/packages/sapiens2-pose/src/sapiens2_pose/gradio_ui.py
@@ -14,9 +14,10 @@ import rerun.blueprint as rrb
 import torch
 from gradio_rerun import Rerun
 from huggingface_hub import hf_hub_download
-from jaxtyping import Float32
+from jaxtyping import Float32, UInt8
 from numpy import ndarray
 from PIL import Image
+from simplecv.rerun_custom_types import Points2DWithConfidence, confidence_scores_to_rgb
 from transformers import DetrForObjectDetection, DetrImageProcessor
 
 from sapiens2_pose.api.pose_artifact import PosePredictionArtifact
@@ -223,7 +224,6 @@ def _log_pose_recording(
 ) -> None:
     skeleton = _get_sapiens_skeleton()
     keypoint_ids = skeleton["ids"]
-    keypoint_colors = skeleton["keypoint_colors"]
 
     rr.send_blueprint(
         rrb.Blueprint(
@@ -250,14 +250,15 @@ def _log_pose_recording(
         kpts_arr = kpts.copy()
         scores_arr = scr.reshape(-1)
         kpts_arr[scores_arr < kpt_thr] = np.nan
+        confidence_rgb: UInt8[ndarray, "k 3"] = confidence_scores_to_rgb(scores_arr.astype(np.float32)[None, :, None])[0]
         rr.log(
             f"image/person_{idx}/keypoints",
-            rr.Points2D(
+            Points2DWithConfidence(
                 positions=kpts_arr,
+                confidences=scores_arr,
                 class_ids=0,
                 keypoint_ids=keypoint_ids,
-                colors=keypoint_colors,
-                show_labels=False,
+                colors=confidence_rgb,
             ),
         )
 

--- a/packages/sapiens2-pose/src/sapiens2_pose/gradio_ui.py
+++ b/packages/sapiens2-pose/src/sapiens2_pose/gradio_ui.py
@@ -14,10 +14,10 @@ import rerun.blueprint as rrb
 import torch
 from gradio_rerun import Rerun
 from huggingface_hub import hf_hub_download
-from jaxtyping import Float32, UInt8
+from jaxtyping import Float32
 from numpy import ndarray
 from PIL import Image
-from simplecv.rerun_custom_types import Points2DWithConfidence, confidence_scores_to_rgb
+from simplecv.rerun_custom_types import Points2DWithConfidence
 from transformers import DetrForObjectDetection, DetrImageProcessor
 
 from sapiens2_pose.api.pose_artifact import PosePredictionArtifact
@@ -125,7 +125,6 @@ def _get_sapiens_skeleton() -> dict[str, Any]:
                 (int(a), int(b))
                 for a, b in meta["skeleton_links"]
             ],
-            "keypoint_colors": np.asarray(meta["keypoint_colors"], dtype=np.uint8),
         }
     return _skeleton_cache
 
@@ -250,7 +249,6 @@ def _log_pose_recording(
         kpts_arr = kpts.copy()
         scores_arr = scr.reshape(-1)
         kpts_arr[scores_arr < kpt_thr] = np.nan
-        confidence_rgb: UInt8[ndarray, "k 3"] = confidence_scores_to_rgb(scores_arr.astype(np.float32)[None, :, None])[0]
         rr.log(
             f"image/person_{idx}/keypoints",
             Points2DWithConfidence(
@@ -258,7 +256,6 @@ def _log_pose_recording(
                 confidences=scores_arr,
                 class_ids=0,
                 keypoint_ids=keypoint_ids,
-                colors=confidence_rgb,
             ),
         )
 

--- a/packages/simplecv/simplecv/apis/convert_to_rrd.py
+++ b/packages/simplecv/simplecv/apis/convert_to_rrd.py
@@ -282,7 +282,6 @@ def log_incremental(
 
     xyz_stack: Float32[ndarray, "n_frames 68 3"] = ego_sequence.xyz_stack
     conf_stack: Float32[ndarray, "n_frames 68 1"] = ego_sequence.conf_stack
-    all_colors_stack: UInt8[ndarray, "n_frames 68 3"] = confidence_scores_to_rgb(confidence_scores=conf_stack)
 
     rr.log(
         "llm_description", rr.TextDocument(text=ego_sequence.llm_description, media_type="text/markdown"), static=True
@@ -304,13 +303,11 @@ def log_incremental(
         )
         current_xyz: Float32[ndarray, "68 3"] = xyz_stack[ts_idx, ...]
         current_conf: Float32[ndarray, "68 1"] = conf_stack[ts_idx, ...]
-        current_colors: UInt8[ndarray, "68 3"] = all_colors_stack[ts_idx]
         rr.log(
             f"{joints_log_path}",
             Points3DWithConfidence(
                 positions=current_xyz,
                 confidences=current_conf.squeeze(),
-                colors=current_colors,
                 class_ids=0,
                 keypoint_ids=AVP_IDS,
                 show_labels=False,
@@ -329,13 +326,13 @@ def log_incremental(
         uv[..., 0] = np.where((uv[..., 0] < 0) | (uv[..., 0] > pinhole.intrinsics.width), np.nan, uv[..., 0])
         uv[..., 1] = np.where((uv[..., 1] < 0) | (uv[..., 1] > pinhole.intrinsics.height), np.nan, uv[..., 1])
 
-        # Log the 2D keypoints
+        # Log the 2D keypoints. uv[..., -1] is the homogeneous camera-space
+        # depth, NOT a confidence -- the tracked confidence lives in conf_stack.
         rr.log(
             f"{video_log_path}/keypoints",
             Points2DWithConfidence(
                 positions=uv[0, :, 0:2],  # Remove the view dimension
-                confidences=uv[0, :, -1],  # Keep the confidence scores
-                colors=current_colors,
+                confidences=current_conf.squeeze(),
                 class_ids=0,
                 keypoint_ids=AVP_IDS,
                 show_labels=False,

--- a/packages/simplecv/simplecv/apis/exoego_tools/wilor_ego_tracking.py
+++ b/packages/simplecv/simplecv/apis/exoego_tools/wilor_ego_tracking.py
@@ -41,7 +41,6 @@ from simplecv.ops.triangulate import batch_triangulate
 from simplecv.rerun_custom_types import (
     Points2DWithConfidence,
     Points3DWithConfidence,
-    confidence_scores_to_rgb,
 )
 from simplecv.rerun_log_utils import RerunTyroConfig
 from simplecv.rerun_rig_logger import log_rig_static
@@ -341,11 +340,6 @@ def run_wilor_ego_tracking(
                     uvc_coco[RIGHT_HAND_IDX, 2] = wilor_preds.scores[0]
 
             # Log 2D keypoints
-            confidence_rgb_stack: UInt8[ndarray, "1 n_kpts 3"] = confidence_scores_to_rgb(
-                uvc_coco[:, 2][np.newaxis, :, np.newaxis]
-            )
-            confidence_rgb: UInt8[ndarray, "n_kpts 3"] = confidence_rgb_stack[0]
-
             rr.log(
                 f"{pinhole_log_path}/coco133_uv",
                 Points2DWithConfidence(
@@ -354,7 +348,6 @@ def run_wilor_ego_tracking(
                     class_ids=int(Coco133AnnotationLayer.RAW_2D),
                     keypoint_ids=COCO_133_IDS,
                     show_labels=False,
-                    colors=confidence_rgb,
                 ),
             )
             # Collect for triangulation
@@ -389,11 +382,6 @@ def run_wilor_ego_tracking(
             invalid_mask: Bool[ndarray, "133"] = (~np.isfinite(confidences_for_log)) | (confidences_for_log <= 0.0)
             positions_for_log[invalid_mask, :] = np.nan
             
-            tri_conf_rgb_stack: UInt8[ndarray, "1 133 3"] = confidence_scores_to_rgb(
-                xyzc_coco[:, 3][np.newaxis, :, np.newaxis]
-            )
-            tri_conf_rgb: UInt8[ndarray, "133 3"] = tri_conf_rgb_stack[0]
-            
             rr.log(
                 f"{parent_log_path}/triangulated_hands/coco133_xyz",
                 Points3DWithConfidence(
@@ -402,7 +390,6 @@ def run_wilor_ego_tracking(
                     class_ids=int(Coco133AnnotationLayer.TRIANGULATED_3D),
                     keypoint_ids=COCO_133_IDS,
                     show_labels=False,
-                    colors=tri_conf_rgb,
                 ),
             )
 

--- a/packages/simplecv/simplecv/apis/metric_exoego_calib.py
+++ b/packages/simplecv/simplecv/apis/metric_exoego_calib.py
@@ -291,10 +291,6 @@ def single_frame_mv_hands(
 
         uvc_coco_list.append(uvc_coco)
         uvc_cam_names.append(ego_cam_name)
-        confidence_rgb_view_stack: UInt8[ndarray, "1 n_kpts 3"] = confidence_scores_to_rgb(
-            uvc_coco[:, 2][np.newaxis, :, np.newaxis]
-        )
-        confidence_rgb_view: UInt8[ndarray, "n_kpts 3"] = confidence_rgb_view_stack[0]
         # log all keypoints
         if debug:
             rr.log(
@@ -305,7 +301,6 @@ def single_frame_mv_hands(
                     class_ids=int(Coco133AnnotationLayer.RAW_2D),
                     keypoint_ids=COCO_133_IDS,
                     show_labels=False,
-                    colors=confidence_rgb_view,
                 ),
             )
     # triangulate 3d keypoints from all ego views (undistort before solving)
@@ -342,11 +337,6 @@ def single_frame_mv_hands(
         keypoints_2d=uvc_coco_stack,
         projection_matrices=Pall,
     )
-    tri_conf_rgb_stack: UInt8[ndarray, "1 n_kpts 3"] = confidence_scores_to_rgb(
-        xyzc_coco[:, 3][np.newaxis, :, np.newaxis]
-    )
-    tri_conf_rgb: UInt8[ndarray, "n_kpts 3"] = tri_conf_rgb_stack[0]
-
     positions_for_log: Float32[ndarray, "n_kpts 3"] = xyzc_coco[:, :3].astype(np.float32, copy=True)
     confidences_for_log: Float32[ndarray, "n_kpts"] = xyzc_coco[:, 3].astype(np.float32, copy=True)
     # Points with zero/invalid confidence correspond to missing detections; log them as NaN
@@ -363,7 +353,6 @@ def single_frame_mv_hands(
                 class_ids=int(Coco133AnnotationLayer.TRIANGULATED_3D),
                 keypoint_ids=COCO_133_IDS,
                 show_labels=False,
-                colors=tri_conf_rgb,
             ),
             static=True,
         )
@@ -409,7 +398,6 @@ def single_frame_mv_hands(
         pinholes_per_view=pinhole_param_list,
         filter_invalid=True,
     )
-    aligned_conf_rgb: UInt8[ndarray, "1 133 3"] = confidence_scores_to_rgb(aligned_conf_full[..., np.newaxis])
     for view_idx, cam_name in enumerate(uvc_cam_names):
         if debug:
             pinhole_log_path: Path = parent_log_path / "ego" / cam_name / "pinhole"
@@ -421,7 +409,6 @@ def single_frame_mv_hands(
                     class_ids=int(Coco133AnnotationLayer.TRIANGULATED_3D),
                     keypoint_ids=COCO_133_IDS,
                     show_labels=False,
-                    colors=aligned_conf_rgb[0],
                 ),
             )
     residuals: Float[ndarray, "n_valid"] = np.linalg.norm(aligned_points - dst_points, axis=1)

--- a/packages/simplecv/simplecv/rerun_custom_types.py
+++ b/packages/simplecv/simplecv/rerun_custom_types.py
@@ -230,7 +230,12 @@ class _ConfidenceAwareColumnList(rr.ComponentColumnList):
 
 
 class Points2DWithConfidence(rr.AsComponents):
-    """Custom Points2D archetype with per-keypoint and average confidences."""
+    """Custom Points2D archetype with per-keypoint and average confidences.
+
+    When ``colors`` is omitted, point colors are derived from ``confidences``
+    with the shared red -> yellow -> green gradient, so per-point colors and the
+    logged confidence components can never disagree.
+    """
 
     def __init__(
         self: Any,
@@ -243,6 +248,9 @@ class Points2DWithConfidence(rr.AsComponents):
         radii: float | None = None,
     ) -> None:
         show_labels_bool: bool = bool(np.all(show_labels)) if np.size(show_labels) else bool(show_labels)
+        confidences_arr: Float[ndarray, "n_kpts"] = np.asarray(confidences, dtype=np.float32)
+        if colors is None:
+            colors = confidence_scores_to_rgb(confidences_arr[None, :, None])[0]
         self.points2d = rr.Points2D(
             positions=positions,
             class_ids=class_ids,
@@ -260,7 +268,6 @@ class Points2DWithConfidence(rr.AsComponents):
             field_name="average_confidence",
             component_type="simplecv.components.KeypointConfidenceMean",
         )
-        confidences_arr: Float[ndarray, "n_kpts"] = np.asarray(confidences, dtype=np.float32)
         mean_confidence: float = float(np.nanmean(confidences_arr)) if confidences_arr.size else float("nan")
         self.confidences = ConfidenceBatch(confidences_arr).described(confidence_descriptor)
         self.average_confidence = AverageConfidenceBatch(mean_confidence).described(average_descriptor)
@@ -275,6 +282,9 @@ class Points2DWithConfidence(rr.AsComponents):
     def columns(
         cls,
         *,
+        # Unlike __init__, the columnar path derives NO default colors: exoego
+        # ingest deliberately omits colors here so annotation-context class
+        # colors win (e.g. quest3_oakd_loader, ingest_exoego_recording).
         positions: Float[ndarray, "n 2"] | None = None,
         confidences: Float[ndarray, "n"] | None = None,
         average_confidences: Float[ndarray, "m"] | None = None,

--- a/packages/simplecv/simplecv/rerun_custom_types.py
+++ b/packages/simplecv/simplecv/rerun_custom_types.py
@@ -5,7 +5,7 @@ from typing import Any
 import numpy as np
 import pyarrow as pa
 import rerun as rr
-from jaxtyping import Float, Int, UInt8
+from jaxtyping import Float, Int, Integer, UInt8
 from numpy import ndarray
 from numpy.typing import ArrayLike
 from typing_extensions import Self
@@ -236,8 +236,8 @@ class Points2DWithConfidence(rr.AsComponents):
         self: Any,
         positions: Float[ndarray, "n_kpts 2"],
         confidences: Float[ndarray, "n_kpts"],
-        class_ids: int,
-        keypoint_ids: list[int],
+        class_ids: int | None = None,
+        keypoint_ids: list[int] | Integer[ndarray, "n_kpts"] | None = None,
         show_labels: bool | Int[ndarray, "..."] = False,
         colors: UInt8[ndarray, "n_kpts 3"] | None = None,
         radii: float | None = None,

--- a/packages/simplecv/simplecv/rerun_custom_types.py
+++ b/packages/simplecv/simplecv/rerun_custom_types.py
@@ -282,14 +282,11 @@ class Points2DWithConfidence(rr.AsComponents):
     def columns(
         cls,
         *,
-        # Unlike __init__, the columnar path derives NO default colors: exoego
-        # ingest deliberately omits colors here so annotation-context class
-        # colors win (e.g. quest3_oakd_loader, ingest_exoego_recording).
         positions: Float[ndarray, "n 2"] | None = None,
         confidences: Float[ndarray, "n"] | None = None,
         average_confidences: Float[ndarray, "m"] | None = None,
         class_ids: Int[ndarray, "n"] | int | None = None,
-        keypoint_ids: Int[ndarray, "n"] | list[int] | None = None,
+        keypoint_ids: Integer[ndarray, "n"] | list[int] | None = None,
         show_labels: bool | ndarray | None = None,
         colors: UInt8[ndarray, "n 3"] | None = None,
         radii: float | Float[ndarray, "n"] | None = None,
@@ -299,6 +296,11 @@ class Points2DWithConfidence(rr.AsComponents):
         Inputs are already flattened to `(n_frames * n_kpts)` by the caller so the
         returned list can be partitioned with per-frame lengths before handing it
         to `rr.send_columns`.
+
+        Unlike ``__init__``, this columnar path derives NO default colors when
+        ``colors`` is omitted: exoego ingest deliberately passes no colors here
+        so annotation-context class colors win (quest3_oakd_loader,
+        ingest_exoego_recording). Do not "fix" the asymmetry.
         """
         show_labels_param: list[bool] | None = (
             None if show_labels is None else [bool(np.all(show_labels)) if np.size(show_labels) else bool(show_labels)]
@@ -515,20 +517,28 @@ class PinholeWithDistortion(rr.AsComponents):
         return cls(pinhole=pinhole, distortion=distortion_obj)
 
 
-class Points3DWithConfidence(rr.ComponentColumn):
-    """Custom Points3D archetype with per-keypoint and average confidences."""
+class Points3DWithConfidence(rr.AsComponents):
+    """Custom Points3D archetype with per-keypoint and average confidences.
+
+    When ``colors`` is omitted, point colors are derived from ``confidences``
+    with the shared red -> yellow -> green gradient, so per-point colors and the
+    logged confidence components can never disagree.
+    """
 
     def __init__(
         self: Any,
         positions: Float[ndarray, "n_kpts 3"],
         confidences: Float[ndarray, "n_kpts"],
-        class_ids: int,
-        keypoint_ids: list[int],
+        class_ids: int | None = None,
+        keypoint_ids: list[int] | Integer[ndarray, "n_kpts"] | None = None,
         show_labels: bool | Int[ndarray, "..."] = False,
         colors: UInt8[ndarray, "n_kpts 3"] | None = None,
         radii: float | None = None,
     ) -> None:
         show_labels_bool: bool = bool(np.all(show_labels)) if np.size(show_labels) else bool(show_labels)
+        confidences_arr: Float[ndarray, "n_kpts"] = np.asarray(confidences, dtype=np.float32)
+        if colors is None:
+            colors = confidence_scores_to_rgb(confidences_arr[None, :, None])[0]
         self.points3d = rr.Points3D(
             positions=positions,
             class_ids=class_ids,
@@ -546,7 +556,6 @@ class Points3DWithConfidence(rr.ComponentColumn):
             field_name="average_confidence",
             component_type="simplecv.components.KeypointConfidenceMean",
         )
-        confidences_arr: Float[ndarray, "n_kpts"] = np.asarray(confidences, dtype=np.float32)
         mean_confidence: float = float(np.nanmean(confidences_arr)) if confidences_arr.size else float("nan")
         self.confidences = ConfidenceBatch(confidences_arr).described(confidence_descriptor)
         self.average_confidence = AverageConfidenceBatch(mean_confidence).described(average_descriptor)
@@ -565,7 +574,7 @@ class Points3DWithConfidence(rr.ComponentColumn):
         confidences: Float[ndarray, "n"] | None = None,
         average_confidences: Float[ndarray, "m"] | None = None,
         class_ids: Int[ndarray, "n"] | int | None = None,
-        keypoint_ids: Int[ndarray, "n"] | list[int] | None = None,
+        keypoint_ids: Integer[ndarray, "n"] | list[int] | None = None,
         show_labels: bool | ndarray | None = None,
         colors: UInt8[ndarray, "n 3"] | None = None,
         radii: float | Float[ndarray, "n"] | None = None,

--- a/packages/simplecv/tests/test_points_with_confidence.py
+++ b/packages/simplecv/tests/test_points_with_confidence.py
@@ -1,0 +1,45 @@
+"""Behavior tests for the confidence-carrying point archetypes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from jaxtyping import Float32
+from numpy import ndarray
+
+from simplecv.rerun_custom_types import Points2DWithConfidence
+
+
+def _batches_by_component(archetype: Any) -> dict[str, Any]:
+    return {batch.component_descriptor().component: batch for batch in archetype.as_component_batches()}
+
+
+def _unpack_rgba(packed: int) -> tuple[int, int, int]:
+    return (packed >> 24) & 0xFF, (packed >> 16) & 0xFF, (packed >> 8) & 0xFF
+
+
+def test_points2d_with_confidence_derives_gradient_colors_when_none() -> None:
+    positions: Float32[ndarray, "3 2"] = np.asarray([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]], dtype=np.float32)
+    confidences: Float32[ndarray, "3"] = np.asarray([0.0, 0.5, 1.0], dtype=np.float32)
+
+    archetype: Points2DWithConfidence = Points2DWithConfidence(positions=positions, confidences=confidences)
+
+    batches: dict[str, Any] = _batches_by_component(archetype)
+    packed_colors: list[int] = batches["Points2D:colors"].as_arrow_array().to_pylist()
+    assert _unpack_rgba(packed_colors[0]) == (255, 0, 0), "confidence 0.0 must derive red"
+    assert _unpack_rgba(packed_colors[1]) == (255, 255, 0), "confidence 0.5 must derive yellow"
+    assert _unpack_rgba(packed_colors[2]) == (0, 255, 0), "confidence 1.0 must derive green"
+
+
+def test_points2d_with_confidence_keeps_explicit_colors() -> None:
+    positions: Float32[ndarray, "2 2"] = np.asarray([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32)
+    confidences: Float32[ndarray, "2"] = np.asarray([0.0, 1.0], dtype=np.float32)
+    explicit: np.ndarray = np.asarray([[1, 2, 3], [4, 5, 6]], dtype=np.uint8)
+
+    archetype: Points2DWithConfidence = Points2DWithConfidence(positions=positions, confidences=confidences, colors=explicit)
+
+    batches: dict[str, Any] = _batches_by_component(archetype)
+    packed_colors: list[int] = batches["Points2D:colors"].as_arrow_array().to_pylist()
+    assert _unpack_rgba(packed_colors[0]) == (1, 2, 3)
+    assert _unpack_rgba(packed_colors[1]) == (4, 5, 6)

--- a/packages/simplecv/tests/test_points_with_confidence.py
+++ b/packages/simplecv/tests/test_points_with_confidence.py
@@ -8,7 +8,7 @@ import numpy as np
 from jaxtyping import Float32
 from numpy import ndarray
 
-from simplecv.rerun_custom_types import Points2DWithConfidence
+from simplecv.rerun_custom_types import Points2DWithConfidence, Points3DWithConfidence
 
 
 def _batches_by_component(archetype: Any) -> dict[str, Any]:
@@ -30,6 +30,32 @@ def test_points2d_with_confidence_derives_gradient_colors_when_none() -> None:
     assert _unpack_rgba(packed_colors[0]) == (255, 0, 0), "confidence 0.0 must derive red"
     assert _unpack_rgba(packed_colors[1]) == (255, 255, 0), "confidence 0.5 must derive yellow"
     assert _unpack_rgba(packed_colors[2]) == (0, 255, 0), "confidence 1.0 must derive green"
+
+
+def test_points2d_columns_derive_no_default_colors() -> None:
+    positions: Float32[ndarray, "2 2"] = np.asarray([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32)
+    confidences: Float32[ndarray, "2"] = np.asarray([0.0, 1.0], dtype=np.float32)
+
+    columns: Any = Points2DWithConfidence.columns(positions=positions, confidences=confidences)
+
+    components: set[str] = {column.component_descriptor().component for column in columns}
+    assert "Points2D:positions" in components
+    assert "simplecv.KeypointConfidence2D:confidences" in components
+    # The columnar path must NOT invent colors: exoego ingest relies on
+    # annotation-context class colors winning when none are passed.
+    assert "Points2D:colors" not in components
+
+
+def test_points3d_with_confidence_derives_gradient_colors_when_none() -> None:
+    positions: Float32[ndarray, "2 3"] = np.asarray([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]], dtype=np.float32)
+    confidences: Float32[ndarray, "2"] = np.asarray([0.0, 1.0], dtype=np.float32)
+
+    archetype: Any = Points3DWithConfidence(positions=positions, confidences=confidences)
+
+    batches: dict[str, Any] = _batches_by_component(archetype)
+    packed_colors: list[int] = batches["Points3D:colors"].as_arrow_array().to_pylist()
+    assert _unpack_rgba(packed_colors[0]) == (255, 0, 0), "confidence 0.0 must derive red"
+    assert _unpack_rgba(packed_colors[1]) == (0, 255, 0), "confidence 1.0 must derive green"
 
 
 def test_points2d_with_confidence_keeps_explicit_colors() -> None:


### PR DESCRIPTION
## What

Every 2D keypoint/landmark logging path now colors points by confidence using the shared simplecv red→yellow→green gradient (`confidence_scores_to_rgb`: 0.0→red, 0.5→yellow, 1.0→green), and logs through `Points2DWithConfidence` so the raw scores ride along as queryable `simplecv.components.KeypointConfidence` (+ mean) components instead of being dropped at the visual layer.

| Package | Change |
|---|---|
| posekit | `log_person_points2d` is the canonical confidence-colored logger (flat per-person point color removed — identity stays on bbox/labels/skeleton); `video_track` adopts the helper instead of inline `rr.Points2D`; new seam test `tests/test_rerun_logging.py` |
| sapiens2-pose | image gradio app, `api/image_pose.py`, and `api/rerun_logging.py` (video app) swap the fixed keypoint palette for confidence colors + raw-score components |
| mamma | `stream_logger.log_tick_landmarks` drops its hand-rolled red↔green visibility ramp for the shared helper (gains the yellow midpoint + queryable values) |
| simplecv | `Points2DWithConfidence` accepts `None`/ndarray `class_ids`/`keypoint_ids` (pure pass-through to `rr.Points2D`) |

Confidence sources per network: SimCC max (rtmpose-m/x, rtmw-x), heatmap max (vitpose, sapiens2 — zeros on the unmapped Goliath→COCO-133 projection gaps), MammaNet visibility for dense-512 landmarks. Threshold masking is unchanged: points below `keypoint_threshold` stay hidden, so red only appears in the threshold–0.5 band unless the threshold is lowered.

No dependency changes; `pixi.lock` untouched.

## Verification

- ruff + pyrefly (with per-package baselines): clean on all four packages
- tests: posekit 21 ✓ (incl. new seam test: 0.0→red, 1.0→green, masking, raw scores unmasked), sapiens2-pose 22 ✓, mamma 30 ✓, simplecv 135 ✓ / 33 skipped
- pixel evidence (headless viewer + live app over HTTPS): sapiens2 TRT image demo, mamma crossing_arms streaming demo, and the unified pose-app rtmw-x + mamma-dense512 TensorRT runs all render the gradient — screenshots in `/tmp/rerun-viewer-validation/20260823-confidence-colors/` on pablo-dl-server

## Review passes (simplify + thermo-nuclear, both applied)

**Simplify (4 parallel reviewers)** → the gradient derivation moved INTO `Points2DWithConfidence.__init__` (`colors=None` → derive from confidences), collapsing every call site to just `confidences=`; sapiens2's masking helper now returns length-reconciled scores; dead `keypoint_colors` plumbing deleted; no-op `.astype` copies and loop-invariant allocations removed.

**Thermo review** → REQUEST CHANGES, all blockers fixed:
- 🐛 **Latent data bug found & fixed** (pre-existing, `convert_to_rrd.py` AVP ingest): 2D keypoints logged homogeneous camera-space **depth** as `confidences` — the explicit `colors=` kept the display right while every AVP `.rrd` carried metres in the queryable confidence component. Exactly the desync class this PR eliminates.
- `Points3DWithConfidence` brought to parity: same derivation, same widened signature, and the correct `rr.AsComponents` base (was `rr.ComponentColumn`, satisfying an `isinstance` it couldn't honor).
- All 10 remaining hand-rolled gradient constructions across mv-api/simplecv/sapiens-coco133 deleted (verified byte-identical to the derived default).
- The `__init__`-derives / `columns()`-doesn't asymmetry is now documented in the `columns()` docstring **and** guarded by a regression test (columnar path must not invent colors — exoego ingest relies on annotation-context colors there).
- NaN (not 0.0) pad for missing scores so `average_confidence` stays honest; `deadcode` gate green.

Deferred as follow-ups (own-task-sized): shared `points2d_with_confidence` builder in simplecv adopted across packages (+ promoting mv-api's `MaskedPoints2D` beside it); consolidating sapiens2's duplicate gradio-vs-api logging lanes; 2D/3D archetype twins share ~90 duplicable lines (base-class extraction); coco133 artifact-side 0.0 fill for unmapped keypoints (needs artifact-consumer audit before switching to NaN).

Final gates: ruff + pyrefly clean ×6 packages, tests 142+21+22+29+30 passed, vulture clean.
