### PR TITLE
zipdepth: fine-tune on catalog pseudo-labels with IO-vs-GPU instrumentation (stack 4/5)

### DIFF
--- a/packages/zipdepth/pyproject.toml
+++ b/packages/zipdepth/pyproject.toml
@@ -37,4 +37,4 @@ paths = ["zipdepth/apis", "zipdepth/catalog", "zipdepth/__init__.py", "tests", "
 exclude = ["*/.pixi/*", "*/__pycache__/*"]
 sort_by_size = true
 min_confidence = 60
-ignore_names = ["rr_config"]
+ignore_names = ["allow_tf32", "benchmark", "forward", "rr_config", "train_epoch"]

--- a/packages/zipdepth/tests/test_catalog_instrument.py
+++ b/packages/zipdepth/tests/test_catalog_instrument.py
@@ -1,0 +1,131 @@
+"""Behavioral tests for catalog loader instrumentation."""
+
+from collections.abc import Iterator
+from pathlib import Path
+from threading import get_ident
+from time import sleep
+from typing import Any
+
+import pytest
+import torch
+from torch.utils.data import DataLoader, IterableDataset
+from torch.utils.tensorboard import SummaryWriter
+
+from zipdepth.catalog.instrument import InstrumentedLoader
+from zipdepth.catalog.stats import CatalogDatasetStats
+
+
+class _FakeDataset(IterableDataset[dict[str, torch.Tensor]]):
+    """Small iterable with the catalog dataset's public control surface."""
+
+    def __init__(self) -> None:
+        self.stats: CatalogDatasetStats = CatalogDatasetStats()
+        self.skipped_frames: int = 0
+        self.epochs: list[int] = []
+
+    def set_epoch(self, epoch: int) -> None:
+        """Record the forwarded epoch."""
+        self.epochs.append(epoch)
+
+    def __iter__(self) -> Iterator[dict[str, torch.Tensor]]:
+        """Yield two one-frame batches."""
+        for value in range(2):
+            yield {"image": torch.tensor([value])}
+
+
+def test_fixed_schedule_cycles_over_reshuffled_dataset_passes() -> None:
+    """Expose the exact run length and reseed every finite dataset pass."""
+    dataset: _FakeDataset = _FakeDataset()
+    loader: DataLoader[dict[str, torch.Tensor]] = DataLoader(dataset, batch_size=1, num_workers=0)
+    instrumented: InstrumentedLoader = InstrumentedLoader(dataset, loader, steps_per_epoch=5, writer=None)
+
+    values: list[int] = [int(batch["image"].item()) for batch in instrumented]
+
+    assert len(instrumented) == 5
+    assert values == [0, 1, 0, 1, 0]
+    assert dataset.epochs == [0, 1, 2]
+    assert instrumented.sampler is None  # compatibility attribute for the vendored trainer probe; there is no set_epoch to call
+
+
+class _RecordingWriter(SummaryWriter):
+    """SummaryWriter that keeps scalar calls visible to tests."""
+
+    def __init__(self, log_dir: Path) -> None:
+        super().__init__(log_dir=str(log_dir))
+        self.scalars: dict[str, list[tuple[float, int]]] = {}
+
+    def add_scalar(
+        self,
+        tag: str,
+        scalar_value: Any,
+        global_step: int | None = None,
+        walltime: float | None = None,
+        new_style: bool = False,
+        double_precision: bool = False,
+    ) -> None:
+        """Record one scalar without writing it to an event file."""
+        del walltime, new_style, double_precision
+        self.scalars.setdefault(tag, []).append((float(scalar_value), int(global_step or 0)))
+
+
+class _DelayedDataset(_FakeDataset):
+    """Yield delayed values and optionally fail from the producing thread."""
+
+    def __init__(self, values: list[int], delay_s: float = 0.0, fail_after: int | None = None) -> None:
+        super().__init__()
+        self._values: list[int] = values
+        self._delay_s: float = delay_s
+        self._fail_after: int | None = fail_after
+        self.producer_thread_ids: set[int] = set()
+
+    def __iter__(self) -> Iterator[dict[str, torch.Tensor]]:
+        """Yield in order, updating catalog-like cumulative stage counters."""
+        value: int
+        for index, value in enumerate(self._values):
+            if self._fail_after is not None and index == self._fail_after:
+                raise RuntimeError("producer failed")
+            self.producer_thread_ids.add(get_ident())
+            sleep(self._delay_s)
+            self.stats.blob_decode += 0.002
+            self.stats.samples_built += 1
+            yield {"image": torch.tensor([[value]])}
+
+
+def test_data_wait_and_compute_are_attributed_separately(tmp_path: Path) -> None:
+    """Measure blocking ``next`` time apart from work done by the consumer."""
+    dataset: _DelayedDataset = _DelayedDataset([0, 1], delay_s=0.015)
+    loader: DataLoader[dict[str, torch.Tensor]] = DataLoader(dataset, batch_size=None, num_workers=0)
+    writer: _RecordingWriter = _RecordingWriter(tmp_path)
+    instrumented: InstrumentedLoader = InstrumentedLoader(
+        dataset,
+        loader,
+        steps_per_epoch=2,
+        writer=writer,
+        log_every=2,
+    )
+
+    iterator: Iterator[dict[str, torch.Tensor]] = iter(instrumented)
+    next(iterator)
+    sleep(0.025)
+    next(iterator)
+
+    data_wait_ms: float = writer.scalars["io/data_wait_ms"][-1][0]
+    compute_ms: float = writer.scalars["io/compute_ms"][-1][0]
+    blob_decode_ms: float = writer.scalars["io/blob_decode_ms"][-1][0]
+    assert data_wait_ms == pytest.approx(15.0, abs=10.0)
+    assert compute_ms == pytest.approx(25.0, abs=10.0)
+    assert blob_decode_ms == pytest.approx(2.0, abs=0.2)
+    assert writer.scalars["io/frames_per_s"][-1][0] > 0.0
+
+
+def test_logging_global_step_persists_across_epochs(tmp_path: Path) -> None:
+    """Keep TensorBoard steps monotonic when the trainer recreates the iterator."""
+    dataset: _DelayedDataset = _DelayedDataset([0])
+    loader: DataLoader[dict[str, torch.Tensor]] = DataLoader(dataset, batch_size=None, num_workers=0)
+    writer: _RecordingWriter = _RecordingWriter(tmp_path)
+    instrumented: InstrumentedLoader = InstrumentedLoader(dataset, loader, steps_per_epoch=1, writer=writer, log_every=1)
+
+    list(instrumented)
+    list(instrumented)
+
+    assert [step for _, step in writer.scalars["io/data_wait_ms"]] == [1, 2]

--- a/packages/zipdepth/tests/test_catalog_train.py
+++ b/packages/zipdepth/tests/test_catalog_train.py
@@ -1,0 +1,110 @@
+"""Pure policy tests for catalog fine-tuning."""
+
+import pytest
+from torch import nn, optim
+
+from zipdepth.apis.train_catalog import TrainCatalogConfig, pin_batchnorm_eval, resolve_max_lr, split_holdout_segments
+from zipdepth.training.trainer import ZipDepthTrainer
+
+
+def test_catalog_training_defaults_to_parallel_segment_producers() -> None:
+    """Keep enough catalog producers and bounded sample prefetch for GPU training."""
+    config: TrainCatalogConfig = TrainCatalogConfig()
+
+    assert config.shuffle_buffer_size == 256
+    assert config.num_producers == 6
+    assert config.prefetch_samples == 256
+    assert not hasattr(config, "prefetch")
+    assert not hasattr(config, "gpu_augment")
+
+
+def test_catalog_training_uses_one_explicit_optimizer_step_schedule() -> None:
+    """Size the run directly without a fabricated epoch or frame-count model."""
+    config: TrainCatalogConfig = TrainCatalogConfig()
+
+    assert config.total_steps == 70_000
+    assert not hasattr(config, "epochs")
+    assert not hasattr(config, "max_steps")
+
+
+@pytest.mark.parametrize(("skip_batches", "expected_skip"), [(0, 0), (None, 3)])
+def test_trainer_accepts_an_explicit_resume_skip_override(skip_batches: int | None, expected_skip: int) -> None:
+    """Bypass decoded-batch replay for unordered streams without changing the upstream default."""
+    model: nn.Linear = nn.Linear(1, 1)
+    optimizer: optim.SGD = optim.SGD(model.parameters(), lr=0.1)
+    trainer: ZipDepthTrainer = ZipDepthTrainer(
+        student=model,
+        train_loader=[{"image": model.weight.detach()}] * 10,
+        optimizer=optimizer,
+        scheduler=None,
+        device="cpu",
+        use_amp=False,
+        is_distributed=True,
+        rank=1,
+    )
+    trainer.global_step = 3
+    observed_skips: list[int] = []
+
+    def fake_train_epoch(epoch: int, num_epochs: int, pbar: object, skip_batches: int = 0, max_steps: int = 0) -> float:
+        del epoch, num_epochs, pbar, max_steps
+        observed_skips.append(skip_batches)
+        trainer.global_step = 4
+        return 0.0
+
+    trainer.train_epoch = fake_train_epoch  # type: ignore[method-assign]
+
+    trainer.train(num_epochs=1, max_steps=4, skip_batches=skip_batches)
+
+    assert observed_skips == [expected_skip]
+
+
+def test_holdout_split_is_deterministic_disjoint_and_complete() -> None:
+    """Reserve one stable holdout without losing or duplicating segments."""
+    segment_ids: list[str] = [f"segment-{index}" for index in range(12)]
+
+    first: tuple[list[str], list[str]] = split_holdout_segments(segment_ids, holdout_count=4, seed=17)
+    second: tuple[list[str], list[str]] = split_holdout_segments(list(reversed(segment_ids)), holdout_count=4, seed=17)
+
+    train_ids: list[str] = first[0]
+    holdout_ids: list[str] = first[1]
+    assert first == second
+    assert set(train_ids).isdisjoint(holdout_ids)
+    assert set(train_ids) | set(holdout_ids) == set(segment_ids)
+    assert len(train_ids) + len(holdout_ids) == len(segment_ids)
+
+
+@pytest.mark.parametrize(
+    ("override", "from_scratch", "expected"),
+    [
+        (None, False, 1e-5),
+        (None, True, 1e-3),
+        (2e-5, False, 2e-5),
+        (2e-5, True, 2e-5),
+    ],
+)
+def test_max_lr_defaults_follow_initialization_policy(override: float | None, from_scratch: bool, expected: float) -> None:
+    """Use one hundredth of upstream LR for fine-tuning and full LR from scratch."""
+    actual: float = resolve_max_lr(config_lr=1e-3, override=override, from_scratch=from_scratch)
+
+    assert actual == pytest.approx(expected)
+
+
+def test_pin_batchnorm_eval_overrides_only_the_model_root_train_method() -> None:
+    """Keep BatchNorm frozen across root mode changes without altering its own API."""
+    model: nn.Sequential = nn.Sequential(nn.Linear(3, 3), nn.BatchNorm1d(3), nn.Sequential(nn.BatchNorm1d(3)))
+    batchnorms: list[nn.modules.batchnorm._BatchNorm] = [module for module in model.modules() if isinstance(module, nn.modules.batchnorm._BatchNorm)]
+
+    pinned: int = pin_batchnorm_eval(model)
+    model.train(False)
+    model.train(True)
+
+    assert pinned == 2
+    assert model.training is True
+    assert model[0].training is True
+    assert all(not module.training for module in batchnorms)
+    batchnorms[0].train(True)
+    assert batchnorms[0].training is True
+    model.train(True)
+    assert all(not module.training for module in batchnorms)
+
+

--- a/packages/zipdepth/tools/train_catalog.py
+++ b/packages/zipdepth/tools/train_catalog.py
@@ -1,0 +1,8 @@
+"""Tyro shim for catalog ZipDepth fine-tuning."""
+
+import tyro
+
+from zipdepth.apis.train_catalog import TrainCatalogConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(TrainCatalogConfig))

--- a/packages/zipdepth/zipdepth/apis/train_catalog.py
+++ b/packages/zipdepth/zipdepth/apis/train_catalog.py
@@ -1,0 +1,486 @@
+"""Fine-tune trainable ZipDepth-base weights on catalog PromptDA targets."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import types
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from random import Random
+from typing import Any, cast
+
+import torch
+import torch.distributed as dist
+from monopriors.models.relative_depth.zipdepth import download_zipdepth_checkpoint
+from monopriors.third_party.zipdepth.architecture import ZipDepth, create_model
+from monopriors.third_party.zipdepth.model_utils import StateDict, strip_state_dict_prefixes
+from torch import Tensor, nn, optim
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.data import DataLoader
+from torch.utils.tensorboard import SummaryWriter
+
+from zipdepth.catalog.instrument import InstrumentedLoader
+from zipdepth.catalog.segments import DEFAULT_CATALOG_URL, PromptDACatalog, load_promptda_catalog
+from zipdepth.catalog.targets import AugmentPolicy
+from zipdepth.training.distributed import barrier, cleanup_distributed, fix_state_dict_prefix, print_main, setup_distributed
+from zipdepth.training.trainer import ZipDepthTrainer
+
+
+@dataclass(slots=True)
+class TrainCatalogConfig:
+    """Catalog fine-tuning configuration."""
+
+    catalog_url: str = DEFAULT_CATALOG_URL
+    """URL of the local Rerun catalog server."""
+    dataset_name: str = "arkitscenes-v2"
+    """Catalog dataset containing ARKitScenes and PromptDA layers."""
+    num_segments: int | None = None
+    """Number of training-split segments to use; None uses all of them."""
+    segment_ids: list[str] | None = None
+    """Explicit training segment identifiers; overrides ``num_segments``."""
+    holdout_count: int = 20
+    """Number of PromptDA segments reserved from training for evaluation."""
+    holdout_seed: int = 0
+    """Seed for the deterministic holdout split."""
+    height: int = 768
+    """Training image height after augmentation."""
+    width: int = 1024
+    """Training image width after augmentation."""
+    batch_size: int = 8
+    """Samples per rank and optimizer step."""
+    total_steps: int = 70_000
+    """Optimizer steps in the run; the OneCycle schedule spans exactly this many. 70k is about one pass over the 875-segment train split at batch 8 (70.5k steps measured 2026-08-28)."""
+    shuffle_buffer_size: int = 256
+    """Maximum decoded samples held for bounded random shuffling. CUDA samples
+    use about 4.7 MB each at 1024x768, so this and the default producer queue
+    retain about 2.4 GB of device memory together."""
+    seed: int = 0
+    """Base seed for dataset segment order and shuffle-buffer eviction."""
+    num_producers: int = 6
+    """Whole-segment catalog producer threads, each with its own video decoder."""
+    prefetch_samples: int = 256
+    """Maximum completed samples buffered across catalog producers."""
+    min_depth_span: float = 1.25
+    """Minimum valid-depth p95/p5 ratio; zero disables flat-frame filtering."""
+    from_scratch: bool = False
+    """Start with random weights instead of the released ZipDepth-base weights."""
+    freeze_bn: bool = True
+    """Pin BatchNorm to eval mode while fine-tuning: forwards use the released running
+    stats instead of batch statistics, and the stats never drift toward the new data.
+    Without this, train-mode forwards rewrite the running stats within ~100 small
+    batches and eval-mode loss degrades even at zero learning rate. Ignored from scratch."""
+    init_checkpoint: Path | None = None
+    """Local trainable ``.pth`` initialization; overrides the released checkpoint."""
+    train_config: Path = Path("configs/default.json")
+    """Upstream JSON providing loss, optimizer, scheduler, AMP, and model settings."""
+    save_dir: Path = Path("data/checkpoints/catalog")
+    """Directory for split manifests, TensorBoard events, and checkpoints."""
+    save_every_steps: int = 500
+    """Write a step checkpoint after this many updates; zero disables step checkpoints."""
+    resume: Path | None = None
+    """Training checkpoint whose model, optimizer, scheduler, and global step are restored."""
+    max_lr: float | None = None
+    """OneCycle peak LR; None uses config LR / 100 for fine-tuning and config LR from scratch.
+    Measured on the fixed probe set: at config/10 (1e-4, batch 4) fine-tuning diverges once
+    warmup ends; at config/100 (1e-5) it improves the probe loss ~29% in 120 steps."""
+
+
+class _LossObserver(nn.Module):
+    """Observe every loss only when the smoke gate supplies a callback."""
+
+    def __init__(self, criterion: nn.Module, callback: Callable[[float], None]) -> None:
+        super().__init__()
+        self._criterion: nn.Module = criterion
+        self._callback: Callable[[float], None] = callback
+
+    def forward(self, pred: Tensor, target: Tensor, mask: Tensor | None = None) -> tuple[Tensor, dict[str, float]]:
+        """Forward the loss and synchronously expose its scalar value to the smoke gate."""
+        result: tuple[Tensor, dict[str, float]] = self._criterion(pred=pred, target=target, mask=mask)
+        self._callback(float(result[0].detach().item()))
+        return result
+
+
+def split_holdout_segments(segment_ids: list[str], holdout_count: int, seed: int) -> tuple[list[str], list[str]]:
+    """Split sorted identifiers into deterministic disjoint train and holdout lists.
+
+    Args:
+        segment_ids: Unique segment identifiers in any input order.
+        holdout_count: Number of identifiers to reserve.
+        seed: Random seed used to select the holdout.
+
+    Returns:
+        The training identifiers followed by the holdout identifiers, both sorted.
+
+    Raises:
+        ValueError: If identifiers repeat or the holdout count is invalid.
+    """
+    if len(set(segment_ids)) != len(segment_ids):
+        raise ValueError("segment_ids must be unique")
+    if not 0 <= holdout_count <= len(segment_ids):
+        raise ValueError(f"holdout_count must be in [0, {len(segment_ids)}]")
+    ordered_ids: list[str] = sorted(segment_ids)
+    holdout_set: set[str] = set(Random(seed).sample(ordered_ids, holdout_count))
+    train_ids: list[str] = [segment_id for segment_id in ordered_ids if segment_id not in holdout_set]
+    holdout_ids: list[str] = [segment_id for segment_id in ordered_ids if segment_id in holdout_set]
+    return train_ids, holdout_ids
+
+
+def resolve_max_lr(config_lr: float, override: float | None, from_scratch: bool) -> float:
+    """Resolve the OneCycle peak learning rate from initialization policy."""
+    max_lr: float = override if override is not None else config_lr if from_scratch else config_lr / 100.0
+    if max_lr <= 0.0:
+        raise ValueError("max_lr must be positive")
+    return max_lr
+
+
+def _select_train_and_holdout(config: TrainCatalogConfig, catalog: PromptDACatalog) -> tuple[list[str], list[str]]:
+    """Apply explicit selection or the deterministic holdout-first train split."""
+    if config.holdout_count < 0:
+        raise ValueError("holdout_count must be non-negative")
+    if config.segment_ids is not None:
+        selected_ids: list[str] = list(config.segment_ids)
+        if len(set(selected_ids)) != len(selected_ids):
+            raise ValueError("explicit segment_ids must be unique")
+        catalog.require_segments(selected_ids)
+        holdout_candidates: list[str] = [segment_id for segment_id in catalog.segment_ids if segment_id not in set(selected_ids)]
+        candidate_split: tuple[list[str], list[str]] = split_holdout_segments(
+            holdout_candidates,
+            config.holdout_count,
+            config.holdout_seed,
+        )
+        holdout_ids: list[str] = candidate_split[1]
+        train_ids: list[str] = selected_ids
+    else:
+        train_ids, holdout_ids = split_holdout_segments(catalog.segment_ids, config.holdout_count, config.holdout_seed)
+        if config.num_segments is not None:
+            if config.num_segments <= 0:
+                raise ValueError("num_segments must be positive when set")
+            train_ids = train_ids[: config.num_segments]
+    if not train_ids:
+        raise RuntimeError("catalog split selected no training segments")
+    return train_ids, holdout_ids
+
+
+def _load_json_config(path: Path) -> dict[str, Any]:
+    """Read the required upstream training JSON."""
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    with path.open() as file:
+        loaded: Any = json.load(file)
+    if not isinstance(loaded, dict):
+        raise ValueError(f"training config must contain a JSON object: {path}")
+    return loaded
+
+
+def load_trainable_checkpoint(model: ZipDepth, checkpoint: Path) -> None:
+    """Strictly load cleaned DDP/compile weights without inference fusion."""
+    loaded: Any = torch.load(checkpoint, map_location="cpu", weights_only=True)
+    if not isinstance(loaded, dict):
+        raise ValueError(f"checkpoint must contain a mapping: {checkpoint}")
+    raw_state: Any = loaded.get("model_state_dict", loaded)
+    if not isinstance(raw_state, dict):
+        raise ValueError(f"checkpoint model state must contain a mapping: {checkpoint}")
+    state_dict: StateDict = strip_state_dict_prefixes(raw_state)
+    model.load_state_dict(state_dict, strict=True)
+
+
+def pin_batchnorm_eval(model: nn.Module) -> int:
+    """Pin every BatchNorm module to eval mode for the whole training run.
+
+    Overrides the root model's ``train`` method to apply the requested mode and
+    then return every BatchNorm module to eval, so the trainer's per-epoch
+    ``model.train()`` cannot flip them back. Affine
+    weights still receive gradients; only the normalization statistics are frozen.
+    State-dict layout is unchanged, so strict checkpoint round-trips still pass.
+
+    Returns:
+        The number of pinned BatchNorm modules.
+    """
+    def train_with_batchnorm_eval(self: nn.Module, mode: bool = True) -> nn.Module:
+        """Apply a root mode change, then restore every BatchNorm to eval."""
+        nn.Module.train(self, mode)
+        child: nn.Module
+        for child in self.modules():
+            if isinstance(child, nn.modules.batchnorm._BatchNorm):
+                child.eval()
+        return self
+
+    pinned: int = sum(isinstance(module, nn.modules.batchnorm._BatchNorm) for module in model.modules())
+    current_mode: bool = model.training
+    model.train = types.MethodType(train_with_batchnorm_eval, model)
+    model.train(current_mode)
+    return pinned
+
+
+def _one_cycle_scheduler(
+    optimizer: optim.Optimizer,
+    max_lr: float,
+    total_steps: int,
+    scheduler_config: dict[str, Any],
+    last_epoch: int = -1,
+) -> optim.lr_scheduler.OneCycleLR:
+    """Build the upstream OneCycle schedule with resolved total steps."""
+    return optim.lr_scheduler.OneCycleLR(
+        optimizer,
+        max_lr=max_lr,
+        total_steps=total_steps,
+        pct_start=float(scheduler_config.get("pct_start", 0.05)),
+        anneal_strategy="cos",
+        div_factor=float(scheduler_config.get("div_factor", 25.0)),
+        final_div_factor=float(scheduler_config.get("final_div_factor", 1000.0)),
+        last_epoch=last_epoch,
+    )
+
+
+def _atomic_latest(final_checkpoint: Path) -> Path:
+    """Publish a recoverable latest checkpoint with an atomic final rename."""
+    latest: Path = final_checkpoint.parent / "latest.pth"
+    temporary: Path = final_checkpoint.parent / ".latest.pth.tmp"
+    shutil.copy2(final_checkpoint, temporary)
+    temporary.replace(latest)
+    return latest
+
+
+def _restore_resume_state(
+    resume: Path,
+    wrapped_model: nn.Module,
+    optimizer: optim.Optimizer,
+    scheduler: optim.lr_scheduler.OneCycleLR,
+    trainer: ZipDepthTrainer,
+    *,
+    device: torch.device,
+    is_distributed: bool,
+    is_main: bool,
+    rank: int,
+    total_steps: int,
+    actual_max_lr: float,
+    scheduler_config: dict[str, Any],
+) -> None:
+    """Restore model, optimizer, schedule, and trainer step."""
+    print_main(f"Resuming from: {resume}", rank)
+    checkpoint: dict[str, Any] | None
+    if is_distributed:
+        loaded_checkpoint: Any = torch.load(resume, map_location="cpu", weights_only=True) if is_main else None
+        checkpoint = loaded_checkpoint if isinstance(loaded_checkpoint, dict) else None
+        barrier()
+        objects: list[Any] = [checkpoint]
+        dist.broadcast_object_list(objects, src=0)
+        checkpoint = objects[0]
+        barrier()
+    else:
+        loaded_checkpoint = torch.load(resume, map_location=device, weights_only=True)
+        checkpoint = loaded_checkpoint if isinstance(loaded_checkpoint, dict) else None
+    if checkpoint is None:
+        raise ValueError(f"resume checkpoint must contain a mapping: {resume}")
+    raw_resume_state: Any = checkpoint.get("model_state_dict", checkpoint)
+    if not isinstance(raw_resume_state, dict):
+        raise ValueError("resume checkpoint has no model state mapping")
+    resume_state: dict[str, Any] = fix_state_dict_prefix(strip_state_dict_prefixes(raw_resume_state), is_distributed)
+    wrapped_model.load_state_dict(resume_state, strict=True)
+    optimizer_state: Any = checkpoint.get("optimizer_state_dict")
+    if not isinstance(optimizer_state, dict):
+        raise ValueError("resume checkpoint has no optimizer state")
+    optimizer.load_state_dict(optimizer_state)
+    trainer.global_step = int(checkpoint.get("global_step", 0))
+    scheduler_state: Any = checkpoint.get("scheduler_state_dict")
+    old_total_steps: int | None = int(scheduler_state["total_steps"]) if isinstance(scheduler_state, dict) and "total_steps" in scheduler_state else None
+    if isinstance(scheduler_state, dict) and old_total_steps == total_steps:
+        scheduler.load_state_dict(scheduler_state)
+    else:
+        rebased_scheduler: optim.lr_scheduler.OneCycleLR = _one_cycle_scheduler(
+            optimizer,
+            actual_max_lr,
+            total_steps,
+            scheduler_config,
+            last_epoch=trainer.global_step - 1,
+        )
+        trainer.scheduler = rebased_scheduler
+        print_main(f"Rebased OneCycle schedule from {old_total_steps} to {total_steps} total steps", rank)
+
+
+def main(
+    config: TrainCatalogConfig,
+    *,
+    writer: SummaryWriter | None = None,
+    step_loss_callback: Callable[[float], None] | None = None,
+) -> Path:
+    """Run catalog fine-tuning and return the atomically published latest checkpoint."""
+    distributed_result: tuple[int, int, int, bool] = setup_distributed()
+    rank: int = distributed_result[0]
+    world_size: int = distributed_result[1]
+    local_rank: int = distributed_result[2]
+    is_distributed: bool = distributed_result[3]
+    is_main: bool = rank == 0
+    owns_writer: bool = False
+    try:
+        if config.height <= 0 or config.width <= 0 or config.batch_size <= 0 or config.total_steps <= 0:
+            raise ValueError("height, width, batch_size, and total_steps must be positive")
+        if config.shuffle_buffer_size <= 0:
+            raise ValueError("shuffle_buffer_size must be positive")
+        if config.num_producers <= 0 or config.prefetch_samples <= 0:
+            raise ValueError("num_producers and prefetch_samples must be positive")
+        if config.save_every_steps < 0:
+            raise ValueError("save_every_steps must be non-negative")
+        torch.backends.cudnn.benchmark = True
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True
+        device: torch.device = torch.device(f"cuda:{local_rank}") if is_distributed else torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+        catalog: PromptDACatalog = load_promptda_catalog(config.catalog_url, config.dataset_name)
+        selected: tuple[list[str], list[str]] = _select_train_and_holdout(config, catalog)
+        train_segment_ids: list[str] = selected[0]
+        holdout_segment_ids: list[str] = selected[1]
+
+        # Catalog-only imports stay local so zipdepth-dev can run the pure policy tests.
+        from zipdepth.catalog.builders import CudaSampleBuilder
+        from zipdepth.catalog.dataset import CatalogPromptDepthDataset
+
+        steps_per_epoch: int = config.total_steps
+        total_steps: int = config.total_steps
+
+        upstream_config: dict[str, Any] = _load_json_config(config.train_config)
+        optimizer_config: dict[str, Any] = dict(upstream_config.get("optimizer", {}))
+        scheduler_config: dict[str, Any] = dict(upstream_config.get("scheduler", {}))
+        loss_config: dict[str, Any] = dict(upstream_config.get("loss", {}))
+        amp_config: dict[str, Any] = dict(upstream_config.get("amp", {}))
+        model_config: dict[str, Any] = dict(upstream_config.get("model", {}))
+        training_config: dict[str, Any] = dict(upstream_config.get("training", {}))
+        config_lr: float = float(optimizer_config.get("lr", 1e-3))
+        actual_max_lr: float = resolve_max_lr(config_lr, config.max_lr, config.from_scratch)
+
+        if is_main:
+            config.save_dir.mkdir(parents=True, exist_ok=True)
+            with (config.save_dir / "train_segments.json").open("w") as file:
+                json.dump(train_segment_ids, file, indent=2)
+            with (config.save_dir / "holdout_segments.json").open("w") as file:
+                json.dump(holdout_segment_ids, file, indent=2)
+            resolved: dict[str, Any] = {
+                **asdict(config),
+                "rank_count": world_size,
+                "steps_per_epoch": steps_per_epoch,
+                "total_steps": total_steps,
+                "resolved_max_lr": actual_max_lr,
+            }
+            with (config.save_dir / "resolved_config.json").open("w") as file:
+                json.dump(resolved, file, indent=2, default=str)
+        barrier()
+
+        if writer is None and is_main:
+            writer = SummaryWriter(log_dir=str(config.save_dir / "runs"))
+            owns_writer = True
+
+        dataset: CatalogPromptDepthDataset = CatalogPromptDepthDataset(
+            catalog.dataset_entry,
+            train_segment_ids,
+            catalog.row_by_id,
+            device=device,
+            builder_factory=lambda: CudaSampleBuilder(
+                (config.height, config.width),
+                AugmentPolicy(),
+                config.min_depth_span,
+                device,
+            ),
+            shuffle_buffer_size=config.shuffle_buffer_size,
+            seed=config.seed,
+            rank=rank,
+            world_size=world_size,
+            num_producers=config.num_producers,
+            prefetch_samples=config.prefetch_samples,
+        )
+        data_loader: DataLoader[dict[str, Tensor]] = DataLoader(
+            dataset,
+            batch_size=config.batch_size,
+            num_workers=0,
+            pin_memory=False,
+            drop_last=True,
+        )
+        train_loader: InstrumentedLoader = InstrumentedLoader(
+            dataset,
+            data_loader,
+            steps_per_epoch=steps_per_epoch,
+            writer=writer if is_main else None,
+        )
+
+        model: ZipDepth = create_model(variant="base", upsample_unfold=bool(model_config.get("upsample_unfold", True)))
+        initialization: Path | None = config.init_checkpoint
+        if initialization is None and not config.from_scratch and config.resume is None:
+            initialization = download_zipdepth_checkpoint()
+        if initialization is not None:
+            print_main(f"Loading trainable initialization: {initialization}", rank)
+            load_trainable_checkpoint(model, initialization)
+        else:
+            print_main("Training ZipDepth-base from scratch", rank)
+        if config.freeze_bn and not config.from_scratch:
+            pinned: int = pin_batchnorm_eval(model)
+            print_main(f"Pinned {pinned} BatchNorm modules to eval (released running stats)", rank)
+        model = model.to(device)
+        wrapped_model: ZipDepth | DDP = (
+            DDP(model, device_ids=[local_rank], output_device=local_rank, find_unused_parameters=False) if is_distributed else model
+        )
+
+        model_parameters: Any = model.parameters()
+        optimizer: optim.AdamW = optim.AdamW(
+            model_parameters,
+            lr=actual_max_lr,
+            weight_decay=float(optimizer_config.get("weight_decay", 0.01)),
+        )
+        scheduler: optim.lr_scheduler.OneCycleLR = _one_cycle_scheduler(optimizer, actual_max_lr, total_steps, scheduler_config)
+        trainer: ZipDepthTrainer = ZipDepthTrainer(
+            student=wrapped_model,
+            train_loader=train_loader,
+            optimizer=optimizer,
+            scheduler=scheduler,
+            device=device,
+            use_amp=bool(amp_config.get("enabled", True)),
+            writer=writer if is_main else None,
+            is_distributed=is_distributed,
+            rank=rank,
+            world_size=world_size,
+            amp_dtype=str(amp_config.get("dtype", "bfloat16")),
+            alpha_ssi=float(loss_config.get("alpha_ssi", 1.0)),
+            alpha_grad=float(loss_config.get("alpha_grad", 2.0)),
+        )
+        if step_loss_callback is not None:
+            trainer.criterion = cast(Any, _LossObserver(trainer.criterion, step_loss_callback))
+
+        if config.resume is not None:
+            _restore_resume_state(
+                config.resume,
+                wrapped_model,
+                optimizer,
+                scheduler,
+                trainer,
+                device=device,
+                is_distributed=is_distributed,
+                is_main=is_main,
+                rank=rank,
+                total_steps=total_steps,
+                actual_max_lr=actual_max_lr,
+                scheduler_config=scheduler_config,
+            )
+
+        print_main(
+            f"Catalog train: {len(train_segment_ids)} segments, {total_steps} optimizer steps, max_lr={actual_max_lr:.2e}, device={device}",
+            rank,
+        )
+        trainer.train(
+            num_epochs=1,
+            save_dir=str(config.save_dir),
+            start_epoch=0,
+            save_every_steps=config.save_every_steps,
+            max_step_checkpoints=int(training_config.get("max_step_checkpoints", 5)),
+            max_steps=total_steps,
+            skip_batches=0,
+        )
+        barrier()
+        latest: Path = config.save_dir / "latest.pth"
+        if is_main:
+            latest = _atomic_latest(config.save_dir / "final_model.pth")
+        barrier()
+        return latest
+    finally:
+        if owns_writer and writer is not None:
+            writer.close()
+        cleanup_distributed()

--- a/packages/zipdepth/zipdepth/catalog/instrument.py
+++ b/packages/zipdepth/zipdepth/catalog/instrument.py
@@ -19,12 +19,7 @@ from zipdepth.catalog.stats import STAGE_FIELDS, CatalogDatasetStats
 
 def _stage_totals(stats: CatalogDatasetStats) -> dict[str, float]:
     """Read the cumulative floating-point duration for every catalog stage."""
-    return {
-        "segment_query": stats.segment_query,
-        "video_decode": stats.video_decode,
-        "blob_decode": stats.blob_decode,
-        "augment": stats.augment,
-    }
+    return {name: getattr(stats, name) for name in STAGE_FIELDS}
 
 
 @dataclass(slots=True)

--- a/packages/zipdepth/zipdepth/catalog/instrument.py
+++ b/packages/zipdepth/zipdepth/catalog/instrument.py
@@ -1,0 +1,202 @@
+"""Measure catalog data stalls separately from trainer compute time."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from itertools import count
+from time import perf_counter
+from typing import Any
+
+import torch
+from beartype.roar import BeartypeException
+from torch import Tensor
+from torch.utils.data import DataLoader
+from torch.utils.tensorboard import SummaryWriter
+
+from zipdepth.catalog.stats import STAGE_FIELDS, CatalogDatasetStats
+
+
+def _stage_totals(stats: CatalogDatasetStats) -> dict[str, float]:
+    """Read the cumulative floating-point duration for every catalog stage."""
+    return {
+        "segment_query": stats.segment_query,
+        "video_decode": stats.video_decode,
+        "blob_decode": stats.blob_decode,
+        "augment": stats.augment,
+    }
+
+
+@dataclass(slots=True)
+class _Interval:
+    """Mutable wait, compute, and frame totals for one logging interval."""
+
+    data_wait_s: float = 0.0
+    """Seconds blocked on the next batch."""
+    data_wait_count: int = 0
+    """Number of measured batch waits."""
+    compute_s: float = 0.0
+    """Seconds spent by the consumer between yielded batches."""
+    compute_count: int = 0
+    """Number of measured consumer intervals."""
+    frames: int = 0
+    """Frames yielded during the interval."""
+
+    def reset(self) -> None:
+        """Clear every interval counter in place."""
+        self.data_wait_s = 0.0
+        self.data_wait_count = 0
+        self.compute_s = 0.0
+        self.compute_count = 0
+        self.frames = 0
+
+
+class InstrumentedLoader:
+    """Wrap a catalog DataLoader with fixed pacing and IO timing."""
+
+    def __init__(
+        self,
+        dataset: Any,
+        loader: DataLoader[dict[str, Tensor]],
+        steps_per_epoch: int,
+        writer: SummaryWriter | None,
+        log_every: int = 50,
+    ) -> None:
+        """Configure fixed-length iteration and periodic instrumentation.
+
+        Args:
+            dataset: Catalog dataset whose epoch and stage counters are exposed.
+            loader: In-process DataLoader; it must use ``num_workers=0``.
+            steps_per_epoch: Batches yielded to the trainer in one epoch.
+            writer: Optional TensorBoard scalar sink.
+            log_every: Number of yielded batches between reports.
+
+        Raises:
+            ValueError: If a count is not positive.
+        """
+        if steps_per_epoch <= 0:
+            raise ValueError("steps_per_epoch must be positive")
+        if log_every <= 0:
+            raise ValueError("log_every must be positive")
+        self._dataset: Any = dataset
+        self._loader: DataLoader[dict[str, Tensor]] = loader
+        self._steps_per_epoch: int = steps_per_epoch
+        self.sampler: None = None
+        """The vendored trainer probes ``loader.sampler.set_epoch``; pass seeding lives in ``__iter__``, so there is none."""
+        self._writer: SummaryWriter | None = writer
+        self._log_every: int = log_every
+        self._global_step: int = 0
+        self._stage_snapshot: dict[str, float] = _stage_totals(dataset.stats)
+        self._samples_built_snapshot: int = dataset.stats.samples_built
+
+    def __len__(self) -> int:
+        """Return the fixed optimizer steps assigned to each epoch."""
+        return self._steps_per_epoch
+
+    def _log_interval(
+        self,
+        *,
+        data_wait_s: float,
+        data_wait_count: int,
+        compute_s: float,
+        compute_count: int,
+        frames: int,
+    ) -> None:
+        """Report one interval to the console and optional TensorBoard writer."""
+        data_wait_ms: float = data_wait_s * 1000.0 / max(data_wait_count, 1)
+        compute_ms: float = compute_s * 1000.0 / max(compute_count, 1)
+        frames_per_s: float = frames / max(data_wait_s + compute_s, 1e-12)
+        current_stages: dict[str, float] = _stage_totals(self._dataset.stats)
+        current_samples_built: int = self._dataset.stats.samples_built
+        built_delta: int = current_samples_built - self._samples_built_snapshot
+        stage_ms: dict[str, float] = {
+            stage: (current_stages[stage] - self._stage_snapshot[stage]) * 1000.0 / max(built_delta, 1.0)
+            for stage in STAGE_FIELDS
+        }
+        self._stage_snapshot = current_stages
+        self._samples_built_snapshot = current_samples_built
+
+        gpu_util_pct: float | None = None
+        try:
+            if torch.cuda.is_available():
+                gpu_util_pct = float(torch.cuda.utilization())
+        except BeartypeException:
+            raise
+        except Exception:
+            gpu_util_pct = None
+
+        gpu_text: str = "n/a" if gpu_util_pct is None else f"{gpu_util_pct:.0f}%"
+        stage_text: str = " ".join(f"{name}={stage_ms[name]:.1f}ms" for name in STAGE_FIELDS)
+        print(
+            f"[catalog io step {self._global_step}] wait={data_wait_ms:.1f}ms compute={compute_ms:.1f}ms "
+            f"throughput={frames_per_s:.2f} frames/s gpu={gpu_text} "
+            f"{stage_text} skipped={self._dataset.skipped_frames}"
+        )
+        if self._writer is None:
+            return
+        scalar_values: dict[str, float] = {
+            "io/data_wait_ms": data_wait_ms,
+            "io/compute_ms": compute_ms,
+            "io/frames_per_s": frames_per_s,
+            "io/skipped_frames": float(self._dataset.skipped_frames),
+        }
+        name: str
+        for name in STAGE_FIELDS:
+            scalar_values[f"io/{name}_ms"] = stage_ms[name]
+        if gpu_util_pct is not None:
+            scalar_values["io/gpu_util_pct"] = gpu_util_pct
+        tag: str
+        value: float
+        for tag, value in scalar_values.items():
+            self._writer.add_scalar(tag, value, self._global_step)
+
+    def __iter__(self) -> Iterator[dict[str, Tensor]]:
+        """Yield the fixed run length across reshuffled finite dataset passes.
+
+        A pass exhausts the filtered stream once. It is not an epoch: the
+        schedule has only an explicit optimizer-step count. Each new pass gets
+        a distinct dataset seed through :meth:`set_epoch`.
+        """
+        interval: _Interval = _Interval()
+        yield_started: float | None = None
+        yielded_batches: int = 0
+        pass_index: int
+        for pass_index in count():
+            self._dataset.set_epoch(pass_index)
+            batches: Iterator[dict[str, Tensor]] = iter(self._loader)
+            pass_batches: int = 0
+            while yielded_batches < self._steps_per_epoch:
+                resumed: float = perf_counter()
+                if yield_started is not None:
+                    interval.compute_s += resumed - yield_started
+                    interval.compute_count += 1
+
+                wait_started: float = perf_counter()
+                try:
+                    batch: dict[str, Tensor] = next(batches)
+                except StopIteration:
+                    break
+                interval.data_wait_s += perf_counter() - wait_started
+                interval.data_wait_count += 1
+                pass_batches += 1
+                yielded_batches += 1
+                image: Tensor = batch["image"]
+                interval.frames += int(image.shape[0]) if image.ndim > 0 else 1
+                self._global_step += 1
+
+                if self._global_step % self._log_every == 0:
+                    self._log_interval(
+                        data_wait_s=interval.data_wait_s,
+                        data_wait_count=interval.data_wait_count,
+                        compute_s=interval.compute_s,
+                        compute_count=interval.compute_count,
+                        frames=interval.frames,
+                    )
+                    interval.reset()
+
+                yield_started = perf_counter()
+                yield batch
+            if yielded_batches >= self._steps_per_epoch:
+                return
+            if pass_batches == 0:
+                raise RuntimeError("catalog dataset pass yielded no batches")

--- a/packages/zipdepth/zipdepth/training/trainer.py
+++ b/packages/zipdepth/zipdepth/training/trainer.py
@@ -124,7 +124,8 @@ class ZipDepthTrainer:
             self.student = torch.compile(self.student, mode="reduce-overhead")
 
     def train(self, num_epochs: int, save_dir: str = './checkpoints', start_epoch: int = 0,
-            save_every_steps: int = 0, max_step_checkpoints: int = 5, max_steps: int = 0):
+            save_every_steps: int = 0, max_step_checkpoints: int = 5, max_steps: int = 0,
+            skip_batches: int | None = None):
         if self.is_main:
             os.makedirs(save_dir, exist_ok=True)
 
@@ -136,7 +137,7 @@ class ZipDepthTrainer:
 
         # When resuming mid-epoch, skip the batches already processed so the
         # scheduler is stepped exactly the right number of times.
-        initial_skip = self.global_step % steps_per_epoch if self.global_step > 0 else 0
+        initial_skip = skip_batches if skip_batches is not None else self.global_step % steps_per_epoch
         if initial_skip > 0 and self.is_main:
             print(f"\nResume: skipping first {initial_skip}/{steps_per_epoch} batches "
                   f"of epoch {start_epoch} (global_step={self.global_step})")
@@ -299,6 +300,11 @@ class ZipDepthTrainer:
                 teacher_depth = batch['depth'].to(self.device, non_blocking=True)
                 teacher_depth = teacher_depth.float().div_(256.0)
 
+                # Local addition: sparse catalog targets carry an explicit validity mask.
+                mask = batch.get('mask')
+                if mask is not None:
+                    mask = mask.to(self.device, non_blocking=True).float()
+
                 del batch
 
                 with torch.amp.autocast('cuda', dtype=self.amp_dtype, enabled=self.use_amp):
@@ -306,6 +312,7 @@ class ZipDepthTrainer:
                     loss, loss_dict = self.criterion(
                         pred=student_depth,
                         target=teacher_depth,
+                        mask=mask,
                     )
 
                 loss_value = loss.item()
@@ -381,7 +388,7 @@ class ZipDepthTrainer:
                     print(f'\n  -> Checkpoint saved at step {self.global_step}')
                     self.cleanup_step_checkpoints()
 
-                del student_depth, teacher_depth, loss
+                del student_depth, teacher_depth, mask, loss
 
                 # Advance profiler schedule (no-op after schedule completes or when profiling disabled)
                 if prof is not None:

--- a/packages/zipdepth/zipdepth/upstream_cli/__init__.py
+++ b/packages/zipdepth/zipdepth/upstream_cli/__init__.py
@@ -2,6 +2,8 @@
 
 Bodies are unmodified apart from model imports (``monopriors.third_party.zipdepth``), ``eval.py``
 running inference through ``monopriors`` ``ZipDepthPredictor``, and ``train.py``'s ``__main__`` block
-wrapped as ``cli()``. Upstream ``infer.py`` was dropped — ``ZipDepthPredictor`` / ``apis/infer_rerun``
+wrapped as ``cli()``. The shared trainer also forwards an optional sparse-target mask to the loss.
+Its ``train`` method accepts a local ``skip_batches`` override so unordered catalog resumes do not decode and discard prior batches; the default preserves upstream behavior.
+Upstream ``infer.py`` was dropped — ``ZipDepthPredictor`` / ``apis/infer_rerun``
 cover it. Converting them to tyro ``apis/`` is phase-2 debt.
 """

--- a/pixi.toml
+++ b/pixi.toml
@@ -695,6 +695,11 @@ cmd = "python tools/catalog_throughput.py"
 cwd = "packages/zipdepth"
 description = "Measure catalog->batch throughput (frames/s, per-stage ms) over warm promptda segments"
 
+[feature.zipdepth-catalog.tasks.zipdepth-train-catalog]
+cmd = "python tools/train_catalog.py"
+cwd = "packages/zipdepth"
+description = "Fine-tune ZipDepth on chosen-frame PromptDA pseudo-labels streamed from the local Rerun catalog"
+
 [feature.zipdepth-catalog.tasks.zipdepth-eval-catalog]
 cmd = "python tools/eval_catalog.py"
 cwd = "packages/zipdepth"


### PR DESCRIPTION
Stack **4/5** (base #133; next #129).

**What**
- `apis/train_catalog.py` (`zipdepth-train-catalog`): fine-tune the released weights on the catalog stream. The four decisions that made it learn: BatchNorm pinned to eval (`pin_batchnorm_eval` — running-stat drift degrades the released model at *any* lr, even 0), peak lr = config/100 (1e-5; 1e-4 diverges after warmup), resize-only augmentation (from stack 2/5), the `min_depth_span` flat-frame filter. An explicit `total_steps` sizes OneCycle exactly and the loader runs endless reshuffled passes (no epoch model). Resume rebases the schedule; minimal DDP.
- `catalog/instrument.py` — `InstrumentedLoader`: separates data-wait from compute per window and logs `io/*` scalars (data_wait_ms, compute_ms, frames_per_s, gpu_util_pct, per-stage ms) to TensorBoard — the live IO-bound-vs-GPU-bound readout.
- Two sanctioned one-line edits in the vendored `training/trainer.py`, documented in `upstream_cli/__init__.py`: forward `batch["mask"]` to the criterion; an optional `skip_batches` override so resume on an unordered stream stops decode-and-discarding batches. `skip_batches=None` keeps upstream behaviour (tested both ways).

**Review focus**: the two vendored hunks against the docstring; `pin_batchnorm_eval` (rebinds the model root's `train`); `InstrumentedLoader.__iter__` (this *is* the step schedule); `_restore_resume_state` (the only cross-rank broadcast); `main()` is the densest ~180 lines in the stack.

**Result this enables** (overnight run, 70k steps, batch 8, ~8 h): holdout 20 segments / 1,299 frames — fine-tuned @768 **AbsRel 0.0864 / δ1 0.9219** vs released @384 0.0935 / 0.9130 (better on 17/20 segments). Loader after the CUDA path: data_wait 0 ms, GPU 90–98 %, 151 f/s.

**Gates**: lint ✓ · pyrefly 0 errors ✓ · deadcode ✓ · 49 passed (catalog env) · 37 passed / 2 skipped (`zipdepth-dev`) ✓

**Live plumbing**: 50-step fine-tune on 2 segments → `latest.pth` / `final_model.pth`, manifests, and the `[catalog io step 50]` line written; the checkpoint loads and scores through eval (@768 AbsRel 0.1515 ≈ the released model's own @768 score of 0.1486 — 50 steps at 1e-5 do not move the model; learning is proven by the 120-step fixed-probe gate in stack 5/5 and by the overnight result above).
