### PR TITLE
monoprior: delete OldMonoPriorPrediction and fix nerfstudio_to_sdfstudio (3/3)

### DIFF
--- a/packages/monoprior/monopriors/models/monoprior/__init__.py
+++ b/packages/monoprior/monopriors/models/monoprior/__init__.py
@@ -3,7 +3,6 @@ from .monoprior_models import (
     MoGeV2MonoPrior,
     MonoPriorModel,
     MonoPriorPrediction,
-    OldMonoPriorPrediction,
 )
 
 __all__: list[str] = [
@@ -11,5 +10,4 @@ __all__: list[str] = [
     "MoGeV2MonoPrior",
     "MonoPriorModel",
     "MonoPriorPrediction",
-    "OldMonoPriorPrediction",
 ]

--- a/packages/monoprior/monopriors/models/monoprior/monoprior_models.py
+++ b/packages/monoprior/monopriors/models/monoprior/monoprior_models.py
@@ -4,7 +4,6 @@ from typing import Literal
 
 import numpy as np
 import torch
-from einops import rearrange
 from jaxtyping import Float, UInt8
 
 from monopriors.models.metric_depth import BaseMetricPredictor, MetricDepthPrediction, get_metric_predictor
@@ -16,53 +15,6 @@ from monopriors.models.surface_normal import (
     SurfaceNormalPrediction,
     get_normal_predictor,
 )
-
-
-@dataclass
-class OldMonoPriorPrediction:
-    """Legacy batched tensor representation of monocular priors."""
-
-    depth_b1hw: Float[torch.Tensor, "b 1 h w"]
-    """Predicted metric depth in BCHW layout."""
-    normal_b3hw: Float[torch.Tensor, "b 3 h w"]
-    """Predicted surface normals in BCHW layout."""
-    K_b33: Float[torch.Tensor, "b 3 3"] | None = None
-    """Optional camera intrinsics for each batch item."""
-    depth_conf_b1hw: Float[torch.Tensor, "b 1 h w"] | None = None
-    """Optional per-pixel depth confidence."""
-    normal_conf_b1hw: Float[torch.Tensor, "b 1 h w"] | None = None
-    """Optional per-pixel normal confidence."""
-
-    def to_numpy(
-        self,
-    ) -> tuple[
-        Float[np.ndarray, "b h w 1"],
-        Float[np.ndarray, "b h w 3"],
-        Float[np.ndarray, "b 3 3"] | None,
-        Float[np.ndarray, "b h w 1"] | None,
-        Float[np.ndarray, "b h w 1"] | None,
-    ]:
-        """Convert legacy Torch predictions to channel-last NumPy arrays.
-
-        Returns:
-            Float depth, normal, intrinsics, depth-confidence, and normal-confidence arrays with their documented shapes.
-        """
-        depth_np_bhw1: Float[np.ndarray, "b h w 1"] = rearrange(self.depth_b1hw, "b c h w -> b h w c").numpy(force=True)
-        normal_np_bhw3: Float[np.ndarray, "b h w 3"] = rearrange(self.normal_b3hw, "b c h w -> b h w c").numpy(force=True)
-        K_np_b33: Float[np.ndarray, "b 3 3"] | None = self.K_b33.numpy(force=True) if self.K_b33 is not None else None
-        depth_conf_np_bhw1: Float[np.ndarray, "b h w 1"] | None = (
-            rearrange(self.depth_conf_b1hw, "b c h w -> b h w c").numpy(force=True) if self.depth_conf_b1hw is not None else None
-        )
-        normal_conf_np_bhw1: Float[np.ndarray, "b h w 1"] | None = (
-            rearrange(self.normal_conf_b1hw, "b c h w -> b h w c").numpy(force=True) if self.normal_conf_b1hw is not None else None
-        )
-        return (
-            depth_np_bhw1,
-            normal_np_bhw3,
-            K_np_b33,
-            depth_conf_np_bhw1,
-            normal_conf_np_bhw1,
-        )
 
 
 @dataclass

--- a/packages/monoprior/tools/utils/nerfstudio_to_sdfstudio.py
+++ b/packages/monoprior/tools/utils/nerfstudio_to_sdfstudio.py
@@ -9,12 +9,12 @@ import cv2
 import matplotlib.pyplot as plt
 import numpy as np
 import rerun as rr
-from jaxtyping import Bool, Float64
+from jaxtyping import Bool, Float, Float64
 from tqdm import tqdm
 
 from monopriors.data.nerfstudio_data import load_nerfstudio_from_json
 from monopriors.data.sdfstudio_data import SceneBox, SDFStudioData, SDFStudioFrame
-from monopriors.models.monoprior import DsineAndUnidepth, OldMonoPriorPrediction
+from monopriors.models.monoprior import DsineAndUnidepth, MonoPriorPrediction
 
 
 def main(
@@ -126,12 +126,13 @@ def main(
         # img.save(target_image)
 
         K_33 = K_b33[idx]
-        pred: OldMonoPriorPrediction = model(rgb, K_33.astype(np.float32))
-        depth_np_bhw1, normal_np_bhw3, _ = pred.to_numpy()
+        pred: MonoPriorPrediction = model(rgb, K_33.astype(np.float32))
+        depth_np_hw: Float[np.ndarray, "h w"] = pred.metric_pred.depth_meters
+        normal_np_hw3: Float[np.ndarray, "h w 3"] = pred.normal_pred.normal_hw3.copy()
 
         # convert to normalized like omnidata (this is what nerfstudio accepts)
-        normal_np_bhw3[..., 2] *= -1
-        normal_np_bhw3 = (normal_np_bhw3 + 1.0) / 2.0
+        normal_np_hw3[..., 2] *= -1
+        normal_np_hw3 = (normal_np_hw3 + 1.0) / 2.0
 
         rgb_path = str(target_image.relative_to(output_dir))
 
@@ -139,20 +140,17 @@ def main(
         mono_depth_path = rgb_path.replace("_rgb.png", "_depth.npy")
         mono_normal_path = rgb_path.replace("_rgb.png", "_normal.npy")
 
-        # convert hw1 depth to hw3 using grayscale to rgb
-        depth_np_hw1 = depth_np_bhw1[0]
         # normalize depth to 0-1
-        depth_np_hw1 = (depth_np_hw1 - depth_np_hw1.min()) / (depth_np_hw1.max() - depth_np_hw1.min())
-        depth_np_hw = depth_np_hw1.squeeze()
+        depth_np_hw = (depth_np_hw - depth_np_hw.min()) / (depth_np_hw.max() - depth_np_hw.min())
         np.save(output_dir / mono_depth_path, depth_np_hw)
-        np.save(output_dir / mono_normal_path, normal_np_bhw3[0])
+        np.save(output_dir / mono_normal_path, normal_np_hw3)
         # save as images
         plt.imsave(
             output_dir / mono_depth_path.replace(".npy", ".png"),
             depth_np_hw,
             cmap="viridis",
         )
-        plt.imsave(output_dir / mono_normal_path.replace(".npy", ".png"), normal_np_bhw3[0])
+        plt.imsave(output_dir / mono_normal_path.replace(".npy", ".png"), normal_np_hw3)
 
         frame = SDFStudioFrame(
             rgb_path=rgb_path,
@@ -190,11 +188,11 @@ def main(
             )
             rr.log(
                 f"{pinhole_log_path}/depth",
-                rr.DepthImage(depth_np_bhw1[0]),
+                rr.DepthImage(depth_np_hw),
             )
             rr.log(
                 f"{pinhole_log_path}/normal",
-                rr.Image(normal_np_bhw3[0]),
+                rr.Image(normal_np_hw3),
             )
 
     # scene bbox for the scannet scene


### PR DESCRIPTION
Stacked on `moge-v2-adapters` (part 2). Part 3/3, tiny and independent in content.

`OldMonoPriorPrediction` (legacy torch BCHW dataclass) had exactly one caller, `tools/utils/nerfstudio_to_sdfstudio.py`, which unpacked three names from its five-tuple `to_numpy()` — so the tool raised `ValueError` on every run. The tool now reads `MonoPriorPrediction.metric_pred.depth_meters` / `.normal_pred.normal_hw3`; the legacy type and its re-export are deleted.

monoprior `lint` / `typecheck` / `deadcode` / `tests` exit 0.
