### PR TITLE
zipdepth: stream catalog PromptDA samples; throughput probe and holdout eval (stack 3/5)

### DIFF
--- a/packages/zipdepth/tests/test_catalog_dataset.py
+++ b/packages/zipdepth/tests/test_catalog_dataset.py
@@ -1,0 +1,153 @@
+"""Import and construction smoke tests for catalog training data."""
+
+from typing import Any
+
+import numpy as np
+import pytest
+import torch
+from jaxtyping import UInt8, UInt16
+from numpy import ndarray
+from numpy.testing import assert_array_equal
+from torch.utils.data import IterableDataset
+
+pytest.importorskip("rerun.catalog", reason="Rerun catalog dependencies live in the zipdepth catalog lane")
+pytest.importorskip("arkitscenes_download", reason="ARKitScenes catalog dependencies live in the zipdepth catalog lane")
+pa = pytest.importorskip("pyarrow", reason="Arrow catalog dependencies live in the zipdepth catalog lane")
+
+from arkitscenes_download.ingest.depth import encode_depth_png  # noqa: E402
+from rerun.catalog import DatasetEntry  # noqa: E402
+
+from zipdepth.apis.catalog_throughput import CatalogThroughputConfig  # noqa: E402
+from zipdepth.catalog.builders import CpuSampleBuilder  # noqa: E402
+from zipdepth.catalog.dataset import CatalogPromptDepthDataset, promptda_blob_views  # noqa: E402
+from zipdepth.catalog.stats import CatalogDatasetStats, total  # noqa: E402
+from zipdepth.catalog.targets import build_eval_transform  # noqa: E402
+
+
+def test_catalog_dataset_constructs_without_contacting_server() -> None:
+    """Store segment metadata and initialize mutable counters without catalog IO."""
+    dataset_entry: DatasetEntry = object.__new__(DatasetEntry)
+    row_by_id: dict[str, dict[str, Any]] = {
+        "segment-a": {
+            "rerun_segment_id": "segment-a",
+            "property:capture:orientation": ["portrait"],
+            "property:capture:orientation_quarter_turns_ccw": [1],
+        }
+    }
+
+    dataset: CatalogPromptDepthDataset = CatalogPromptDepthDataset(
+        dataset_entry,
+        ["segment-a"],
+        row_by_id,
+        device=torch.device("cpu"),
+        builder_factory=lambda: CpuSampleBuilder(build_eval_transform(8, 8), min_depth_span=0.0),
+    )
+    dataset.set_epoch(2)
+
+    assert isinstance(dataset, IterableDataset)
+    assert dataset.stats == CatalogDatasetStats()
+    assert dataset.skipped_frames == 0
+
+
+def test_cpu_sample_builder_decodes_and_reports_local_stats() -> None:
+    """Build one CPU sample through the typed callable and retain lock-free counters."""
+    rgb_chw: UInt8[torch.Tensor, "3 h w"] = torch.arange(3 * 6 * 8, dtype=torch.uint8).reshape(3, 6, 8)
+    depth_mm_hw: UInt16[ndarray, "h w"] = np.arange(6 * 8, dtype=np.uint16).reshape(6, 8) + 100
+    blob_u8: UInt8[ndarray, "n"] = np.frombuffer(encode_depth_png(depth_mm_hw), dtype=np.uint8)
+    builder: CpuSampleBuilder = CpuSampleBuilder(build_eval_transform(6, 8), min_depth_span=0.0)
+
+    sample: dict[str, torch.Tensor] | None = builder(rgb_chw, blob_u8, quarter_turns=0, sample_seed=17)
+
+    assert sample is not None
+    assert sample["image"].shape == (3, 6, 8)
+    assert builder.stats.samples_built == 1
+    assert builder.stats.png_fallbacks == 0
+    assert builder.stats.blob_decode > 0.0
+    assert builder.stats.augment > 0.0
+
+
+def test_catalog_stats_add_and_total_every_field() -> None:
+    """Aggregate producer-local timings and counters without shared mutation."""
+    first: CatalogDatasetStats = CatalogDatasetStats(segment_query=1.5, samples_built=2, skipped_frames=1)
+    second: CatalogDatasetStats = CatalogDatasetStats(video_decode=2.5, samples_built=3, png_fallbacks=4)
+
+    combined: CatalogDatasetStats = total([first, second])
+
+    assert combined == CatalogDatasetStats(
+        segment_query=1.5,
+        video_decode=2.5,
+        samples_built=5,
+        png_fallbacks=4,
+        skipped_frames=1,
+    )
+
+
+@pytest.mark.parametrize(("num_producers", "prefetch_samples"), [(0, 64), (1, 0)])
+def test_catalog_dataset_rejects_invalid_producer_settings(num_producers: int, prefetch_samples: int) -> None:
+    """Reject producer counts and queue capacities that cannot make progress."""
+    dataset_entry: DatasetEntry = object.__new__(DatasetEntry)
+
+    with pytest.raises(ValueError, match="positive"):
+        CatalogPromptDepthDataset(
+            dataset_entry,
+            [],
+            {},
+            device=torch.device("cpu"),
+            builder_factory=lambda: CpuSampleBuilder(build_eval_transform(8, 8), min_depth_span=0.0),
+            num_producers=num_producers,
+            prefetch_samples=prefetch_samples,
+        )
+
+
+def test_promptda_blob_views_extract_one_instance_per_row_without_python_lists() -> None:
+    """Expose each list-of-list uint8 row as the same bytes as Arrow's Python conversion."""
+    expected: list[list[list[int]]] = [[[1, 2, 3]], [[10, 20]], [[255, 0, 17, 4]]]
+    column = pa.chunked_array(
+        [pa.array(expected[:2], type=pa.list_(pa.list_(pa.uint8()))), pa.array(expected[2:], type=pa.list_(pa.list_(pa.uint8())))]
+    )
+    assert column.num_chunks == 2
+
+    views = promptda_blob_views(column)
+
+    assert len(views) == len(expected)
+    for view, python_row in zip(views, column.to_pylist(), strict=True):
+        assert not view.flags.owndata
+        assert_array_equal(view, python_row[0])
+
+
+def test_promptda_blob_views_rejects_sliced_outer_arrays() -> None:
+    """Reject nonzero Arrow offsets before applying zero-based row arithmetic."""
+    source = pa.array([[[1]], [[2, 3]]], type=pa.list_(pa.list_(pa.uint8())))
+    column = pa.chunked_array([source]).slice(1, 1)
+
+    with pytest.raises(ValueError, match="EncodedDepthImage:blob.*offset"):
+        promptda_blob_views(column)
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        [[[1]], [[2], [3]]],
+        [[[1]], None],
+        [[[1]], [None]],
+    ],
+)
+def test_promptda_blob_views_rejects_invalid_component_instances(values: list[object]) -> None:
+    """Reject multi-instance and null rows with a column-specific error."""
+    column = pa.chunked_array([pa.array(values, type=pa.list_(pa.list_(pa.uint8())))])
+
+    with pytest.raises(ValueError, match="EncodedDepthImage:blob"):
+        promptda_blob_views(column)
+
+
+def test_catalog_throughput_config_has_safe_smoke_defaults() -> None:
+    """Keep the throughput probe small unless the caller requests more data."""
+    config: CatalogThroughputConfig = CatalogThroughputConfig()
+
+    assert config.dataset_name == "arkitscenes-v2"
+    assert config.num_segments == 2
+    assert config.batch_size == 8
+    assert config.builder == "cuda"
+    assert config.num_producers == 6
+    assert config.prefetch_samples == 256
+    assert config.segment_ids is None

--- a/packages/zipdepth/tests/test_catalog_dataset.py
+++ b/packages/zipdepth/tests/test_catalog_dataset.py
@@ -1,5 +1,6 @@
-"""Import and construction smoke tests for catalog training data."""
+"""Behavioral and construction tests for catalog training data."""
 
+from threading import Event, Thread
 from typing import Any
 
 import numpy as np
@@ -19,9 +20,31 @@ from rerun.catalog import DatasetEntry  # noqa: E402
 
 from zipdepth.apis.catalog_throughput import CatalogThroughputConfig  # noqa: E402
 from zipdepth.catalog.builders import CpuSampleBuilder  # noqa: E402
-from zipdepth.catalog.dataset import CatalogPromptDepthDataset, promptda_blob_views  # noqa: E402
+from zipdepth.catalog.dataset import CatalogPromptDepthDataset, ShuffleBuffer, _ProducerSlot, promptda_blob_views  # noqa: E402
 from zipdepth.catalog.stats import CatalogDatasetStats  # noqa: E402
 from zipdepth.catalog.targets import build_eval_transform  # noqa: E402
+
+
+def test_shuffle_buffer_is_seeded_and_preserves_every_sample() -> None:
+    """Produce one deterministic streaming permutation without drops or duplicates."""
+
+    def shuffled(seed: int) -> list[int]:
+        """Shuffle one fixed range through the streaming buffer."""
+        buffer: ShuffleBuffer[int] = ShuffleBuffer(size=3, seed=seed)
+        output: list[int] = []
+        value: int
+        for value in range(10):
+            evicted: int | None = buffer.push(value)
+            if evicted is not None:
+                output.append(evicted)
+        output.extend(buffer.flush())
+        return output
+
+    first: list[int] = shuffled(17)
+    second: list[int] = shuffled(17)
+
+    assert first == second
+    assert sorted(first) == list(range(10))
 
 
 def test_catalog_dataset_constructs_without_contacting_server() -> None:
@@ -47,6 +70,37 @@ def test_catalog_dataset_constructs_without_contacting_server() -> None:
     assert isinstance(dataset, IterableDataset)
     assert dataset.stats == CatalogDatasetStats()
     assert dataset.skipped_frames == 0
+
+
+def test_iter_parallel_refuses_a_slot_owned_by_a_live_thread() -> None:
+    """Reject builder reuse while a producer from the previous pass is still alive."""
+    dataset_entry: DatasetEntry = object.__new__(DatasetEntry)
+    row_by_id: dict[str, dict[str, Any]] = {
+        "segment-a": {
+            "rerun_segment_id": "segment-a",
+            "property:capture:orientation": ["portrait"],
+            "property:capture:orientation_quarter_turns_ccw": [1],
+        }
+    }
+    builder: CpuSampleBuilder = CpuSampleBuilder(build_eval_transform(8, 8), min_depth_span=0.0)
+    dataset: CatalogPromptDepthDataset = CatalogPromptDepthDataset(
+        dataset_entry,
+        ["segment-a"],
+        row_by_id,
+        device=torch.device("cpu"),
+        builder_factory=lambda: CpuSampleBuilder(build_eval_transform(8, 8), min_depth_span=0.0),
+    )
+    release: Event = Event()
+    owner: Thread = Thread(target=release.wait, name="test-stale-zipdepth-producer")
+    owner.start()
+    dataset._slots = [_ProducerSlot(builder, CatalogDatasetStats(), owner=owner)]
+
+    try:
+        with pytest.raises(RuntimeError, match="still owns builder slot"):
+            next(dataset._iter_parallel(["segment-a"]))
+    finally:
+        release.set()
+        owner.join(timeout=2.0)
 
 
 def test_cpu_sample_builder_decodes_and_reports_local_stats() -> None:

--- a/packages/zipdepth/tests/test_catalog_dataset.py
+++ b/packages/zipdepth/tests/test_catalog_dataset.py
@@ -20,7 +20,7 @@ from rerun.catalog import DatasetEntry  # noqa: E402
 from zipdepth.apis.catalog_throughput import CatalogThroughputConfig  # noqa: E402
 from zipdepth.catalog.builders import CpuSampleBuilder  # noqa: E402
 from zipdepth.catalog.dataset import CatalogPromptDepthDataset, promptda_blob_views  # noqa: E402
-from zipdepth.catalog.stats import CatalogDatasetStats, total  # noqa: E402
+from zipdepth.catalog.stats import CatalogDatasetStats  # noqa: E402
 from zipdepth.catalog.targets import build_eval_transform  # noqa: E402
 
 
@@ -64,22 +64,6 @@ def test_cpu_sample_builder_decodes_and_reports_local_stats() -> None:
     assert builder.stats.png_fallbacks == 0
     assert builder.stats.blob_decode > 0.0
     assert builder.stats.augment > 0.0
-
-
-def test_catalog_stats_add_and_total_every_field() -> None:
-    """Aggregate producer-local timings and counters without shared mutation."""
-    first: CatalogDatasetStats = CatalogDatasetStats(segment_query=1.5, samples_built=2, skipped_frames=1)
-    second: CatalogDatasetStats = CatalogDatasetStats(video_decode=2.5, samples_built=3, png_fallbacks=4)
-
-    combined: CatalogDatasetStats = total([first, second])
-
-    assert combined == CatalogDatasetStats(
-        segment_query=1.5,
-        video_decode=2.5,
-        samples_built=5,
-        png_fallbacks=4,
-        skipped_frames=1,
-    )
 
 
 @pytest.mark.parametrize(("num_producers", "prefetch_samples"), [(0, 64), (1, 0)])

--- a/packages/zipdepth/tests/test_eval_catalog.py
+++ b/packages/zipdepth/tests/test_eval_catalog.py
@@ -1,0 +1,22 @@
+"""Pure scoring tests for catalog evaluation."""
+
+import numpy as np
+import pytest
+from jaxtyping import Bool, Float32
+from numpy import ndarray
+
+from zipdepth.apis.eval_catalog import CatalogDepthMetrics, align_and_score_inverse_depth
+
+
+def test_inverse_depth_alignment_recovers_affine_prediction_and_excludes_masked_pixels() -> None:
+    """Fit affine inverse depth only on valid pixels before AbsRel and delta1."""
+    target_hw: Float32[ndarray, "4 4"] = np.linspace(0.5, 2.0, 16, dtype=np.float32).reshape(4, 4)
+    prediction_hw: Float32[ndarray, "4 4"] = 3.0 * target_hw + 7.0
+    valid_hw: Bool[ndarray, "4 4"] = np.ones((4, 4), dtype=bool)
+    valid_hw[0, 0] = False
+    prediction_hw[0, 0] = -10000.0
+
+    metrics: CatalogDepthMetrics = align_and_score_inverse_depth(prediction_hw, target_hw, valid_hw)
+
+    assert metrics.abs_rel == pytest.approx(0.0, abs=1e-6)
+    assert metrics.delta1 == 1.0

--- a/packages/zipdepth/tools/catalog_throughput.py
+++ b/packages/zipdepth/tools/catalog_throughput.py
@@ -1,0 +1,6 @@
+import tyro
+
+from zipdepth.apis.catalog_throughput import CatalogThroughputConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(CatalogThroughputConfig))

--- a/packages/zipdepth/tools/eval_catalog.py
+++ b/packages/zipdepth/tools/eval_catalog.py
@@ -1,0 +1,8 @@
+"""Tyro shim for held-out catalog evaluation."""
+
+import tyro
+
+from zipdepth.apis.eval_catalog import EvalCatalogConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(EvalCatalogConfig))

--- a/packages/zipdepth/zipdepth/apis/catalog_throughput.py
+++ b/packages/zipdepth/zipdepth/apis/catalog_throughput.py
@@ -1,0 +1,125 @@
+"""Measure catalog-to-batch throughput for ZipDepth training data."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from time import perf_counter
+from typing import Literal
+
+import torch
+from torch import Tensor
+from torch.utils.data import DataLoader
+
+from zipdepth.catalog.builders import CpuSampleBuilder, CudaSampleBuilder, SampleBuilder
+from zipdepth.catalog.dataset import CatalogPromptDepthDataset
+from zipdepth.catalog.segments import DEFAULT_CATALOG_URL, PromptDACatalog, load_promptda_catalog
+from zipdepth.catalog.stats import CatalogDatasetStats
+from zipdepth.catalog.targets import AugmentPolicy, build_train_transform
+
+
+@dataclass(slots=True)
+class CatalogThroughputConfig:
+    """Configuration for the catalog throughput probe."""
+
+    catalog_url: str = DEFAULT_CATALOG_URL
+    """URL of the local Rerun catalog server."""
+    dataset_name: str = "arkitscenes-v2"
+    """Catalog dataset containing ARKitScenes and PromptDA layers."""
+    num_segments: int = 2
+    """Number of leading PromptDA segments to use when ``segment_ids`` is absent."""
+    segment_ids: list[str] | None = None
+    """Explicit PromptDA segment identifiers; overrides ``num_segments`` when set."""
+    height: int = 768
+    """Augmented training image height."""
+    width: int = 1024
+    """Augmented training image width."""
+    batch_size: int = 8
+    """Samples per DataLoader batch."""
+    builder: Literal["cuda", "cpu"] = "cuda"
+    """Sample builder implementation used by the A/B throughput probe."""
+    num_producers: int = 6
+    """Whole-segment producer threads, each with its own video decoder."""
+    prefetch_samples: int = 256
+    """Maximum completed samples buffered across segment producers."""
+    min_depth_span: float = 1.25
+    """Minimum valid-depth p95/p5 ratio; zero disables flat-frame filtering."""
+    max_batches: int | None = None
+    """Optional limit on yielded batches, including shuffle-buffer warmup cost."""
+
+
+def main(config: CatalogThroughputConfig) -> None:
+    """Read catalog samples and print overall and per-stage throughput.
+
+    Args:
+        config: Catalog, resize, batching, and stopping settings.
+
+    Raises:
+        RuntimeError: If no eligible segment or sample is available.
+        ValueError: If numeric limits are not positive or an explicit segment lacks PromptDA.
+    """
+    if config.segment_ids is None and config.num_segments <= 0:
+        raise ValueError("num_segments must be positive")
+    if config.batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+    if config.num_producers <= 0 or config.prefetch_samples <= 0:
+        raise ValueError("num_producers and prefetch_samples must be positive")
+    if config.max_batches is not None and config.max_batches <= 0:
+        raise ValueError("max_batches must be positive when set")
+
+    catalog: PromptDACatalog = load_promptda_catalog(config.catalog_url, config.dataset_name)
+    if config.segment_ids is None:
+        segment_ids: list[str] = catalog.segment_ids[: config.num_segments]
+    else:
+        segment_ids = list(config.segment_ids)
+        catalog.require_segments(segment_ids)
+    if not segment_ids:
+        raise RuntimeError(f"dataset {config.dataset_name!r} has no selected PromptDA segments")
+
+    device: torch.device = torch.device("cuda")
+    policy: AugmentPolicy = AugmentPolicy()
+    builder_factory: Callable[[], SampleBuilder]
+    if config.builder == "cuda":
+        builder_factory = lambda: CudaSampleBuilder((config.height, config.width), policy, config.min_depth_span, device)  # noqa: E731
+    else:
+        builder_factory = lambda: CpuSampleBuilder(  # noqa: E731
+            build_train_transform(config.height, config.width, policy), config.min_depth_span
+        )
+    samples: CatalogPromptDepthDataset = CatalogPromptDepthDataset(
+        catalog.dataset_entry,
+        segment_ids,
+        catalog.row_by_id,
+        device=device,
+        builder_factory=builder_factory,
+        num_producers=config.num_producers,
+        prefetch_samples=config.prefetch_samples,
+    )
+    loader: DataLoader[dict[str, Tensor]] = DataLoader(samples, batch_size=config.batch_size, num_workers=0)
+    started: float = perf_counter()
+    frames: int = 0
+    batches: int = 0
+    batch: dict[str, Tensor]
+    for batch in loader:
+        if config.builder == "cuda":
+            torch.cuda.synchronize()
+        frames += int(batch["image"].shape[0])
+        batches += 1
+        if config.max_batches is not None and batches >= config.max_batches:
+            break
+    elapsed: float = perf_counter() - started
+    if frames == 0 or samples.stats.samples_built == 0:
+        raise RuntimeError("catalog dataset yielded no training samples")
+
+    stats: CatalogDatasetStats = samples.stats
+    built_frames: int = stats.samples_built
+    video_attempts: int = built_frames + samples.skipped_frames
+    print(
+        f"config: builder={config.builder}, producers={config.num_producers}, "
+        f"prefetch_samples={config.prefetch_samples}, batch_size={config.batch_size}, out={config.width}x{config.height}"
+    )
+    print(f"overall: {frames / elapsed:.2f} frames/s ({frames} yielded, {built_frames} built, {batches} batches, {elapsed:.2f}s)")
+    print(f"segment_query: {stats.segment_query * 1000.0 / built_frames:.3f} ms/frame")
+    print(f"video_decode: {stats.video_decode * 1000.0 / video_attempts:.3f} ms/frame")
+    print(f"blob_decode: {stats.blob_decode * 1000.0 / built_frames:.3f} ms/frame")
+    print(f"augment: {stats.augment * 1000.0 / built_frames:.3f} ms/frame")
+    print(f"png fallbacks: {stats.png_fallbacks}")
+    print(f"skipped frames: {samples.skipped_frames}")
+    print(f"skipped flat frames: {samples.skipped_flat_frames}")

--- a/packages/zipdepth/zipdepth/apis/eval_catalog.py
+++ b/packages/zipdepth/zipdepth/apis/eval_catalog.py
@@ -1,0 +1,196 @@
+"""Evaluate ZipDepth inverse depth on held-out catalog PromptDA targets."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import numpy as np
+import torch
+from jaxtyping import Bool, Float, Float32, UInt8
+from monopriors.models.relative_depth.zipdepth import ZipDepthPredictor, download_zipdepth_checkpoint
+from numpy import ndarray
+from torch import Tensor
+from torch.utils.data import DataLoader
+
+from zipdepth.catalog.segments import DEFAULT_CATALOG_URL, PromptDACatalog, load_promptda_catalog
+from zipdepth.catalog.targets import INV_DEPTH_SCALE, build_eval_transform
+from zipdepth.data.transforms import AlbumentationsWrapper
+from zipdepth.evaluation.metrics import abs_relative_difference, align_depth_least_square, delta1_acc, disparity2depth
+
+
+@dataclass(slots=True)
+class EvalCatalogConfig:
+    """Held-out catalog evaluation configuration."""
+
+    catalog_url: str = DEFAULT_CATALOG_URL
+    """URL of the local Rerun catalog server."""
+    dataset_name: str = "arkitscenes-v2"
+    """Catalog dataset containing ARKitScenes and PromptDA layers."""
+    save_dir: Path = Path("data/checkpoints/catalog")
+    """Training output directory containing ``holdout_segments.json`` and receiving results."""
+    segment_ids: list[str] | None = None
+    """Explicit evaluation segment identifiers; overrides the saved holdout manifest."""
+    checkpoint: Path | None = None
+    """Trainable checkpoint to evaluate; None uses released ZipDepth-base weights."""
+    height: int = 768
+    """Deterministic evaluation image height."""
+    width: int = 1024
+    """Deterministic evaluation image width."""
+    frame_stride: int = 10
+    """Evaluate every Nth chosen PromptDA frame within each segment."""
+    input_size: int = 384
+    """Shorter image side the network runs at (``ZipDepthPredictor`` resizes to it, then upsamples the disparity).
+    384 is the released model's training size; catalog fine-tunes train the network directly at ``height`` x ``width``,
+    so score those with ``input_size=height`` to avoid a train/eval resolution mismatch."""
+    max_segments: int | None = None
+    """Optional limit on the selected evaluation segments."""
+
+
+@dataclass(slots=True, frozen=True)
+class CatalogDepthMetrics:
+    """Depth metrics after scale-and-shift alignment in inverse-depth space."""
+
+    abs_rel: float
+    """Mean absolute relative depth error over valid pixels."""
+    delta1: float
+    """Fraction of valid depth ratios below 1.25."""
+
+
+def align_and_score_inverse_depth(
+    prediction_hw: Float[ndarray, "h w"],
+    target_hw: Float[ndarray, "h w"],
+    valid_hw: Bool[ndarray, "h w"],
+) -> CatalogDepthMetrics:
+    """Align and score affine-invariant inverse depth.
+
+    A closed-form least-squares scale and shift fits ``prediction`` to target
+    inverse depth over finite, positive, valid pixels. Both aligned disparities
+    are converted to depth before standard AbsRel and delta1 are computed over
+    that same mask. At least ten valid pixels are required, matching the
+    vendored evaluation helper and protocol.
+
+    Args:
+        prediction_hw: Predicted floating inverse depth with shape ``(H, W)``.
+        target_hw: PromptDA floating inverse depth with shape ``(H, W)``.
+        valid_hw: Boolean validity mask with shape ``(H, W)``.
+
+    Returns:
+        Aligned AbsRel and delta1 metrics.
+
+    Raises:
+        ValueError: If shapes differ or fewer than ten pixels are valid after filtering.
+    """
+    if prediction_hw.shape != target_hw.shape or valid_hw.shape != target_hw.shape:
+        raise ValueError("prediction, target, and validity mask must have equal shapes")
+    fit_hw: Bool[ndarray, "h w"] = valid_hw & np.isfinite(prediction_hw) & np.isfinite(target_hw) & (target_hw > 0.0)
+    if int(np.count_nonzero(fit_hw)) < 10:
+        raise ValueError("at least ten valid inverse-depth pixels are required")
+    aligned_hw: Float[ndarray, "h w"] = align_depth_least_square(target_hw, prediction_hw, fit_hw)
+    metric_hw: Bool[ndarray, "h w"] = fit_hw & np.isfinite(aligned_hw) & (aligned_hw > 0.0)
+    prediction_depth_hw: Float[ndarray, "h w"] = disparity2depth(aligned_hw)
+    target_depth_hw: Float[ndarray, "h w"] = disparity2depth(target_hw)
+    return CatalogDepthMetrics(
+        abs_rel=abs_relative_difference(prediction_depth_hw, target_depth_hw, metric_hw),
+        delta1=delta1_acc(prediction_depth_hw, target_depth_hw, metric_hw),
+    )
+
+
+def _selected_segments(config: EvalCatalogConfig, catalog: PromptDACatalog) -> list[str]:
+    """Resolve explicit segments or the saved training holdout manifest."""
+    if config.segment_ids is None:
+        manifest: Path = config.save_dir / "holdout_segments.json"
+        if not manifest.is_file():
+            raise FileNotFoundError(manifest)
+        with manifest.open() as file:
+            loaded: object = json.load(file)
+        if not isinstance(loaded, list) or not all(isinstance(value, str) for value in loaded):
+            raise ValueError(f"holdout manifest must contain a JSON string list: {manifest}")
+        segment_ids: list[str] = list(loaded)
+    else:
+        segment_ids = list(config.segment_ids)
+    catalog.require_segments(segment_ids)
+    if config.max_segments is not None:
+        if config.max_segments <= 0:
+            raise ValueError("max_segments must be positive when set")
+        segment_ids = segment_ids[: config.max_segments]
+    if not segment_ids:
+        raise RuntimeError("no evaluation segments selected")
+    return segment_ids
+
+
+def main(config: EvalCatalogConfig) -> Path:
+    """Evaluate selected segments, print summaries, and write a JSON report."""
+    if config.frame_stride <= 0:
+        raise ValueError("frame_stride must be positive")
+    catalog: PromptDACatalog = load_promptda_catalog(config.catalog_url, config.dataset_name)
+    segment_ids: list[str] = _selected_segments(config, catalog)
+    transform: AlbumentationsWrapper = build_eval_transform(config.height, config.width)
+    device: torch.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    checkpoint: Path = config.checkpoint or download_zipdepth_checkpoint()
+    predictor: ZipDepthPredictor = ZipDepthPredictor(
+        device="cuda" if device.type == "cuda" else "cpu", checkpoint=checkpoint, input_size=config.input_size
+    )
+
+    # Catalog-only import stays local so pure metric tests run in zipdepth-dev.
+    from zipdepth.catalog.builders import CpuSampleBuilder
+    from zipdepth.catalog.dataset import CatalogPromptDepthDataset
+
+    per_segment: list[dict[str, float | int | str]] = []
+    all_abs_rel: list[float] = []
+    all_delta1: list[float] = []
+    segment_id: str
+    for segment_id in segment_ids:
+        dataset: CatalogPromptDepthDataset = CatalogPromptDepthDataset(
+            catalog.dataset_entry,
+            [segment_id],
+            catalog.row_by_id,
+            device=device,
+            builder_factory=lambda: CpuSampleBuilder(transform, min_depth_span=1.25),
+            shuffle_buffer_size=1,
+            frame_stride=config.frame_stride,
+            num_producers=1,
+            prefetch_samples=4,
+        )
+        loader: DataLoader[dict[str, Tensor]] = DataLoader(dataset, batch_size=1, num_workers=0)
+        segment_abs_rel: list[float] = []
+        segment_delta1: list[float] = []
+        batch: dict[str, Tensor]
+        for batch in loader:
+            image_chw: UInt8[ndarray, "3 h w"] = batch["image"][0].numpy()
+            rgb_hw3: UInt8[ndarray, "h w 3"] = np.ascontiguousarray(np.moveaxis(image_chw, 0, -1))
+            target_hw: Float32[ndarray, "h w"] = batch["depth"][0, 0].numpy().astype(np.float32) / INV_DEPTH_SCALE
+            valid_hw: Bool[ndarray, "h w"] = batch["mask"][0, 0].numpy().astype(bool, copy=False)
+            prediction_hw: Float32[ndarray, "h w"] = predictor(rgb_hw3, None).disparity
+            metrics: CatalogDepthMetrics = align_and_score_inverse_depth(prediction_hw, target_hw, valid_hw)
+            segment_abs_rel.append(metrics.abs_rel)
+            segment_delta1.append(metrics.delta1)
+        if not segment_abs_rel:
+            print(f"{segment_id}: no frames")
+            continue
+        mean_abs_rel: float = float(np.mean(segment_abs_rel))
+        mean_delta1: float = float(np.mean(segment_delta1))
+        frame_count: int = len(segment_abs_rel)
+        print(f"{segment_id}: AbsRel={mean_abs_rel:.6f} delta1={mean_delta1:.6f} frames={frame_count}")
+        per_segment.append({"segment_id": segment_id, "abs_rel": mean_abs_rel, "delta1": mean_delta1, "frame_count": frame_count})
+        all_abs_rel.extend(segment_abs_rel)
+        all_delta1.extend(segment_delta1)
+
+    if not all_abs_rel:
+        raise RuntimeError("evaluation yielded no valid frames")
+    overall_abs_rel: float = float(np.mean(all_abs_rel))
+    overall_delta1: float = float(np.mean(all_delta1))
+    overall_frames: int = len(all_abs_rel)
+    print(f"overall: AbsRel={overall_abs_rel:.6f} delta1={overall_delta1:.6f} frames={overall_frames}")
+
+    config.save_dir.mkdir(parents=True, exist_ok=True)
+    output: Path = config.save_dir / f"eval_{checkpoint.stem}_net{config.input_size}.json"
+    report: dict[str, object] = {
+        "config": {**asdict(config), "checkpoint": str(checkpoint)},
+        "per_segment": per_segment,
+        "overall": {"abs_rel": overall_abs_rel, "delta1": overall_delta1, "frame_count": overall_frames},
+    }
+    with output.open("w") as file:
+        json.dump(report, file, indent=2, default=str)
+    return output

--- a/packages/zipdepth/zipdepth/catalog/builders.py
+++ b/packages/zipdepth/zipdepth/catalog/builders.py
@@ -1,0 +1,153 @@
+"""Typed CPU and CUDA builders for catalog training samples."""
+
+from time import perf_counter
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+import torch
+from arkitscenes_download.ingest.depth import decode_depth_png, decode_depth_png_fast, inflate_depth_png_rows
+from jaxtyping import Float32, Int32, UInt8, UInt16
+from numpy import ndarray
+from torch import Tensor
+
+from zipdepth.catalog.png import unfilter_up_cuda
+from zipdepth.catalog.stats import BuilderStats
+from zipdepth.catalog.targets import (
+    AugmentPolicy,
+    build_training_sample,
+    build_training_sample_cuda,
+    depth_span_ratio,
+    depth_span_ratio_cuda,
+)
+from zipdepth.data.transforms import AlbumentationsWrapper
+
+
+@runtime_checkable
+class SampleBuilder(Protocol):
+    """Build one collatable training sample from aligned catalog inputs."""
+
+    stats: BuilderStats
+    """Counters owned by this builder and its producer thread."""
+
+    def __call__(
+        self,
+        frame_chw: UInt8[Tensor, "3 h w"],
+        blob_u8: UInt8[ndarray, "n"],
+        quarter_turns: int,
+        sample_seed: int,
+    ) -> dict[str, Tensor] | None:
+        """Build a sample, or return None when the flat-depth filter rejects it."""
+
+
+class CpuSampleBuilder:
+    """Decode depth and build samples on the CPU."""
+
+    def __init__(self, transform: AlbumentationsWrapper, min_depth_span: float) -> None:
+        """Configure deterministic transform and optional flat-depth filtering."""
+        if min_depth_span < 0.0:
+            raise ValueError("min_depth_span must be non-negative")
+        self._transform: AlbumentationsWrapper = transform
+        self._min_depth_span: float = min_depth_span
+        self.stats: BuilderStats = BuilderStats()
+        """Counters local to this builder."""
+
+    def __call__(
+        self,
+        frame_chw: UInt8[Tensor, "3 h w"],
+        blob_u8: UInt8[ndarray, "n"],
+        quarter_turns: int,
+        sample_seed: int,
+    ) -> dict[str, Tensor] | None:
+        """Decode, orient, filter, and transform one CPU sample."""
+        del sample_seed
+        started: float = perf_counter()
+        depth_mm_hw: UInt16[ndarray, "h w"] | None = decode_depth_png_fast(blob_u8)
+        if depth_mm_hw is None:
+            depth_mm_hw = decode_depth_png(blob_u8)
+            self.stats.png_fallbacks += 1
+        if self._min_depth_span > 0.0 and depth_span_ratio(depth_mm_hw) < self._min_depth_span:
+            self.stats.blob_decode += perf_counter() - started
+            self.stats.skipped_flat_frames += 1
+            return None
+        self.stats.blob_decode += perf_counter() - started
+
+        started = perf_counter()
+        rgb_chw: UInt8[ndarray, "3 h w"] = frame_chw.cpu().numpy()
+        rgb_hw3: UInt8[ndarray, "h w 3"] = np.moveaxis(rgb_chw, 0, -1)
+        rgb_landscape_hw3: UInt8[ndarray, "landscape_h landscape_w 3"] = np.ascontiguousarray(np.rot90(rgb_hw3, quarter_turns))
+        depth_landscape_mm_hw: UInt16[ndarray, "landscape_h landscape_w"] = np.ascontiguousarray(np.rot90(depth_mm_hw, quarter_turns))
+        sample: dict[str, Tensor] = build_training_sample(rgb_landscape_hw3, depth_landscape_mm_hw, self._transform)
+        self.stats.augment += perf_counter() - started
+        self.stats.samples_built += 1
+        return sample
+
+
+class CudaSampleBuilder:
+    """Inflate depth and build samples on one producer-owned CUDA stream."""
+
+    def __init__(self, out_hw: tuple[int, int], policy: AugmentPolicy, min_depth_span: float, device: torch.device) -> None:
+        """Configure output shape, augmentation, filtering, and CUDA state."""
+        if out_hw[0] <= 0 or out_hw[1] <= 0:
+            raise ValueError("output height and width must be positive")
+        if min_depth_span < 0.0:
+            raise ValueError("min_depth_span must be non-negative")
+        if device.type != "cuda":
+            raise ValueError("CudaSampleBuilder requires a CUDA device")
+        self._out_hw: tuple[int, int] = out_hw
+        self._policy: AugmentPolicy = policy
+        self._min_depth_span: float = min_depth_span
+        self._device: torch.device = device
+        self._generator: torch.Generator = torch.Generator()
+        self._stream: torch.cuda.Stream = torch.cuda.Stream(device=device)
+        self.stats: BuilderStats = BuilderStats()
+        """Counters local to this builder."""
+
+    def __call__(
+        self,
+        frame_chw: UInt8[Tensor, "3 h w"],
+        blob_u8: UInt8[ndarray, "n"],
+        quarter_turns: int,
+        sample_seed: int,
+    ) -> dict[str, Tensor] | None:
+        """Inflate, unfilter, filter, and augment one CUDA sample."""
+        self._stream.wait_stream(torch.cuda.current_stream(self._device))
+        frame_chw.record_stream(self._stream)
+        started: float = perf_counter()
+        with torch.cuda.stream(self._stream):
+            inflated: tuple[UInt8[ndarray, "h row_bytes"], tuple[int, int]] | None = inflate_depth_png_rows(blob_u8)
+            if inflated is None:
+                depth_mm_hw: UInt16[ndarray, "h w"] = decode_depth_png(blob_u8)
+                depth_mm_cuda_hw: Int32[Tensor, "h w"] = torch.from_numpy(depth_mm_hw).to(
+                    device=self._device,
+                    dtype=torch.int32,
+                    non_blocking=True,
+                )
+                self.stats.png_fallbacks += 1
+            else:
+                filtered_hwb: UInt8[ndarray, "h row_bytes"] = inflated[0]
+                filtered_cuda_hwb: UInt8[Tensor, "h row_bytes"] = torch.from_numpy(filtered_hwb).to(
+                    device=self._device,
+                    non_blocking=True,
+                )
+                depth_mm_cuda_hw = unfilter_up_cuda(filtered_cuda_hwb)
+            span_ratio: Float32[Tensor, ""] = depth_span_ratio_cuda(depth_mm_cuda_hw)
+        self.stats.blob_decode += perf_counter() - started
+
+        self._generator.manual_seed(sample_seed)
+        started = perf_counter()
+        with torch.cuda.stream(self._stream):
+            sample: dict[str, Tensor] = build_training_sample_cuda(
+                frame_chw,
+                depth_mm_cuda_hw,
+                quarter_turns,
+                self._out_hw,
+                self._generator,
+                self._policy,
+            )
+            self._stream.synchronize()
+        self.stats.augment += perf_counter() - started
+        if self._min_depth_span > 0.0 and float(span_ratio.item()) < self._min_depth_span:
+            self.stats.skipped_flat_frames += 1
+            return None
+        self.stats.samples_built += 1
+        return sample

--- a/packages/zipdepth/zipdepth/catalog/dataset.py
+++ b/packages/zipdepth/zipdepth/catalog/dataset.py
@@ -1,0 +1,300 @@
+"""Stream chosen-frame PromptDA targets from a Rerun catalog."""
+
+from collections.abc import Callable, Generator, Iterator
+from functools import partial
+from queue import Empty, Queue
+from random import Random
+from time import perf_counter
+from typing import Any
+from warnings import warn
+
+import numpy as np
+import pyarrow as pa
+import torch
+from arkitscenes_download.ingest.cells import landscape_quarter_turns
+from arkitscenes_download.ingest.paths import DEPTH_PROMPTDA, TIMELINE, VIDEO_WIDE
+from arkitscenes_download.ingest.timestamps import match_exact_timestamps, table_timestamps
+from beartype.roar import BeartypeException
+from datafusion import col
+from jaxtyping import Int64, Shaped, UInt8
+from numpy import ndarray
+from rerun.catalog import DatasetEntry
+from simplecv.rerun_dataloader import open_segment_decoder
+from torch import Tensor
+from torch.utils.data import IterableDataset, get_worker_info
+from torchcodec.decoders import VideoDecoder
+
+from zipdepth.catalog.builders import SampleBuilder
+from zipdepth.catalog.stats import CatalogDatasetStats, total
+from zipdepth.catalog.threaded import ShuffleBuffer, iter_threaded
+
+PROMPTDA_BLOB_COLUMN: str = f"/{DEPTH_PROMPTDA}:EncodedDepthImage:blob"
+"""Catalog column containing uint16 PromptDA PNG blobs."""
+NATIVE_VIDEO_FPS: int = 60
+"""Nominal frame rate used when wrapping the segment's encoded AV1 packets."""
+
+
+def promptda_blob_views(column: pa.ChunkedArray) -> list[UInt8[ndarray, "n_bytes"]]:
+    """Return byte views into each Arrow chunk for one blob instance per row.
+
+    Args:
+        column: PromptDA ``list<list<uint8>>`` component column. Each outer row
+            must contain exactly one component instance.
+
+    Returns:
+        One zero-copy uint8 view into its source chunk's values buffer per row.
+    """
+    views: list[UInt8[ndarray, "n_bytes"]] = []
+    chunk: pa.Array
+    for chunk in column.chunks:
+        if not isinstance(chunk, pa.ListArray):
+            raise ValueError(f"{PROMPTDA_BLOB_COLUMN}: expected list rows, got {chunk.type}")
+        if chunk.offset != 0:
+            raise ValueError(f"{PROMPTDA_BLOB_COLUMN}: outer chunk offset must be zero, got {chunk.offset}")
+        if chunk.null_count != 0:
+            raise ValueError(f"{PROMPTDA_BLOB_COLUMN}: outer rows must not be null")
+        outer_offsets: Shaped[ndarray, "n_rows_plus_one"] = chunk.offsets.to_numpy()
+        if not bool(np.all(np.diff(outer_offsets) == 1)):
+            raise ValueError(f"{PROMPTDA_BLOB_COLUMN}: each row must contain exactly one blob instance")
+
+        inner: pa.Array = chunk.values
+        if not isinstance(inner, pa.ListArray):
+            raise ValueError(f"{PROMPTDA_BLOB_COLUMN}: expected list blob instances, got {inner.type}")
+        if inner.offset != 0:
+            raise ValueError(f"{PROMPTDA_BLOB_COLUMN}: inner array offset must be zero, got {inner.offset}")
+        if inner.null_count != 0:
+            raise ValueError(f"{PROMPTDA_BLOB_COLUMN}: blob instances must not be null")
+        data: pa.Array = inner.values
+        if not pa.types.is_uint8(data.type):
+            raise ValueError(f"{PROMPTDA_BLOB_COLUMN}: expected uint8 blob values, got {data.type}")
+        if data.null_count != 0:
+            raise ValueError(f"{PROMPTDA_BLOB_COLUMN}: blob values must not be null")
+        data_buffer: pa.Buffer | None = data.buffers()[1]
+        if data_buffer is None:
+            raise ValueError(f"{PROMPTDA_BLOB_COLUMN}: blob values have no Arrow data buffer")
+        all_bytes_n: UInt8[ndarray, "all_bytes"] = np.frombuffer(data_buffer, dtype=np.uint8, offset=data.offset, count=len(data))
+        inner_offsets: Shaped[ndarray, "n_instances_plus_one"] = inner.offsets.to_numpy()
+        row: int
+        for row in range(len(chunk)):
+            instance: int = int(outer_offsets[row])
+            start: int = int(inner_offsets[instance]) - data.offset
+            end: int = int(inner_offsets[instance + 1]) - data.offset
+            views.append(all_bytes_n[start:end])
+    return views
+
+
+class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
+    """Yield augmented ZipDepth samples from catalog PromptDA rows.
+
+    Use this dataset only with ``DataLoader(num_workers=0)`` so CUDA decoding
+    stays in the training process. Producer threads claim whole segments, and
+    each producer owns one sample builder and one video decoder at a time. A
+    bounded queue limits decoded-sample memory. One producer uses the same path
+    and preserves segment order for evaluation and fixed probes.
+    """
+
+    def __init__(
+        self,
+        dataset_entry: DatasetEntry,
+        segment_ids: list[str],
+        row_by_id: dict[str, dict[str, Any]],
+        *,
+        device: torch.device,
+        builder_factory: Callable[[], SampleBuilder],
+        shuffle_buffer_size: int = 256,
+        seed: int = 0,
+        rank: int = 0,
+        world_size: int = 1,
+        frame_stride: int = 1,
+        num_producers: int = 6,
+        prefetch_samples: int = 256,
+    ) -> None:
+        """Configure catalog streaming without opening the server or decoder.
+
+        Args:
+            dataset_entry: Rerun catalog dataset containing ARKitScenes segments.
+            segment_ids: Segment identifiers eligible for this dataset.
+            row_by_id: Segment-table rows keyed by identifier, used for orientation.
+            device: Device used by each whole-segment video decoder.
+            builder_factory: Construct one sample builder per producer thread.
+            shuffle_buffer_size: Maximum samples held for bounded random shuffling.
+            seed: Base seed for segment and sample ordering.
+            rank: Distributed rank used for segment sharding.
+            world_size: Number of distributed ranks sharing the segment list.
+            frame_stride: Keep every Nth chosen PromptDA row within each segment.
+            num_producers: Whole-segment producer threads. One preserves order.
+            prefetch_samples: Maximum completed samples queued by producers.
+
+        Raises:
+            ValueError: If sizes or distributed shard settings are invalid.
+        """
+        if shuffle_buffer_size <= 0:
+            raise ValueError("shuffle_buffer_size must be positive")
+        if world_size <= 0 or not 0 <= rank < world_size:
+            raise ValueError(f"rank {rank} must be in [0, {world_size})")
+        if frame_stride <= 0:
+            raise ValueError("frame_stride must be positive")
+        if num_producers <= 0:
+            raise ValueError("num_producers must be positive")
+        if prefetch_samples <= 0:
+            raise ValueError("prefetch_samples must be positive")
+        self._dataset_entry: DatasetEntry = dataset_entry
+        self._segment_ids: list[str] = list(segment_ids)
+        self._row_by_id: dict[str, dict[str, Any]] = row_by_id
+        self._device: torch.device = device
+        self._builder_factory: Callable[[], SampleBuilder] = builder_factory
+        self._shuffle_buffer_size: int = shuffle_buffer_size
+        self._seed: int = seed
+        self._rank: int = rank
+        self._world_size: int = world_size
+        self._epoch: int = 0
+        self._frame_stride: int = frame_stride
+        self._num_producers: int = num_producers
+        self._prefetch_samples: int = prefetch_samples
+        self._segment_seed_index: dict[str, int] = {segment_id: index for index, segment_id in enumerate(self._segment_ids)}
+        self._producer_stats: dict[int, CatalogDatasetStats] = {}
+        self._builders: list[SampleBuilder] = []
+
+    @property
+    def stats(self) -> CatalogDatasetStats:
+        """Return a snapshot summed across producer-local dataset and builder counters."""
+        builder_stats: list[CatalogDatasetStats] = [
+            CatalogDatasetStats(
+                blob_decode=builder.stats.blob_decode,
+                augment=builder.stats.augment,
+                samples_built=builder.stats.samples_built,
+                png_fallbacks=builder.stats.png_fallbacks,
+                skipped_flat_frames=builder.stats.skipped_flat_frames,
+            )
+            for builder in self._builders
+        ]
+        return total([*self._producer_stats.values(), *builder_stats])
+
+    @property
+    def skipped_frames(self) -> int:
+        """Return the number of video frames skipped after decode errors."""
+        return self.stats.skipped_frames
+
+    @property
+    def skipped_flat_frames(self) -> int:
+        """Return the number of frames rejected by the depth-span filter."""
+        return self.stats.skipped_flat_frames
+
+    def set_epoch(self, epoch: int) -> None:
+        """Set the pass index used to seed segment and sample shuffling."""
+        self._epoch = epoch
+
+    def _iter_segment(self, segment_id: str, builder: SampleBuilder) -> Generator[dict[str, Tensor], None, None]:
+        """Run the complete query, decode, filter, and build pipeline for one segment."""
+        stats: CatalogDatasetStats = self._producer_stats[id(builder)]
+        started: float = perf_counter()
+        table: pa.Table = (
+            self._dataset_entry.filter_segments(segment_id)
+            .reader(index=TIMELINE, fill_latest_at=True)
+            .filter(col(f'"{PROMPTDA_BLOB_COLUMN}"').is_not_null())
+            .select(TIMELINE, PROMPTDA_BLOB_COLUMN)
+            .sort(TIMELINE)
+            .to_arrow_table()
+        )
+        stats.segment_query += perf_counter() - started
+        if table.num_rows == 0:
+            return
+
+        all_times_n: Shaped[ndarray, "n_rows"] = table_timestamps(table)
+        chosen_times_n: Shaped[ndarray, "n_chosen"] = all_times_n[:: self._frame_stride]
+        all_blobs: list[UInt8[ndarray, "n_bytes"]] = promptda_blob_views(table.column(PROMPTDA_BLOB_COLUMN))
+        chosen_blobs: list[UInt8[ndarray, "n_bytes"]] = all_blobs[:: self._frame_stride]
+
+        started = perf_counter()
+        decoder_result: tuple[Shaped[ndarray, "n_packets"], list[bytes], list[bool], VideoDecoder] = open_segment_decoder(
+            self._dataset_entry,
+            segment_id,
+            VIDEO_WIDE,
+            TIMELINE,
+            self._device,
+            NATIVE_VIDEO_FPS,
+        )
+        stats.segment_query += perf_counter() - started
+        packet_times_n: Shaped[ndarray, "n_packets"] = decoder_result[0]
+        decoder: VideoDecoder = decoder_result[3]
+        del decoder_result
+        packet_indices_n: Int64[ndarray, "n_chosen"] = match_exact_timestamps(packet_times_n, chosen_times_n)
+        quarter_turns: int = landscape_quarter_turns(self._row_by_id[segment_id])
+        segment_seed: int = (
+            self._seed
+            + self._epoch * 1_000_003
+            + self._rank * 10_000_019
+            + self._segment_seed_index[segment_id] * 100_000_007
+        )
+
+        blob_u8: UInt8[ndarray, "n_bytes"]
+        packet_index: np.int64
+        first_decode_error_reported: bool = False
+        for sample_index, (blob_u8, packet_index) in enumerate(zip(chosen_blobs, packet_indices_n, strict=True)):
+            try:
+                started = perf_counter()
+                frame_chw: UInt8[Tensor, "3 stored_h stored_w"] = decoder.get_frame_at(int(packet_index)).data
+                stats.video_decode += perf_counter() - started
+            except BeartypeException:
+                raise
+            except Exception as error:
+                stats.video_decode += perf_counter() - started
+                stats.skipped_frames += 1
+                if not first_decode_error_reported:
+                    warn(f"{segment_id}: first video decode exception: {error!r}", RuntimeWarning, stacklevel=2)
+                    first_decode_error_reported = True
+                continue
+            sample: dict[str, Tensor] | None = builder(
+                frame_chw,
+                blob_u8,
+                quarter_turns,
+                (segment_seed + sample_index) % (2**63 - 1),
+            )
+            if sample is not None:
+                yield sample
+
+    def _iter_parallel(self, segment_ids: list[str]) -> Generator[dict[str, Tensor], None, None]:
+        """Yield complete samples from independent whole-segment worker threads."""
+        if not self._builders:
+            # One long-lived builder (and, on CUDA, one stream) per producer slot: reused by every
+            # pass so counters stay cumulative and nothing accumulates across passes.
+            self._builders = [self._builder_factory() for _ in range(self._num_producers)]
+            self._producer_stats = {id(builder): CatalogDatasetStats() for builder in self._builders}
+        segment_queue: Queue[str] = Queue()
+        segment_id: str
+        for segment_id in segment_ids:
+            segment_queue.put(segment_id)
+
+        def produce(builder: SampleBuilder) -> Generator[dict[str, Tensor], None, None]:
+            """Claim whole segments with one builder until the queue is empty."""
+            while True:
+                try:
+                    claimed_segment_id: str = segment_queue.get_nowait()
+                except Empty:
+                    return
+                yield from self._iter_segment(claimed_segment_id, builder)
+
+        workers: list[Callable[[], Generator[dict[str, Tensor], None, None]]] = [partial(produce, builder) for builder in self._builders]
+        yield from iter_threaded(workers, maxsize=self._prefetch_samples)
+
+    def __iter__(self) -> Iterator[dict[str, Tensor]]:
+        """Decode, build, and bounded-shuffle this rank's segment shard."""
+        if get_worker_info() is not None:
+            raise RuntimeError("CatalogPromptDepthDataset requires DataLoader(num_workers=0) for its in-process CUDA decoder")
+
+        segment_ids: list[str] = list(self._segment_ids[self._rank :: self._world_size])
+        Random(self._seed + self._epoch).shuffle(segment_ids)
+        shuffle_buffer: ShuffleBuffer[dict[str, Tensor]] = ShuffleBuffer(
+            size=self._shuffle_buffer_size,
+            seed=self._seed + self._epoch * self._world_size + self._rank,
+        )
+        parallel_samples: Generator[dict[str, Tensor], None, None] = self._iter_parallel(segment_ids)
+        try:
+            sample: dict[str, Tensor]
+            for sample in parallel_samples:
+                evicted: dict[str, Tensor] | None = shuffle_buffer.push(sample)
+                if evicted is not None:
+                    yield evicted
+        finally:
+            parallel_samples.close()
+        yield from shuffle_buffer.flush()

--- a/packages/zipdepth/zipdepth/catalog/dataset.py
+++ b/packages/zipdepth/zipdepth/catalog/dataset.py
@@ -152,23 +152,13 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
         self._num_producers: int = num_producers
         self._prefetch_samples: int = prefetch_samples
         self._segment_seed_index: dict[str, int] = {segment_id: index for index, segment_id in enumerate(self._segment_ids)}
-        self._producer_stats: dict[int, CatalogDatasetStats] = {}
-        self._builders: list[SampleBuilder] = []
+        self._slots: list[tuple[SampleBuilder, CatalogDatasetStats]] = []
+        """One (builder, dataset counters) pair per producer thread, created on the first pass."""
 
     @property
     def stats(self) -> CatalogDatasetStats:
-        """Return a snapshot summed across producer-local dataset and builder counters."""
-        builder_stats: list[CatalogDatasetStats] = [
-            CatalogDatasetStats(
-                blob_decode=builder.stats.blob_decode,
-                augment=builder.stats.augment,
-                samples_built=builder.stats.samples_built,
-                png_fallbacks=builder.stats.png_fallbacks,
-                skipped_flat_frames=builder.stats.skipped_flat_frames,
-            )
-            for builder in self._builders
-        ]
-        return total([*self._producer_stats.values(), *builder_stats])
+        """Return a snapshot summed across every producer slot's dataset and builder counters."""
+        return total([stats + CatalogDatasetStats.from_builder(builder.stats) for builder, stats in self._slots])
 
     @property
     def skipped_frames(self) -> int:
@@ -184,9 +174,13 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
         """Set the pass index used to seed segment and sample shuffling."""
         self._epoch = epoch
 
-    def _iter_segment(self, segment_id: str, builder: SampleBuilder) -> Generator[dict[str, Tensor], None, None]:
+    def _iter_segment(
+        self,
+        segment_id: str,
+        builder: SampleBuilder,
+        stats: CatalogDatasetStats,
+    ) -> Generator[dict[str, Tensor], None, None]:
         """Run the complete query, decode, filter, and build pipeline for one segment."""
-        stats: CatalogDatasetStats = self._producer_stats[id(builder)]
         started: float = perf_counter()
         table: pa.Table = (
             self._dataset_entry.filter_segments(segment_id)
@@ -255,26 +249,25 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
 
     def _iter_parallel(self, segment_ids: list[str]) -> Generator[dict[str, Tensor], None, None]:
         """Yield complete samples from independent whole-segment worker threads."""
-        if not self._builders:
-            # One long-lived builder (and, on CUDA, one stream) per producer slot: reused by every
-            # pass so counters stay cumulative and nothing accumulates across passes.
-            self._builders = [self._builder_factory() for _ in range(self._num_producers)]
-            self._producer_stats = {id(builder): CatalogDatasetStats() for builder in self._builders}
+        if not self._slots:
+            # One long-lived builder (and, on CUDA, one stream) per producer thread, never more
+            # threads than segments: reused by every pass so counters stay cumulative and nothing leaks.
+            self._slots = [(self._builder_factory(), CatalogDatasetStats()) for _ in range(min(self._num_producers, len(segment_ids)))]
         segment_queue: Queue[str] = Queue()
         segment_id: str
         for segment_id in segment_ids:
             segment_queue.put(segment_id)
 
-        def produce(builder: SampleBuilder) -> Generator[dict[str, Tensor], None, None]:
+        def produce(builder: SampleBuilder, stats: CatalogDatasetStats) -> Generator[dict[str, Tensor], None, None]:
             """Claim whole segments with one builder until the queue is empty."""
             while True:
                 try:
                     claimed_segment_id: str = segment_queue.get_nowait()
                 except Empty:
                     return
-                yield from self._iter_segment(claimed_segment_id, builder)
+                yield from self._iter_segment(claimed_segment_id, builder, stats)
 
-        workers: list[Callable[[], Generator[dict[str, Tensor], None, None]]] = [partial(produce, builder) for builder in self._builders]
+        workers: list[Callable[[], Generator[dict[str, Tensor], None, None]]] = [partial(produce, builder, stats) for builder, stats in self._slots]
         yield from iter_threaded(workers, maxsize=self._prefetch_samples)
 
     def __iter__(self) -> Iterator[dict[str, Tensor]]:

--- a/packages/zipdepth/zipdepth/catalog/dataset.py
+++ b/packages/zipdepth/zipdepth/catalog/dataset.py
@@ -1,11 +1,13 @@
 """Stream chosen-frame PromptDA targets from a Rerun catalog."""
 
 from collections.abc import Callable, Generator, Iterator
+from dataclasses import dataclass
 from functools import partial
 from queue import Empty, Queue
 from random import Random
+from threading import Thread, current_thread
 from time import perf_counter
-from typing import Any
+from typing import Any, Generic, TypeVar
 from warnings import warn
 
 import numpy as np
@@ -26,12 +28,54 @@ from torchcodec.decoders import VideoDecoder
 
 from zipdepth.catalog.builders import SampleBuilder
 from zipdepth.catalog.stats import CatalogDatasetStats, total
-from zipdepth.catalog.threaded import ShuffleBuffer, iter_threaded
+from zipdepth.catalog.threaded import iter_threaded
 
 PROMPTDA_BLOB_COLUMN: str = f"/{DEPTH_PROMPTDA}:EncodedDepthImage:blob"
 """Catalog column containing uint16 PromptDA PNG blobs."""
 NATIVE_VIDEO_FPS: int = 60
 """Nominal frame rate used when wrapping the segment's encoded AV1 packets."""
+ItemT = TypeVar("ItemT")
+
+
+class ShuffleBuffer(Generic[ItemT]):  # noqa: UP046 — beartype does not support PEP 695 generics
+    """Seeded streaming shuffle with bounded memory."""
+
+    def __init__(self, size: int, seed: int) -> None:
+        """Create an empty buffer."""
+        if size <= 0:
+            raise ValueError("shuffle buffer size must be positive")
+        self._size: int = size
+        self._rng: Random = Random(seed)
+        self._samples: list[ItemT] = []
+
+    def push(self, sample: ItemT) -> ItemT | None:
+        """Add one sample and return a random eviction when the buffer is full."""
+        if len(self._samples) < self._size:
+            self._samples.append(sample)
+            return None
+        index: int = self._rng.randrange(self._size)
+        evicted: ItemT = self._samples[index]
+        self._samples[index] = sample
+        return evicted
+
+    def flush(self) -> Generator[ItemT, None, None]:
+        """Yield all remaining samples in seeded random order and empty the buffer."""
+        remaining: list[ItemT] = list(self._samples)
+        self._samples.clear()
+        self._rng.shuffle(remaining)
+        yield from remaining
+
+
+@dataclass(slots=True)
+class _ProducerSlot:
+    """Long-lived builder state owned by at most one producer thread."""
+
+    builder: SampleBuilder
+    """Sample builder reused across dataset passes."""
+    stats: CatalogDatasetStats
+    """Dataset counters accumulated across passes."""
+    owner: Thread | None = None
+    """Producer thread currently driving this builder; None when idle."""
 
 
 def promptda_blob_views(column: pa.ChunkedArray) -> list[UInt8[ndarray, "n_bytes"]]:
@@ -152,13 +196,13 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
         self._num_producers: int = num_producers
         self._prefetch_samples: int = prefetch_samples
         self._segment_seed_index: dict[str, int] = {segment_id: index for index, segment_id in enumerate(self._segment_ids)}
-        self._slots: list[tuple[SampleBuilder, CatalogDatasetStats]] = []
-        """One (builder, dataset counters) pair per producer thread, created on the first pass."""
+        self._slots: list[_ProducerSlot] = []
+        """One builder, its counters, and its current owner per producer slot."""
 
     @property
     def stats(self) -> CatalogDatasetStats:
         """Return a snapshot summed across every producer slot's dataset and builder counters."""
-        return total([stats + CatalogDatasetStats.from_builder(builder.stats) for builder, stats in self._slots])
+        return total([slot.stats + CatalogDatasetStats.from_builder(slot.builder.stats) for slot in self._slots])
 
     @property
     def skipped_frames(self) -> int:
@@ -249,25 +293,37 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
 
     def _iter_parallel(self, segment_ids: list[str]) -> Generator[dict[str, Tensor], None, None]:
         """Yield complete samples from independent whole-segment worker threads."""
+        for index, slot in enumerate(self._slots):
+            if slot.owner is not None and slot.owner.is_alive():
+                raise RuntimeError(
+                    f"producer thread {slot.owner.name!r} from a previous pass still owns builder slot {index}; refusing to reuse it"
+                )
         if not self._slots:
             # One long-lived builder (and, on CUDA, one stream) per producer thread, never more
             # threads than segments: reused by every pass so counters stay cumulative and nothing leaks.
-            self._slots = [(self._builder_factory(), CatalogDatasetStats()) for _ in range(min(self._num_producers, len(segment_ids)))]
+            self._slots = [
+                _ProducerSlot(self._builder_factory(), CatalogDatasetStats())
+                for _ in range(min(self._num_producers, len(segment_ids)))
+            ]
         segment_queue: Queue[str] = Queue()
         segment_id: str
         for segment_id in segment_ids:
             segment_queue.put(segment_id)
 
-        def produce(builder: SampleBuilder, stats: CatalogDatasetStats) -> Generator[dict[str, Tensor], None, None]:
+        def produce(slot: _ProducerSlot) -> Generator[dict[str, Tensor], None, None]:
             """Claim whole segments with one builder until the queue is empty."""
-            while True:
-                try:
-                    claimed_segment_id: str = segment_queue.get_nowait()
-                except Empty:
-                    return
-                yield from self._iter_segment(claimed_segment_id, builder, stats)
+            slot.owner = current_thread()
+            try:
+                while True:
+                    try:
+                        claimed_segment_id: str = segment_queue.get_nowait()
+                    except Empty:
+                        return
+                    yield from self._iter_segment(claimed_segment_id, slot.builder, slot.stats)
+            finally:
+                slot.owner = None
 
-        workers: list[Callable[[], Generator[dict[str, Tensor], None, None]]] = [partial(produce, builder, stats) for builder, stats in self._slots]
+        workers: list[Callable[[], Generator[dict[str, Tensor], None, None]]] = [partial(produce, slot) for slot in self._slots]
         yield from iter_threaded(workers, maxsize=self._prefetch_samples)
 
     def __iter__(self) -> Iterator[dict[str, Tensor]]:

--- a/packages/zipdepth/zipdepth/catalog/segments.py
+++ b/packages/zipdepth/zipdepth/catalog/segments.py
@@ -1,0 +1,54 @@
+"""PromptDA catalog connection and segment metadata."""
+
+from dataclasses import dataclass
+from typing import Any
+
+import pyarrow as pa
+from rerun.catalog import CatalogClient, DatasetEntry
+
+# Matches arkitscenes_download.ingest.catalog.DEFAULT_CATALOG_URL. Keeping the
+# literal here lets pure policy tests import this module without catalog-only deps.
+DEFAULT_CATALOG_URL: str = "rerun+http://127.0.0.1:51235"
+PROMPTDA_LAYER: str = "promptda"
+"""Catalog layer containing the chosen-frame pseudo-depth targets."""
+
+_ROW_FIELDS: tuple[str, ...] = (
+    "rerun_segment_id",
+    "property:capture:orientation",
+    "property:capture:orientation_quarter_turns_ccw",
+)
+
+
+@dataclass(slots=True, frozen=True)
+class PromptDACatalog:
+    """Connected PromptDA catalog metadata shared by train, eval, and smoke."""
+
+    dataset_entry: DatasetEntry
+    """Connected Rerun catalog dataset."""
+    row_by_id: dict[str, dict[str, Any]]
+    """Required PromptDA segment properties keyed by segment identifier."""
+    segment_ids: list[str]
+    """Sorted identifiers for every segment carrying the PromptDA layer."""
+
+    def require_segments(self, segment_ids: list[str]) -> None:
+        """Reject identifiers that are absent or lack the PromptDA layer."""
+        missing_ids: list[str] = [segment_id for segment_id in segment_ids if segment_id not in self.row_by_id]
+        if missing_ids:
+            raise ValueError(f"segments are absent or lack the {PROMPTDA_LAYER!r} layer: {missing_ids}")
+
+
+def load_promptda_catalog(catalog_url: str, dataset_name: str) -> PromptDACatalog:
+    """Connect once and collect the PromptDA segment-selection metadata."""
+    dataset_entry: DatasetEntry = CatalogClient(catalog_url).get_dataset(dataset_name)
+    segment_table: pa.Table = pa.Table.from_batches(dataset_entry.segment_table().collect())
+    row_by_id: dict[str, dict[str, Any]] = {}
+    row: dict[str, Any]
+    for row in segment_table.to_pylist():
+        layer_names: list[str] = [str(layer_name) for layer_name in (row.get("rerun_layer_names") or [])]
+        if PROMPTDA_LAYER in layer_names:
+            segment_id: str = str(row["rerun_segment_id"])
+            row_by_id[segment_id] = {field: row.get(field) for field in _ROW_FIELDS}
+    segment_ids: list[str] = sorted(row_by_id)
+    if not segment_ids:
+        raise RuntimeError(f"dataset {dataset_name!r} has no segments with the {PROMPTDA_LAYER!r} layer")
+    return PromptDACatalog(dataset_entry=dataset_entry, row_by_id=row_by_id, segment_ids=segment_ids)

--- a/pixi.toml
+++ b/pixi.toml
@@ -690,6 +690,16 @@ nvidia-ml-py = "*"
 [feature.zipdepth-catalog.pypi-dependencies]
 arkitscenes-download = { path = "packages/arkitscenes-download", editable = true }
 
+[feature.zipdepth-catalog.tasks.zipdepth-catalog-throughput]
+cmd = "python tools/catalog_throughput.py"
+cwd = "packages/zipdepth"
+description = "Measure catalog->batch throughput (frames/s, per-stage ms) over warm promptda segments"
+
+[feature.zipdepth-catalog.tasks.zipdepth-eval-catalog]
+cmd = "python tools/eval_catalog.py"
+cwd = "packages/zipdepth"
+description = "Scale-shift-aligned AbsRel/delta1 vs PromptDA pseudo-labels on held-out catalog segments (released vs trained)"
+
 # ═══════════════════════════════════════════════════════════════════════════
 # wilor-nano
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Stack **3/5** (base #132; next #134). The PR most likely to hide a real defect — budget review time here.

**What**
- `segments.py` — one catalog connection; the PromptDA segment rows (id + orientation properties).
- `builders.py` — `CpuSampleBuilder` / `CudaSampleBuilder`: one decoded frame + one PNG blob → one training sample. The CUDA path runs entirely on a producer-owned stream (libdeflate inflate → `unfilter_up_cuda` → span filter → resize/flip/color on the GPU); frames never leave CUDA.
- `dataset.py` — `CatalogPromptDepthDataset`: per-segment datafusion query at the real chosen-packet timestamps, zero-copy Arrow views of the blob column (`promptda_blob_views`), an NVDEC decoder over the segment's AV1 packets joined by exact timestamp, N whole-segment producer threads (one long-lived builder each) feeding a bounded shuffle buffer; rank sharding for DDP.
- Read-only consumers: `zipdepth-catalog-throughput` (frames/s + per-stage ms) and `zipdepth-eval-catalog` (scale-shift-aligned AbsRel/δ1 against the pseudo-labels — the released-weights baseline the training PR has to beat).

**Review focus**: `promptda_blob_views` offset arithmetic (every `ValueError` guard is load-bearing); CUDA stream discipline in `CudaSampleBuilder` (`wait_stream`, `record_stream`, one `synchronize` per sample); the decode-error path in `_iter_segment` (warn once, count, continue).

**Gates**: lint ✓ · pyrefly 0 errors ✓ · deadcode ✓ · 36 passed (catalog env) · 24 passed / 2 skipped (`zipdepth-dev`) ✓

**Live**, against the local catalog (`arkitscenes-v2`), 2 producers × 2 segments × 30 batches:

| builder | frames/s | blob_decode | augment | PNG fallbacks | decode skips |
|---|---:|---:|---:|---:|---:|
| CUDA | **26.5** | 7.8 ms | **3.7 ms** | 0 | 0 |
| CPU | 19.4 | 9.3 ms | 16.2 ms | 0 | 0 |

Eval baseline, released weights, holdout segment `42447275` @ net 384: **AbsRel 0.0909 / δ1 0.898** (15 frames, stride 60).
