### PR TITLE
posekit: click-to-track follow-ups (stream tee, gr.State sessions, shared reader)

### DIFF
--- a/packages/posekit/src/posekit/apis/click_tracker.py
+++ b/packages/posekit/src/posekit/apis/click_tracker.py
@@ -10,21 +10,19 @@ forward and backward from the first prompted frame.
 from __future__ import annotations
 
 import threading
-from collections.abc import Callable, Iterator
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TypeVar
 
 import torch
 from einops import rearrange
 from jaxtyping import Bool, UInt8
+from simplecv.video_io import TorchCodecVideoReader
 from torch import Tensor
 from torch.nn import functional as F
 
 OBJ_ID: int = 0
 """The single tracked object."""
-T = TypeVar("T")
 _INFERENCE_LOCK = threading.Lock()  # no annotation: beartype rejects the builtin lock type hint
 """Serialize calls into the shared GPU predictor, one inference step at a time."""
 
@@ -57,6 +55,16 @@ class MaskResult:
     """Sigmoid object-presence score."""
 
 
+@dataclass(frozen=True, slots=True)
+class PointEdit:
+    """Outcome of removing one point from the prompt set."""
+
+    point: Point | None
+    """Removed point, or ``None`` when no point matched."""
+    result: MaskResult | None
+    """Refreshed mask on the edited frame, or ``None`` when it has no points."""
+
+
 class ClickTracker:
     """Stateful single-object tracker driven by clicks on arbitrary frames."""
 
@@ -81,8 +89,6 @@ class ClickTracker:
         Raises:
             ValueError: If the clip has no decodable frames.
         """
-        from torchcodec.decoders import VideoDecoder
-
         self.predictor = predictor
         self.device: str = device
         self.remove_radius_px: float = remove_radius_px
@@ -91,15 +97,12 @@ class ClickTracker:
         # 201" / "Could not receive frame from decoder"), even when serialized. Web
         # callbacks run on pool threads, so the decoder lives on its own thread and
         # every decode is executed there.
-        self._decode_thread = ThreadPoolExecutor(max_workers=1, thread_name_prefix="click-tracker-decode")
-        self._decoder = self._decode(lambda: VideoDecoder(video_path, dimension_order="NHWC", device=device))
-        total: int | None = self._decoder.metadata.num_frames
-        if total is None or total <= 0:
+        self._video_reader: TorchCodecVideoReader = TorchCodecVideoReader(video_path, device=device, thread_owned=True)
+        if self._video_reader.frame_cnt <= 0:
             raise ValueError(f"{video_path} has no decodable frames.")
-        self.num_frames: int = int(total)
-        first = self._decode(lambda: self._decoder.get_frame_at(0))
-        self.frame_hw: tuple[int, int] = (int(first.data.shape[0]), int(first.data.shape[1]))
-        self.points: list[Point] = []
+        self.num_frames: int = self._video_reader.frame_cnt
+        self.frame_hw: tuple[int, int] = (self._video_reader.height, self._video_reader.width)
+        self._points: list[Point] = []
         """Every live point, in insertion order (the undo order)."""
         self._memory_window_size: int = memory_window_size
         self._state = self._new_state()
@@ -116,20 +119,17 @@ class ClickTracker:
 
     # ── frames ────────────────────────────────────────────────────────────
 
-    def _decode(self, fn: Callable[[], T]) -> T:
-        """Run a decoder call on the decoder's own thread and return its result."""
-        return self._decode_thread.submit(fn).result()
-
     def close(self) -> None:
         """Stop the thread-affine decoder executor. Safe to call more than once."""
         if self._closed:
             return
         self._closed = True
-        self._decode_thread.shutdown(wait=True, cancel_futures=True)
+        self._video_reader.close()
 
     def frame(self, frame_idx: int) -> UInt8[Tensor, "h w 3"]:
         """Decode one frame on the inference device."""
-        return self._decode(lambda: self._decoder.get_frame_at(frame_idx)).data
+        frame_chw: UInt8[Tensor, "3 h w"] = self._video_reader.get_frame(frame_idx)
+        return rearrange(frame_chw, "c h w -> h w c")
 
     def _embeddings(self, frame_idx: int) -> tuple[list[Tensor], list[Tensor]]:
         """Image-encoder output for one frame; the last frame's is cached (Kineo's one-frame cache)."""
@@ -142,42 +142,47 @@ class ClickTracker:
 
     # ── points ────────────────────────────────────────────────────────────
 
-    def points_on(self, frame_idx: int) -> list[Point]:
-        """The live points placed on one frame."""
-        return [p for p in self.points if p.frame_idx == frame_idx]
+    @property
+    def points(self) -> tuple[Point, ...]:
+        """All live points in insertion order."""
+        return tuple(self._points)
 
-    def prompted_frames(self) -> list[int]:
+    def points_on(self, frame_idx: int) -> tuple[Point, ...]:
+        """The live points placed on one frame."""
+        return tuple(point for point in self._points if point.frame_idx == frame_idx)
+
+    def prompted_frames(self) -> tuple[int, ...]:
         """Sorted frame indices that carry at least one point."""
-        return sorted({p.frame_idx for p in self.points})
+        return tuple(sorted({point.frame_idx for point in self._points}))
 
     def add_point(self, frame_idx: int, x: float, y: float, *, positive: bool, resegment: bool = False) -> MaskResult:
         """Add a point on a frame and return that frame's re-prompted mask."""
-        self.points.append(Point(frame_idx=frame_idx, x=float(x), y=float(y), positive=positive))
+        self._points.append(Point(frame_idx=frame_idx, x=float(x), y=float(y), positive=positive))
         result = self.refresh(frame_idx, resegment=resegment)
         assert result is not None
         return result
 
-    def remove_point_near(self, frame_idx: int, x: float, y: float) -> tuple[Point | None, MaskResult | None]:
+    def remove_point_near(self, frame_idx: int, x: float, y: float) -> PointEdit:
         """Remove the closest point on the frame within ``remove_radius_px`` (Kineo's Shift+Click)."""
-        candidates: list[Point] = self.points_on(frame_idx)
+        candidates: tuple[Point, ...] = self.points_on(frame_idx)
         if not candidates:
-            return None, None
+            return PointEdit(point=None, result=None)
         nearest: Point = min(candidates, key=lambda p: (p.x - x) ** 2 + (p.y - y) ** 2)
         if (nearest.x - x) ** 2 + (nearest.y - y) ** 2 > self.remove_radius_px**2:
-            return None, None
-        self.points.remove(nearest)
-        return nearest, self.refresh(frame_idx)
+            return PointEdit(point=None, result=None)
+        self._points.remove(nearest)
+        return PointEdit(point=nearest, result=self.refresh(frame_idx))
 
-    def undo(self) -> tuple[Point | None, MaskResult | None]:
+    def undo(self) -> PointEdit:
         """Remove the most recently added point."""
-        if not self.points:
-            return None, None
-        last: Point = self.points.pop()
-        return last, self.refresh(last.frame_idx)
+        if not self._points:
+            return PointEdit(point=None, result=None)
+        last: Point = self._points.pop()
+        return PointEdit(point=last, result=self.refresh(last.frame_idx))
 
     def clear(self) -> None:
         """Drop every point and every memory."""
-        self.points = []
+        self._points.clear()
         self._state = self._new_state()
 
     # ── inference ─────────────────────────────────────────────────────────
@@ -191,7 +196,7 @@ class ClickTracker:
         """
         from sam2.modeling.sam2_prompt import SAM2Prompt
 
-        frame_points: list[Point] = self.points_on(frame_idx)
+        frame_points: tuple[Point, ...] = self.points_on(frame_idx)
         if not frame_points:
             self._state.memory_bank.clear_conditional_memories_in_frame(frame_idx=frame_idx)
             self._state.memory_bank.clear_non_conditional_memories_in_frame(frame_idx=frame_idx)
@@ -203,7 +208,7 @@ class ClickTracker:
         embeddings: tuple[list[Tensor], list[Tensor]] = self._embeddings(frame_idx)
         img_embeddings: list[Tensor] = embeddings[0]
         img_pos_embeddings: list[Tensor] = embeddings[1]
-        has_other_prompt: bool = any(point.frame_idx != frame_idx for point in self.points)
+        has_other_prompt: bool = any(point.frame_idx != frame_idx for point in self._points)
         if resegment or not has_other_prompt:
             prompt = SAM2Prompt(obj_id=OBJ_ID, points_coords=user_coords, points_labels=user_labels)
             with _INFERENCE_LOCK:
@@ -280,7 +285,7 @@ class ClickTracker:
             self._state.memory_bank.prune_memories(obj_ids=[OBJ_ID], current_frame_idx=frame_idx)
         return self._result(frame_idx, selected)
 
-    def _sample_anchors(self, mask: Bool[Tensor, "h w"], frame_points: list[Point]) -> Tensor:
+    def _sample_anchors(self, mask: Bool[Tensor, "h w"], frame_points: tuple[Point, ...]) -> Tensor:
         """Sample four to six separated positives from an eroded mask interior."""
         area: int = int(mask.sum())
         erosion_radius: int = max(3, min(12, round(area**0.5 / 80.0)))
@@ -321,7 +326,7 @@ class ClickTracker:
             min_distance_sq = torch.minimum(min_distance_sq, distance_sq)
         return coords_xy[chosen]
 
-    def _select_candidate(self, result, propagated_mask: Bool[Tensor, "h w"], frame_points: list[Point]):
+    def _select_candidate(self, result, propagated_mask: Bool[Tensor, "h w"], frame_points: tuple[Point, ...]):
         """Choose a multimask candidate by user-click satisfaction, then prior-mask IoU."""
         from sam2.modeling.sam2_result import SAM2Result
 
@@ -353,7 +358,7 @@ class ClickTracker:
         Returns:
             ``None`` when nothing has been prompted yet.
         """
-        if not self.points:
+        if not self._points:
             return None
         if self.points_on(frame_idx):
             return self.refresh(frame_idx)
@@ -378,15 +383,14 @@ class ClickTracker:
         Raises:
             ValueError: If no point has been placed.
         """
-        prompted: list[int] = self.prompted_frames()
+        prompted: tuple[int, ...] = self.prompted_frames()
         if not prompted:
             raise ValueError("Place at least one point before tracking.")
         self._state.memory_bank.clear_all_non_conditional_memories()
         self._embedding_cache = None
         for start in range(prompted[0], self.num_frames, chunk):
             stop: int = min(start + chunk, self.num_frames)
-            batch = self._decode(lambda a=start, b=stop: self._decoder.get_frames_in_range(a, b))
-            frames_rgb: UInt8[Tensor, "c h w 3"] = batch.data.contiguous()
+            frames_rgb: UInt8[Tensor, "b 3 h w"] = self._video_reader.get_frames_in_range(start, stop).contiguous()
             for offset in range(int(frames_rgb.shape[0])):
                 frame_idx: int = start + offset
                 if self.points_on(frame_idx):
@@ -394,7 +398,7 @@ class ClickTracker:
                     assert result is not None
                     yield result
                     continue
-                frame_chw: UInt8[Tensor, "3 h w"] = rearrange(frames_rgb[offset], "h w c -> c h w").contiguous()
+                frame_chw: UInt8[Tensor, "3 h w"] = frames_rgb[offset]
                 with _INFERENCE_LOCK:
                     results = self.predictor.forward(
                         self._state, frame_idx, frame_chw, prompts=[], multimask_output=True, create_memory=True
@@ -405,11 +409,10 @@ class ClickTracker:
         self._embedding_cache = None
         for stop in range(prompted[0], 0, -chunk):
             start: int = max(0, stop - chunk)
-            batch = self._decode(lambda a=start, b=stop: self._decoder.get_frames_in_range(a, b))
-            frames_rgb = batch.data.contiguous()
+            frames_rgb = self._video_reader.get_frames_in_range(start, stop).contiguous()
             for offset in range(int(frames_rgb.shape[0]) - 1, -1, -1):
                 frame_idx = start + offset
-                frame_chw = rearrange(frames_rgb[offset], "h w c -> c h w").contiguous()
+                frame_chw = frames_rgb[offset]
                 with _INFERENCE_LOCK:
                     results = self.predictor.forward(
                         self._state,
@@ -432,4 +435,4 @@ class ClickTracker:
         )
 
 
-__all__ = ("ClickTracker", "MaskResult", "Point")
+__all__ = ("ClickTracker", "MaskResult", "Point", "PointEdit")

--- a/packages/posekit/src/posekit/track_ui.py
+++ b/packages/posekit/src/posekit/track_ui.py
@@ -152,10 +152,18 @@ def _open_recording(session: Session, *, write_part: bool = True) -> tuple[rr.Re
 
 
 def _merge_rrd_parts(session: Session) -> Path:
-    """Merge this session's footerless callback parts into one valid RRD."""
+    """Merge this session's footerless callback parts into one valid, compacted RRD.
+
+    The parts are hundreds of tiny per-callback chunks; ``rrd optimize`` re-batches
+    them into fewer, larger chunks and re-derives video keyframes so the download loads fast.
+    """
     output: Path = RRD_DIR / f"{session.recording_id}.rrd"
+    merged: Path = RRD_DIR / f"{session.recording_id}.merged.rrd"
     parts: list[Path] = sorted((RRD_DIR / session.recording_id).glob("*.rrd"))
-    subprocess.run(["rerun", "rrd", "merge", "--output", str(output), *(str(part) for part in parts)], check=True)
+    subprocess.run(["rerun", "rrd", "merge", "--output", str(merged), *(str(part) for part in parts)], check=True)
+    # --fix-keyframe: the Mp4Reader stream logs is_keyframe=false rows, which blocks GoP rebatching of the video.
+    subprocess.run(["rerun", "rrd", "optimize", "--fix-keyframe", "--output", str(output), str(merged)], check=True)
+    merged.unlink()
     return output
 
 

--- a/packages/posekit/src/posekit/track_ui.py
+++ b/packages/posekit/src/posekit/track_ui.py
@@ -15,7 +15,8 @@ Rerun recording; each viewer event appends to that recording through
 from __future__ import annotations
 
 import functools
-import threading
+import shutil
+import subprocess
 import time
 import uuid
 from collections.abc import Iterator
@@ -33,8 +34,9 @@ from gradio_rerun.events import Pause, Play, SelectionChange, TimeUpdate
 from jaxtyping import Int, UInt8
 from numpy import ndarray
 from simplecv.rerun_log_utils import log_video
+from simplecv.video_utils import frame_at
 
-from posekit.apis.click_tracker import ClickTracker, MaskResult, Point
+from posekit.apis.click_tracker import ClickTracker, MaskResult, Point, PointEdit
 from posekit.models.sam2_video import Sam2Variant, Sam2VideoSegmenterConfig
 
 APP_ID: str = "posekit_click_to_track"
@@ -45,7 +47,6 @@ MODES: list[Mode] = ["+ Include", "− Exclude", "✕ Remove"]
 POSITIVE_COLOR: tuple[int, int, int] = (76, 220, 96)
 NEGATIVE_COLOR: tuple[int, int, int] = (255, 87, 51)
 MASK_COLOR: tuple[int, int, int] = (51, 178, 255)
-MAX_SESSIONS: int = 4
 RRD_DIR: Path = Path("/tmp/posekit-rrd")
 _EXAMPLES_DIR: Path = Path(__file__).resolve().parents[2] / "assets" / "examples"
 EXAMPLE_VIDEOS: list[str] = [
@@ -82,7 +83,7 @@ class Session:
     video_path: Path
     """Input video used by the live and downloadable recordings."""
     recording_id: str
-    """Rerun recording ID and session-table key."""
+    """Rerun recording ID."""
     frame_timestamps_ns: Int[ndarray, "n"]
     """Viewer timestamps returned by the logged video stream."""
     current_frame: int = 0
@@ -99,24 +100,12 @@ class Session:
     """Frames that carry a mask; anything else must show none (latest-at would otherwise keep the last one)."""
     pointed_frames: set[int] = field(default_factory=set)
     """Frames that carry temporal point data."""
-    tracked_frames: dict[int, TrackedFrame] = field(default_factory=dict)
-    """Completed or in-progress Track outputs kept on CPU for RRD export."""
+    tracked_frame_indices: set[int] = field(default_factory=set)
+    """Frames written by the latest Track run, retained only for invalidation."""
+    rrd_part_counter: int = 0
+    """Monotonic callback-part number within this session."""
 
 
-@dataclass(frozen=True, slots=True)
-class TrackedFrame:
-    """One tracked frame retained for the downloadable recording."""
-
-    mask_bits: UInt8[ndarray, "n"]
-    """Binary object mask, ``np.packbits`` of the flattened h*w mask (8x smaller than a byte per pixel)."""
-    score: float
-    """SAM decoder predicted IoU."""
-    object_score: float
-    """Sigmoid object-presence score."""
-
-
-_SESSIONS: dict[str, Session] = {}
-_SESSIONS_LOCK = threading.Lock()  # no annotation: beartype rejects the builtin lock type hint
 VARIANT: Sam2Variant = "efficienttam-s-512"
 
 
@@ -140,38 +129,34 @@ def _blueprint() -> rrb.Blueprint:
     )
 
 
-def _store_session(session: Session, previous_recording_id: str | None) -> None:
-    """Replace this browser's old session and evict the oldest excess sessions."""
-    removed: list[Session] = []
-    with _SESSIONS_LOCK:
-        if previous_recording_id and previous_recording_id != session.recording_id:
-            previous: Session | None = _SESSIONS.pop(previous_recording_id, None)
-            if previous is not None:
-                removed.append(previous)
-        _SESSIONS[session.recording_id] = session
-        while len(_SESSIONS) > MAX_SESSIONS:
-            oldest_id: str = next(iter(_SESSIONS))
-            removed.append(_SESSIONS.pop(oldest_id))
-    for old_session in removed:
-        _close_session(old_session)
-
-
-def _close_session(session: Session) -> None:
+def _close_session(session: Session | None) -> None:
     """Release a session's decoder thread and its downloadable recording."""
+    if session is None:
+        return
     session.tracker.close()
     (RRD_DIR / f"{session.recording_id}.rrd").unlink(missing_ok=True)
+    shutil.rmtree(RRD_DIR / session.recording_id, ignore_errors=True)
 
 
-def _drop_session(recording_id: str | None) -> None:
-    """Close and remove one session if it still exists."""
-    with _SESSIONS_LOCK:
-        session: Session | None = _SESSIONS.pop(recording_id or "", None)
-    if session is not None:
-        _close_session(session)
+def _open_recording(session: Session, *, write_part: bool = True) -> tuple[rr.RecordingStream, rr.BinaryStream]:
+    """Open one callback recording with a browser stream and, except for previews, a footerless file part."""
+    rec: rr.RecordingStream = rr.RecordingStream(application_id=APP_ID, recording_id=session.recording_id)
+    stream: rr.BinaryStream = rec.binary_stream()
+    if write_part:
+        part_dir: Path = RRD_DIR / session.recording_id
+        part_dir.mkdir(parents=True, exist_ok=True)
+        part: Path = part_dir / f"{session.rrd_part_counter:04d}.rrd"
+        session.rrd_part_counter += 1
+        rec.set_sinks(stream, rr.FileSink(str(part), write_footer=False))
+    return rec, stream
 
 
-def _rec(session: Session) -> rr.RecordingStream:
-    return rr.RecordingStream(application_id=APP_ID, recording_id=session.recording_id)
+def _merge_rrd_parts(session: Session) -> Path:
+    """Merge this session's footerless callback parts into one valid RRD."""
+    output: Path = RRD_DIR / f"{session.recording_id}.rrd"
+    parts: list[Path] = sorted((RRD_DIR / session.recording_id).glob("*.rrd"))
+    subprocess.run(["rerun", "rrd", "merge", "--output", str(output), *(str(part) for part in parts)], check=True)
+    return output
 
 
 def _viewer_time_s(session: Session, frame_idx: int) -> float:
@@ -203,7 +188,7 @@ def _log_points(rec: rr.RecordingStream, session: Session, frame_idx: int) -> No
     """Log the frame's points (or a clear) at that frame's time so markers show only where they belong."""
     entity: str = f"{VIDEO}/points"
     rec.set_time(TIMELINE, duration=_viewer_time_s(session, frame_idx))
-    points: list[Point] = session.tracker.points_on(frame_idx)
+    points: tuple[Point, ...] = session.tracker.points_on(frame_idx)
     if not points:
         session.pointed_frames.discard(frame_idx)
         rec.log(entity, rr.Clear(recursive=False))
@@ -240,7 +225,7 @@ def _log_mask(rec: rr.RecordingStream, session: Session, mask_hw: UInt8[ndarray,
 
 
 def _mask_hw(result: MaskResult | None) -> UInt8[ndarray, "h w"] | None:
-    """One GPU→CPU copy of a result's mask, shared by live logging and the export cache."""
+    """Copy one result mask from the inference device for Rerun logging."""
     return None if result is None else result.mask.cpu().numpy().astype(np.uint8)
 
 
@@ -251,118 +236,60 @@ def _log_confidence(rec: rr.RecordingStream, session: Session, result: MaskResul
     rec.log(f"{VIDEO}/object_score", rr.Scalars(result.object_score))
 
 
-def _remember_result(session: Session, result: MaskResult, mask_hw: UInt8[ndarray, "h w"]) -> None:
-    """Keep one result on the CPU (bit-packed) for the completed downloadable recording."""
-    session.tracked_frames[result.frame_idx] = TrackedFrame(
-        mask_bits=np.packbits(mask_hw.reshape(-1)),
-        score=result.score,
-        object_score=result.object_score,
-    )
-
-
 def _invalidate_track(rec: rr.RecordingStream, session: Session) -> bool:
     """Clear propagated overlays and confidence after a point edit."""
-    if not session.tracked_frames:
+    if not session.tracked_frame_indices:
         return False
     prompted: set[int] = set(session.tracker.prompted_frames())
     for frame_idx in sorted(session.masked_frames - prompted):
         rec.set_time(TIMELINE, duration=_viewer_time_s(session, frame_idx))
         rec.log(f"{VIDEO}/mask", rr.Clear(recursive=False))
-    for frame_idx in sorted(session.tracked_frames):
+    for frame_idx in sorted(session.tracked_frame_indices):
         rec.set_time(TIMELINE, duration=_viewer_time_s(session, frame_idx))
         rec.log(f"{VIDEO}/confidence", rr.Clear(recursive=False))
         rec.log(f"{VIDEO}/object_score", rr.Clear(recursive=False))
     session.masked_frames = prompted
-    session.tracked_frames.clear()
+    session.tracked_frame_indices.clear()
     return True
 
 
-def _save_recording(session: Session) -> Path:
-    """Write the video, prompts, tracked masks, and confidence to one RRD."""
-    RRD_DIR.mkdir(parents=True, exist_ok=True)
-    output: Path = RRD_DIR / f"{session.recording_id}.rrd"
-    rec: rr.RecordingStream = rr.RecordingStream(application_id=APP_ID, recording_id=session.recording_id)
-    rec.save(output, default_blueprint=_blueprint())
-    rec.log(
-        VIDEO,
-        rr.AnnotationContext(
-            [
-                rr.AnnotationInfo(id=0, label="background", color=(0, 0, 0, 0)),
-                rr.AnnotationInfo(id=1, label="object", color=MASK_COLOR),
-            ]
-        ),
-        static=True,
-    )
-    log_video(session.video_path, Path(VIDEO), timeline=TIMELINE, recording=rec)
-    prompted: set[int] = set(session.tracker.prompted_frames())
-    for frame_idx in sorted(prompted):
-        rec.set_time(TIMELINE, duration=_viewer_time_s(session, frame_idx))
-        points: list[Point] = session.tracker.points_on(frame_idx)
-        rec.log(
-            f"{VIDEO}/points",
-            rr.Points2D(
-                np.asarray([[point.x, point.y] for point in points], dtype=np.float32),
-                colors=[POSITIVE_COLOR if point.positive else NEGATIVE_COLOR for point in points],
-                radii=6,
-                labels=["+" if point.positive else "−" for point in points],
-            ),
-        )
-        nxt: int = frame_idx + 1
-        if nxt < session.tracker.num_frames and nxt not in prompted:
-            rec.set_time(TIMELINE, duration=_viewer_time_s(session, nxt))
-            rec.log(f"{VIDEO}/points", rr.Clear(recursive=False))
-    for frame_idx, tracked in sorted(session.tracked_frames.items()):
-        rec.set_time(TIMELINE, duration=_viewer_time_s(session, frame_idx))
-        h, w = session.tracker.frame_hw
-        mask_hw: UInt8[ndarray, "h w"] = np.unpackbits(tracked.mask_bits)[: h * w].reshape(h, w)
-        rec.log(f"{VIDEO}/mask", rr.SegmentationImage(mask_hw))
-        rec.log(f"{VIDEO}/confidence", rr.Scalars(tracked.score))
-        rec.log(f"{VIDEO}/object_score", rr.Scalars(tracked.object_score))
-    rec.disconnect()
-    return output
-
-
-def frame_at(frame_timestamps_ns: Int[ndarray, "n"], time_ns: float) -> int:
-    """The frame the viewer shows at a time: the last frame whose pts <= t (latest-at), like the viewer itself.
-
-    The viewer reports duration timelines in nanoseconds.
-    """
-    idx: int = int(np.searchsorted(frame_timestamps_ns, time_ns, side="right")) - 1
-    return max(0, min(idx, int(frame_timestamps_ns.shape[0]) - 1))
-
-
 def _status(session: Session, prefix: str) -> str:
-    frames: list[int] = session.tracker.prompted_frames()
+    frames: tuple[int, ...] = session.tracker.prompted_frames()
     return f"{prefix} {len(session.tracker.points)} point(s) on frame(s) {frames} · viewer at frame {session.current_frame}."
 
 
 # ── callbacks ─────────────────────────────────────────────────────────────
 
 
-def load_video(video: str | None, previous_recording_id: str | None) -> Iterator[tuple[bytes | None, str, str, str, Any, Any]]:
+def load_video(video: str | None, previous_session: Session | None) -> Iterator[tuple[bytes | None, Session | None, str, str, Any, Any]]:
     """Start a fresh session + recording for the clip (generators only: the streaming viewer rejects plain bytes)."""
-    _drop_session(previous_recording_id)
+    _close_session(previous_session)
     if video is None:
-        yield None, "", "Upload a video to begin.", "Upload a video to begin.", gr.Tabs(selected="input"), gr.DownloadButton(visible=False)
+        yield None, None, "Upload a video to begin.", "Upload a video to begin.", gr.Tabs(selected="input"), gr.DownloadButton(visible=False)
         return
     recording_id: str = str(uuid.uuid4())
     video_path: Path = Path(video)
-    tracker = ClickTracker(video_path, _predictor(VARIANT))
-    rec = rr.RecordingStream(application_id=APP_ID, recording_id=recording_id)
-    stream: rr.BinaryStream = rec.binary_stream()
+    tracker: ClickTracker = ClickTracker(video_path, _predictor(VARIANT))
+    session: Session = Session(
+        tracker=tracker,
+        video_path=video_path,
+        recording_id=recording_id,
+        frame_timestamps_ns=np.empty(0, dtype=np.int64),
+    )
+    rec, stream = _open_recording(session)
     rec.send_blueprint(_blueprint())
     rec.log(
         VIDEO,
         rr.AnnotationContext([rr.AnnotationInfo(id=0, label="background", color=(0, 0, 0, 0)), rr.AnnotationInfo(id=1, label="object", color=MASK_COLOR)]),
         static=True,
     )
-    timestamps_ns = log_video(video_path, Path(VIDEO), timeline=TIMELINE, recording=rec)
-    session = Session(tracker=tracker, video_path=video_path, recording_id=recording_id, frame_timestamps_ns=timestamps_ns)
-    _store_session(session, None)
+    session.frame_timestamps_ns = log_video(video_path, Path(VIDEO), timeline=TIMELINE, recording=rec)
     stream.flush()
+    payload: bytes | None = stream.read()
+    rec.disconnect()
     yield (
-        stream.read(),
-        recording_id,
+        payload,
+        session,
         "Click the object on frame 0, or scrub (drag / ← →) to another frame first. Add − to exclude; Remove deletes a point.",
         "Click the object on frame 0, or scrub (drag / ← →) to another frame first. Add − to exclude; Remove deletes a point.",
         gr.Tabs(selected="input"),
@@ -370,13 +297,12 @@ def load_video(video: str | None, previous_recording_id: str | None) -> Iterator
     )
 
 
-def record_time(recording_id: str | None, stamp: float | None, evt: TimeUpdate) -> None:
+def record_time(session: Session | None, stamp: float | None, evt: TimeUpdate) -> None:
     """Record the viewer's frame instantly (no queue, no outputs) so a click right after a scrub reads the right frame.
 
     ``stamp`` is the browser's ``performance.now()`` at dispatch (see the ``js`` hook): unqueued
     requests can complete out of order, so an older event must never overwrite a newer one.
     """
-    session: Session | None = _SESSIONS.get(recording_id or "")
     if session is None:
         return
     stamp_value: float = float(stamp) if stamp is not None else session.last_stamp + 1.0
@@ -387,23 +313,20 @@ def record_time(recording_id: str | None, stamp: float | None, evt: TimeUpdate) 
     session.last_time_update = time.monotonic()
 
 
-def on_play(recording_id: str | None, evt: Play) -> None:
+def on_play(session: Session | None, evt: Play) -> None:
     """Playback emits no time_update: remember that the frame is unknown until the viewer pauses."""
-    session: Session | None = _SESSIONS.get(recording_id or "")
     if session is not None:
         session.playing = True
 
 
-def on_pause(recording_id: str | None, evt: Pause) -> None:
+def on_pause(session: Session | None, evt: Pause) -> None:
     """The viewer paused; the next time_update (or the pre-play frame) is authoritative again."""
-    session: Session | None = _SESSIONS.get(recording_id or "")
     if session is not None:
         session.playing = False
 
 
-def on_time_update(recording_id: str | None, evt: TimeUpdate) -> Iterator[tuple[bytes | None, str, str]]:
+def on_time_update(session: Session | None, evt: TimeUpdate) -> Iterator[tuple[bytes | None, str, str]]:
     """When prompts exist, preview the memory-conditioned mask on the frame under the cursor."""
-    session: Session | None = _SESSIONS.get(recording_id or "")
     if session is None:
         yield b"", gr.skip(), gr.skip()
         return
@@ -413,11 +336,12 @@ def on_time_update(recording_id: str | None, evt: TimeUpdate) -> Iterator[tuple[
         if not session.preview_visible:
             yield b"", gr.skip(), gr.skip()
             return
-        rec = _rec(session)
-        stream: rr.BinaryStream = rec.binary_stream()
+        rec, stream = _open_recording(session, write_part=False)
         _clear_preview(rec, session)
         stream.flush()
-        yield stream.read(), gr.skip(), gr.skip()
+        payload: bytes | None = stream.read()
+        rec.disconnect()
+        yield payload, gr.skip(), gr.skip()
         return
     # This handler is queued (always_last) and may run late; it must never write
     # session.current_frame — only the unqueued record_time does, or a backlog of
@@ -426,8 +350,7 @@ def on_time_update(recording_id: str | None, evt: TimeUpdate) -> Iterator[tuple[
     frame_text: str = f"Viewer at frame {frame_idx} — a click prompts this frame."
     # The preview is *static* (no timeline → no ticks, overwritten in place), so it
     # must go away the moment the cursor leaves the frame it was computed for.
-    rec = _rec(session)
-    stream: rr.BinaryStream = rec.binary_stream()
+    rec, stream = _open_recording(session, write_part=False)
     _clear_preview(rec, session)
     stamp: float = session.last_stamp
     wants_preview: bool = bool(session.tracker.points) and not session.tracker.points_on(frame_idx)
@@ -439,17 +362,18 @@ def on_time_update(recording_id: str | None, evt: TimeUpdate) -> Iterator[tuple[
             rec.log(f"{VIDEO}/preview", rr.SegmentationImage(result.mask.cpu().numpy().astype(np.uint8)), static=True)
             session.preview_visible = True
     stream.flush()
-    yield stream.read(), frame_text, frame_text
+    payload = stream.read()
+    rec.disconnect()
+    yield payload, frame_text, frame_text
 
 
-def on_select(recording_id: str | None, mode: str, resegment: bool, evt: SelectionChange) -> Iterator[tuple[bytes | None, str, str]]:
+def on_select(session: Session | None, mode: str, resegment: bool, evt: SelectionChange) -> Iterator[tuple[bytes | None, str, str]]:
     """A click on the video at the current frame: add a +/− point or remove the nearest one, then show the mask."""
     # The viewer fires selection_change on recording open and on every click
     # anywhere; ignored selections must still yield a chunk for the streaming
     # viewer output (gr.skip() there crashes Gradio's end_stream).
     # A click on a masked pixel selects both /video/mask and /video, so take the
     # first positioned entity under the video rather than demanding exactly one.
-    session: Session | None = _SESSIONS.get(recording_id or "")
     hits = [i for i in evt.payload.items if i.type == "entity" and i.position is not None and i.entity_path.startswith(f"/{VIDEO}")]
     if session is None or not hits:
         yield b"", gr.skip(), gr.skip()
@@ -464,13 +388,13 @@ def on_select(recording_id: str | None, mode: str, resegment: bool, evt: Selecti
     while time.monotonic() - session.last_time_update < 0.12 and time.monotonic() < deadline:
         time.sleep(0.02)
     frame_idx: int = session.current_frame
-    rec = _rec(session)
-    stream: rr.BinaryStream = rec.binary_stream()
+    rec, stream = _open_recording(session)
     _clear_preview(rec, session)
     changed: bool = True
     if mode == "✕ Remove":
-        removed, result = session.tracker.remove_point_near(frame_idx, x, y)
-        changed = removed is not None
+        edit: PointEdit = session.tracker.remove_point_near(frame_idx, x, y)
+        changed = edit.point is not None
+        result: MaskResult | None = edit.result
         prefix: str = "Removed a point." if changed else f"No point within {session.tracker.remove_radius_px:.0f}px on this frame."
     else:
         positive: bool = mode != "− Exclude"
@@ -481,43 +405,44 @@ def on_select(recording_id: str | None, mode: str, resegment: bool, evt: Selecti
     _log_mask(rec, session, _mask_hw(result), frame_idx)
     _log_points(rec, session, frame_idx)
     stream.flush()
+    payload = stream.read()
+    rec.disconnect()
     if stale:
         prefix += " The previous track is stale — Track again."
     status_text: str = _status(session, prefix)
-    yield stream.read(), status_text, status_text
+    yield payload, status_text, status_text
 
 
-def undo(recording_id: str | None) -> Iterator[tuple[bytes | None, str, str]]:
+def undo(session: Session | None) -> Iterator[tuple[bytes | None, str, str]]:
     """Remove the most recently added point."""
-    session: Session | None = _SESSIONS.get(recording_id or "")
     if session is None:
         raise gr.Error("Upload a video first.")
-    rec = _rec(session)
-    stream: rr.BinaryStream = rec.binary_stream()
+    rec, stream = _open_recording(session)
     _clear_preview(rec, session)
-    last, result = session.tracker.undo()
-    if last is None:
+    edit: PointEdit = session.tracker.undo()
+    if edit.point is None:
+        rec.disconnect()
         status_text: str = _status(session, "Nothing to undo.")
         yield b"", status_text, status_text
         return
     stale: bool = _invalidate_track(rec, session)
-    _log_mask(rec, session, _mask_hw(result), last.frame_idx)
-    _log_points(rec, session, last.frame_idx)
+    _log_mask(rec, session, _mask_hw(edit.result), edit.point.frame_idx)
+    _log_points(rec, session, edit.point.frame_idx)
     stream.flush()
-    prefix: str = f"Undid the point on frame {last.frame_idx}."
+    payload = stream.read()
+    rec.disconnect()
+    prefix: str = f"Undid the point on frame {edit.point.frame_idx}."
     if stale:
         prefix += " The previous track is stale — Track again."
     status_text = _status(session, prefix)
-    yield stream.read(), status_text, status_text
+    yield payload, status_text, status_text
 
 
-def clear(recording_id: str | None) -> Iterator[tuple[bytes | None, str, str]]:
+def clear(session: Session | None) -> Iterator[tuple[bytes | None, str, str]]:
     """Drop every point, every memory, and every overlay."""
-    session: Session | None = _SESSIONS.get(recording_id or "")
     if session is None:
         raise gr.Error("Upload a video first.")
-    rec = _rec(session)
-    stream: rr.BinaryStream = rec.binary_stream()
+    rec, stream = _open_recording(session)
     _clear_preview(rec, session)
     session.tracker.clear()
     stale: bool = _invalidate_track(rec, session)
@@ -528,20 +453,20 @@ def clear(recording_id: str | None) -> Iterator[tuple[bytes | None, str, str]]:
             rec.log(entity, rr.Clear(recursive=False))
         frames.clear()
     stream.flush()
+    payload = stream.read()
+    rec.disconnect()
     suffix: str = " The previous track is stale — add a point and Track again." if stale else ""
     status_text: str = f"Cleared all points and memory.{suffix}"
-    yield stream.read(), status_text, status_text
+    yield payload, status_text, status_text
 
 
-def track(recording_id: str | None) -> Iterator[tuple[bytes | None, str, str, Any, Any]]:
+def track(session: Session | None) -> Iterator[tuple[bytes | None, str, str, Any, Any]]:
     """Propagate in both directions, stream masks, and write the downloadable RRD."""
-    session: Session | None = _SESSIONS.get(recording_id or "")
     if session is None:
         raise gr.Error("Upload a video first.")
     if not session.tracker.points:
         raise gr.Error("Click at least one point on the object first.")
-    rec = _rec(session)
-    stream: rr.BinaryStream = rec.binary_stream()
+    rec, stream = _open_recording(session)
     _clear_preview(rec, session)
     _invalidate_track(rec, session)
     stream.flush()
@@ -556,7 +481,7 @@ def track(recording_id: str | None) -> Iterator[tuple[bytes | None, str, str, An
         # points were already logged (and bounded) when they were placed.
         _log_mask(rec, session, mask_hw, result.frame_idx, bound=False)
         _log_confidence(rec, session, result)
-        _remember_result(session, result, mask_hw)
+        session.tracked_frame_indices.add(result.frame_idx)
         done += 1
         low_score += int(result.score < 0.5)
         if done % 30 == 0:
@@ -568,10 +493,12 @@ def track(recording_id: str | None) -> Iterator[tuple[bytes | None, str, str, An
                 gr.skip(),
                 gr.skip(),
             )
-    output: Path = _save_recording(session)
     stream.flush()
+    payload = stream.read()
+    rec.disconnect()
+    output: Path = _merge_rrd_parts(session)
     yield (
-        stream.read(),
+        payload,
         f"Done: tracked all {done} frames; {low_score} low-confidence frame(s). Add a corrective click where needed, then Track again.",
         f"Done: tracked all {done} frames; {low_score} low-confidence frame(s). Add a corrective click where needed, then Track again.",
         gr.Tabs(selected="outputs"),
@@ -661,7 +588,7 @@ footer { display: none !important; }
 
 with gr.Blocks(title="posekit: Click to Track") as demo:
     gr.Markdown(DESCRIPTION, elem_id="app-description")
-    recording_state: gr.State = gr.State("")
+    recording_state: gr.State = gr.State(value=None, delete_callback=_close_session)
     stamp_in: gr.Number = gr.Number(value=0.0, visible=False)
     with gr.Row(elem_id="main-row"):
         with gr.Column(scale=1, elem_id="left-column"):
@@ -714,7 +641,7 @@ with gr.Blocks(title="posekit: Click to Track") as demo:
         outputs=None,
         queue=False,
         trigger_mode="multiple",
-        js="(rid, _stamp) => [rid, performance.now()]",
+        js="(session, _stamp) => [session, performance.now()]",
         api_visibility="private",
     )
     viewer.play(fn=on_play, inputs=[recording_state], outputs=None, queue=False, trigger_mode="multiple", api_visibility="private")

--- a/packages/posekit/tests/test_click_tracker.py
+++ b/packages/posekit/tests/test_click_tracker.py
@@ -7,12 +7,24 @@ from pathlib import Path
 import pytest
 import torch
 
-from posekit.apis.click_tracker import ClickTracker
+from posekit.apis.click_tracker import ClickTracker, Point, PointEdit
 from posekit.models.sam2_video import Sam2VideoSegmenterConfig
 
 cuda_only = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 CLIP: Path = Path(__file__).resolve().parents[2] / "wilor-nano" / "assets" / "video.mp4"
 CHEST: tuple[float, float] = (360.0, 450.0)
+
+
+def test_point_accessors_are_read_only_and_edits_are_explicit() -> None:
+    tracker: ClickTracker = object.__new__(ClickTracker)
+    tracker._points = [Point(frame_idx=2, x=3.0, y=4.0, positive=True)]
+
+    assert tracker.points == (Point(frame_idx=2, x=3.0, y=4.0, positive=True),)
+    assert tracker.points_on(2) == tracker.points
+    assert tracker.prompted_frames() == (2,)
+
+    tracker._points.clear()
+    assert tracker.undo() == PointEdit(point=None, result=None)
 
 
 @pytest.fixture(scope="module")
@@ -54,10 +66,10 @@ def test_negative_point_shrinks_and_removal_restores(tracker: ClickTracker) -> N
     full = tracker.add_point(0, *CHEST, positive=True)
     shrunk = tracker.add_point(0, 320.0, 320.0, positive=False)  # on the face
     assert int(shrunk.mask.sum()) < int(full.mask.sum())
-    removed, restored = tracker.remove_point_near(0, 325.0, 318.0)
-    assert removed is not None and not removed.positive and restored is not None
-    assert abs(int(restored.mask.sum()) - int(full.mask.sum())) < 0.02 * int(full.mask.sum())
-    assert tracker.remove_point_near(0, 10.0, 10.0) == (None, None)
+    edit: PointEdit = tracker.remove_point_near(0, 325.0, 318.0)
+    assert edit.point is not None and not edit.point.positive and edit.result is not None
+    assert abs(int(edit.result.mask.sum()) - int(full.mask.sum())) < 0.02 * int(full.mask.sum())
+    assert tracker.remove_point_near(0, 10.0, 10.0) == PointEdit(point=None, result=None)
 
 
 @cuda_only
@@ -65,10 +77,10 @@ def test_undo_last_point_clears_its_frame_memory(tracker: ClickTracker) -> None:
     tracker.clear()
     tracker.add_point(0, *CHEST, positive=True)
     tracker.add_point(40, *CHEST, positive=True)
-    assert tracker.prompted_frames() == [0, 40]
-    last, result = tracker.undo()
-    assert last is not None and last.frame_idx == 40 and result is None
-    assert tracker.prompted_frames() == [0]
+    assert tracker.prompted_frames() == (0, 40)
+    edit: PointEdit = tracker.undo()
+    assert edit.point is not None and edit.point.frame_idx == 40 and edit.result is None
+    assert tracker.prompted_frames() == (0,)
     assert tracker._state.memory_bank.count_conditional_memories() == 1
 
 

--- a/packages/posekit/tests/test_track_ui.py
+++ b/packages/posekit/tests/test_track_ui.py
@@ -1,5 +1,6 @@
 """Pure helpers of the click-to-track UI."""
 
+import subprocess
 from pathlib import Path
 from typing import cast
 from unittest.mock import Mock
@@ -7,63 +8,19 @@ from unittest.mock import Mock
 import numpy as np
 import rerun as rr
 import rerun.experimental as rrx
-import torch
-from sam2.modeling.memory import ObjectMemory
-from sam2.modeling.sam2_memory import SAM2ObjectMemoryBank, _select_N_closest_conditional_memories
 
 import posekit.track_ui as track_ui
-from posekit.apis.click_tracker import ClickTracker, Point
-from posekit.track_ui import MAX_SESSIONS, Session, TrackedFrame, _invalidate_track, _save_recording, _store_session, frame_at
+from posekit.apis.click_tracker import ClickTracker
+from posekit.track_ui import Session, _close_session, _invalidate_track, _merge_rrd_parts, _open_recording
 
 CLIP: Path = Path(__file__).resolve().parents[2] / "wilor-nano" / "assets" / "video.mp4"
-
-
-def test_frame_at_matches_viewer_latest_at_semantics() -> None:
-    ts_ns = (np.arange(10) * 33_333_333).astype(np.int64)  # 30 fps
-    assert frame_at(ts_ns, 0.0) == 0
-    assert frame_at(ts_ns, 10_000_000.0) == 0  # 10 ms -> still frame 0
-    assert frame_at(ts_ns, 30_000_000.0) == 0  # 30 ms -> still frame 0 (viewer shows pts <= t)
-    assert frame_at(ts_ns, 33_333_333.0) == 1
-    assert frame_at(ts_ns, 10_833_333_333.0) == 9  # past the end saturates
-    assert frame_at(ts_ns, -5.0) == 0
-
-
-def _memory(frame_idx: int, *, conditional: bool) -> ObjectMemory:
-    return ObjectMemory(
-        obj_id=0,
-        frame_idx=frame_idx,
-        memory_embeddings=torch.zeros(1, 1, 1, 1),
-        memory_pos_embeddings=torch.zeros(1, 1, 1, 1),
-        ptr=torch.zeros(1, 1),
-        is_conditional=conditional,
-    )
-
-
-def test_conditional_memory_selection_is_bounded_and_does_not_mutate_bank() -> None:
-    conditional = [_memory(frame_idx, conditional=True) for frame_idx in (0, 10, 20, 30, 40)]
-    selected, unselected = _select_N_closest_conditional_memories(conditional, N=3, current_frame_idx=25)
-    assert [memory.frame_idx for memory in selected] == [20, 30, 10]
-    assert {memory.frame_idx for memory in unselected} == {0, 40}
-
-    bank = SAM2ObjectMemoryBank()
-    bank.known_obj_ids.add(0)
-    bank.conditional_memories[0] = conditional
-    bank.non_conditional_memories[0] = [_memory(24, conditional=False)]
-    bank.select_memories(
-        obj_ids=[0],
-        current_frame_idx=25,
-        max_conditional_memories=3,
-        max_non_conditional_memories=2,
-        max_ptr_memories=2,
-    )
-    assert [memory.frame_idx for memory in bank.non_conditional_memories[0]] == [24]
 
 
 def _session(recording_id: str, *, prompted: list[int] | None = None) -> tuple[Session, Mock]:
     tracker_mock: Mock = Mock(spec=ClickTracker)
     tracker_mock.prompted_frames.return_value = [1] if prompted is None else prompted
     tracker_mock.num_frames = 4
-    tracker_mock.points = []
+    tracker_mock.points = ()
     session = Session(
         tracker=cast(ClickTracker, tracker_mock),
         video_path=CLIP,
@@ -76,44 +33,50 @@ def _session(recording_id: str, *, prompted: list[int] | None = None) -> tuple[S
 def test_invalidating_track_clears_propagated_masks_and_confidence() -> None:
     session, _ = _session("stale")
     session.masked_frames = {0, 1, 2}
-    tracked = TrackedFrame(mask_bits=np.packbits(np.ones(4, dtype=np.uint8)), score=0.8, object_score=0.9)
-    session.tracked_frames = {0: tracked, 1: tracked, 2: tracked}
+    session.tracked_frame_indices = {0, 1, 2}
     rec_mock: Mock = Mock(spec=rr.RecordingStream)
 
     assert _invalidate_track(cast(rr.RecordingStream, rec_mock), session)
     assert session.masked_frames == {1}
-    assert session.tracked_frames == {}
+    assert session.tracked_frame_indices == set()
     entities = [call.args[0] for call in rec_mock.log.call_args_list]
     assert entities.count("video/mask") == 2
     assert entities.count("video/confidence") == 3
     assert entities.count("video/object_score") == 3
 
 
-def test_session_store_evicts_oldest_tracker() -> None:
-    track_ui._SESSIONS.clear()
-    sessions: list[Session] = []
-    trackers: list[Mock] = []
-    for index in range(MAX_SESSIONS + 1):
-        session, tracker = _session(str(index))
-        sessions.append(session)
-        trackers.append(tracker)
-        _store_session(session, None)
-    assert list(track_ui._SESSIONS) == [str(index) for index in range(1, MAX_SESSIONS + 1)]
-    trackers[0].close.assert_called_once_with()
-    track_ui._SESSIONS.clear()
+def test_state_delete_callback_closes_tracker_and_removes_rrds(tmp_path: Path, monkeypatch) -> None:
+    session, tracker = _session("expired")
+    monkeypatch.setattr(track_ui, "RRD_DIR", tmp_path)
+    part_dir = tmp_path / session.recording_id
+    part_dir.mkdir()
+    (part_dir / "0000.rrd").touch()
+    (tmp_path / f"{session.recording_id}.rrd").touch()
+
+    assert track_ui.recording_state.delete_callback is _close_session
+    _close_session(session)
+
+    tracker.close.assert_called_once_with()
+    assert not part_dir.exists()
+    assert not (tmp_path / f"{session.recording_id}.rrd").exists()
 
 
 def test_download_recording_contains_video_prompts_masks_and_confidence(tmp_path: Path, monkeypatch) -> None:
-    timestamps_ns = rr.AssetVideo(path=CLIP).read_frame_timestamps_nanos()
-    session, tracker = _session("download", prompted=[0])
-    session.frame_timestamps_ns = timestamps_ns
-    tracker.num_frames = len(timestamps_ns)
-    tracker.points_on.return_value = [Point(frame_idx=0, x=360.0, y=450.0, positive=True)]
-    tracker.frame_hw = (720, 1280)
-    tracked = TrackedFrame(mask_bits=np.packbits(np.ones(720 * 1280, dtype=np.uint8)), score=0.8, object_score=0.9)
-    session.tracked_frames = {0: tracked, 1: tracked}
+    session, _ = _session("download", prompted=[0])
     monkeypatch.setattr(track_ui, "RRD_DIR", tmp_path)
 
-    output = _save_recording(session)
+    rec, _ = _open_recording(session)
+    rec.log("video", rr.AssetVideo(path=CLIP), static=True)
+    rec.log("video/points", rr.Points2D([[360.0, 450.0]]))
+    rec.disconnect()
+    rec, _ = _open_recording(session)
+    rec.log("video/mask", rr.SegmentationImage(np.ones((2, 2), dtype=np.uint8)))
+    rec.log("video/confidence", rr.Scalars(0.8))
+    rec.log("video/object_score", rr.Scalars(0.9))
+    rec.disconnect()
+
+    output = _merge_rrd_parts(session)
+    stats = subprocess.run(["rerun", "rrd", "stats", str(output)], check=True, capture_output=True, text=True)
     entities = {str(chunk.entity_path) for chunk in rrx.RrdReader(output).stream()}
     assert {"/video", "/video/points", "/video/mask", "/video/confidence", "/video/object_score"} <= entities
+    assert "/video/mask" in stats.stdout

--- a/packages/sam2-streaming/tests/test_sam2_memory.py
+++ b/packages/sam2-streaming/tests/test_sam2_memory.py
@@ -1,0 +1,39 @@
+"""Regression tests for SAM2 memory selection."""
+
+import torch
+
+from sam2.modeling.memory import ObjectMemory
+from sam2.modeling.sam2_memory import SAM2ObjectMemoryBank, _select_N_closest_conditional_memories
+
+
+def _memory(frame_idx: int, *, conditional: bool) -> ObjectMemory:
+    return ObjectMemory(
+        obj_id=0,
+        frame_idx=frame_idx,
+        memory_embeddings=torch.zeros(1, 1, 1, 1),
+        memory_pos_embeddings=torch.zeros(1, 1, 1, 1),
+        ptr=torch.zeros(1, 1),
+        is_conditional=conditional,
+    )
+
+
+def test_conditional_memory_selection_is_bounded_and_does_not_mutate_bank() -> None:
+    conditional: list[ObjectMemory] = [_memory(frame_idx, conditional=True) for frame_idx in (0, 10, 20, 30, 40)]
+    selected: list[ObjectMemory]
+    unselected: list[ObjectMemory]
+    selected, unselected = _select_N_closest_conditional_memories(conditional, N=3, current_frame_idx=25)
+    assert [memory.frame_idx for memory in selected] == [20, 30, 10]
+    assert {memory.frame_idx for memory in unselected} == {0, 40}
+
+    bank: SAM2ObjectMemoryBank = SAM2ObjectMemoryBank()
+    bank.known_obj_ids.add(0)
+    bank.conditional_memories[0] = conditional
+    bank.non_conditional_memories[0] = [_memory(24, conditional=False)]
+    bank.select_memories(
+        obj_ids=[0],
+        current_frame_idx=25,
+        max_conditional_memories=3,
+        max_non_conditional_memories=2,
+        max_ptr_memories=2,
+    )
+    assert [memory.frame_idx for memory in bank.non_conditional_memories[0]] == [24]

--- a/packages/simplecv/simplecv/video_io.py
+++ b/packages/simplecv/simplecv/video_io.py
@@ -1,10 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from collections import OrderedDict
-from collections.abc import Generator, Sequence
+from collections.abc import Callable, Generator, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from itertools import repeat
 from pathlib import Path
-from typing import Literal
+from typing import Literal, TypeVar
 
 import cv2
 import numpy as np
@@ -21,6 +21,8 @@ from einops import rearrange
 from jaxtyping import UInt8
 
 from simplecv.image_types import BGRList, ImageBGR
+
+T = TypeVar("T")
 
 
 def validate_video_file_path(video_path: Path) -> Path:
@@ -378,6 +380,7 @@ class TorchCodecVideoReader:
         num_ffmpeg_threads: int = 0,
         seek_mode: Literal["exact", "approximate"] = "approximate",
         resize_hw: tuple[int, int] | None = None,
+        thread_owned: bool = False,
     ) -> None:
         """Initialize the TorchCodec tensor video reader.
 
@@ -394,6 +397,9 @@ class TorchCodecVideoReader:
                 materialized. ``width``/``height``/``resolution`` report the
                 post-resize dimensions; use ``source_width``/``source_height``
                 for the native ones.
+            thread_owned: Create the decoder and run every decode on one owned
+                thread. CUDA TorchCodec decoders are thread-affine, so use this
+                when callers may access one reader from several threads.
         """
         from torchcodec.decoders import VideoDecoder
 
@@ -402,6 +408,9 @@ class TorchCodecVideoReader:
         self.num_ffmpeg_threads: int = num_ffmpeg_threads
         self.seek_mode: Literal["exact", "approximate"] = seek_mode
         self.resize_hw: tuple[int, int] | None = resize_hw
+        self._decode_thread: ThreadPoolExecutor | None = (
+            ThreadPoolExecutor(max_workers=1, thread_name_prefix="torchcodec-video-reader") if thread_owned else None
+        )
 
         # On CPU, resize during decoding (FFmpeg scale filter). On CUDA, decode
         # native via NVDEC and resize on-GPU after decode.
@@ -411,16 +420,18 @@ class TorchCodecVideoReader:
 
             decode_time_transforms = [_TorchCodecResize(size=list(resize_hw))]
 
-        self._decoder: VideoDecoder = VideoDecoder(
-            source,
-            device=self.device,
-            seek_mode=self.seek_mode,
-            num_ffmpeg_threads=self.num_ffmpeg_threads,
-            dimension_order="NCHW",
-            transforms=decode_time_transforms,
+        self._decoder: VideoDecoder = self._decode(
+            lambda: VideoDecoder(
+                source,
+                device=self.device,
+                seek_mode=self.seek_mode,
+                num_ffmpeg_threads=self.num_ffmpeg_threads,
+                dimension_order="NCHW",
+                transforms=decode_time_transforms,
+            )
         )
 
-        metadata = self._decoder.metadata
+        metadata = self._decode(lambda: self._decoder.metadata)
         self._source_width: int = required_torchcodec_int(metadata.width, "width")
         self._source_height: int = required_torchcodec_int(metadata.height, "height")
         self._width: int = self._source_width if resize_hw is None else int(resize_hw[1])
@@ -439,6 +450,18 @@ class TorchCodecVideoReader:
         self._read_buffer: UInt8[torch.Tensor, "b 3 h w"] | None = None
         self._read_buffer_start: int = 0
         self._read_buffer_stop: int = 0
+
+    def _decode(self, callback: Callable[[], T]) -> T:
+        """Run decoder work on its owned thread when thread affinity is enabled."""
+        if self._decode_thread is None:
+            return callback()
+        return self._decode_thread.submit(callback).result()
+
+    def close(self) -> None:
+        """Stop the owned decoder thread. Safe to call more than once."""
+        if self._decode_thread is not None:
+            self._decode_thread.shutdown(wait=True, cancel_futures=True)
+            self._decode_thread = None
 
     @property
     def width(self) -> int:
@@ -518,7 +541,7 @@ class TorchCodecVideoReader:
         if frame_id < 0 or frame_id >= self._frame_cnt:
             raise IndexError(f'"frame_id" must be between 0 and {self._frame_cnt - 1}')
 
-        frame: UInt8[torch.Tensor, "3 h w"] = self._decoder.get_frame_at(frame_id).data
+        frame: UInt8[torch.Tensor, "3 h w"] = self._decode(lambda: self._decoder.get_frame_at(frame_id).data)
         if self._needs_post_resize:
             frame = self._maybe_resize(frame.unsqueeze(0)).squeeze(0)
         return frame
@@ -557,7 +580,7 @@ class TorchCodecVideoReader:
                 device=self.device,
             )
             return empty
-        video: UInt8[torch.Tensor, "b 3 h w"] = self._decoder.get_frames_in_range(start, clamped_stop).data
+        video: UInt8[torch.Tensor, "b 3 h w"] = self._decode(lambda: self._decoder.get_frames_in_range(start, clamped_stop).data)
         video = self._maybe_resize(video)
         return video
 
@@ -617,8 +640,8 @@ class TorchCodecVideoReader:
     def __enter__(self):
         return self
 
-    def __exit__(self, _exc_type, _exc_value, _traceback):
-        pass  # No explicit cleanup needed for TorchCodec
+    def __exit__(self, _exc_type, _exc_value, _traceback) -> None:
+        self.close()
 
 
 class TorchCodecMultiVideoReader:

--- a/packages/simplecv/simplecv/video_utils.py
+++ b/packages/simplecv/simplecv/video_utils.py
@@ -7,6 +7,24 @@ from pathlib import Path
 from timeit import default_timer as timer
 from typing import Literal, TypeAlias
 
+import numpy as np
+from jaxtyping import Int
+from numpy import ndarray
+
+
+def frame_at(frame_timestamps_ns: Int[ndarray, "n"], time_ns: float) -> int:
+    """Return the latest frame at or before a viewer time.
+
+    Args:
+        frame_timestamps_ns: Int[np.ndarray, "n"] monotonic frame timestamps in nanoseconds.
+        time_ns: Viewer time in nanoseconds.
+
+    Returns:
+        Zero-based frame index, clamped to the available timeline.
+    """
+    frame_idx: int = int(np.searchsorted(frame_timestamps_ns, time_ns, side="right")) - 1
+    return max(0, min(frame_idx, int(frame_timestamps_ns.shape[0]) - 1))
+
 
 def create_temp_video_from_img_dir(
     image_directory: Path,

--- a/packages/simplecv/tests/test_torchcodec_video_io.py
+++ b/packages/simplecv/tests/test_torchcodec_video_io.py
@@ -5,6 +5,8 @@ These tests use the street_dance videos which are synced multi-camera recordings
 
 from __future__ import annotations
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import numpy as np
@@ -219,6 +221,38 @@ class TestTorchCodecVideoReader:
         assert second_frame is not None
         assert int(first_frame[0, 0, 0].item()) == 0
         assert int(second_frame[0, 0, 0].item()) == 1
+
+    def test_thread_owned_reader_routes_random_access_to_decoder_thread(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A thread-owned reader must create and use its decoder on one thread."""
+        import sys
+        import types
+
+        class _Metadata:
+            width: int = 4
+            height: int = 2
+            num_frames: int = 1
+            average_fps: float = 30.0
+
+        class _FrameBatch:
+            data: torch.Tensor = torch.zeros((3, 2, 4), dtype=torch.uint8)
+
+        class _FakeVideoDecoder:
+            def __init__(self, _source: Path, **_kwargs: object) -> None:
+                self.metadata: _Metadata = _Metadata()
+                self.owner_thread: int = threading.get_ident()
+
+            def get_frame_at(self, _frame_id: int) -> _FrameBatch:
+                assert threading.get_ident() == self.owner_thread
+                return _FrameBatch()
+
+        monkeypatch.setitem(sys.modules, "torchcodec.decoders", types.SimpleNamespace(VideoDecoder=_FakeVideoDecoder))
+        reader: TorchCodecVideoReader = TorchCodecVideoReader(Path("cam0.mp4"), device="cpu", thread_owned=True)
+        try:
+            with ThreadPoolExecutor(max_workers=1) as caller:
+                frame: UInt8[torch.Tensor, "3 h w"] = caller.submit(reader.get_frame, 0).result()
+            assert tuple(frame.shape) == (3, 2, 4)
+        finally:
+            reader.close()
 
     def test_random_access(self, sample_video_path: Path) -> None:
         """Test random access to frames."""

--- a/packages/simplecv/tests/test_video_utils.py
+++ b/packages/simplecv/tests/test_video_utils.py
@@ -1,0 +1,16 @@
+"""Tests for shared video timeline helpers."""
+
+import numpy as np
+
+from simplecv.video_utils import frame_at
+
+
+def test_frame_at_matches_viewer_latest_at_semantics() -> None:
+    timestamps_ns = (np.arange(10) * 33_333_333).astype(np.int64)
+
+    assert frame_at(timestamps_ns, 0.0) == 0
+    assert frame_at(timestamps_ns, 10_000_000.0) == 0
+    assert frame_at(timestamps_ns, 30_000_000.0) == 0
+    assert frame_at(timestamps_ns, 33_333_333.0) == 1
+    assert frame_at(timestamps_ns, 10_833_333_333.0) == 9
+    assert frame_at(timestamps_ns, -5.0) == 0

--- a/pixi.toml
+++ b/pixi.toml
@@ -1160,6 +1160,11 @@ cmd = "python tools/apps/track_app.py"
 cwd = "packages/posekit"
 description = "Launch the click-to-track video Gradio app (SAM2-streaming/EfficientTAM + Rerun)"
 
+[feature.posekit.tasks.sam2-streaming-tests]
+cmd = "pytest -q tests"
+cwd = "packages/sam2-streaming"
+description = "Run SAM2-streaming regression tests"
+
 # ═══════════════════════════════════════════════════════════════════════════
 # robocap-slam
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Stacked on #138. Cleanups from the four-reviewer /simplify pass on that PR (implemented via Codex, verified locally).

- **Download .rrd as a tee, not a replay**: each callback recording also writes a footerless `FileSink` part (the 4DAnyone Space pattern); Track merges them with `rerun rrd merge` — plain byte concatenation repeats stream framing on Rerun 0.36. Deletes the per-session export cache (`TrackedFrame`, `_save_recording`). Scrub previews are ephemeral and never hit a part.
- **Sessions in `gr.State(delete_callback=…)`** instead of a process-global table with manual eviction; the callback closes the decoder thread and removes the session's files.
- **Shared decoder**: `simplecv.video_io.TorchCodecVideoReader(thread_owned=True)` (torchcodec's CUDA decoder is thread-affine) + range decode on device; `ClickTracker` composes it instead of raw torchcodec.
- **`simplecv.video_utils.frame_at`**: shared latest-at frame lookup for a viewer time in ns.
- **`ClickTracker` API**: private `_points` with read-only accessors; `PointEdit` dataclass instead of optional pairs.
- **SAM2 memory-selection test** moved to `packages/sam2-streaming/tests` with a `sam2-streaming-tests` pixi task (no lockfile change).

Not done here (upstream): carrying timeline/time in gradio-rerun's selection payload would remove the click-time stamp/settle machinery in `track_ui.py`.

Verification: posekit 35 passed (GPU), lint/typecheck/deadcode clean; `sam2-streaming-tests` 1 passed; simplecv focused tests + lint/typecheck clean; browser smoke: 329/329 frames tracked, download present, merged .rrd contains `/video`, `/video/points`, `/video/mask`, `/video/confidence`.
