### PR TITLE
zipdepth: live catalog train smoke gate (stack 5/5)

### DIFF
--- a/packages/zipdepth/tools/train_catalog_smoke.py
+++ b/packages/zipdepth/tools/train_catalog_smoke.py
@@ -1,0 +1,8 @@
+"""Tyro shim for the live catalog training smoke gate."""
+
+import tyro
+
+from zipdepth.apis.train_catalog_smoke import TrainCatalogSmokeConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(TrainCatalogSmokeConfig))

--- a/packages/zipdepth/zipdepth/apis/train_catalog_smoke.py
+++ b/packages/zipdepth/zipdepth/apis/train_catalog_smoke.py
@@ -1,0 +1,229 @@
+"""Live end-to-end smoke gate for catalog train, resume, DDP, and inference."""
+
+from __future__ import annotations
+
+import tempfile
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+import numpy as np
+import torch
+from jaxtyping import UInt8
+from monopriors.models.relative_depth.zipdepth import download_zipdepth_checkpoint
+from monopriors.third_party.zipdepth.architecture import ZipDepth, create_model
+from numpy import ndarray
+from torch import Tensor
+from torch.utils.data import DataLoader
+from torch.utils.tensorboard import SummaryWriter
+
+from zipdepth.apis.train_catalog import TrainCatalogConfig, load_trainable_checkpoint
+from zipdepth.apis.train_catalog import main as train_catalog
+from zipdepth.apis.train_smoke import check_checkpoint, example_rgb, publish_latest, run_required
+from zipdepth.catalog.segments import DEFAULT_CATALOG_URL, PromptDACatalog, load_promptda_catalog
+from zipdepth.catalog.targets import build_eval_transform
+from zipdepth.data.transforms import AlbumentationsWrapper
+from zipdepth.loss import ZipDepthLoss
+
+
+@dataclass(slots=True)
+class TrainCatalogSmokeConfig:
+    """Small live catalog smoke configuration."""
+
+    catalog_url: str = DEFAULT_CATALOG_URL
+    """URL of the live local Rerun catalog server."""
+    dataset_name: str = "arkitscenes-v2"
+    """Catalog dataset containing ARKitScenes and PromptDA layers."""
+    work_dir: Path = Path("data/smoke/catalog-runs")
+    """Parent directory whose ``latest`` child is published after every gate passes."""
+    train_config: Path = Path("configs/default.json")
+    """Upstream training JSON used by every smoke leg."""
+    total_steps: int = 120
+    """Initial fine-tuning updates; 120 is the shortest horizon that moved the fixed probe reliably (36 was order-sensitive)."""
+    resume_steps: int = 4
+    """Additional updates after resuming the atomic latest checkpoint."""
+    ddp_steps: int = 4
+    """Updates in the one-process torchrun leg."""
+    probe_batches: int = 12
+    """Fixed probe batches (of the training batch size) scored before and after training."""
+
+
+class _LossWriter(SummaryWriter):
+    """TensorBoard writer that also retains smoke-step losses in memory."""
+
+    def __init__(self, log_dir: Path) -> None:
+        super().__init__(log_dir=str(log_dir))
+        self.losses: list[float] = []
+
+    def record_loss(self, loss: float) -> None:
+        """Append and emit one trainer loss using a monotonic one-based step."""
+        self.losses.append(loss)
+        self.add_scalar("smoke/train_loss", loss, len(self.losses))
+
+
+def collect_probe_batches(catalog_url: str, dataset_name: str, batch_size: int, num_batches: int) -> list[dict[str, Tensor]]:
+    """Materialize a fixed, deterministic probe set from the smoke's two training segments.
+
+    Uses the deterministic eval transform (no flip or color jitter), a stride that
+    spreads the probe across each segment's easy and hard sections, and a
+    unit shuffle buffer so ordering stays reproducible. The probe measures
+    before/after training loss on IDENTICAL data — a windowed mean over the live
+    stream confounds learning with scene difficulty (later scene sections score
+    ~2.5x worse under the frozen released model).
+    """
+    # Catalog-only imports stay local so zipdepth-dev can import this module.
+    from zipdepth.catalog.builders import CpuSampleBuilder
+    from zipdepth.catalog.dataset import CatalogPromptDepthDataset
+
+    catalog: PromptDACatalog = load_promptda_catalog(catalog_url, dataset_name)
+    transform: AlbumentationsWrapper = build_eval_transform(768, 1024)
+    dataset: CatalogPromptDepthDataset = CatalogPromptDepthDataset(
+        catalog.dataset_entry,
+        catalog.segment_ids[:2],
+        catalog.row_by_id,
+        device=torch.device("cuda"),
+        builder_factory=lambda: CpuSampleBuilder(transform, min_depth_span=1.25),
+        shuffle_buffer_size=1,
+        frame_stride=8,
+        num_producers=1,
+        prefetch_samples=4,
+    )
+    loader: DataLoader[dict[str, Tensor]] = DataLoader(dataset, batch_size=batch_size, num_workers=0, drop_last=True)
+    batches: list[dict[str, Tensor]] = []
+    batch: dict[str, Tensor]
+    for batch in loader:
+        batches.append({key: value.clone() for key, value in batch.items()})
+        if len(batches) >= num_batches:
+            break
+    if len(batches) < num_batches:
+        raise RuntimeError(f"probe collection produced {len(batches)} batches, expected {num_batches}")
+    return batches
+
+
+def mean_probe_loss(checkpoint: Path | None, batches: list[dict[str, Tensor]]) -> float:
+    """Score one trainable checkpoint (None = released weights) on the fixed probe set.
+
+    Mirrors the trainer's batch arithmetic (image/255, depth/256, float mask) but
+    runs eval-mode fp32 so released and trained weights are compared identically.
+    """
+    device: torch.device = torch.device("cuda")
+    model: ZipDepth = create_model(variant="base")
+    load_trainable_checkpoint(model, checkpoint if checkpoint is not None else download_zipdepth_checkpoint())
+    model = model.to(device).eval()
+    criterion: ZipDepthLoss = ZipDepthLoss()
+    losses: list[float] = []
+    with torch.no_grad():
+        batch: dict[str, Tensor]
+        for batch in batches:
+            image: Tensor = batch["image"].to(device).float() / 255.0
+            depth: Tensor = batch["depth"].to(device).float() / 256.0
+            mask: Tensor = batch["mask"].to(device).float()
+            pred: Tensor = model(image)
+            loss: Tensor = criterion(pred=pred, target=depth, mask=mask)[0]
+            losses.append(float(loss.item()))
+    del model
+    torch.cuda.empty_cache()
+    return float(np.mean(losses))
+
+
+def main(config: TrainCatalogSmokeConfig) -> None:
+    """Run the live catalog smoke and atomically publish its output directory."""
+    if config.total_steps <= 0:
+        raise ValueError("total_steps must be positive")
+    if config.resume_steps <= 0 or config.ddp_steps <= 0:
+        raise ValueError("resume_steps and ddp_steps must be positive")
+    if config.probe_batches <= 0:
+        raise ValueError("probe_batches must be positive")
+    config.work_dir.mkdir(parents=True, exist_ok=True)
+    run_dir: Path = Path(tempfile.mkdtemp(prefix="run-", dir=config.work_dir))
+    single_dir: Path = run_dir / "single"
+    ddp_dir: Path = run_dir / "ddp"
+    writer: _LossWriter = _LossWriter(single_dir / "runs-smoke")
+    base: TrainCatalogConfig = TrainCatalogConfig(
+        catalog_url=config.catalog_url,
+        dataset_name=config.dataset_name,
+        num_segments=2,
+        holdout_count=0,
+        height=768,
+        width=1024,
+        batch_size=4,
+        total_steps=config.total_steps,
+        shuffle_buffer_size=32,
+        num_producers=1,
+        prefetch_samples=8,
+        train_config=config.train_config,
+        save_dir=single_dir,
+        save_every_steps=5,
+    )
+    try:
+        probe: list[dict[str, Tensor]] = collect_probe_batches(config.catalog_url, config.dataset_name, base.batch_size, config.probe_batches)
+        released_loss: float = mean_probe_loss(None, probe)
+
+        latest_checkpoint: Path = train_catalog(base, writer=writer, step_loss_callback=writer.record_loss)
+        if len(writer.losses) != config.total_steps:
+            raise RuntimeError(f"expected {config.total_steps} captured losses, got {len(writer.losses)}")
+
+        trained_loss: float = mean_probe_loss(latest_checkpoint, probe)
+        if not trained_loss < released_loss:
+            raise RuntimeError(f"fixed-probe loss did not fall: released={released_loss:.6f}, trained={trained_loss:.6f}")
+        print(f"loss gate passed on the fixed probe set: released={released_loss:.6f}, trained={trained_loss:.6f}")
+
+        resume_config: TrainCatalogConfig = replace(
+            base,
+            resume=latest_checkpoint,
+            total_steps=config.total_steps + config.resume_steps,
+        )
+        resumed_checkpoint: Path = train_catalog(resume_config, writer=writer, step_loss_callback=writer.record_loss)
+        expected_losses: int = config.total_steps + config.resume_steps
+        if len(writer.losses) != expected_losses:
+            raise RuntimeError(f"resume reached {len(writer.losses)} captured losses, expected {expected_losses}")
+    finally:
+        writer.close()
+
+    tool_path: Path = Path(__file__).resolve().parents[2] / "tools" / "train_catalog.py"
+    ddp: TrainCatalogConfig = replace(
+        base,
+        total_steps=config.ddp_steps,
+        save_dir=ddp_dir,
+        save_every_steps=2,
+        init_checkpoint=resumed_checkpoint,
+    )
+    command: list[str] = [
+        "torchrun",
+        "--nproc_per_node=1",
+        str(tool_path),
+        "--catalog-url",
+        ddp.catalog_url,
+        "--dataset-name",
+        ddp.dataset_name,
+        "--num-segments",
+        str(ddp.num_segments),
+        "--holdout-count",
+        str(ddp.holdout_count),
+        "--height",
+        str(ddp.height),
+        "--width",
+        str(ddp.width),
+        "--batch-size",
+        str(ddp.batch_size),
+        "--total-steps",
+        str(ddp.total_steps),
+        "--shuffle-buffer-size",
+        str(ddp.shuffle_buffer_size),
+        "--train-config",
+        str(ddp.train_config),
+        "--save-dir",
+        str(ddp.save_dir),
+        "--save-every-steps",
+        str(ddp.save_every_steps),
+        "--init-checkpoint",
+        str(resumed_checkpoint),
+    ]
+    run_required(command)
+
+    image_path: Path = Path(__file__).resolve().parents[2] / "assets" / "examples" / "im0.jpg"
+    rgb_hw3: UInt8[ndarray, "h w 3"] = example_rgb(image_path)
+    check_checkpoint(single_dir / "final_model.pth", rgb_hw3)
+    check_checkpoint(ddp_dir / "final_model.pth", rgb_hw3)
+
+    latest_dir: Path = publish_latest(config.work_dir, run_dir)
+    print(f"catalog smoke passed; outputs in {latest_dir}")

--- a/packages/zipdepth/zipdepth/apis/train_smoke.py
+++ b/packages/zipdepth/zipdepth/apis/train_smoke.py
@@ -14,9 +14,11 @@ from pathlib import Path
 import cv2
 import numpy as np
 import torch
+from jaxtyping import UInt8
 from monopriors.models.relative_depth.zipdepth import ZipDepthPredictor
 from monopriors.third_party.zipdepth.architecture import create_model
 from monopriors.third_party.zipdepth.model_utils import strip_state_dict_prefixes
+from numpy import ndarray
 
 from zipdepth.apis.smoke_data import SmokeDataConfig, build_smoke_data, smoke_data_ready
 
@@ -33,12 +35,29 @@ class TrainSmokeConfig:
     save_every_steps: int = 5
 
 
-def _run(argv: list[str]) -> None:
+def run_required(argv: list[str]) -> None:
+    """Run one required subprocess and fail on a non-zero exit."""
     print("$", " ".join(argv), flush=True)
     subprocess.run(argv, check=True)
 
 
-def check_checkpoint(path: Path, rgb: np.ndarray) -> None:
+def example_rgb(path: Path) -> UInt8[ndarray, "h w 3"]:
+    """Read one required example image and convert it from BGR to RGB."""
+    bgr_hw3: UInt8[ndarray, "h w 3"] | None = cv2.imread(str(path))
+    if bgr_hw3 is None:
+        raise FileNotFoundError(path)
+    return cv2.cvtColor(bgr_hw3, cv2.COLOR_BGR2RGB)
+
+
+def publish_latest(work_dir: Path, run_dir: Path) -> Path:
+    """Replace the published smoke output only after every gate has passed."""
+    latest_dir: Path = work_dir / "latest"
+    shutil.rmtree(latest_dir, ignore_errors=True)
+    run_dir.rename(latest_dir)
+    return latest_dir
+
+
+def check_checkpoint(path: Path, rgb: UInt8[ndarray, "h w 3"]) -> None:
     """A training checkpoint must load strictly into the vendored model and run through ZipDepthPredictor."""
     ckpt = torch.load(path, map_location="cpu", weights_only=True)
     missing_sections = {"model_state_dict", "optimizer_state_dict", "scheduler_state_dict"} - set(ckpt)
@@ -66,18 +85,13 @@ def train_smoke(config: TrainSmokeConfig) -> None:
         "--batch-size", str(config.batch_size), "--num-workers", str(config.num_workers),
         "--save-every-steps", str(config.save_every_steps),
     ]  # fmt: skip
-    _run([sys.executable, *common, "--epochs", "2", "--save-dir", str(single)])
-    _run([sys.executable, *common, "--epochs", "2", "--save-dir", str(single), "--resume", str(single / "epoch_0.pth")])
-    _run(["torchrun", "--nproc_per_node=1", *common, "--epochs", "1", "--save-dir", str(ddp)])
+    run_required([sys.executable, *common, "--epochs", "2", "--save-dir", str(single)])
+    run_required([sys.executable, *common, "--epochs", "2", "--save-dir", str(single), "--resume", str(single / "epoch_0.pth")])
+    run_required(["torchrun", "--nproc_per_node=1", *common, "--epochs", "1", "--save-dir", str(ddp)])
 
-    bgr = cv2.imread(str(config.data.image))
-    if bgr is None:
-        raise FileNotFoundError(config.data.image)
-    rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+    rgb: UInt8[ndarray, "h w 3"] = example_rgb(config.data.image)
     check_checkpoint(single / "final_model.pth", rgb)
     check_checkpoint(ddp / "final_model.pth", rgb)
 
-    latest = config.work_dir / "latest"
-    shutil.rmtree(latest, ignore_errors=True)
-    run_dir.rename(latest)
+    latest: Path = publish_latest(config.work_dir, run_dir)
     print(f"smoke passed; checkpoints in {latest}")

--- a/pixi.toml
+++ b/pixi.toml
@@ -700,6 +700,11 @@ cmd = "python tools/train_catalog.py"
 cwd = "packages/zipdepth"
 description = "Fine-tune ZipDepth on chosen-frame PromptDA pseudo-labels streamed from the local Rerun catalog"
 
+[feature.zipdepth-catalog.tasks.zipdepth-catalog-train-smoke]
+cmd = "python tools/train_catalog_smoke.py"
+cwd = "packages/zipdepth"
+description = "Smoke: 2 catalog segments -> short fine-tune -> resume -> torchrun -> checkpoint loads through ZipDepthPredictor"
+
 [feature.zipdepth-catalog.tasks.zipdepth-eval-catalog]
 cmd = "python tools/eval_catalog.py"
 cwd = "packages/zipdepth"


### PR DESCRIPTION
Stack **5/5** — top of the ZipDepth catalog fine-tuning stack. Review bottom-up:

| | PR | what | lines |
|---|---|---|---:|
| 1 | #131 | `arkitscenes-download`: depth-PNG decoders, `landscape_quarter_turns` | +315 |
| 2 | #132 | `zipdepth-catalog` env lane + sample primitives (`targets`, `png`, `threaded`, `stats`) | +900 |
| 3 | #133 | catalog streaming dataset + CUDA builders; throughput probe; holdout eval | +1,027 |
| 4 | #134 | fine-tuning entry point, IO-vs-GPU instrumentation, two vendored trainer lines | +956 |
| 5 | this | live smoke gate; shared `train_smoke` helpers | +269 |

Merge bottom-up and retarget each child to `main` as its parent merges (never `--delete-branch` a stack parent — it closes the child). The whole stack = the former single PR #129, re-cut from its final tree by responsibility (not by commit) after a simplify pass and a structural review; plus, made during the cut: per-module test files, a flat `tools/`, vulture now scanning `zipdepth/catalog`, and one long-lived builder per producer slot instead of `num_producers` new builders (and CUDA streams) per pass.

## This PR
`zipdepth-catalog-train-smoke` is the end-to-end proof for the lane: collect a fixed deterministic probe set from two catalog segments, score the released weights on it, fine-tune 120 steps, assert the probe loss fell, resume, run one `torchrun` leg, and load both checkpoints through `ZipDepthPredictor` before publishing the run directory. `run_required` / `example_rgb` / `publish_latest` move out of the pre-existing `train_smoke` so both smokes share them.

**Review focus**: `collect_probe_batches` (why a windowed mean over the live stream is not a learning signal: later sections of a scene score ~2.5× worse under frozen weights); probe determinism (eval transform, one producer, `shuffle_buffer_size=1`); the `train_smoke.py` refactor belongs to the non-catalog lane.

**Gates**: lint ✓ · pyrefly 0 errors ✓ · deadcode ✓ · 49 passed (catalog env) · 37 passed / 2 skipped (`zipdepth-dev`) ✓
Live: `zipdepth-catalog-train-smoke` passed — fixed-probe loss released 0.752 → trained 0.549 after 120 steps, resume + torchrun legs, both checkpoints load through `ZipDepthPredictor`; `zipdepth-train-smoke` (non-catalog lane, whose helpers moved) passed.

## Results (overnight run, stack 1–4)
| | before | after |
|---|---:|---:|
| data-wait per step | 481 ms | 0 ms |
| GPU utilization | 4% | 92% |
| throughput | 17 f/s | 151 f/s (~1 h per pass over the corpus) |

Holdout (20 segments, scored at training resolution 768): fine-tuned **AbsRel 0.086 / δ1 0.922** vs released 0.094 / 0.913.

## Things learned the hard way
- Windowed train-loss gates on an ordered stream measure scene difficulty, not learning → the smoke scores a fixed probe set.
- Fine-tuning a BatchNorm-heavy net degrades eval even at lr=0 (running-stat drift) → BatchNorm pinned to eval.
- `config/10` diverges after warmup at small batch; `config/100` works.
- No GPU PNG decoder exists anywhere (nvImageCodec's PNG path is `cv::imdecode`; nvCOMP on a single IDAT is 180 ms). libdeflate + threads is the answer.
- `pixi lock --check` is red on `main` under pixi 0.78 (v7 platform-alias re-keying) — a separate workspace PR.

## Follow-ups
Nested `CatalogStreamConfig` for the three tyro configs · `TrainPlan` decomposition of `train_catalog.main` · batched holdout eval · shared zero-copy Arrow views in `simplecv`/`prompt-da` · flat-frame statistic at ingest · viewer pixel side-by-side (released vs fine-tuned) before undrafting.

Reports: [time budget](https://pablos-4800gt.ilish-ruler.ts.net:8768/zipdepth/data-pipeline-time-budget.html) · [before/after](https://pablos-4800gt.ilish-ruler.ts.net:8768/zipdepth/data-pipeline-before-after.html) · [GPU PNG research](https://pablos-4800gt.ilish-ruler.ts.net:8768/zipdepth/gpu-png-decode-research.html)
