### PR TITLE
zipdepth: catalog env lane and sample primitives (stack 2/5)

### DIFF
--- a/packages/zipdepth/pyproject.toml
+++ b/packages/zipdepth/pyproject.toml
@@ -33,7 +33,7 @@ ignore = ["E501", "F722", "F821", "UP037", "UP040"]
 
 [tool.vulture]
 # authored code only; the unmodified upstream tree is a vendor boundary
-paths = ["zipdepth/apis", "zipdepth/__init__.py", "tests", "tools"]
+paths = ["zipdepth/apis", "zipdepth/catalog", "zipdepth/__init__.py", "tests", "tools"]
 exclude = ["*/.pixi/*", "*/__pycache__/*"]
 sort_by_size = true
 min_confidence = 60

--- a/packages/zipdepth/tests/test_catalog_png.py
+++ b/packages/zipdepth/tests/test_catalog_png.py
@@ -1,0 +1,35 @@
+"""Bit-exact test for ZipDepth's CUDA PNG Up unfilter."""
+
+import numpy as np
+import pytest
+import torch
+from jaxtyping import UInt8, UInt16
+from numpy import ndarray
+from numpy.testing import assert_array_equal
+
+pytest.importorskip("imagecodecs", reason="Fast PNG inflate lives in the zipdepth catalog lane")
+pytest.importorskip("arkitscenes_download", reason="Representative depth encoding lives in the zipdepth catalog lane")
+
+from arkitscenes_download.ingest.depth import decode_depth_png, encode_depth_png, inflate_depth_png_rows  # noqa: E402
+
+from zipdepth.catalog.png import unfilter_up_cuda  # noqa: E402
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA Up reconstruction needs a GPU")
+def test_unfilter_up_cuda_matches_cpu_decode_for_ingest_pngs() -> None:
+    """Reconstruct Up-filtered uint16 depth on CUDA bit-exactly."""
+    rng: np.random.Generator = np.random.default_rng(7)
+    expected_hw: UInt16[ndarray, "h w"] = rng.integers(100, 4001, (96, 128), dtype=np.uint16)
+    blob_u8: UInt8[ndarray, "n"] = np.frombuffer(encode_depth_png(expected_hw, level=1), dtype=np.uint8)
+
+    inflated: tuple[UInt8[ndarray, "h row_bytes"], tuple[int, int]] | None = inflate_depth_png_rows(blob_u8)
+    assert inflated is not None
+    filtered_hwb: UInt8[ndarray, "h row_bytes"] = inflated[0]
+    assert inflated[1] == expected_hw.shape
+    filtered_cuda: torch.Tensor = torch.from_numpy(filtered_hwb).to(device="cuda")
+
+    actual_cuda: torch.Tensor = unfilter_up_cuda(filtered_cuda)
+
+    assert actual_cuda.dtype == torch.int32
+    assert actual_cuda.device.type == "cuda"
+    assert_array_equal(actual_cuda.cpu().numpy(), decode_depth_png(blob_u8))

--- a/packages/zipdepth/tests/test_catalog_stats.py
+++ b/packages/zipdepth/tests/test_catalog_stats.py
@@ -1,0 +1,34 @@
+"""Behavioral tests for catalog pipeline counters."""
+
+from dataclasses import fields
+
+from zipdepth.catalog.stats import STAGE_FIELDS, BuilderStats, CatalogDatasetStats, total
+
+
+def test_stage_fields_name_every_float_timer_of_the_dataset_stats() -> None:
+    """Keep the instrumentation's stage-timer list in step with the dataclass."""
+    float_fields: tuple[str, ...] = tuple(field.name for field in fields(CatalogDatasetStats) if field.type is float)
+
+    assert float_fields == STAGE_FIELDS
+
+
+def test_builder_stats_are_a_named_subset_of_the_dataset_stats() -> None:
+    """Let a dataset snapshot absorb every builder counter by field name."""
+    builder_names: set[str] = {field.name for field in fields(BuilderStats)}
+    dataset_names: set[str] = {field.name for field in fields(CatalogDatasetStats)}
+
+    assert builder_names == {"blob_decode", "augment", "samples_built", "png_fallbacks", "skipped_flat_frames"}
+    assert builder_names <= dataset_names
+    assert BuilderStats() == BuilderStats(blob_decode=0.0, augment=0.0, samples_built=0, png_fallbacks=0, skipped_flat_frames=0)
+
+
+def test_total_sums_field_wise_without_mutating_inputs() -> None:
+    """Fold any number of snapshots into one, leaving the operands untouched."""
+    first: CatalogDatasetStats = CatalogDatasetStats(segment_query=1.0, samples_built=2)
+    second: CatalogDatasetStats = CatalogDatasetStats(segment_query=0.5, video_decode=2.0, skipped_frames=3)
+
+    combined: CatalogDatasetStats = total([first, second])
+
+    assert combined == CatalogDatasetStats(segment_query=1.5, video_decode=2.0, samples_built=2, skipped_frames=3)
+    assert first == CatalogDatasetStats(segment_query=1.0, samples_built=2)
+    assert total([]) == CatalogDatasetStats()

--- a/packages/zipdepth/tests/test_catalog_stats.py
+++ b/packages/zipdepth/tests/test_catalog_stats.py
@@ -5,6 +5,20 @@ from dataclasses import fields
 from zipdepth.catalog.stats import STAGE_FIELDS, BuilderStats, CatalogDatasetStats, total
 
 
+def _every_field(scale: int) -> CatalogDatasetStats:
+    """Return stats with every field set to a distinct multiple of ``scale``."""
+    return CatalogDatasetStats(
+        segment_query=1.0 * scale,
+        video_decode=2.0 * scale,
+        blob_decode=3.0 * scale,
+        augment=4.0 * scale,
+        samples_built=5 * scale,
+        png_fallbacks=6 * scale,
+        skipped_frames=7 * scale,
+        skipped_flat_frames=8 * scale,
+    )
+
+
 def test_stage_fields_name_every_float_timer_of_the_dataset_stats() -> None:
     """Keep the instrumentation's stage-timer list in step with the dataclass."""
     float_fields: tuple[str, ...] = tuple(field.name for field in fields(CatalogDatasetStats) if field.type is float)
@@ -12,23 +26,25 @@ def test_stage_fields_name_every_float_timer_of_the_dataset_stats() -> None:
     assert float_fields == STAGE_FIELDS
 
 
-def test_builder_stats_are_a_named_subset_of_the_dataset_stats() -> None:
-    """Let a dataset snapshot absorb every builder counter by field name."""
+def test_builder_stats_lift_into_the_dataset_schema_by_name() -> None:
+    """Project builder-local counters onto the dataset counters; dataset-only fields stay zero."""
     builder_names: set[str] = {field.name for field in fields(BuilderStats)}
-    dataset_names: set[str] = {field.name for field in fields(CatalogDatasetStats)}
+    builder_stats: BuilderStats = BuilderStats(blob_decode=1.5, augment=0.5, samples_built=3, png_fallbacks=1, skipped_flat_frames=2)
 
-    assert builder_names == {"blob_decode", "augment", "samples_built", "png_fallbacks", "skipped_flat_frames"}
-    assert builder_names <= dataset_names
-    assert BuilderStats() == BuilderStats(blob_decode=0.0, augment=0.0, samples_built=0, png_fallbacks=0, skipped_flat_frames=0)
+    lifted: CatalogDatasetStats = CatalogDatasetStats.from_builder(builder_stats)
+
+    assert builder_names <= {field.name for field in fields(CatalogDatasetStats)}
+    assert lifted == CatalogDatasetStats(blob_decode=1.5, augment=0.5, samples_built=3, png_fallbacks=1, skipped_flat_frames=2)
 
 
-def test_total_sums_field_wise_without_mutating_inputs() -> None:
-    """Fold any number of snapshots into one, leaving the operands untouched."""
-    first: CatalogDatasetStats = CatalogDatasetStats(segment_query=1.0, samples_built=2)
-    second: CatalogDatasetStats = CatalogDatasetStats(segment_query=0.5, video_decode=2.0, skipped_frames=3)
+def test_total_sums_every_field_without_mutating_inputs() -> None:
+    """Fold any number of snapshots field-wise into one, leaving the operands untouched."""
+    first: CatalogDatasetStats = _every_field(1)
+    second: CatalogDatasetStats = _every_field(10)
 
     combined: CatalogDatasetStats = total([first, second])
 
-    assert combined == CatalogDatasetStats(segment_query=1.5, video_decode=2.0, samples_built=2, skipped_frames=3)
-    assert first == CatalogDatasetStats(segment_query=1.0, samples_built=2)
+    assert all(getattr(first, field.name) != 0 for field in fields(CatalogDatasetStats)), "helper must set every field"
+    assert combined == _every_field(11)
+    assert first == _every_field(1)
     assert total([]) == CatalogDatasetStats()

--- a/packages/zipdepth/tests/test_catalog_targets.py
+++ b/packages/zipdepth/tests/test_catalog_targets.py
@@ -1,0 +1,216 @@
+"""Behavioral tests for catalog depth targets."""
+
+import numpy as np
+import pytest
+import torch
+from jaxtyping import Float32, UInt8, UInt16
+from numpy import ndarray
+from numpy.testing import assert_allclose, assert_array_equal
+
+from zipdepth.catalog.targets import (
+    INV_DEPTH_SCALE,
+    AugmentPolicy,
+    build_eval_transform,
+    build_train_transform,
+    build_training_sample,
+    build_training_sample_cuda,
+    depth_span_ratio,
+    depth_span_ratio_cuda,
+    inverse_depth_from_mm,
+    quantize_inverse_depth,
+)
+from zipdepth.data.transforms import AlbumentationsWrapper, get_train_transforms
+
+
+def test_inverse_depth_masks_holes_and_out_of_range_values() -> None:
+    """Keep only 100--4000 mm targets and convert them to inverse metres."""
+    depth_mm_hw: UInt16[ndarray, "1 7"] = np.array([[0, 99, 100, 1000, 4000, 4001, 65535]], dtype=np.uint16)
+
+    inverse_depth_hw: Float32[ndarray, "1 7"] = inverse_depth_from_mm(depth_mm_hw)
+
+    assert inverse_depth_hw.dtype == np.float32
+    assert_array_equal(inverse_depth_hw, np.array([[0.0, 0.0, 10.0, 1.0, 0.25, 0.0, 0.0]], dtype=np.float32))
+
+
+def test_augment_policy_is_the_single_probability_source() -> None:
+    """Keep CPU and CUDA augmentation defaults in one immutable value."""
+    policy: AugmentPolicy = AugmentPolicy()
+
+    assert policy == AugmentPolicy(flip_p=0.5, channel_shuffle_p=0.05, gray_p=0.05)
+
+
+def test_inverse_depth_quantization_roundtrips_valid_depth_without_overflow() -> None:
+    """Keep the full valid metric range within 1% after uint16 quantization."""
+    depth_mm_hw: UInt16[ndarray, "1 6"] = np.array([[100, 101, 500, 1000, 3999, 4000]], dtype=np.uint16)
+    inverse_depth_hw: Float32[ndarray, "1 6"] = inverse_depth_from_mm(depth_mm_hw)
+
+    quantized_hw: UInt16[ndarray, "1 6"] = quantize_inverse_depth(inverse_depth_hw)
+    reconstructed_mm_hw: Float32[ndarray, "1 6"] = 1000.0 / (quantized_hw.astype(np.float32) / INV_DEPTH_SCALE)
+
+    assert quantized_hw.dtype == np.uint16
+    assert int(quantized_hw[0, 0]) == 60000
+    assert_allclose(reconstructed_mm_hw, depth_mm_hw.astype(np.float32), rtol=0.01)
+
+
+def test_depth_span_ratio_uses_the_stride_16_spatial_sample() -> None:
+    """Estimate p95/p5 from the fixed spatial sample instead of all image pixels."""
+    depth_mm_hw: UInt16[ndarray, "32 32"] = np.full((32, 32), 1000, dtype=np.uint16)
+    depth_mm_hw[0, 0] = 100
+    depth_mm_hw[0, 16] = 200
+    depth_mm_hw[16, 0] = 300
+    depth_mm_hw[16, 16] = 400
+
+    ratio: float = depth_span_ratio(depth_mm_hw)
+
+    assert ratio == pytest.approx(385.0 / 115.0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA depth-span filtering needs a GPU")
+def test_depth_span_ratio_cuda_matches_cpu_stride_sample() -> None:
+    """Keep the CPU percentile semantics when the flat-frame filter moves to CUDA."""
+    depth_mm_hw: UInt16[ndarray, "32 32"] = np.full((32, 32), 1000, dtype=np.uint16)
+    depth_mm_hw[0, 0] = 100
+    depth_mm_hw[0, 16] = 200
+    depth_mm_hw[16, 0] = 300
+    depth_mm_hw[16, 16] = 400
+
+    ratio_cuda: torch.Tensor = depth_span_ratio_cuda(torch.from_numpy(depth_mm_hw.astype(np.int32)).to(device="cuda"))
+
+    assert ratio_cuda.device.type == "cuda"
+    assert float(ratio_cuda.item()) == pytest.approx(depth_span_ratio(depth_mm_hw))
+
+
+def test_build_training_sample_matches_upstream_layout_through_augmentation() -> None:
+    """Produce collatable uint8 RGB, uint16 inverse depth, and a binary validity mask."""
+    height: int = 768
+    width: int = 1024
+    rgb_hw3: UInt8[ndarray, "height width 3"] = np.full((height, width, 3), 127, dtype=np.uint8)
+    depth_mm_hw: UInt16[ndarray, "height width"] = np.full((height, width), 1000, dtype=np.uint16)
+    depth_mm_hw[:, : width // 2] = 0
+    transform: AlbumentationsWrapper = get_train_transforms(height, width)
+
+    sample: dict[str, torch.Tensor] = build_training_sample(rgb_hw3, depth_mm_hw, transform)
+
+    assert sample["image"].shape == (3, height, width)
+    assert sample["image"].dtype == torch.uint8
+    assert sample["image"].is_contiguous()
+    assert sample["depth"].shape == (1, height, width)
+    assert sample["depth"].dtype == torch.uint16
+    assert sample["depth"].is_contiguous()
+    assert sample["mask"].shape == (1, height, width)
+    assert sample["mask"].dtype == torch.bool
+    assert sample["mask"].is_contiguous()
+    assert set(sample["mask"].unique().tolist()) == {False, True}
+    depth_hw: UInt16[ndarray, "height width"] = sample["depth"].numpy()[0]
+    assert_array_equal(sample["mask"].numpy()[0], depth_hw > 0)
+    assert np.any(depth_hw == 0)
+
+
+def test_build_training_sample_does_not_create_depth_in_holes() -> None:
+    """Keep an all-hole target empty through the real random augmentation pipeline."""
+    height: int = 768
+    width: int = 1024
+    rgb_hw3: UInt8[ndarray, "height width 3"] = np.full((height, width, 3), 127, dtype=np.uint8)
+    holes_mm_hw: UInt16[ndarray, "height width"] = np.zeros((height, width), dtype=np.uint16)
+
+    sample: dict[str, torch.Tensor] = build_training_sample(rgb_hw3, holes_mm_hw, get_train_transforms(height, width))
+
+    assert np.count_nonzero(sample["depth"].numpy()) == 0
+    assert not bool(sample["mask"].any())
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA sample construction needs a GPU")
+def test_build_training_sample_cuda_matches_deterministic_cpu_path() -> None:
+    """Match CPU resize targets exactly and RGB within backend rounding tolerance."""
+    rng: np.random.Generator = np.random.default_rng(29)
+    rgb_hw3: UInt8[ndarray, "source_h source_w 3"] = rng.integers(0, 256, (19, 27, 3), dtype=np.uint8)
+    depth_mm_hw: UInt16[ndarray, "source_h source_w"] = rng.integers(0, 5000, (19, 27), dtype=np.uint16)
+    transform: AlbumentationsWrapper = build_eval_transform(13, 17)
+    expected: dict[str, torch.Tensor] = build_training_sample(rgb_hw3, depth_mm_hw, transform)
+    rgb_chw: UInt8[ndarray, "3 source_h source_w"] = np.ascontiguousarray(np.moveaxis(rgb_hw3, -1, 0))
+    generator: torch.Generator = torch.Generator(device="cuda").manual_seed(101)
+
+    actual: dict[str, torch.Tensor] = build_training_sample_cuda(
+        torch.from_numpy(rgb_chw).to(device="cuda"),
+        torch.from_numpy(depth_mm_hw.astype(np.int32)).to(device="cuda"),
+        quarter_turns=0,
+        out_hw=(13, 17),
+        generator=generator,
+        policy=AugmentPolicy(flip_p=0.0, channel_shuffle_p=0.0, gray_p=0.0),
+    )
+
+    assert actual["image"].dtype == torch.uint8
+    assert actual["depth"].dtype == torch.uint16
+    assert actual["mask"].dtype == torch.bool
+    assert all(value.device.type == "cuda" for value in actual.values())
+    assert_array_equal(actual["depth"].cpu().numpy(), expected["depth"].numpy())
+    assert_array_equal(actual["mask"].cpu().numpy(), expected["mask"].numpy())
+    image_error: ndarray = np.abs(actual["image"].cpu().numpy().astype(np.int16) - expected["image"].numpy().astype(np.int16))
+    assert float(image_error.mean()) < 1.0
+    assert int(image_error.max()) <= 3
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA sample construction needs a GPU")
+@pytest.mark.parametrize("quarter_turns", [0, 1, 2, 3])
+def test_build_training_sample_cuda_rotates_counter_clockwise_like_numpy(quarter_turns: int) -> None:
+    """Use the same counter-clockwise quarter-turn convention as NumPy."""
+    rgb_hw3: UInt8[ndarray, "source_h source_w 3"] = np.arange(4 * 7 * 3, dtype=np.uint8).reshape(4, 7, 3)
+    depth_mm_hw: UInt16[ndarray, "source_h source_w"] = np.full((4, 7), 1000, dtype=np.uint16)
+    expected_hw3: UInt8[ndarray, "rotated_h rotated_w 3"] = np.ascontiguousarray(np.rot90(rgb_hw3, quarter_turns))
+    rgb_chw: UInt8[ndarray, "3 source_h source_w"] = np.ascontiguousarray(np.moveaxis(rgb_hw3, -1, 0))
+    generator: torch.Generator = torch.Generator(device="cuda").manual_seed(11)
+
+    actual: dict[str, torch.Tensor] = build_training_sample_cuda(
+        torch.from_numpy(rgb_chw).to(device="cuda"),
+        torch.from_numpy(depth_mm_hw.astype(np.int32)).to(device="cuda"),
+        quarter_turns=quarter_turns,
+        out_hw=expected_hw3.shape[:2],
+        generator=generator,
+        policy=AugmentPolicy(flip_p=0.0, channel_shuffle_p=0.0, gray_p=0.0),
+    )
+
+    actual_hw3: ndarray = np.moveaxis(actual["image"].cpu().numpy(), 0, -1)
+    assert_array_equal(actual_hw3, expected_hw3)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA sample construction needs a GPU")
+def test_build_training_sample_cuda_is_reproducible_from_the_sample_generator() -> None:
+    """Repeat stochastic augmentation exactly from an equal per-sample seed."""
+    rgb_chw: torch.Tensor = torch.arange(3 * 8 * 12, dtype=torch.int32, device="cuda").remainder(256).to(dtype=torch.uint8).reshape(3, 8, 12)
+    depth_mm_hw: torch.Tensor = torch.full((8, 12), 1000, dtype=torch.int32, device="cuda")
+
+    first: dict[str, torch.Tensor] = build_training_sample_cuda(
+        rgb_chw,
+        depth_mm_hw,
+        quarter_turns=0,
+        out_hw=(8, 12),
+        generator=torch.Generator().manual_seed(317),
+        policy=AugmentPolicy(flip_p=0.5, channel_shuffle_p=1.0, gray_p=0.5),
+    )
+    second: dict[str, torch.Tensor] = build_training_sample_cuda(
+        rgb_chw,
+        depth_mm_hw,
+        quarter_turns=0,
+        out_hw=(8, 12),
+        generator=torch.Generator().manual_seed(317),
+        policy=AugmentPolicy(flip_p=0.5, channel_shuffle_p=1.0, gray_p=0.5),
+    )
+
+    assert all(torch.equal(first[key], second[key]) for key in first)
+
+
+def test_build_train_transform_is_the_eval_resize_with_optional_mirroring() -> None:
+    """Match the eval transform when every augmentation is off, and mirror both targets on flip."""
+    rgb_hw3: UInt8[ndarray, "12 16 3"] = np.random.default_rng(0).integers(0, 256, size=(12, 16, 3), dtype=np.uint8)
+    depth_mm_hw: UInt16[ndarray, "12 16"] = np.random.default_rng(1).integers(100, 4000, size=(12, 16), dtype=np.uint16)
+    off: AugmentPolicy = AugmentPolicy(flip_p=0.0, channel_shuffle_p=0.0, gray_p=0.0)
+    mirror: AugmentPolicy = AugmentPolicy(flip_p=1.0, channel_shuffle_p=0.0, gray_p=0.0)
+
+    expected: dict[str, torch.Tensor] = build_training_sample(rgb_hw3, depth_mm_hw, build_eval_transform(6, 8))
+    actual: dict[str, torch.Tensor] = build_training_sample(rgb_hw3, depth_mm_hw, build_train_transform(6, 8, off))
+    flipped: dict[str, torch.Tensor] = build_training_sample(rgb_hw3, depth_mm_hw, build_train_transform(6, 8, mirror))
+
+    key: str
+    for key in ("image", "depth", "mask"):
+        assert torch.equal(actual[key], expected[key])
+        assert_array_equal(flipped[key].numpy(), np.flip(expected[key].numpy(), axis=-1))

--- a/packages/zipdepth/tests/test_catalog_threaded.py
+++ b/packages/zipdepth/tests/test_catalog_threaded.py
@@ -1,0 +1,46 @@
+"""Behavioral tests for the bounded shuffle buffer and threaded producers."""
+
+from collections.abc import Iterator
+
+import pytest
+
+from zipdepth.catalog.threaded import ShuffleBuffer, iter_threaded
+
+
+def test_shuffle_buffer_is_seeded_and_preserves_every_sample() -> None:
+    """Produce one deterministic streaming permutation without drops or duplicates."""
+
+    def shuffled(seed: int) -> list[int]:
+        buffer: ShuffleBuffer[int] = ShuffleBuffer(size=3, seed=seed)
+        output: list[int] = []
+        value: int
+        for value in range(10):
+            evicted: int | None = buffer.push(value)
+            if evicted is not None:
+                output.append(evicted)
+        output.extend(buffer.flush())
+        return output
+
+    first: list[int] = shuffled(17)
+    second: list[int] = shuffled(17)
+
+    assert first == second
+    assert sorted(first) == list(range(10))
+
+
+def test_iter_threaded_yields_every_worker_item() -> None:
+    """Deliver every item from every producer through one bounded queue."""
+    values: list[int] = list(iter_threaded([lambda: range(4), lambda: range(4, 9)], maxsize=2))
+
+    assert sorted(values) == list(range(9))
+
+
+def test_iter_threaded_propagates_worker_exceptions() -> None:
+    """Raise a worker failure in the consuming thread."""
+
+    def failing_worker() -> Iterator[int]:
+        yield 1
+        raise RuntimeError("threaded worker failed")
+
+    with pytest.raises(RuntimeError, match="threaded worker failed"):
+        list(iter_threaded([failing_worker], maxsize=1))

--- a/packages/zipdepth/tests/test_catalog_threaded.py
+++ b/packages/zipdepth/tests/test_catalog_threaded.py
@@ -1,31 +1,12 @@
-"""Behavioral tests for the bounded shuffle buffer and threaded producers."""
+"""Behavioral tests for bounded threaded producers."""
 
-from collections.abc import Iterator
+import threading
+from collections.abc import Generator, Iterator
+from time import monotonic, sleep
 
 import pytest
 
-from zipdepth.catalog.threaded import ShuffleBuffer, iter_threaded
-
-
-def test_shuffle_buffer_is_seeded_and_preserves_every_sample() -> None:
-    """Produce one deterministic streaming permutation without drops or duplicates."""
-
-    def shuffled(seed: int) -> list[int]:
-        buffer: ShuffleBuffer[int] = ShuffleBuffer(size=3, seed=seed)
-        output: list[int] = []
-        value: int
-        for value in range(10):
-            evicted: int | None = buffer.push(value)
-            if evicted is not None:
-                output.append(evicted)
-        output.extend(buffer.flush())
-        return output
-
-    first: list[int] = shuffled(17)
-    second: list[int] = shuffled(17)
-
-    assert first == second
-    assert sorted(first) == list(range(10))
+from zipdepth.catalog.threaded import iter_threaded
 
 
 def test_iter_threaded_yields_every_worker_item() -> None:
@@ -44,3 +25,49 @@ def test_iter_threaded_propagates_worker_exceptions() -> None:
 
     with pytest.raises(RuntimeError, match="threaded worker failed"):
         list(iter_threaded([failing_worker], maxsize=1))
+
+
+def test_early_close_leaves_no_live_producer_threads() -> None:
+    """Stop producers blocked on a full queue when the consumer closes early."""
+
+    def many_items() -> Iterator[int]:
+        """Yield enough items to fill the bounded queue."""
+        yield from range(10_000)
+
+    samples: Generator[int, None, None] = iter_threaded([many_items, many_items], maxsize=1, join_timeout=0.1)
+    next(samples)
+    samples.close()
+
+    deadline: float = monotonic() + 2.0
+    live_producers: list[threading.Thread] = [
+        thread for thread in threading.enumerate() if thread.name.startswith("zipdepth-producer-") and thread.is_alive()
+    ]
+    while live_producers and monotonic() < deadline:
+        sleep(0.01)
+        live_producers = [
+            thread for thread in threading.enumerate() if thread.name.startswith("zipdepth-producer-") and thread.is_alive()
+        ]
+
+    assert live_producers == []
+
+
+def test_failure_is_delivered_after_the_items_queued_before_it() -> None:
+    """Preserve FIFO order between worker items and its terminal failure."""
+
+    def failing_worker() -> Iterator[int]:
+        """Queue two items before failing."""
+        yield 1
+        yield 2
+        raise RuntimeError("failure after queued items")
+
+    samples: Generator[int, None, None] = iter_threaded([failing_worker], maxsize=3)
+
+    assert next(samples) == 1
+    assert next(samples) == 2
+    with pytest.raises(RuntimeError, match="failure after queued items"):
+        next(samples)
+
+
+def test_zero_workers_terminates() -> None:
+    """Return immediately when no worker factories are supplied."""
+    assert list(iter_threaded([], maxsize=1)) == []

--- a/packages/zipdepth/zipdepth/catalog/__init__.py
+++ b/packages/zipdepth/zipdepth/catalog/__init__.py
@@ -1,0 +1,1 @@
+"""Training data read from Rerun catalogs."""

--- a/packages/zipdepth/zipdepth/catalog/png.py
+++ b/packages/zipdepth/zipdepth/catalog/png.py
@@ -1,0 +1,38 @@
+"""CUDA reconstruction for the constrained depth PNGs stored in the catalog."""
+
+import torch
+from jaxtyping import Int32, UInt8
+from torch import Tensor
+
+
+def unfilter_up_cuda(filtered_hwb: UInt8[Tensor, "h row_bytes"]) -> Int32[Tensor, "h w"]:
+    """Reconstruct a 16-bit grayscale PNG's all-Up rows on CUDA.
+
+    PNG Up filtering operates on bytes. An int32 cumulative sum down the rows,
+    reduced modulo 256, reconstructs those bytes. Adjacent big-endian byte pairs
+    are then combined into int32 millimetres because many PyTorch uint16
+    operations are unsupported.
+
+    Args:
+        filtered_hwb: CUDA uint8 filtered rows with shape
+            ``(height, 1 + 2 * width)`` and filter byte 2 in every row.
+
+    Returns:
+        CUDA int32 metric depth with shape ``(height, width)``.
+
+    Raises:
+        ValueError: If the input is not a two-dimensional CUDA uint8 matrix with
+            a filter byte followed by complete byte pairs.
+    """
+    if filtered_hwb.ndim != 2 or filtered_hwb.dtype != torch.uint8 or not filtered_hwb.is_cuda:
+        raise ValueError("filtered PNG rows must be a two-dimensional CUDA uint8 tensor")
+    pixel_bytes: int = int(filtered_hwb.shape[1]) - 1
+    if pixel_bytes <= 0 or pixel_bytes % 2 != 0:
+        raise ValueError("filtered PNG rows must contain complete 16-bit pixels")
+    reconstructed_hwb: Int32[Tensor, "h pixel_bytes"] = torch.bitwise_and(
+        torch.cumsum(filtered_hwb[:, 1:], dim=0, dtype=torch.int32),
+        0xFF,
+    )
+    high_hw: Int32[Tensor, "h w"] = reconstructed_hwb[:, 0::2]
+    low_hw: Int32[Tensor, "h w"] = reconstructed_hwb[:, 1::2]
+    return torch.bitwise_or(torch.bitwise_left_shift(high_hw, 8), low_hw)

--- a/packages/zipdepth/zipdepth/catalog/stats.py
+++ b/packages/zipdepth/zipdepth/catalog/stats.py
@@ -1,0 +1,67 @@
+"""Dependency-free catalog pipeline statistics."""
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+STAGE_FIELDS: tuple[str, ...] = ("segment_query", "video_decode", "blob_decode", "augment")
+"""Floating-point stage timers reported by catalog instrumentation."""
+
+
+@dataclass(slots=True)
+class BuilderStats:
+    """Mutable counters owned by one sample builder."""
+
+    blob_decode: float = 0.0
+    """PromptDA PNG blob decode time in seconds."""
+    augment: float = 0.0
+    """Orientation, target construction, and augmentation time in seconds."""
+    samples_built: int = 0
+    """Samples successfully built."""
+    png_fallbacks: int = 0
+    """PromptDA frames handled by the general PNG decoder."""
+    skipped_flat_frames: int = 0
+    """Frames rejected by the configured depth-span filter."""
+
+
+@dataclass(slots=True)
+class CatalogDatasetStats:
+    """Cumulative catalog pipeline time and counters."""
+
+    segment_query: float = 0.0
+    """Target/video catalog query and decoder-initialization time in seconds."""
+    video_decode: float = 0.0
+    """Video frame decode time in seconds."""
+    blob_decode: float = 0.0
+    """PromptDA PNG blob decode time in seconds."""
+    augment: float = 0.0
+    """Orientation, target construction, and augmentation time in seconds."""
+    samples_built: int = 0
+    """Samples successfully built, including samples not yet yielded."""
+    png_fallbacks: int = 0
+    """PromptDA frames handled by the general PNG decoder."""
+    skipped_frames: int = 0
+    """Video frames skipped after decode errors."""
+    skipped_flat_frames: int = 0
+    """Frames rejected by the configured depth-span filter."""
+
+    def __add__(self, other: "CatalogDatasetStats") -> "CatalogDatasetStats":
+        """Return field-wise sums without mutating either operand."""
+        return CatalogDatasetStats(
+            segment_query=self.segment_query + other.segment_query,
+            video_decode=self.video_decode + other.video_decode,
+            blob_decode=self.blob_decode + other.blob_decode,
+            augment=self.augment + other.augment,
+            samples_built=self.samples_built + other.samples_built,
+            png_fallbacks=self.png_fallbacks + other.png_fallbacks,
+            skipped_frames=self.skipped_frames + other.skipped_frames,
+            skipped_flat_frames=self.skipped_flat_frames + other.skipped_flat_frames,
+        )
+
+
+def total(stats: Iterable[CatalogDatasetStats]) -> CatalogDatasetStats:
+    """Return the field-wise sum of catalog statistics."""
+    combined: CatalogDatasetStats = CatalogDatasetStats()
+    item: CatalogDatasetStats
+    for item in stats:
+        combined = combined + item
+    return combined

--- a/packages/zipdepth/zipdepth/catalog/stats.py
+++ b/packages/zipdepth/zipdepth/catalog/stats.py
@@ -1,7 +1,7 @@
 """Dependency-free catalog pipeline statistics."""
 
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 
 STAGE_FIELDS: tuple[str, ...] = ("segment_query", "video_decode", "blob_decode", "augment")
 """Floating-point stage timers reported by catalog instrumentation."""
@@ -43,6 +43,11 @@ class CatalogDatasetStats:
     """Video frames skipped after decode errors."""
     skipped_flat_frames: int = 0
     """Frames rejected by the configured depth-span filter."""
+
+    @classmethod
+    def from_builder(cls, builder_stats: BuilderStats) -> "CatalogDatasetStats":
+        """Lift builder-local counters into the dataset schema; dataset-only counters stay zero."""
+        return cls(**asdict(builder_stats))
 
     def __add__(self, other: "CatalogDatasetStats") -> "CatalogDatasetStats":
         """Return field-wise sums without mutating either operand."""

--- a/packages/zipdepth/zipdepth/catalog/targets.py
+++ b/packages/zipdepth/zipdepth/catalog/targets.py
@@ -1,0 +1,297 @@
+"""Helpers for building ZipDepth training targets (numpy/torch/albumentations only)."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TypeAlias
+
+import albumentations as A
+import cv2
+import numpy as np
+import torch
+from jaxtyping import Bool, Float32, Int64, Shaped, UInt8, UInt16
+from numpy import ndarray
+from torch import Tensor
+from torch.nn import functional as F
+
+from zipdepth.data.transforms import AlbumentationsWrapper
+
+MIN_DEPTH_MM: int = 100
+"""Nearest valid pseudo-depth, in millimetres."""
+MAX_DEPTH_MM: int = 4000
+"""Furthest valid pseudo-depth, in millimetres."""
+INV_DEPTH_SCALE: float = 6000.0
+"""Inverse-depth quantization scale; 10 1/m maps to 60000 without uint16 overflow.
+
+The SSI loss is scale-invariant, so only the resulting floating-point exponent
+range matters after the trainer divides the integer target by 256.
+"""
+
+_DepthTransform: TypeAlias = Callable[
+    [UInt8[ndarray, "h w 3"], Float32[ndarray, "h w"]],
+    tuple[UInt8[ndarray, "out_h out_w 3"], Float32[ndarray, "out_h out_w"] | None],
+]
+
+
+@dataclass(frozen=True, slots=True)
+class AugmentPolicy:
+    """Probabilities shared by CPU and CUDA training augmentation."""
+
+    flip_p: float = 0.5
+    """Probability of an aligned horizontal flip."""
+    channel_shuffle_p: float = 0.05
+    """Probability of a random RGB channel permutation."""
+    gray_p: float = 0.05
+    """Probability of grayscale conversion replicated to three channels."""
+
+    def __post_init__(self) -> None:
+        """Reject probabilities outside the closed unit interval."""
+        probability: float
+        for probability in (self.flip_p, self.channel_shuffle_p, self.gray_p):
+            if not 0.0 <= probability <= 1.0:
+                raise ValueError("augmentation probabilities must be in [0, 1]")
+
+
+def inverse_depth_from_mm(depth_mm_hw: UInt16[ndarray, "h w"]) -> Float32[ndarray, "h w"]:
+    """Convert valid millimetre depth to inverse metres and set invalid pixels to zero.
+
+    Args:
+        depth_mm_hw: Unsigned 16-bit depth in millimetres with shape ``(H, W)``.
+
+    Returns:
+        Float32 inverse depth in inverse metres with shape ``(H, W)``. Values
+        outside ``[MIN_DEPTH_MM, MAX_DEPTH_MM]`` are zero.
+    """
+    valid_hw: Bool[ndarray, "h w"] = (depth_mm_hw >= MIN_DEPTH_MM) & (depth_mm_hw <= MAX_DEPTH_MM)
+    inverse_depth_hw: Float32[ndarray, "h w"] = np.zeros(depth_mm_hw.shape, dtype=np.float32)
+    inverse_depth_hw[valid_hw] = 1000.0 / depth_mm_hw[valid_hw]
+    return inverse_depth_hw
+
+
+def quantize_inverse_depth(inverse_depth_hw: Float32[ndarray, "h w"]) -> UInt16[ndarray, "h w"]:
+    """Round inverse depth into the uint16 target range.
+
+    Args:
+        inverse_depth_hw: Float32 inverse depth in inverse metres with shape ``(H, W)``.
+
+    Returns:
+        Quantized unsigned 16-bit inverse depth with shape ``(H, W)``.
+    """
+    scaled_hw: Float32[ndarray, "h w"] = np.rint(inverse_depth_hw * INV_DEPTH_SCALE)
+    quantized_hw: UInt16[ndarray, "h w"] = np.clip(scaled_hw, 0.0, float(np.iinfo(np.uint16).max)).astype(np.uint16)
+    return quantized_hw
+
+
+def build_train_transform(height: int, width: int, policy: AugmentPolicy) -> AlbumentationsWrapper:
+    """Deterministic-resize training transform: flip and mild color, no crop zoom.
+
+    The vendored ``get_train_transforms`` randomly zooms half the samples via
+    SmallestMaxSize + RandomCrop; at 4:3 -> 1024x768 that trains a ~1.33x-zoom
+    domain the full-FOV probe and eval never see. This keeps upstream's flip and
+    color augmentation but resizes deterministically to the training size.
+    """
+    return AlbumentationsWrapper(
+        A.Compose(
+            [
+                A.Resize(height=height, width=width, interpolation=cv2.INTER_LINEAR),
+                A.HorizontalFlip(p=policy.flip_p),
+                A.ChannelShuffle(p=policy.channel_shuffle_p),
+                A.ToGray(num_output_channels=3, p=policy.gray_p),
+            ],
+            additional_targets={"mask": "mask"},
+        )
+    )
+
+
+def build_eval_transform(height: int, width: int) -> AlbumentationsWrapper:
+    """Build deterministic aligned RGB/mask resizing for evaluation."""
+    if height <= 0 or width <= 0:
+        raise ValueError("evaluation height and width must be positive")
+    transform: A.Compose = A.Compose(
+        [A.Resize(height=height, width=width, interpolation=cv2.INTER_LINEAR, mask_interpolation=cv2.INTER_NEAREST)],
+        additional_targets={"mask": "mask"},
+    )
+    return AlbumentationsWrapper(transform)
+
+
+def depth_span_ratio(depth_mm_hw: UInt16[ndarray, "h w"]) -> float:
+    """Return the p95/p5 ratio of valid depth, or 0.0 when nothing is valid.
+
+    Capture-start closeups (a floor or wall filling the frame) have a nearly
+    constant depth; under the scale-and-shift-invariant loss their MAD-normalized
+    targets amplify sensor noise into large, unlearnable gradients. The span
+    ratio lets the dataset skip such degenerate frames. A fixed stride-16 spatial
+    sample preserves this coarse scene-span decision while reducing percentile
+    input by 256x (about 200x faster on 1920x1440 targets).
+    """
+    sampled_mm_hw: UInt16[ndarray, "sample_h sample_w"] = depth_mm_hw[::16, ::16]
+    valid: Float32[ndarray, "n"] = sampled_mm_hw[(sampled_mm_hw >= MIN_DEPTH_MM) & (sampled_mm_hw <= MAX_DEPTH_MM)].astype(np.float32)
+    if valid.size == 0:
+        return 0.0
+    p5: float = float(np.percentile(valid, 5))
+    p95: float = float(np.percentile(valid, 95))
+    return p95 / max(p5, 1.0)
+
+
+def depth_span_ratio_cuda(depth_mm_hw: Shaped[Tensor, "h w"]) -> Float32[Tensor, ""]:
+    """Return the CPU span metric from the same stride-16 sample on CUDA.
+
+    Invalid values sort behind the valid sample. GPU scalar indices then apply
+    NumPy's linear percentile interpolation without copying the sample to the
+    host. An all-invalid image returns a CUDA scalar zero.
+
+    Args:
+        depth_mm_hw: CUDA int32 or floating metric depth with shape ``(H, W)``.
+
+    Returns:
+        CUDA float32 scalar containing valid-depth p95/p5, or zero when no
+        sampled depth is valid.
+
+    Raises:
+        ValueError: If the input is not a two-dimensional CUDA tensor.
+    """
+    if depth_mm_hw.ndim != 2 or not depth_mm_hw.is_cuda:
+        raise ValueError("depth_mm_hw must be a two-dimensional CUDA tensor")
+    sampled_n: Float32[Tensor, "sample_n"] = depth_mm_hw[::16, ::16].flatten().to(dtype=torch.float32)
+    valid_n: Bool[Tensor, "sample_n"] = (sampled_n >= MIN_DEPTH_MM) & (sampled_n <= MAX_DEPTH_MM)
+    sortable_n: Float32[Tensor, "sample_n"] = torch.where(valid_n, sampled_n, torch.full_like(sampled_n, torch.inf))
+    sorted_n: Float32[Tensor, "sample_n"] = torch.sort(sortable_n).values
+    valid_count: Tensor = valid_n.sum()
+    last_valid_index: Float32[Tensor, ""] = torch.clamp(valid_count - 1, min=0).to(dtype=torch.float32)
+
+    positions_2: Float32[Tensor, "2"] = last_valid_index * torch.tensor([0.05, 0.95], device=depth_mm_hw.device)
+    lower_float_2: Float32[Tensor, "2"] = torch.floor(positions_2)
+    lower_2: Int64[Tensor, "2"] = lower_float_2.to(dtype=torch.int64)
+    upper_2: Int64[Tensor, "2"] = torch.ceil(positions_2).to(dtype=torch.int64)
+    percentiles_2: Float32[Tensor, "2"] = torch.lerp(sorted_n[lower_2], sorted_n[upper_2], positions_2 - lower_float_2)
+    p5: Float32[Tensor, ""] = percentiles_2[0]
+    p95: Float32[Tensor, ""] = percentiles_2[1]
+    ratio: Float32[Tensor, ""] = p95 / torch.clamp(p5, min=1.0)
+    return torch.where(valid_count > 0, ratio, torch.zeros_like(ratio))
+
+
+def build_training_sample(
+    rgb_hw3: UInt8[ndarray, "h w 3"], depth_mm_hw: UInt16[ndarray, "h w"], transform: _DepthTransform
+) -> dict[str, Tensor]:
+    """Augment aligned RGB and inverse depth, then build one collatable sample.
+
+    Args:
+        rgb_hw3: Unsigned 8-bit RGB image with shape ``(H, W, 3)``.
+        depth_mm_hw: Unsigned 16-bit metric depth with shape ``(H, W)``.
+        transform: ZipDepth augmentation callable applied to RGB and float32
+            inverse depth together. It treats depth as an Albumentations mask,
+            so spatial resizing uses nearest-neighbor interpolation.
+
+    Returns:
+        A dictionary containing contiguous ``image`` uint8 ``(3, H, W)``,
+        ``depth`` uint16 ``(1, H, W)``, and ``mask`` bool ``(1, H, W)`` tensors.
+        This preserves the vendored loader's uint16 storage dtype; the trainer
+        immediately converts it to float32 and divides by 256.
+
+    Raises:
+        RuntimeError: If the transform drops the depth target.
+    """
+    inverse_depth_hw: Float32[ndarray, "h w"] = inverse_depth_from_mm(depth_mm_hw)
+    transformed: tuple[UInt8[ndarray, "out_h out_w 3"], Float32[ndarray, "out_h out_w"] | None] = transform(rgb_hw3, inverse_depth_hw)
+    augmented_rgb_hw3: UInt8[ndarray, "out_h out_w 3"] = transformed[0]
+    augmented_inverse_depth_hw: Float32[ndarray, "out_h out_w"] | None = transformed[1]
+    if augmented_inverse_depth_hw is None:
+        raise RuntimeError("training transform dropped the inverse-depth target")
+    quantized_hw: UInt16[ndarray, "out_h out_w"] = quantize_inverse_depth(augmented_inverse_depth_hw)
+    image_chw: UInt8[ndarray, "3 out_h out_w"] = np.ascontiguousarray(np.moveaxis(augmented_rgb_hw3, -1, 0))
+    depth_1hw: UInt16[ndarray, "1 out_h out_w"] = np.ascontiguousarray(quantized_hw[None])
+    mask_1hw: Bool[ndarray, "1 out_h out_w"] = np.ascontiguousarray(depth_1hw > 0)
+    image_tensor: UInt8[Tensor, "3 out_h out_w"] = torch.from_numpy(image_chw)
+    depth_tensor: UInt16[Tensor, "1 out_h out_w"] = torch.from_numpy(depth_1hw)
+    mask_tensor: Bool[Tensor, "1 out_h out_w"] = torch.from_numpy(mask_1hw)
+    return {"image": image_tensor, "depth": depth_tensor, "mask": mask_tensor}
+
+
+def build_training_sample_cuda(
+    rgb_chw: UInt8[Tensor, "3 h w"],
+    depth_mm_hw: Shaped[Tensor, "h w"],
+    quarter_turns: int,
+    out_hw: tuple[int, int],
+    generator: torch.Generator,
+    policy: AugmentPolicy,
+) -> dict[str, Tensor]:
+    """Build one augmented training sample without leaving CUDA.
+
+    Rotation follows NumPy's counter-clockwise ``rot90`` convention. Spatial
+    resizing matches the CPU path's bilinear RGB and nearest-neighbor inverse
+    depth policy. The returned depth uses uint16 storage, but all arithmetic is
+    performed in float32 or int32 because PyTorch has limited uint16 support.
+
+    Args:
+        rgb_chw: CUDA uint8 RGB with shape ``(3, H, W)``.
+        depth_mm_hw: CUDA int32 or floating metric depth with shape ``(H, W)``.
+        quarter_turns: Counter-clockwise rotations, normalized modulo four.
+        out_hw: Output ``(height, width)``.
+        generator: Random generator seeded for this sample. A CPU generator
+            avoids a device synchronization when selecting augmentations.
+        policy: Shared probabilities for flip, channel shuffle, and grayscale.
+
+    Returns:
+        CUDA tensors: uint8 ``image`` ``(3, h, w)``, uint16 ``depth``
+        ``(1, h, w)``, and bool ``mask`` ``(1, h, w)``.
+
+    Raises:
+        ValueError: If inputs, output size, or probabilities violate the CUDA
+            sample-building contract.
+    """
+    if rgb_chw.ndim != 3 or rgb_chw.shape[0] != 3 or rgb_chw.dtype != torch.uint8 or not rgb_chw.is_cuda:
+        raise ValueError("rgb_chw must be a CUDA uint8 tensor with shape (3, H, W)")
+    if depth_mm_hw.ndim != 2 or not depth_mm_hw.is_cuda or tuple(depth_mm_hw.shape) != tuple(rgb_chw.shape[-2:]):
+        raise ValueError("depth_mm_hw must be a CUDA tensor aligned with rgb_chw")
+    if depth_mm_hw.dtype not in (torch.int32, torch.float16, torch.float32, torch.float64, torch.bfloat16):
+        raise ValueError("depth_mm_hw must use int32 or a floating dtype")
+    out_height: int = out_hw[0]
+    out_width: int = out_hw[1]
+    if out_height <= 0 or out_width <= 0:
+        raise ValueError("output height and width must be positive")
+    turns: int = quarter_turns % 4
+    rotated_rgb_chw: UInt8[Tensor, "3 rotated_h rotated_w"] = torch.rot90(rgb_chw, turns, dims=(-2, -1))
+    rotated_depth_mm_hw: Shaped[Tensor, "rotated_h rotated_w"] = torch.rot90(depth_mm_hw, turns, dims=(-2, -1))
+    depth_float_hw: Float32[Tensor, "rotated_h rotated_w"] = rotated_depth_mm_hw.to(dtype=torch.float32)
+    valid_hw: Bool[Tensor, "rotated_h rotated_w"] = (depth_float_hw >= MIN_DEPTH_MM) & (depth_float_hw <= MAX_DEPTH_MM)
+    inverse_depth_hw: Float32[Tensor, "rotated_h rotated_w"] = torch.where(
+        valid_hw,
+        1000.0 / depth_float_hw,
+        torch.zeros_like(depth_float_hw),
+    )
+    resized_rgb_float_chw: Float32[Tensor, "3 out_h out_w"] = F.interpolate(
+        rotated_rgb_chw.unsqueeze(0).to(dtype=torch.float32),
+        size=(out_height, out_width),
+        mode="bilinear",
+        align_corners=False,
+        antialias=False,
+    ).squeeze(0)
+    resized_rgb_chw: UInt8[Tensor, "3 out_h out_w"] = torch.round(resized_rgb_float_chw).clamp_(0.0, 255.0).to(dtype=torch.uint8)
+    resized_inverse_depth_hw: Float32[Tensor, "out_h out_w"] = F.interpolate(
+        inverse_depth_hw.unsqueeze(0).unsqueeze(0),
+        size=(out_height, out_width),
+        mode="nearest",
+    ).squeeze(0).squeeze(0)
+
+    random_values_n: Float32[Tensor, "3"] = torch.rand(3, device=generator.device, generator=generator)
+    random_values: list[float] = random_values_n.cpu().tolist()
+
+    if random_values[0] < policy.flip_p:
+        resized_rgb_chw = torch.flip(resized_rgb_chw, dims=(-1,))
+        resized_inverse_depth_hw = torch.flip(resized_inverse_depth_hw, dims=(-1,))
+
+    if random_values[1] < policy.channel_shuffle_p:
+        channel_order: Int64[Tensor, "3"] = torch.randperm(3, device=generator.device, generator=generator).to(device=rgb_chw.device)
+        resized_rgb_chw = resized_rgb_chw[channel_order]
+
+    if random_values[2] < policy.gray_p:
+        rgb_float_chw: Float32[Tensor, "3 out_h out_w"] = resized_rgb_chw.to(dtype=torch.float32)
+        gray_hw: Float32[Tensor, "out_h out_w"] = (
+            0.299 * rgb_float_chw[0] + 0.587 * rgb_float_chw[1] + 0.114 * rgb_float_chw[2]
+        )
+        resized_rgb_chw = torch.round(gray_hw).clamp_(0.0, 255.0).to(dtype=torch.uint8).expand_as(resized_rgb_chw)
+
+    quantized_i32_hw: Shaped[Tensor, "out_h out_w"] = torch.round(resized_inverse_depth_hw * INV_DEPTH_SCALE).clamp_(0.0, 65535.0).to(dtype=torch.int32)
+    mask_1hw: Bool[Tensor, "1 out_h out_w"] = (quantized_i32_hw > 0).unsqueeze(0).contiguous()
+    depth_1hw: UInt16[Tensor, "1 out_h out_w"] = quantized_i32_hw.to(dtype=torch.uint16).unsqueeze(0).contiguous()
+    image_chw: UInt8[Tensor, "3 out_h out_w"] = resized_rgb_chw.contiguous()
+    return {"image": image_chw, "depth": depth_1hw, "mask": mask_1hw}

--- a/packages/zipdepth/zipdepth/catalog/threaded.py
+++ b/packages/zipdepth/zipdepth/catalog/threaded.py
@@ -1,55 +1,21 @@
-"""Bounded producer/consumer iteration shared by catalog pipelines."""
+"""Bounded threaded fan-in for catalog producer pipelines."""
 
 from collections.abc import Callable, Generator, Iterable, Sequence
 from dataclasses import dataclass
 from queue import Full, Queue
-from random import Random
 from threading import Event, Thread
-from typing import Generic, TypeVar
+from typing import TypeVar
 from warnings import warn
 
 ItemT = TypeVar("ItemT")
 
 
-class ShuffleBuffer(Generic[ItemT]):  # noqa: UP046 — beartype does not support PEP 695 generics
-    """Seeded streaming shuffle with bounded memory."""
-
-    def __init__(self, size: int, seed: int) -> None:
-        """Create an empty buffer."""
-        if size <= 0:
-            raise ValueError("shuffle buffer size must be positive")
-        self._size: int = size
-        self._rng: Random = Random(seed)
-        self._samples: list[ItemT] = []
-
-    def push(self, sample: ItemT) -> ItemT | None:
-        """Add one sample and return a random eviction when the buffer is full."""
-        if len(self._samples) < self._size:
-            self._samples.append(sample)
-            return None
-        index: int = self._rng.randrange(self._size)
-        evicted: ItemT = self._samples[index]
-        self._samples[index] = sample
-        return evicted
-
-    def flush(self) -> Generator[ItemT, None, None]:
-        """Yield all remaining samples in seeded random order and empty the buffer."""
-        remaining: list[ItemT] = list(self._samples)
-        self._samples.clear()
-        self._rng.shuffle(remaining)
-        yield from remaining
-
-
 @dataclass(slots=True)
-class _Failure:
-    """Exception transported from a producer thread to the consumer."""
+class _Done:
+    """Terminal message transported from one producer to the consumer."""
 
-    error: BaseException
-    """Original worker exception with its traceback."""
-
-
-_END: object = object()
-"""Queue sentinel emitted once by each normally exhausted worker."""
+    error: BaseException | None
+    """Original worker exception with its traceback, or None after normal exhaustion."""
 
 
 def iter_threaded(  # noqa: UP047 — beartype does not support PEP 695 type parameters
@@ -76,10 +42,10 @@ def iter_threaded(  # noqa: UP047 — beartype does not support PEP 695 type par
     if join_timeout <= 0.0:
         raise ValueError("threaded iterator join_timeout must be positive")
 
-    queue: Queue[ItemT | _Failure | object] = Queue(maxsize=maxsize)
+    queue: Queue[ItemT | _Done] = Queue(maxsize=maxsize)
     stop: Event = Event()
 
-    def put_unless_stopped(item: ItemT | _Failure | object) -> bool:
+    def put_unless_stopped(item: ItemT | _Done) -> bool:
         """Bound queue writes while allowing a closed consumer to stop workers."""
         while not stop.is_set():
             try:
@@ -96,9 +62,9 @@ def iter_threaded(  # noqa: UP047 — beartype does not support PEP 695 type par
             for item in worker():
                 if not put_unless_stopped(item):
                     return
-            put_unless_stopped(_END)
+            put_unless_stopped(_Done(None))
         except BaseException as error:
-            if put_unless_stopped(_Failure(error)):
+            if put_unless_stopped(_Done(error)):
                 stop.set()
 
     threads: list[Thread] = [
@@ -111,13 +77,13 @@ def iter_threaded(  # noqa: UP047 — beartype does not support PEP 695 type par
     completed: int = 0
     try:
         while completed < len(threads):
-            queued: ItemT | _Failure | object = queue.get()
-            if queued is _END:
+            queued: ItemT | _Done = queue.get()
+            if isinstance(queued, _Done):
+                if queued.error is not None:
+                    raise queued.error
                 completed += 1
                 continue
-            if isinstance(queued, _Failure):
-                raise queued.error
-            yield queued  # type: ignore[misc]  # narrowed by the private queue transports above
+            yield queued
     finally:
         stop.set()
         for thread in threads:

--- a/packages/zipdepth/zipdepth/catalog/threaded.py
+++ b/packages/zipdepth/zipdepth/catalog/threaded.py
@@ -1,0 +1,126 @@
+"""Bounded producer/consumer iteration shared by catalog pipelines."""
+
+from collections.abc import Callable, Generator, Iterable, Sequence
+from dataclasses import dataclass
+from queue import Full, Queue
+from random import Random
+from threading import Event, Thread
+from typing import Generic, TypeVar
+from warnings import warn
+
+ItemT = TypeVar("ItemT")
+
+
+class ShuffleBuffer(Generic[ItemT]):  # noqa: UP046 — beartype does not support PEP 695 generics
+    """Seeded streaming shuffle with bounded memory."""
+
+    def __init__(self, size: int, seed: int) -> None:
+        """Create an empty buffer."""
+        if size <= 0:
+            raise ValueError("shuffle buffer size must be positive")
+        self._size: int = size
+        self._rng: Random = Random(seed)
+        self._samples: list[ItemT] = []
+
+    def push(self, sample: ItemT) -> ItemT | None:
+        """Add one sample and return a random eviction when the buffer is full."""
+        if len(self._samples) < self._size:
+            self._samples.append(sample)
+            return None
+        index: int = self._rng.randrange(self._size)
+        evicted: ItemT = self._samples[index]
+        self._samples[index] = sample
+        return evicted
+
+    def flush(self) -> Generator[ItemT, None, None]:
+        """Yield all remaining samples in seeded random order and empty the buffer."""
+        remaining: list[ItemT] = list(self._samples)
+        self._samples.clear()
+        self._rng.shuffle(remaining)
+        yield from remaining
+
+
+@dataclass(slots=True)
+class _Failure:
+    """Exception transported from a producer thread to the consumer."""
+
+    error: BaseException
+    """Original worker exception with its traceback."""
+
+
+_END: object = object()
+"""Queue sentinel emitted once by each normally exhausted worker."""
+
+
+def iter_threaded(  # noqa: UP047 — beartype does not support PEP 695 type parameters
+    workers: Sequence[Callable[[], Iterable[ItemT]]],
+    maxsize: int,
+    join_timeout: float = 30.0,
+) -> Generator[ItemT, None, None]:
+    """Yield items from bounded worker threads and propagate their failures.
+
+    Args:
+        workers: Zero-argument factories whose iterables run in separate threads.
+        maxsize: Maximum items buffered between all workers and the consumer.
+        join_timeout: Seconds to wait for each worker during generator cleanup.
+
+    Yields:
+        Items from every worker in arrival order.
+
+    Raises:
+        ValueError: If the queue capacity or join timeout is not positive.
+        BaseException: Any exception raised by a worker.
+    """
+    if maxsize <= 0:
+        raise ValueError("threaded iterator maxsize must be positive")
+    if join_timeout <= 0.0:
+        raise ValueError("threaded iterator join_timeout must be positive")
+
+    queue: Queue[ItemT | _Failure | object] = Queue(maxsize=maxsize)
+    stop: Event = Event()
+
+    def put_unless_stopped(item: ItemT | _Failure | object) -> bool:
+        """Bound queue writes while allowing a closed consumer to stop workers."""
+        while not stop.is_set():
+            try:
+                queue.put(item, timeout=0.05)
+                return True
+            except Full:
+                continue
+        return False
+
+    def produce(worker: Callable[[], Iterable[ItemT]]) -> None:
+        """Exhaust one worker iterable into the shared queue."""
+        try:
+            item: ItemT
+            for item in worker():
+                if not put_unless_stopped(item):
+                    return
+            put_unless_stopped(_END)
+        except BaseException as error:
+            if put_unless_stopped(_Failure(error)):
+                stop.set()
+
+    threads: list[Thread] = [
+        Thread(target=produce, args=(worker,), name=f"zipdepth-producer-{index}", daemon=True)
+        for index, worker in enumerate(workers)
+    ]
+    thread: Thread
+    for thread in threads:
+        thread.start()
+    completed: int = 0
+    try:
+        while completed < len(threads):
+            queued: ItemT | _Failure | object = queue.get()
+            if queued is _END:
+                completed += 1
+                continue
+            if isinstance(queued, _Failure):
+                raise queued.error
+            yield queued  # type: ignore[misc]  # narrowed by the private queue transports above
+    finally:
+        stop.set()
+        for thread in threads:
+            thread.join(timeout=join_timeout)
+            if thread.is_alive():
+                warn(f"catalog producer thread {thread.name!r} did not stop within {join_timeout:.1f}s", RuntimeWarning, stacklevel=2)

--- a/pixi.lock
+++ b/pixi.lock
@@ -45771,6 +45771,1004 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fd/80/c959c5933adedb9ac15152e4067c702a808ea183a8b64cf8f31af8ad3155/multidict-6.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
       - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-11.2.1.2.tar.gz
+  zipdepth-catalog:
+    channels:
+    - url: https://prefix.dev/ai-demos/
+    - url: https://prefix.dev/conda-forge/
+    indexes:
+    - https://pypi.org/simple
+    packages:
+      p1:
+      - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-h7cc23a3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h57e6904_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/av-18.0.0-py312h46547aa_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.4-h4610da3_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.15-h6bbde05_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.14.3-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-h01ee8f8_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.11.0-hbe094ff_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.27.5-h4f381ba_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.13.1-h7508075_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.7-h01ee8f8_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-h01ee8f8_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils_linux-64-2.46.1-default_h4852527_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/brotli-1.2.0-h505cf86_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/brotli-bin-1.2.0-h9908984_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/brunsli-0.1-hd1e3526_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-blosc2-3.3.2-hc31b594_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-compiler-2.0.0-ha29393d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/charls-2.4.4-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/conda-gcc-specs-15.3.0-h8846f6e_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-crt-13.0.88-h69a702a_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-crt-tools-13.0.88-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-ctadvisor-13.0.85-h676940d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-13.0.96-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-dev-13.0.96-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-static-13.0.96-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cuobjdump-13.0.85-hffce074_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cupti-13.0.85-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cuxxfilt-13.0.85-hffce074_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-driver-dev-13.0.96-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-13.0.88-hcdd1206_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-impl-13.0.88-h85509e4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-tools-13.0.88-he02047a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc_linux-64-13.0.88-hb2fc203_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvdisasm-13.0.85-hffce074_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvml-dev-13.0.87-hffce074_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvprune-13.0.85-hffce074_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvrtc-13.0.88-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvrtc-dev-13.0.88-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvtx-13.0.85-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvtx-dev-13.0.85-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvvm-impl-13.0.88-h4bc722e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvvm-tools-13.0.88-h4bc722e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-profiler-api-13.0.85-h7938cbb_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cudnn-9.25.0.15-h886f0b6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cusparselt-0.9.1.1-h7bcfba5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cxx-compiler-2.0.0-hdab9b82_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-8.1.2-gpl_h95e667c_906.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fmt-12.1.0-h76c4fd7_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fonttools-4.63.0-py312h8a5da7c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/freetype-2.14.3-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fribidi-1.0.16-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc-15.3.0-hc6a0c74_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-15.3.0-h6f13dc8_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-15.3.0-h7df7c86_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gdk-pixbuf-2.44.8-h68053f1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/giflib-5.2.2-ha257d8a_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/glslang-16.5.0-h980caa0_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gmp-6.3.0-hfd2156b_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gmpy2-2.3.1-py312h04c1168_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/graphite2-1.3.15-h54a6638_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/grpcio-1.83.0-py312ha084767_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx-15.3.0-hc6a0c74_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx_impl_linux-64-15.3.0-h90d9265_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-15.3.0-h8c4937a_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-14.4.0-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.2.0-nompi_hc529623_100.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hf-transfer-0.1.9-py312h914ccca_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hf-xet-1.5.2-py310hb823017_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.8.16-py312h3d3c6f4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/imath-3.2.2-hde8ca8f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/intel-gmmlib-22.10.0-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/intel-media-driver-26.1.6-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/kiwisolver-1.5.0-py312h0a2e395_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lerc-4.2.0-hdb68285_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/level-zero-1.29.0-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20260526.0-cxx17_h0dc7533_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libass-0.17.5-h434b012_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libavif16-1.4.2-h0ed3d04_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-9_h5875eb1_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcap-2.78-h084b8d7_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-9_hfef963f_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libclang-cpp23.1-23.1.0-default_h0acdd01_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libclang13-23.1.0-default_h56ed263_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcublas-13.1.1.3-h676940d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcublas-dev-13.1.1.3-h676940d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudnn-9.25.0.15-ha4b6413_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudnn-dev-9.25.0.15-h7bcfba5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudss-0.8.0.10-h7bcfba5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudss-dev-0.8.0.10-h21fdb18_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufft-12.0.0.61-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufft-dev-12.0.0.61-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufile-1.15.1.6-hbc026e6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufile-dev-1.15.1.6-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurand-10.4.0.35-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurand-dev-10.4.0.35-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.21.0-ha042cf0_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusolver-12.0.4.66-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusolver-dev-12.0.4.66-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusparse-12.6.3.3-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusparse-dev-12.6.3.3-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdovi-3.4.0-ha23c83e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdrm-2.4.129-h7cc23a3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libfreetype6-2.14.3-h5e6c136_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-16.2.0-h69a702a_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-16.2.0-h6b99dfc_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.88.3-h45c3219_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgrpc-1.83.0-h792040b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libharfbuzz-14.4.0-h23af247_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libharfbuzz-devel-14.4.0-h23af247_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhwloc-2.13.0-default_he001693_1000.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhwy-1.4.0-h57c4cff_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libjxl-0.12.0-heb2dce7_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-9_h5e43f62_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-9_hdba1596_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libllvm23-23.1.0-h474f4eb_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmagma-2.10.0-hd93470c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmagma_sparse-2.10.0-hbc3fd83_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnl-3.11.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnpp-13.0.1.2-h676940d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvjitlink-13.3.33-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvjpeg-13.0.1.86-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvptxcompiler-dev-13.0.88-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopencv-5.0.0-qt6_h469fc51_605.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-2026.3.0-hb2f3c86_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-batch-plugin-2026.3.0-h9f30d58_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-plugin-2026.3.0-h9f30d58_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-hetero-plugin-2026.3.0-hfeb6f35_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2026.3.0-hb2f3c86_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2026.3.0-hb2f3c86_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-npu-plugin-2026.3.0-hb2f3c86_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-ir-frontend-2026.3.0-hfeb6f35_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-onnx-frontend-2026.3.0-h6c33c14_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-paddle-frontend-2026.3.0-h6c33c14_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-pytorch-frontend-2026.3.0-h0542e35_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-frontend-2026.3.0-h565fa1b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2026.3.0-h0542e35_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopus-1.6.1-hebe6cf0_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpciaccess-0.19-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libplacebo-7.360.1-hc50b9dd_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpng-1.6.58-h922cc85_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpq-18.6-h9d76c99_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libprotobuf-7.35.1-h622638d_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpsl-0.23.1-hd9e3e90_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libraqm-0.11.0-h6406941_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libre2-11-2025.11.05-h60473fc_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/librsvg-2.62.3-h4c96295_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-15.3.0-h54950a5_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-h6154650_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-16.2.0-hdf11a46_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsystemd0-261.2-h6f4a2f1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libtiff-4.7.2-hcc2c06a_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libtorch-2.12.1-cuda130_mkl_h5535f43_300.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libudev1-261.2-h6f4a2f1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liburing-2.14-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libva-2.24.1-hb83e432_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvpl-2.16.0-h54a6638_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvpx-1.15.2-hd2095e1_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvulkan-loader-1.4.357.0-h0e34353_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxcb-1.17.0-hb83e432_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.13.2-h51789e4_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxslt-1.1.43-h711ed8c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libzopfli-1.0.3-h9c3ff4c_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/llvm-openmp-23.1.0-h7148c6a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lz4-c-1.10.0-hee9eb32_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/matplotlib-3.11.1-py312h6a12a82_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/matplotlib-base-3.11.1-py312h4c94fcb_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mkl-2026.1.0-hd2095e1_245.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpc-1.4.0-ha2cb11d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpfr-4.2.2-ha2cb11d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpg123-1.32.9-h8142553_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/nccl-2.30.7.1-h1aa9b5a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.5.2-py312h33ff503_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ocl-icd-2.3.4-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/onednn-3.12-omp_h83de36e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/onnxruntime-1.28.0-py312h99cb659_200_cuda130.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/opencl-headers-2025.06.13-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openexr-3.4.15-ha9edf89_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openh264-2.6.0-h8c49934_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openjph-0.31.0-h8d634f6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/optree-0.20.0-py312ha5105d2_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pango-1.58.2-hda50119_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.47-h8b3dc9c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pillow-12.3.0-py312h50c33e8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pixman-0.46.4-h54a6638_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/protobuf-7.35.1-py312h7bd0bee_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pthread-stubs-0.4-hb03c661_1003.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/py-opencv-5.0.0-qt6_h6945e2d_605.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyside6-6.11.2-py312hf143aa3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/python-3.12.14-h8ab3286_0_cpython.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pytorch-2.12.1-cuda130_mkl_py312_h24b5296_300.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pytorch-gpu-2.12.1-cuda129_mkl_h0d04637_300.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/qt6-main-6.11.2-pl5321h9df5c37_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/rav1e-0.8.1-h1fbca29_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/rdma-core-63.1-h192683f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/re2-2025.11.05-h94463f1_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/regex-2026.7.19-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.6-h7e3ee7f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/safetensors-0.8.0-py312h868fb18_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/scipy-1.18.0-py312h54fa4ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sdl3-3.4.14-hdeec2a5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/shaderc-2026.3-hcebf71c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/spirv-tools-2026.3-h7148c6a_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-4.2.0-hd2095e1_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tensorboard-data-server-0.7.0-py312h4eba8b5_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tokenizers-0.23.1-py312hf875000_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/torchcodec-0.14.0-cuda130_py312_h0ea267f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/torchvision-0.28.0-cuda130_py312_h2966ecb_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.8-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/triton-3.7.1-cuda130py312hc6dca4b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.26.0-hc1c935e_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-h280c20c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libsm-1.2.6-h0d788c3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxext-1.3.7-h7cc23a3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxfixes-6.0.2-h7cc23a3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxi-1.8.3-h7cc23a3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrandr-1.5.5-h7cc23a3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrender-0.9.12-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxtst-1.2.5-h7cc23a3_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-xorgproto-2025.1-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/yaml-0.2.5-hebe6cf0_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zfp-1.0.1-h909a3a2_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zlib-ng-2.3.3-hce19668_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+      - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/absl-py-2.5.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/anyio-4.14.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/beartype-0.22.9-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/casefy-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.7.22-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.12.14-py312hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cccl_linux-64-13.0.85-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-compiler-13.0.3-hbad6d8a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-crt-dev_linux-64-13.0.88-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart-dev_linux-64-13.0.96-h376f20c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart-static_linux-64-13.0.96-h376f20c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart_linux-64-13.0.96-h376f20c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-driver-dev_linux-64-13.0.96-h376f20c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-nvcc-dev_linux-64-13.0.88-he91c749_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-nvvm-dev_linux-64-13.0.88-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-version-13.0-hc7b4dd1_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/docstring_parser-0.18.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/eval_type_backport-0.4.0-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/filelock-3.32.4-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/frozendict-2.4.7-pyh851646a_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/fsspec-2026.7.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h2-4.4.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/huggingface_hub-1.29.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/idna-3.19-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jaxtyping-0.2.36-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/kernel-headers_linux-64-5.14.0-he073ed8_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-15.3.0-h2b852eb_104.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libnvptxcompiler-dev_linux-64-13.0.88-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-15.3.0-hb2c5482_104.conda
+      - conda: https://prefix.dev/conda-forge/noarch/markdown-3.10.3-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/nvidia-ml-py-13.610.43-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/plum-dispatch-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-3.0.4-pyh293190f_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-global-3.0.4-pyh648e204_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pygments-2.21.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pyserde-0.31.8-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-flatbuffers-25.12.19-pyh9d96877_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.12.14-hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/setuptools-81.0.0-pyh332efcf_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/shtab-1.12.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-64-2.34-h087de78_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tensorboard-2.20.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/transformers-5.16.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/trimesh-5.0.0-pyh7b2049a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typeguard-2.13.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/typer-0.27.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tyro-0.9.1-pyhff2d567_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.49-hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/werkzeug-3.1.8-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - pypi: ./packages/arkitscenes-download
+      - pypi: ./packages/monoprior
+      - pypi: ./packages/sam3
+      - pypi: ./packages/simplecv
+      - pypi: ./packages/zipdepth
+      - pypi: https://files.pythonhosted.org/packages/03/e8/5c880ffd8d4bb9df4cdf75ab8b44fc8f7011b6cb629b3e6242f3d5944b4f/stringzilla-5.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0a/e2/91f145e1f32428e9e1f21f46a7022ffe63d11f549ee55c3b9265ff5207fc/albucore-0.0.24-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/60/17ed502ab8258e36b6caf478974994f15691c73e3c46abf82a2ec63e9eda/omnidata_tools-0.0.23-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/98/e976540c1addf70442be7842a18cf70884a964abbf69442504f4d2939989/pandas-3.0.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/2f/c9c617f8556e3b6e8c24880d91b8e7a7b242f32b85cf23602b029d705c05/nvidia_cuda_runtime_cu13-0.0.0a0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/25/f4/ead6e0e37209b07c9baa3e984ccdb0348ca370b77cea3aaea8ddbb097e00/lightning_utilities-0.15.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/28/7f/cfd9bc4b1f5e424eeea83d0493e43f3b1b02707ce8e50c47945873982bd5/wrapt-2.3.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/5f/e315fbb8c4b7091e2a2b21bc50c764d4eef25196eb0897564e6809237729/tensorrt_cu13_libs-11.2.1.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/30/c5/6290519dec32f3cdf6827e3bbcbf7a9f4fb29a55a9204199901fed69957b/aiobotocore-3.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/35/bf/9cad857b630c840738003eb24c1adb63490a1024ec40a9dcc3a753300c38/asciimatics-1.15.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/38/31/7ff3f7768eded7535c621abc2fecb9d181a34ea4cae3afe682feb796f242/cuda_python-13.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3c/28/7ae846998728326759eab771afd83ad721b6c10e9cef7da2b5ca9bdd4a7b/simsimd-6.5.16-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/45/e4/19d92435fb102320ece532fc9df58f0e39deee675f5b5d204dfc667a4ed3/tensorrt_cu13_bindings-11.2.1.2-cp312-none-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/52/b7/7cd31f29d6055bd711ae6e669367fba6f5ae9de463910a793e30556a8db7/aiohttp-3.14.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/5a/ee/ff5b0456cee872322ea9793044d5def1e01f86dc701c78629e6e2ed8249d/fastcore-2.2.16-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5c/cd/86fe9e659e9699f62f8dd5ecd8c6725474334b23cab8aa71d82b5f56f1a4/botocore-1.43.56-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/60/c9/711ca85d79f1ec98f29a5eae2b051e25b4ecec5de3e3c0e2d5c5dcb15664/pyarrow-25.0.1-cp312-cp312-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/e4/b19be937c95df9a02d6337178088b56fe77c2656eab46489344c7ac510e9/pyturbojpeg-2.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6f/89/bb5108dc6c3651dca963f2b0a3ba19bbcb370c94e1b6d3e0e844a58e6dca/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/70/bd/cb98519aa658b488710aef0d5bac1435e7b95756b7e28c8c97ca394f5260/lovely_numpy-0.2.24-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/71/70/38998b950a97ea279e6bd657575d22d1a2047256caf707d9a10fbce4f065/multiprocess-0.70.19-py312-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/82/9707c7b0336bca53b75f52fc350956a93da66eb6be632b370bc933216fb4/icecream-2.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8b/4d/5740c27110b83634d8491c3b5facf0111b3e554c3164f4fb953be9bddaf6/pytorch_lightning-2.6.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8e/64/013409c451a44b61310fb757af4527f3de57fc98a00f40448de28b864290/albumentations-2.0.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/91/cd/6d1637172eb59c7b18ac90ed089d1f599a11fe0e63b4db2d017f3bb38a32/onnx_ir-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/98/cc/bcde19a37952ecc58e7d9d67ecaa048e1e21b17d014ce0863a6a6101e606/s3fs-2026.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9b/21/f6ef335f6e65724aa78b8d792b48d40a48c381715f1e62f5a5049e09d07e/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/5c/fe9f95abd5eaedfa69f31e450f7e2768bef121dbdf25bcddee2cd3087a16/pyfiglet-1.0.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/4d/603557ab3cb171cc2a61d3678a39cb4dae3fd21275078bfbd1c0b0b5230b/cuda_core-1.0.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/b1/ef21259ec74fe0b265ed201379de1d0ef7c14178313ee03705952f1b7093/cuda_pathfinder-1.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a7/00/4823f06357892d1e60d6f34e7299d2ba4ed2108c487cc394f7ce85a3ff14/onnx-1.21.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a8/81/e69008e3479f4d0134875bc4ae39503bedcd55ca2597e71392c963c651b4/datafusion-54.0.0-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a8/db/253133d7e7cb40d3af384bb2f5c0b4a2b7fdcffbc95c688cc67a20a3c103/accelerate-1.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/29/c028a0731e202035f0e2e0bfbf1a3e46ad6c628cbb17f6f1cc9eea5d9ff1/pathlib_abc-0.5.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/1f/73c53fcbfb0b5a78f91176df41945ca466e71e9d9d836e5c522abda39ee7/pydantic-2.11.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/76/de1bfac17d183c49c6d0887903d3064ced51cf1d9ba7a8d611c1a8808c4f/timm-1.0.28-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c3/a2/c7f6ebf546f8f644edf0f999aa98ece106986a77a7b922316bf6414ff825/torchmetrics-1.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c7/12/6f3fcd5067a9cbf4f8664b32957973498da8b083455203c8d9cab83a725c/platformdirs-4.11.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c7/f9/7d76c1eae866f5d4636401b31b6d6dd90e4b4ced1fa7cfdfcca9c60e4bd3/ml_dtypes-0.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/d4/2b/04b8a15f3a1c77bc79ddf5c73875327f34b4fa75982df2b76e45e402d364/asttokens-3.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/d0/d56c859b8222116f5d68459199f48359e0bf121b6f65a69bf329b3602ba0/yarl-1.24.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/db/df/ffb593ebed2a068d2d6be44261283f39a6b809c0fcdfdcafbd448cbeec77/diffusers-0.40.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dc/95/1ec57df6c52152fb4c776da5fbb2896f19af52de3776899d91e7140e7654/aria2p-0.12.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dd/1a/5d9a402b39ec892d856bbdd9db502ff73ce28cdf4aff72eb1ce1d6843506/universal_pathlib-0.3.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dd/bd/a0c8e737b6afda10e42a597787d53d5b66e00268df6f59184701eeae37d9/onnxscript-0.7.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e7/66/9c3e574c6c359a2a58af9fed67dad7895e507eb37fb4967d9203eb1a4006/rerun_sdk-0.36.2-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ed/1f/95cb961341bf33e534a472672ef4916c90046dc3c57b1442f5586dda72f1/geffnet-1.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-11.2.1.2.tar.gz
+  zipdepth-catalog-dev:
+    channels:
+    - url: https://prefix.dev/ai-demos/
+    - url: https://prefix.dev/conda-forge/
+    indexes:
+    - https://pypi.org/simple
+    packages:
+      p1:
+      - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-h7cc23a3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h57e6904_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/av-18.0.0-py312h46547aa_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.4-h4610da3_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.15-h6bbde05_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.14.3-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-h01ee8f8_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.11.0-hbe094ff_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.27.5-h4f381ba_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.13.1-h7508075_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.7-h01ee8f8_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-h01ee8f8_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils_linux-64-2.46.1-default_h4852527_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/brotli-1.2.0-h505cf86_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/brotli-bin-1.2.0-h9908984_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/brunsli-0.1-hd1e3526_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-blosc2-3.3.2-hc31b594_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-compiler-2.0.0-ha29393d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/charls-2.4.4-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/conda-gcc-specs-15.3.0-h8846f6e_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-crt-13.0.88-h69a702a_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-crt-tools-13.0.88-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-ctadvisor-13.0.85-h676940d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-13.0.96-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-dev-13.0.96-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cudart-static-13.0.96-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cuobjdump-13.0.85-hffce074_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cupti-13.0.85-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-cuxxfilt-13.0.85-hffce074_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-driver-dev-13.0.96-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-13.0.88-hcdd1206_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-impl-13.0.88-h85509e4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc-tools-13.0.88-he02047a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvcc_linux-64-13.0.88-hb2fc203_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvdisasm-13.0.85-hffce074_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvml-dev-13.0.87-hffce074_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvprune-13.0.85-hffce074_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvrtc-13.0.88-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvrtc-dev-13.0.88-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvtx-13.0.85-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvtx-dev-13.0.85-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvvm-impl-13.0.88-h4bc722e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvvm-tools-13.0.88-h4bc722e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cuda-profiler-api-13.0.85-h7938cbb_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cudnn-9.25.0.15-h886f0b6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cusparselt-0.9.1.1-h7bcfba5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cxx-compiler-2.0.0-hdab9b82_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-8.1.2-gpl_h95e667c_906.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fmt-12.1.0-h76c4fd7_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fonttools-4.63.0-py312h8a5da7c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/freetype-2.14.3-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fribidi-1.0.16-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc-15.3.0-hc6a0c74_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-15.3.0-h6f13dc8_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-15.3.0-h7df7c86_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gdk-pixbuf-2.44.8-h68053f1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/giflib-5.2.2-ha257d8a_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/glslang-16.5.0-h980caa0_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gmp-6.3.0-hfd2156b_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gmpy2-2.3.1-py312h04c1168_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/graphite2-1.3.15-h54a6638_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/grpcio-1.83.0-py312ha084767_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx-15.3.0-hc6a0c74_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx_impl_linux-64-15.3.0-h90d9265_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-15.3.0-h8c4937a_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-14.4.0-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.2.0-nompi_hc529623_100.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hf-transfer-0.1.9-py312h914ccca_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hf-xet-1.5.2-py310hb823017_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hypothesis-6.165.10-py312hc767a74_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.8.16-py312h3d3c6f4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/imath-3.2.2-hde8ca8f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/intel-gmmlib-22.10.0-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/intel-media-driver-26.1.6-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/kiwisolver-1.5.0-py312h0a2e395_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lerc-4.2.0-hdb68285_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/level-zero-1.29.0-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20260526.0-cxx17_h0dc7533_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libass-0.17.5-h434b012_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libavif16-1.4.2-h0ed3d04_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-9_h5875eb1_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcap-2.78-h084b8d7_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-9_hfef963f_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libclang-cpp23.1-23.1.0-default_h0acdd01_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libclang13-23.1.0-default_h56ed263_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcublas-13.1.1.3-h676940d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcublas-dev-13.1.1.3-h676940d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudnn-9.25.0.15-ha4b6413_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudnn-dev-9.25.0.15-h7bcfba5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudss-0.8.0.10-h7bcfba5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcudss-dev-0.8.0.10-h21fdb18_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufft-12.0.0.61-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufft-dev-12.0.0.61-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufile-1.15.1.6-hbc026e6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcufile-dev-1.15.1.6-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurand-10.4.0.35-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurand-dev-10.4.0.35-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.21.0-ha042cf0_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusolver-12.0.4.66-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusolver-dev-12.0.4.66-h676940d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusparse-12.6.3.3-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcusparse-dev-12.6.3.3-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdovi-3.4.0-ha23c83e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdrm-2.4.129-h7cc23a3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libfreetype6-2.14.3-h5e6c136_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-16.2.0-h69a702a_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-16.2.0-h6b99dfc_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.88.3-h45c3219_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgrpc-1.83.0-h792040b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libharfbuzz-14.4.0-h23af247_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libharfbuzz-devel-14.4.0-h23af247_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhwloc-2.13.0-default_he001693_1000.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhwy-1.4.0-h57c4cff_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libjxl-0.12.0-heb2dce7_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-9_h5e43f62_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-9_hdba1596_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libllvm23-23.1.0-h474f4eb_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmagma-2.10.0-hd93470c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmagma_sparse-2.10.0-hbc3fd83_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnl-3.11.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnpp-13.0.1.2-h676940d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvjitlink-13.3.33-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvjpeg-13.0.1.86-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libnvptxcompiler-dev-13.0.88-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopencv-5.0.0-qt6_h469fc51_605.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-2026.3.0-hb2f3c86_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-batch-plugin-2026.3.0-h9f30d58_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-plugin-2026.3.0-h9f30d58_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-hetero-plugin-2026.3.0-hfeb6f35_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2026.3.0-hb2f3c86_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2026.3.0-hb2f3c86_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-intel-npu-plugin-2026.3.0-hb2f3c86_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-ir-frontend-2026.3.0-hfeb6f35_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-onnx-frontend-2026.3.0-h6c33c14_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-paddle-frontend-2026.3.0-h6c33c14_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-pytorch-frontend-2026.3.0-h0542e35_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-frontend-2026.3.0-h565fa1b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2026.3.0-h0542e35_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libopus-1.6.1-hebe6cf0_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpciaccess-0.19-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libplacebo-7.360.1-hc50b9dd_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpng-1.6.58-h922cc85_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpq-18.6-h9d76c99_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libprotobuf-7.35.1-h622638d_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libpsl-0.23.1-hd9e3e90_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libraqm-0.11.0-h6406941_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libre2-11-2025.11.05-h60473fc_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/librsvg-2.62.3-h4c96295_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-15.3.0-h54950a5_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-h6154650_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-16.2.0-hdf11a46_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsystemd0-261.2-h6f4a2f1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libtiff-4.7.2-hcc2c06a_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libtorch-2.12.1-cuda130_mkl_h5535f43_300.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libudev1-261.2-h6f4a2f1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liburing-2.14-hb700be7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libva-2.24.1-hb83e432_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvpl-2.16.0-h54a6638_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvpx-1.15.2-hd2095e1_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libvulkan-loader-1.4.357.0-h0e34353_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxcb-1.17.0-hb83e432_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.13.2-h51789e4_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxslt-1.1.43-h711ed8c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libzopfli-1.0.3-h9c3ff4c_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/llvm-openmp-23.1.0-h7148c6a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/lz4-c-1.10.0-hee9eb32_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/matplotlib-3.11.1-py312h6a12a82_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/matplotlib-base-3.11.1-py312h4c94fcb_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mkl-2026.1.0-hd2095e1_245.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpc-1.4.0-ha2cb11d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpfr-4.2.2-ha2cb11d_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpg123-1.32.9-h8142553_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/nccl-2.30.7.1-h1aa9b5a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.5.2-py312h33ff503_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ocl-icd-2.3.4-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/onednn-3.12-omp_h83de36e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/onnxruntime-1.28.0-py312h99cb659_200_cuda130.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/opencl-headers-2025.06.13-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openexr-3.4.15-ha9edf89_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openh264-2.6.0-h8c49934_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openjph-0.31.0-h8d634f6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/optree-0.20.0-py312ha5105d2_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pango-1.58.2-hda50119_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.47-h8b3dc9c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pillow-12.3.0-py312h50c33e8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pixman-0.46.4-h54a6638_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/protobuf-7.35.1-py312h7bd0bee_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pthread-stubs-0.4-hb03c661_1003.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/py-opencv-5.0.0-qt6_h6945e2d_605.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyrefly-1.2.0-hb17b654_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyside6-6.11.2-py312hf143aa3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/python-3.12.14-h8ab3286_0_cpython.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pytorch-2.12.1-cuda130_mkl_py312_h24b5296_300.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pytorch-gpu-2.12.1-cuda129_mkl_h0d04637_300.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/qt6-main-6.11.2-pl5321h9df5c37_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/rav1e-0.8.1-h1fbca29_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/rdma-core-63.1-h192683f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/re2-2025.11.05-h94463f1_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/regex-2026.7.19-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ruff-0.16.5-hdfdb5ae_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.6-h7e3ee7f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/safetensors-0.8.0-py312h868fb18_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/scipy-1.18.0-py312h54fa4ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sdl3-3.4.14-hdeec2a5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/shaderc-2026.3-hcebf71c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/spirv-tools-2026.3-h7148c6a_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-4.2.0-hd2095e1_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tensorboard-data-server-0.7.0-py312h4eba8b5_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tokenizers-0.23.1-py312hf875000_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/torchcodec-0.14.0-cuda130_py312_h0ea267f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/torchvision-0.28.0-cuda130_py312_h2966ecb_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.8-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/triton-3.7.1-cuda130py312hc6dca4b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.26.0-hc1c935e_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-h280c20c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libsm-1.2.6-h0d788c3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxext-1.3.7-h7cc23a3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxfixes-6.0.2-h7cc23a3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxi-1.8.3-h7cc23a3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrandr-1.5.5-h7cc23a3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrender-0.9.12-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxtst-1.2.5-h7cc23a3_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xorg-xorgproto-2025.1-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/yaml-0.2.5-hebe6cf0_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zfp-1.0.1-h909a3a2_5.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zlib-ng-2.3.3-hce19668_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+      - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/absl-py-2.5.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/anyio-4.14.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/beartype-0.22.9-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/casefy-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.7.22-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.12.14-py312hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cccl_linux-64-13.0.85-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-compiler-13.0.3-hbad6d8a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-crt-dev_linux-64-13.0.88-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart-dev_linux-64-13.0.96-h376f20c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart-static_linux-64-13.0.96-h376f20c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart_linux-64-13.0.96-h376f20c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-driver-dev_linux-64-13.0.96-h376f20c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-nvcc-dev_linux-64-13.0.88-he91c749_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-nvvm-dev_linux-64-13.0.88-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-version-13.0-hc7b4dd1_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/docstring_parser-0.18.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/eval_type_backport-0.4.0-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/filelock-3.32.4-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/frozendict-2.4.7-pyh851646a_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/fsspec-2026.7.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h2-4.4.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/huggingface_hub-1.29.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/idna-3.19-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jaxtyping-0.2.36-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/kernel-headers_linux-64-5.14.0-he073ed8_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-15.3.0-h2b852eb_104.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libnvptxcompiler-dev_linux-64-13.0.88-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-15.3.0-hb2c5482_104.conda
+      - conda: https://prefix.dev/conda-forge/noarch/markdown-3.10.3-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/nvidia-ml-py-13.610.43-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/plum-dispatch-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-3.0.4-pyh293190f_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-global-3.0.4-pyh648e204_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pygments-2.21.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pyserde-0.31.8-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-flatbuffers-25.12.19-pyh9d96877_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.12.14-hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/setuptools-81.0.0-pyh332efcf_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/shtab-1.12.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-64-2.34-h087de78_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tensorboard-2.20.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/transformers-5.16.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/trimesh-5.0.0-pyh7b2049a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typeguard-2.13.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/typer-0.27.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tyro-0.9.1-pyhff2d567_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/vulture-2.16-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.49-hd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/werkzeug-3.1.8-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - pypi: ./packages/arkitscenes-download
+      - pypi: ./packages/monoprior
+      - pypi: ./packages/sam3
+      - pypi: ./packages/simplecv
+      - pypi: ./packages/zipdepth
+      - pypi: https://files.pythonhosted.org/packages/03/e8/5c880ffd8d4bb9df4cdf75ab8b44fc8f7011b6cb629b3e6242f3d5944b4f/stringzilla-5.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0a/e2/91f145e1f32428e9e1f21f46a7022ffe63d11f549ee55c3b9265ff5207fc/albucore-0.0.24-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/60/17ed502ab8258e36b6caf478974994f15691c73e3c46abf82a2ec63e9eda/omnidata_tools-0.0.23-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/98/e976540c1addf70442be7842a18cf70884a964abbf69442504f4d2939989/pandas-3.0.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/2f/c9c617f8556e3b6e8c24880d91b8e7a7b242f32b85cf23602b029d705c05/nvidia_cuda_runtime_cu13-0.0.0a0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/25/f4/ead6e0e37209b07c9baa3e984ccdb0348ca370b77cea3aaea8ddbb097e00/lightning_utilities-0.15.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/28/7f/cfd9bc4b1f5e424eeea83d0493e43f3b1b02707ce8e50c47945873982bd5/wrapt-2.3.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/5f/e315fbb8c4b7091e2a2b21bc50c764d4eef25196eb0897564e6809237729/tensorrt_cu13_libs-11.2.1.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/30/c5/6290519dec32f3cdf6827e3bbcbf7a9f4fb29a55a9204199901fed69957b/aiobotocore-3.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/35/bf/9cad857b630c840738003eb24c1adb63490a1024ec40a9dcc3a753300c38/asciimatics-1.15.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/38/31/7ff3f7768eded7535c621abc2fecb9d181a34ea4cae3afe682feb796f242/cuda_python-13.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3c/28/7ae846998728326759eab771afd83ad721b6c10e9cef7da2b5ca9bdd4a7b/simsimd-6.5.16-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/45/e4/19d92435fb102320ece532fc9df58f0e39deee675f5b5d204dfc667a4ed3/tensorrt_cu13_bindings-11.2.1.2-cp312-none-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/52/b7/7cd31f29d6055bd711ae6e669367fba6f5ae9de463910a793e30556a8db7/aiohttp-3.14.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/5a/ee/ff5b0456cee872322ea9793044d5def1e01f86dc701c78629e6e2ed8249d/fastcore-2.2.16-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5c/cd/86fe9e659e9699f62f8dd5ecd8c6725474334b23cab8aa71d82b5f56f1a4/botocore-1.43.56-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/60/c9/711ca85d79f1ec98f29a5eae2b051e25b4ecec5de3e3c0e2d5c5dcb15664/pyarrow-25.0.1-cp312-cp312-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/6c/e4/b19be937c95df9a02d6337178088b56fe77c2656eab46489344c7ac510e9/pyturbojpeg-2.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6f/89/bb5108dc6c3651dca963f2b0a3ba19bbcb370c94e1b6d3e0e844a58e6dca/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/70/bd/cb98519aa658b488710aef0d5bac1435e7b95756b7e28c8c97ca394f5260/lovely_numpy-0.2.24-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/71/70/38998b950a97ea279e6bd657575d22d1a2047256caf707d9a10fbce4f065/multiprocess-0.70.19-py312-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/82/9707c7b0336bca53b75f52fc350956a93da66eb6be632b370bc933216fb4/icecream-2.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/f0/b0e2a33c0367e79806054f556159f0b43e6a98d7e728aea1b07028a56ee4/types_tqdm-4.70.0.20260827-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8b/4d/5740c27110b83634d8491c3b5facf0111b3e554c3164f4fb953be9bddaf6/pytorch_lightning-2.6.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8e/64/013409c451a44b61310fb757af4527f3de57fc98a00f40448de28b864290/albumentations-2.0.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/91/cd/6d1637172eb59c7b18ac90ed089d1f599a11fe0e63b4db2d017f3bb38a32/onnx_ir-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/98/cc/bcde19a37952ecc58e7d9d67ecaa048e1e21b17d014ce0863a6a6101e606/s3fs-2026.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9b/21/f6ef335f6e65724aa78b8d792b48d40a48c381715f1e62f5a5049e09d07e/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/5c/fe9f95abd5eaedfa69f31e450f7e2768bef121dbdf25bcddee2cd3087a16/pyfiglet-1.0.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/4d/603557ab3cb171cc2a61d3678a39cb4dae3fd21275078bfbd1c0b0b5230b/cuda_core-1.0.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/b1/ef21259ec74fe0b265ed201379de1d0ef7c14178313ee03705952f1b7093/cuda_pathfinder-1.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a7/00/4823f06357892d1e60d6f34e7299d2ba4ed2108c487cc394f7ce85a3ff14/onnx-1.21.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a8/81/e69008e3479f4d0134875bc4ae39503bedcd55ca2597e71392c963c651b4/datafusion-54.0.0-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a8/db/253133d7e7cb40d3af384bb2f5c0b4a2b7fdcffbc95c688cc67a20a3c103/accelerate-1.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/29/c028a0731e202035f0e2e0bfbf1a3e46ad6c628cbb17f6f1cc9eea5d9ff1/pathlib_abc-0.5.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/1f/73c53fcbfb0b5a78f91176df41945ca466e71e9d9d836e5c522abda39ee7/pydantic-2.11.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/76/de1bfac17d183c49c6d0887903d3064ced51cf1d9ba7a8d611c1a8808c4f/timm-1.0.28-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c3/a2/c7f6ebf546f8f644edf0f999aa98ece106986a77a7b922316bf6414ff825/torchmetrics-1.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c7/12/6f3fcd5067a9cbf4f8664b32957973498da8b083455203c8d9cab83a725c/platformdirs-4.11.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c7/f9/7d76c1eae866f5d4636401b31b6d6dd90e4b4ced1fa7cfdfcca9c60e4bd3/ml_dtypes-0.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/d4/2b/04b8a15f3a1c77bc79ddf5c73875327f34b4fa75982df2b76e45e402d364/asttokens-3.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/d0/d56c859b8222116f5d68459199f48359e0bf121b6f65a69bf329b3602ba0/yarl-1.24.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/db/df/ffb593ebed2a068d2d6be44261283f39a6b809c0fcdfdcafbd448cbeec77/diffusers-0.40.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dc/95/1ec57df6c52152fb4c776da5fbb2896f19af52de3776899d91e7140e7654/aria2p-0.12.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dd/1a/5d9a402b39ec892d856bbdd9db502ff73ce28cdf4aff72eb1ce1d6843506/universal_pathlib-0.3.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dd/bd/a0c8e737b6afda10e42a597787d53d5b66e00268df6f59184701eeae37d9/onnxscript-0.7.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e7/66/9c3e574c6c359a2a58af9fed67dad7895e507eb37fb4967d9203eb1a4006/rerun_sdk-0.36.2-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ed/1f/95cb961341bf33e534a472672ef4916c90046dc3c57b1442f5586dda72f1/geffnet-1.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-11.2.1.2.tar.gz
   zipdepth-dev:
     channels:
     - url: https://prefix.dev/ai-demos/
@@ -52602,6 +53600,53 @@ packages:
   run_exports: {}
   size: 2318456
   timestamp: 1781743148101
+- conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.8.16-py312h3d3c6f4_0.conda
+  sha256: 52a761b5b9fbd73539ab645277c10956d6380029f9a72cb4b168613a456ecfa3
+  md5: 73e40d83cd7352a74fab99cd08ccca5b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - blosc >=1.21.6,<2.0a0
+  - brunsli >=0.1,<1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-blosc2 >=3.3.2,<3.4.0a0
+  - charls >=2.4.4,<2.5.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - jxrlib >=1.1,<1.2.0a0
+  - lcms2 >=2.19.1,<3.0a0
+  - lerc >=4.2.0,<5.0a0
+  - libaec >=1.1.5,<2.0a0
+  - libavif16 >=1.4.2,<2.0a0
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libgcc >=15
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libstdcxx >=15
+  - libtiff >=4.7.2,<4.8.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libzopfli >=1.0.3,<1.1.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - numpy >=1.25,<3
+  - openjpeg >=2.5.4,<3.0a0
+  - openjph >=0.31.0,<0.32.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - snappy >=1.2.2,<1.3.0a0
+  - zfp >=1.0.1,<2.0a0
+  - zlib-ng >=2.3.3,<2.4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/imagecodecs?source=hash-mapping
+  run_exports: {}
+  size: 2285384
+  timestamp: 1786846577148
 - conda: https://prefix.dev/conda-forge/linux-64/imath-3.2.2-hde8ca8f_0.conda
   sha256: 43f30e6fd8cbe1fef59da760d1847c9ceff3fb69ceee7fd4a34538b0927959dd
   md5: c427448c6f3972c76e8a4474e0fe367b
@@ -60156,6 +61201,7 @@ packages:
   - libstdcxx >=15
   - __glibc >=2.17,<3.0.a0
   license: BSD-2-Clause
+  license_family: BSD
   purls: []
   run_exports:
     weak:
@@ -81971,6 +83017,7 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/hyperframe?source=hash-mapping
+  run_exports: {}
   size: 17397
   timestamp: 1737618427549
 - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.155.7-pyha770c72_0.conda
@@ -83609,6 +84656,21 @@ packages:
   run_exports: {}
   size: 16817
   timestamp: 1733408419340
+- conda: https://prefix.dev/conda-forge/noarch/nvidia-ml-py-13.610.43-pyhd8ed1ab_0.conda
+  sha256: 664b0f81fdc1f5ecd046feac22d85721b475a62a87e98e7a09dc20547f16e8d9
+  md5: 17cdeea29f316aba0c85b4886183418e
+  depends:
+  - python >=3.10
+  constrains:
+  - nvidia-ml ==9999999999
+  - pynvml ~=13.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/nvidia-ml-py?source=hash-mapping
+  run_exports: {}
+  size: 50107
+  timestamp: 1780355713540
 - conda: https://prefix.dev/conda-forge/noarch/onnx-ir-0.2.1-pyhd8ed1ab_0.conda
   sha256: 7e82e3b725a44635231832317cbe5302ed8f6420966c35729a28c254e3301c5a
   md5: a08fe3050acaa9d447d3c566c7440278
@@ -84958,6 +86020,7 @@ packages:
   license_family: APACHE
   purls:
   - pkg:pypi/sortedcontainers?source=hash-mapping
+  run_exports: {}
   size: 28657
   timestamp: 1738440459037
 - conda: https://prefix.dev/conda-forge/noarch/soupsieve-2.8.4-pyhd8ed1ab_0.conda
@@ -94482,6 +95545,11 @@ packages:
   - wrapt>=1.10.10,<3.0.0
   - httpx>=0.25.1,<0.29 ; extra == 'httpx'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/6f/89/bb5108dc6c3651dca963f2b0a3ba19bbcb370c94e1b6d3e0e844a58e6dca/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: charset-normalizer
+  version: 3.5.1
+  sha256: b9af956078716df40d985fb0dfeb2c2120c5ca92ba4ff4b388acfd01cdc14d08
+  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/6f/b6/eeb5903586645ef8a49b4b7892580438741acc3df91d7a5bd0f3a59ea9cb/onnx-1.21.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
   name: onnx
   version: 1.21.0
@@ -96060,6 +97128,18 @@ packages:
   requires_dist:
   - numpy
   - pytest>=7.0.0 ; extra == 'test'
+- pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
+  name: requests
+  version: 2.34.2
+  sha256: 2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0
+  requires_dist:
+  - charset-normalizer>=2,<4
+  - idna>=2.5,<4
+  - urllib3>=1.26,<3
+  - certifi>=2023.5.7
+  - pysocks>=1.5.6,!=1.5.7 ; extra == 'socks'
+  - chardet>=3.0.2,<8 ; extra == 'use-chardet-on-py3'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/a1/02/6224312aacb3c8ecbaa959897af57181fb6cf3a3d7917fd44d0f2917e6f2/pydantic_core-2.33.2-cp312-cp312-macosx_11_0_arm64.whl
   name: pydantic-core
   version: 2.33.2
@@ -96895,6 +97975,11 @@ packages:
   - pyarrow>=16.0.0 ; python_full_version < '3.14'
   - pyarrow>=22.0.0 ; python_full_version >= '3.14'
   - typing-extensions ; python_full_version < '3.13'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/c7/12/6f3fcd5067a9cbf4f8664b32957973498da8b083455203c8d9cab83a725c/platformdirs-4.11.5-py3-none-any.whl
+  name: platformdirs
+  version: 4.11.5
+  sha256: 89f8d42695853b89c7170bd49bc3dc593f98a71e695ede88e06a3b247bc4563b
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/c7/56/3fda522118a012acbff390f85d4c0332e56e54ed54b6802abaa1109264ba/rerun_sdk-0.36.2-cp310-abi3-manylinux_2_28_aarch64.whl
   name: rerun-sdk

--- a/pixi.toml
+++ b/pixi.toml
@@ -657,7 +657,7 @@ pyturbojpeg = ">=2.0.0,<3"
 [feature.zipdepth.activation.env]
 PACKAGE_DIR = "packages/zipdepth"
 # authored code only; the unmodified upstream tree (data/loss/training/evaluation/upstream_cli) is a vendor boundary
-PYREFLY_TARGET = "zipdepth/apis zipdepth/__init__.py tests tools"
+PYREFLY_TARGET = "zipdepth/apis zipdepth/catalog zipdepth/__init__.py tests tools"
 
 [feature.zipdepth.tasks.zipdepth-infer-rerun]
 cmd = "python tools/infer_rerun.py"
@@ -668,6 +668,27 @@ description = "ZipDepth single-image inference visualized in Rerun (2D + 3D); --
 cmd = "python tools/train_smoke.py"
 cwd = "packages/zipdepth"
 description = "Smoke: self-distilled example data -> train -> resume -> torchrun -> checkpoints load through monopriors ZipDepthPredictor"
+
+# Catalog training lane: chosen-frame PromptDA pseudo-labels from the local Rerun catalog.
+# linux-64 only: NVDEC decode via torchcodec, mirroring prompt-da-stream.
+[feature.zipdepth-catalog]
+platforms = ["linux-64"]
+
+[feature.zipdepth-catalog.dependencies]
+# arkitscenes_download.ingest imports these at package load.
+imagecodecs = ">=2024.9.22"
+trimesh = "*"
+pillow = "*"
+av = ">=18"
+# simplecv's open_segment_decoder decodes the segment's AV1 packets on NVDEC.
+torchcodec = "*"
+# ffmpeg <902 links libjxl 0.11 and dlopen-fails beside the env's 0.12.
+ffmpeg = { version = ">=8.1", build-number = ">=902" }
+# torch.cuda.utilization() backend for the IO-vs-GPU training instrumentation.
+nvidia-ml-py = "*"
+
+[feature.zipdepth-catalog.pypi-dependencies]
+arkitscenes-download = { path = "packages/arkitscenes-download", editable = true }
 
 # ═══════════════════════════════════════════════════════════════════════════
 # wilor-nano
@@ -2623,6 +2644,21 @@ zipdepth-dev = { features = [
     "zipdepth",
     "dev",
 ], solve-group = "zipdepth", no-default-feature = true }
+zipdepth-catalog = { features = [
+    "catalog-common",
+    "rerun-prerelease",
+    "cuda",
+    "zipdepth",
+    "zipdepth-catalog",
+], solve-group = "zipdepth-catalog", no-default-feature = true }
+zipdepth-catalog-dev = { features = [
+    "catalog-common",
+    "rerun-prerelease",
+    "cuda",
+    "zipdepth",
+    "zipdepth-catalog",
+    "dev",
+], solve-group = "zipdepth-catalog", no-default-feature = true }
 wilor-nano = { features = [
     "common",
     "cuda",

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -113,6 +113,8 @@ site-package-path = [
     ".pixi/envs/prompt-da-stream-dev/lib/python3.12/site-packages/rerun_sdk",
     ".pixi/envs/zipdepth-dev/lib/python3.12/site-packages",
     ".pixi/envs/zipdepth-dev/lib/python3.12/site-packages/rerun_sdk",
+    ".pixi/envs/zipdepth-catalog-dev/lib/python3.12/site-packages",
+    ".pixi/envs/zipdepth-catalog-dev/lib/python3.12/site-packages/rerun_sdk",
     ".pixi/envs/wilor-nano-dev/lib/python3.12/site-packages",
     ".pixi/envs/sam3d-body-dev/lib/python3.12/site-packages",
     ".pixi/envs/sam3-dev/lib/python3.12/site-packages",


### PR DESCRIPTION
Stack **2/5** (base #131; next #133). The only PR in the stack that touches `pixi.toml` dependencies or `pixi.lock`.

**What**
- New `zipdepth-catalog` / `zipdepth-catalog-dev` envs: `catalog-common` + `rerun-prerelease` + `cuda` + `zipdepth`, plus torchcodec, imagecodecs, ffmpeg ≥ 8.1 build 902 (older builds dlopen-fail on libjxl), nvidia-ml-py, editable `arkitscenes-download`. Registered in `pyrefly.toml`; `PYREFLY_TARGET` and `[tool.vulture] paths` gain `zipdepth/catalog`. `platforms = ["linux-64"]` follows the `prompt-da` (#98) and `posekit` (#109) lanes. No task blocks yet — each lands beside its script.
- `zipdepth/catalog/` primitives with no catalog dependency:
  - `targets.py` — the numerical contract: inverse depth × `INV_DEPTH_SCALE` 6000 as uint16, `[100, 4000] mm` validity → mask, resize-only `build_train_transform` (drops the vendored random crop-zoom on purpose: at 4:3 → 1024×768 it trains a 1.33× zoom domain that eval never sees), `depth_span_ratio` flat-frame statistic, paired CPU/CUDA `build_training_sample` (tested bit-exact on depth/mask, RGB within resize rounding).
  - `png.py` — `unfilter_up_cuda`: PNG Up-filter reversal as an int32 cumsum on the GPU.
  - `threaded.py` — bounded `ShuffleBuffer`; `iter_threaded` with exception transport, stop event, join timeout.
  - `stats.py` — per-stage counters.

**Review focus**: the constants and tolerances in `targets.py` / `test_catalog_targets.py`; the env composition (this lane drops `common` for `catalog-common`).

**Lock**: `pixi.lock` differs from `main` only in the two new environments (checked env-by-env). `pixi lock --check` is red on untouched `main` as well under pixi 0.78 — it re-keys the v7 platform aliases and rewrites the file — so that re-serialization is a separate workspace PR and is not carried here.

**Gates** (`zipdepth-catalog-dev`, GPU): lint ✓ · pyrefly 0 errors ✓ · deadcode ✓ · 24 passed (CUDA tests run, not skipped) ✓ · `zipdepth-dev` 23 passed / 1 skipped ✓
