### PR TITLE
dataforge: robocap blueprints — trail, follow-cam, segment-table preview

### DIFF
--- a/packages/dataforge/README.md
+++ b/packages/dataforge/README.md
@@ -21,14 +21,14 @@ land with the next dataset).
 
 | dataset | raw corpus | one sequence | rrd contents |
 | --- | --- | --- | --- |
-| `robocap` | `/mnt/nas/datasets/robocap` | one `(device, session, segment)` | 6 fisheye video streams, the dev0 IMU, the cap mesh |
+| `robocap` | `/mnt/nas/datasets/robocap` | one `(device, session)`; file-roll segments merge at convert | 6 fisheye video streams, the dev0 IMU, the cap mesh |
 | `selfcap` | `/mnt/nas/datasets/exoego-self-collected/main` | one cut episode | 4 iPhone exo rigs + the OAK ego rig + the Quest (9 cameras), the OAK IMU, the Quest head-pose track |
 
 **Verbs**, each a thin `tools/apps/*.py` shim over `dataforge/apis/`:
 
 ```bash
 pixi run -e dataforge --frozen dataforge-download selfcap        # fetch, or verify a local corpus
-pixi run -e dataforge --frozen dataforge-convert robocap --sequence f408193e6447b3b0/s1/seg1
+pixi run -e dataforge --frozen dataforge-convert robocap --sequence f408193e6447b3b0/s1
 pixi run -e dataforge --frozen dataforge-register selfcap        # into a local `rerun server` catalog
 pixi run -e dataforge --frozen dataforge-view robocap --rr-config.headless
 ```

--- a/packages/dataforge/dataforge/apis/register.py
+++ b/packages/dataforge/dataforge/apis/register.py
@@ -40,11 +40,18 @@ def main(config: Config) -> None:
         on_duplicate=OnDuplicateSegmentLayer.SKIP,
     ).wait()
 
-    blueprint: rrb.Blueprint | None = dataset_config.setup().default_blueprint()
+    dataset_instance = dataset_config.setup()
+    blueprint: rrb.Blueprint | None = dataset_instance.default_blueprint()
     if blueprint is not None:
         blueprint_path: Path = paths.output_root() / "blueprints" / f"{name}.rbl"
         # A re-register must never truncate the .rbl a live catalog server still holds open.
         with writing.atomic_write(blueprint_path) as temp_path:
             blueprint.save(name, str(temp_path))
         dataset.register_blueprint(blueprint_path.resolve().as_uri(), set_default=True)
+    table_blueprint: rrb.Blueprint | None = dataset_instance.table_blueprint()
+    if table_blueprint is not None:
+        table_path: Path = paths.output_root() / "blueprints" / f"{name}-table.rbl"
+        with writing.atomic_write(table_path) as temp_path:
+            table_blueprint.save(name, str(temp_path))
+        dataset.register_blueprint(table_path.resolve().as_uri(), segment_table=True)
     print(f"registered {len(rrd_paths)} {paths.BASE_LAYER}-layer rrds into '{name}' at {config.catalog_url}")

--- a/packages/dataforge/dataforge/apis/register.py
+++ b/packages/dataforge/dataforge/apis/register.py
@@ -10,7 +10,7 @@ from rerun.catalog import CatalogClient, DatasetEntry, OnDuplicateSegmentLayer
 
 from dataforge import paths, writing
 from dataforge.datasets import AnnotatedDatasetUnion, RobocapConfig
-from dataforge.datasets.base import DataforgeDatasetConfig
+from dataforge.datasets.base import DataforgeDataset, DataforgeDatasetConfig
 
 
 @dataclass
@@ -40,17 +40,17 @@ def main(config: Config) -> None:
         on_duplicate=OnDuplicateSegmentLayer.SKIP,
     ).wait()
 
-    dataset_instance = dataset_config.setup()
-    blueprint: rrb.Blueprint | None = dataset_instance.default_blueprint()
+    dataforge_dataset: DataforgeDataset = dataset_config.setup()
+    # A re-register must never truncate an .rbl that a live catalog server still holds open.
+    blueprint: rrb.Blueprint | None = dataforge_dataset.default_blueprint()
     if blueprint is not None:
-        blueprint_path: Path = paths.output_root() / "blueprints" / f"{name}.rbl"
-        # A re-register must never truncate the .rbl a live catalog server still holds open.
+        blueprint_path: Path = paths.blueprint_path(paths.output_root(), name)
         with writing.atomic_write(blueprint_path) as temp_path:
             blueprint.save(name, str(temp_path))
         dataset.register_blueprint(blueprint_path.resolve().as_uri(), set_default=True)
-    table_blueprint: rrb.Blueprint | None = dataset_instance.table_blueprint()
+    table_blueprint: rrb.Blueprint | None = dataforge_dataset.table_blueprint()
     if table_blueprint is not None:
-        table_path: Path = paths.output_root() / "blueprints" / f"{name}-table.rbl"
+        table_path: Path = paths.blueprint_path(paths.output_root(), name, segment_table=True)
         with writing.atomic_write(table_path) as temp_path:
             table_blueprint.save(name, str(temp_path))
         dataset.register_blueprint(table_path.resolve().as_uri(), segment_table=True)

--- a/packages/dataforge/dataforge/datasets/base.py
+++ b/packages/dataforge/dataforge/datasets/base.py
@@ -78,3 +78,13 @@ class DataforgeDataset(Generic[ConfigT, SourceT], ABC):
         no sensible corpus-wide layout.
         """
         return None
+
+    def table_blueprint(self) -> rrb.Blueprint | None:
+        """Lightweight segment-table preview card, registered with ``segment_table=True``.
+
+        The viewer renders every visible dataset row through this blueprint at
+        once ("Table cards and blueprints" experimental setting), so it must
+        stay cheap — exclude video entities from ``contents`` rather than
+        hiding them, or the cards decode every stream. ``None`` skips it.
+        """
+        return None

--- a/packages/dataforge/dataforge/datasets/base.py
+++ b/packages/dataforge/dataforge/datasets/base.py
@@ -84,7 +84,7 @@ class DataforgeDataset(Generic[ConfigT, SourceT], ABC):
 
         The viewer renders every visible dataset row through this blueprint at
         once ("Table cards and blueprints" experimental setting), so it must
-        stay cheap — exclude video entities from ``contents`` rather than
-        hiding them, or the cards decode every stream. ``None`` skips it.
+        stay cheap — cards decode exactly one stream (the front-stereo pane);
+        everything else is excluded rather than hidden. ``None`` skips it.
         """
         return None

--- a/packages/dataforge/dataforge/datasets/robocap.py
+++ b/packages/dataforge/dataforge/datasets/robocap.py
@@ -273,12 +273,49 @@ def build_blueprint(camera_names: list[str]) -> rrb.Blueprint:
     )
 
 
+def build_table_blueprint(camera_names: list[str]) -> rrb.Blueprint:
+    """Segment-table preview card: follow-framed 3D (full trajectory, all frusta,
+    NO video textures) beside the single front-stereo video pane.
+
+    Every visible table row renders through this at once, so video is *excluded*
+    from the 3D contents rather than hidden — excluded entities never decode
+    (ARKitScenes profiled ~15 cards saturating 12 cores when they did).
+    """
+    video_exclusions: list[str] = [f"- {schema.video_path(RIG, index)}/**" for index in range(len(camera_names))]
+    front_name: str = "left_front" if "left_front" in camera_names else camera_names[0]
+    front_index: int = camera_names.index(front_name)
+    return rrb.Blueprint(
+        rrb.Horizontal(
+            rrb.Spatial3DView(
+                name="Follow",
+                origin=schema.rig_path(RIG),
+                contents=["/**", *video_exclusions, "- /world/runs/basalt/trail/**"],
+                line_grid=True,
+                eye_controls=rrb.EyeControls3D(
+                    kind=rrb.Eye3DKind.FirstPerson,
+                    position=(0.8, -0.8, 0.6),
+                    look_target=(0.0, 0.0, 0.0),
+                    eye_up=(0.0, 0.0, 1.0),
+                    spin_speed=0.0,
+                ),
+            ),
+            rrb.Spatial2DView(name=front_name, origin=schema.pinhole_path(RIG, front_index), contents=f"{schema.pinhole_path(RIG, front_index)}/**"),
+            column_shares=[3, 2],
+        ),
+        rrb.TimePanel(timeline="video_time"),
+    )
+
+
 class RobocapDataset(DataforgeDataset[RobocapConfig, RobocapSource]):
     """Converts RoboCap segments into exoego:v2 base-layer recordings."""
 
     def default_blueprint(self) -> rrb.Blueprint:
         """Corpus-wide layout: every RoboCap rig has the same six cameras."""
         return build_blueprint(list(CAMERA_DISPLAY_ORDER))
+
+    def table_blueprint(self) -> rrb.Blueprint:
+        """Cheap preview card for the dataset's segment table."""
+        return build_table_blueprint(list(CAMERA_DISPLAY_ORDER))
 
     # ── raw-tree discovery ────────────────────────────────────────────────
     def session_dirs(self) -> list[Path]:

--- a/packages/dataforge/dataforge/datasets/robocap.py
+++ b/packages/dataforge/dataforge/datasets/robocap.py
@@ -367,7 +367,9 @@ class RobocapDataset(DataforgeDataset[RobocapConfig, RobocapSource]):
                     found.setdefault((device, session), (session_dir, set()))[1].add(int(video_match["segment"]))
         return [
             (
-                SequenceIdentity(dataset=self.config.name, parts=(device, f"s{session}")),
+                # Zero-padded so lexicographic ordering (catalog tables, file
+                # listings) matches capture order for any conceivable corpus size.
+                SequenceIdentity(dataset=self.config.name, parts=(device, f"s{session:08d}")),
                 RobocapSource(session_dir=session_dir, device=device, session=session, segments=tuple(sorted(segments))),
             )
             for (device, session), (session_dir, segments) in sorted(found.items())

--- a/packages/dataforge/dataforge/datasets/robocap.py
+++ b/packages/dataforge/dataforge/datasets/robocap.py
@@ -208,11 +208,25 @@ def build_blueprint(camera_names: list[str]) -> rrb.Blueprint:
         rrb.Spatial2DView(name=name, origin=schema.pinhole_path(RIG, index), contents=f"{schema.pinhole_path(RIG, index)}/**")
         for index, name in enumerate(camera_names)
     ]
+    # SLAM-layer trajectory defaults: the full path overwhelms long sessions, so it
+    # starts hidden and a 10 s trail (per-pose segments windowed by the blueprint's
+    # VisibleTimeRange) shows recent motion instead. Overrides on entities a
+    # base-only recording lacks are simply inert.
+    slam_overrides: dict[str, rrb.EntityBehavior | rrb.VisibleTimeRanges] = {
+        "/world/runs/basalt/trajectory": rrb.EntityBehavior(visible=False),
+        "/world/runs/basalt/trail": rrb.VisibleTimeRanges(
+            rrb.VisibleTimeRange(
+                "video_time",
+                start=rrb.TimeRangeBoundary.cursor_relative(seconds=-10.0),
+                end=rrb.TimeRangeBoundary.cursor_relative(),
+            )
+        ),
+    }
     # TODO(dataforge): once dev1/dev2 are emitted, fan the plots out to one pane pair per IMU.
     return rrb.Blueprint(
         rrb.Vertical(
             rrb.Horizontal(
-                rrb.Spatial3DView(name="Rig", origin="/", line_grid=True),
+                rrb.Spatial3DView(name="Rig", origin="/", line_grid=True, overrides=slam_overrides),
                 rrb.Grid(*camera_views, grid_columns=3, name="Synchronized cameras"),
             ),
             rrb.Horizontal(

--- a/packages/dataforge/dataforge/datasets/robocap.py
+++ b/packages/dataforge/dataforge/datasets/robocap.py
@@ -245,10 +245,11 @@ def build_blueprint(camera_names: list[str]) -> rrb.Blueprint:
                             kind=rrb.Eye3DKind.FirstPerson,
                             # Rig-frame coordinates: the dev0 IMU frame's -Z is the
                             # wearer's up (the cap mesh alignment maps scan-up there).
-                            position=(0.8, -0.95, -0.6),
-                            # Aim at the cap, not the rig origin: the mesh sits at
-                            # MESH_TRANSLATION, ~15 cm off the dev0 IMU point.
-                            look_target=(0.0, -0.15, 0.025),
+                            position=(0.8, -0.8, -0.6),
+                            # The rig origin coincides with the front-stereo cameras
+                            # (left_front is ~4 cm away), so this lines the view up
+                            # with where the wearer faces.
+                            look_target=(0.0, 0.0, 0.0),
                             eye_up=(0.0, 0.0, -1.0),
                             spin_speed=0.0,
                         ),
@@ -298,8 +299,8 @@ def build_table_blueprint(camera_names: list[str]) -> rrb.Blueprint:
                 eye_controls=rrb.EyeControls3D(
                     kind=rrb.Eye3DKind.FirstPerson,
                     # Rig-frame coordinates: wearer-up is -Z (see the segment Follow view).
-                    position=(0.8, -0.95, -0.6),
-                    look_target=(0.0, -0.15, 0.025),  # the cap (MESH_TRANSLATION), not the rig origin
+                    position=(0.8, -0.8, -0.6),
+                    look_target=(0.0, 0.0, 0.0),  # ~= the front-stereo cameras (see the segment Follow view)
                     eye_up=(0.0, 0.0, -1.0),
                     spin_speed=0.0,
                 ),

--- a/packages/dataforge/dataforge/datasets/robocap.py
+++ b/packages/dataforge/dataforge/datasets/robocap.py
@@ -243,9 +243,11 @@ def build_blueprint(camera_names: list[str]) -> rrb.Blueprint:
                         overrides=follow_overrides,
                         eye_controls=rrb.EyeControls3D(
                             kind=rrb.Eye3DKind.FirstPerson,
-                            position=(0.8, -0.8, 0.6),
+                            # Rig-frame coordinates: the dev0 IMU frame's -Z is the
+                            # wearer's up (the cap mesh alignment maps scan-up there).
+                            position=(0.8, -0.8, -0.6),
                             look_target=(0.0, 0.0, 0.0),
-                            eye_up=(0.0, 0.0, 1.0),
+                            eye_up=(0.0, 0.0, -1.0),
                             spin_speed=0.0,
                         ),
                     ),
@@ -293,9 +295,10 @@ def build_table_blueprint(camera_names: list[str]) -> rrb.Blueprint:
                 line_grid=True,
                 eye_controls=rrb.EyeControls3D(
                     kind=rrb.Eye3DKind.FirstPerson,
-                    position=(0.8, -0.8, 0.6),
+                    # Rig-frame coordinates: wearer-up is -Z (see the segment Follow view).
+                    position=(0.8, -0.8, -0.6),
                     look_target=(0.0, 0.0, 0.0),
-                    eye_up=(0.0, 0.0, 1.0),
+                    eye_up=(0.0, 0.0, -1.0),
                     spin_speed=0.0,
                 ),
             ),

--- a/packages/dataforge/dataforge/datasets/robocap.py
+++ b/packages/dataforge/dataforge/datasets/robocap.py
@@ -208,11 +208,15 @@ def build_blueprint(camera_names: list[str]) -> rrb.Blueprint:
         rrb.Spatial2DView(name=name, origin=schema.pinhole_path(RIG, index), contents=f"{schema.pinhole_path(RIG, index)}/**")
         for index, name in enumerate(camera_names)
     ]
-    # SLAM-layer trajectory defaults: the full path overwhelms long sessions, so it
-    # starts hidden and a 10 s trail (per-pose segments windowed by the blueprint's
-    # VisibleTimeRange) shows recent motion instead. Overrides on entities a
-    # base-only recording lacks are simply inert.
-    slam_overrides: dict[str, rrb.EntityBehavior | rrb.VisibleTimeRanges] = {
+    # SLAM-layer trajectory defaults, split per view: the overview shows the whole
+    # path (its trail stays hidden), while the follow-cam shows only a 10 s trail
+    # (per-pose segments windowed by the blueprint's VisibleTimeRange — the window
+    # is a viewer setting). Overrides on entities a base-only recording lacks are
+    # simply inert.
+    overview_overrides: dict[str, rrb.EntityBehavior] = {
+        "/world/runs/basalt/trail": rrb.EntityBehavior(visible=False),
+    }
+    follow_overrides: dict[str, rrb.EntityBehavior | rrb.VisibleTimeRanges] = {
         "/world/runs/basalt/trajectory": rrb.EntityBehavior(visible=False),
         "/world/runs/basalt/trail": rrb.VisibleTimeRanges(
             rrb.VisibleTimeRange(
@@ -227,7 +231,7 @@ def build_blueprint(camera_names: list[str]) -> rrb.Blueprint:
         rrb.Vertical(
             rrb.Horizontal(
                 rrb.Vertical(
-                    rrb.Spatial3DView(name="Rig", origin="/", line_grid=True, overrides=slam_overrides),
+                    rrb.Spatial3DView(name="Rig", origin="/", line_grid=True, overrides=overview_overrides),
                     # Follow-cam (rerun-io/eye_control_example pattern): the view's
                     # origin IS the rig frame, so a fixed first-person eye in that
                     # frame rides the rig. Inert until a pose layer animates rig_00.
@@ -236,7 +240,7 @@ def build_blueprint(camera_names: list[str]) -> rrb.Blueprint:
                         origin=schema.rig_path(RIG),
                         contents="/**",
                         line_grid=True,
-                        overrides=slam_overrides,
+                        overrides=follow_overrides,
                         eye_controls=rrb.EyeControls3D(
                             kind=rrb.Eye3DKind.FirstPerson,
                             position=(1.6, -1.6, 1.2),

--- a/packages/dataforge/dataforge/datasets/robocap.py
+++ b/packages/dataforge/dataforge/datasets/robocap.py
@@ -245,8 +245,10 @@ def build_blueprint(camera_names: list[str]) -> rrb.Blueprint:
                             kind=rrb.Eye3DKind.FirstPerson,
                             # Rig-frame coordinates: the dev0 IMU frame's -Z is the
                             # wearer's up (the cap mesh alignment maps scan-up there).
-                            position=(0.8, -0.8, -0.6),
-                            look_target=(0.0, 0.0, 0.0),
+                            position=(0.8, -0.95, -0.6),
+                            # Aim at the cap, not the rig origin: the mesh sits at
+                            # MESH_TRANSLATION, ~15 cm off the dev0 IMU point.
+                            look_target=(0.0, -0.15, 0.025),
                             eye_up=(0.0, 0.0, -1.0),
                             spin_speed=0.0,
                         ),
@@ -296,8 +298,8 @@ def build_table_blueprint(camera_names: list[str]) -> rrb.Blueprint:
                 eye_controls=rrb.EyeControls3D(
                     kind=rrb.Eye3DKind.FirstPerson,
                     # Rig-frame coordinates: wearer-up is -Z (see the segment Follow view).
-                    position=(0.8, -0.8, -0.6),
-                    look_target=(0.0, 0.0, 0.0),
+                    position=(0.8, -0.95, -0.6),
+                    look_target=(0.0, -0.15, 0.025),  # the cap (MESH_TRANSLATION), not the rig origin
                     eye_up=(0.0, 0.0, -1.0),
                     spin_speed=0.0,
                 ),

--- a/packages/dataforge/dataforge/datasets/robocap.py
+++ b/packages/dataforge/dataforge/datasets/robocap.py
@@ -243,7 +243,7 @@ def build_blueprint(camera_names: list[str]) -> rrb.Blueprint:
                         overrides=follow_overrides,
                         eye_controls=rrb.EyeControls3D(
                             kind=rrb.Eye3DKind.FirstPerson,
-                            position=(1.6, -1.6, 1.2),
+                            position=(0.8, -0.8, 0.6),
                             look_target=(0.0, 0.0, 0.0),
                             eye_up=(0.0, 0.0, 1.0),
                             spin_speed=0.0,

--- a/packages/dataforge/dataforge/datasets/robocap.py
+++ b/packages/dataforge/dataforge/datasets/robocap.py
@@ -12,7 +12,9 @@ gap at a roll boundary is ~30 ms). The sequence unit is therefore the
 **session**, and ``convert`` merges all of its segments into one recording —
 a pure remux per segment, no re-encoding, joined on the shared device clock.
 Each segment's video starts with its own IDR frame, so the viewer's decoder
-resets cleanly at every boundary.
+resets cleanly at every boundary. Converted rrds span 16 MB to 22.7 GB. Both
+``should_skip`` and mid-write failure are all-or-nothing at session granularity;
+that tradeoff is accepted for v1 and should be revisited if resumability matters.
 
 Clocks. Both sensors share one nanosecond device clock (boot-relative, NOT a
 Unix epoch — values sit around tens of seconds), offset by a fixed constant:
@@ -193,13 +195,30 @@ def video_epoch_ns(video_path: Path) -> int:
     return int(comment) * 1_000
 
 
+def follow_eye_controls() -> rrb.EyeControls3D:
+    """First-person eye controls aligned with RoboCap's rig frame."""
+    # EyeControls3D is marked unstable by the SDK; re-validate this factory on Rerun bumps.
+    return rrb.EyeControls3D(
+        kind=rrb.Eye3DKind.FirstPerson,
+        # Rig-frame coordinates: the dev0 IMU frame's -Z is the wearer's up
+        # (the cap mesh alignment maps scan-up there).
+        position=(0.8, -0.8, -0.6),
+        # The rig origin coincides with the front-stereo cameras (left_front is
+        # ~4 cm away), so this lines the view up with where the wearer faces.
+        look_target=(0.0, 0.0, 0.0),
+        eye_up=(0.0, 0.0, -1.0),
+        spin_speed=0.0,
+    )
+
+
 def build_blueprint(camera_names: list[str]) -> rrb.Blueprint:
     """Default layout: 3D rig + a grid of camera panes over gyro/accel plots.
 
     Mirrors basalt's ``basalt_vio_blueprint.py`` layout, on exoego:v2 paths.
 
     Args:
-        camera_names: Human camera labels in ``cam_00..cam_NN`` order.
+        camera_names: Full canonical camera labels in ``cam_00..cam_NN`` order;
+            callers pass ``list(CAMERA_DISPLAY_ORDER)`` so panes stay stable.
 
     Returns:
         The blueprint embedded in every RoboCap base-layer rrd.
@@ -208,30 +227,19 @@ def build_blueprint(camera_names: list[str]) -> rrb.Blueprint:
         rrb.Spatial2DView(name=name, origin=schema.pinhole_path(RIG, index), contents=f"{schema.pinhole_path(RIG, index)}/**")
         for index, name in enumerate(camera_names)
     ]
-    # SLAM-layer trajectory defaults, split per view: the overview shows the whole
-    # path (its trail stays hidden), while the follow-cam shows only a 10 s trail
-    # (per-pose segments windowed by the blueprint's VisibleTimeRange — the window
-    # is a viewer setting). Overrides on entities a base-only recording lacks are
-    # simply inert.
-    overview_overrides: dict[str, rrb.EntityBehavior] = {
-        "/world/runs/basalt/trail": rrb.EntityBehavior(visible=False),
-    }
-    follow_overrides: dict[str, rrb.EntityBehavior | rrb.VisibleTimeRanges] = {
-        "/world/runs/basalt/trajectory": rrb.EntityBehavior(visible=False),
-        "/world/runs/basalt/trail": rrb.VisibleTimeRanges(
-            rrb.VisibleTimeRange(
-                "video_time",
-                start=rrb.TimeRangeBoundary.cursor_relative(seconds=-10.0),
-                end=rrb.TimeRangeBoundary.cursor_relative(),
-            )
-        ),
-    }
     # TODO(dataforge): once dev1/dev2 are emitted, fan the plots out to one pane pair per IMU.
     return rrb.Blueprint(
         rrb.Vertical(
             rrb.Horizontal(
                 rrb.Vertical(
-                    rrb.Spatial3DView(name="Rig", origin="/", line_grid=True, overrides=overview_overrides),
+                    rrb.Spatial3DView(
+                        name="Rig",
+                        origin="/",
+                        line_grid=True,
+                        # The overview shows the whole SLAM path, while its trail stays hidden.
+                        # Overrides on entities a base-only recording lacks are simply inert.
+                        overrides={schema.trail_path("basalt"): rrb.EntityBehavior(visible=False)},
+                    ),
                     # Follow-cam (rerun-io/eye_control_example pattern): the view's
                     # origin IS the rig frame, so a fixed first-person eye in that
                     # frame rides the rig. Inert until a pose layer animates rig_00.
@@ -240,19 +248,19 @@ def build_blueprint(camera_names: list[str]) -> rrb.Blueprint:
                         origin=schema.rig_path(RIG),
                         contents="/**",
                         line_grid=True,
-                        overrides=follow_overrides,
-                        eye_controls=rrb.EyeControls3D(
-                            kind=rrb.Eye3DKind.FirstPerson,
-                            # Rig-frame coordinates: the dev0 IMU frame's -Z is the
-                            # wearer's up (the cap mesh alignment maps scan-up there).
-                            position=(0.8, -0.8, -0.6),
-                            # The rig origin coincides with the front-stereo cameras
-                            # (left_front is ~4 cm away), so this lines the view up
-                            # with where the wearer faces.
-                            look_target=(0.0, 0.0, 0.0),
-                            eye_up=(0.0, 0.0, -1.0),
-                            spin_speed=0.0,
-                        ),
+                        # The follow view hides the full path and shows only a 10 s
+                        # cursor-relative trail. The window is a viewer setting.
+                        overrides={
+                            schema.trajectory_path("basalt"): rrb.EntityBehavior(visible=False),
+                            schema.trail_path("basalt"): rrb.VisibleTimeRanges(
+                                rrb.VisibleTimeRange(
+                                    "video_time",
+                                    start=rrb.TimeRangeBoundary.cursor_relative(seconds=-10.0),
+                                    end=rrb.TimeRangeBoundary.cursor_relative(),
+                                )
+                            ),
+                        },
+                        eye_controls=follow_eye_controls(),
                     ),
                 ),
                 rrb.Grid(*camera_views, grid_columns=2, name="Synchronized cameras"),
@@ -274,6 +282,7 @@ def build_blueprint(camera_names: list[str]) -> rrb.Blueprint:
             ),
             row_shares=[3, 1],
         ),
+        rrb.TimePanel(timeline="video_time"),
         collapse_panels=True,
     )
 
@@ -282,30 +291,28 @@ def build_table_blueprint(camera_names: list[str]) -> rrb.Blueprint:
     """Segment-table preview card: follow-framed 3D (full trajectory, all frusta,
     NO video textures) beside the single front-stereo video pane.
 
-    Every visible table row renders through this at once, so video is *excluded*
-    from the 3D contents rather than hidden — excluded entities never decode
-    (ARKitScenes profiled ~15 cards saturating 12 cores when they did).
+    Cards decode exactly one stream (the front-stereo pane); everything else is
+    excluded rather than hidden. Every visible table row renders through this at
+    once (ARKitScenes profiled ~15 cards saturating 12 cores when they decoded all).
+
+    Args:
+        camera_names: Full canonical camera labels in ``cam_00..cam_NN`` order.
     """
     video_exclusions: list[str] = [f"- {schema.video_path(RIG, index)}/**" for index in range(len(camera_names))]
-    front_name: str = "left_front" if "left_front" in camera_names else camera_names[0]
-    front_index: int = camera_names.index(front_name)
     return rrb.Blueprint(
         rrb.Horizontal(
             rrb.Spatial3DView(
                 name="Follow",
                 origin=schema.rig_path(RIG),
-                contents=["/**", *video_exclusions, "- /world/runs/basalt/trail/**"],
+                contents=["/**", *video_exclusions, f"- {schema.trail_path('basalt')}/**"],
                 line_grid=True,
-                eye_controls=rrb.EyeControls3D(
-                    kind=rrb.Eye3DKind.FirstPerson,
-                    # Rig-frame coordinates: wearer-up is -Z (see the segment Follow view).
-                    position=(0.8, -0.8, -0.6),
-                    look_target=(0.0, 0.0, 0.0),  # ~= the front-stereo cameras (see the segment Follow view)
-                    eye_up=(0.0, 0.0, -1.0),
-                    spin_speed=0.0,
-                ),
+                eye_controls=follow_eye_controls(),
             ),
-            rrb.Spatial2DView(name=front_name, origin=schema.pinhole_path(RIG, front_index), contents=f"{schema.pinhole_path(RIG, front_index)}/**"),
+            rrb.Spatial2DView(
+                name=CAMERA_DISPLAY_ORDER[0],
+                origin=schema.pinhole_path(RIG, 0),
+                contents=f"{schema.pinhole_path(RIG, 0)}/**",
+            ),
             column_shares=[3, 2],
         ),
         rrb.TimePanel(timeline="video_time"),
@@ -313,7 +320,7 @@ def build_table_blueprint(camera_names: list[str]) -> rrb.Blueprint:
 
 
 class RobocapDataset(DataforgeDataset[RobocapConfig, RobocapSource]):
-    """Converts RoboCap segments into exoego:v2 base-layer recordings."""
+    """Converts RoboCap sessions into exoego:v2 base-layer recordings."""
 
     def default_blueprint(self) -> rrb.Blueprint:
         """Corpus-wide layout: every RoboCap rig has the same six cameras."""
@@ -333,9 +340,17 @@ class RobocapDataset(DataforgeDataset[RobocapConfig, RobocapSource]):
         missing: list[str] = transports.local_verify(self.config.root, required=["*_session_*", "0factory-calibration-*"])
         if missing:
             raise FileNotFoundError(f"RoboCap corpus at {self.config.root} is missing: {', '.join(missing)}")
+        session_dirs: list[Path] = self.session_dirs()
         discovered: list[tuple[SequenceIdentity, RobocapSource]] = self.discover()
         num_segments: int = sum(len(source.segments) for _, source in discovered)
-        print(f"robocap: {self.config.root} — {len(discovered)} sessions ({num_segments} segments), calibration present")
+        print(
+            f"robocap: {self.config.root} — {len(session_dirs)} session dirs, {len(discovered)} with videos "
+            f"({num_segments} segments), calibration present"
+        )
+        discovered_dirs: set[Path] = {source.session_dir for _, source in discovered}
+        video_less_session_dirs: list[Path] = sorted(set(session_dirs) - discovered_dirs)
+        if video_less_session_dirs:
+            print(f"  warning: session directories contain no videos: {', '.join(path.name for path in video_less_session_dirs)}")
 
     def discover(self) -> list[tuple[SequenceIdentity, RobocapSource]]:
         """Pair every ``(device, session)`` on disk with its directory and the segments inside."""
@@ -418,14 +433,18 @@ class RobocapDataset(DataforgeDataset[RobocapConfig, RobocapSource]):
             name for name in CAMERA_DISPLAY_ORDER if name in cameras and any(name in epochs for epochs in segment_epochs.values())
         ]
         if not camera_names:
-            raise FileNotFoundError(f"No calibrated, timestamped cameras for {identity.sequence_key} in {source.session_dir}")
+            raise ValueError(
+                f"no camera stream in {source.session_dir} carries a comment epoch tag "
+                f"({len(cameras)} calibrated cameras, {len(source.segments)} segments scanned)"
+            )
         segment_starts_ns: dict[int, int] = {segment: min(epochs.values()) for segment, epochs in segment_epochs.items() if epochs}
+        ordered_segment_starts_ns: list[int] = [segment_starts_ns[segment] for segment in sorted(segment_starts_ns)]
 
         with writing.atomic_recording(
             target,
             application_id="dataforge",
             recording_id=identity.recording_id,
-            default_blueprint=build_blueprint(camera_names),
+            default_blueprint=build_blueprint(list(CAMERA_DISPLAY_ORDER)),
         ) as recording:
             # Deliberately NO ViewCoordinates at "/": the pose layer owns the root
             # ViewCoordinates (its world is gravity-aligned Z-up).
@@ -433,7 +452,8 @@ class RobocapDataset(DataforgeDataset[RobocapConfig, RobocapSource]):
             self._log_mesh(recording)
 
             frames_per_camera: dict[str, int] = dict.fromkeys(camera_names, 0)
-            for index, cam_name in enumerate(camera_names):
+            for cam_name in camera_names:
+                index: int = CAMERA_DISPLAY_ORDER.index(cam_name)
                 rr.log(
                     schema.cam_path(RIG, index),
                     rr.AnyValues(name=cam_name, kind="grayscale"),
@@ -468,7 +488,8 @@ class RobocapDataset(DataforgeDataset[RobocapConfig, RobocapSource]):
                 num_frames=max(frames_per_camera.values()),
                 start_time_ns=min(segment_starts_ns.values()),
                 num_segments=len(source.segments),
-                segment_starts_ns=", ".join(str(segment_starts_ns[segment]) for segment in sorted(segment_starts_ns)),
+                num_timed_segments=len(segment_starts_ns),
+                segment_starts_ns=ordered_segment_starts_ns,
             )
 
         print(f"done {identity.sequence_key} → {target} ({len(camera_names)} cameras, {len(source.segments)} segments, {max(frames_per_camera.values())} frames)")

--- a/packages/dataforge/dataforge/datasets/robocap.py
+++ b/packages/dataforge/dataforge/datasets/robocap.py
@@ -226,8 +226,28 @@ def build_blueprint(camera_names: list[str]) -> rrb.Blueprint:
     return rrb.Blueprint(
         rrb.Vertical(
             rrb.Horizontal(
-                rrb.Spatial3DView(name="Rig", origin="/", line_grid=True, overrides=slam_overrides),
-                rrb.Grid(*camera_views, grid_columns=3, name="Synchronized cameras"),
+                rrb.Vertical(
+                    rrb.Spatial3DView(name="Rig", origin="/", line_grid=True, overrides=slam_overrides),
+                    # Follow-cam (rerun-io/eye_control_example pattern): the view's
+                    # origin IS the rig frame, so a fixed first-person eye in that
+                    # frame rides the rig. Inert until a pose layer animates rig_00.
+                    rrb.Spatial3DView(
+                        name="Follow",
+                        origin=schema.rig_path(RIG),
+                        contents="/**",
+                        line_grid=True,
+                        overrides=slam_overrides,
+                        eye_controls=rrb.EyeControls3D(
+                            kind=rrb.Eye3DKind.FirstPerson,
+                            position=(1.6, -1.6, 1.2),
+                            look_target=(0.0, 0.0, 0.0),
+                            eye_up=(0.0, 0.0, 1.0),
+                            spin_speed=0.0,
+                        ),
+                    ),
+                ),
+                rrb.Grid(*camera_views, grid_columns=2, name="Synchronized cameras"),
+                column_shares=[3, 2],
             ),
             rrb.Horizontal(
                 rrb.TimeSeriesView(

--- a/packages/dataforge/dataforge/paths.py
+++ b/packages/dataforge/dataforge/paths.py
@@ -5,6 +5,7 @@ pixi tasks run with ``cwd = packages/dataforge``):
 
     data/raw/<dataset>/...            upstream layout, untouched
     data/dataforge/rrd/<layer>/<recording_id>.rrd
+    data/dataforge/rrd/blueprints/<name>[-table].rbl
 """
 
 from __future__ import annotations
@@ -31,3 +32,8 @@ def raw_root() -> Path:
 def rrd_path(root: Path, *, layer: str, identity: SequenceIdentity) -> Path:
     """Layer-major rrd location: ``<root>/<layer>/<recording_id>.rrd``."""
     return root / layer / f"{identity.recording_id}.rrd"
+
+
+def blueprint_path(root: Path, name: str, *, segment_table: bool = False) -> Path:
+    """Blueprint location: ``<root>/blueprints/<name>[-table].rbl``."""
+    return root / "blueprints" / f"{name}{'-table' if segment_table else ''}.rbl"

--- a/packages/dataforge/dataforge/schema.py
+++ b/packages/dataforge/dataforge/schema.py
@@ -60,6 +60,21 @@ def accel_path(rig: int, imu: int) -> str:
     return f"{imu_path(rig, imu)}/accel"
 
 
+def run_path(source: str) -> str:
+    """``/world/runs/<source>`` — derived outputs from one processing source."""
+    return f"/world/runs/{source}"
+
+
+def trajectory_path(source: str) -> str:
+    """``.../runs/<source>/trajectory`` — the source's full rig trajectory."""
+    return f"{run_path(source)}/trajectory"
+
+
+def trail_path(source: str) -> str:
+    """``.../runs/<source>/trail`` — the source's cursor-relative trajectory trail."""
+    return f"{run_path(source)}/trail"
+
+
 def capture_property(name: str) -> str:
     """``property:capture:<name>`` — recording-level capture metadata key."""
     return f"property:capture:{name}"

--- a/packages/dataforge/tests/test_robocap.py
+++ b/packages/dataforge/tests/test_robocap.py
@@ -7,9 +7,12 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+import rerun.blueprint as rrb
 from jaxtyping import Float64, Int64
 from numpy import ndarray
+from simplecv.data.ego.robocap_ego import CAMERA_DISPLAY_ORDER
 
+from dataforge import schema
 from dataforge.datasets.robocap import (
     ACCEL_SCALE,
     CAMERA_TO_IMU_OFFSET_NS,
@@ -17,6 +20,8 @@ from dataforge.datasets.robocap import (
     RobocapConfig,
     RobocapDataset,
     RobocapSource,
+    build_blueprint,
+    build_table_blueprint,
     read_imu_database,
 )
 from dataforge.identity import SequenceIdentity
@@ -39,11 +44,12 @@ def make_segment(session_dir: Path, session: int, segment: int) -> None:
 
 @pytest.fixture
 def corpus(tmp_path: Path) -> Path:
-    """A fake RoboCap root: two sessions, three segments, one ``-old`` decoy."""
+    """A fake RoboCap root: two video sessions, one empty session, and one ``-old`` decoy."""
     (tmp_path / f"0factory-calibration-{DEVICE}").mkdir()
     make_segment(tmp_path / f"{DEVICE}_session_1", session=1, segment=1)
     make_segment(tmp_path / f"{DEVICE}_session_1", session=1, segment=2)
     make_segment(tmp_path / f"{DEVICE}_session_10", session=10, segment=1)
+    (tmp_path / f"{DEVICE}_session_20").mkdir()
     make_segment(tmp_path / f"{DEVICE}_session_10-old", session=10, segment=9)
     return tmp_path
 
@@ -63,12 +69,30 @@ def test_discover_pairs_every_session_with_its_segments_and_skips_old_dirs(corpu
     assert dataset.sequences() == [identity for identity, _ in discovered]
 
 
-def test_download_verifies_local_corpus(corpus: Path, tmp_path: Path) -> None:
+def test_download_verifies_local_corpus_and_reports_video_less_sessions(corpus: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     RobocapConfig(root=corpus).setup().download()
+    output: str = capsys.readouterr().out
+    assert "3 session dirs, 2 with videos" in output
+    assert f"warning: session directories contain no videos: {DEVICE}_session_20" in output
     empty_root: Path = tmp_path / "empty"
     empty_root.mkdir()
     with pytest.raises(FileNotFoundError, match="missing"):
         RobocapConfig(root=empty_root).setup().download()
+
+
+def test_blueprints_serialize_with_canonical_camera_order(tmp_path: Path) -> None:
+    camera_names: list[str] = list(CAMERA_DISPLAY_ORDER)
+    segment_blueprint: rrb.Blueprint = build_blueprint(camera_names)
+    table_blueprint: rrb.Blueprint = build_table_blueprint(camera_names)
+    segment_path: Path = tmp_path / "robocap.rbl"
+    table_path: Path = tmp_path / "robocap-table.rbl"
+
+    segment_blueprint.save("robocap", str(segment_path))
+    table_blueprint.save("robocap", str(table_path))
+
+    assert segment_path.stat().st_size > 0
+    assert table_path.stat().st_size > 0
+    assert schema.trail_path("basalt") == "/world/runs/basalt/trail"
 
 
 def write_imu_db(db_path: Path) -> None:

--- a/packages/dataforge/tests/test_robocap.py
+++ b/packages/dataforge/tests/test_robocap.py
@@ -58,10 +58,10 @@ def test_discover_pairs_every_session_with_its_segments_and_skips_old_dirs(corpu
     dataset: RobocapDataset = RobocapDataset(RobocapConfig(root=corpus))
     discovered: list[tuple[SequenceIdentity, RobocapSource]] = dataset.discover()
     assert [identity.sequence_key for identity, _ in discovered] == [
-        f"{DEVICE}/s1",
-        f"{DEVICE}/s10",
+        f"{DEVICE}/s00000001",
+        f"{DEVICE}/s00000010",
     ]
-    assert discovered[0][0].recording_id == f"robocap__{DEVICE}__s1"
+    assert discovered[0][0].recording_id == f"robocap__{DEVICE}__s00000001"
     # The session is the sequence unit; its file-roll segments merge at convert.
     assert discovered[0][1] == RobocapSource(session_dir=corpus / f"{DEVICE}_session_1", device=DEVICE, session=1, segments=(1, 2))
     assert discovered[1][1].segments == (1,)

--- a/packages/dataforge/tests/test_schema.py
+++ b/packages/dataforge/tests/test_schema.py
@@ -10,6 +10,9 @@ from dataforge.schema import (
     imu_path,
     pinhole_path,
     rig_path,
+    run_path,
+    trail_path,
+    trajectory_path,
     video_path,
 )
 
@@ -37,3 +40,9 @@ def test_indices_must_be_nonnegative() -> None:
 def test_capture_property_keys() -> None:
     assert capture_property("num_frames") == "property:capture:num_frames"
     assert capture_property("schema") == "property:capture:schema"
+
+
+def test_run_paths_are_nested_below_the_source() -> None:
+    assert run_path("basalt") == "/world/runs/basalt"
+    assert trajectory_path("basalt") == "/world/runs/basalt/trajectory"
+    assert trail_path("basalt") == "/world/runs/basalt/trail"


### PR DESCRIPTION
Stacked on #114. Six commits shaping how robocap reads in the viewer; no schema changes, layout and defaults only.

## Segment blueprint (opens when you click a session)
- Top row 60/40: two stacked 3D views beside a 2-column camera grid.
- **Rig overview**: full SLAM trajectory visible (its trail hidden).
- **Follow-cam** ([eye_control_example](https://github.com/rerun-io/eye_control_example) pattern — the view's origin IS the rig frame, fixed first-person eye ~1.3 m out): shows only a **10 s trail**, windowed by a per-entity blueprint `VisibleTimeRange` (cursor−10s → cursor), so the window is a viewer setting, not data.
- The trail itself is a new slam-layer entity: the same path as per-pose segments stamped with their times (~2× layer size, still ≤ a few MB).

## Segment-table preview blueprint (dataset browsing cards)
ARKitScenes pattern: `register_blueprint(segment_table=True)`, new optional `table_blueprint()` hook on the dataset base class. One follow-framed 3D view (full trajectory, all six frusta, video entities **excluded** from contents so cards decode nothing) beside the single `left_front` video pane.

## Fix
Both rig-origin follow eyes initially declared `eye_up=+Z`, but the dev0 IMU frame's wearer-up is **−Z** (the cap-mesh alignment maps scan-up to (0,0,−1)) — the cap rendered upside down in every follow view. Flipped, with the eye offset mirrored.

Every step pixel-validated on s21; all 15 existing slam layers rebuilt with trails and re-registered.