### PR TITLE
monoprior: single-image MoGe v2 wrappers become adapters over the core (2/3)

### DIFF
--- a/packages/monoprior/monopriors/models/metric_depth/moge_v2.py
+++ b/packages/monoprior/monopriors/models/metric_depth/moge_v2.py
@@ -1,55 +1,35 @@
-from timeit import default_timer as timer
+"""Single-image metric-depth adapter for the unified MoGe v2 core."""
+
 from typing import Literal
 
 import numpy as np
-import torch
-from einops import rearrange
 from jaxtyping import Float, UInt8
 
-from monopriors.third_party.moge.model._inference import InferenceOutput
+from monopriors.models.metric_depth.base_metric_depth import BaseMetricPredictor, MetricDepthPrediction
+from monopriors.models.moge_v2.adapters import geometry_to_metric_prediction, rgb_to_cuda_batch
+from monopriors.models.moge_v2.export import Encoder
+from monopriors.models.moge_v2.predictor import MoGeV2GeometryOutput, MoGeV2TorchPredictor
 from monopriors.third_party.moge.model.v2 import MoGeModel
-
-from .base_metric_depth import BaseMetricPredictor, MetricDepthPrediction
-
-MOGE_V2_CHECKPOINTS: dict[tuple[str, bool], tuple[str, str]] = {
-    ("vitl", False): ("Ruicheng/moge-2-vitl", "39c4d5e957afe587e04eec59dc2bcc3be5ecd968"),
-    ("vitl", True): ("Ruicheng/moge-2-vitl-normal", "b135031bae30b5ac2ae141a0e68717795ce38340"),
-    ("vitb", True): ("Ruicheng/moge-2-vitb-normal", "54ad3a693e61907ea4633d13dec6ee682fa09419"),
-    ("vits", True): ("Ruicheng/moge-2-vits-normal", "679230677b4d282c6f304189a93e98e14f085902"),
-}
-"""Mapping of (encoder, with_normals) to Hugging Face repository and revision."""
 
 
 class MoGeV2MetricPredictor(BaseMetricPredictor[MoGeModel]):
-    """MoGe v2 predictor producing metric-scale depth.
+    """MoGe v2 metric-depth adapter using the normal-capable checkpoint."""
 
-    Uses the depth-only checkpoint when available, otherwise falls back
-    to the depth+normals checkpoint (ignoring the normal output).
-    """
-
-    def __init__(
-        self,
-        device: Literal["cpu", "cuda"],
-        encoder: Literal["vits", "vitb", "vitl"] = "vitl",
-    ) -> None:
-        """Load a pinned MoGe v2 metric checkpoint.
+    def __init__(self, device: Literal["cpu", "cuda"], encoder: Encoder = "vitl") -> None:
+        """Load the unified geometry core.
 
         Args:
-            device: Torch device used for inference.
+            device: Must be ``"cuda"``; MoGe v2 inference is GPU-only.
             encoder: DINOv2 encoder size.
+
+        Raises:
+            ValueError: If CPU is requested.
         """
         super().__init__()
-        # Prefer depth-only checkpoint; fall back to depth+normals
-        checkpoint: tuple[str, str] = MOGE_V2_CHECKPOINTS.get(
-            (encoder, False),
-            MOGE_V2_CHECKPOINTS[(encoder, True)],
-        )
-        repo_id: str = checkpoint[0]
-        revision: str = checkpoint[1]
-        print(f"Loading MoGe v2 metric model ({repo_id})...")
-        start: float = timer()
-        self.model: MoGeModel = MoGeModel.from_pretrained(repo_id, revision=revision).to(device)
-        print(f"MoGe v2 metric model loaded. Time: {timer() - start:.2f}s")
+        if device == "cpu":
+            raise ValueError("MoGe v2 predictors require CUDA; device='cpu' is unsupported.")
+        self.predictor: MoGeV2TorchPredictor = MoGeV2TorchPredictor(encoder=encoder, heads="geometry")
+        self.model: MoGeModel = self.predictor.model
         self.device: Literal["cpu", "cuda"] = device
 
     def __call__(
@@ -57,48 +37,14 @@ class MoGeV2MetricPredictor(BaseMetricPredictor[MoGeModel]):
         rgb: UInt8[np.ndarray, "h w 3"],
         K_33: Float[np.ndarray, "3 3"] | None = None,
     ) -> MetricDepthPrediction:
-        """Predict metric depth from an RGB image.
+        """Predict metric depth, binary confidence, and pixel intrinsics.
 
         Args:
-            rgb: uint8 RGB image shaped ``h w 3``.
-            K_33: Optional float camera intrinsics shaped ``3 3``; MoGe v2 estimates its own intrinsics.
+            rgb: uint8 NumPy RGB image shaped ``h w 3``.
+            K_33: Ignored caller intrinsics; MoGe v2 estimates its own.
 
         Returns:
-            Metric depth, confidence, and estimated intrinsics.
+            Float32 metric depth, binary confidence, and pixel intrinsics.
         """
-        h: int
-        w: int
-        h, w, _ = rgb.shape
-        input_image: Float[torch.Tensor, "3 h w"] = rearrange(torch.from_numpy(rgb), "h w c -> c h w").to(
-            device=self.device,
-            dtype=torch.float32,
-        )
-        input_image.div_(255.0)
-
-        output: InferenceOutput = self.model.infer(
-            input_image,
-            force_projection=False,
-            output_heads=("points", "mask", "scale"),
-        )
-        # v2 output keys: "points" (H,W,3), "depth" (H,W), "mask" (H,W),
-        # "intrinsics" (3,3), and optionally "normal" (H,W,3).
-        # Depth is metric-scale. Intrinsics are normalized.
-
-        normalized_k: Float[np.ndarray, "3 3"] = output["intrinsics"].numpy(force=True)
-        fx: float = float(normalized_k[0, 0] * w)
-        fy: float = float(normalized_k[1, 1] * h)
-        cx: float = float(normalized_k[0, 2] * w)
-        cy: float = float(normalized_k[1, 2] * h)
-
-        intrinsics: Float[np.ndarray, "3 3"] = np.array(
-            [[fx, 0.0, cx], [0.0, fy, cy], [0.0, 0.0, 1.0]],
-            dtype=np.float32,
-        )
-        depth_meters: Float[np.ndarray, "h w"] = output["depth"].numpy(force=True)
-        confidence: Float[np.ndarray, "h w"] = output["mask"].numpy(force=True).astype(np.float32)
-
-        return MetricDepthPrediction(
-            depth_meters=depth_meters,
-            confidence=confidence,
-            K_33=intrinsics,
-        )
+        output: MoGeV2GeometryOutput = self.predictor.predict_geometry(rgb_to_cuda_batch(rgb))
+        return geometry_to_metric_prediction(output)

--- a/packages/monoprior/monopriors/models/moge_v2/adapters.py
+++ b/packages/monoprior/monopriors/models/moge_v2/adapters.py
@@ -1,0 +1,73 @@
+"""Shared NumPy conversions for single-image MoGe v2 adapters."""
+
+import numpy as np
+import torch
+from jaxtyping import Bool, Float32, UInt8
+from torch import Tensor
+
+from monopriors.models.metric_depth.base_metric_depth import MetricDepthPrediction
+from monopriors.models.moge_v2.predictor import MoGeV2GeometryOutput, MoGeV2NormalOutput
+from monopriors.models.surface_normal.base_normal_model import SurfaceNormalPrediction
+
+
+def rgb_to_cuda_batch(rgb_hw3: UInt8[np.ndarray, "h w 3"]) -> UInt8[Tensor, "1 h w 3"]:
+    """Move one uint8 NumPy RGB image into a CUDA batch.
+
+    Args:
+        rgb_hw3: uint8 NumPy RGB image shaped ``h w 3``.
+
+    Returns:
+        uint8 CUDA RGB tensor shaped ``1 h w 3``.
+    """
+    rgb_bhw3: UInt8[Tensor, "1 h w 3"] = torch.from_numpy(rgb_hw3).to(device="cuda")[None]
+    return rgb_bhw3
+
+
+def geometry_to_metric_prediction(output: MoGeV2GeometryOutput) -> MetricDepthPrediction:
+    """Convert one batched geometry result to the metric-depth contract.
+
+    Args:
+        output: Owning float32 geometry tensors with a batch size of one.
+
+    Returns:
+        Float32 caller-resolution depth, binary confidence, and pixel intrinsics.
+
+    Raises:
+        ValueError: If the output batch size is not one.
+    """
+    if output.depth_bhw.shape[0] != 1:
+        raise ValueError(f"Single-image adapters require batch size 1, got {output.depth_bhw.shape[0]}.")
+
+    height: int = output.depth_bhw.shape[1]
+    width: int = output.depth_bhw.shape[2]
+    valid_hw: Bool[np.ndarray, "h w"] = output.mask_bhw[0].numpy(force=True) > 0.5
+    raw_depth_hw: Float32[np.ndarray, "h w"] = output.depth_bhw[0].numpy(force=True).astype(np.float32, copy=False)
+    depth_meters_hw: Float32[np.ndarray, "h w"] = np.where(valid_hw, raw_depth_hw, np.inf).astype(np.float32, copy=False)
+    confidence_hw: Float32[np.ndarray, "h w"] = valid_hw.astype(np.float32)
+    normalized_K_33: Float32[np.ndarray, "3 3"] = output.intrinsics_b33[0].numpy(force=True).astype(np.float32, copy=False)
+    K_33: Float32[np.ndarray, "3 3"] = normalized_K_33.copy()
+    K_33[0, :] *= width
+    K_33[1, :] *= height
+    return MetricDepthPrediction(depth_meters=depth_meters_hw, confidence=confidence_hw, K_33=K_33)
+
+
+def normal_to_surface_prediction(output: MoGeV2NormalOutput | MoGeV2GeometryOutput) -> SurfaceNormalPrediction:
+    """Convert one batched normal result to the surface-normal contract.
+
+    Args:
+        output: Owning float32 normal or geometry tensors with batch size one.
+
+    Returns:
+        Float32 normals zeroed outside the binary-valid mask and binary confidence.
+
+    Raises:
+        ValueError: If the output batch size is not one.
+    """
+    if output.normals_bhw3.shape[0] != 1:
+        raise ValueError(f"Single-image adapters require batch size 1, got {output.normals_bhw3.shape[0]}.")
+
+    valid_hw: Bool[np.ndarray, "h w"] = output.mask_bhw[0].numpy(force=True) > 0.5
+    raw_normals_hw3: Float32[np.ndarray, "h w 3"] = output.normals_bhw3[0].numpy(force=True).astype(np.float32, copy=False)
+    normals_hw3: Float32[np.ndarray, "h w 3"] = np.where(valid_hw[..., None], raw_normals_hw3, 0.0).astype(np.float32, copy=False)
+    confidence_hw1: Float32[np.ndarray, "h w 1"] = valid_hw[..., None].astype(np.float32)
+    return SurfaceNormalPrediction(normal_hw3=normals_hw3, confidence_hw1=confidence_hw1)

--- a/packages/monoprior/monopriors/models/monoprior/monoprior_models.py
+++ b/packages/monoprior/monopriors/models/monoprior/monoprior_models.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from timeit import default_timer as timer
 from typing import Literal
 
 import numpy as np
@@ -9,14 +8,14 @@ from einops import rearrange
 from jaxtyping import Float, UInt8
 
 from monopriors.models.metric_depth import BaseMetricPredictor, MetricDepthPrediction, get_metric_predictor
-from monopriors.models.metric_depth.moge_v2 import MOGE_V2_CHECKPOINTS
+from monopriors.models.moge_v2.adapters import geometry_to_metric_prediction, normal_to_surface_prediction, rgb_to_cuda_batch
+from monopriors.models.moge_v2.export import Encoder
+from monopriors.models.moge_v2.predictor import MoGeV2GeometryOutput, MoGeV2TorchPredictor
 from monopriors.models.surface_normal import (
     BaseNormalPredictor,
     SurfaceNormalPrediction,
     get_normal_predictor,
 )
-from monopriors.third_party.moge.model._inference import InferenceOutput
-from monopriors.third_party.moge.model.v2 import MoGeModel
 
 
 @dataclass
@@ -126,7 +125,7 @@ class MoGeV2MonoPrior(MonoPriorModel):
 
     def __init__(
         self,
-        encoder: Literal["vits", "vitb", "vitl"] = "vitl",
+        encoder: Encoder = "vitl",
     ) -> None:
         """Load a pinned normal-capable MoGe v2 checkpoint.
 
@@ -134,13 +133,7 @@ class MoGeV2MonoPrior(MonoPriorModel):
             encoder: DINOv2 encoder size.
         """
         super().__init__()
-        checkpoint: tuple[str, str] = MOGE_V2_CHECKPOINTS[(encoder, True)]
-        repo_id: str = checkpoint[0]
-        revision: str = checkpoint[1]
-        print(f"Loading MoGe v2 mono-prior model ({repo_id})...")
-        start: float = timer()
-        self.model: MoGeModel = MoGeModel.from_pretrained(repo_id, revision=revision).to(self.device)
-        print(f"MoGe v2 mono-prior model loaded. Time: {timer() - start:.2f}s")
+        self.predictor: MoGeV2TorchPredictor = MoGeV2TorchPredictor(encoder=encoder, heads="geometry")
 
     def __call__(
         self,
@@ -156,41 +149,7 @@ class MoGeV2MonoPrior(MonoPriorModel):
         Returns:
             Combined metric-depth and surface-normal prediction.
         """
-        h: int
-        w: int
-        h, w, _ = rgb.shape
-        input_image: Float[torch.Tensor, "3 h w"] = rearrange(torch.from_numpy(rgb), "h w c -> c h w").to(
-            device=self.device,
-            dtype=torch.float32,
-        )
-        input_image.div_(255.0)
-
-        output: InferenceOutput = self.model.infer(input_image, force_projection=False)
-
-        # Build intrinsics from normalized values
-        normalized_k: Float[np.ndarray, "3 3"] = output["intrinsics"].numpy(force=True)
-        fx: float = float(normalized_k[0, 0] * w)
-        fy: float = float(normalized_k[1, 1] * h)
-        cx: float = float(normalized_k[0, 2] * w)
-        cy: float = float(normalized_k[1, 2] * h)
-        intrinsics: Float[np.ndarray, "3 3"] = np.array(
-            [[fx, 0.0, cx], [0.0, fy, cy], [0.0, 0.0, 1.0]],
-            dtype=np.float32,
-        )
-
-        depth_meters: Float[np.ndarray, "h w"] = output["depth"].numpy(force=True)
-        confidence: Float[np.ndarray, "h w"] = output["mask"].numpy(force=True).astype(np.float32)
-        normal_hw3: Float[np.ndarray, "h w 3"] = output["normal"].numpy(force=True)
-        confidence_hw1: Float[np.ndarray, "h w 1"] = confidence[:, :, np.newaxis]
-
-        metric_pred: MetricDepthPrediction = MetricDepthPrediction(
-            depth_meters=depth_meters,
-            confidence=confidence,
-            K_33=intrinsics,
-        )
-        normal_pred: SurfaceNormalPrediction = SurfaceNormalPrediction(
-            normal_hw3=normal_hw3,
-            confidence_hw1=confidence_hw1,
-        )
-
+        output: MoGeV2GeometryOutput = self.predictor.predict_geometry(rgb_to_cuda_batch(rgb))
+        metric_pred: MetricDepthPrediction = geometry_to_metric_prediction(output)
+        normal_pred: SurfaceNormalPrediction = normal_to_surface_prediction(output)
         return MonoPriorPrediction(metric_pred=metric_pred, normal_pred=normal_pred)

--- a/packages/monoprior/monopriors/models/surface_normal/moge_v2.py
+++ b/packages/monoprior/monopriors/models/surface_normal/moge_v2.py
@@ -1,50 +1,37 @@
-from timeit import default_timer as timer
+"""Single-image surface-normal adapter for the unified MoGe v2 core."""
+
 from typing import Literal
 
 import numpy as np
-import torch
-from einops import rearrange
 from jaxtyping import Float, UInt8
 
-from monopriors.models.metric_depth.moge_v2 import MOGE_V2_CHECKPOINTS
-from monopriors.third_party.moge.model._inference import InferenceOutput
+from monopriors.models.moge_v2.export import MOGE_V2_CHECKPOINTS, Encoder
+from monopriors.models.moge_v2.predictor import MoGeV2NormalOutput, MoGeV2TorchPredictor
+from monopriors.models.surface_normal.base_normal_model import BaseNormalPredictor, SurfaceNormalPrediction
 from monopriors.third_party.moge.model.v2 import MoGeModel
 
-from .base_normal_model import BaseNormalPredictor, SurfaceNormalPrediction
-
-MOGE_V2_NORMAL_CHECKPOINTS: dict[str, tuple[str, str]] = {
-    "vitl": MOGE_V2_CHECKPOINTS[("vitl", True)],
-    "vitb": MOGE_V2_CHECKPOINTS[("vitb", True)],
-    "vits": MOGE_V2_CHECKPOINTS[("vits", True)],
-}
-"""Mapping of encoder to Hugging Face repository and revision (all include normals)."""
+MOGE_V2_NORMAL_CHECKPOINTS: dict[Encoder, tuple[str, str]] = MOGE_V2_CHECKPOINTS
+"""Backward-compatible name for the unified normal-capable checkpoint table."""
 
 
 class MoGeV2NormalPredictor(BaseNormalPredictor[MoGeModel]):
-    """MoGe v2 predictor producing surface normals.
+    """MoGe v2 surface-normal adapter using the normal-only heads."""
 
-    Requires a ``-normal`` checkpoint variant.
-    """
-
-    def __init__(
-        self,
-        device: Literal["cpu", "cuda"],
-        encoder: Literal["vits", "vitb", "vitl"] = "vitl",
-    ) -> None:
-        """Load a pinned normal-capable MoGe v2 checkpoint.
+    def __init__(self, device: Literal["cpu", "cuda"], encoder: Encoder = "vitl") -> None:
+        """Load the unified normal-only core.
 
         Args:
-            device: Torch device used for inference.
+            device: Must be ``"cuda"``; MoGe v2 inference is GPU-only.
             encoder: DINOv2 encoder size.
+
+        Raises:
+            ValueError: If CPU is requested.
         """
         super().__init__()
-        checkpoint: tuple[str, str] = MOGE_V2_NORMAL_CHECKPOINTS[encoder]
-        repo_id: str = checkpoint[0]
-        revision: str = checkpoint[1]
-        print(f"Loading MoGe v2 normal model ({repo_id})...")
-        start: float = timer()
-        self.model: MoGeModel = MoGeModel.from_pretrained(repo_id, revision=revision).to(device)
-        print(f"MoGe v2 normal model loaded. Time: {timer() - start:.2f}s")
+        if device == "cpu":
+            raise ValueError("MoGe v2 predictors require CUDA; device='cpu' is unsupported.")
+        self.predictor: MoGeV2TorchPredictor = MoGeV2TorchPredictor(encoder=encoder, heads="normal")
+        self.model: MoGeModel = self.predictor.model
         self.device: Literal["cpu", "cuda"] = device
 
     def __call__(
@@ -52,36 +39,16 @@ class MoGeV2NormalPredictor(BaseNormalPredictor[MoGeModel]):
         rgb: UInt8[np.ndarray, "h w 3"],
         K_33: Float[np.ndarray, "3 3"] | None = None,
     ) -> SurfaceNormalPrediction:
-        """Predict surface normals from an RGB image.
+        """Predict surface normals and binary confidence.
 
         Args:
-            rgb: uint8 RGB image shaped ``h w 3``.
-            K_33: Optional float camera intrinsics shaped ``3 3``; normals do not use it.
+            rgb: uint8 NumPy RGB image shaped ``h w 3``.
+            K_33: Ignored camera intrinsics; the normal head does not use them.
 
         Returns:
-            Surface normals and per-pixel confidence.
+            Float32 normals zeroed outside the binary-valid mask and confidence.
         """
-        h: int
-        w: int
-        h, w, _ = rgb.shape
-        input_image: Float[torch.Tensor, "3 h w"] = rearrange(torch.from_numpy(rgb), "h w c -> c h w").to(
-            device=self.device,
-            dtype=torch.float32,
-        )
-        input_image.div_(255.0)
+        from monopriors.models.moge_v2.adapters import normal_to_surface_prediction, rgb_to_cuda_batch
 
-        output: InferenceOutput = self.model.infer(
-            input_image,
-            force_projection=False,
-            output_heads=("normal", "mask"),
-        )
-        # v2 normal checkpoint output includes "normal" (H,W,3) and "mask" (H,W)
-
-        normal_hw3: Float[np.ndarray, "h w 3"] = output["normal"].numpy(force=True)
-        mask: Float[np.ndarray, "h w"] = output["mask"].numpy(force=True).astype(np.float32)
-        confidence_hw1: Float[np.ndarray, "h w 1"] = mask[:, :, np.newaxis]
-
-        return SurfaceNormalPrediction(
-            normal_hw3=normal_hw3,
-            confidence_hw1=confidence_hw1,
-        )
+        output: MoGeV2NormalOutput = self.predictor.predict_normals(rgb_to_cuda_batch(rgb))
+        return normal_to_surface_prediction(output)

--- a/packages/monoprior/pyproject.toml
+++ b/packages/monoprior/pyproject.toml
@@ -87,6 +87,7 @@ ignore_names = [
     "print_model_summary",
     "fuse_remaining_conv_bn",
     "StableNormalPredictor",
+    "MOGE_V2_NORMAL_CHECKPOINTS",
     "aabb",
     "camera_model",
     "camtoworld",

--- a/packages/monoprior/tests/test_moge_v2_adapters.py
+++ b/packages/monoprior/tests/test_moge_v2_adapters.py
@@ -1,0 +1,160 @@
+"""Contracts for MoGe v2 single-image NumPy adapters."""
+
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+import torch
+from conftest import requires_cuda, slow_cuda
+from einops import rearrange
+from jaxtyping import Bool, Float32, UInt8
+from torch import Tensor
+
+from monopriors.models.metric_depth import MetricDepthPrediction
+from monopriors.models.moge_v2 import MoGeV2GeometryOutput, MoGeV2NormalOutput
+from monopriors.models.moge_v2.adapters import geometry_to_metric_prediction, normal_to_surface_prediction
+from monopriors.models.surface_normal import SurfaceNormalPrediction
+
+
+def test_geometry_conversion_uses_pixel_intrinsics_binary_confidence_and_infinite_fill() -> None:
+    """Metric conversion returns caller-pixel intrinsics and masks invalid depth."""
+    geometry: MoGeV2GeometryOutput = MoGeV2GeometryOutput(
+        depth_bhw=torch.tensor([[[2.0, 3.0], [-1.0, 5.0]]], dtype=torch.float32),
+        points_bhw3=torch.zeros((1, 2, 2, 3), dtype=torch.float32),
+        normals_bhw3=torch.zeros((1, 2, 2, 3), dtype=torch.float32),
+        mask_bhw=torch.tensor([[[0.6, 0.5], [0.0, 1.0]]], dtype=torch.float32),
+        intrinsics_b33=torch.tensor([[[0.75, 0.0, 0.4], [0.0, 0.8, 0.6], [0.0, 0.0, 1.0]]], dtype=torch.float32),
+        metric_scale_b=torch.ones(1, dtype=torch.float32),
+        shift_b=torch.zeros(1, dtype=torch.float32),
+    )
+
+    prediction: MetricDepthPrediction = geometry_to_metric_prediction(geometry)
+
+    expected_depth_hw: Float32[np.ndarray, "2 2"] = np.array([[2.0, np.inf], [np.inf, 5.0]], dtype=np.float32)
+    expected_confidence_hw: Float32[np.ndarray, "2 2"] = np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
+    expected_K_33: Float32[np.ndarray, "3 3"] = np.array(
+        [[1.5, 0.0, 0.8], [0.0, 1.6, 1.2], [0.0, 0.0, 1.0]],
+        dtype=np.float32,
+    )
+    np.testing.assert_array_equal(prediction.depth_meters, expected_depth_hw)
+    np.testing.assert_array_equal(prediction.confidence, expected_confidence_hw)
+    np.testing.assert_allclose(prediction.K_33, expected_K_33)
+
+
+def test_normal_conversion_zeros_invalid_vectors_and_returns_binary_confidence() -> None:
+    """Normal conversion applies the strict mask threshold to both outputs."""
+    output: MoGeV2NormalOutput = MoGeV2NormalOutput(
+        normals_bhw3=torch.tensor(
+            [[[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], [[0.0, 0.0, 1.0], [-1.0, 0.0, 0.0]]]],
+            dtype=torch.float32,
+        ),
+        mask_bhw=torch.tensor([[[0.51, 0.5], [0.0, 1.0]]], dtype=torch.float32),
+    )
+
+    prediction: SurfaceNormalPrediction = normal_to_surface_prediction(output)
+
+    expected_normals_hw3: Float32[np.ndarray, "2 2 3"] = np.array(
+        [[[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]], [[0.0, 0.0, 0.0], [-1.0, 0.0, 0.0]]],
+        dtype=np.float32,
+    )
+    expected_confidence_hw1: Float32[np.ndarray, "2 2 1"] = np.array([[[1.0], [0.0]], [[0.0], [1.0]]], dtype=np.float32)
+    np.testing.assert_array_equal(prediction.normal_hw3, expected_normals_hw3)
+    np.testing.assert_array_equal(prediction.confidence_hw1, expected_confidence_hw1)
+
+
+def test_single_image_adapters_reject_cpu_at_construction() -> None:
+    """Both registry adapters fail early with the shared CUDA-only message."""
+    from monopriors.models.metric_depth.moge_v2 import MoGeV2MetricPredictor
+    from monopriors.models.surface_normal.moge_v2 import MoGeV2NormalPredictor
+
+    with pytest.raises(ValueError, match="^MoGe v2 predictors require CUDA;"):
+        MoGeV2MetricPredictor(device="cpu")
+    with pytest.raises(ValueError, match="^MoGe v2 predictors require CUDA;"):
+        MoGeV2NormalPredictor(device="cpu")
+
+
+@slow_cuda
+@requires_cuda
+def test_all_single_image_adapters_match_vendored_infer_on_room() -> None:
+    """Metric, normal, and paired adapters match the pinned vendored reference."""
+    from monopriors.models.metric_depth.moge_v2 import MoGeV2MetricPredictor
+    from monopriors.models.moge_v2 import MOGE_V2_CHECKPOINTS
+    from monopriors.models.monoprior import MoGeV2MonoPrior, MonoPriorPrediction
+    from monopriors.models.surface_normal.moge_v2 import MoGeV2NormalPredictor
+    from monopriors.third_party.moge.model._inference import InferenceOutput
+    from monopriors.third_party.moge.model.v2 import MoGeModel
+
+    image_path: Path = Path("data/examples/single-image/room.jpg")
+    bgr_hw3: UInt8[np.ndarray, "h w 3"] | None = cv2.imread(str(image_path), cv2.IMREAD_COLOR)
+    if bgr_hw3 is None:
+        pytest.skip(f"{image_path} missing; run the monoprior download task")
+    rgb_hw3: UInt8[np.ndarray, "h w 3"] = cv2.cvtColor(bgr_hw3, cv2.COLOR_BGR2RGB)
+    image_3hw: Float32[Tensor, "3 h w"] = rearrange(torch.from_numpy(rgb_hw3).to(device="cuda"), "h w c -> c h w").float() / 255.0  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    checkpoint: tuple[str, str] = MOGE_V2_CHECKPOINTS["vitl"]
+    reference_model: MoGeModel = MoGeModel.from_pretrained(checkpoint[0], revision=checkpoint[1]).to("cuda").eval()
+    reference: InferenceOutput = reference_model.infer(image_3hw, force_projection=False, apply_mask=True)
+    reference_depth_hw: Float32[np.ndarray, "h w"] = reference["depth"].numpy(force=True)
+    reference_K_33: Float32[np.ndarray, "3 3"] = reference["intrinsics"].numpy(force=True).astype(np.float32, copy=True)
+    reference_K_33[0, :] *= rgb_hw3.shape[1]
+    reference_K_33[1, :] *= rgb_hw3.shape[0]
+    reference_normals_hw3: Float32[np.ndarray, "h w 3"] = reference["normal"].numpy(force=True)
+    reference_confidence_hw: Float32[np.ndarray, "h w"] = reference["mask"].numpy(force=True).astype(np.float32)
+    del reference_model, reference
+    torch.cuda.empty_cache()
+
+    metric_adapter: MoGeV2MetricPredictor = MoGeV2MetricPredictor(device="cuda")
+    metric_adapter.set_model_device("cuda")
+    metric_prediction: MetricDepthPrediction = metric_adapter(rgb_hw3)
+    del metric_adapter
+    torch.cuda.empty_cache()
+    normal_adapter: MoGeV2NormalPredictor = MoGeV2NormalPredictor(device="cuda")
+    normal_prediction: SurfaceNormalPrediction = normal_adapter(rgb_hw3)
+    del normal_adapter
+    torch.cuda.empty_cache()
+    paired_adapter: MoGeV2MonoPrior = MoGeV2MonoPrior()
+    paired_prediction: MonoPriorPrediction = paired_adapter(rgb_hw3)
+    del paired_adapter
+    torch.cuda.empty_cache()
+
+    valid_metric_hw: Bool[np.ndarray, "h w"] = np.isfinite(reference_depth_hw) & np.isfinite(metric_prediction.depth_meters)
+    metric_relative_error_valid: Float32[np.ndarray, "valid"] = np.abs(
+        metric_prediction.depth_meters[valid_metric_hw] - reference_depth_hw[valid_metric_hw]
+    ) / np.maximum(
+        np.abs(reference_depth_hw[valid_metric_hw]), 1e-6
+    )
+    assert np.median(metric_relative_error_valid) < 0.01
+    intrinsics_indices: tuple[tuple[int, ...], tuple[int, ...]] = ((0, 1, 0, 1), (0, 1, 2, 2))
+    np.testing.assert_allclose(
+        metric_prediction.K_33[intrinsics_indices],
+        reference_K_33[intrinsics_indices],
+        rtol=0.01,
+        atol=0.0,
+    )
+    assert np.mean(metric_prediction.confidence == reference_confidence_hw) > 0.99
+
+    valid_normal_hw: Bool[np.ndarray, "h w"] = (normal_prediction.confidence_hw1[..., 0] > 0.5) & (reference_confidence_hw > 0.5)
+    normal_cosine_valid: Float32[np.ndarray, "valid"] = np.sum(normal_prediction.normal_hw3 * reference_normals_hw3, axis=-1)[valid_normal_hw].clip(
+        -1.0, 1.0
+    )
+    assert np.rad2deg(np.arccos(normal_cosine_valid)).mean() < 1.0
+    assert np.mean(normal_prediction.confidence_hw1[..., 0] == reference_confidence_hw) > 0.99
+
+    valid_paired_hw: Bool[np.ndarray, "h w"] = np.isfinite(reference_depth_hw) & np.isfinite(paired_prediction.metric_pred.depth_meters)
+    paired_relative_error_valid: Float32[np.ndarray, "valid"] = np.abs(
+        paired_prediction.metric_pred.depth_meters[valid_paired_hw] - reference_depth_hw[valid_paired_hw]
+    ) / np.maximum(np.abs(reference_depth_hw[valid_paired_hw]), 1e-6)
+    assert np.median(paired_relative_error_valid) < 0.01
+    paired_normal_valid_hw: Bool[np.ndarray, "h w"] = (paired_prediction.normal_pred.confidence_hw1[..., 0] > 0.5) & (reference_confidence_hw > 0.5)
+    paired_cosine_valid: Float32[np.ndarray, "valid"] = np.sum(paired_prediction.normal_pred.normal_hw3 * reference_normals_hw3, axis=-1)[
+        paired_normal_valid_hw
+    ].clip(-1.0, 1.0)
+    assert np.rad2deg(np.arccos(paired_cosine_valid)).mean() < 1.0
+    np.testing.assert_allclose(
+        paired_prediction.metric_pred.K_33[intrinsics_indices],
+        reference_K_33[intrinsics_indices],
+        rtol=0.01,
+        atol=0.0,
+    )
+    assert np.mean(paired_prediction.metric_pred.confidence == reference_confidence_hw) > 0.99
+    assert np.mean(paired_prediction.normal_pred.confidence_hw1[..., 0] == reference_confidence_hw) > 0.99


### PR DESCRIPTION
Stacked on `moge-v2-core` (part 1). Part 2/3 of the MoGe v2 wrapper consolidation. **This is the PR with the behaviour change** — review the numbers below.

## What

`MoGeV2MetricPredictor`, `MoGeV2NormalPredictor` and `MoGeV2MonoPrior` become ~30-line adapters over `MoGeV2TorchPredictor` via `moge_v2/adapters.py` (numpy HWC → CUDA → numpy). Contracts and registry names unchanged: pixel-space `K_33`, binary `confidence`, `+inf` at invalid depth, normals zeroed where invalid, caller H×W. The old per-wrapper `infer` calls and intrinsics denormalization are gone.

## Behaviour changes (decided with the owner)

1. `device="cpu"` raises — ViT-L single-image CPU inference was never practical; nothing in the repo used it.
2. **One `-normal` checkpoint per encoder everywhere.** `MoGeV2MetricPredictor` with `vitl` previously loaded the plain `Ruicheng/moge-2-vitl`. On `room.jpg` the `-normal` weights differ by **4.1 % median / 5.5 % p95 relative depth and 3.6 % focal (−27 px)**. Consumers of the metric registry entry (metric gradio UI, `calibrate_synced_videos`, sam3d-body's `K_33`) see a one-time shift. Neither checkpoint is ground truth; MoGe's model card rates the plain variant marginally better on depth.

## Verification
monoprior `lint` / `typecheck` (0 errors) / `deadcode` / `tests` (78 fast) exit 0; `pytest -m slow` includes each adapter vs vendored `MoGeModel.infer` on the same weights (depth median < 1 %, `K_33` < 1 %, normals mean < 1°, confidence agreement > 99 %). `pixi run -e monoprior monoprior` runs headless end-to-end with the new `MoGeV2MonoPrior` (RGB, depth, normals, confidence, point cloud rendered and checked).
