### PR TITLE
simplecv: log_video streams timestamps from the VideoStream chunks (no AssetVideo probe) + output_codec

### DIFF
--- a/packages/simplecv/simplecv/rerun_log_utils.py
+++ b/packages/simplecv/simplecv/rerun_log_utils.py
@@ -4,6 +4,7 @@ import json
 import os
 import shutil
 import sys
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from fractions import Fraction
 from pathlib import Path
@@ -255,6 +256,7 @@ def log_video(
     timeline: str = "video_time",
     *,
     recording: rr.RecordingStream | None = None,
+    output_codec: rr.VideoCodec | None = None,
 ) -> Int[ndarray, "num_frames"]:
     """
     Logs a video and its frame timestamps.
@@ -264,6 +266,7 @@ def log_video(
         video_log_path: The entity path where the video log will be saved.
         timeline: Timeline name for frame timestamps.
         recording: Optional specific recording stream to log to.
+        output_codec: Output codec override; ``None`` keeps the source codec.
 
     Returns:
         Frame timestamps in nanoseconds, sorted ascending.
@@ -271,30 +274,34 @@ def log_video(
     Raises:
         RuntimeError: When Rerun cannot ingest or transcode the MP4.
     """
-    try:
-        frame_timestamps_ns: Int[ndarray, "num_frames"] = rr.AssetVideo(
-            path=video_source
-        ).read_frame_timestamps_nanos()
-    except RuntimeError as exc:
-        raise RuntimeError(f"Failed to read frame timestamps from {video_source}: {exc}") from exc
-
     target_recording: rr.RecordingStream | None = (
         recording if recording is not None else rr.get_global_data_recording()
     )
     if target_recording is None:
         raise RuntimeError("No active Rerun recording. Call rr.init() or pass recording= before logging video.")
+    # The VideoStream chunks carry the sample times on ``timeline``; they are the frame
+    # timestamps, so no separate AssetVideo probe (which rejects QuickTime-brand .MOV files).
+    times: list[Int[ndarray, "rows"]] = []
     try:
-        reader = rr.experimental.Mp4Reader(
+        reader: rr.experimental.Mp4Reader = rr.experimental.Mp4Reader(
             video_source,
             mode="stream",
             entity_path=str(video_log_path),
             timeline_name=timeline,
-            transcode=rr.experimental.Mp4TranscodeOptions(try_gpu=True),
+            transcode=rr.experimental.Mp4TranscodeOptions(output_codec=output_codec, try_gpu=True),
         )
-        target_recording.send_chunks(reader.stream())
+
+        def _chunks_recording_times() -> Iterator[rr.experimental.Chunk]:
+            for chunk in reader.stream():
+                if not chunk.is_static:
+                    times.append(chunk.to_record_batch().column(timeline).to_numpy().astype("timedelta64[ns]").astype(np.int64))
+                yield chunk
+
+        target_recording.send_chunks(_chunks_recording_times())
     except RuntimeError as exc:
         raise RuntimeError(f"Mp4Reader failed for {video_source}: {exc}") from exc
 
+    frame_timestamps_ns: Int[ndarray, "num_frames"] = np.sort(np.concatenate(times)) if times else np.empty(0, dtype=np.int64)
     return frame_timestamps_ns
 
 

--- a/packages/simplecv/tests/test_log_video.py
+++ b/packages/simplecv/tests/test_log_video.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import socket
+from collections.abc import Iterable, Iterator
 from pathlib import Path
+from typing import TypeAlias
 
 import av
 import numpy as np
 import pytest
 import rerun as rr
-from jaxtyping import UInt8
+from jaxtyping import Int64, UInt8
 from numpy import ndarray
+from pyarrow import ChunkedArray
 
 from simplecv.rerun_log_utils import (
     log_video,
@@ -22,6 +25,7 @@ _FRAME_COUNT: int = 12
 _WIDTH: int = 64
 _HEIGHT: int = 64
 _FPS: int = 30
+VideoStreamData: TypeAlias = tuple[rr.VideoCodec, ChunkedArray, ChunkedArray]
 
 
 def _frame_pixels(i: int) -> UInt8[ndarray, "h w 3"]:
@@ -79,6 +83,25 @@ def synthetic_mpeg4_mp4(tmp_path_factory: pytest.TempPathFactory) -> Path:
     return out_path
 
 
+@pytest.fixture(scope="session")
+def synthetic_hevc_mp4(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Deterministic HEVC MP4 large enough for the NVENC transcode path."""
+    out_path: Path = tmp_path_factory.mktemp("log_video") / "synthetic-hevc.mp4"
+    container: av.container.OutputContainer = av.open(str(out_path), mode="w")
+    stream: av.video.stream.VideoStream = container.add_stream("libx265", rate=_FPS, options={"preset": "ultrafast"})
+    stream.width = _WIDTH * 4
+    stream.height = _HEIGHT * 4
+    stream.pix_fmt = "yuv420p"
+    for i in range(_FRAME_COUNT):
+        big_rgb: UInt8[ndarray, "h w 3"] = np.tile(_frame_pixels(i), (4, 4, 1))
+        for packet in stream.encode(av.VideoFrame.from_ndarray(big_rgb, format="rgb24")):
+            container.mux(packet)
+    for packet in stream.encode():
+        container.mux(packet)
+    container.close()
+    return out_path
+
+
 def _decode_mp4(source: Path) -> list[UInt8[ndarray, "h w 3"]]:
     container: av.container.InputContainer = av.open(str(source), mode="r")
     frames: list[UInt8[ndarray, "h w 3"]] = []
@@ -126,12 +149,94 @@ def test_log_video_timestamps_match(synthetic_h264_mp4: Path, tmp_path: Path) ->
     rec_stream.save(str(tmp_path / "stream.rrd"))
 
     entity: Path = Path("/video")
-    ts_asset: ndarray = rr.AssetVideo(path=synthetic_h264_mp4).read_frame_timestamps_nanos()
-    ts_stream: ndarray = log_video(synthetic_h264_mp4, entity, recording=rec_stream)
+    ts_asset: Int64[ndarray, "num_frames"] = rr.AssetVideo(path=synthetic_h264_mp4).read_frame_timestamps_nanos()
+    ts_stream: Int64[ndarray, "num_frames"] = log_video(synthetic_h264_mp4, entity, recording=rec_stream)
 
     assert len(ts_asset) == _FRAME_COUNT
     assert len(ts_stream) == _FRAME_COUNT
     np.testing.assert_array_equal(np.sort(ts_asset), np.sort(ts_stream))
+
+
+def test_log_video_accepts_quicktime_brand(synthetic_h264_mp4: Path, tmp_path: Path) -> None:
+    """iPhone .MOV files carry the ``qt`` brand (sniffed as video/quicktime, which rr.AssetVideo rejects)."""
+    mov_path: Path = tmp_path / "clip.MOV"
+    with av.open(str(synthetic_h264_mp4)) as src, av.open(str(mov_path), mode="w", format="mov") as dst:
+        in_stream: av.video.stream.VideoStream = src.streams.video[0]
+        out_stream: av.video.stream.VideoStream = dst.add_stream_from_template(in_stream)
+        for packet in src.demux(in_stream):
+            if packet.dts is None:
+                continue
+            packet.stream = out_stream
+            dst.mux(packet)
+    assert mov_path.read_bytes()[4:12] == b"ftypqt  "
+
+    rec: rr.RecordingStream = rr.RecordingStream(application_id="test-log-video-mov", recording_id="mov")
+    rec.save(str(tmp_path / "mov.rrd"))
+    ts_stream: Int64[ndarray, "num_frames"] = log_video(mov_path, Path("/video"), recording=rec)
+    assert len(ts_stream) == _FRAME_COUNT
+
+
+def test_log_video_sends_chunks_incrementally(synthetic_h264_mp4: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The recording receives Mp4Reader's lazy iterator instead of a materialized chunk list."""
+    received: list[rr.experimental.Chunk] = []
+
+    def consume_lazily(_recording: rr.RecordingStream, chunks: Iterable[rr.experimental.Chunk]) -> None:
+        assert not isinstance(chunks, list)
+        chunk_iterator: Iterator[rr.experimental.Chunk] = iter(chunks)
+        assert chunk_iterator is chunks
+        received.extend(chunks)
+
+    monkeypatch.setattr(rr.RecordingStream, "send_chunks", consume_lazily)
+    rec: rr.RecordingStream = rr.RecordingStream(application_id="test-log-video-lazy", recording_id="lazy")
+
+    timestamps_ns: Int64[ndarray, "num_frames"] = log_video(synthetic_h264_mp4, Path("/video"), recording=rec)
+
+    assert received
+    assert len(timestamps_ns) == _FRAME_COUNT
+
+
+def test_log_video_reencodes_hevc_to_h264(synthetic_hevc_mp4: Path, tmp_path: Path) -> None:
+    """Callers can request H.264 output for browser compatibility."""
+    if not _can_open_local_socket():
+        pytest.skip("Rerun RRD query server cannot open a local socket in this environment")
+    rrd_path: Path = tmp_path / "hevc.rrd"
+    rec: rr.RecordingStream = rr.RecordingStream(application_id="test-log-video-hevc", recording_id="hevc")
+    rec.save(str(rrd_path))
+    ts_stream: Int64[ndarray, "num_frames"] = log_video(
+        synthetic_hevc_mp4,
+        Path("/video"),
+        timeline="video_time",
+        recording=rec,
+        output_codec=rr.VideoCodec.H264,
+    )
+    rec.flush()
+    rec.disconnect()
+    assert len(ts_stream) == _FRAME_COUNT
+    stream_data: VideoStreamData = read_video_stream_from_rrd(str(rrd_path), "video", "video_time")
+    codec: rr.VideoCodec = stream_data[0]
+    assert codec == rr.VideoCodec.H264
+
+
+def test_log_video_keeps_hevc_without_output_codec(synthetic_hevc_mp4: Path, tmp_path: Path) -> None:
+    """The shared helper preserves the source codec unless its caller requests another one."""
+    if not _can_open_local_socket():
+        pytest.skip("Rerun RRD query server cannot open a local socket in this environment")
+    rrd_path: Path = tmp_path / "hevc-preserved.rrd"
+    rec: rr.RecordingStream = rr.RecordingStream(application_id="test-log-video-hevc-preserved", recording_id="hevc-preserved")
+    rec.save(str(rrd_path))
+    ts_stream: Int64[ndarray, "num_frames"] = log_video(
+        synthetic_hevc_mp4,
+        Path("/video"),
+        timeline="video_time",
+        recording=rec,
+    )
+    rec.flush()
+    rec.disconnect()
+
+    assert len(ts_stream) == _FRAME_COUNT
+    stream_data: VideoStreamData = read_video_stream_from_rrd(str(rrd_path), "video", "video_time")
+    codec: rr.VideoCodec = stream_data[0]
+    assert codec == rr.VideoCodec.H265
 
 
 def test_log_video_stream_requires_supported_codec(
@@ -163,7 +268,7 @@ def test_log_video_preserves_video_read_failure_context(tmp_path: Path) -> None:
     )
     rec.save(str(tmp_path / "corrupt.rrd"))
 
-    with pytest.raises(RuntimeError, match="Failed to read frame timestamps from") as exc_info:
+    with pytest.raises(RuntimeError, match="Mp4Reader failed for") as exc_info:
         log_video(corrupt_mp4, Path("/video"), recording=rec)
 
     assert str(corrupt_mp4) in str(exc_info.value)
@@ -191,11 +296,14 @@ def test_log_video_stream_roundtrip_pixels_match_source(
         entity=entity,
         timeline=timeline,
     )
-    codec, times, samples_chunked = read_video_stream_from_rrd(
+    stream_data: VideoStreamData = read_video_stream_from_rrd(
         str(stream_rrd),
         entity.lstrip("/"),
         timeline,
     )
+    codec: rr.VideoCodec = stream_data[0]
+    times: ChunkedArray = stream_data[1]
+    samples_chunked: ChunkedArray = stream_data[2]
     assert codec == rr.VideoCodec.H264
     stream_mp4: Path = tmp_path / "stream_remuxed.mp4"
     mux_h264_to_mp4(times, samples_chunked, str(stream_mp4))


### PR DESCRIPTION
Stacked on #139 (only because posekit's next PR needs `output_codec`; the diff itself touches simplecv only).

- Frame timestamps now come from the `Mp4Reader` chunks' timeline column, tapped by a generator that still streams lazily into `send_chunks`. The former `rr.AssetVideo(...).read_frame_timestamps_nanos()` probe rejected QuickTime-brand files (`iPhone .MOV` → "MIME type 'video/quicktime' is not supported").
- New keyword-only `output_codec: rr.VideoCodec | None = None`. `None` keeps the source codec (AV1 pipelines such as exoego ingest are unchanged). B-frame sources are re-encoded by Rerun either way; `try_gpu=True` uses NVENC/VideoToolbox when present.
- Tests: `qt`-brand `.MOV` logs; HEVC stays HEVC by default and becomes H.264 on request; chunks reach `send_chunks` as an iterator, not a list; corrupt file keeps the `Mp4Reader failed for` context.

Verified: simplecv lint/typecheck, `test_log_video.py` 8 passed; on a 70 s 1080p HEVC iPhone clip the H.264 request takes 4.0 s on a 5090.