### PR TITLE
arkitscenes-download: depth-PNG decoders and landscape_quarter_turns (stack 1/5)

### DIFF
--- a/packages/arkitscenes-download/arkitscenes_download/ingest/cells.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/cells.py
@@ -19,38 +19,37 @@ def component_instance(value: Any, column_name: str) -> Any:
     return value
 
 
-def landscape_quarter_turns(row: dict[str, Any]) -> int:
-    """Return counter-clockwise quarter turns that bring a stored segment to landscape; 0 for landscape segments.
+def segment_property(row: dict[str, Any], name: str) -> Any:
+    """Return one segment property as a scalar.
 
-    Args:
-        row: Catalog segment row with scalar- or list-shaped orientation properties.
-
-    Returns:
-        Counter-clockwise quarter turns in ``[0, 3]``.
+    Segment rows come from the catalog reader's ``to_pylist()`` as untyped cells whose shape
+    depends on the column: a scalar, a one-element list, a one-element array, or a nested
+    component instance. This is the one place that narrows that shape; callers validate the value.
 
     Raises:
-        KeyError: If a required portrait property is absent.
-        ValueError: If a property is empty or invalid.
+        KeyError: If the property is absent or null.
+        ValueError: If the property cell does not hold exactly one value.
     """
-    orientation_name: str = "property:capture:orientation"
-    if orientation_name not in row or row[orientation_name] is None:
-        raise KeyError(f"segment {row.get('rerun_segment_id', '<unknown>')!r} is missing {orientation_name!r}")
-    orientation: Any = component_instance(row[orientation_name], orientation_name)
-    if isinstance(orientation, (list, np.ndarray)):
-        if len(orientation) != 1:
-            raise ValueError(f"column {orientation_name!r} must contain one value")
-        orientation = orientation[0]
-    if orientation not in ("portrait", "landscape"):
-        raise ValueError(f"column {orientation_name!r} has invalid value {orientation!r}")
-    if orientation == "landscape":
-        return 0
+    if row.get(name) is None:
+        raise KeyError(f"segment {row.get('rerun_segment_id', '<unknown>')!r} is missing {name!r}")
+    value: Any = component_instance(row[name], name)
+    if isinstance(value, (list, np.ndarray)):
+        if len(value) != 1:
+            raise ValueError(f"column {name!r} must contain one value")
+        value = value[0]
+    return value
 
-    turns_name: str = "property:capture:orientation_quarter_turns_ccw"
-    if turns_name not in row or row[turns_name] is None:
-        raise KeyError(f"segment {row.get('rerun_segment_id', '<unknown>')!r} is missing {turns_name!r}")
-    turns: Any = component_instance(row[turns_name], turns_name)
-    if isinstance(turns, (list, np.ndarray)):
-        if len(turns) != 1:
-            raise ValueError(f"column {turns_name!r} must contain one value")
-        turns = turns[0]
-    return (-int(turns)) % 4
+
+def portrait_from_segment_row(row: dict[str, Any]) -> bool:
+    """Return whether the segment was captured in portrait, from its stored orientation property."""
+    orientation: Any = segment_property(row, "property:capture:orientation")
+    if orientation not in ("portrait", "landscape"):
+        raise ValueError(f"column 'property:capture:orientation' has invalid value {orientation!r}")
+    return orientation == "portrait"
+
+
+def landscape_quarter_turns(row: dict[str, Any]) -> int:
+    """Return counter-clockwise quarter turns that bring a stored segment to landscape; 0 for landscape segments."""
+    if not portrait_from_segment_row(row):
+        return 0
+    return (-int(segment_property(row, "property:capture:orientation_quarter_turns_ccw"))) % 4

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/cells.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/cells.py
@@ -17,3 +17,40 @@ def component_instance(value: Any, column_name: str) -> Any:
         if len(value) == 1 and isinstance(value[0], (list, np.ndarray, bytes)):
             return value[0]
     return value
+
+
+def landscape_quarter_turns(row: dict[str, Any]) -> int:
+    """Return counter-clockwise quarter turns that bring a stored segment to landscape; 0 for landscape segments.
+
+    Args:
+        row: Catalog segment row with scalar- or list-shaped orientation properties.
+
+    Returns:
+        Counter-clockwise quarter turns in ``[0, 3]``.
+
+    Raises:
+        KeyError: If a required portrait property is absent.
+        ValueError: If a property is empty or invalid.
+    """
+    orientation_name: str = "property:capture:orientation"
+    if orientation_name not in row or row[orientation_name] is None:
+        raise KeyError(f"segment {row.get('rerun_segment_id', '<unknown>')!r} is missing {orientation_name!r}")
+    orientation: Any = component_instance(row[orientation_name], orientation_name)
+    if isinstance(orientation, (list, np.ndarray)):
+        if len(orientation) != 1:
+            raise ValueError(f"column {orientation_name!r} must contain one value")
+        orientation = orientation[0]
+    if orientation not in ("portrait", "landscape"):
+        raise ValueError(f"column {orientation_name!r} has invalid value {orientation!r}")
+    if orientation == "landscape":
+        return 0
+
+    turns_name: str = "property:capture:orientation_quarter_turns_ccw"
+    if turns_name not in row or row[turns_name] is None:
+        raise KeyError(f"segment {row.get('rerun_segment_id', '<unknown>')!r} is missing {turns_name!r}")
+    turns: Any = component_instance(row[turns_name], turns_name)
+    if isinstance(turns, (list, np.ndarray)):
+        if len(turns) != 1:
+            raise ValueError(f"column {turns_name!r} must contain one value")
+        turns = turns[0]
+    return (-int(turns)) % 4

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/depth.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/depth.py
@@ -7,8 +7,12 @@ from pathlib import Path
 
 import imagecodecs
 import numpy as np
+from jaxtyping import Shaped, UInt8, UInt16
+from numpy import ndarray
 
 from arkitscenes_download.ingest.clock import timestamp_from_path
+
+_PNG_SIGNATURE: bytes = b"\x89PNG\r\n\x1a\n"
 
 
 class ArkitDepthConfidence(IntEnum):
@@ -24,7 +28,7 @@ def _png_chunk(tag: bytes, data: bytes) -> bytes:
     return struct.pack(">I", len(data)) + tag + data + struct.pack(">I", zlib.crc32(tag + data))
 
 
-def encode_depth_png(image_hw: np.ndarray, level: int = 4) -> bytes:
+def encode_depth_png(image_hw: UInt16[ndarray, "h w"], level: int = 4) -> bytes:
     """Encode a standard 16-bit grayscale PNG with an Up filter and libdeflate.
 
     Level 4 favors size for ingest's write-once assets; inference-time encoders
@@ -39,6 +43,122 @@ def encode_depth_png(image_hw: np.ndarray, level: int = 4) -> bytes:
     idat: bytes = imagecodecs.deflate_encode(up_hw2.tobytes(), level=level, raw=False)  # pyrefly: ignore  # bad-assignment
     ihdr: bytes = struct.pack(">IIBBBBB", image_hw.shape[1], image_hw.shape[0], 16, 0, 0, 0, 0)
     return b"\x89PNG\r\n\x1a\n" + _png_chunk(b"IHDR", ihdr) + _png_chunk(b"IDAT", idat) + _png_chunk(b"IEND", b"")
+
+
+def inflate_depth_png_rows(blob_u8: UInt8[ndarray, "n"]) -> tuple[UInt8[ndarray, "h row_bytes"], tuple[int, int]] | None:
+    """Inflate filtered rows from an encoder-contract depth PNG.
+
+    The fast contract is a non-interlaced 16-bit grayscale PNG with the Up
+    filter on every row, exactly as :func:`encode_depth_png` writes it. PNG CRCs
+    are skipped because catalog ingest already validated stored blobs.
+
+    Args:
+        blob_u8: Complete encoded PNG bytes with shape ``(N,)`` and dtype uint8.
+
+    Returns:
+        Filtered rows and ``(height, width)``, or None when a valid PNG is
+        outside the encoder contract.
+
+    Raises:
+        ValueError: If the PNG structure is truncated or malformed.
+    """
+    if blob_u8.ndim != 1:
+        raise ValueError("depth PNG blob must be one-dimensional")
+    blob_view: memoryview = memoryview(blob_u8)
+    if len(blob_view) < len(_PNG_SIGNATURE) or bytes(blob_view[:8]) != _PNG_SIGNATURE:
+        raise ValueError("invalid PNG signature")
+
+    position: int = len(_PNG_SIGNATURE)
+    width: int | None = None
+    height: int | None = None
+    fast_ihdr: bool = False
+    idat_payloads: list[memoryview] = []
+    while position < len(blob_view):
+        if position + 12 > len(blob_view):
+            raise ValueError("truncated PNG chunk header")
+        length: int = struct.unpack_from(">I", blob_view, position)[0]
+        payload_start: int = position + 8
+        payload_end: int = payload_start + length
+        chunk_end: int = payload_end + 4
+        if chunk_end > len(blob_view):
+            raise ValueError("truncated PNG chunk payload")
+        tag: bytes = bytes(blob_view[position + 4 : position + 8])
+        payload: memoryview = blob_view[payload_start:payload_end]
+        position = chunk_end
+        if tag == b"IHDR":
+            if length != 13:
+                raise ValueError("PNG IHDR must contain 13 bytes")
+            width, height, bit_depth, color_type, compression, filter_method, interlace = struct.unpack(">IIBBBBB", payload)
+            if width <= 0 or height <= 0:
+                raise ValueError("PNG dimensions must be positive")
+            fast_ihdr = (bit_depth, color_type, compression, filter_method, interlace) == (16, 0, 0, 0, 0)
+        elif tag == b"IDAT":
+            idat_payloads.append(payload)
+        elif tag == b"IEND":
+            break
+
+    if width is None or height is None:
+        raise ValueError("PNG has no IHDR chunk")
+    if not idat_payloads:
+        raise ValueError("PNG has no IDAT chunk")
+    if not fast_ihdr:
+        return None
+
+    row_bytes: int = 1 + 2 * width
+    inflated_size: int = height * row_bytes
+    inflated_n: UInt8[ndarray, "inflated_size"] = np.empty(inflated_size, dtype=np.uint8)
+    compressed: memoryview | bytes = idat_payloads[0] if len(idat_payloads) == 1 else b"".join(idat_payloads)
+    inflated_result: bytes | bytearray | memoryview = imagecodecs.deflate_decode(compressed, out=memoryview(inflated_n), raw=False)
+    if len(inflated_result) != inflated_size:
+        raise ValueError(f"PNG inflated to {len(inflated_result)} bytes, expected {inflated_size}")
+    filtered_hwb: UInt8[ndarray, "h row_bytes"] = inflated_n.reshape(height, row_bytes)
+    filter_types_h: UInt8[ndarray, "h"] = filtered_hwb[:, 0]
+    if not bool(np.all(filter_types_h == 2)):
+        return None
+    return filtered_hwb, (height, width)
+
+
+def decode_depth_png_fast(blob_u8: UInt8[ndarray, "n"]) -> UInt16[ndarray, "h w"] | None:
+    """Decode an encoder-contract depth PNG without a general PNG codec.
+
+    Args:
+        blob_u8: Complete encoded PNG bytes with shape ``(N,)`` and dtype uint8.
+
+    Returns:
+        Native-endian uint16 depth with shape ``(H, W)``, or None when the PNG
+        is outside the encoder contract.
+    """
+    inflated: tuple[UInt8[ndarray, "h row_bytes"], tuple[int, int]] | None = inflate_depth_png_rows(blob_u8)
+    if inflated is None:
+        return None
+    filtered_hwb: UInt8[ndarray, "h row_bytes"] = inflated[0]
+    height: int = inflated[1][0]
+    width: int = inflated[1][1]
+    reconstructed_hwb: UInt8[ndarray, "h pixel_bytes"] = filtered_hwb[:, 1:].copy()
+    row: int
+    for row in range(1, height):
+        reconstructed_hwb[row] += reconstructed_hwb[row - 1]
+    big_endian_hw: Shaped[ndarray, "h w"] = reconstructed_hwb.view(">u2").reshape(height, width)
+    return big_endian_hw.astype(np.uint16, copy=True)
+
+
+def decode_depth_png(blob_u8: UInt8[ndarray, "n"]) -> UInt16[ndarray, "h w"]:
+    """Decode a general PNG and enforce the depth-image contract.
+
+    Args:
+        blob_u8: Complete encoded PNG bytes with shape ``(N,)`` and dtype uint8.
+
+    Returns:
+        Native-endian uint16 depth with shape ``(H, W)``.
+
+    Raises:
+        RuntimeError: If decoding does not produce a two-dimensional uint16 image.
+    """
+    decoded: ndarray = imagecodecs.png_decode(np.ascontiguousarray(blob_u8))
+    if decoded.dtype != np.uint16 or decoded.ndim != 2:
+        raise RuntimeError("depth PNG failed to decode as a two-dimensional uint16 image")
+    depth_mm_hw: UInt16[ndarray, "h w"] = decoded
+    return depth_mm_hw
 
 
 def sorted_timestamped_paths(directory: Path, suffix: str = ".png") -> list[Path]:

--- a/packages/arkitscenes-download/arkitscenes_download/ingest/depth.py
+++ b/packages/arkitscenes-download/arkitscenes_download/ingest/depth.py
@@ -134,10 +134,8 @@ def decode_depth_png_fast(blob_u8: UInt8[ndarray, "n"]) -> UInt16[ndarray, "h w"
     filtered_hwb: UInt8[ndarray, "h row_bytes"] = inflated[0]
     height: int = inflated[1][0]
     width: int = inflated[1][1]
-    reconstructed_hwb: UInt8[ndarray, "h pixel_bytes"] = filtered_hwb[:, 1:].copy()
-    row: int
-    for row in range(1, height):
-        reconstructed_hwb[row] += reconstructed_hwb[row - 1]
+    # Undo the Up filter: each byte is the sum of the bytes above it, modulo 256.
+    reconstructed_hwb: UInt8[ndarray, "h pixel_bytes"] = np.cumsum(filtered_hwb[:, 1:], axis=0, dtype=np.uint8)
     big_endian_hw: Shaped[ndarray, "h w"] = reconstructed_hwb.view(">u2").reshape(height, width)
     return big_endian_hw.astype(np.uint16, copy=True)
 

--- a/packages/arkitscenes-download/tests/test_cells.py
+++ b/packages/arkitscenes-download/tests/test_cells.py
@@ -3,7 +3,34 @@
 import numpy as np
 import pytest
 
-from arkitscenes_download.ingest.cells import landscape_quarter_turns
+from arkitscenes_download.ingest.cells import landscape_quarter_turns, portrait_from_segment_row, segment_property
+
+
+@pytest.mark.parametrize(
+    ("cell", "expected"),
+    [("portrait", "portrait"), (["portrait"], "portrait"), (np.array([3]), 3), ([[7]], 7)],
+)
+def test_segment_property_narrows_every_reader_cell_shape(cell: object, expected: object) -> None:
+    """Return the one scalar behind a scalar, list, array, or nested component cell."""
+    assert segment_property({"property:x": cell}, "property:x") == expected
+
+
+def test_segment_property_rejects_missing_and_multi_valued_cells() -> None:
+    """Name the segment when a property is absent; refuse cells with several values."""
+    with pytest.raises(KeyError, match="'seg-1' is missing 'property:x'"):
+        segment_property({"rerun_segment_id": "seg-1", "property:x": None}, "property:x")
+    with pytest.raises(ValueError, match="exactly one value|must contain one value"):
+        segment_property({"property:x": ["a", "b"]}, "property:x")
+
+
+def test_portrait_from_segment_row_validates_the_orientation_value() -> None:
+    """Map the stored orientation to a portrait flag and reject anything else."""
+    assert portrait_from_segment_row({"property:capture:orientation": ["portrait"]}) is True
+    assert portrait_from_segment_row({"property:capture:orientation": "landscape"}) is False
+    with pytest.raises(ValueError, match="invalid value 'upside-down'"):
+        portrait_from_segment_row({"property:capture:orientation": "upside-down"})
+    with pytest.raises(KeyError, match="orientation"):
+        portrait_from_segment_row({})
 
 
 @pytest.mark.parametrize(
@@ -16,9 +43,10 @@ from arkitscenes_download.ingest.cells import landscape_quarter_turns
             },
             3,
         ),
+        ({"property:capture:orientation": ["portrait"], "property:capture:orientation_quarter_turns_ccw": [3]}, 1),
         ({"property:capture:orientation": "landscape"}, 0),
     ],
 )
-def test_landscape_quarter_turns_parses_list_and_scalar_properties(row: dict[str, object], expected: int) -> None:
-    """Return the counter-clockwise rotation that restores stored frames to landscape."""
+def test_landscape_quarter_turns_undoes_the_stored_rotation(row: dict[str, object], expected: int) -> None:
+    """Return the counter-clockwise rotation that restores stored frames to landscape; landscape needs no turns property."""
     assert landscape_quarter_turns(row) == expected

--- a/packages/arkitscenes-download/tests/test_cells.py
+++ b/packages/arkitscenes-download/tests/test_cells.py
@@ -1,0 +1,24 @@
+"""Behavior checks for catalog cell parsing."""
+
+import numpy as np
+import pytest
+
+from arkitscenes_download.ingest.cells import landscape_quarter_turns
+
+
+@pytest.mark.parametrize(
+    ("row", "expected"),
+    [
+        (
+            {
+                "property:capture:orientation": ["portrait"],
+                "property:capture:orientation_quarter_turns_ccw": np.array([1]),
+            },
+            3,
+        ),
+        ({"property:capture:orientation": "landscape"}, 0),
+    ],
+)
+def test_landscape_quarter_turns_parses_list_and_scalar_properties(row: dict[str, object], expected: int) -> None:
+    """Return the counter-clockwise rotation that restores stored frames to landscape."""
+    assert landscape_quarter_turns(row) == expected

--- a/packages/arkitscenes-download/tests/test_depth_png.py
+++ b/packages/arkitscenes-download/tests/test_depth_png.py
@@ -1,0 +1,84 @@
+"""Bit-exact tests for the canonical ARKitScenes depth PNG decoders."""
+
+import struct
+import zlib
+
+import cv2
+import numpy as np
+import pytest
+from jaxtyping import UInt8, UInt16
+from numpy import ndarray
+from numpy.testing import assert_array_equal
+
+from arkitscenes_download.ingest.depth import decode_depth_png, decode_depth_png_fast, encode_depth_png, inflate_depth_png_rows
+
+
+def _structured_depth() -> UInt16[ndarray, "h w"]:
+    """Build deterministic metric depth with both smooth structure and noise."""
+    rng: np.random.Generator = np.random.default_rng(7)
+    y_h1: UInt16[ndarray, "h 1"] = np.linspace(100, 2800, 96, dtype=np.uint16)[:, None]
+    x_1w: UInt16[ndarray, "1 w"] = np.linspace(0, 900, 128, dtype=np.uint16)[None, :]
+    noise_hw: UInt16[ndarray, "h w"] = rng.integers(0, 301, (96, 128), dtype=np.uint16)
+    return np.clip(y_h1 + x_1w + noise_hw, 100, 4000).astype(np.uint16)
+
+
+@pytest.mark.parametrize("level", [1, 4])
+def test_fast_and_general_decoders_match_ingest_pngs(level: int) -> None:
+    """Decode representative Up-filtered ingest PNGs bit-exactly."""
+    expected_hw: UInt16[ndarray, "h w"] = _structured_depth()
+    blob_u8: UInt8[ndarray, "n"] = np.frombuffer(encode_depth_png(expected_hw, level=level), dtype=np.uint8)
+
+    fast_hw: UInt16[ndarray, "h w"] | None = decode_depth_png_fast(blob_u8)
+    general_hw: UInt16[ndarray, "h w"] = decode_depth_png(blob_u8)
+
+    assert fast_hw is not None
+    assert fast_hw.dtype == np.uint16
+    assert_array_equal(fast_hw, expected_hw)
+    assert_array_equal(general_hw, expected_hw)
+
+
+def test_fast_decoder_declines_non_up_filters_and_general_decoder_handles_them() -> None:
+    """Return None outside the fast contract without weakening the general decoder."""
+    expected_hw: UInt16[ndarray, "h w"] = _structured_depth()
+    encoded: tuple[bool, ndarray] = cv2.imencode(".png", expected_hw)
+    assert encoded[0]
+    blob_u8: UInt8[ndarray, "n"] = encoded[1]
+
+    assert inflate_depth_png_rows(blob_u8) is None
+    assert decode_depth_png_fast(blob_u8) is None
+    assert_array_equal(decode_depth_png(blob_u8), expected_hw)
+
+
+def test_fast_decoder_concatenates_multiple_idat_chunks() -> None:
+    """Decode one zlib stream split across two consecutive IDAT chunks."""
+    expected_hw: UInt16[ndarray, "h w"] = _structured_depth()
+    original: bytes = encode_depth_png(expected_hw, level=1)
+    position: int = 8
+    chunks: list[bytes] = []
+    while position < len(original):
+        length: int = struct.unpack_from(">I", original, position)[0]
+        tag: bytes = original[position + 4 : position + 8]
+        payload: bytes = original[position + 8 : position + 8 + length]
+        position += length + 12
+        if tag == b"IDAT":
+            midpoint: int = len(payload) // 2
+            for half in (payload[:midpoint], payload[midpoint:]):
+                chunks.append(struct.pack(">I", len(half)) + tag + half + struct.pack(">I", zlib.crc32(tag + half)))
+        else:
+            chunks.append(struct.pack(">I", length) + tag + payload + struct.pack(">I", zlib.crc32(tag + payload)))
+    blob_u8: UInt8[ndarray, "n"] = np.frombuffer(b"\x89PNG\r\n\x1a\n" + b"".join(chunks), dtype=np.uint8)
+
+    actual_hw: UInt16[ndarray, "h w"] | None = decode_depth_png_fast(blob_u8)
+
+    assert actual_hw is not None
+    assert_array_equal(actual_hw, expected_hw)
+
+
+def test_general_decoder_rejects_wrong_bit_depth() -> None:
+    """Reject an 8-bit image after the decoder reports a non-depth dtype."""
+    image_hw: UInt8[ndarray, "h w"] = np.arange(64, dtype=np.uint8).reshape(8, 8)
+    encoded: tuple[bool, ndarray] = cv2.imencode(".png", image_hw)
+    assert encoded[0]
+
+    with pytest.raises(RuntimeError, match="uint16"):
+        decode_depth_png(encoded[1])

--- a/packages/arkitscenes-download/tests/test_timestamps.py
+++ b/packages/arkitscenes-download/tests/test_timestamps.py
@@ -1,0 +1,49 @@
+"""Behavior checks for exact catalog timestamp matching."""
+
+import numpy as np
+import pyarrow as pa
+import pytest
+from jaxtyping import Int64, Shaped
+from numpy import ndarray
+from numpy.testing import assert_array_equal
+
+from arkitscenes_download.ingest.paths import TIMELINE
+from arkitscenes_download.ingest.timestamps import match_exact_timestamps, table_timestamps
+
+
+def test_table_timestamps_returns_the_timeline_column_as_timedelta_ns() -> None:
+    """Read a chunked catalog timeline column into one ``timedelta64[ns]`` array."""
+    first_chunk: pa.Array = pa.array([100, 200], type=pa.duration("ns"))
+    second_chunk: pa.Array = pa.array([300], type=pa.duration("ns"))
+    table: pa.Table = pa.Table.from_batches(
+        [
+            pa.record_batch({TIMELINE: first_chunk}),
+            pa.record_batch({TIMELINE: second_chunk}),
+        ]
+    )
+
+    times_n: Shaped[ndarray, "3"] = table_timestamps(table)
+
+    assert times_n.dtype == np.dtype("timedelta64[ns]")
+    assert_array_equal(times_n, np.array([100, 200, 300], dtype="timedelta64[ns]"))
+
+
+def test_match_exact_timestamps_maps_packet_positions() -> None:
+    """Map each chosen timestamp to its exact packet position."""
+    packet_times_n: Shaped[ndarray, "4"] = np.array([100, 200, 300, 400], dtype="timedelta64[ns]")
+    chosen_times_n: Shaped[ndarray, "3"] = np.array([100, 300, 400], dtype="timedelta64[ns]")
+
+    packet_indices_n: Int64[ndarray, "3"] = match_exact_timestamps(packet_times_n, chosen_times_n)
+
+    assert packet_indices_n.dtype == np.int64
+    assert_array_equal(packet_indices_n, np.array([0, 2, 3], dtype=np.int64))
+
+
+@pytest.mark.parametrize("chosen_ns", [250, 500])
+def test_match_exact_timestamps_rejects_missing_packet_times(chosen_ns: int) -> None:
+    """Reject missing timestamps both within and beyond the packet range."""
+    packet_times_n: Shaped[ndarray, "4"] = np.array([100, 200, 300, 400], dtype="timedelta64[ns]")
+    chosen_times_n: Shaped[ndarray, "1"] = np.array([chosen_ns], dtype="timedelta64[ns]")
+
+    with pytest.raises(ValueError, match="no exact video-packet match"):
+        match_exact_timestamps(packet_times_n, chosen_times_n)

--- a/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_arkitscenes.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_arkitscenes.py
@@ -9,7 +9,6 @@ from collections.abc import Iterable, Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 import cv2
 import numpy as np
@@ -19,6 +18,7 @@ import rerun as rr
 import torch
 from arkitscenes_download.ingest.blueprint import DEPTH_RANGE_MM, make_blueprint
 from arkitscenes_download.ingest.catalog import DEFAULT_CATALOG_URL
+from arkitscenes_download.ingest.cells import landscape_quarter_turns, portrait_from_segment_row
 from arkitscenes_download.ingest.depth import encode_depth_png
 from arkitscenes_download.ingest.paths import DEPTH_PROMPTDA, PROMPTDA_MESH, TIMELINE
 from arkitscenes_download.ingest.recording import atomic_recording
@@ -118,34 +118,6 @@ class CompletedPromptDABatch:
     """Native frame height and width in catalog orientation."""
 
 
-def portrait_from_segment_row(row: dict[str, Any]) -> bool:
-    """Parse the required catalog orientation property from one segment row."""
-    property_name: str = "property:capture:orientation"
-    if property_name not in row or row[property_name] is None:
-        raise KeyError(f"segment {row.get('rerun_segment_id', '<unknown>')!r} is missing the orientation property")
-    value: Any = row[property_name]
-    if isinstance(value, (list, np.ndarray)):
-        if len(value) == 0:
-            raise ValueError(f"segment {row.get('rerun_segment_id', '<unknown>')!r} has an empty orientation property")
-        value = value[0]
-    if value not in ("portrait", "landscape"):
-        raise ValueError(f"segment {row.get('rerun_segment_id', '<unknown>')!r} has an invalid orientation property: {value!r}")
-    return value == "portrait"
-
-
-def orientation_quarter_turns_from_segment_row(row: dict[str, Any]) -> int:
-    """Parse the ingest rotation needed to undo a stored portrait segment."""
-    property_name: str = "property:capture:orientation_quarter_turns_ccw"
-    if property_name not in row or row[property_name] is None:
-        raise KeyError(f"segment {row.get('rerun_segment_id', '<unknown>')!r} is missing the orientation quarter-turn property")
-    value: Any = row[property_name]
-    if isinstance(value, (list, np.ndarray)):
-        if len(value) == 0:
-            raise ValueError(f"segment {row.get('rerun_segment_id', '<unknown>')!r} has an empty orientation quarter-turn property")
-        value = value[0]
-    return int(value) % 4
-
-
 def log_promptda_frame(
     recording: rr.RecordingStream, timestamp_ns: int, predicted_depth_hw: UInt16[ndarray, "h w"]
 ) -> None:
@@ -224,8 +196,7 @@ def fuse_and_log_batch(
 def grid_batches(
     dataset_entry: DatasetEntry,
     segment_id: str,
-    portrait: bool,
-    orientation_quarter_turns: int,
+    quarter_turns: int,
     config: PDAArkitScenesConfig,
 ) -> tuple[Iterator[PromptDABatch], int]:
     """Yield fixed-rate sampling-grid batches for one segment, plus the grid slot count."""
@@ -241,7 +212,7 @@ def grid_batches(
         collate_fn=PromptDACollate(
             samples,
             device,
-            quarter_turns=(-orientation_quarter_turns) % 4 if portrait else 0,
+            quarter_turns=quarter_turns,
             timestamp_step_ns=round(1_000_000_000 / NATIVE_FPS) * stride,
         ),
     )
@@ -329,12 +300,12 @@ def process_segment(
     dataset_entry: DatasetEntry,
     segment_id: str,
     portrait: bool,
-    orientation_quarter_turns: int,
+    quarter_turns: int,
     config: PDAArkitScenesConfig,
     predictor: PromptDATrtPredictor,
 ) -> SegmentResult:
     """Infer and fuse one catalog segment's sampling grid into a PromptDA RRD."""
-    batches, grid_slots = grid_batches(dataset_entry, segment_id, portrait, orientation_quarter_turns, config)
+    batches, grid_slots = grid_batches(dataset_entry, segment_id, quarter_turns, config)
     return run_segment(
         batches,
         segment_id,
@@ -365,9 +336,7 @@ def main(config: PDAArkitScenesConfig) -> None:
         batch_size=config.batch_size,
     )
     portrait_by_id: dict[str, bool] = {str(row["rerun_segment_id"]): portrait_from_segment_row(row) for row in rows}
-    orientation_quarter_turns_by_id: dict[str, int] = {
-        str(row["rerun_segment_id"]): orientation_quarter_turns_from_segment_row(row) for row in rows
-    }
+    quarter_turns_by_id: dict[str, int] = {str(row["rerun_segment_id"]): landscape_quarter_turns(row) for row in rows}
     results: list[SegmentResult] = []
     registration_handles: list[RegistrationHandle] = []
     for segment_id in segment_ids:
@@ -375,7 +344,7 @@ def main(config: PDAArkitScenesConfig) -> None:
             dataset_entry,
             segment_id,
             portrait_by_id[segment_id],
-            orientation_quarter_turns_by_id[segment_id],
+            quarter_turns_by_id[segment_id],
             config,
             predictor,
         )

--- a/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_chosen.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_chosen.py
@@ -20,7 +20,7 @@ import numpy as np
 import pyarrow as pa
 import torch
 from arkitscenes_download.ingest.catalog import DEFAULT_CATALOG_URL
-from arkitscenes_download.ingest.cells import component_instance
+from arkitscenes_download.ingest.cells import component_instance, landscape_quarter_turns, portrait_from_segment_row
 from arkitscenes_download.ingest.layer_batch import LayerBatchSummary, run_layer_batch, segment_ids_from_selection
 from arkitscenes_download.ingest.paths import CONFIDENCE, DEPTH, FRAME_SELECTION_WIDE, PINHOLE_WIDE, RIG, TIMELINE, VIDEO_WIDE
 from arkitscenes_download.ingest.timestamps import match_exact_timestamps, table_timestamps
@@ -35,8 +35,6 @@ from rerun_prompt_da.apis.arkitscenes_shared import NATIVE_FPS, connect_catalog,
 from rerun_prompt_da.apis.prompt_da_arkitscenes import (
     PROMPTDA_LAYER,
     SegmentResult,
-    orientation_quarter_turns_from_segment_row,
-    portrait_from_segment_row,
     run_segment,
 )
 from rerun_prompt_da.apis.prompt_da_trt_polycam import network_image_hw
@@ -162,7 +160,7 @@ def main(config: PDAChosenConfig) -> None:
     def generate(video_id: str, rrd_path: Path) -> str:
         row: dict[str, Any] = row_by_id[video_id]
         portrait: bool = portrait_from_segment_row(row)
-        quarter_turns: int = (-orientation_quarter_turns_from_segment_row(row)) % 4 if portrait else 0
+        quarter_turns: int = landscape_quarter_turns(row)
         result: SegmentResult = run_segment(
             chosen_batches(dataset, video_id, quarter_turns, config.batch_size),
             video_id,

--- a/packages/prompt-da/tests/test_prompt_da_arkitscenes.py
+++ b/packages/prompt-da/tests/test_prompt_da_arkitscenes.py
@@ -35,8 +35,6 @@ from rerun_prompt_da.apis.prompt_da_arkitscenes import (  # noqa: E402
     PDAArkitScenesConfig,
     fuse_and_log_batch,
     log_promptda_frame,
-    orientation_quarter_turns_from_segment_row,
-    portrait_from_segment_row,
 )
 from rerun_prompt_da.promptda_stream import PromptDACollate, promptda_dataset  # noqa: E402
 
@@ -158,23 +156,6 @@ def test_fuse_and_log_batch_preserves_frame_order_and_fusion_inputs(monkeypatch:
     assert logged_timestamps == [100, 200]
     assert len(fused_depths) == 2
     assert_array_equal(fused_depths[0], np.full((2, 3), 1500, dtype=np.uint16))
-
-
-def test_portrait_property_parses_catalog_list_value() -> None:
-    """Interpret the first catalog property value instead of list truthiness."""
-    assert portrait_from_segment_row({"property:capture:orientation": ["portrait"]}) is True
-    assert portrait_from_segment_row({"property:capture:orientation": ["landscape"]}) is False
-
-
-def test_portrait_property_is_required() -> None:
-    """Reject segments whose required orientation metadata is absent."""
-    with pytest.raises(KeyError, match="orientation"):
-        portrait_from_segment_row({})
-
-
-def test_orientation_quarter_turns_parses_catalog_list_value() -> None:
-    """Preserve ingest's stored rotation direction for portrait inference."""
-    assert orientation_quarter_turns_from_segment_row({"property:capture:orientation_quarter_turns_ccw": [3]}) == 3
 
 
 def test_stride_for_uses_nearest_native_frame_interval() -> None:


### PR DESCRIPTION
Stack **1/5** for ZipDepth catalog fine-tuning: this → #132 → #133 → #134 → #129. Standalone: nothing in the repo calls these yet; the tests are the contract. Merge bottom-up and retarget each child to `main` as its parent merges (never `--delete-branch` a stack parent — it closes the child).

**What**
- `ingest/depth.py`: the inverse of `encode_depth_png`, kept beside it. `inflate_depth_png_rows` + `decode_depth_png_fast` inflate the encoder's own fixed Up-filter 16-bit grayscale contract with libdeflate (no CRC, no generic filter dispatch) and return `None` for any other PNG; `decode_depth_png` is the general imagecodecs fallback. `encode_depth_png` gains the `UInt16[ndarray, "h w"]` annotation its four callers (gauss-surf, prompt-da ×2, ingest cli) already satisfy.
- `ingest/cells.py`: `landscape_quarter_turns(row)` — the two `capture:orientation*` segment properties → counter-clockwise `rot90` count.
- Tests: PNG round-trip (bit-exact vs imagecodecs), malformed input, orientation, and the existing `table_timestamps` / `match_exact_timestamps` contract from #128 (`table_timestamps` had no in-package consumer, so `deadcode` was red on `main`).

**Review focus**: the chunk walk in `inflate_depth_png_rows` (truncation checks, multi-IDAT concat, IHDR gate, "every filter byte is 2" gate) and the big-endian `.view(">u2")` in `decode_depth_png_fast`.

**Gates** (`arkitscenes-download-dev`): lint ✓ · pyrefly 0 errors ✓ · deadcode ✓ · 74 passed ✓
