### PR TITLE
trtkit: support portable prebuilt TensorRT engines

### DIFF
--- a/packages/monoprior/monopriors/models/surface_normal/moge_v2_trt.py
+++ b/packages/monoprior/monopriors/models/surface_normal/moge_v2_trt.py
@@ -22,6 +22,7 @@ from monopriors.models.surface_normal.moge_v2 import MOGE_V2_NORMAL_CHECKPOINTS
 from monopriors.third_party.moge.model.v2 import ForwardOutput, MoGeModel
 
 Encoder: TypeAlias = Literal["vits", "vitb", "vitl"]
+HardwareCompatibility: TypeAlias = Literal["none", "same_compute_capability"]
 
 DEFAULT_CACHE_DIR: Path = Path(os.environ.get("MONOPRIOR_TRT_CACHE", "~/.cache/monoprior")).expanduser()
 """Cache root holding portable ``onnx/`` and machine-local ``trt/`` artifacts."""
@@ -349,6 +350,8 @@ class MoGeV2TrtNormalPredictor:
         resolution_level: int = 9,
         batch_size: int = 8,
         cache_dir: Path = DEFAULT_CACHE_DIR,
+        hardware_compatibility: HardwareCompatibility = "none",
+        engine_path: Path | None = None,
     ) -> None:
         """Export ONNX and build or load the machine-local engine on first use.
 
@@ -359,20 +362,32 @@ class MoGeV2TrtNormalPredictor:
                 3600 tokens for the pinned checkpoints.
             batch_size: Engine profile maximum and optimization batch.
             cache_dir: Cache root for ONNX and TensorRT artifacts.
+            hardware_compatibility: Plan portability requested when building an engine.
+            engine_path: Optional prebuilt engine. When provided, ONNX export and engine build are skipped.
         """
-        from trtkit import TrtBuildConfig, ensure_engine
         from trtkit.tensorrt_runtime import TensorRtRuntime
 
-        onnx_path: Path = export_moge_v2_normal_onnx(
-            encoder=encoder,
-            image_hw=image_hw,
-            resolution_level=resolution_level,
-            max_batch_size=batch_size,
-            cache_dir=cache_dir,
-        )
-        config: TrtBuildConfig = TrtBuildConfig(max_batch_size=batch_size, opt_batch_size=batch_size)
-        engine_path: Path = ensure_engine(onnx_path, config, cache_dir=cache_dir / "trt")
-        self.runtime: TensorRtRuntime = TensorRtRuntime(engine_path)
+        resolved_engine_path: Path
+        if engine_path is None:
+            from trtkit import TrtBuildConfig, ensure_engine
+
+            onnx_path: Path = export_moge_v2_normal_onnx(
+                encoder=encoder,
+                image_hw=image_hw,
+                resolution_level=resolution_level,
+                max_batch_size=batch_size,
+                cache_dir=cache_dir,
+            )
+            config: TrtBuildConfig = TrtBuildConfig(
+                max_batch_size=batch_size,
+                opt_batch_size=batch_size,
+                hardware_compatibility=hardware_compatibility,
+            )
+            resolved_engine_path = ensure_engine(onnx_path, config, cache_dir=cache_dir / "trt")
+        else:
+            resolved_engine_path = engine_path
+        self.engine_path: Path = resolved_engine_path
+        self.runtime: TensorRtRuntime = TensorRtRuntime(resolved_engine_path)
         self.image_hw: tuple[int, int] = image_hw
 
     def __call__(self, rgb_bhw3: UInt8[Tensor, "b h w 3"]) -> MoGeV2NormalOutput:

--- a/packages/monoprior/tests/test_moge_v2_trt_normals.py
+++ b/packages/monoprior/tests/test_moge_v2_trt_normals.py
@@ -1,5 +1,9 @@
 """Contract, parity, and convention tests for batched MoGe v2 normals."""
 
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 import torch
@@ -7,6 +11,27 @@ from jaxtyping import Bool, Float32, UInt8
 from torch import Tensor
 
 requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+
+def test_trt_predictor_loads_prebuilt_engine_without_export(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A supplied engine bypasses ONNX export and TensorRT build work."""
+    import monopriors.models.surface_normal.moge_v2_trt as moge_v2_trt
+
+    class FakeRuntime:
+        def __init__(self, engine_path: Path) -> None:
+            self.engine_path: Path = engine_path
+
+    def fail_export(*args: object, **kwargs: object) -> Path:
+        raise AssertionError("prebuilt engine path must bypass ONNX export")
+
+    engine_path: Path = tmp_path / "moge.engine"
+    engine_path.write_bytes(b"engine")
+    monkeypatch.setattr(moge_v2_trt, "export_moge_v2_normal_onnx", fail_export)
+    monkeypatch.setitem(sys.modules, "trtkit.tensorrt_runtime", SimpleNamespace(TensorRtRuntime=FakeRuntime))
+
+    predictor: moge_v2_trt.MoGeV2TrtNormalPredictor = moge_v2_trt.MoGeV2TrtNormalPredictor(engine_path=engine_path)
+
+    assert predictor.runtime.engine_path == engine_path
 
 
 def _synthetic_rgb_batch(batch_size: int, image_hw: tuple[int, int]) -> UInt8[Tensor, "b h w 3"]:

--- a/packages/trtkit/src/trtkit/__init__.py
+++ b/packages/trtkit/src/trtkit/__init__.py
@@ -13,9 +13,9 @@ and mamma. It splits into two layers (vision-rt's crate layering, in Python):
   :mod:`trtkit.trt_builder` (build + cache key + manifest) and
   :mod:`trtkit.onnx_graph` (generic ONNX graph surgery).
 
-ONNX files are the portable artifacts; engines are machine-locked (TensorRT
-version + compute capability), never committed, and rebuilt from ONNX on each
-machine. Model-specific concerns — export wrappers, checkpoint resolution,
+ONNX files are the universally portable artifacts. TensorRT engines remain
+version-specific and are device-specific unless explicitly built for compatible
+hardware. Model-specific concerns — export wrappers, checkpoint resolution,
 pre/postprocessing — stay in the model packages.
 """
 
@@ -40,11 +40,20 @@ from trtkit.onnx_export import export_onnx, sweep_stale_onnx_exports
 from trtkit.onnx_graph import onnx_static_batch_size
 from trtkit.tensorrt_runtime import TensorRtRuntime
 from trtkit.torch_runtime import TorchRuntime
-from trtkit.trt_builder import DEFAULT_TRT_CACHE_DIR, TrtBuildConfig, build_engine, cached_engine_path, ensure_engine, onnx_content_hash
+from trtkit.trt_builder import (
+    DEFAULT_TRT_CACHE_DIR,
+    HardwareCompatibility,
+    TrtBuildConfig,
+    build_engine,
+    cached_engine_path,
+    ensure_engine,
+    onnx_content_hash,
+)
 
 __all__ = (
     "BackendConfig",
     "DEFAULT_TRT_CACHE_DIR",
+    "HardwareCompatibility",
     "OnnxBackendConfig",
     "OnnxCudaRuntime",
     "OnnxOrTrtBackendConfig",

--- a/packages/trtkit/src/trtkit/trt_builder.py
+++ b/packages/trtkit/src/trtkit/trt_builder.py
@@ -1,8 +1,9 @@
 """TensorRT engine building and machine-local caching (the hub layer).
 
-Engines are never committed or downloaded: they are sm-/version-specific
-artifacts built once from a model's ONNX interchange file into a local cache
-directory, with a JSON manifest recording how each engine was produced.
+Device-specific engines stay machine-local. Engines built with an explicit
+hardware-compatibility level may be distributed to matching targets. Every
+plan remains TensorRT-version-specific, and a JSON manifest records how it was
+produced.
 
 When TensorRT miscompiles a graph whose fusion spans an input-derived
 reduction all the way to an output (garbage/NaN at every precision), mark the
@@ -16,7 +17,7 @@ import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, TypeAlias
 
 import torch
 from rich.console import Console
@@ -24,6 +25,9 @@ from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 
 DEFAULT_TRT_CACHE_DIR: Path = Path(os.environ.get("TRTKIT_TRT_CACHE", "~/.cache/trtkit/trt")).expanduser()
 """Machine-local engine cache; override with the ``TRTKIT_TRT_CACHE`` env var."""
+
+HardwareCompatibility: TypeAlias = Literal["none", "same_compute_capability"]
+"""TensorRT plan portability requested at build time."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -43,6 +47,8 @@ class TrtBuildConfig:
     memory, not an upfront allocation."""
     builder_optimization_level: int = 3
     """TensorRT builder optimization level (0-5)."""
+    hardware_compatibility: HardwareCompatibility = "none"
+    """Plan portability: device-specific, or portable across GPUs with the same compute capability."""
     extra_output_patterns: tuple[str, ...] = ()
     """Mark every intermediate tensor whose name contains one of these substrings as
     an additional engine output. Materializing a tensor bars TensorRT from fusing it
@@ -81,9 +87,10 @@ def cached_engine_path(onnx_path: Path, config: TrtBuildConfig, *, cache_dir: Pa
         if config.extra_output_patterns
         else ""
     )
+    hardware_key: str = "_hcsamecc" if config.hardware_compatibility == "same_compute_capability" else ""
     name: str = (
         f"{onnx_path.stem}_b1-{config.opt_batch_size}-{config.max_batch_size}_{precision_key}"
-        f"_w{config.workspace_gib:g}o{config.builder_optimization_level}{extra_outputs_key}"
+        f"_w{config.workspace_gib:g}o{config.builder_optimization_level}{hardware_key}{extra_outputs_key}"
         f"_trt{trt.__version__}_sm{capability[0]}{capability[1]}_{onnx_hash}.engine"
     )
     return cache_dir / name
@@ -133,6 +140,8 @@ def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig, *, 
     builder_config: Any = builder.create_builder_config()
     builder_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, int(config.workspace_gib * (1 << 30)))
     builder_config.builder_optimization_level = int(config.builder_optimization_level)
+    if config.hardware_compatibility == "same_compute_capability":
+        builder_config.hardware_compatibility_level = trt.HardwareCompatibilityLevel.SAME_COMPUTE_CAPABILITY
     if not config.allow_tf32:
         builder_config.clear_flag(trt.BuilderFlag.TF32)
     profile: Any = builder.create_optimization_profile()
@@ -178,14 +187,15 @@ def build_engine(onnx_path: Path, engine_path: Path, config: TrtBuildConfig, *, 
         "onnx_path": str(onnx_path),
         "onnx_sha256": onnx_sha256 or onnx_content_hash(onnx_path),
         "engine_path": str(engine_path),
-        "portable_engine": False,
-        "rebuild_from_onnx_on_target_machine": True,
+        "portable_engine": config.hardware_compatibility != "none",
+        "rebuild_from_onnx_on_target_machine": config.hardware_compatibility == "none",
         "max_batch_size": config.max_batch_size,
         "opt_batch_size": config.opt_batch_size,
         "strongly_typed": True,
         "allow_tf32": config.allow_tf32,
         "workspace_gib": config.workspace_gib,
         "builder_optimization_level": config.builder_optimization_level,
+        "hardware_compatibility": config.hardware_compatibility,
         "build_seconds": build_seconds,
         "tensorrt_version": str(trt.__version__),
         "cuda_device_name": torch.cuda.get_device_name(),

--- a/packages/trtkit/tests/test_trtkit.py
+++ b/packages/trtkit/tests/test_trtkit.py
@@ -5,14 +5,18 @@ covered by posekit's test suite through its re-exports; this covers what
 trtkit adds: the ``allow_tf32`` build axis.
 """
 
+import json
 import os
+import sys
 import time
 from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
 
 import pytest
 import torch
 
-from trtkit import TrtBuildConfig, cached_engine_path, export_onnx, sweep_stale_onnx_exports
+from trtkit import TrtBuildConfig, build_engine, cached_engine_path, export_onnx, sweep_stale_onnx_exports
 
 cuda_only = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 
@@ -116,6 +120,85 @@ def test_allow_tf32_cache_key(tmp_path: Path) -> None:
     assert "notf32" not in default_path.name
 
 
+def test_same_compute_capability_build_is_cache_keyed_and_recorded(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A portable plan applies TensorRT's same-CC mode and records that build axis."""
+
+    class FakeBuilderConfig:
+        def __init__(self) -> None:
+            self.builder_optimization_level: int = -1
+            self.hardware_compatibility_level: object | None = None
+
+        def set_memory_pool_limit(self, pool: object, limit: int) -> None:
+            self.memory_pool_limit: tuple[object, int] = (pool, limit)
+
+        def clear_flag(self, flag: object) -> None:
+            self.cleared_flag: object = flag
+
+        def add_optimization_profile(self, profile: object) -> None:
+            self.optimization_profile: object = profile
+
+    class FakeBuilder:
+        def __init__(self, config: FakeBuilderConfig) -> None:
+            self.config: FakeBuilderConfig = config
+
+        def create_network(self, flags: int) -> SimpleNamespace:
+            self.network_flags: int = flags
+            return SimpleNamespace(num_inputs=0, num_layers=0)
+
+        def create_builder_config(self) -> FakeBuilderConfig:
+            return self.config
+
+        def create_optimization_profile(self) -> SimpleNamespace:
+            return SimpleNamespace()
+
+        def build_serialized_network(self, network: object, config: FakeBuilderConfig) -> bytes:
+            self.built_network: object = network
+            self.build_config: FakeBuilderConfig = config
+            return b"engine"
+
+    class FakeParser:
+        num_errors: int = 0
+
+        def parse_from_file(self, path: str) -> bool:
+            self.parsed_path: str = path
+            return True
+
+    class FakeLogger:
+        WARNING: int = 1
+
+        def __init__(self, severity: int) -> None:
+            self.severity: int = severity
+
+    fake_builder_config: FakeBuilderConfig = FakeBuilderConfig()
+    fake_builder: FakeBuilder = FakeBuilder(fake_builder_config)
+    fake_trt: SimpleNamespace = SimpleNamespace(
+        __version__="11.2.1.2",
+        Builder=lambda logger: fake_builder,
+        BuilderFlag=SimpleNamespace(TF32=1),
+        HardwareCompatibilityLevel=SimpleNamespace(SAME_COMPUTE_CAPABILITY="same-compute-capability"),
+        Logger=FakeLogger,
+        MemoryPoolType=SimpleNamespace(WORKSPACE=1),
+        NetworkDefinitionCreationFlag=SimpleNamespace(STRONGLY_TYPED=0),
+        OnnxParser=lambda network, logger: FakeParser(),
+    )
+    monkeypatch.setitem(sys.modules, "tensorrt", fake_trt)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda: (12, 0))
+    monkeypatch.setattr(torch.cuda, "get_device_name", lambda: "test-gpu")
+    onnx_path: Path = tmp_path / "model.onnx"
+    onnx_path.write_bytes(b"onnx")
+    config: TrtBuildConfig = TrtBuildConfig(hardware_compatibility="same_compute_capability")
+
+    engine_path: Path = cached_engine_path(onnx_path, config, cache_dir=tmp_path)
+    build_engine(onnx_path, engine_path, config)
+
+    manifest: dict[str, object] = json.loads(engine_path.with_suffix(".engine.json").read_text())
+    assert "samecc" in engine_path.name
+    assert fake_builder_config.hardware_compatibility_level == "same-compute-capability"
+    assert manifest["portable_engine"] is True
+    assert manifest["rebuild_from_onnx_on_target_machine"] is False
+    assert manifest["hardware_compatibility"] == "same_compute_capability"
+
+
 def test_fp32_transposed_conv_islands_share_weights_without_mutating() -> None:
     """bf16 exports isolate transposed convs in fp32 without touching the caller's model."""
     from trtkit.onnx_export import _Fp32Island, _with_fp32_transposed_convs
@@ -124,12 +207,12 @@ def test_fp32_transposed_conv_islands_share_weights_without_mutating() -> None:
         torch.nn.Conv2d(2, 4, 3, padding=1),
         torch.nn.ConvTranspose2d(4, 2, 2, stride=2),
     ).eval()
-    wrapped = _with_fp32_transposed_convs(model)
+    wrapped: torch.nn.Sequential = cast(torch.nn.Sequential, _with_fp32_transposed_convs(model))
 
     assert isinstance(wrapped[1], _Fp32Island)
     assert wrapped[1].inner is model[1], "island must share the original conv (weights by reference)"
     assert not any(isinstance(m, _Fp32Island) for m in model.modules()), "caller's tree must stay unmodified"
-    rewrapped = _with_fp32_transposed_convs(wrapped)
+    rewrapped: torch.nn.Sequential = cast(torch.nn.Sequential, _with_fp32_transposed_convs(wrapped))
     assert rewrapped[1] is wrapped[1], "re-wrapping must be idempotent"
 
     x = torch.randn(1, 2, 8, 8)


### PR DESCRIPTION
## Summary

- add TensorRT same-compute-capability builds and include the mode in cache keys and manifests
- let Monoprior's MoGe v2 predictor load a prebuilt engine without exporting ONNX or compiling on the serving host
- test builder flags, manifest metadata, cache separation, and the prebuilt-engine path

## Why

This lets us build a TensorRT plan once on an SM 12.0 GPU and serve it on a compatible SM 12.0 target such as Hugging Face ZeroGPU. The serving allocation can spend its limited GPU time on inference instead of engine compilation.

## Validation

- `pixi run -e trtkit-dev --frozen tests` — 7 passed
- `pixi run -e monoprior-dev --frozen pytest -q packages/monoprior/tests/test_moge_v2_trt_normals.py` — 4 passed
- lint, type checking, and dead-code checks passed in both development environments

Reference deployment: https://huggingface.co/spaces/pablovela5620/moge-v2-tensorrt-zerogpu
