### PR TITLE
monoprior: make the depth-compare app serve ZipDepth over the tailnet

### DIFF
--- a/packages/monoprior/monopriors/apis/depth_compare_app.py
+++ b/packages/monoprior/monopriors/apis/depth_compare_app.py
@@ -1,0 +1,59 @@
+"""Gradio depth-comparison app: side-by-side relative/metric depth models in an embedded Rerun viewer."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import gradio as gr
+
+from monopriors.gradio_ui.depth_compare_ui import EXAMPLE_DATA_DIR, relative_compare_block
+from monopriors.gradio_ui.depth_inference_ui import depth_inference_block
+
+
+@dataclass
+class DepthCompareAppConfig:
+    """Server settings for the depth-comparison Gradio app."""
+
+    server_name: str = "127.0.0.1"
+    """Interface to bind. Keep loopback and front it with ``tailscale serve --https=<port>`` for the tailnet."""
+
+    port: int = 7861
+    """Port to bind."""
+
+    root_path: str = ""
+    """Root path for reverse-proxy deployments that mount the app under a sub-path (e.g. ``/depth-compare``).
+    Leave empty when the proxy forwards ``/`` unchanged, as ``tailscale serve --https=<port>`` does."""
+
+    allowed_paths: tuple[Path, ...] = ()
+    """Extra directories Gradio may serve files from; the example-image directory is always allowed."""
+
+
+def build_demo() -> gr.Blocks:
+    """Assemble the two-tab app (comparison + single-model inference)."""
+    with gr.Blocks(title="Depth Comparison") as demo:
+        gr.Markdown("# Depth Comparison")
+        gr.Markdown("Demo to help compare different depth models. Including both Scale | Shift Invariant and Metric Depth types.")
+        gr.Markdown(
+            "Invariant models mean they have no true scale and are only relative, "
+            "where as Metric models have a true scale and are absolute (meters)."
+        )
+        gr.Markdown(
+            "Checkout the [Github Repo](https://github.com/pablovela5620/monoprior) "
+            "[![GitHub Repo stars](https://img.shields.io/github/stars/pablovela5620/monoprior)](https://github.com/pablovela5620/monoprior)"
+        )
+        gr.Markdown("### Depth Prediction demo")
+        with gr.Tab(label="Depth Comparison"):
+            relative_compare_block.render()
+        with gr.Tab(label="Depth Inference"):
+            depth_inference_block.render()
+    return demo
+
+
+def main(config: DepthCompareAppConfig) -> None:
+    demo = build_demo()
+    demo.queue().launch(
+        server_name=config.server_name,
+        server_port=config.port,
+        root_path=config.root_path or None,
+        allowed_paths=[str(EXAMPLE_DATA_DIR), *(str(p) for p in config.allowed_paths)],
+        ssr_mode=False,
+    )

--- a/packages/monoprior/monopriors/gradio_ui/depth_compare_ui.py
+++ b/packages/monoprior/monopriors/gradio_ui/depth_compare_ui.py
@@ -1,6 +1,6 @@
 import gc
 from pathlib import Path
-from typing import Literal, get_args, overload
+from typing import Final, Literal, get_args, overload
 
 import cv2
 import gradio as gr
@@ -36,6 +36,8 @@ except ImportError:
 
 model_load_status: str = "Models loaded and ready to use!"
 DEVICE: Literal["cuda"] | Literal["cpu"] = "cuda" if torch.cuda.is_available() else "cpu"
+EXAMPLE_DATA_DIR: Final[Path] = Path(__file__).resolve().parents[2] / "data" / "examples" / "single-image"
+"""Fetched by the ``_monoprior-download-single-image`` pixi task; the app task depends on it."""
 
 
 @overload
@@ -89,6 +91,8 @@ def _relative_predictor_name(model_name: RELATIVE_PREDICTORS | METRIC_PREDICTORS
             return "UniDepthRelativePredictor"
         case "MoGeV1Predictor":
             return "MoGeV1Predictor"
+        case "ZipDepthPredictor":
+            return "ZipDepthPredictor"
         case _:
             raise gr.Error(f"{model_name} is not a relative depth predictor.")
 
@@ -154,6 +158,7 @@ def on_submit(
                 rgb_hw3=rgb,
                 remove_flying_pixels=remove_flying_pixels,
                 depth_edge_threshold=depth_map_threshold,
+                log_disparity=True,  # the compare blueprint carves out a disparity view per model
             )
 
     return stream.read() or b""
@@ -232,10 +237,7 @@ with gr.Blocks() as relative_compare_block:
         outputs=[model_1_dropdown, model_2_dropdown],
     )
 
-    # get all jpegs in examples path
-    examples_paths = Path("examples").glob("*.jpeg")
-    # set the examples to be the sorted list of input parameterss (path, remove_flying_pixels, depth_map_threshold)
-    examples_list = sorted([[str(path)] for path in examples_paths])
+    examples_list = sorted([str(path)] for path in EXAMPLE_DATA_DIR.glob("*.jp*g"))
     examples = gr.Examples(
         examples=examples_list,
         inputs=[input_image, remove_flying_pixels, depth_map_threshold, model_type, model_1_dropdown, model_2_dropdown],

--- a/packages/monoprior/monopriors/gradio_ui/depth_inference_ui.py
+++ b/packages/monoprior/monopriors/gradio_ui/depth_inference_ui.py
@@ -2,7 +2,7 @@ import gc
 import os
 import tempfile
 from pathlib import Path
-from typing import get_args
+from typing import Final, get_args
 
 import cv2
 import gradio as gr
@@ -28,6 +28,7 @@ except ImportError:
     print("Not running on Zero")
 
 model_load_status: str = "Models loaded and ready to use!"
+EXAMPLE_DATA_DIR: Final[Path] = Path(__file__).resolve().parents[2] / "data" / "examples" / "single-image"
 if gr.NO_RELOAD:
     DEPTH_PREDICTOR: BaseRelativePredictor = get_relative_predictor("MoGeV1Predictor")(device="cuda")
 
@@ -184,10 +185,7 @@ with gr.Blocks() as depth_inference_block:
             },
         )
 
-    # get all jpegs in examples path
-    examples_paths = Path("examples").glob("*.jpeg")
-    # set the examples to be the sorted list of input parameterss (path, remove_flying_pixels, depth_map_threshold)
-    examples_list = sorted([[str(path)] for path in examples_paths])
+    examples_list = sorted([str(path)] for path in EXAMPLE_DATA_DIR.glob("*.jp*g"))
     examples = gr.Examples(
         examples=examples_list,
         inputs=[

--- a/packages/monoprior/monopriors/rr_logging_utils.py
+++ b/packages/monoprior/monopriors/rr_logging_utils.py
@@ -130,7 +130,8 @@ def create_compare_depth_blueprint(
 ) -> rrb.Blueprint:
     # model_names: list[str] = [model.__class__.__name__ for model in models]
     contents = [
-        rrb.Spatial3DView(origin=f"{model_names[0]}"),
+        # disparity has no pinhole, so the 3D view can't back-project it; keep it out of the 3D view to avoid the warning badge
+        rrb.Spatial3DView(origin=f"{model_names[0]}", contents=["$origin/**", "- $origin/camera/disparity"]),
         rrb.Vertical(
             rrb.Spatial2DView(
                 origin=f"{model_names[0]}/camera/pinhole/image",
@@ -142,7 +143,8 @@ def create_compare_depth_blueprint(
                 origin=f"{model_names[0]}/camera/disparity",
             ),
         ),
-        rrb.Spatial3DView(origin=f"{model_names[1]}"),
+        # disparity has no pinhole, so the 3D view can't back-project it; keep it out of the 3D view to avoid the warning badge
+        rrb.Spatial3DView(origin=f"{model_names[1]}", contents=["$origin/**", "- $origin/camera/disparity"]),
         rrb.Vertical(
             rrb.Spatial2DView(
                 origin=f"{model_names[1]}/camera/pinhole/image",

--- a/packages/monoprior/tests/test_depth_compare_ui.py
+++ b/packages/monoprior/tests/test_depth_compare_ui.py
@@ -1,0 +1,33 @@
+"""Depth-compare UI: every registered predictor must be selectable from the model dropdowns.
+
+The dropdowns are populated from ``RELATIVE_PREDICTORS`` / ``METRIC_PREDICTORS``, while the submit
+handler narrows the chosen name through ``_relative_predictor_name`` / ``_metric_predictor_name``.
+A predictor registered in the Literal but missing from the narrowing match is shown to the user and
+then rejected with "is not a ... predictor" on submit.
+"""
+
+from typing import get_args
+
+import gradio as gr
+import pytest
+
+from monopriors.gradio_ui.depth_compare_ui import _metric_predictor_name, _relative_predictor_name
+from monopriors.models.metric_depth import METRIC_PREDICTORS
+from monopriors.models.relative_depth import RELATIVE_PREDICTORS
+
+
+@pytest.mark.parametrize("name", get_args(RELATIVE_PREDICTORS))
+def test_every_relative_predictor_is_selectable(name: str) -> None:
+    assert _relative_predictor_name(name) == name  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("name", get_args(METRIC_PREDICTORS))
+def test_every_metric_predictor_is_selectable(name: str) -> None:
+    assert _metric_predictor_name(name) == name  # type: ignore[arg-type]
+
+
+def test_cross_type_selection_is_rejected() -> None:
+    with pytest.raises(gr.Error):
+        _relative_predictor_name("UniDepthMetricPredictor")
+    with pytest.raises(gr.Error):
+        _metric_predictor_name("ZipDepthPredictor")

--- a/packages/monoprior/tools/apps/depth_compare_app.py
+++ b/packages/monoprior/tools/apps/depth_compare_app.py
@@ -1,26 +1,6 @@
-import gradio as gr
+import tyro
 
-from monopriors.gradio_ui.depth_compare_ui import relative_compare_block
-from monopriors.gradio_ui.depth_inference_ui import depth_inference_block
-
-title = "# Depth Comparison"
-description1 = (
-    """Demo to help compare different depth models. Including both Scale | Shift Invariant and Metric Depth types."""
-)
-description2 = """Invariant models mean they have no true scale and are only relative, where as Metric models have a true scale and are absolute (meters)."""
-description3 = """Checkout the [Github Repo](https://github.com/pablovela5620/monoprior) [![GitHub Repo stars](https://img.shields.io/github/stars/pablovela5620/monoprior)](https://github.com/pablovela5620/monoprior)"""
-model_load_status: str = "Models loaded and ready to use!"
-
-with gr.Blocks() as demo:
-    gr.Markdown(title)
-    gr.Markdown(description1)
-    gr.Markdown(description2)
-    gr.Markdown(description3)
-    gr.Markdown("### Depth Prediction demo")
-    with gr.Tab(label="Depth Comparison"):
-        relative_compare_block.render()
-    with gr.Tab(label="Depth Inference"):
-        depth_inference_block.render()
+from monopriors.apis.depth_compare_app import DepthCompareAppConfig, main
 
 if __name__ == "__main__":
-    demo.queue().launch()
+    main(tyro.cli(DepthCompareAppConfig))

--- a/pixi.toml
+++ b/pixi.toml
@@ -481,8 +481,9 @@ description = "Run monoprior (metric depth + normals) on example image"
 # ── App tasks (Gradio UIs) ──────────────────────────────────────────────
 [feature.monoprior.tasks.monoprior-depth-compare-app]
 cmd = "python tools/apps/depth_compare_app.py"
+depends-on = ["_monoprior-download-single-image"]
 cwd = "packages/monoprior"
-description = "Launch Gradio depth comparison UI"
+description = "Launch Gradio depth comparison UI (binds 127.0.0.1:7861; pass --port/--root-path to override)"
 
 [feature.monoprior.tasks.monoprior-calibration-app]
 cmd = "python tools/apps/calibration_app.py"


### PR DESCRIPTION
## What

Gets `monoprior-depth-compare-app` running behind `tailscale serve` with ZipDepth actually selectable.

- **Bug**: `_relative_predictor_name` had no `ZipDepthPredictor` case, so the dropdown offered it and submit rejected it with `gr.Error("... is not a relative depth predictor")`. New `tests/test_depth_compare_ui.py` asserts every registered relative/metric predictor round-trips through the narrowing helpers (and cross-type picks are rejected), so the next predictor added can't regress this.
- **Examples**: both tabs globbed a cwd-relative `examples/*.jpeg` (HF-Spaces relic; the dir doesn't exist). Now `data/examples/single-image`, and the app task `depends-on` `_monoprior-download-single-image`.
- **Launch config**: new `monopriors/apis/depth_compare_app.py` with a tyro `DepthCompareAppConfig` (`server_name`, `port`, `root_path`, `allowed_paths`; `ssr_mode=False` like the sibling apps). `tools/apps/depth_compare_app.py` is now a thin shim per AGENTS.md. `root_path` stays empty for `tailscale serve --https=<port>` (mounts at `/`); it's there for sub-path proxies.
- **Blueprint**: the compare blueprint always carved out a `/camera/disparity` pane per model, but the relative path never logged disparity → blank panes. Relative predictions now log disparity; the 3D views exclude `camera/disparity` because a `DepthImage` without a pinhole can't be back-projected (was a warning badge on the 3D views).

## Validation

Served at `https://pablo-dl-server.ilish-ruler.ts.net:7861` (`tailscale serve --bg --https=7861 http://127.0.0.1:7861`), driven with headless playwright at 1920×1080: example `room.jpg`, Model1 = ZipDepthPredictor, Model2 = MoGeV1Predictor, Compare Depth. Server log shows `Loading ZipDepth model... 0.15s`; the embedded Rerun viewer renders both point clouds and all six 2D panes. Evidence (4 screenshots + notes): `/tmp/rerun-viewer-validation/20260828-085351-monoprior-depth-compare/` on pablo-dl-server.

Gates (`monoprior-dev`): ruff clean, pyrefly 0 errors, vulture clean, 17 tests pass.

Independent of #129 (nothing under `packages/monoprior` differs between that branch and `main`; the cherry-pick onto `main` is conflict-free).