### PR TITLE
posekit: click-to-track Config tab, quarter-res masks, iPhone .MOV support

### DIFF
--- a/packages/posekit/README.md
+++ b/packages/posekit/README.md
@@ -99,6 +99,41 @@ pixi run -e posekit --frozen posekit-video-pose --video-path video.mp4 rtdetr vi
 pixi run -e posekit --frozen posekit-video-track --video-path video.mp4
 ```
 
+## Click-to-track app (SAM2 + Rerun)
+
+A Gradio app for single-object video segmentation: upload a clip, click the object in
+the embedded Rerun viewer, refine on any frame, and propagate the mask through the clip.
+
+```bash
+pixi run -e posekit --frozen posekit-track-app            # http://127.0.0.1:7870
+pixi run -e posekit --frozen posekit-track-app --port 7870 --variant efficienttam-s-512
+```
+
+The embedded viewer needs a secure context; on the tailnet expose it with
+`tailscale serve --bg --https=7870 http://127.0.0.1:7870` and open
+`https://<host>.<tailnet>.ts.net:7870/` (served at `/`, so `--root-path` stays empty).
+Run it in a shell without `DISPLAY`: the app never spawns a native viewer.
+
+Using it:
+
+- **Click** the object in the viewer at the current frame (`+ Include`); `− Exclude` and
+  `✕ Remove` add negative points / delete the nearest point. Pause the viewer before
+  clicking — while it plays the click's frame is unknown. Scrubbing shows a memory-conditioned
+  preview of the current mask.
+- **Track** propagates from the first prompted frame forward, then backward to frame 0, and
+  streams masks plus per-frame confidence traces. Clicking again after a track refines it;
+  Track re-runs from the kept prompts.
+- **Config** tab: model (`efficienttam-s-512` default, `-ti-512` faster), SAM2 memory window,
+  point-removal radius, and "re-segment" (clicks replace the object instead of refining it).
+  Model and memory window reload the clip and clear the points.
+- **Outputs** tab: after a track, download a self-contained `.rrd` (video, prompts, masks,
+  confidence). Masks are logged at 1/4 resolution under a `Transform3D(scale=4)` on
+  both `video/mask` and `video/preview`; apply it when reading them back.
+
+H.264 input passes through unchanged. HEVC input in MP4 or MOV is transcoded to H.264,
+using the GPU when available, so browsers can decode it. Other codecs depend on Rerun
+`Mp4Reader` support; MPEG-4 Part 2 (`mp4v`) is not supported and fails at load.
+
 ## What runs today, and how well
 
 Every implementation is parity-validated against its reference:

--- a/packages/posekit/src/posekit/apis/click_tracker.py
+++ b/packages/posekit/src/posekit/apis/click_tracker.py
@@ -75,7 +75,6 @@ class ClickTracker:
         *,
         device: str = "cuda",
         memory_window_size: int = 10,
-        remove_radius_px: float = 100.0,
     ) -> None:
         """Open the clip and start an empty memory state.
 
@@ -84,20 +83,23 @@ class ClickTracker:
             predictor: A ``SAM2GenericVideoPredictor`` (e.g. ``Sam2VideoSegmenter(...).predictor``).
             device: CUDA device for decode + inference.
             memory_window_size: Non-conditional memories kept around the current frame.
-            remove_radius_px: How close a click must be to an existing point to remove it.
 
         Raises:
             ValueError: If the clip has no decodable frames.
         """
         self.predictor = predictor
         self.device: str = device
-        self.remove_radius_px: float = remove_radius_px
         # torchcodec's CUDA (NVDEC) decoder is thread-affine: any call from a thread
         # other than the one that created it fails ("Failed to create NVDEC decoder:
         # 201" / "Could not receive frame from decoder"), even when serialized. Web
         # callbacks run on pool threads, so the decoder lives on its own thread and
         # every decode is executed there.
-        self._video_reader: TorchCodecVideoReader = TorchCodecVideoReader(video_path, device=device, thread_owned=True)
+        # Clicks are random access, so seek exactly despite the open-time index scan: the
+        # approximate header index overshoots on some clips (iPhone .MOV), and the last
+        # frames then fail with "Requested next frame while there are no more frames left to decode".
+        self._video_reader: TorchCodecVideoReader = TorchCodecVideoReader(
+            video_path, device=device, thread_owned=True, seek_mode="exact"
+        )
         if self._video_reader.frame_cnt <= 0:
             raise ValueError(f"{video_path} has no decodable frames.")
         self.num_frames: int = self._video_reader.frame_cnt
@@ -162,13 +164,13 @@ class ClickTracker:
         assert result is not None
         return result
 
-    def remove_point_near(self, frame_idx: int, x: float, y: float) -> PointEdit:
-        """Remove the closest point on the frame within ``remove_radius_px`` (Kineo's Shift+Click)."""
+    def remove_point_near(self, frame_idx: int, x: float, y: float, *, radius_px: float) -> PointEdit:
+        """Remove the closest point on the frame within ``radius_px`` (Kineo's Shift+Click)."""
         candidates: tuple[Point, ...] = self.points_on(frame_idx)
         if not candidates:
             return PointEdit(point=None, result=None)
         nearest: Point = min(candidates, key=lambda p: (p.x - x) ** 2 + (p.y - y) ** 2)
-        if (nearest.x - x) ** 2 + (nearest.y - y) ** 2 > self.remove_radius_px**2:
+        if (nearest.x - x) ** 2 + (nearest.y - y) ** 2 > radius_px**2:
             return PointEdit(point=None, result=None)
         self._points.remove(nearest)
         return PointEdit(point=nearest, result=self.refresh(frame_idx))

--- a/packages/posekit/src/posekit/track_ui.py
+++ b/packages/posekit/src/posekit/track_ui.py
@@ -22,7 +22,7 @@ import uuid
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal, TypeAlias
+from typing import Literal, TypeAlias, get_args
 
 import gradio as gr
 import numpy as np
@@ -44,9 +44,14 @@ VIDEO: str = "video"
 TIMELINE: str = "video_time"
 Mode: TypeAlias = Literal["+ Include", "− Exclude", "✕ Remove"]
 MODES: list[Mode] = ["+ Include", "− Exclude", "✕ Remove"]
+TabName: TypeAlias = Literal["Input", "Config", "Outputs"]
+RecordingPair: TypeAlias = tuple[rr.RecordingStream, rr.BinaryStream]
 POSITIVE_COLOR: tuple[int, int, int] = (76, 220, 96)
 NEGATIVE_COLOR: tuple[int, int, int] = (255, 87, 51)
 MASK_COLOR: tuple[int, int, int] = (51, 178, 255)
+MASK_SCALE: int = 4
+"""Masks are logged at 1/MASK_SCALE resolution under a static scale transform: a full-res
+uint8 mask per frame costs ~40x the video in viewer memory, and SAM2's logits are 128^2 anyway."""
 RRD_DIR: Path = Path("/tmp/posekit-rrd")
 _EXAMPLES_DIR: Path = Path(__file__).resolve().parents[2] / "assets" / "examples"
 EXAMPLE_VIDEOS: list[str] = [
@@ -60,6 +65,7 @@ EXAMPLE_VIDEOS: list[str] = [
     )
     if path.is_file()
 ]
+DEFAULT_VARIANT: Sam2Variant = "efficienttam-s-512"
 
 
 @dataclass(frozen=True, slots=True)
@@ -70,7 +76,7 @@ class AppConfig:
     """Port to serve on."""
     root_path: str = ""
     """Root path when mounted under a reverse-proxy subpath (empty when served at ``/``)."""
-    variant: Sam2Variant = "efficienttam-s-512"
+    variant: Sam2Variant = DEFAULT_VARIANT
     """SAM2-family checkpoint. -s (Kineo's pick) holds a point-seeded track through the clip where -ti drifts."""
 
 
@@ -106,7 +112,10 @@ class Session:
     """Monotonic callback-part number within this session."""
 
 
-VARIANT: Sam2Variant = "efficienttam-s-512"
+SAM2_VARIANTS: list[Sam2Variant] = list(get_args(Sam2Variant))
+# The interactive tracker favors a longer window than Sam2VideoSegmenterConfig's streaming default of 7.
+DEFAULT_MEMORY_WINDOW: int = 10
+DEFAULT_REMOVE_RADIUS_PX: float = 100.0
 
 
 @functools.cache
@@ -178,7 +187,11 @@ def _viewer_time_s(session: Session, frame_idx: int) -> float:
 
 
 def _clear_preview(rec: rr.RecordingStream, session: Session) -> None:
-    """Remove the static scrub preview (no-op when none is shown)."""
+    """Remove the static scrub preview (no-op when none is shown).
+
+    A native Rerun 0.36.2 pixel check confirms that this same-entity static
+    ``Clear`` leaves ``video/preview``'s static scale transform in effect.
+    """
     if session.preview_visible:
         rec.log(f"{VIDEO}/preview", rr.Clear(recursive=False), static=True)
         session.preview_visible = False
@@ -232,9 +245,13 @@ def _log_mask(rec: rr.RecordingStream, session: Session, mask_hw: UInt8[ndarray,
         _bound_next_frame(rec, session, entity, frame_idx, session.masked_frames)
 
 
-def _mask_hw(result: MaskResult | None) -> UInt8[ndarray, "h w"] | None:
-    """Copy one result mask from the inference device for Rerun logging."""
-    return None if result is None else result.mask.cpu().numpy().astype(np.uint8)
+def _mask_hw(result: MaskResult) -> UInt8[ndarray, "h w"]:
+    """Copy one result mask from the inference device, downsampled for Rerun logging.
+
+    Strided sampling rounds each output dimension up, so a non-multiple of
+    ``MASK_SCALE`` can overhang the full-resolution image by up to three pixels.
+    """
+    return result.mask[::MASK_SCALE, ::MASK_SCALE].cpu().numpy().astype(np.uint8)
 
 
 def _log_confidence(rec: rr.RecordingStream, session: Session, result: MaskResult) -> None:
@@ -269,29 +286,69 @@ def _status(session: Session, prefix: str) -> str:
 # ── callbacks ─────────────────────────────────────────────────────────────
 
 
-def load_video(video: str | None, previous_session: Session | None) -> Iterator[tuple[bytes | None, Session | None, str, str, Any, Any]]:
-    """Start a fresh session + recording for the clip (generators only: the streaming viewer rejects plain bytes)."""
-    _close_session(previous_session)
+def show_control_tab(selected: TabName) -> tuple[gr.Column, gr.Column, gr.Column]:
+    """Show only the controls panel selected by the tab-strip radio."""
+    return (
+        gr.Column(visible=selected == "Input"),
+        gr.Column(visible=selected == "Config"),
+        gr.Column(visible=selected == "Outputs"),
+    )
+
+
+def load_video(
+    video: str | None,
+    previous_session: Session | None,
+    variant: str,
+    memory_window: float,
+    *,
+    selected_tab: TabName = "Input",
+) -> Iterator[tuple[bytes | None, Session | None, str, str, TabName, gr.DownloadButton]]:
+    """Start a fresh session + recording for the clip (generators only: the streaming viewer rejects plain bytes).
+
+    ``variant`` and ``memory_window`` come from the Config panel; both shape the
+    tracker's memory state, so changing them re-runs this and starts the clip over.
+    """
     if video is None:
-        yield None, None, "Upload a video to begin.", "Upload a video to begin.", gr.Tabs(selected="input"), gr.DownloadButton(visible=False)
+        _close_session(previous_session)
+        yield (
+            None,
+            None,
+            "Upload a video to begin.",
+            "Upload a video to begin.",
+            selected_tab,
+            gr.DownloadButton(visible=False),
+        )
         return
     recording_id: str = str(uuid.uuid4())
     video_path: Path = Path(video)
-    tracker: ClickTracker = ClickTracker(video_path, _predictor(VARIANT))
+    if variant not in SAM2_VARIANTS:
+        raise gr.Error(f"Unknown model {variant!r}.")
+    tracker: ClickTracker = ClickTracker(video_path, _predictor(variant), memory_window_size=int(memory_window))
+    _close_session(previous_session)
     session: Session = Session(
         tracker=tracker,
         video_path=video_path,
         recording_id=recording_id,
         frame_timestamps_ns=np.empty(0, dtype=np.int64),
     )
-    rec, stream = _open_recording(session)
+    recording_pair: RecordingPair = _open_recording(session)
+    rec: rr.RecordingStream = recording_pair[0]
+    stream: rr.BinaryStream = recording_pair[1]
     rec.send_blueprint(_blueprint())
     rec.log(
         VIDEO,
         rr.AnnotationContext([rr.AnnotationInfo(id=0, label="background", color=(0, 0, 0, 0)), rr.AnnotationInfo(id=1, label="object", color=MASK_COLOR)]),
         static=True,
     )
-    session.frame_timestamps_ns = log_video(video_path, Path(VIDEO), timeline=TIMELINE, recording=rec)
+    for entity in (f"{VIDEO}/mask", f"{VIDEO}/preview"):
+        rec.log(entity, rr.Transform3D(scale=float(MASK_SCALE)), static=True)
+    session.frame_timestamps_ns = log_video(
+        video_path,
+        Path(VIDEO),
+        timeline=TIMELINE,
+        recording=rec,
+        output_codec=rr.VideoCodec.H264,
+    )
     stream.flush()
     payload: bytes | None = stream.read()
     rec.disconnect()
@@ -300,9 +357,19 @@ def load_video(video: str | None, previous_session: Session | None) -> Iterator[
         session,
         "Click the object on frame 0, or scrub (drag / ← →) to another frame first. Add − to exclude; Remove deletes a point.",
         "Click the object on frame 0, or scrub (drag / ← →) to another frame first. Add − to exclude; Remove deletes a point.",
-        gr.Tabs(selected="input"),
+        selected_tab,
         gr.DownloadButton(visible=False),
     )
+
+
+def _reload_video_from_config(
+    video: str | None,
+    previous_session: Session | None,
+    variant: str,
+    memory_window: float,
+) -> Iterator[tuple[bytes | None, Session | None, str, str, TabName, gr.DownloadButton]]:
+    """Reload tracker configuration without moving the controls away from Config."""
+    yield from load_video(video, previous_session, variant, memory_window, selected_tab="Config")
 
 
 def record_time(session: Session | None, stamp: float | None, evt: TimeUpdate) -> None:
@@ -344,7 +411,9 @@ def on_time_update(session: Session | None, evt: TimeUpdate) -> Iterator[tuple[b
         if not session.preview_visible:
             yield b"", gr.skip(), gr.skip()
             return
-        rec, stream = _open_recording(session, write_part=False)
+        recording_pair: RecordingPair = _open_recording(session, write_part=False)
+        rec: rr.RecordingStream = recording_pair[0]
+        stream: rr.BinaryStream = recording_pair[1]
         _clear_preview(rec, session)
         stream.flush()
         payload: bytes | None = stream.read()
@@ -358,7 +427,9 @@ def on_time_update(session: Session | None, evt: TimeUpdate) -> Iterator[tuple[b
     frame_text: str = f"Viewer at frame {frame_idx} — a click prompts this frame."
     # The preview is *static* (no timeline → no ticks, overwritten in place), so it
     # must go away the moment the cursor leaves the frame it was computed for.
-    rec, stream = _open_recording(session, write_part=False)
+    recording_pair = _open_recording(session, write_part=False)
+    rec = recording_pair[0]
+    stream = recording_pair[1]
     _clear_preview(rec, session)
     stamp: float = session.last_stamp
     wants_preview: bool = bool(session.tracker.points) and not session.tracker.points_on(frame_idx)
@@ -367,7 +438,8 @@ def on_time_update(session: Session | None, evt: TimeUpdate) -> Iterator[tuple[b
     if wants_preview and session.last_stamp == stamp:
         result: MaskResult | None = session.tracker.preview(frame_idx)
         if result is not None and session.last_stamp == stamp and not session.playing:  # discard late results
-            rec.log(f"{VIDEO}/preview", rr.SegmentationImage(result.mask.cpu().numpy().astype(np.uint8)), static=True)
+            preview_hw: UInt8[ndarray, "h w"] = _mask_hw(result)
+            rec.log(f"{VIDEO}/preview", rr.SegmentationImage(preview_hw), static=True)
             session.preview_visible = True
     stream.flush()
     payload = stream.read()
@@ -375,42 +447,49 @@ def on_time_update(session: Session | None, evt: TimeUpdate) -> Iterator[tuple[b
     yield payload, frame_text, frame_text
 
 
-def on_select(session: Session | None, mode: str, resegment: bool, evt: SelectionChange) -> Iterator[tuple[bytes | None, str, str]]:
+def on_select(
+    session: Session | None, mode: str, resegment: bool, remove_radius_px: float, evt: SelectionChange
+) -> Iterator[tuple[bytes | None, str, str]]:
     """A click on the video at the current frame: add a +/− point or remove the nearest one, then show the mask."""
     # The viewer fires selection_change on recording open and on every click
     # anywhere; ignored selections must still yield a chunk for the streaming
     # viewer output (gr.skip() there crashes Gradio's end_stream).
-    # A click on a masked pixel selects both /video/mask and /video, so take the
-    # first positioned entity under the video rather than demanding exactly one.
-    hits = [i for i in evt.payload.items if i.type == "entity" and i.position is not None and i.entity_path.startswith(f"/{VIDEO}")]
-    if session is None or not hits:
+    # A masked pixel can report both the scaled overlay and the source video.
+    # Only the source entity's hit is guaranteed to use video pixel coordinates.
+    position: list[float] | None = next(
+        (item.position for item in evt.payload.items if item.type == "entity" and item.entity_path == f"/{VIDEO}" and item.position is not None),
+        None,
+    )
+    if session is None or position is None:
         yield b"", gr.skip(), gr.skip()
         return
-    position: list[float] | None = hits[0].position
-    assert position is not None
     if session.playing:
         raise gr.Error("Pause the viewer first — while it plays, the click's frame is unknown.")
-    x, y = float(position[0]), float(position[1])
+    position_xy: tuple[float, float] = (float(position[0]), float(position[1]))
+    x: float = position_xy[0]
+    y: float = position_xy[1]
     # The viewer sends the final time_update of a scrub just before the click; wait for the stream to go quiet.
     deadline: float = time.monotonic() + 0.4
     while time.monotonic() - session.last_time_update < 0.12 and time.monotonic() < deadline:
         time.sleep(0.02)
     frame_idx: int = session.current_frame
-    rec, stream = _open_recording(session)
+    recording_pair: RecordingPair = _open_recording(session)
+    rec: rr.RecordingStream = recording_pair[0]
+    stream: rr.BinaryStream = recording_pair[1]
     _clear_preview(rec, session)
     changed: bool = True
     if mode == "✕ Remove":
-        edit: PointEdit = session.tracker.remove_point_near(frame_idx, x, y)
+        edit: PointEdit = session.tracker.remove_point_near(frame_idx, x, y, radius_px=float(remove_radius_px))
         changed = edit.point is not None
         result: MaskResult | None = edit.result
-        prefix: str = "Removed a point." if changed else f"No point within {session.tracker.remove_radius_px:.0f}px on this frame."
+        prefix: str = "Removed a point." if changed else f"No point within {remove_radius_px:.0f}px on this frame."
     else:
         positive: bool = mode != "− Exclude"
         result = session.tracker.add_point(frame_idx, x, y, positive=positive, resegment=resegment)
         action: str = "Re-segmented +" if resegment else ("Added +" if positive else "Added −")
         prefix = f"{action} at ({x:.0f}, {y:.0f}) on frame {frame_idx}."
     stale: bool = _invalidate_track(rec, session) if changed else False
-    _log_mask(rec, session, _mask_hw(result), frame_idx)
+    _log_mask(rec, session, _mask_hw(result) if result is not None else None, frame_idx)
     _log_points(rec, session, frame_idx)
     stream.flush()
     payload = stream.read()
@@ -425,7 +504,9 @@ def undo(session: Session | None) -> Iterator[tuple[bytes | None, str, str]]:
     """Remove the most recently added point."""
     if session is None:
         raise gr.Error("Upload a video first.")
-    rec, stream = _open_recording(session)
+    recording_pair: RecordingPair = _open_recording(session)
+    rec: rr.RecordingStream = recording_pair[0]
+    stream: rr.BinaryStream = recording_pair[1]
     _clear_preview(rec, session)
     edit: PointEdit = session.tracker.undo()
     if edit.point is None:
@@ -434,7 +515,7 @@ def undo(session: Session | None) -> Iterator[tuple[bytes | None, str, str]]:
         yield b"", status_text, status_text
         return
     stale: bool = _invalidate_track(rec, session)
-    _log_mask(rec, session, _mask_hw(edit.result), edit.point.frame_idx)
+    _log_mask(rec, session, _mask_hw(edit.result) if edit.result is not None else None, edit.point.frame_idx)
     _log_points(rec, session, edit.point.frame_idx)
     stream.flush()
     payload = stream.read()
@@ -450,7 +531,9 @@ def clear(session: Session | None) -> Iterator[tuple[bytes | None, str, str]]:
     """Drop every point, every memory, and every overlay."""
     if session is None:
         raise gr.Error("Upload a video first.")
-    rec, stream = _open_recording(session)
+    recording_pair: RecordingPair = _open_recording(session)
+    rec: rr.RecordingStream = recording_pair[0]
+    stream: rr.BinaryStream = recording_pair[1]
     _clear_preview(rec, session)
     session.tracker.clear()
     stale: bool = _invalidate_track(rec, session)
@@ -468,23 +551,30 @@ def clear(session: Session | None) -> Iterator[tuple[bytes | None, str, str]]:
     yield payload, status_text, status_text
 
 
-def track(session: Session | None) -> Iterator[tuple[bytes | None, str, str, Any, Any]]:
+def track(session: Session | None) -> Iterator[tuple[bytes | None, str, str, object, object]]:
     """Propagate in both directions, stream masks, and write the downloadable RRD."""
     if session is None:
         raise gr.Error("Upload a video first.")
     if not session.tracker.points:
         raise gr.Error("Click at least one point on the object first.")
-    rec, stream = _open_recording(session)
+    recording_pair: RecordingPair = _open_recording(session)
+    rec: rr.RecordingStream = recording_pair[0]
+    stream: rr.BinaryStream = recording_pair[1]
     _clear_preview(rec, session)
     _invalidate_track(rec, session)
     stream.flush()
     status_text: str = "Tracking from the prompted frame in both directions…"
-    yield stream.read(), status_text, status_text, gr.Tabs(selected="outputs"), gr.DownloadButton(visible=False)
+    yield (
+        stream.read(),
+        status_text,
+        status_text,
+        "Outputs",
+        gr.DownloadButton(visible=False),
+    )
     done: int = 0
     low_score: int = 0
     for result in session.tracker.track():
-        mask_hw: UInt8[ndarray, "h w"] | None = _mask_hw(result)
-        assert mask_hw is not None
+        mask_hw: UInt8[ndarray, "h w"] = _mask_hw(result)
         # Dense output: every frame gets its own mask, so no next-frame bounds, and
         # points were already logged (and bounded) when they were placed.
         _log_mask(rec, session, mask_hw, result.frame_idx, bound=False)
@@ -509,7 +599,7 @@ def track(session: Session | None) -> Iterator[tuple[bytes | None, str, str, Any
         payload,
         f"Done: tracked all {done} frames; {low_score} low-confidence frame(s). Add a corrective click where needed, then Track again.",
         f"Done: tracked all {done} frames; {low_score} low-confidence frame(s). Add a corrective click where needed, then Track again.",
-        gr.Tabs(selected="outputs"),
+        "Outputs",
         gr.DownloadButton(value=str(output), visible=True),
     )
 
@@ -562,9 +652,21 @@ html, body, gradio-app, .gradio-container {
     overflow: hidden;
 }
 #left-column, #viewer-column { min-height: 0; }
+/* Only the controls scroll on short viewports; the viewer never moves. Reserve the
+   scrollbar gutter so the controls do not shift horizontally when it appears. */
+#left-column { height: 100%; max-height: 100%; overflow-y: auto; scrollbar-gutter: stable; flex-wrap: nowrap; }
+#left-column > * { flex-shrink: 0; }
 #source-video { height: auto !important; }
 #source-video video { max-height: 225px !important; }
 #examples { flex: none; }
+/* Radio-based tab strip: Gradio 6.13 loops in Svelte when this app renders three
+   native Tab components. The panels below are ordinary Columns. */
+#control-tabs { overflow: visible; min-width: 0 !important; }
+#control-tabs .wrap { display: flex; gap: 0; border-bottom: 1px solid var(--border-color-primary); }
+#control-tabs label { flex: 1; justify-content: center; margin: 0; border: 0; border-bottom: 2px solid transparent; border-radius: 0; background: transparent; padding: 0.55rem 0.4rem; color: var(--body-text-color); cursor: pointer; }
+#control-tabs label.selected { border-bottom-color: var(--color-accent); color: var(--color-accent); }
+#control-tabs input { display: none; }
+#control-tabs span { font-weight: 600; }
 /* Click-mode radio as a segmented pill group. */
 #click-mode .wrap { display: flex; gap: 0; border: 1px solid var(--border-color-primary); border-radius: var(--radius-lg); overflow: hidden; }
 #click-mode label { flex: 1; justify-content: center; margin: 0; border-radius: 0; border: 0; background: var(--background-fill-secondary); padding: 0.45rem 0.4rem; cursor: pointer; }
@@ -594,94 +696,129 @@ footer { display: none !important; }
 """
 
 
-with gr.Blocks(title="posekit: Click to Track") as demo:
-    gr.Markdown(DESCRIPTION, elem_id="app-description")
-    recording_state: gr.State = gr.State(value=None, delete_callback=_close_session)
-    stamp_in: gr.Number = gr.Number(value=0.0, visible=False)
-    with gr.Row(elem_id="main-row"):
-        with gr.Column(scale=1, elem_id="left-column"):
-            # Video and status sit above the tabs: the status must stay visible when
-            # Track auto-switches to Outputs, and it belongs right under the input.
-            video_in: gr.Video = gr.Video(label="Video", height=240, elem_id="source-video")
-            status: gr.Markdown = gr.Markdown("Upload a video to begin.", elem_id="run-status")
-            with gr.Tabs(selected="input") as tabs:
-                with gr.Tab("Input", id="input"):
+def build_demo(config: AppConfig) -> gr.Blocks:
+    """Build a click-to-track app with the requested initial model variant."""
+    with gr.Blocks(title="posekit: Click to Track") as demo:
+        gr.Markdown(DESCRIPTION, elem_id="app-description")
+        recording_state: gr.State = gr.State(value=None, delete_callback=_close_session)
+        stamp_in: gr.Number = gr.Number(value=0.0, visible=False)
+        with gr.Row(elem_id="main-row"):
+            with gr.Column(scale=1, elem_id="left-column"):
+                # Video and status sit above the tabs: the status must stay visible when
+                # Track auto-switches to Outputs, and it belongs right under the input.
+                video_in: gr.Video = gr.Video(label="Video", height=240, elem_id="source-video")
+                status: gr.Markdown = gr.Markdown("Upload a video to begin.", elem_id="run-status")
+                # Three native gr.Tab components trigger a Svelte effect loop in Gradio 6.13.
+                tabs_radio: gr.Radio = gr.Radio(
+                    choices=["Input", "Config", "Outputs"],
+                    value="Input",
+                    show_label=False,
+                    container=False,
+                    elem_id="control-tabs",
+                )
+                with gr.Column() as input_panel:
                     # A segmented control (see #click-mode CSS): the three everyday click modes on one line.
                     mode: gr.Radio = gr.Radio(choices=MODES, value=MODES[0], show_label=False, container=False, elem_id="click-mode")
                     with gr.Row():
                         undo_btn: gr.Button = gr.Button("Undo point", size="sm")
                         clear_btn: gr.Button = gr.Button("Clear", size="sm")
-                    with gr.Accordion("Advanced", open=False):
-                        resegment_box: gr.Checkbox = gr.Checkbox(
-                            value=False,
-                            label="Clicks replace the object (re-segment) instead of refining the propagated mask",
-                        )
-                with gr.Tab("Outputs", id="outputs"):
-                    gr.Markdown("When tracking finishes, download a self-contained Rerun recording with the video, prompts, masks, and confidence traces.")
+                with gr.Column(visible=False) as config_panel:
+                    model_dd: gr.Dropdown = gr.Dropdown(label="Model", choices=SAM2_VARIANTS, value=config.variant)
+                    memory_window_slider: gr.Slider = gr.Slider(
+                        label="Memory window (frames)", minimum=1, maximum=32, step=1, value=DEFAULT_MEMORY_WINDOW
+                    )
+                    remove_radius_slider: gr.Slider = gr.Slider(
+                        label="Remove radius (px)", minimum=10, maximum=300, step=10, value=DEFAULT_REMOVE_RADIUS_PX
+                    )
+                    resegment_box: gr.Checkbox = gr.Checkbox(
+                        value=False,
+                        label="Clicks replace the object (re-segment) instead of refining the propagated mask",
+                    )
+                    gr.Markdown("Model and memory window apply when the clip loads: changing them reloads it and clears the points.")
+                with gr.Column(visible=False) as outputs_panel:
+                    gr.Markdown(
+                        "When tracking finishes, download a self-contained Rerun recording with the video, prompts, masks, and confidence traces."
+                    )
                     download: gr.DownloadButton = gr.DownloadButton("Download the recording (.rrd)", visible=False)
-            with gr.Row():
-                track_btn: gr.Button = gr.Button("Track", variant="primary")
-                stop_btn: gr.Button = gr.Button("Stop", variant="stop")
-            status_probe: gr.Textbox = gr.Textbox(value="Upload a video to begin.", visible="hidden", elem_id="status-probe")
-            # Examples last: a secondary "pick a sample" action, below the controls it feeds.
-            gr.Examples(examples=EXAMPLE_VIDEOS, inputs=[video_in], cache_examples=False, examples_per_page=4, elem_id="examples")
-        with gr.Column(scale=3, elem_id="viewer-column"):
-            viewer: Rerun = Rerun(
-                label="Click to track",
-                streaming=True,
-                panel_states={"time": "expanded", "blueprint": "hidden", "selection": "hidden"},
-                # A CSS height keeps the viewer's own frame inside the fold; a pixel
-                # height would overflow whatever the wrapper is sized to.
-                height=VIEWER_HEIGHT,
-                elem_id="rerun-viewer",
-            )
+                with gr.Row():
+                    track_btn: gr.Button = gr.Button("Track", variant="primary")
+                    stop_btn: gr.Button = gr.Button("Stop", variant="stop")
+                status_probe: gr.Textbox = gr.Textbox(value="Upload a video to begin.", visible="hidden", elem_id="status-probe")
+                # Examples last: a secondary "pick a sample" action, below the controls it feeds.
+                gr.Examples(examples=EXAMPLE_VIDEOS, inputs=[video_in], cache_examples=False, examples_per_page=4, elem_id="examples")
+            with gr.Column(scale=3, elem_id="viewer-column"):
+                viewer: Rerun = Rerun(
+                    label="Click to track",
+                    streaming=True,
+                    panel_states={"time": "expanded", "blueprint": "hidden", "selection": "hidden"},
+                    # A CSS height keeps the viewer's own frame inside the fold; a pixel
+                    # height would overflow whatever the wrapper is sized to.
+                    height=VIEWER_HEIGHT,
+                    elem_id="rerun-viewer",
+                )
 
-    video_in.change(
-        fn=load_video,
-        inputs=[video_in, recording_state],
-        outputs=[viewer, recording_state, status, status_probe, tabs, download],
-        api_visibility="private",
-    )
-    # always_last coalesces the flood of time updates while scrubbing/playing into "the latest one".
-    viewer.time_update(
-        fn=record_time,
-        inputs=[recording_state, stamp_in],
-        outputs=None,
-        queue=False,
-        trigger_mode="multiple",
-        js="(session, _stamp) => [session, performance.now()]",
-        api_visibility="private",
-    )
-    viewer.play(fn=on_play, inputs=[recording_state], outputs=None, queue=False, trigger_mode="multiple", api_visibility="private")
-    viewer.pause(fn=on_pause, inputs=[recording_state], outputs=None, queue=False, trigger_mode="multiple", api_visibility="private")
-    viewer.time_update(
-        fn=on_time_update,
-        inputs=[recording_state],
-        outputs=[viewer, status, status_probe],
-        trigger_mode="always_last",
-        show_progress="hidden",
-        api_visibility="private",
-    )
-    viewer.selection_change(
-        fn=on_select,
-        inputs=[recording_state, mode, resegment_box],
-        outputs=[viewer, status, status_probe],
-        show_progress="hidden",
-        api_visibility="private",
-    )
-    undo_btn.click(fn=undo, inputs=[recording_state], outputs=[viewer, status, status_probe], api_visibility="private")
-    clear_btn.click(fn=clear, inputs=[recording_state], outputs=[viewer, status, status_probe], api_visibility="private")
-    track_event = track_btn.click(fn=track, inputs=[recording_state], outputs=[viewer, status, status_probe, tabs, download])
-    stop_btn.click(fn=stop_tracking, outputs=[status, status_probe], cancels=[track_event], queue=False)
+        video_in.change(
+            fn=load_video,
+            inputs=[video_in, recording_state, model_dd, memory_window_slider],
+            outputs=[viewer, recording_state, status, status_probe, tabs_radio, download],
+            api_visibility="private",
+        )
+        # Model and memory window shape the tracker state, so each change reloads the clip while Config stays selected.
+        for event in (model_dd.change, memory_window_slider.release):
+            event(
+                fn=_reload_video_from_config,
+                inputs=[video_in, recording_state, model_dd, memory_window_slider],
+                outputs=[viewer, recording_state, status, status_probe, tabs_radio, download],
+                api_visibility="private",
+            )
+        tabs_radio.change(
+            fn=show_control_tab,
+            inputs=[tabs_radio],
+            outputs=[input_panel, config_panel, outputs_panel],
+            queue=False,
+            show_progress="hidden",
+            api_visibility="private",
+        )
+        # always_last coalesces the flood of time updates while scrubbing/playing into "the latest one".
+        viewer.time_update(
+            fn=record_time,
+            inputs=[recording_state, stamp_in],
+            outputs=None,
+            queue=False,
+            trigger_mode="multiple",
+            js="(session, _stamp) => [session, performance.now()]",
+            api_visibility="private",
+        )
+        viewer.play(fn=on_play, inputs=[recording_state], outputs=None, queue=False, trigger_mode="multiple", api_visibility="private")
+        viewer.pause(fn=on_pause, inputs=[recording_state], outputs=None, queue=False, trigger_mode="multiple", api_visibility="private")
+        viewer.time_update(
+            fn=on_time_update,
+            inputs=[recording_state],
+            outputs=[viewer, status, status_probe],
+            trigger_mode="always_last",
+            show_progress="hidden",
+            api_visibility="private",
+        )
+        viewer.selection_change(
+            fn=on_select,
+            inputs=[recording_state, mode, resegment_box, remove_radius_slider],
+            outputs=[viewer, status, status_probe],
+            show_progress="hidden",
+            api_visibility="private",
+        )
+        undo_btn.click(fn=undo, inputs=[recording_state], outputs=[viewer, status, status_probe], api_visibility="private")
+        clear_btn.click(fn=clear, inputs=[recording_state], outputs=[viewer, status, status_probe], api_visibility="private")
+        track_event = track_btn.click(fn=track, inputs=[recording_state], outputs=[viewer, status, status_probe, tabs_radio, download])
+        stop_btn.click(fn=stop_tracking, outputs=[status, status_probe], cancels=[track_event], queue=False)
+
+    return demo
 
 
 # The embedded viewer stream needs a secure context: on the tailnet use
 # `tailscale serve --bg --https=<port> http://127.0.0.1:<port>` (served at `/`, so root_path stays empty).
 def launch(config: AppConfig) -> None:
     """Launch the click-to-track Gradio app."""
-    global VARIANT
-    VARIANT = config.variant  # read by load_video, which caches one predictor per variant
-    demo.launch(
+    build_demo(config).launch(
         server_port=config.port,
         root_path=config.root_path,
         allowed_paths=sorted({str(Path(example).parent) for example in EXAMPLE_VIDEOS} | {str(RRD_DIR)}),

--- a/packages/posekit/tests/test_click_tracker.py
+++ b/packages/posekit/tests/test_click_tracker.py
@@ -66,10 +66,10 @@ def test_negative_point_shrinks_and_removal_restores(tracker: ClickTracker) -> N
     full = tracker.add_point(0, *CHEST, positive=True)
     shrunk = tracker.add_point(0, 320.0, 320.0, positive=False)  # on the face
     assert int(shrunk.mask.sum()) < int(full.mask.sum())
-    edit: PointEdit = tracker.remove_point_near(0, 325.0, 318.0)
+    edit: PointEdit = tracker.remove_point_near(0, 325.0, 318.0, radius_px=100.0)
     assert edit.point is not None and not edit.point.positive and edit.result is not None
     assert abs(int(edit.result.mask.sum()) - int(full.mask.sum())) < 0.02 * int(full.mask.sum())
-    assert tracker.remove_point_near(0, 10.0, 10.0) == PointEdit(point=None, result=None)
+    assert tracker.remove_point_near(0, 10.0, 10.0, radius_px=100.0) == PointEdit(point=None, result=None)
 
 
 @cuda_only

--- a/packages/posekit/tests/test_track_ui.py
+++ b/packages/posekit/tests/test_track_ui.py
@@ -1,37 +1,47 @@
 """Pure helpers of the click-to-track UI."""
 
+import json
 import subprocess
 from pathlib import Path
-from typing import cast
+from typing import TypeAlias, cast
 from unittest.mock import Mock
 
+import gradio as gr
 import numpy as np
+import pytest
 import rerun as rr
 import rerun.experimental as rrx
+import torch
+from gradio_rerun.events import SelectionChange
+from jaxtyping import Int64, UInt8
+from numpy import ndarray
 
 import posekit.track_ui as track_ui
-from posekit.apis.click_tracker import ClickTracker
-from posekit.track_ui import Session, _close_session, _invalidate_track, _merge_rrd_parts, _open_recording
+from posekit.apis.click_tracker import ClickTracker, MaskResult
+from posekit.track_ui import MASK_SCALE, Session, _close_session, _invalidate_track, _mask_hw, _merge_rrd_parts, _open_recording
 
 CLIP: Path = Path(__file__).resolve().parents[2] / "wilor-nano" / "assets" / "video.mp4"
+SessionWithMock: TypeAlias = tuple[Session, Mock]
 
 
-def _session(recording_id: str, *, prompted: list[int] | None = None) -> tuple[Session, Mock]:
+def _session(recording_id: str, *, prompted: list[int] | None = None) -> SessionWithMock:
     tracker_mock: Mock = Mock(spec=ClickTracker)
-    tracker_mock.prompted_frames.return_value = [1] if prompted is None else prompted
+    tracker_mock.prompted_frames.return_value = (1,) if prompted is None else tuple(prompted)
     tracker_mock.num_frames = 4
     tracker_mock.points = ()
-    session = Session(
+    frame_timestamps_ns: Int64[ndarray, "num_frames"] = (np.arange(4) * 33_333_333).astype(np.int64)
+    session: Session = Session(
         tracker=cast(ClickTracker, tracker_mock),
         video_path=CLIP,
         recording_id=recording_id,
-        frame_timestamps_ns=(np.arange(4) * 33_333_333).astype(np.int64),
+        frame_timestamps_ns=frame_timestamps_ns,
     )
     return session, tracker_mock
 
 
 def test_invalidating_track_clears_propagated_masks_and_confidence() -> None:
-    session, _ = _session("stale")
+    session_with_mock: SessionWithMock = _session("stale")
+    session: Session = session_with_mock[0]
     session.masked_frames = {0, 1, 2}
     session.tracked_frame_indices = {0, 1, 2}
     rec_mock: Mock = Mock(spec=rr.RecordingStream)
@@ -45,15 +55,24 @@ def test_invalidating_track_clears_propagated_masks_and_confidence() -> None:
     assert entities.count("video/object_score") == 3
 
 
-def test_state_delete_callback_closes_tracker_and_removes_rrds(tmp_path: Path, monkeypatch) -> None:
-    session, tracker = _session("expired")
+def test_state_delete_callback_closes_tracker_and_removes_rrds(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    session_with_mock: SessionWithMock = _session("expired")
+    session: Session = session_with_mock[0]
+    tracker: Mock = session_with_mock[1]
     monkeypatch.setattr(track_ui, "RRD_DIR", tmp_path)
-    part_dir = tmp_path / session.recording_id
+    config: track_ui.AppConfig = track_ui.AppConfig(variant="efficienttam-ti-512")
+    demo: gr.Blocks = track_ui.build_demo(config)
+    states: list[gr.State] = [block for block in demo.blocks.values() if isinstance(block, gr.State)]
+    model_dropdowns: list[gr.Dropdown] = [block for block in demo.blocks.values() if isinstance(block, gr.Dropdown) and block.label == "Model"]
+    assert len(states) == 1
+    assert states[0].delete_callback is _close_session
+    assert len(model_dropdowns) == 1
+    assert model_dropdowns[0].value == config.variant
+    part_dir: Path = tmp_path / session.recording_id
     part_dir.mkdir()
     (part_dir / "0000.rrd").touch()
     (tmp_path / f"{session.recording_id}.rrd").touch()
 
-    assert track_ui.recording_state.delete_callback is _close_session
     _close_session(session)
 
     tracker.close.assert_called_once_with()
@@ -61,15 +80,18 @@ def test_state_delete_callback_closes_tracker_and_removes_rrds(tmp_path: Path, m
     assert not (tmp_path / f"{session.recording_id}.rrd").exists()
 
 
-def test_download_recording_contains_video_prompts_masks_and_confidence(tmp_path: Path, monkeypatch) -> None:
-    session, _ = _session("download", prompted=[0])
+def test_download_recording_contains_video_prompts_masks_and_confidence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    session_with_mock: SessionWithMock = _session("download", prompted=[0])
+    session: Session = session_with_mock[0]
     monkeypatch.setattr(track_ui, "RRD_DIR", tmp_path)
 
-    rec, _ = _open_recording(session)
+    recording_pair: tuple[rr.RecordingStream, rr.BinaryStream] = _open_recording(session)
+    rec: rr.RecordingStream = recording_pair[0]
     rec.log("video", rr.AssetVideo(path=CLIP), static=True)
     rec.log("video/points", rr.Points2D([[360.0, 450.0]]))
     rec.disconnect()
-    rec, _ = _open_recording(session)
+    recording_pair = _open_recording(session)
+    rec = recording_pair[0]
     rec.log("video/mask", rr.SegmentationImage(np.ones((2, 2), dtype=np.uint8)))
     rec.log("video/confidence", rr.Scalars(0.8))
     rec.log("video/object_score", rr.Scalars(0.9))
@@ -80,3 +102,107 @@ def test_download_recording_contains_video_prompts_masks_and_confidence(tmp_path
     entities = {str(chunk.entity_path) for chunk in rrx.RrdReader(output).stream()}
     assert {"/video", "/video/points", "/video/mask", "/video/confidence", "/video/object_score"} <= entities
     assert "/video/mask" in stats.stdout
+
+
+def test_mask_hw_downsamples_by_mask_scale() -> None:
+    result: MaskResult = MaskResult(
+        frame_idx=0,
+        mask=torch.ones((64, 96), dtype=torch.bool),
+        score=1.0,
+        object_score=1.0,
+    )
+
+    mask_hw: UInt8[ndarray, "h w"] = _mask_hw(result)
+
+    assert mask_hw.shape == (64 // MASK_SCALE, 96 // MASK_SCALE)
+
+
+def test_click_position_comes_from_video_entity_before_mask(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_with_mock: SessionWithMock = _session("selection")
+    session: Session = session_with_mock[0]
+    tracker: Mock = session_with_mock[1]
+    tracker.points_on.return_value = ()
+    tracker.add_point.return_value = MaskResult(
+        frame_idx=0,
+        mask=torch.ones((64, 96), dtype=torch.bool),
+        score=1.0,
+        object_score=1.0,
+    )
+    rec_mock: Mock = Mock(spec=rr.RecordingStream)
+    stream_mock: Mock = Mock(spec=rr.BinaryStream)
+    stream_mock.read.return_value = b"payload"
+    monkeypatch.setattr(track_ui, "_open_recording", lambda _session: (rec_mock, stream_mock))
+    event_json: str = json.dumps(
+        {
+            "type": "selection_change",
+            "application_id": "test",
+            "recording_id": session.recording_id,
+            "items": [
+                {"type": "entity", "entity_path": "/video/mask", "position": [8.0, 9.0]},
+                {"type": "entity", "entity_path": "/video", "position": [80.0, 90.0]},
+            ],
+        }
+    )
+    event: SelectionChange = SelectionChange(None, event_json)
+
+    list(track_ui.on_select(session, "+ Include", False, 100.0, event))
+
+    tracker.add_point.assert_called_once_with(0, 80.0, 90.0, positive=True, resegment=False)
+
+
+def test_load_video_forwards_model_and_memory_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    observed: dict[str, object] = {}
+    predictor: object = object()
+
+    class FakeClickTracker(ClickTracker):
+        def __init__(self, video_path: Path, actual_predictor: object, *, memory_window_size: int) -> None:
+            observed.update(video_path=video_path, predictor=actual_predictor, memory_window_size=memory_window_size)
+
+    def fake_log_video(
+        video_path: Path,
+        video_log_path: Path,
+        timeline: str,
+        *,
+        recording: rr.RecordingStream,
+        output_codec: rr.VideoCodec | None = None,
+    ) -> Int64[ndarray, "num_frames"]:
+        observed.update(video_log_path=video_log_path, timeline=timeline, recording=recording, output_codec=output_codec)
+        return np.arange(4, dtype=np.int64)
+
+    rec_mock: Mock = Mock(spec=rr.RecordingStream)
+    stream_mock: Mock = Mock(spec=rr.BinaryStream)
+    stream_mock.read.return_value = b"payload"
+    monkeypatch.setattr(track_ui, "ClickTracker", FakeClickTracker)
+    monkeypatch.setattr(track_ui, "_predictor", lambda _variant: predictor)
+    monkeypatch.setattr(track_ui, "_open_recording", lambda _session: (rec_mock, stream_mock))
+    monkeypatch.setattr(track_ui, "log_video", fake_log_video)
+
+    outputs: list[tuple[object, ...]] = list(track_ui.load_video(str(CLIP), None, "efficienttam-ti-512", 17.0))
+    config_outputs: list[tuple[object, ...]] = list(track_ui._reload_video_from_config(str(CLIP), None, "efficienttam-ti-512", 17.0))
+
+    assert observed["video_path"] == CLIP
+    assert observed["predictor"] is predictor
+    assert observed["memory_window_size"] == 17
+    assert observed["output_codec"] == rr.VideoCodec.H264
+    assert outputs[-1][4] == "Input"
+    assert config_outputs[-1][4] == "Config"
+
+
+def test_failed_reload_keeps_previous_session_open(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    session_with_mock: SessionWithMock = _session("previous")
+    previous_session: Session = session_with_mock[0]
+    previous_tracker: Mock = session_with_mock[1]
+    corrupt_video: Path = tmp_path / "corrupt.mp4"
+    corrupt_video.write_bytes(b"not an mp4")
+    monkeypatch.setattr(track_ui, "_predictor", lambda _variant: object())
+
+    with pytest.raises((RuntimeError, ValueError)):
+        next(track_ui.load_video(str(corrupt_video), previous_session, "efficienttam-s-512", 10.0))
+
+    previous_tracker.close.assert_not_called()
+
+
+def test_control_tab_shows_only_selected_panel() -> None:
+    updates: tuple[gr.Column, gr.Column, gr.Column] = track_ui.show_control_tab("Config")
+
+    assert [panel.visible for panel in updates] == [False, True, False]


### PR DESCRIPTION
Stacked on the simplecv `log_video` PR (needs `output_codec`).

- **Config tab** — model (`efficienttam-s-512` / `-ti-512`), SAM2 memory window, point-removal radius, re-segment — on a `gr.Radio` styled as a tab strip. Three native `gr.Tab` components trigger a Svelte `effect_update_depth` loop in Gradio 6.13 (measured: every variant ~140 errors/4 s, two tabs 0). Config-triggered reloads stay on Config; a new upload goes to Input; Track goes to Outputs.
- **Masks at 1/4 resolution** under a static `Transform3D(scale=4)` on `video/mask` and `video/preview`: 240 MiB → 28 MiB in the viewer for the 10 s 720p example, still `SegmentationImage` with class ids / annotation colors. Alignment pixel-verified against a full-res mask; a preview logged after the static `Clear` still renders scaled (verified in a native viewer).
- **iPhone `.MOV`**: `log_video(..., output_codec=H264)` so HEVC clips play in every browser; `ClickTracker` opens the decoder with `seek_mode="exact"` (the approximate index overshoots these clips and the last frames failed with "no more frames left to decode").
- Hardening from review: reload builds the new tracker before closing the old session; clicks take their position from the `/video` hit only; `remove_point_near(radius_px=...)` instead of mutable tracker state; `_mask_hw` is total; `build_demo(config)` replaces the module-level app and launch-time component mutation.
- Tests (+5): mask scaling, hit precedence, config forwarding, tab panels, failed-reload atomicity. README section for the app.

Reviewed with two independent thermo-nuclear passes (Opus 5 + Codex); all agreed items applied; splitting `track_ui.py` (~830 lines) is a follow-up.

Verified: posekit lint/typecheck/deadcode, 40 tests (28 s); end-to-end Track 299/299 frames; Playwright tab check 0 loop errors.