### PR TITLE
Fix CUDA/NVDEC initialization across Mamma decode threads

### DIFF
--- a/packages/mamma/src/mamma/engine/pipeline.py
+++ b/packages/mamma/src/mamma/engine/pipeline.py
@@ -256,6 +256,7 @@ def build_streaming_pipeline(
     hires_crops: bool = True,
     proxy_dir: Path | None = None,
     seg_stride: int = 5,
+    decode_device: str | None = None,
 ) -> StreamingPipeline:
     """Assemble the standard decode->track->landmarks->fit->log pipeline.
 
@@ -264,6 +265,10 @@ def build_streaming_pipeline(
     ``tracker_config``; landmarks additionally need ``mammanet_weights``;
     fitting additionally needs ``fitter_config``. ``device`` is propagated
     into the stage configs here so callers never mutate them.
+
+    ``decode_device`` may place video decoding on a different device from the
+    model stages. It defaults to ``device`` for backward compatibility. This is
+    useful when a CUDA inference runtime invalidates an existing NVDEC context.
 
     ``proxy_dir`` (from ``tools/make_proxies.py``) swaps the decode source to
     pre-transcoded ``<proxy_dir>/<cam>.mp4`` videos already at ``resize_hw``,
@@ -285,7 +290,12 @@ def build_streaming_pipeline(
     scaled_cams: list[CameraCalibration] = sequence.scaled_cameras(resize_hw)
     # hires_crops: decode at native resolution; the pipeline downscales to
     # resize_hw per tick for tracking/logging and crops landmarks from native.
-    reader = TorchCodecMultiVideoReader(list(decode_sequence.video_paths), device=device, resize_hw=None if hires_crops else resize_hw)
+    reader_device: str = device if decode_device is None else decode_device
+    reader = TorchCodecMultiVideoReader(
+        list(decode_sequence.video_paths),
+        device=reader_device,
+        resize_hw=None if hires_crops else resize_hw,
+    )
     logger = StreamLogger(sequence, resize_hw=resize_hw, seg_stride=seg_stride)
 
     tracker: MultiViewTracker | None = None

--- a/packages/mamma/src/mamma/engine/pipeline.py
+++ b/packages/mamma/src/mamma/engine/pipeline.py
@@ -288,14 +288,6 @@ def build_streaming_pipeline(
         hires_crops = False
 
     scaled_cams: list[CameraCalibration] = sequence.scaled_cameras(resize_hw)
-    # hires_crops: decode at native resolution; the pipeline downscales to
-    # resize_hw per tick for tracking/logging and crops landmarks from native.
-    reader_device: str = device if decode_device is None else decode_device
-    reader = TorchCodecMultiVideoReader(
-        list(decode_sequence.video_paths),
-        device=reader_device,
-        resize_hw=None if hires_crops else resize_hw,
-    )
     logger = StreamLogger(sequence, resize_hw=resize_hw, seg_stride=seg_stride)
 
     tracker: MultiViewTracker | None = None
@@ -311,6 +303,16 @@ def build_streaming_pipeline(
     if landmarks is not None and fitter_config is not None:
         fitter_config.device = device
         fitting = FittingStage(scaled_cams, fitter_config)
+
+    # Construct NVDEC only after every CUDA model/runtime. Some runtimes replace
+    # the active CUDA context during initialization; a decoder made earlier then
+    # fails on its first read with CUDA_ERROR_INVALID_CONTEXT.
+    reader_device: str = device if decode_device is None else decode_device
+    reader = TorchCodecMultiVideoReader(
+        list(decode_sequence.video_paths),
+        device=reader_device,
+        resize_hw=None if hires_crops else resize_hw,
+    )
 
     return StreamingPipeline(
         decode_sequence,  # proxy paths drive the reader; logger keeps the native sequence

--- a/packages/mamma/tests/test_pipeline_builder.py
+++ b/packages/mamma/tests/test_pipeline_builder.py
@@ -1,0 +1,71 @@
+"""Public construction contracts for the streaming pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from simplecv.video_io import TorchCodecMultiVideoReader
+
+from mamma.calibration.npz_contract import CameraCalibration
+from mamma.datasets.sequence import MultiViewSequence
+from mamma.engine.pipeline import StreamingPipeline, build_streaming_pipeline
+
+
+def test_decode_device_is_independent_from_compute_device(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """CPU decoding must not move model stages off CUDA."""
+    captured_devices: list[str] = []
+
+    def fake_reader_init(
+        reader: TorchCodecMultiVideoReader,
+        video_sources: list[Path | bytes],
+        device: str | None = None,
+        num_workers: int | None = None,
+        num_ffmpeg_threads: int = 0,
+        seek_mode: str = "approximate",
+        resize_hw: tuple[int, int] | None = None,
+    ) -> None:
+        del num_workers, num_ffmpeg_threads, seek_mode
+        captured_devices.append(str(device))
+        reader.device = str(device)
+        reader.resize_hw = resize_hw
+        reader._video_paths = [Path(source) for source in video_sources]
+        reader._video_readers = []
+        reader._height = 480
+        reader._width = 640
+        reader._fps = 25.0
+        reader._frame_cnt = 121
+
+    monkeypatch.setattr(TorchCodecMultiVideoReader, "__init__", fake_reader_init)
+    camera: CameraCalibration = CameraCalibration(
+        name="0",
+        k_matrix=np.eye(3, dtype=np.float64),
+        world_to_cam=np.eye(4, dtype=np.float64),
+        width=640,
+        height=480,
+    )
+    sequence: MultiViewSequence = MultiViewSequence(
+        name="decode-device-test",
+        cameras=[camera],
+        video_paths=[tmp_path / "0.mp4"],
+        fps=25.0,
+        frame_count=121,
+    )
+
+    pipeline: StreamingPipeline = build_streaming_pipeline(
+        sequence,
+        resize_hw=(480, 640),
+        device="cuda",
+        decode_device="cpu",
+        hires_crops=True,
+    )
+    try:
+        assert captured_devices == ["cpu"]
+        assert pipeline.reader.device == "cpu"
+        assert pipeline.engine_hw == (480, 640)
+    finally:
+        pipeline.logger._video_worker.shutdown(wait=True)

--- a/packages/mamma/tests/test_pipeline_builder.py
+++ b/packages/mamma/tests/test_pipeline_builder.py
@@ -11,6 +11,7 @@ from simplecv.video_io import TorchCodecMultiVideoReader
 from mamma.calibration.npz_contract import CameraCalibration
 from mamma.datasets.sequence import MultiViewSequence
 from mamma.engine.pipeline import StreamingPipeline, build_streaming_pipeline
+from mamma.tracking.tracker import MultiViewTracker, TrackerConfig
 
 
 def test_decode_device_is_independent_from_compute_device(
@@ -67,5 +68,72 @@ def test_decode_device_is_independent_from_compute_device(
         assert captured_devices == ["cpu"]
         assert pipeline.reader.device == "cpu"
         assert pipeline.engine_hw == (480, 640)
+    finally:
+        pipeline.logger._video_worker.shutdown(wait=True)
+
+
+def test_cuda_decoder_is_constructed_after_cuda_models(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Model initialization must finish before the NVDEC context is created."""
+    construction_order: list[str] = []
+
+    def fake_tracker_init(
+        tracker: MultiViewTracker,
+        cameras: list[CameraCalibration],
+        config: TrackerConfig,
+    ) -> None:
+        construction_order.append("tracker")
+        tracker.cameras = cameras
+        tracker.config = config
+
+    def fake_reader_init(
+        reader: TorchCodecMultiVideoReader,
+        video_sources: list[Path | bytes],
+        device: str | None = None,
+        num_workers: int | None = None,
+        num_ffmpeg_threads: int = 0,
+        seek_mode: str = "approximate",
+        resize_hw: tuple[int, int] | None = None,
+    ) -> None:
+        del num_workers, num_ffmpeg_threads, seek_mode
+        construction_order.append("reader")
+        reader.device = str(device)
+        reader.resize_hw = resize_hw
+        reader._video_paths = [Path(source) for source in video_sources]
+        reader._video_readers = []
+        reader._height = 480
+        reader._width = 640
+        reader._fps = 25.0
+        reader._frame_cnt = 121
+
+    monkeypatch.setattr(MultiViewTracker, "__init__", fake_tracker_init)
+    monkeypatch.setattr(TorchCodecMultiVideoReader, "__init__", fake_reader_init)
+    camera: CameraCalibration = CameraCalibration(
+        name="0",
+        k_matrix=np.eye(3, dtype=np.float64),
+        world_to_cam=np.eye(4, dtype=np.float64),
+        width=640,
+        height=480,
+    )
+    sequence: MultiViewSequence = MultiViewSequence(
+        name="decoder-order-test",
+        cameras=[camera],
+        video_paths=[tmp_path / "0.mp4"],
+        fps=25.0,
+        frame_count=121,
+    )
+
+    pipeline: StreamingPipeline = build_streaming_pipeline(
+        sequence,
+        resize_hw=(480, 640),
+        device="cuda",
+        tracker_config=TrackerConfig(),
+        hires_crops=True,
+    )
+    try:
+        assert construction_order == ["tracker", "reader"]
+        assert pipeline.reader.device == "cuda"
     finally:
         pipeline.logger._video_worker.shutdown(wait=True)

--- a/packages/mamma/tools/refine_calibration_ba.py
+++ b/packages/mamma/tools/refine_calibration_ba.py
@@ -95,8 +95,8 @@ class RefineConfig:
     landmark as a ground point."""
     device: str = "cuda"
     """Compute device."""
-    decode_device: str = "cpu"
-    """Video-decode device; CPU avoids CUDA decoder-context conflicts during inference."""
+    decode_device: str = "cuda"
+    """Video-decode device; defaults to NVDEC after all CUDA models initialize."""
     seed: int = 0
     """Correspondence-subsampling seed (determinism)."""
 

--- a/packages/mamma/tools/refine_calibration_ba.py
+++ b/packages/mamma/tools/refine_calibration_ba.py
@@ -95,6 +95,8 @@ class RefineConfig:
     landmark as a ground point."""
     device: str = "cuda"
     """Compute device."""
+    decode_device: str = "cpu"
+    """Video-decode device; CPU avoids CUDA decoder-context conflicts during inference."""
     seed: int = 0
     """Correspondence-subsampling seed (determinism)."""
 
@@ -262,6 +264,7 @@ def main(config: RefineConfig) -> int:
         trt_engine=config.trt_engine,
         collector=collector,
         hires_crops=preset.hires_crops,
+        decode_device=config.decode_device,
     )
     try:
         stats = pipeline.run(chunk_size=32, max_frames=config.max_calib_frames)

--- a/packages/simplecv/simplecv/video_io.py
+++ b/packages/simplecv/simplecv/video_io.py
@@ -518,6 +518,7 @@ class TorchCodecVideoReader:
         if frame_id < 0 or frame_id >= self._frame_cnt:
             raise IndexError(f'"frame_id" must be between 0 and {self._frame_cnt - 1}')
 
+        self._activate_decode_device()
         frame: UInt8[torch.Tensor, "3 h w"] = self._decoder.get_frame_at(frame_id).data
         if self._needs_post_resize:
             frame = self._maybe_resize(frame.unsqueeze(0)).squeeze(0)
@@ -557,9 +558,16 @@ class TorchCodecVideoReader:
                 device=self.device,
             )
             return empty
+        self._activate_decode_device()
         video: UInt8[torch.Tensor, "b 3 h w"] = self._decoder.get_frames_in_range(start, clamped_stop).data
         video = self._maybe_resize(video)
         return video
+
+    def _activate_decode_device(self) -> None:
+        """Make a CUDA decoder's context current on the calling thread."""
+        if self.device.startswith("cuda"):
+            device_index: int | None = torch.device(self.device).index
+            torch.cuda.set_device(torch.cuda.current_device() if device_index is None else device_index)
 
     def iter_chunks(
         self,

--- a/packages/simplecv/tests/test_torchcodec_video_io.py
+++ b/packages/simplecv/tests/test_torchcodec_video_io.py
@@ -220,6 +220,36 @@ class TestTorchCodecVideoReader:
         assert int(first_frame[0, 0, 0].item()) == 0
         assert int(second_frame[0, 0, 0].item()) == 1
 
+    def test_cuda_range_decode_activates_context_on_calling_thread(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A worker thread must make the decoder's CUDA context current."""
+
+        class _FrameBatch:
+            def __init__(self, data: torch.Tensor) -> None:
+                self.data: torch.Tensor = data
+
+        class _FakeCudaDecoder:
+            def get_frames_in_range(self, start: int, stop: int) -> _FrameBatch:
+                return _FrameBatch(torch.zeros((stop - start, 3, 2, 4), dtype=torch.uint8))
+
+        activated_devices: list[int] = []
+        monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+        monkeypatch.setattr(torch.cuda, "set_device", activated_devices.append)
+        reader: TorchCodecVideoReader = object.__new__(TorchCodecVideoReader)
+        reader.device = "cuda"
+        reader._decoder = _FakeCudaDecoder()
+        reader._frame_cnt = 1
+        reader._height = 2
+        reader._width = 4
+        reader._needs_post_resize = False
+
+        frames: UInt8[torch.Tensor, "b 3 h w"] = reader.get_frames_in_range(0, 1)
+
+        assert activated_devices == [0]
+        assert frames.shape == (1, 3, 2, 4)
+
     def test_random_access(self, sample_video_path: Path) -> None:
         """Test random access to frames."""
         reader: TorchCodecVideoReader = TorchCodecVideoReader(sample_video_path, device="cpu")


### PR DESCRIPTION
This stack isolates the decode-device work needed by the eight-camera Mamma calibration pipeline.

- decouples video decode placement from model inference placement
- initializes NVDEC after CUDA model setup
- activates the CUDA context in worker decode threads

Validation:
- Mamma: 3 passed, 1 data-dependent skip
- SimpleCV: 12 passed, 17 data-dependent skips
- Ruff: clean
- real eight-camera worker-thread NVDEC decode completed on the RTX 5090