### PR TITLE
monopriors: optional confidence, logged as full spectrum + semantic mask

### DIFF
--- a/packages/monoprior/monopriors/apis/metric_depth.py
+++ b/packages/monoprior/monopriors/apis/metric_depth.py
@@ -85,6 +85,8 @@ def main(config: MetricDepthCLIConfig) -> None:
     from simplecv.camera_parameters import Extrinsics, Intrinsics, PinholeParameters
     from simplecv.rerun_log_utils import log_pinhole
 
+    from monopriors.rr_logging_utils import log_confidence
+
     parent_log_path: Path = Path("world")
 
     # Load image
@@ -138,4 +140,4 @@ def main(config: MetricDepthCLIConfig) -> None:
 
     rr.log(f"{cam_log_path}/pinhole/image", rr.Image(rgb, color_model=rr.ColorModel.RGB).compress(), static=True)
     rr.log(f"{cam_log_path}/pinhole/depth", rr.DepthImage(result.depth_meters, meter=1), static=True)
-    rr.log(f"{cam_log_path}/pinhole/confidence", rr.Image(result.confidence, color_model=rr.ColorModel.L), static=True)
+    log_confidence(cam_log_path / "pinhole", result.confidence, static=True)

--- a/packages/monoprior/monopriors/apis/relative_depth_inference.py
+++ b/packages/monoprior/monopriors/apis/relative_depth_inference.py
@@ -48,9 +48,19 @@ def relative_depth_from_img(config: PredictorConfig) -> None:
     relative_pred: RelativeDepthPrediction = predictor.__call__(rgb=rgb_hw3, K_33=None)
 
     pinhole_path = parent_log_path / "camera" / "pinhole"
-    image_views = [rrb.Spatial2DView(origin=f"{pinhole_path}/image"), rrb.Spatial2DView(origin=f"{pinhole_path}/depth")]
+    image_views: list[rrb.Container | rrb.View] = [
+        rrb.Spatial2DView(origin=f"{pinhole_path}/image"),
+        rrb.Spatial2DView(origin=f"{pinhole_path}/depth"),
+    ]
     if relative_pred.confidence is not None:
-        image_views += [rrb.Spatial2DView(origin=f"{pinhole_path}/confidence"), rrb.Spatial2DView(origin=f"{pinhole_path}/confidence_mask")]
+        # semantic mask is the default tab; the full spectrum sits behind it
+        image_views.append(
+            rrb.Tabs(
+                rrb.Spatial2DView(origin=f"{pinhole_path}/confidence_mask", name="confidence mask"),
+                rrb.Spatial2DView(origin=f"{pinhole_path}/confidence", name="confidence"),
+                active_tab=0,
+            )
+        )
     rr.send_blueprint(
         rrb.Blueprint(
             rrb.Horizontal(rrb.Spatial3DView(), rrb.Vertical(*image_views), column_shares=[3, 1]),

--- a/packages/monoprior/monopriors/apis/relative_depth_inference.py
+++ b/packages/monoprior/monopriors/apis/relative_depth_inference.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import cv2
 import numpy as np
 import rerun as rr
-import rerun.blueprint as rrb
 from simplecv.rerun_log_utils import RerunTyroConfig
 
 from monopriors.models.relative_depth import (
@@ -13,7 +12,7 @@ from monopriors.models.relative_depth import (
     get_relative_predictor,
 )
 from monopriors.models.relative_depth.base_relative_depth import BaseRelativePredictor
-from monopriors.rr_logging_utils import log_relative_pred
+from monopriors.rr_logging_utils import CONFIDENCE_THRESHOLD, create_relative_depth_blueprint, log_relative_pred
 
 
 @dataclass
@@ -22,6 +21,8 @@ class PredictorConfig:
     image_path: Path = Path("data/examples/single-image/room.jpg")
     predictor_name: RELATIVE_PREDICTORS = "MoGeV1Predictor"
     depth_edge_threshold: float = 0.1
+    confidence_threshold: float = CONFIDENCE_THRESHOLD
+    """Confidence above which a pixel counts as confident in the semantic mask view (models with a confidence head only)."""
 
 
 def resize_image(image: np.ndarray, max_dim: int = 1024) -> np.ndarray:
@@ -36,6 +37,7 @@ def resize_image(image: np.ndarray, max_dim: int = 1024) -> np.ndarray:
 
 def relative_depth_from_img(config: PredictorConfig) -> None:
     parent_log_path = Path("world")
+    rr.send_blueprint(create_relative_depth_blueprint(parent_log_path))
     bgr_hw3 = cv2.imread(str(config.image_path))
     if bgr_hw3 is None:
         raise FileNotFoundError(f"Failed to read image {config.image_path}")
@@ -47,26 +49,8 @@ def relative_depth_from_img(config: PredictorConfig) -> None:
     predictor: BaseRelativePredictor = get_relative_predictor(config.predictor_name)(device="cuda")
     relative_pred: RelativeDepthPrediction = predictor.__call__(rgb=rgb_hw3, K_33=None)
 
-    pinhole_path = parent_log_path / "camera" / "pinhole"
-    image_views: list[rrb.Container | rrb.View] = [
-        rrb.Spatial2DView(origin=f"{pinhole_path}/image"),
-        rrb.Spatial2DView(origin=f"{pinhole_path}/depth"),
-    ]
-    if relative_pred.confidence is not None:
-        # semantic mask is the default tab; the full spectrum sits behind it
-        image_views.append(
-            rrb.Tabs(
-                rrb.Spatial2DView(origin=f"{pinhole_path}/confidence_mask", name="confidence mask"),
-                rrb.Spatial2DView(origin=f"{pinhole_path}/confidence", name="confidence"),
-                active_tab=0,
-            )
-        )
-    rr.send_blueprint(
-        rrb.Blueprint(
-            rrb.Horizontal(rrb.Spatial3DView(), rrb.Vertical(*image_views), column_shares=[3, 1]),
-            collapse_panels=True,
-        )
-    )
     rr.set_time("time", sequence=0)
     rr.log("/", rr.ViewCoordinates.RDF, static=True)
-    log_relative_pred(parent_log_path, relative_pred, rgb_hw3, depth_edge_threshold=config.depth_edge_threshold)
+    log_relative_pred(
+        parent_log_path, relative_pred, rgb_hw3, depth_edge_threshold=config.depth_edge_threshold, confidence_threshold=config.confidence_threshold
+    )

--- a/packages/monoprior/monopriors/apis/relative_depth_inference.py
+++ b/packages/monoprior/monopriors/apis/relative_depth_inference.py
@@ -36,19 +36,6 @@ def resize_image(image: np.ndarray, max_dim: int = 1024) -> np.ndarray:
 
 def relative_depth_from_img(config: PredictorConfig) -> None:
     parent_log_path = Path("world")
-    blueprint = rrb.Blueprint(
-        rrb.Horizontal(
-            rrb.Spatial3DView(),
-            rrb.Vertical(
-                rrb.Spatial2DView(origin=f"{parent_log_path}/camera/pinhole/image"),
-                rrb.Spatial2DView(origin=f"{parent_log_path}/camera/pinhole/depth"),
-                rrb.Spatial2DView(origin=f"{parent_log_path}/camera/pinhole/confidence"),
-            ),
-            column_shares=[3, 1],
-        ),
-        collapse_panels=True,
-    )
-    rr.send_blueprint(blueprint=blueprint)
     bgr_hw3 = cv2.imread(str(config.image_path))
     if bgr_hw3 is None:
         raise FileNotFoundError(f"Failed to read image {config.image_path}")
@@ -59,6 +46,17 @@ def relative_depth_from_img(config: PredictorConfig) -> None:
 
     predictor: BaseRelativePredictor = get_relative_predictor(config.predictor_name)(device="cuda")
     relative_pred: RelativeDepthPrediction = predictor.__call__(rgb=rgb_hw3, K_33=None)
+
+    pinhole_path = parent_log_path / "camera" / "pinhole"
+    image_views = [rrb.Spatial2DView(origin=f"{pinhole_path}/image"), rrb.Spatial2DView(origin=f"{pinhole_path}/depth")]
+    if relative_pred.confidence is not None:
+        image_views += [rrb.Spatial2DView(origin=f"{pinhole_path}/confidence"), rrb.Spatial2DView(origin=f"{pinhole_path}/confidence_mask")]
+    rr.send_blueprint(
+        rrb.Blueprint(
+            rrb.Horizontal(rrb.Spatial3DView(), rrb.Vertical(*image_views), column_shares=[3, 1]),
+            collapse_panels=True,
+        )
+    )
     rr.set_time("time", sequence=0)
     rr.log("/", rr.ViewCoordinates.RDF, static=True)
     log_relative_pred(parent_log_path, relative_pred, rgb_hw3, depth_edge_threshold=config.depth_edge_threshold)

--- a/packages/monoprior/monopriors/gradio_ui/metric_depth_ui.py
+++ b/packages/monoprior/monopriors/gradio_ui/metric_depth_ui.py
@@ -32,6 +32,7 @@ from simplecv.rerun_log_utils import log_pinhole
 
 from monopriors.apis.metric_depth import MetricDepthNodeConfig, create_metric_predictor, run_metric_depth
 from monopriors.models.metric_depth import METRIC_PREDICTORS, BaseMetricPredictor, MetricDepthPrediction
+from monopriors.rr_logging_utils import log_confidence
 
 PARENT_LOG_PATH: Final[Path] = Path("world")
 EXAMPLE_DATA_DIR: Final[Path] = Path(__file__).resolve().parents[2] / "data" / "examples" / "multiview"
@@ -164,7 +165,7 @@ def _log_results(
         # Log image, depth, confidence
         rr.log(f"{cam_log_path}/pinhole/image", rr.Image(img, color_model=rr.ColorModel.RGB).compress(), static=True)
         rr.log(f"{cam_log_path}/pinhole/depth", rr.DepthImage(result.depth_meters, meter=1), static=True)
-        rr.log(f"{cam_log_path}/pinhole/confidence", rr.Image(result.confidence, color_model=rr.ColorModel.L), static=True)
+        log_confidence(cam_log_path / "pinhole", result.confidence, static=True)
 
     yield stream.read(), "Metric depth complete"
 

--- a/packages/monoprior/monopriors/models/metric_depth/unidepth.py
+++ b/packages/monoprior/monopriors/models/metric_depth/unidepth.py
@@ -11,6 +11,7 @@ from monopriors.models.metric_depth.base_metric_depth import (
     BaseMetricPredictor,
     MetricDepthPrediction,
 )
+from monopriors.models.relative_depth.unidepth import predicted_error_to_confidence
 
 
 class UniDepthPredictions(TypedDict):
@@ -97,8 +98,7 @@ class UniDepthMetricPredictor(BaseMetricPredictor[UniDepthModel]):
 
         assert depth_b1hw.shape[0] == 1, "Batch size must be 1"
 
-        # normalize the confidence to 0-1
-        conf_b1hw = (conf_b1hw - conf_b1hw.min()) / (conf_b1hw.max() - conf_b1hw.min())
+        conf_b1hw = predicted_error_to_confidence(conf_b1hw)
 
         # convert to numpy and rearrange
         depth_hw = rearrange(depth_b1hw, "1 1 h w -> h w").numpy(force=True)

--- a/packages/monoprior/monopriors/models/relative_depth/base_relative_depth.py
+++ b/packages/monoprior/monopriors/models/relative_depth/base_relative_depth.py
@@ -18,7 +18,7 @@ class RelativeDepthPrediction:
     # relative depth
     K_33: Float32[np.ndarray, "3 3"]
     # intrinsics
-    confidence: Float32[np.ndarray, "h w"] | None = None
+    confidence: Float32[np.ndarray, "h w"] | None
     # per-pixel confidence in [0, 1]; None when the model has no confidence head
     # (DepthAnything v1/v2, VideoDepthAnything, ZipDepth). MoGe gives a validity mask,
     # UniDepth a normalized confidence.

--- a/packages/monoprior/monopriors/models/relative_depth/base_relative_depth.py
+++ b/packages/monoprior/monopriors/models/relative_depth/base_relative_depth.py
@@ -16,10 +16,12 @@ class RelativeDepthPrediction:
     # relative disparity
     depth: Float32[np.ndarray, "h w"]
     # relative depth
-    confidence: Float32[np.ndarray, "h w"]
-    # confidence values
     K_33: Float32[np.ndarray, "3 3"]
     # intrinsics
+    confidence: Float32[np.ndarray, "h w"] | None = None
+    # per-pixel confidence in [0, 1]; None when the model has no confidence head
+    # (DepthAnything v1/v2, VideoDepthAnything, ZipDepth). MoGe gives a validity mask,
+    # UniDepth a normalized confidence.
 
 
 class BaseRelativePredictor(ABC, Generic[ModelT]):

--- a/packages/monoprior/monopriors/models/relative_depth/depth_anything_v1.py
+++ b/packages/monoprior/monopriors/models/relative_depth/depth_anything_v1.py
@@ -79,6 +79,7 @@ class DepthAnythingV1Predictor(BaseRelativePredictor[torch.nn.Module]):
             disparity=disparity,
             depth=disparity_to_depth(disparity, focal_length=int(K_33[0, 0])),
             K_33=K_33,
+            confidence=None,
         )
 
         return relative_prediction

--- a/packages/monoprior/monopriors/models/relative_depth/depth_anything_v1.py
+++ b/packages/monoprior/monopriors/models/relative_depth/depth_anything_v1.py
@@ -78,7 +78,6 @@ class DepthAnythingV1Predictor(BaseRelativePredictor[torch.nn.Module]):
         relative_prediction = RelativeDepthPrediction(
             disparity=disparity,
             depth=disparity_to_depth(disparity, focal_length=int(K_33[0, 0])),
-            confidence=np.ones_like(disparity),
             K_33=K_33,
         )
 

--- a/packages/monoprior/monopriors/models/relative_depth/depth_anything_v2.py
+++ b/packages/monoprior/monopriors/models/relative_depth/depth_anything_v2.py
@@ -76,7 +76,6 @@ class DepthAnythingV2Predictor(BaseRelativePredictor[DepthAnythingV2]):
         relative_prediction = RelativeDepthPrediction(
             disparity=disparity,
             depth=disparity_to_depth(disparity, focal_length=int(K_33[0, 0])),
-            confidence=np.ones_like(disparity),
             K_33=K_33,
         )
 

--- a/packages/monoprior/monopriors/models/relative_depth/depth_anything_v2.py
+++ b/packages/monoprior/monopriors/models/relative_depth/depth_anything_v2.py
@@ -77,6 +77,7 @@ class DepthAnythingV2Predictor(BaseRelativePredictor[DepthAnythingV2]):
             disparity=disparity,
             depth=disparity_to_depth(disparity, focal_length=int(K_33[0, 0])),
             K_33=K_33,
+            confidence=None,
         )
 
         return relative_prediction

--- a/packages/monoprior/monopriors/models/relative_depth/unidepth.py
+++ b/packages/monoprior/monopriors/models/relative_depth/unidepth.py
@@ -14,6 +14,18 @@ from monopriors.models.relative_depth.base_relative_depth import (
 )
 
 
+def predicted_error_to_confidence(raw_b1hw: Float[torch.Tensor, "b 1 h w"]) -> Float[torch.Tensor, "b 1 h w"]:
+    """Map UniDepthV2's "confidence" output to a confidence in (0, 1].
+
+    The head is trained so that ``confidence.log()`` matches the absolute, median-rescaled depth
+    error in metres (``unidepth/ops/losses/confidence.py``), i.e. ``log(raw)`` *is* the predicted
+    error: higher = worse, spiking at depth edges. ``1 / (1 + error)`` makes the default 0.5 mask
+    threshold mean "predicted error under one metre".
+    """
+    predicted_error_b1hw: Float[torch.Tensor, "b 1 h w"] = raw_b1hw.log().clamp_min(0.0)
+    return 1.0 / (1.0 + predicted_error_b1hw)
+
+
 class UniDepthPredictions(TypedDict):
     """Tensor outputs returned by UniDepth inference."""
 
@@ -93,12 +105,7 @@ class UniDepthRelativePredictor(BaseRelativePredictor[UniDepthModel]):
 
         assert depth_b1hw.shape[0] == 1, "Batch size must be 1"
 
-        # UniDepthV2's "confidence" head is trained so that log(confidence) matches the absolute
-        # (median-rescaled) depth error, i.e. it is a *predicted error*: higher = worse, and it
-        # spikes at depth edges. Map it to a confidence in (0, 1]: 1 / (1 + predicted_error), so
-        # the default 0.5 mask threshold means "predicted error below one depth unit".
-        predicted_error_b1hw = conf_b1hw.log().clamp_min(0.0)
-        conf_b1hw = 1.0 / (1.0 + predicted_error_b1hw)
+        conf_b1hw = predicted_error_to_confidence(conf_b1hw)
 
         # convert to numpy and rearrange
         depth_hw = rearrange(depth_b1hw, "1 1 h w -> h w").numpy(force=True)

--- a/packages/monoprior/monopriors/models/relative_depth/unidepth.py
+++ b/packages/monoprior/monopriors/models/relative_depth/unidepth.py
@@ -93,8 +93,12 @@ class UniDepthRelativePredictor(BaseRelativePredictor[UniDepthModel]):
 
         assert depth_b1hw.shape[0] == 1, "Batch size must be 1"
 
-        # normalize the confidence to 0-1
-        conf_b1hw = (conf_b1hw - conf_b1hw.min()) / (conf_b1hw.max() - conf_b1hw.min())
+        # UniDepthV2's "confidence" head is trained so that log(confidence) matches the absolute
+        # (median-rescaled) depth error, i.e. it is a *predicted error*: higher = worse, and it
+        # spikes at depth edges. Map it to a confidence in (0, 1]: 1 / (1 + predicted_error), so
+        # the default 0.5 mask threshold means "predicted error below one depth unit".
+        predicted_error_b1hw = conf_b1hw.log().clamp_min(0.0)
+        conf_b1hw = 1.0 / (1.0 + predicted_error_b1hw)
 
         # convert to numpy and rearrange
         depth_hw = rearrange(depth_b1hw, "1 1 h w -> h w").numpy(force=True)

--- a/packages/monoprior/monopriors/models/relative_depth/video_depth_anything.py
+++ b/packages/monoprior/monopriors/models/relative_depth/video_depth_anything.py
@@ -269,7 +269,6 @@ class VideoDepthAnythingPredictor(BaseVideoRelativePredictor[VideoDepthAnything]
             RelativeDepthPrediction(
                 disparity=disparity,
                 depth=disparity_to_depth(disparity, focal_length=int(K_33_f32[0, 0])),
-                confidence=np.ones_like(disparity),
                 K_33=K_33_f32,
             )
             for disparity in aligned_depth_list
@@ -364,7 +363,6 @@ class VideoDepthAnythingPredictor(BaseVideoRelativePredictor[VideoDepthAnything]
             RelativeDepthPrediction(
                 disparity=disparity,
                 depth=disparity_to_depth(disparity, focal_length=int(K_33_f32[0, 0])),
-                confidence=np.ones_like(disparity),
                 K_33=K_33_f32,
             )
             for disparity in aligned_depth_list

--- a/packages/monoprior/monopriors/models/relative_depth/video_depth_anything.py
+++ b/packages/monoprior/monopriors/models/relative_depth/video_depth_anything.py
@@ -270,6 +270,7 @@ class VideoDepthAnythingPredictor(BaseVideoRelativePredictor[VideoDepthAnything]
                 disparity=disparity,
                 depth=disparity_to_depth(disparity, focal_length=int(K_33_f32[0, 0])),
                 K_33=K_33_f32,
+                confidence=None,
             )
             for disparity in aligned_depth_list
         ]
@@ -364,6 +365,7 @@ class VideoDepthAnythingPredictor(BaseVideoRelativePredictor[VideoDepthAnything]
                 disparity=disparity,
                 depth=disparity_to_depth(disparity, focal_length=int(K_33_f32[0, 0])),
                 K_33=K_33_f32,
+                confidence=None,
             )
             for disparity in aligned_depth_list
         ]

--- a/packages/monoprior/monopriors/models/relative_depth/zipdepth.py
+++ b/packages/monoprior/monopriors/models/relative_depth/zipdepth.py
@@ -87,6 +87,5 @@ class ZipDepthPredictor(BaseRelativePredictor[ZipDepth]):
         return RelativeDepthPrediction(
             disparity=disparity,
             depth=disparity_to_depth(disparity, focal_length=int(K_33_f32[0, 0])),
-            confidence=np.ones_like(disparity),
             K_33=K_33_f32,
         )

--- a/packages/monoprior/monopriors/models/relative_depth/zipdepth.py
+++ b/packages/monoprior/monopriors/models/relative_depth/zipdepth.py
@@ -88,4 +88,5 @@ class ZipDepthPredictor(BaseRelativePredictor[ZipDepth]):
             disparity=disparity,
             depth=disparity_to_depth(disparity, focal_length=int(K_33_f32[0, 0])),
             K_33=K_33_f32,
+            confidence=None,
         )

--- a/packages/monoprior/monopriors/rr_logging_utils.py
+++ b/packages/monoprior/monopriors/rr_logging_utils.py
@@ -11,6 +11,20 @@ from monopriors.models.metric_depth import METRIC_PREDICTORS, MetricDepthPredict
 from monopriors.models.relative_depth import RELATIVE_PREDICTORS, RelativeDepthPrediction
 from monopriors.models.surface_normal.base_normal_model import SurfaceNormalPrediction
 
+CONFIDENCE_CLASSES = [
+    rr.AnnotationInfo(id=0, label="not confident", color=(220, 60, 60)),
+    rr.AnnotationInfo(id=1, label="confident", color=(60, 200, 90)),
+]
+
+
+def log_confidence(pinhole_path: Path, confidence_hw: Float32[np.ndarray, "h w"], threshold: float = 0.5) -> None:
+    """Log a confidence map twice: the full [0, 1] spectrum as grayscale, and its thresholded
+    semantic version (``confident`` / ``not confident``) as a segmentation image."""
+    confidence_u8: UInt8[np.ndarray, "h w"] = (np.clip(confidence_hw, 0.0, 1.0) * 255).astype(np.uint8)
+    rr.log(f"{pinhole_path}/confidence", rr.Image(confidence_u8, color_model=rr.ColorModel.L))
+    rr.log(f"{pinhole_path}/confidence_mask", rr.AnnotationContext(CONFIDENCE_CLASSES), static=True)
+    rr.log(f"{pinhole_path}/confidence_mask", rr.SegmentationImage((confidence_hw > threshold).astype(np.uint8)))
+
 
 def log_relative_pred(
     parent_log_path: Path,
@@ -20,6 +34,7 @@ def log_relative_pred(
     log_disparity: bool = False,
     jpeg_quality: int = 90,
     depth_edge_threshold: int | float = 1.1,
+    confidence_threshold: float = 0.5,
 ) -> None:
     cam_log_path: Path = parent_log_path / "camera"
     pinhole_path: Path = cam_log_path / "pinhole"
@@ -56,8 +71,8 @@ def log_relative_pred(
 
     rr.log(f"{pinhole_path}/depth", rr.DepthImage(depth_hw))
 
-    confidence_hw: Bool[np.ndarray, "h w"] = relative_pred.confidence > 0.5
-    rr.log(f"{pinhole_path}/confidence", rr.Image((confidence_hw * 255).astype(np.uint8)))
+    if relative_pred.confidence is not None:
+        log_confidence(pinhole_path, relative_pred.confidence, threshold=confidence_threshold)
 
     if log_disparity:
         # removes outliers from disparity (sometimes we can get weirdly large values)

--- a/packages/monoprior/monopriors/rr_logging_utils.py
+++ b/packages/monoprior/monopriors/rr_logging_utils.py
@@ -11,19 +11,52 @@ from monopriors.models.metric_depth import METRIC_PREDICTORS, MetricDepthPredict
 from monopriors.models.relative_depth import RELATIVE_PREDICTORS, RelativeDepthPrediction
 from monopriors.models.surface_normal.base_normal_model import SurfaceNormalPrediction
 
-CONFIDENCE_CLASSES = [
-    rr.AnnotationInfo(id=0, label="not confident", color=(220, 60, 60)),
-    rr.AnnotationInfo(id=1, label="confident", color=(60, 200, 90)),
-]
+CONFIDENCE_THRESHOLD: float = 0.5
+"""Confidence in [0, 1] above which a pixel is shown as ``confident`` in the semantic mask."""
 
 
-def log_confidence(pinhole_path: Path, confidence_hw: Float32[np.ndarray, "h w"], threshold: float = 0.5) -> None:
-    """Log a confidence map twice: the full [0, 1] spectrum as grayscale, and its thresholded
-    semantic version (``confident`` / ``not confident``) as a segmentation image."""
+def log_confidence(
+    pinhole_path: Path,
+    confidence_hw: Float32[np.ndarray, "h w"],
+    threshold: float = CONFIDENCE_THRESHOLD,
+    static: bool = False,
+) -> None:
+    """Log a confidence map twice: the full [0, 1] spectrum as grayscale (``confidence``), and its
+    thresholded semantic version as a segmentation image (``confidence_mask``: confident / not confident)."""
     confidence_u8: UInt8[np.ndarray, "h w"] = (np.clip(confidence_hw, 0.0, 1.0) * 255).astype(np.uint8)
-    rr.log(f"{pinhole_path}/confidence", rr.Image(confidence_u8, color_model=rr.ColorModel.L))
-    rr.log(f"{pinhole_path}/confidence_mask", rr.AnnotationContext(CONFIDENCE_CLASSES), static=True)
-    rr.log(f"{pinhole_path}/confidence_mask", rr.SegmentationImage((confidence_hw > threshold).astype(np.uint8)))
+    rr.log(f"{pinhole_path}/confidence", rr.Image(confidence_u8, color_model=rr.ColorModel.L), static=static)
+    classes: list[rr.AnnotationInfo] = [
+        rr.AnnotationInfo(id=0, label="not confident", color=(220, 60, 60)),
+        rr.AnnotationInfo(id=1, label="confident", color=(60, 200, 90)),
+    ]
+    rr.log(f"{pinhole_path}/confidence_mask", rr.AnnotationContext(classes), static=True)
+    rr.log(f"{pinhole_path}/confidence_mask", rr.SegmentationImage((confidence_hw > threshold).astype(np.uint8)), static=static)
+
+
+def create_relative_depth_blueprint(parent_log_path: Path) -> rrb.Blueprint:
+    """3D view beside image / depth / confidence (mask tab first, spectrum behind it).
+
+    The confidence views stay in the layout even for predictors without a confidence head; an
+    empty view is cheaper than a blueprint that depends on the prediction. Image-plane quads are
+    excluded from the 3D view so only the point cloud and camera are drawn there.
+    """
+    pinhole_path: Path = parent_log_path / "camera" / "pinhole"
+    return rrb.Blueprint(
+        rrb.Horizontal(
+            rrb.Spatial3DView(contents=["$origin/**", f"- {pinhole_path}/image", f"- {pinhole_path}/confidence", f"- {pinhole_path}/confidence_mask"]),
+            rrb.Vertical(
+                rrb.Spatial2DView(origin=f"{pinhole_path}/image"),
+                rrb.Spatial2DView(origin=f"{pinhole_path}/depth"),
+                rrb.Tabs(
+                    rrb.Spatial2DView(origin=f"{pinhole_path}/confidence_mask", name="confidence mask"),
+                    rrb.Spatial2DView(origin=f"{pinhole_path}/confidence", name="confidence"),
+                    active_tab=0,
+                ),
+            ),
+            column_shares=[3, 1],
+        ),
+        collapse_panels=True,
+    )
 
 
 def log_relative_pred(
@@ -34,7 +67,7 @@ def log_relative_pred(
     log_disparity: bool = False,
     jpeg_quality: int = 90,
     depth_edge_threshold: int | float = 1.1,
-    confidence_threshold: float = 0.5,
+    confidence_threshold: float = CONFIDENCE_THRESHOLD,
 ) -> None:
     cam_log_path: Path = parent_log_path / "camera"
     pinhole_path: Path = cam_log_path / "pinhole"

--- a/packages/monoprior/tests/test_log_relative_pred.py
+++ b/packages/monoprior/tests/test_log_relative_pred.py
@@ -1,0 +1,37 @@
+"""log_relative_pred logs confidence only when the prediction has one, as grayscale + semantic mask."""
+
+from pathlib import Path
+
+import numpy as np
+import rerun as rr
+import rerun.experimental as rrx
+
+from monopriors.models.relative_depth import RelativeDepthPrediction
+from monopriors.rr_logging_utils import log_relative_pred
+
+
+def _logged_entities(tmp_path: Path, confidence: np.ndarray | None) -> set[str]:
+    rrd = tmp_path / "pred.rrd"
+    rec = rr.RecordingStream("test_log_relative_pred")
+    rec.save(str(rrd))
+    h, w = 8, 12
+    depth = np.linspace(1.0, 5.0, h * w, dtype=np.float32).reshape(h, w)
+    pred = RelativeDepthPrediction(disparity=1.0 / depth, depth=depth, K_33=np.eye(3, dtype=np.float32) * 10, confidence=confidence)
+    with rec:
+        log_relative_pred(Path("world"), pred, np.zeros((h, w, 3), dtype=np.uint8), remove_flying_pixels=False)
+    rec.flush(timeout_sec=10.0)
+    rec.disconnect()
+    reader = rrx.RrdReader(str(rrd))
+    return {str(chunk.entity_path) for store in reader.recordings() for chunk in reader.stream(store=store).to_chunks()}
+
+
+def test_no_confidence_head_logs_nothing(tmp_path: Path) -> None:
+    entities = _logged_entities(tmp_path, None)
+    assert "/world/camera/pinhole/depth" in entities
+    assert not [e for e in entities if "confidence" in e]
+
+
+def test_confidence_logs_spectrum_and_mask(tmp_path: Path) -> None:
+    conf = np.linspace(0.0, 1.0, 8 * 12, dtype=np.float32).reshape(8, 12)
+    entities = _logged_entities(tmp_path, conf)
+    assert {"/world/camera/pinhole/confidence", "/world/camera/pinhole/confidence_mask"} <= entities

--- a/packages/monoprior/tests/test_log_relative_pred.py
+++ b/packages/monoprior/tests/test_log_relative_pred.py
@@ -1,4 +1,4 @@
-"""log_relative_pred logs confidence only when the prediction has one, as grayscale + semantic mask."""
+"""log_relative_pred logs confidence only when the prediction has one: grayscale spectrum + static-annotated semantic mask."""
 
 from pathlib import Path
 
@@ -9,29 +9,37 @@ import rerun.experimental as rrx
 from monopriors.models.relative_depth import RelativeDepthPrediction
 from monopriors.rr_logging_utils import log_relative_pred
 
+H, W = 8, 12
 
-def _logged_entities(tmp_path: Path, confidence: np.ndarray | None) -> set[str]:
+
+def _logged_chunks(tmp_path: Path, confidence: np.ndarray | None) -> dict[str, list[tuple[set[str], bool]]]:
+    """entity path -> [(column names, is_static)] for everything log_relative_pred wrote."""
     rrd = tmp_path / "pred.rrd"
     rec = rr.RecordingStream("test_log_relative_pred")
     rec.save(str(rrd))
-    h, w = 8, 12
-    depth = np.linspace(1.0, 5.0, h * w, dtype=np.float32).reshape(h, w)
+    depth = np.linspace(1.0, 5.0, H * W, dtype=np.float32).reshape(H, W)
     pred = RelativeDepthPrediction(disparity=1.0 / depth, depth=depth, K_33=np.eye(3, dtype=np.float32) * 10, confidence=confidence)
     with rec:
-        log_relative_pred(Path("world"), pred, np.zeros((h, w, 3), dtype=np.uint8), remove_flying_pixels=False)
-    rec.flush(timeout_sec=10.0)
-    rec.disconnect()
+        log_relative_pred(Path("world"), pred, np.zeros((H, W, 3), dtype=np.uint8), remove_flying_pixels=False)
     reader = rrx.RrdReader(str(rrd))
-    return {str(chunk.entity_path) for store in reader.recordings() for chunk in reader.stream(store=store).to_chunks()}
+    chunks: dict[str, list[tuple[set[str], bool]]] = {}
+    for store in reader.recordings():
+        for chunk in reader.stream(store=store).to_chunks():
+            chunks.setdefault(str(chunk.entity_path), []).append(({f.name for f in chunk.to_record_batch().schema}, chunk.is_static))
+    return chunks
 
 
 def test_no_confidence_head_logs_nothing(tmp_path: Path) -> None:
-    entities = _logged_entities(tmp_path, None)
-    assert "/world/camera/pinhole/depth" in entities
-    assert not [e for e in entities if "confidence" in e]
+    chunks = _logged_chunks(tmp_path, None)
+    assert "/world/camera/pinhole/depth" in chunks
+    assert not [e for e in chunks if "confidence" in e]
 
 
-def test_confidence_logs_spectrum_and_mask(tmp_path: Path) -> None:
-    conf = np.linspace(0.0, 1.0, 8 * 12, dtype=np.float32).reshape(8, 12)
-    entities = _logged_entities(tmp_path, conf)
-    assert {"/world/camera/pinhole/confidence", "/world/camera/pinhole/confidence_mask"} <= entities
+def test_confidence_logs_grayscale_spectrum_and_semantic_mask(tmp_path: Path) -> None:
+    conf = np.linspace(0.0, 1.0, H * W, dtype=np.float32).reshape(H, W)
+    chunks = _logged_chunks(tmp_path, conf)
+    spectrum = chunks["/world/camera/pinhole/confidence"]
+    assert any("Image:buffer" in cols and not static for cols, static in spectrum)
+    mask = chunks["/world/camera/pinhole/confidence_mask"]
+    assert any("SegmentationImage:buffer" in cols and not static for cols, static in mask)
+    assert any("AnnotationContext:context" in cols and static for cols, static in mask)

--- a/packages/monoprior/tests/test_unidepth_confidence.py
+++ b/packages/monoprior/tests/test_unidepth_confidence.py
@@ -1,0 +1,16 @@
+"""UniDepthV2's head predicts error (log(raw) == |pred - gt|); the predictor maps it to a confidence in (0, 1]."""
+
+import torch
+
+from monopriors.models.relative_depth.unidepth import predicted_error_to_confidence
+from monopriors.rr_logging_utils import CONFIDENCE_THRESHOLD
+
+
+def test_mapping_is_monotone_bounded_and_thresholds_at_one_metre() -> None:
+    raw = torch.tensor([[[[0.5, 1.0, torch.e, 280.0]]]])  # log: negative (clamped to 0), 0, 1 metre, ~5.6 metres
+    conf = predicted_error_to_confidence(raw)
+    assert conf.shape == raw.shape
+    assert torch.allclose(conf[0, 0, 0, :2], torch.tensor([1.0, 1.0]))  # no predicted error -> fully confident
+    assert torch.isclose(conf[0, 0, 0, 2], torch.tensor(CONFIDENCE_THRESHOLD))  # exactly one metre sits on the mask threshold
+    assert 0.0 < conf[0, 0, 0, 3] < CONFIDENCE_THRESHOLD  # large predicted error -> not confident
+    assert torch.all(conf[0, 0, 0, :-1] >= conf[0, 0, 0, 1:])  # monotone decreasing in raw

--- a/packages/monoprior/tests/test_zipdepth_predictor.py
+++ b/packages/monoprior/tests/test_zipdepth_predictor.py
@@ -44,7 +44,7 @@ def test_call_contract(predictor: ZipDepthPredictor) -> None:
     pred = predictor(rgb, None)
     assert pred.disparity.shape == (48, 72) and pred.disparity.dtype == np.float32 and np.isfinite(pred.disparity).all()
     assert pred.depth.shape == (48, 72) and pred.depth.dtype == np.float32
-    assert pred.confidence.shape == (48, 72)
+    assert pred.confidence is None  # ZipDepth has no confidence head
     assert pred.K_33.dtype == np.float32 and pred.K_33[0, 2] == 36.0 and pred.K_33[1, 2] == 24.0
 
 

--- a/packages/vistadream/src/vistadream/api/single_img_pipeline.py
+++ b/packages/vistadream/src/vistadream/api/single_img_pipeline.py
@@ -335,6 +335,7 @@ class SingleImagePipeline:
         frame.inpaint_wo_edge = frame_inpaint & ~edges_mask
 
         # Get depth confidence mask from depth prediction confidence
+        assert depth_prediction.confidence is not None, "VistaDream needs a predictor with a confidence head (MoGe/UniDepth)"
         dpt_conf_mask: Float[np.ndarray, "H W"] = depth_prediction.confidence
         dpt_conf_mask_bool: Bool[np.ndarray, "H W"] = dpt_conf_mask > 0
         frame.dpt_conf_mask = dpt_conf_mask_bool
@@ -426,6 +427,7 @@ class SingleImagePipeline:
             # Just use the input image for depth prediction since there's no outpainting
             outpaint_rgb_hw3: UInt8[np.ndarray, "H W 3"] = np.array(outpaint_img.convert("RGB"))
             outpaint_rel_depth: RelativeDepthPrediction = self.predictor.__call__(rgb=outpaint_rgb_hw3, K_33=None)
+            assert outpaint_rel_depth.confidence is not None, "VistaDream needs a predictor with a confidence head (MoGe/UniDepth)"
             dpt_conf_mask: Float[np.ndarray, "h w"] = outpaint_rel_depth.confidence
             # convert to boolean mask, depth confidence mask is a binary mask where values > 0 are considered confident
             dpt_conf_mask: Bool[np.ndarray, "H W"] = dpt_conf_mask > 0
@@ -463,6 +465,7 @@ class SingleImagePipeline:
 
             outpaint_rgb_hw3: UInt8[np.ndarray, "H W 3"] = np.array(outpaint_img.convert("RGB"))
             outpaint_rel_depth: RelativeDepthPrediction = self.predictor.__call__(rgb=outpaint_rgb_hw3, K_33=None)
+            assert outpaint_rel_depth.confidence is not None, "VistaDream needs a predictor with a confidence head (MoGe/UniDepth)"
             dpt_conf_mask: Float[np.ndarray, "h w"] = outpaint_rel_depth.confidence
             # convert to boolean mask, depth confidence mask is a binary mask where values > 0 are considered confident
             dpt_conf_mask: Bool[np.ndarray, "H W"] = dpt_conf_mask > 0

--- a/packages/vistadream/src/vistadream/api/single_img_pipeline.py
+++ b/packages/vistadream/src/vistadream/api/single_img_pipeline.py
@@ -86,6 +86,13 @@ def log_frame(parent_log_path: Path, frame: Frame, cam_params: PinholeParameters
 
 
 @dataclass
+
+def _confidence_mask(prediction: RelativeDepthPrediction) -> Bool[np.ndarray, "H W"]:
+    """MoGe's confidence is a 0/1 validity mask; VistaDream requires a predictor that emits one."""
+    if prediction.confidence is None:
+        raise ValueError("VistaDream requires MoGe (the only relative predictor with a validity mask)")
+    return prediction.confidence > 0
+
 class SingleImageConfig:
     """
     Configuration for Single Image Processing.
@@ -335,10 +342,7 @@ class SingleImagePipeline:
         frame.inpaint_wo_edge = frame_inpaint & ~edges_mask
 
         # Get depth confidence mask from depth prediction confidence
-        assert depth_prediction.confidence is not None, "VistaDream needs a predictor with a confidence head (MoGe/UniDepth)"
-        dpt_conf_mask: Float[np.ndarray, "H W"] = depth_prediction.confidence
-        dpt_conf_mask_bool: Bool[np.ndarray, "H W"] = dpt_conf_mask > 0
-        frame.dpt_conf_mask = dpt_conf_mask_bool
+        frame.dpt_conf_mask = _confidence_mask(depth_prediction)
 
         # Further refine inpaint_wo_edge with depth confidence mask
         frame.inpaint_wo_edge = frame.inpaint_wo_edge & dpt_conf_mask_bool
@@ -427,10 +431,7 @@ class SingleImagePipeline:
             # Just use the input image for depth prediction since there's no outpainting
             outpaint_rgb_hw3: UInt8[np.ndarray, "H W 3"] = np.array(outpaint_img.convert("RGB"))
             outpaint_rel_depth: RelativeDepthPrediction = self.predictor.__call__(rgb=outpaint_rgb_hw3, K_33=None)
-            assert outpaint_rel_depth.confidence is not None, "VistaDream needs a predictor with a confidence head (MoGe/UniDepth)"
-            dpt_conf_mask: Float[np.ndarray, "h w"] = outpaint_rel_depth.confidence
-            # convert to boolean mask, depth confidence mask is a binary mask where values > 0 are considered confident
-            dpt_conf_mask: Bool[np.ndarray, "H W"] = dpt_conf_mask > 0
+            dpt_conf_mask: Bool[np.ndarray, "H W"] = _confidence_mask(outpaint_rel_depth)
 
             outpaint_depth_hw: Float[np.ndarray, "H W"] = outpaint_rel_depth.depth
 
@@ -465,10 +466,7 @@ class SingleImagePipeline:
 
             outpaint_rgb_hw3: UInt8[np.ndarray, "H W 3"] = np.array(outpaint_img.convert("RGB"))
             outpaint_rel_depth: RelativeDepthPrediction = self.predictor.__call__(rgb=outpaint_rgb_hw3, K_33=None)
-            assert outpaint_rel_depth.confidence is not None, "VistaDream needs a predictor with a confidence head (MoGe/UniDepth)"
-            dpt_conf_mask: Float[np.ndarray, "h w"] = outpaint_rel_depth.confidence
-            # convert to boolean mask, depth confidence mask is a binary mask where values > 0 are considered confident
-            dpt_conf_mask: Bool[np.ndarray, "H W"] = dpt_conf_mask > 0
+            dpt_conf_mask: Bool[np.ndarray, "H W"] = _confidence_mask(outpaint_rel_depth)
 
             outpaint_depth_hw: Float[np.ndarray, "H W"] = outpaint_rel_depth.depth
             # remove any nans or infs and set them to 0


### PR DESCRIPTION
Stack 2/3 — on top of #124.

## Why
`log_relative_pred` thresholded `confidence > 0.5` and logged it as a `uint8` `rr.Image` (inferred `ColorModel.L`): a binary mask presented as a confidence map, and a solid white panel for every model that has no confidence head (they filled in `np.ones`).

## What
- `RelativeDepthPrediction.confidence: Float32[h w] | None = None`. DepthAnything v1/v2, VideoDepthAnything and ZipDepth return `None`; MoGe (validity mask) and UniDepth keep theirs. VistaDream asserts the head it relied on implicitly.
- `log_relative_pred` → `log_confidence` (only when present):
  - `pinhole/confidence` — `rr.Image(uint8, color_model=L)`, the full 0–1 spectrum
  - `pinhole/confidence_mask` — `rr.SegmentationImage(conf > threshold)` + `AnnotationContext {0: not confident (red), 1: confident (green)}`; `confidence_threshold` parameter (default 0.5)
- `create_relative_depth_blueprint()` (rr_logging_utils) is sent **before** model load; the two confidence views are **tabs** (`rrb.Tabs(..., active_tab=0)`, semantic mask first) and always present — empty for models without a head; image-plane quads are excluded from the 3D view.
- **UniDepth fix (found by the new views):** UniDepthV2's "confidence" head is trained so `log(confidence)` matches the absolute depth error — it is a *predicted error*, higher = worse. The predictor min-max normalized it as if higher were better, so outliers (~280 at depth edges) pushed every other pixel to ~0 and the mask was all red. Now `predicted_error_to_confidence()` = `1 / (1 + clamp(log(raw), 0))` (unit-tested; 0.5 threshold ⇔ predicted error under one metre), applied to **both** the relative and the metric UniDepth predictors.

## Validation (headless viewer, RTX 5090)
| ZipDepth (no head) | MoGe (validity mask) | UniDepth (continuous) |
|---|---|---|
| image + depth only, no confidence panels | spectrum all-white, mask all-green (MoGe marks the whole indoor image valid) | spectrum white with dark depth edges; mask green nearly everywhere, red at discontinuities |

Screenshots (section 5): https://pablos-4800gt.ilish-ruler.ts.net:8768/zipdepth/zipdepth-viewer-validation.html

Also from the thermo-nuclear review: `apis/metric_depth.py` and the gradio metric UI route through `log_confidence` (fixes a pre-existing float32-into-`ColorModel.L` render bug); `confidence` is nullable-but-required (heads pass `None` explicitly); VistaDream uses one `_confidence_mask()` that raises (asserts vanish under `-O`); `CONFIDENCE_THRESHOLD` is a constant exposed on `PredictorConfig`.

Tests: `tests/test_log_relative_pred.py` asserts the archetype columns (`Image`, `SegmentationImage`, static `AnnotationContext`) present iff confidence given; `tests/test_unidepth_confidence.py` pins the mapping; ZipDepth predictor asserts `None`. monoprior-dev lint / typecheck / deadcode / full tests green; zipdepth-dev green.


