### PR TITLE
dataforge: wildcap dataset — bare self-collected exo/ego mp4s → exoego:v2 base layer

### DIFF
--- a/packages/dataforge/dataforge/apis/register.py
+++ b/packages/dataforge/dataforge/apis/register.py
@@ -41,15 +41,18 @@ def main(config: Config) -> None:
     ).wait()
 
     dataforge_dataset: DataforgeDataset = dataset_config.setup()
-    # A re-register must never truncate an .rbl that a live catalog server still holds open.
+    # Blueprints register once: every register_blueprint call adds a NEW entry to the
+    # dataset's blueprint list (cluttering the viewer's selector), so an incremental
+    # re-register skips them. To refresh a blueprint, delete the dataset and re-register.
+    # A re-register must also never truncate an .rbl a live catalog server holds open.
     blueprint: rrb.Blueprint | None = dataforge_dataset.default_blueprint()
-    if blueprint is not None:
+    if blueprint is not None and dataset.default_blueprint() is None:
         blueprint_path: Path = paths.blueprint_path(paths.output_root(), name)
         with writing.atomic_write(blueprint_path) as temp_path:
             blueprint.save(name, str(temp_path))
         dataset.register_blueprint(blueprint_path.resolve().as_uri(), set_default=True)
     table_blueprint: rrb.Blueprint | None = dataforge_dataset.table_blueprint()
-    if table_blueprint is not None:
+    if table_blueprint is not None and dataset.default_segment_table_blueprint() is None:
         table_path: Path = paths.blueprint_path(paths.output_root(), name, segment_table=True)
         with writing.atomic_write(table_path) as temp_path:
             table_blueprint.save(name, str(temp_path))

--- a/packages/dataforge/dataforge/apis/register.py
+++ b/packages/dataforge/dataforge/apis/register.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 
-import rerun.blueprint as rrb
 from rerun.catalog import CatalogClient, DatasetEntry, OnDuplicateSegmentLayer
 
 from dataforge import paths, writing
@@ -33,28 +32,27 @@ def main(config: Config) -> None:
         raise FileNotFoundError(f"no {paths.BASE_LAYER}-layer rrds for {name} under {layer_root}")
 
     client: CatalogClient = CatalogClient(config.catalog_url)
-    dataset: DatasetEntry = client.create_dataset(name, exist_ok=True)
-    dataset.register(
+    entry: DatasetEntry = client.create_dataset(name, exist_ok=True)
+    entry.register(
         [path.resolve().as_uri() for path in rrd_paths],
         layer_name=paths.BASE_LAYER,
         on_duplicate=OnDuplicateSegmentLayer.SKIP,
     ).wait()
 
-    dataforge_dataset: DataforgeDataset = dataset_config.setup()
+    dataset: DataforgeDataset = dataset_config.setup()
     # Blueprints register once: every register_blueprint call adds a NEW entry to the
-    # dataset's blueprint list (cluttering the viewer's selector), so an incremental
-    # re-register skips them. To refresh a blueprint, delete the dataset and re-register.
-    # A re-register must also never truncate an .rbl a live catalog server holds open.
-    blueprint: rrb.Blueprint | None = dataforge_dataset.default_blueprint()
-    if blueprint is not None and dataset.default_blueprint() is None:
+    # catalog dataset's blueprint list (cluttering the viewer's selector), so an
+    # incremental re-register skips a blueprint the catalog already has a default for.
+    # To refresh a blueprint, delete the dataset and re-register. A re-register must
+    # also never truncate an .rbl a live catalog server holds open.
+    if entry.default_blueprint() is None:
         blueprint_path: Path = paths.blueprint_path(paths.output_root(), name)
         with writing.atomic_write(blueprint_path) as temp_path:
-            blueprint.save(name, str(temp_path))
-        dataset.register_blueprint(blueprint_path.resolve().as_uri(), set_default=True)
-    table_blueprint: rrb.Blueprint | None = dataforge_dataset.table_blueprint()
-    if table_blueprint is not None and dataset.default_segment_table_blueprint() is None:
+            dataset.default_blueprint().save(name, str(temp_path))
+        entry.register_blueprint(blueprint_path.resolve().as_uri(), set_default=True)
+    if entry.default_segment_table_blueprint() is None:
         table_path: Path = paths.blueprint_path(paths.output_root(), name, segment_table=True)
         with writing.atomic_write(table_path) as temp_path:
-            table_blueprint.save(name, str(temp_path))
-        dataset.register_blueprint(table_path.resolve().as_uri(), segment_table=True)
+            dataset.table_blueprint().save(name, str(temp_path))
+        entry.register_blueprint(table_path.resolve().as_uri(), segment_table=True)
     print(f"registered {len(rrd_paths)} {paths.BASE_LAYER}-layer rrds into '{name}' at {config.catalog_url}")

--- a/packages/dataforge/dataforge/datasets/__init__.py
+++ b/packages/dataforge/dataforge/datasets/__init__.py
@@ -9,8 +9,16 @@ from dataforge.datasets.robocap import RobocapConfig
 from dataforge.datasets.selfcap import SelfcapConfig
 from dataforge.datasets.wildcap import WildcapConfig
 
-dataset_defaults: dict[str, DataforgeDatasetConfig] = {config.name: config for config in (RobocapConfig(), SelfcapConfig(), WildcapConfig())}
-"""Every dataset dataforge knows about, keyed by its own ``name`` (the single source of truth)."""
+dataset_defaults: dict[str, DataforgeDatasetConfig] = {
+    RobocapConfig.name: RobocapConfig(),
+    SelfcapConfig.name: SelfcapConfig(),
+    "wildcap": WildcapConfig(),
+}
+"""Every dataset dataforge knows about, keyed by its CLI subcommand.
+
+For robocap/selfcap the key IS ``config.name``. Wildcap is one subcommand for
+many corpora: ``--corpus`` picks the topology family and ``config.name``
+becomes ``wildcap-<corpus>`` (the catalog dataset and rrd prefix)."""
 
 DatasetUnion = tyro.extras.subcommand_type_from_defaults(dataset_defaults, prefix_names=False)
 """Config type every verb's ``Config.dataset`` field uses (one tyro subcommand per registry key).

--- a/packages/dataforge/dataforge/datasets/__init__.py
+++ b/packages/dataforge/dataforge/datasets/__init__.py
@@ -9,16 +9,11 @@ from dataforge.datasets.robocap import RobocapConfig
 from dataforge.datasets.selfcap import SelfcapConfig
 from dataforge.datasets.wildcap import WildcapConfig
 
-dataset_defaults: dict[str, DataforgeDatasetConfig] = {
-    RobocapConfig.name: RobocapConfig(),
-    SelfcapConfig.name: SelfcapConfig(),
-    "wildcap": WildcapConfig(),
-}
-"""Every dataset dataforge knows about, keyed by its CLI subcommand.
+dataset_defaults: dict[str, DataforgeDatasetConfig] = {config.command: config for config in (RobocapConfig(), SelfcapConfig(), WildcapConfig())}
+"""Every dataset dataforge knows about, keyed by its CLI subcommand (``config.command``).
 
-For robocap/selfcap the key IS ``config.name``. Wildcap is one subcommand for
-many corpora: ``--corpus`` picks the topology family and ``config.name``
-becomes ``wildcap-<corpus>`` (the catalog dataset and rrd prefix)."""
+``config.name`` — the catalog dataset — equals the command for fixed datasets and
+is derived per corpus for wildcap (``wildcap-<corpus>``)."""
 
 DatasetUnion = tyro.extras.subcommand_type_from_defaults(dataset_defaults, prefix_names=False)
 """Config type every verb's ``Config.dataset`` field uses (one tyro subcommand per registry key).

--- a/packages/dataforge/dataforge/datasets/__init__.py
+++ b/packages/dataforge/dataforge/datasets/__init__.py
@@ -7,8 +7,9 @@ import tyro
 from dataforge.datasets.base import DataforgeDatasetConfig
 from dataforge.datasets.robocap import RobocapConfig
 from dataforge.datasets.selfcap import SelfcapConfig
+from dataforge.datasets.wildcap import WildcapConfig
 
-dataset_defaults: dict[str, DataforgeDatasetConfig] = {config.name: config for config in (RobocapConfig(), SelfcapConfig())}
+dataset_defaults: dict[str, DataforgeDatasetConfig] = {config.name: config for config in (RobocapConfig(), SelfcapConfig(), WildcapConfig())}
 """Every dataset dataforge knows about, keyed by its own ``name`` (the single source of truth)."""
 
 DatasetUnion = tyro.extras.subcommand_type_from_defaults(dataset_defaults, prefix_names=False)

--- a/packages/dataforge/dataforge/datasets/base.py
+++ b/packages/dataforge/dataforge/datasets/base.py
@@ -28,12 +28,20 @@ from dataforge.identity import SequenceIdentity
 class DataforgeDatasetConfig:
     """Base config for a dataforge dataset; ``setup()`` builds the dataset."""
 
-    name: ClassVar[str]
-    """Registry key of the dataset: the CLI subcommand, the catalog dataset, and
-    the ``dataset`` part of every ``SequenceIdentity`` it produces."""
+    command: ClassVar[str]
+    """CLI subcommand of the dataset, and its key in the registry."""
 
     _target: type
     """Dataset class instantiated by ``setup()``."""
+
+    @property
+    def name(self) -> str:
+        """Catalog dataset name and the ``dataset`` part of every ``SequenceIdentity``.
+
+        The command itself for a fixed dataset; a dataset that serves many
+        corpora from one command (wildcap) derives a per-instance name.
+        """
+        return self.command
 
     def setup(self) -> DataforgeDataset:
         """Instantiate the dataset this config describes."""

--- a/packages/dataforge/dataforge/datasets/base.py
+++ b/packages/dataforge/dataforge/datasets/base.py
@@ -71,17 +71,17 @@ class DataforgeDataset(Generic[ConfigT, SourceT], ABC):
         """Write the base-layer rrd for one discovered sequence and return its path."""
 
     @abstractmethod
-    def default_blueprint(self) -> rrb.Blueprint | None:
+    def default_blueprint(self) -> rrb.Blueprint:
         """Dataset-wide default blueprint, registered on the catalog dataset.
 
         Per-recording blueprints are embedded at convert; this is the "dataset
-        default at register" half of the design. Every dataset must decide this
-        explicitly — return ``None`` only when the corpus genuinely has no
-        derivable layout (e.g. it is empty), never as a default.
+        default at register" half of the design. A dataset that cannot produce
+        one (e.g. a corpus-derived layout with no readable captures) raises
+        rather than degrading to viewer heuristics.
         """
 
     @abstractmethod
-    def table_blueprint(self) -> rrb.Blueprint | None:
+    def table_blueprint(self) -> rrb.Blueprint:
         """Lightweight segment-table preview card, registered with ``segment_table=True``.
 
         The viewer renders every visible dataset row through this blueprint at

--- a/packages/dataforge/dataforge/datasets/base.py
+++ b/packages/dataforge/dataforge/datasets/base.py
@@ -70,21 +70,24 @@ class DataforgeDataset(Generic[ConfigT, SourceT], ABC):
     def convert(self, identity: SequenceIdentity, source: SourceT, *, force: bool) -> Path:
         """Write the base-layer rrd for one discovered sequence and return its path."""
 
+    @abstractmethod
     def default_blueprint(self) -> rrb.Blueprint | None:
         """Dataset-wide default blueprint, registered on the catalog dataset.
 
         Per-recording blueprints are embedded at convert; this is the "dataset
-        default at register" half of the design. ``None`` means the dataset has
-        no sensible corpus-wide layout.
+        default at register" half of the design. Every dataset must decide this
+        explicitly — return ``None`` only when the corpus genuinely has no
+        derivable layout (e.g. it is empty), never as a default.
         """
-        return None
 
+    @abstractmethod
     def table_blueprint(self) -> rrb.Blueprint | None:
         """Lightweight segment-table preview card, registered with ``segment_table=True``.
 
         The viewer renders every visible dataset row through this blueprint at
         once ("Table cards and blueprints" experimental setting), so it must
         stay cheap — cards decode exactly one stream (the front-stereo pane);
-        everything else is excluded rather than hidden. ``None`` skips it.
+        everything else is excluded rather than hidden. Mandatory for the same
+        reason: without it, table cards fall back to viewer heuristics that
+        decode every stream of every visible row.
         """
-        return None

--- a/packages/dataforge/dataforge/datasets/robocap.py
+++ b/packages/dataforge/dataforge/datasets/robocap.py
@@ -117,7 +117,7 @@ class RobocapSource:
 class RobocapConfig(DataforgeDatasetConfig):
     """RoboCap capture-rig recordings (6 fisheye cameras, 3 IMUs, no labels)."""
 
-    name: ClassVar[str] = "robocap"
+    command: ClassVar[str] = "robocap"
     """Registry key, catalog dataset name, and identity ``dataset`` part."""
 
     _target: type = field(default_factory=lambda: RobocapDataset)

--- a/packages/dataforge/dataforge/datasets/selfcap.py
+++ b/packages/dataforge/dataforge/datasets/selfcap.py
@@ -223,7 +223,7 @@ class EpisodePlan:
 class SelfcapConfig(DataforgeDatasetConfig):
     """Self-collected exo/ego/Quest captures, cut into per-task episodes."""
 
-    name: ClassVar[str] = "selfcap"
+    command: ClassVar[str] = "selfcap"
     """Registry key, catalog dataset name, and identity ``dataset`` part."""
 
     _target: type = field(default_factory=lambda: SelfcapDataset)

--- a/packages/dataforge/dataforge/datasets/selfcap.py
+++ b/packages/dataforge/dataforge/datasets/selfcap.py
@@ -573,6 +573,15 @@ class SelfcapDataset(DataforgeDataset[SelfcapConfig, Path]):
         panes += [CameraPane(name=f"quest {stream}", rig=DEFAULT_EXO_CAMERAS + 1, cam=index, kind="quest") for index, (stream, _) in enumerate(QUEST_STREAM_LAYOUTS)]
         return build_blueprint(tuple(panes), ego_rig=DEFAULT_EXO_CAMERAS)
 
+    def table_blueprint(self) -> rrb.Blueprint:
+        """Cheap preview card: the ego rgb stream only, nothing else decoded.
+
+        Every visible table row renders through this at once, so the card must
+        decode exactly one video (see the base-class contract).
+        """
+        ego_rgb: str = schema.pinhole_path(DEFAULT_EXO_CAMERAS, 0)
+        return rrb.Blueprint(rrb.Spatial2DView(name="ego rgb", origin=ego_rgb, contents=f"{ego_rgb}/**"), collapse_panels=True)
+
     # ── raw-tree discovery ────────────────────────────────────────────────
     def subset_root(self) -> Path:
         """Root of the configured subset, e.g. ``<root>/cut``."""

--- a/packages/dataforge/dataforge/datasets/wildcap.py
+++ b/packages/dataforge/dataforge/datasets/wildcap.py
@@ -60,15 +60,19 @@ def video_height(video_path: Path) -> int | None:
     when the file cannot be probed (corrupt, empty, or ffprobe missing)."""
     try:
         probe = subprocess.run(
-            ["ffprobe", "-v", "error", "-select_streams", "v:0", "-show_entries", "stream=height", "-of", "csv=p=0", str(video_path)],
+            ["ffprobe", "-v", "error", "-select_streams", "v:0", "-show_entries", "stream=height", "-of", "default=nw=1:nk=1", str(video_path)],
             capture_output=True,
             text=True,
             check=False,
         )
     except FileNotFoundError:
         return None
-    out: str = probe.stdout.strip()
-    return int(out.splitlines()[0]) if probe.returncode == 0 and out else None
+    if probe.returncode != 0 or not probe.stdout.strip():
+        return None
+    # Some streams make ffprobe's writers emit trailing separators ("2560,"), so
+    # keep only the leading digits of the first line.
+    first: str = probe.stdout.strip().splitlines()[0].strip().rstrip(",")
+    return int(first) if first.isdigit() else None
 
 
 def group_page_size(videos: list[Path]) -> int:

--- a/packages/dataforge/dataforge/datasets/wildcap.py
+++ b/packages/dataforge/dataforge/datasets/wildcap.py
@@ -44,6 +44,12 @@ from dataforge.logging_toolkit import log_rig_node, log_video_stream
 EGO_RIG_NAME: str = "ego"
 """Device label of the single moving rig; the raw tree names no device."""
 
+DEFAULT_EXO_CAMERAS: int = 4
+"""Exo cameras in the modal self-collected capture (four static phones)."""
+
+DEFAULT_EGO_STREAMS: int = 3
+"""Ego streams in the modal self-collected capture (the OAK's left/rgb/right)."""
+
 
 @dataclass
 class WildcapConfig(DataforgeDatasetConfig):
@@ -85,28 +91,44 @@ def group_videos(capture_dir: Path, group: str) -> list[Path]:
     return videos
 
 
-def build_blueprint(exo: list[Path], ego: list[Path]) -> rrb.Blueprint:
-    """Default layout: the ego cameras over an exo row — SelfCap's layout minus
-    the 3D scene and IMU strip, which would both be empty here.
+def build_blueprint(exo: list[str], ego: list[str]) -> rrb.Blueprint:
+    """Ego cameras over an exo row — SelfCap's layout minus the 3D scene and
+    IMU strip, which would both be empty here.
 
     Args:
-        exo: Exo mp4s in stem order; mp4 ``N`` is rig ``N``, camera 0.
-        ego: Ego mp4s in stem order; all on rig ``len(exo)`` as camera 0..
+        exo: Pane label per exo camera; label ``N`` is rig ``N``, camera 0.
+        ego: Pane label per ego stream, all on rig ``len(exo)`` as camera 0..
 
     Returns:
-        The blueprint embedded in every WildCap base-layer rrd.
+        The blueprint embedded at convert (real device names) and registered as
+        the dataset default (index labels, see ``default_blueprint``).
     """
     def view(name: str, rig: int, cam: int) -> rrb.Spatial2DView:
         return rrb.Spatial2DView(name=name, origin=schema.pinhole_path(rig, cam), contents=f"{schema.pinhole_path(rig, cam)}/**")
 
-    ego_row: list[rrb.Spatial2DView] = [view(f"ego {video_path.stem}", len(exo), cam) for cam, video_path in enumerate(ego)]
-    exo_row: list[rrb.Spatial2DView] = [view(video_path.stem, rig, 0) for rig, video_path in enumerate(exo)]
+    ego_row: list[rrb.Spatial2DView] = [view(name, len(exo), cam) for cam, name in enumerate(ego)]
+    exo_row: list[rrb.Spatial2DView] = [view(name, rig, 0) for rig, name in enumerate(exo)]
     rows: list[rrb.Container] = [rrb.Horizontal(*views, name=name) for name, views in (("Ego", ego_row), ("Exo", exo_row)) if views]
     return rrb.Blueprint(rrb.Vertical(*rows), collapse_panels=True)
 
 
 class WildcapDataset(DataforgeDataset[WildcapConfig, Path]):
     """Converts bare exo/ego mp4 captures into exoego:v2 base-layer recordings."""
+
+    def default_blueprint(self) -> rrb.Blueprint:
+        """Corpus-wide layout for the modal self-collected capture.
+
+        Device names vary per capture, so the dataset default labels panes by
+        index; the per-recording blueprint embedded at convert uses real names.
+        """
+        return build_blueprint([f"exo {rig}" for rig in range(DEFAULT_EXO_CAMERAS)], [f"ego {cam}" for cam in range(DEFAULT_EGO_STREAMS)])
+
+    def table_blueprint(self) -> rrb.Blueprint:
+        """Cheap preview card: the first exo camera's video, nothing else decoded."""
+        return rrb.Blueprint(
+            rrb.Spatial2DView(name="exo 0", origin=schema.pinhole_path(0, 0), contents=f"{schema.pinhole_path(0, 0)}/**"),
+            collapse_panels=True,
+        )
 
     def download(self) -> None:
         """Verify the local tree; WildCap is user-assembled and has no upstream fetch."""
@@ -144,7 +166,7 @@ class WildcapDataset(DataforgeDataset[WildcapConfig, Path]):
             target,
             application_id="dataforge",
             recording_id=identity.recording_id,
-            default_blueprint=build_blueprint(exo, ego),
+            default_blueprint=build_blueprint([video_path.stem for video_path in exo], [f"ego {video_path.stem}" for video_path in ego]),
         ) as recording:
             num_frames: int = 0
             for rig, video_path in enumerate(exo):

--- a/packages/dataforge/dataforge/datasets/wildcap.py
+++ b/packages/dataforge/dataforge/datasets/wildcap.py
@@ -29,6 +29,7 @@ know:
 from __future__ import annotations
 
 import os
+import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import ClassVar
@@ -50,9 +51,29 @@ DEFAULT_EXO_CAMERAS: int = 4
 DEFAULT_EGO_STREAMS: int = 3
 """Ego streams in the modal self-collected capture (the OAK's left/rgb/right)."""
 
-MAX_ROW_PANES: int = 6
-"""Cameras shown side by side before a row's panes become unreadable slivers
-(a 30-camera capture would get ~60px per pane); past this the row becomes tabs."""
+def grid_page_size(max_height: int) -> int:
+    """Cameras per grid page, by the sharpest stream in the group.
+
+    Higher-resolution streams stay legible in fewer, larger panes: 8 panes for
+    1080p and below, 4 for 2K-class footage, 2 for anything sharper. A group
+    larger than its page becomes tabs of grid pages (see ``build_blueprint``).
+    """
+    if max_height <= 1080:
+        return 8
+    if max_height <= 1600:
+        return 4
+    return 2
+
+
+def video_height(video_path: Path) -> int:
+    """Pixel height of the first video stream, via the env's ffprobe."""
+    probe = subprocess.run(
+        ["ffprobe", "-v", "error", "-select_streams", "v:0", "-show_entries", "stream=height", "-of", "csv=p=0", str(video_path)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return int(probe.stdout.strip().splitlines()[0])
 
 
 @dataclass
@@ -95,13 +116,19 @@ def group_videos(capture_dir: Path, group: str) -> list[Path]:
     return videos
 
 
-def build_blueprint(exo: list[str], ego: list[str]) -> rrb.Blueprint:
-    """Ego cameras over an exo row — SelfCap's layout minus the 3D scene and
-    IMU strip, which would both be empty here.
+def build_blueprint(exo: list[str], ego: list[str], *, exo_page: int = 8, ego_page: int = 8) -> rrb.Blueprint:
+    """Ego cameras over the exo cameras — SelfCap's layout minus the 3D scene
+    and IMU strip, which would both be empty here.
+
+    Each device group is a grid of at most one page of cameras; a larger group
+    becomes tabs of grid pages, so a 32-camera capture pages instead of
+    shrinking every pane into a sliver.
 
     Args:
         exo: Pane label per exo camera; label ``N`` is rig ``N``, camera 0.
         ego: Pane label per ego stream, all on rig ``len(exo)`` as camera 0..
+        exo_page: Cameras per exo grid page (``grid_page_size`` of the group).
+        ego_page: Cameras per ego grid page.
 
     Returns:
         The blueprint embedded at convert (real device names) and registered as
@@ -110,14 +137,18 @@ def build_blueprint(exo: list[str], ego: list[str]) -> rrb.Blueprint:
     def view(name: str, rig: int, cam: int) -> rrb.Spatial2DView:
         return rrb.Spatial2DView(name=name, origin=schema.pinhole_path(rig, cam), contents=f"{schema.pinhole_path(rig, cam)}/**")
 
-    ego_row: list[rrb.Spatial2DView] = [view(name, len(exo), cam) for cam, name in enumerate(ego)]
-    exo_row: list[rrb.Spatial2DView] = [view(name, rig, 0) for rig, name in enumerate(exo)]
-    rows: list[rrb.Container] = [
-        rrb.Horizontal(*views, name=name) if len(views) <= MAX_ROW_PANES else rrb.Tabs(*views, name=name)
-        for name, views in (("Ego", ego_row), ("Exo", exo_row))
-        if views
+    def paged(views: list[rrb.Spatial2DView], name: str, page: int) -> rrb.Container:
+        if len(views) <= page:
+            return rrb.Grid(*views, name=name)
+        chunks: list[list[rrb.Spatial2DView]] = [views[start : start + page] for start in range(0, len(views), page)]
+        return rrb.Tabs(*[rrb.Grid(*chunk, name=f"{name} {i * page + 1}-{i * page + len(chunk)}") for i, chunk in enumerate(chunks)], name=name)
+
+    ego_views: list[rrb.Spatial2DView] = [view(name, len(exo), cam) for cam, name in enumerate(ego)]
+    exo_views: list[rrb.Spatial2DView] = [view(name, rig, 0) for rig, name in enumerate(exo)]
+    groups: list[rrb.Container] = [
+        paged(views, name, page) for name, views, page in (("Ego", ego_views, ego_page), ("Exo", exo_views, exo_page)) if views
     ]
-    return rrb.Blueprint(rrb.Vertical(*rows), collapse_panels=True)
+    return rrb.Blueprint(rrb.Vertical(*groups), collapse_panels=True)
 
 
 class WildcapDataset(DataforgeDataset[WildcapConfig, Path]):
@@ -174,7 +205,12 @@ class WildcapDataset(DataforgeDataset[WildcapConfig, Path]):
             target,
             application_id="dataforge",
             recording_id=identity.recording_id,
-            default_blueprint=build_blueprint([video_path.stem for video_path in exo], [f"ego {video_path.stem}" for video_path in ego]),
+            default_blueprint=build_blueprint(
+                [video_path.stem for video_path in exo],
+                [f"ego {video_path.stem}" for video_path in ego],
+                exo_page=grid_page_size(max(video_height(p) for p in exo)) if exo else 8,
+                ego_page=grid_page_size(max(video_height(p) for p in ego)) if ego else 8,
+            ),
         ) as recording:
             num_frames: int = 0
             for rig, video_path in enumerate(exo):

--- a/packages/dataforge/dataforge/datasets/wildcap.py
+++ b/packages/dataforge/dataforge/datasets/wildcap.py
@@ -1,0 +1,164 @@
+"""WildCap: in-the-wild exo/ego mp4s — nothing else — → one exoego:v2 base rrd per capture.
+
+Raw layout on disk (user-assembled; ``download`` only verifies it)::
+
+    <root>/<capture-name>/
+        exo/*.mp4     one file per static exo camera
+        ego/*.mp4     one or more streams from a single head-mounted device
+
+That is the whole contract: no calibration, no per-frame csvs, no IMU, no
+poses. The ``.mp4`` match is case-insensitive; ``.mov`` files (iPhones ship
+them) are warned about and skipped — Rerun does not support them, so remux
+to mp4 first. Each exo video becomes its own single-camera rig (``rig_00..``
+in stem order); every ego video lands on one final moving rig as ``cam_00..``
+(also in stem order). The base layer therefore only asserts what the mp4s themselves
+know:
+
+* Videos go to the canonical ``.../cam_MM/pinhole/video`` paths, but the
+  ``pinhole`` node carries **no** ``Pinhole`` — a calibration layer (e.g. a
+  gravity-aligned VGGT + MoGe pass) logs intrinsics there later without any
+  path change.
+* No root ``ViewCoordinates`` and no transforms anywhere: nothing is posed,
+  so the localization layer that first establishes a world frame owns both.
+* The clock is each file's as-encoded PTS on ``video_time``, unshifted.
+  Nothing guarantees the files are mutually synced; a sync layer can retime
+  them later. Files trimmed to a common start (like the SelfCap cutting
+  pipeline's output) line up as-is.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import ClassVar
+
+import rerun as rr
+import rerun.blueprint as rrb
+
+from dataforge import paths, schema, transports, writing
+from dataforge.datasets.base import DataforgeDataset, DataforgeDatasetConfig
+from dataforge.identity import SequenceIdentity
+from dataforge.logging_toolkit import log_rig_node, log_video_stream
+
+EGO_RIG_NAME: str = "ego"
+"""Device label of the single moving rig; the raw tree names no device."""
+
+
+@dataclass
+class WildcapConfig(DataforgeDatasetConfig):
+    """In-the-wild exo/ego video captures: bare mp4s, no calibration, no metadata."""
+
+    name: ClassVar[str] = "wildcap"
+    """Registry key, catalog dataset name, and identity ``dataset`` part."""
+
+    _target: type = field(default_factory=lambda: WildcapDataset)
+    """Dataset class instantiated by ``setup()``."""
+    root: Path = Path("data/raw/wildcap")
+    """Corpus root holding one ``<capture-name>/{exo,ego}/*.mp4`` tree per capture."""
+
+
+def group_videos(capture_dir: Path, group: str) -> list[Path]:
+    """Readable mp4s of one device group, in stem order.
+
+    Args:
+        capture_dir: A ``<root>/<capture-name>`` directory.
+        group: ``exo`` or ``ego``.
+
+    Returns:
+        Video paths sorted by filename. Unreadable files and ``.mov`` files
+        (which Rerun does not support) are warned about and dropped.
+    """
+    if not (capture_dir / group).is_dir():
+        return []
+    videos: list[Path] = []
+    for video_path in sorted((capture_dir / group).iterdir()):
+        if video_path.suffix.lower() == ".mov":
+            print(f"  warning: skipping {video_path} — Rerun does not support .mov; remux it to mp4 first")
+            continue
+        if video_path.suffix.lower() != ".mp4":
+            continue
+        if not os.access(video_path, os.R_OK):
+            print(f"  warning: skipping unreadable {video_path}")
+            continue
+        videos.append(video_path)
+    return videos
+
+
+def build_blueprint(exo: list[Path], ego: list[Path]) -> rrb.Blueprint:
+    """Default layout: the ego cameras over an exo row — SelfCap's layout minus
+    the 3D scene and IMU strip, which would both be empty here.
+
+    Args:
+        exo: Exo mp4s in stem order; mp4 ``N`` is rig ``N``, camera 0.
+        ego: Ego mp4s in stem order; all on rig ``len(exo)`` as camera 0..
+
+    Returns:
+        The blueprint embedded in every WildCap base-layer rrd.
+    """
+    def view(name: str, rig: int, cam: int) -> rrb.Spatial2DView:
+        return rrb.Spatial2DView(name=name, origin=schema.pinhole_path(rig, cam), contents=f"{schema.pinhole_path(rig, cam)}/**")
+
+    ego_row: list[rrb.Spatial2DView] = [view(f"ego {video_path.stem}", len(exo), cam) for cam, video_path in enumerate(ego)]
+    exo_row: list[rrb.Spatial2DView] = [view(video_path.stem, rig, 0) for rig, video_path in enumerate(exo)]
+    rows: list[rrb.Container] = [rrb.Horizontal(*views, name=name) for name, views in (("Ego", ego_row), ("Exo", exo_row)) if views]
+    return rrb.Blueprint(rrb.Vertical(*rows), collapse_panels=True)
+
+
+class WildcapDataset(DataforgeDataset[WildcapConfig, Path]):
+    """Converts bare exo/ego mp4 captures into exoego:v2 base-layer recordings."""
+
+    def download(self) -> None:
+        """Verify the local tree; WildCap is user-assembled and has no upstream fetch."""
+        missing: list[str] = transports.local_verify(self.config.root, required=["*/*/*.mp4"])
+        if missing:
+            raise FileNotFoundError(f"WildCap tree at {self.config.root} is missing: {', '.join(missing)}")
+        print(f"wildcap: {self.config.root} — {len(self.sequences())} convertible capture(s)")
+
+    def discover(self) -> list[tuple[SequenceIdentity, Path]]:
+        """Pair every capture directory holding at least one readable mp4 with its path."""
+        pairs: list[tuple[SequenceIdentity, Path]] = []
+        for capture_dir in sorted(path for path in self.config.root.glob("*") if path.is_dir()):
+            if not any(group_videos(capture_dir, group) for group in ("exo", "ego")):
+                continue
+            pairs.append((SequenceIdentity(dataset=self.config.name, parts=(capture_dir.name,)), capture_dir))
+        return pairs
+
+    def convert(self, identity: SequenceIdentity, source: Path, *, force: bool) -> Path:
+        """Write one capture's base-layer rrd: the videos, and deliberately nothing else.
+
+        No root ``ViewCoordinates``, no ``Pinhole``, no transforms — see the
+        module docstring; those belong to the calibration/localization layers.
+        """
+        target: Path = paths.rrd_path(paths.output_root(), layer=paths.BASE_LAYER, identity=identity)
+        if writing.should_skip(target, force=force):
+            print(f"skip {identity.sequence_key} → {target}")
+            return target
+
+        # The blueprint (built before the recording opens) and the loops below derive
+        # from the same two lists, so it can only describe cameras that really get logged.
+        exo: list[Path] = group_videos(source, "exo")
+        ego: list[Path] = group_videos(source, "ego")
+
+        with writing.atomic_recording(
+            target,
+            application_id="dataforge",
+            recording_id=identity.recording_id,
+            default_blueprint=build_blueprint(exo, ego),
+        ) as recording:
+            num_frames: int = 0
+            for rig, video_path in enumerate(exo):
+                log_rig_node(recording, rig, reference="cam_00", num_cameras=1, name=video_path.stem, kind="exo")
+                rr.log(schema.cam_path(rig, 0), rr.AnyValues(name=video_path.stem), static=True, recording=recording)
+                # Raw PTS is the only clock the raw tree has (see the module docstring), so no shift.
+                num_frames = max(num_frames, log_video_stream(recording, video_path, schema.video_path(rig, 0)))
+            if ego:
+                ego_rig: int = len(exo)
+                log_rig_node(recording, ego_rig, reference="cam_00", num_cameras=len(ego), name=EGO_RIG_NAME, kind="ego")
+                for cam, video_path in enumerate(ego):
+                    rr.log(schema.cam_path(ego_rig, cam), rr.AnyValues(name=video_path.stem), static=True, recording=recording)
+                    num_frames = max(num_frames, log_video_stream(recording, video_path, schema.video_path(ego_rig, cam)))
+            writing.send_capture_properties(recording, identity, num_cameras=len(exo) + len(ego), num_frames=num_frames)
+
+        print(f"done {identity.sequence_key} → {target} ({len(exo) + len(ego)} cameras, {num_frames} frames)")
+        return target

--- a/packages/dataforge/dataforge/datasets/wildcap.py
+++ b/packages/dataforge/dataforge/datasets/wildcap.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import ClassVar
 
 import av
 import rerun as rr
@@ -84,6 +85,9 @@ class WildcapConfig(DataforgeDatasetConfig):
     captures), not more segments in an existing dataset.
     """
 
+    command: ClassVar[str] = "wildcap"
+    """One subcommand for every wildcap corpus; ``--corpus`` picks the dataset."""
+
     _target: type = field(default_factory=lambda: WildcapDataset)
     """Dataset class instantiated by ``setup()``."""
     corpus: str = "selfcollected"
@@ -93,10 +97,9 @@ class WildcapConfig(DataforgeDatasetConfig):
     Pair it with ``corpus``: ``--corpus mamma32 --root data/raw/wildcap-mamma32``."""
 
     @property
-    # pyrefly: ignore[bad-override]  # the ClassVar contract holds for fixed datasets; wildcap's name is per-corpus by design
     def name(self) -> str:
         """Catalog dataset name and identity ``dataset`` part: ``wildcap-<corpus>``."""
-        return f"wildcap-{self.corpus}"
+        return f"{self.command}-{self.corpus}"
 
 
 def group_videos(capture_dir: Path, group: str) -> list[Path]:

--- a/packages/dataforge/dataforge/datasets/wildcap.py
+++ b/packages/dataforge/dataforge/datasets/wildcap.py
@@ -29,10 +29,10 @@ know:
 from __future__ import annotations
 
 import os
-import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import av
 import rerun as rr
 import rerun.blueprint as rrb
 
@@ -56,23 +56,13 @@ def grid_page_size(max_height: int) -> int:
 
 
 def video_height(video_path: Path) -> int | None:
-    """Pixel height of the first video stream via the env's ffprobe, or ``None``
-    when the file cannot be probed (corrupt, empty, or ffprobe missing)."""
+    """Pixel height of the first video stream (PyAV, in-process header read), or
+    ``None`` when the file has no decodable video stream."""
     try:
-        probe = subprocess.run(
-            ["ffprobe", "-v", "error", "-select_streams", "v:0", "-show_entries", "stream=height", "-of", "default=nw=1:nk=1", str(video_path)],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-    except FileNotFoundError:
+        with av.open(str(video_path)) as container:
+            return container.streams.video[0].height if container.streams.video else None
+    except (av.error.FFmpegError, OSError):
         return None
-    if probe.returncode != 0 or not probe.stdout.strip():
-        return None
-    # Some streams make ffprobe's writers emit trailing separators ("2560,"), so
-    # keep only the leading digits of the first line.
-    first: str = probe.stdout.strip().splitlines()[0].strip().rstrip(",")
-    return int(first) if first.isdigit() else None
 
 
 def group_page_size(videos: list[Path]) -> int:
@@ -174,17 +164,22 @@ def build_blueprint(exo: list[str], ego: list[str], *, exo_page: int = 8, ego_pa
 class WildcapDataset(DataforgeDataset[WildcapConfig, Path]):
     """Converts bare exo/ego mp4 captures into exoego:v2 base-layer recordings."""
 
-    def default_blueprint(self) -> rrb.Blueprint | None:
+    def default_blueprint(self) -> rrb.Blueprint:
         """Corpus-derived dataset default: the first discovered capture's shape.
 
         The corpus is one topology family (see ``WildcapConfig``), so the first
         capture speaks for all of them. Device names still vary per capture, so
         panes are labeled by index; the per-recording blueprint embedded at
-        convert uses real names. ``None`` when the corpus is empty.
+        convert uses real names.
+
+        Raises:
+            FileNotFoundError: No readable capture under ``root`` — the layout
+                cannot be derived, and a wrong ``--root`` must not silently
+                register a dataset without blueprints.
         """
         discovered: list[tuple[SequenceIdentity, Path]] = self.discover()
         if not discovered:
-            return None
+            raise FileNotFoundError(f"{self.config.name}: no readable captures under {self.config.root} to derive a blueprint from")
         _, capture_dir = discovered[0]
         exo: list[Path] = group_videos(capture_dir, "exo")
         ego: list[Path] = group_videos(capture_dir, "ego")

--- a/packages/dataforge/dataforge/datasets/wildcap.py
+++ b/packages/dataforge/dataforge/datasets/wildcap.py
@@ -50,6 +50,10 @@ DEFAULT_EXO_CAMERAS: int = 4
 DEFAULT_EGO_STREAMS: int = 3
 """Ego streams in the modal self-collected capture (the OAK's left/rgb/right)."""
 
+MAX_ROW_PANES: int = 6
+"""Cameras shown side by side before a row's panes become unreadable slivers
+(a 30-camera capture would get ~60px per pane); past this the row becomes tabs."""
+
 
 @dataclass
 class WildcapConfig(DataforgeDatasetConfig):
@@ -108,7 +112,11 @@ def build_blueprint(exo: list[str], ego: list[str]) -> rrb.Blueprint:
 
     ego_row: list[rrb.Spatial2DView] = [view(name, len(exo), cam) for cam, name in enumerate(ego)]
     exo_row: list[rrb.Spatial2DView] = [view(name, rig, 0) for rig, name in enumerate(exo)]
-    rows: list[rrb.Container] = [rrb.Horizontal(*views, name=name) for name, views in (("Ego", ego_row), ("Exo", exo_row)) if views]
+    rows: list[rrb.Container] = [
+        rrb.Horizontal(*views, name=name) if len(views) <= MAX_ROW_PANES else rrb.Tabs(*views, name=name)
+        for name, views in (("Ego", ego_row), ("Exo", exo_row))
+        if views
+    ]
     return rrb.Blueprint(rrb.Vertical(*rows), collapse_panels=True)
 
 

--- a/packages/dataforge/dataforge/datasets/wildcap.py
+++ b/packages/dataforge/dataforge/datasets/wildcap.py
@@ -45,12 +45,6 @@ from dataforge.logging_toolkit import log_rig_node, log_video_stream
 EGO_RIG_NAME: str = "ego"
 """Device label of the single moving rig; the raw tree names no device."""
 
-DEFAULT_EXO_CAMERAS: int = 4
-"""Exo cameras in the modal self-collected capture (four static phones)."""
-
-DEFAULT_EGO_STREAMS: int = 3
-"""Ego streams in the modal self-collected capture (the OAK's left/rgb/right)."""
-
 def grid_page_size(max_height: int) -> int:
     """Cameras per grid page, by the sharpest stream in the group.
 
@@ -65,27 +59,47 @@ def grid_page_size(max_height: int) -> int:
     return 2
 
 
-def video_height(video_path: Path) -> int:
-    """Pixel height of the first video stream, via the env's ffprobe."""
-    probe = subprocess.run(
-        ["ffprobe", "-v", "error", "-select_streams", "v:0", "-show_entries", "stream=height", "-of", "csv=p=0", str(video_path)],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return int(probe.stdout.strip().splitlines()[0])
+def video_height(video_path: Path) -> int | None:
+    """Pixel height of the first video stream via the env's ffprobe, or ``None``
+    when the file cannot be probed (corrupt, empty, or ffprobe missing)."""
+    try:
+        probe = subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "v:0", "-show_entries", "stream=height", "-of", "csv=p=0", str(video_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return None
+    out: str = probe.stdout.strip()
+    return int(out.splitlines()[0]) if probe.returncode == 0 and out else None
+
+
+def group_page_size(videos: list[Path]) -> int:
+    """Grid page size for one device group, from its sharpest probeable stream
+    (mixed-resolution groups page for the stream that needs the most pixels).
+    Falls back to the 1080p page when nothing probes."""
+    heights: list[int] = [height for height in (video_height(path) for path in videos) if height is not None]
+    return grid_page_size(max(heights)) if heights else 8
 
 
 @dataclass
 class WildcapConfig(DataforgeDatasetConfig):
-    """In-the-wild exo/ego video captures: bare mp4s, no calibration, no metadata."""
+    """In-the-wild exo/ego video captures: bare mp4s, no calibration, no metadata.
 
-    name: ClassVar[str] = "wildcap"
+    One wildcap catalog dataset holds one topology family (one corpus root),
+    because the catalog applies a single default blueprint to every segment of
+    a dataset. A new corpus with a different camera layout gets its own
+    subclass with its own ``name`` and ``root`` (e.g. a 32-camera mocap stage
+    beside the self-collected exoego captures), not more segments here.
+    """
+
+    name: ClassVar[str] = "wildcap-selfcollected"
     """Registry key, catalog dataset name, and identity ``dataset`` part."""
 
     _target: type = field(default_factory=lambda: WildcapDataset)
     """Dataset class instantiated by ``setup()``."""
-    root: Path = Path("data/raw/wildcap")
+    root: Path = Path("data/raw/wildcap-selfcollected")
     """Corpus root holding one ``<capture-name>/{exo,ego}/*.mp4`` tree per capture."""
 
 
@@ -154,13 +168,26 @@ def build_blueprint(exo: list[str], ego: list[str], *, exo_page: int = 8, ego_pa
 class WildcapDataset(DataforgeDataset[WildcapConfig, Path]):
     """Converts bare exo/ego mp4 captures into exoego:v2 base-layer recordings."""
 
-    def default_blueprint(self) -> rrb.Blueprint:
-        """Corpus-wide layout for the modal self-collected capture.
+    def default_blueprint(self) -> rrb.Blueprint | None:
+        """Corpus-derived dataset default: the first discovered capture's shape.
 
-        Device names vary per capture, so the dataset default labels panes by
-        index; the per-recording blueprint embedded at convert uses real names.
+        The corpus is one topology family (see ``WildcapConfig``), so the first
+        capture speaks for all of them. Device names still vary per capture, so
+        panes are labeled by index; the per-recording blueprint embedded at
+        convert uses real names. ``None`` when the corpus is empty.
         """
-        return build_blueprint([f"exo {rig}" for rig in range(DEFAULT_EXO_CAMERAS)], [f"ego {cam}" for cam in range(DEFAULT_EGO_STREAMS)])
+        discovered: list[tuple[SequenceIdentity, Path]] = self.discover()
+        if not discovered:
+            return None
+        _, capture_dir = discovered[0]
+        exo: list[Path] = group_videos(capture_dir, "exo")
+        ego: list[Path] = group_videos(capture_dir, "ego")
+        return build_blueprint(
+            [f"exo {rig}" for rig in range(len(exo))],
+            [f"ego {cam}" for cam in range(len(ego))],
+            exo_page=group_page_size(exo),
+            ego_page=group_page_size(ego),
+        )
 
     def table_blueprint(self) -> rrb.Blueprint:
         """Cheap preview card: the first exo camera's video, nothing else decoded."""
@@ -208,8 +235,8 @@ class WildcapDataset(DataforgeDataset[WildcapConfig, Path]):
             default_blueprint=build_blueprint(
                 [video_path.stem for video_path in exo],
                 [f"ego {video_path.stem}" for video_path in ego],
-                exo_page=grid_page_size(max(video_height(p) for p in exo)) if exo else 8,
-                ego_page=grid_page_size(max(video_height(p) for p in ego)) if ego else 8,
+                exo_page=group_page_size(exo),
+                ego_page=group_page_size(ego),
             ),
         ) as recording:
             num_frames: int = 0

--- a/packages/dataforge/dataforge/datasets/wildcap.py
+++ b/packages/dataforge/dataforge/datasets/wildcap.py
@@ -49,14 +49,11 @@ def grid_page_size(max_height: int) -> int:
     """Cameras per grid page, by the sharpest stream in the group.
 
     Higher-resolution streams stay legible in fewer, larger panes: 8 panes for
-    1080p and below, 4 for 2K-class footage, 2 for anything sharper. A group
-    larger than its page becomes tabs of grid pages (see ``build_blueprint``).
+    1080p and below, 4 for anything sharper (2 per page felt too sparse). A
+    group larger than its page becomes tabs of grid pages (see
+    ``build_blueprint``).
     """
-    if max_height <= 1080:
-        return 8
-    if max_height <= 1600:
-        return 4
-    return 2
+    return 8 if max_height <= 1080 else 4
 
 
 def video_height(video_path: Path) -> int | None:

--- a/packages/dataforge/dataforge/datasets/wildcap.py
+++ b/packages/dataforge/dataforge/datasets/wildcap.py
@@ -32,7 +32,6 @@ import os
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import ClassVar
 
 import rerun as rr
 import rerun.blueprint as rrb
@@ -87,17 +86,23 @@ class WildcapConfig(DataforgeDatasetConfig):
     One wildcap catalog dataset holds one topology family (one corpus root),
     because the catalog applies a single default blueprint to every segment of
     a dataset. A new corpus with a different camera layout gets its own
-    subclass with its own ``name`` and ``root`` (e.g. a 32-camera mocap stage
-    beside the self-collected exoego captures), not more segments here.
+    ``--corpus`` (e.g. a 32-camera mocap stage beside the self-collected exoego
+    captures), not more segments in an existing dataset.
     """
-
-    name: ClassVar[str] = "wildcap-selfcollected"
-    """Registry key, catalog dataset name, and identity ``dataset`` part."""
 
     _target: type = field(default_factory=lambda: WildcapDataset)
     """Dataset class instantiated by ``setup()``."""
+    corpus: str = "selfcollected"
+    """Topology family this run works on; the dataset is ``wildcap-<corpus>``."""
     root: Path = Path("data/raw/wildcap-selfcollected")
-    """Corpus root holding one ``<capture-name>/{exo,ego}/*.mp4`` tree per capture."""
+    """Corpus root holding one ``<capture-name>/{exo,ego}/*.mp4`` tree per capture.
+    Pair it with ``corpus``: ``--corpus mamma32 --root data/raw/wildcap-mamma32``."""
+
+    @property
+    # pyrefly: ignore[bad-override]  # the ClassVar contract holds for fixed datasets; wildcap's name is per-corpus by design
+    def name(self) -> str:
+        """Catalog dataset name and identity ``dataset`` part: ``wildcap-<corpus>``."""
+        return f"wildcap-{self.corpus}"
 
 
 def group_videos(capture_dir: Path, group: str) -> list[Path]:

--- a/packages/dataforge/dataforge/logging_toolkit.py
+++ b/packages/dataforge/dataforge/logging_toolkit.py
@@ -8,6 +8,7 @@ fresh row ids), and the IMU node's mandatory static ``rig_T_imu``.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -102,11 +103,18 @@ def log_video_stream(recording: rr.RecordingStream, video_path: Path, entity_pat
         retimed: pa.RecordBatch = record_batch.set_column(index, record_batch.schema.field(index), shifted)
         return rr.experimental.Chunk.from_record_batch(retimed)  # invariant 3
 
+    # A B-frame source (iPhone/insta360 HEVC) forces Mp4Reader into an FFmpeg
+    # re-encode; everything else passes through untouched, and then these options
+    # are documented no-ops. try_gpu turns that unavoidable re-encode into NVENC
+    # when the ffmpeg build has it — conda-forge's does not, so DATAFORGE_FFMPEG
+    # points at an NVENC-capable binary (e.g. the fleet's ~/.pixi/bin/ffmpeg).
+    ffmpeg_override: str | None = os.environ.get("DATAFORGE_FFMPEG")
     reader: rr.experimental.Mp4Reader = rr.experimental.Mp4Reader(
         video_path,
         mode="stream",
         entity_path=entity_path,
         timeline_name=schema.TIMELINE,
+        transcode=rr.experimental.Mp4TranscodeOptions(try_gpu=True, ffmpeg_override=ffmpeg_override),
     )
     recording.send_chunks(reader.stream().flat_map(tap))  # invariant 2
     return sample_count

--- a/packages/dataforge/tests/test_import.py
+++ b/packages/dataforge/tests/test_import.py
@@ -11,3 +11,15 @@ def test_package_imports_with_beartype_activation(monkeypatch) -> None:
     module = importlib.import_module("dataforge")
     assert module.__name__ == "dataforge"
     assert os.environ["PIXI_DEV_MODE"] == "1"
+
+
+def test_every_registered_dataset_implements_both_blueprint_hooks() -> None:
+    """``setup()`` instantiates the ABC — a dataset missing ``default_blueprint``
+    or ``table_blueprint`` raises ``TypeError`` here instead of silently
+    registering without catalog blueprints."""
+    from dataforge.datasets import dataset_defaults
+
+    for name, config in dataset_defaults.items():
+        dataset = config.setup()
+        assert callable(dataset.default_blueprint), name
+        assert callable(dataset.table_blueprint), name

--- a/packages/dataforge/tests/test_wildcap.py
+++ b/packages/dataforge/tests/test_wildcap.py
@@ -103,4 +103,5 @@ def test_default_blueprint_derives_from_the_corpus(corpus: Path, tmp_path: Path)
     assert dataset.table_blueprint() is not None
     empty_root: Path = tmp_path / "no-captures"
     empty_root.mkdir()
-    assert WildcapConfig(root=empty_root).setup().default_blueprint() is None
+    with pytest.raises(FileNotFoundError, match="no readable captures"):
+        WildcapConfig(root=empty_root).setup().default_blueprint()

--- a/packages/dataforge/tests/test_wildcap.py
+++ b/packages/dataforge/tests/test_wildcap.py
@@ -1,0 +1,92 @@
+"""WildCap discovery and video grouping against synthetic fixtures (no corpus needed)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dataforge.datasets.wildcap import WildcapConfig, WildcapDataset, group_videos
+from dataforge.identity import SequenceIdentity
+
+UNREADABLE: int = 0o000
+"""The mode a botched sync can leave on a file."""
+
+
+def make_capture(capture_dir: Path, *, exo: tuple[str, ...] = ("cam-a", "cam-b"), ego: tuple[str, ...] = ("head",)) -> None:
+    """Create a minimal WildCap capture: bare mp4s under ``exo/`` and ``ego/``.
+
+    Args:
+        capture_dir: Target ``<root>/<capture-name>`` directory.
+        exo: File stems written as ``exo/<stem>.mp4``.
+        ego: File stems written as ``ego/<stem>.mp4``.
+    """
+    for group, stems in (("exo", exo), ("ego", ego)):
+        if not stems:
+            continue
+        (capture_dir / group).mkdir(parents=True)
+        for stem in stems:
+            (capture_dir / group / f"{stem}.mp4").touch()
+
+
+@pytest.fixture
+def corpus(tmp_path: Path) -> Path:
+    """A fake WildCap root: two convertible captures and two that must be skipped."""
+    make_capture(tmp_path / "kitchen-01", exo=("iphone-1", "iphone-2"), ego=("rgb", "left"))
+    make_capture(tmp_path / "garage-02", exo=("gopro",), ego=())
+    make_capture(tmp_path / "empty-03", exo=(), ego=())  # no videos at all
+    make_capture(tmp_path / "locked-04", exo=("iphone-1",), ego=())
+    (tmp_path / "locked-04" / "exo" / "iphone-1.mp4").chmod(UNREADABLE)
+    (tmp_path / "notes.txt").write_text("not a capture")
+    return tmp_path
+
+
+def test_discover_keeps_only_captures_with_a_readable_video(corpus: Path) -> None:
+    dataset: WildcapDataset = WildcapDataset(WildcapConfig(root=corpus))
+    discovered: list[tuple[SequenceIdentity, Path]] = dataset.discover()
+    assert [identity.sequence_key for identity, _ in discovered] == ["garage-02", "kitchen-01"]
+    assert dataset.sequences() == [identity for identity, _ in discovered]
+
+
+def test_discover_pairs_each_identity_with_its_capture_directory(corpus: Path) -> None:
+    dataset: WildcapDataset = WildcapDataset(WildcapConfig(root=corpus))
+    pair: tuple[SequenceIdentity, Path] = dataset.discover()[1]
+    assert pair[0].recording_id == "wildcap__kitchen-01"
+    assert pair[1] == corpus / "kitchen-01"
+
+
+def test_download_verifies_the_local_corpus(corpus: Path, tmp_path: Path) -> None:
+    WildcapConfig(root=corpus).setup().download()
+    empty_root: Path = tmp_path / "empty"
+    empty_root.mkdir()
+    with pytest.raises(FileNotFoundError, match="missing"):
+        WildcapConfig(root=empty_root).setup().download()
+
+
+def test_group_videos_sorts_each_group_by_stem(corpus: Path) -> None:
+    capture_dir: Path = corpus / "kitchen-01"
+    assert [video.stem for video in group_videos(capture_dir, "exo")] == ["iphone-1", "iphone-2"]
+    assert [video.stem for video in group_videos(capture_dir, "ego")] == ["left", "rgb"]
+
+
+def test_group_videos_returns_empty_for_a_missing_group(corpus: Path) -> None:
+    assert group_videos(corpus / "garage-02", "ego") == []
+
+
+def test_group_videos_skips_unreadable_videos(corpus: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert group_videos(corpus / "locked-04", "exo") == []
+    assert "skipping" in capsys.readouterr().out
+
+
+def test_group_videos_skips_mov_files_and_accepts_uppercase_mp4(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    # iPhones ship .MOV, which Rerun does not support; Pixels ship .mp4/.MP4.
+    capture_dir: Path = tmp_path / "phones-01"
+    (capture_dir / "exo").mkdir(parents=True)
+    (capture_dir / "exo" / "IMG_0078.MOV").touch()
+    (capture_dir / "exo" / "PXL_1234.MP4").touch()
+    assert [video.stem for video in group_videos(capture_dir, "exo")] == ["PXL_1234"]
+    assert "IMG_0078.MOV — Rerun does not support .mov" in capsys.readouterr().out
+
+
+def test_default_blueprint_is_none_because_camera_counts_vary() -> None:
+    assert WildcapConfig().setup().default_blueprint() is None

--- a/packages/dataforge/tests/test_wildcap.py
+++ b/packages/dataforge/tests/test_wildcap.py
@@ -94,7 +94,7 @@ def test_grid_page_size_shrinks_with_resolution() -> None:
     assert grid_page_size(720) == 8
     assert grid_page_size(1080) == 8
     assert grid_page_size(1504) == 4  # 2K-class (the mamma capture rigs)
-    assert grid_page_size(2160) == 2
+    assert grid_page_size(2160) == 4
 
 
 def test_default_blueprint_derives_from_the_corpus(corpus: Path, tmp_path: Path) -> None:

--- a/packages/dataforge/tests/test_wildcap.py
+++ b/packages/dataforge/tests/test_wildcap.py
@@ -88,6 +88,15 @@ def test_group_videos_skips_mov_files_and_accepts_uppercase_mp4(tmp_path: Path, 
     assert "IMG_0078.MOV — Rerun does not support .mov" in capsys.readouterr().out
 
 
+def test_grid_page_size_shrinks_with_resolution() -> None:
+    from dataforge.datasets.wildcap import grid_page_size
+
+    assert grid_page_size(720) == 8
+    assert grid_page_size(1080) == 8
+    assert grid_page_size(1504) == 4  # 2K-class (the mamma capture rigs)
+    assert grid_page_size(2160) == 2
+
+
 def test_dataset_blueprints_exist_for_the_modal_capture_shape() -> None:
     dataset = WildcapConfig().setup()
     assert dataset.default_blueprint() is not None

--- a/packages/dataforge/tests/test_wildcap.py
+++ b/packages/dataforge/tests/test_wildcap.py
@@ -51,7 +51,7 @@ def test_discover_keeps_only_captures_with_a_readable_video(corpus: Path) -> Non
 def test_discover_pairs_each_identity_with_its_capture_directory(corpus: Path) -> None:
     dataset: WildcapDataset = WildcapDataset(WildcapConfig(root=corpus))
     pair: tuple[SequenceIdentity, Path] = dataset.discover()[1]
-    assert pair[0].recording_id == "wildcap__kitchen-01"
+    assert pair[0].recording_id == "wildcap-selfcollected__kitchen-01"
     assert pair[1] == corpus / "kitchen-01"
 
 
@@ -97,7 +97,10 @@ def test_grid_page_size_shrinks_with_resolution() -> None:
     assert grid_page_size(2160) == 2
 
 
-def test_dataset_blueprints_exist_for_the_modal_capture_shape() -> None:
-    dataset = WildcapConfig().setup()
+def test_default_blueprint_derives_from_the_corpus(corpus: Path, tmp_path: Path) -> None:
+    dataset = WildcapConfig(root=corpus).setup()
     assert dataset.default_blueprint() is not None
     assert dataset.table_blueprint() is not None
+    empty_root: Path = tmp_path / "no-captures"
+    empty_root.mkdir()
+    assert WildcapConfig(root=empty_root).setup().default_blueprint() is None

--- a/packages/dataforge/tests/test_wildcap.py
+++ b/packages/dataforge/tests/test_wildcap.py
@@ -88,5 +88,7 @@ def test_group_videos_skips_mov_files_and_accepts_uppercase_mp4(tmp_path: Path, 
     assert "IMG_0078.MOV — Rerun does not support .mov" in capsys.readouterr().out
 
 
-def test_default_blueprint_is_none_because_camera_counts_vary() -> None:
-    assert WildcapConfig().setup().default_blueprint() is None
+def test_dataset_blueprints_exist_for_the_modal_capture_shape() -> None:
+    dataset = WildcapConfig().setup()
+    assert dataset.default_blueprint() is not None
+    assert dataset.table_blueprint() is not None


### PR DESCRIPTION
Stacks on #119. Adds `wildcap`, the zero-metadata entry point to the exoego:v2 schema for self-collected exo/ego footage that arrives as bare video files.

## Contract

A capture is just two directories — `<name>/exo/*.mp4` (one file per static camera) plus `<name>/ego/*.mp4` (streams from one head-mounted device). No calibration, no IMU, no per-frame CSVs, no sync manifest. `download` only verifies the tree exists (the corpus is user-assembled); `convert` writes one base rrd per capture.

The base layer asserts only what the mp4s themselves know:

- Videos land on the canonical `rig_NN/cam_MM/pinhole/video` paths, but the `pinhole` node carries **no** `Pinhole` — a calibration layer logs intrinsics at the same path later with zero path churn.
- No root `ViewCoordinates` and no transforms: nothing is posed, so the localization layer that first establishes a world frame owns both.
- The clock is each file's as-encoded PTS, unshifted; mutual sync is a later layer's job. Footage cut to a common start lines up as-is.

Topology mirrors selfcap: exo mp4 N becomes rig N cam 0 (stem order), all ego mp4s share one moving rig as cam 00…. The embedded blueprint (ego row over exo row, 2D only) and the logging loops derive from the same two sorted file lists, so the blueprint can only describe cameras that really get logged. `.mov` files are warned about and skipped (remux first).

`log_video_stream` gains an optional NVENC escape hatch: a B-frame HEVC source forces Mp4Reader into an FFmpeg re-encode, and `DATAFORGE_FFMPEG` + `try_gpu` route that unavoidable re-encode through an NVENC-capable binary. Pass-through sources are untouched.

## Verified

- lint / typecheck / deadcode / 50 tests green.
- End-to-end on self-collected exoego captures (OAK ego trio + four named static exo cameras): 3 episodes converted and registered as 3 segments with a `base` layer on the local catalog, matching selfcap's shape.
- Converted rrds structurally verified: correct static components on rig/cam nodes, video-only `video_time` timeline, no stray Pinhole/ViewCoordinates/transforms, blueprint embedded.