### PR TITLE
posekit: split track_ui.py into recording helpers, theme strings, and the Gradio app

### DIFF
--- a/packages/posekit/src/posekit/apis/track_recording.py
+++ b/packages/posekit/src/posekit/apis/track_recording.py
@@ -1,0 +1,223 @@
+"""Owns each session's Rerun recording: the live-stream tee and downloadable RRD parts, with overlays logged beneath the scale transform."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TypeAlias
+
+import numpy as np
+import rerun as rr
+import rerun.blueprint as rrb
+from jaxtyping import Int, UInt8
+from numpy import ndarray
+
+from posekit.apis.click_tracker import ClickTracker, MaskResult, Point
+
+APP_ID: str = "posekit_click_to_track"
+VIDEO: str = "video"
+TIMELINE: str = "video_time"
+RecordingPair: TypeAlias = tuple[rr.RecordingStream, rr.BinaryStream]
+POSITIVE_COLOR: tuple[int, int, int] = (76, 220, 96)
+NEGATIVE_COLOR: tuple[int, int, int] = (255, 87, 51)
+MASK_COLOR: tuple[int, int, int] = (51, 178, 255)
+MASK_SCALE: int = 4
+"""Masks are logged at 1/MASK_SCALE resolution under a static scale transform: a full-res
+uint8 mask per frame costs ~40x the video in viewer memory, and SAM2's logits are 128^2 anyway."""
+RRD_DIR: Path = Path("/tmp/posekit-rrd")
+
+
+@dataclass(slots=True)
+class Session:
+    """Per-browser-session state: the tracker, its recording, and the viewer's current frame."""
+
+    tracker: ClickTracker
+    """Clip-local prompts, decoder, and SAM memory state."""
+    video_path: Path
+    """Input video used by the live and downloadable recordings."""
+    recording_id: str
+    """Rerun recording ID."""
+    frame_timestamps_ns: Int[ndarray, "n"]
+    """Viewer timestamps returned by the logged video stream."""
+    current_frame: int = 0
+    """Frame under the viewer cursor: 0 at load (the viewer starts paused there), then updated by time_update."""
+    last_time_update: float = 0.0
+    """``time.monotonic()`` of the last time_update, so a click can wait for the scrub to go quiet."""
+    last_stamp: float = -1.0
+    """Browser ``performance.now()`` of the newest time_update applied; unqueued requests can finish out of order."""
+    playing: bool = False
+    """Set by the viewer's play/pause events; clicks while playing have no known frame and are refused."""
+    preview_visible: bool = False
+    """A static preview mask is currently shown on ``video/preview``."""
+    masked_frames: set[int] = field(default_factory=set)
+    """Frames that carry a mask; anything else must show none (latest-at would otherwise keep the last one)."""
+    pointed_frames: set[int] = field(default_factory=set)
+    """Frames that carry temporal point data."""
+    tracked_frame_indices: set[int] = field(default_factory=set)
+    """Frames written by the latest Track run, retained only for invalidation."""
+    rrd_part_counter: int = 0
+    """Monotonic callback-part number within this session."""
+
+
+
+def _blueprint() -> rrb.Blueprint:
+    """Viewer layout shared by the live stream and downloadable recording."""
+    return rrb.Blueprint(
+        rrb.Vertical(
+            rrb.Spatial2DView(name="Click to track", origin=VIDEO),
+            rrb.TimeSeriesView(name="Confidence", origin=VIDEO),
+            row_shares=[4, 1],
+        ),
+        rrb.BlueprintPanel(state="hidden"),
+        rrb.SelectionPanel(state="hidden"),
+        rrb.TimePanel(state="expanded", timeline=TIMELINE, play_state=rrb.components.PlayState.Paused),
+    )
+
+
+def _close_session(session: Session | None) -> None:
+    """Release a session's decoder thread and its downloadable recording."""
+    if session is None:
+        return
+    session.tracker.close()
+    (RRD_DIR / f"{session.recording_id}.rrd").unlink(missing_ok=True)
+    shutil.rmtree(RRD_DIR / session.recording_id, ignore_errors=True)
+
+
+def _open_recording(session: Session, *, write_part: bool = True) -> tuple[rr.RecordingStream, rr.BinaryStream]:
+    """Open one callback recording with a browser stream and, except for previews, a footerless file part."""
+    rec: rr.RecordingStream = rr.RecordingStream(application_id=APP_ID, recording_id=session.recording_id)
+    stream: rr.BinaryStream = rec.binary_stream()
+    if write_part:
+        part_dir: Path = RRD_DIR / session.recording_id
+        part_dir.mkdir(parents=True, exist_ok=True)
+        part: Path = part_dir / f"{session.rrd_part_counter:04d}.rrd"
+        session.rrd_part_counter += 1
+        rec.set_sinks(stream, rr.FileSink(str(part), write_footer=False))
+    return rec, stream
+
+
+def _merge_rrd_parts(session: Session) -> Path:
+    """Merge this session's footerless callback parts into one valid, compacted RRD.
+
+    The parts are hundreds of tiny per-callback chunks; ``rrd optimize`` re-batches
+    them into fewer, larger chunks and re-derives video keyframes so the download loads fast.
+    """
+    output: Path = RRD_DIR / f"{session.recording_id}.rrd"
+    merged: Path = RRD_DIR / f"{session.recording_id}.merged.rrd"
+    parts: list[Path] = sorted((RRD_DIR / session.recording_id).glob("*.rrd"))
+    subprocess.run(["rerun", "rrd", "merge", "--output", str(merged), *(str(part) for part in parts)], check=True)
+    # --fix-keyframe: the Mp4Reader stream logs is_keyframe=false rows, which blocks GoP rebatching of the video.
+    subprocess.run(["rerun", "rrd", "optimize", "--fix-keyframe", "--output", str(output), str(merged)], check=True)
+    merged.unlink()
+    return output
+
+
+def _viewer_time_s(session: Session, frame_idx: int) -> float:
+    """The viewer's ``video_time`` for a frame — from the logged video stream, never torchcodec pts.
+
+    A clip cut with ``-ss`` carries an edit-list offset (torchcodec frame 0 at 0.033 s
+    while the stream's frame 0 is at 0.0), so overlays stamped with decoder pts
+    land after the cursor and only show up later.
+    """
+    return float(session.frame_timestamps_ns[frame_idx]) / 1e9
+
+
+def _clear_preview(rec: rr.RecordingStream, session: Session) -> None:
+    """Remove the static scrub preview (no-op when none is shown).
+
+    A native Rerun 0.36.2 pixel check confirms that this same-entity static
+    ``Clear`` leaves ``video/preview``'s static scale transform in effect.
+    """
+    if session.preview_visible:
+        rec.log(f"{VIDEO}/preview", rr.Clear(recursive=False), static=True)
+        session.preview_visible = False
+
+
+def _bound_next_frame(rec: rr.RecordingStream, session: Session, entity: str, frame_idx: int, frames_with_data: set[int]) -> None:
+    """Rerun shows the latest logged value until the next one: clear the entity on the following frame unless it has its own data."""
+    nxt: int = frame_idx + 1
+    if nxt < session.tracker.num_frames and nxt not in frames_with_data:
+        rec.set_time(TIMELINE, duration=_viewer_time_s(session, nxt))
+        rec.log(entity, rr.Clear(recursive=False))
+
+
+def _log_points(rec: rr.RecordingStream, session: Session, frame_idx: int) -> None:
+    """Log the frame's points (or a clear) at that frame's time so markers show only where they belong."""
+    entity: str = f"{VIDEO}/points"
+    rec.set_time(TIMELINE, duration=_viewer_time_s(session, frame_idx))
+    points: tuple[Point, ...] = session.tracker.points_on(frame_idx)
+    if not points:
+        session.pointed_frames.discard(frame_idx)
+        rec.log(entity, rr.Clear(recursive=False))
+        return
+    rec.log(
+        entity,
+        rr.Points2D(
+            np.asarray([[p.x, p.y] for p in points], dtype=np.float32),
+            colors=[POSITIVE_COLOR if p.positive else NEGATIVE_COLOR for p in points],
+            radii=6,
+            labels=["+" if p.positive else "−" for p in points],
+        ),
+    )
+    session.pointed_frames.add(frame_idx)
+    _bound_next_frame(rec, session, entity, frame_idx, session.pointed_frames)
+
+
+def _log_mask(rec: rr.RecordingStream, session: Session, mask_hw: UInt8[ndarray, "h w"] | None, frame_idx: int, *, bound: bool = True) -> None:
+    """Log the mask at its frame (or clear it) on the ``video_time`` timeline.
+
+    ``bound`` writes the next-frame Clear that keeps a lone mask on its own frame;
+    dense tracking skips it because the next frame gets its own mask anyway.
+    """
+    entity: str = f"{VIDEO}/mask"
+    rec.set_time(TIMELINE, duration=_viewer_time_s(session, frame_idx))
+    if mask_hw is None:
+        session.masked_frames.discard(frame_idx)
+        rec.log(entity, rr.Clear(recursive=False))
+        return
+    rec.log(entity, rr.SegmentationImage(mask_hw))
+    session.masked_frames.add(frame_idx)
+    if bound:
+        _bound_next_frame(rec, session, entity, frame_idx, session.masked_frames)
+
+
+def _mask_hw(result: MaskResult) -> UInt8[ndarray, "h w"]:
+    """Copy one result mask from the inference device, downsampled for Rerun logging.
+
+    Strided sampling rounds each output dimension up, so a non-multiple of
+    ``MASK_SCALE`` can overhang the full-resolution image by up to three pixels.
+    """
+    return result.mask[::MASK_SCALE, ::MASK_SCALE].cpu().numpy().astype(np.uint8)
+
+
+def _log_confidence(rec: rr.RecordingStream, session: Session, result: MaskResult) -> None:
+    """Log decoder IoU and object-presence confidence at one frame."""
+    rec.set_time(TIMELINE, duration=_viewer_time_s(session, result.frame_idx))
+    rec.log(f"{VIDEO}/confidence", rr.Scalars(result.score))
+    rec.log(f"{VIDEO}/object_score", rr.Scalars(result.object_score))
+
+
+def _invalidate_track(rec: rr.RecordingStream, session: Session) -> bool:
+    """Clear propagated overlays and confidence after a point edit."""
+    if not session.tracked_frame_indices:
+        return False
+    prompted: set[int] = set(session.tracker.prompted_frames())
+    for frame_idx in sorted(session.masked_frames - prompted):
+        rec.set_time(TIMELINE, duration=_viewer_time_s(session, frame_idx))
+        rec.log(f"{VIDEO}/mask", rr.Clear(recursive=False))
+    for frame_idx in sorted(session.tracked_frame_indices):
+        rec.set_time(TIMELINE, duration=_viewer_time_s(session, frame_idx))
+        rec.log(f"{VIDEO}/confidence", rr.Clear(recursive=False))
+        rec.log(f"{VIDEO}/object_score", rr.Clear(recursive=False))
+    session.masked_frames = prompted
+    session.tracked_frame_indices.clear()
+    return True
+
+
+def _status(session: Session, prefix: str) -> str:
+    frames: tuple[int, ...] = session.tracker.prompted_frames()
+    return f"{prefix} {len(session.tracker.points)} point(s) on frame(s) {frames} · viewer at frame {session.current_frame}."
+
+

--- a/packages/posekit/src/posekit/models/sam2_video.py
+++ b/packages/posekit/src/posekit/models/sam2_video.py
@@ -9,6 +9,7 @@ detections with GPU masks and stable ``track_ids``.
 
 from __future__ import annotations
 
+import functools
 from dataclasses import dataclass
 from typing import Literal, TypeAlias
 
@@ -30,6 +31,12 @@ SAM2_VARIANT_WEIGHTS: dict[Sam2Variant, tuple[str, str, str]] = {
     "efficienttam-ti-512": ("pablovela5620/mamma-streaming-data", "dataset", "weights/efficienttam/efficienttam_ti.pt"),
     "efficienttam-s-512": ("yunyangx/efficient-track-anything", "model", "efficienttam_s_512x512.pt"),
 }
+
+
+@functools.cache
+def cached_predictor(variant: Sam2Variant):
+    """Load one SAM2-streaming predictor per variant."""
+    return Sam2VideoSegmenterConfig(variant=variant).setup().predictor
 
 
 @dataclass(frozen=True, slots=True)
@@ -171,4 +178,4 @@ class Sam2VideoSegmenter(VideoSegmenter):
         return sam2_prompts
 
 
-__all__ = ("Sam2VideoSegmenter", "Sam2VideoSegmenterConfig")
+__all__ = ("Sam2VideoSegmenter", "Sam2VideoSegmenterConfig", "cached_predictor")

--- a/packages/posekit/src/posekit/track_recording.py
+++ b/packages/posekit/src/posekit/track_recording.py
@@ -219,5 +219,3 @@ def _invalidate_track(rec: rr.RecordingStream, session: Session) -> bool:
 def _status(session: Session, prefix: str) -> str:
     frames: tuple[int, ...] = session.tracker.prompted_frames()
     return f"{prefix} {len(session.tracker.points)} point(s) on frame(s) {frames} · viewer at frame {session.current_frame}."
-
-

--- a/packages/posekit/src/posekit/track_ui.py
+++ b/packages/posekit/src/posekit/track_ui.py
@@ -33,7 +33,8 @@ from simplecv.rerun_log_utils import log_video
 from simplecv.video_utils import frame_at
 
 from posekit.apis.click_tracker import ClickTracker, MaskResult, PointEdit
-from posekit.apis.track_recording import (
+from posekit.models.sam2_video import Sam2Variant, cached_predictor
+from posekit.track_recording import (
     MASK_COLOR,
     MASK_SCALE,
     RRD_DIR,
@@ -54,7 +55,6 @@ from posekit.apis.track_recording import (
     _status,
     _viewer_time_s,
 )
-from posekit.models.sam2_video import Sam2Variant, cached_predictor
 from posekit.track_ui_theme import APP_CSS, DESCRIPTION, FORCE_DARK_HEAD, VIEWER_HEIGHT
 
 Mode: TypeAlias = Literal["+ Include", "− Exclude", "✕ Remove"]

--- a/packages/posekit/src/posekit/track_ui.py
+++ b/packages/posekit/src/posekit/track_ui.py
@@ -14,45 +14,52 @@ Rerun recording; each viewer event appends to that recording through
 
 from __future__ import annotations
 
-import functools
-import shutil
-import subprocess
 import time
 import uuid
 from collections.abc import Iterator
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, TypeAlias, get_args
 
 import gradio as gr
 import numpy as np
 import rerun as rr
-import rerun.blueprint as rrb
 import tyro
 from gradio_rerun import Rerun
 from gradio_rerun.events import Pause, Play, SelectionChange, TimeUpdate
-from jaxtyping import Int, UInt8
+from jaxtyping import UInt8
 from numpy import ndarray
 from simplecv.rerun_log_utils import log_video
 from simplecv.video_utils import frame_at
 
-from posekit.apis.click_tracker import ClickTracker, MaskResult, Point, PointEdit
-from posekit.models.sam2_video import Sam2Variant, Sam2VideoSegmenterConfig
+from posekit.apis.click_tracker import ClickTracker, MaskResult, PointEdit
+from posekit.apis.track_recording import (
+    MASK_COLOR,
+    MASK_SCALE,
+    RRD_DIR,
+    TIMELINE,
+    VIDEO,
+    RecordingPair,
+    Session,
+    _blueprint,
+    _clear_preview,
+    _close_session,
+    _invalidate_track,
+    _log_confidence,
+    _log_mask,
+    _log_points,
+    _mask_hw,
+    _merge_rrd_parts,
+    _open_recording,
+    _status,
+    _viewer_time_s,
+)
+from posekit.models.sam2_video import Sam2Variant, cached_predictor
+from posekit.track_ui_theme import APP_CSS, DESCRIPTION, FORCE_DARK_HEAD, VIEWER_HEIGHT
 
-APP_ID: str = "posekit_click_to_track"
-VIDEO: str = "video"
-TIMELINE: str = "video_time"
 Mode: TypeAlias = Literal["+ Include", "− Exclude", "✕ Remove"]
 MODES: list[Mode] = ["+ Include", "− Exclude", "✕ Remove"]
 TabName: TypeAlias = Literal["Input", "Config", "Outputs"]
-RecordingPair: TypeAlias = tuple[rr.RecordingStream, rr.BinaryStream]
-POSITIVE_COLOR: tuple[int, int, int] = (76, 220, 96)
-NEGATIVE_COLOR: tuple[int, int, int] = (255, 87, 51)
-MASK_COLOR: tuple[int, int, int] = (51, 178, 255)
-MASK_SCALE: int = 4
-"""Masks are logged at 1/MASK_SCALE resolution under a static scale transform: a full-res
-uint8 mask per frame costs ~40x the video in viewer memory, and SAM2's logits are 128^2 anyway."""
-RRD_DIR: Path = Path("/tmp/posekit-rrd")
 _EXAMPLES_DIR: Path = Path(__file__).resolve().parents[2] / "assets" / "examples"
 EXAMPLE_VIDEOS: list[str] = [
     str(path)
@@ -80,207 +87,10 @@ class AppConfig:
     """SAM2-family checkpoint. -s (Kineo's pick) holds a point-seeded track through the clip where -ti drifts."""
 
 
-@dataclass(slots=True)
-class Session:
-    """Per-browser-session state: the tracker, its recording, and the viewer's current frame."""
-
-    tracker: ClickTracker
-    """Clip-local prompts, decoder, and SAM memory state."""
-    video_path: Path
-    """Input video used by the live and downloadable recordings."""
-    recording_id: str
-    """Rerun recording ID."""
-    frame_timestamps_ns: Int[ndarray, "n"]
-    """Viewer timestamps returned by the logged video stream."""
-    current_frame: int = 0
-    """Frame under the viewer cursor: 0 at load (the viewer starts paused there), then updated by time_update."""
-    last_time_update: float = 0.0
-    """``time.monotonic()`` of the last time_update, so a click can wait for the scrub to go quiet."""
-    last_stamp: float = -1.0
-    """Browser ``performance.now()`` of the newest time_update applied; unqueued requests can finish out of order."""
-    playing: bool = False
-    """Set by the viewer's play/pause events; clicks while playing have no known frame and are refused."""
-    preview_visible: bool = False
-    """A static preview mask is currently shown on ``video/preview``."""
-    masked_frames: set[int] = field(default_factory=set)
-    """Frames that carry a mask; anything else must show none (latest-at would otherwise keep the last one)."""
-    pointed_frames: set[int] = field(default_factory=set)
-    """Frames that carry temporal point data."""
-    tracked_frame_indices: set[int] = field(default_factory=set)
-    """Frames written by the latest Track run, retained only for invalidation."""
-    rrd_part_counter: int = 0
-    """Monotonic callback-part number within this session."""
-
-
 SAM2_VARIANTS: list[Sam2Variant] = list(get_args(Sam2Variant))
 # The interactive tracker favors a longer window than Sam2VideoSegmenterConfig's streaming default of 7.
 DEFAULT_MEMORY_WINDOW: int = 10
 DEFAULT_REMOVE_RADIUS_PX: float = 100.0
-
-
-@functools.cache
-def _predictor(variant: Sam2Variant):
-    """Load one SAM2-streaming predictor per variant."""
-    return Sam2VideoSegmenterConfig(variant=variant).setup().predictor
-
-
-def _blueprint() -> rrb.Blueprint:
-    """Viewer layout shared by the live stream and downloadable recording."""
-    return rrb.Blueprint(
-        rrb.Vertical(
-            rrb.Spatial2DView(name="Click to track", origin=VIDEO),
-            rrb.TimeSeriesView(name="Confidence", origin=VIDEO),
-            row_shares=[4, 1],
-        ),
-        rrb.BlueprintPanel(state="hidden"),
-        rrb.SelectionPanel(state="hidden"),
-        rrb.TimePanel(state="expanded", timeline=TIMELINE, play_state=rrb.components.PlayState.Paused),
-    )
-
-
-def _close_session(session: Session | None) -> None:
-    """Release a session's decoder thread and its downloadable recording."""
-    if session is None:
-        return
-    session.tracker.close()
-    (RRD_DIR / f"{session.recording_id}.rrd").unlink(missing_ok=True)
-    shutil.rmtree(RRD_DIR / session.recording_id, ignore_errors=True)
-
-
-def _open_recording(session: Session, *, write_part: bool = True) -> tuple[rr.RecordingStream, rr.BinaryStream]:
-    """Open one callback recording with a browser stream and, except for previews, a footerless file part."""
-    rec: rr.RecordingStream = rr.RecordingStream(application_id=APP_ID, recording_id=session.recording_id)
-    stream: rr.BinaryStream = rec.binary_stream()
-    if write_part:
-        part_dir: Path = RRD_DIR / session.recording_id
-        part_dir.mkdir(parents=True, exist_ok=True)
-        part: Path = part_dir / f"{session.rrd_part_counter:04d}.rrd"
-        session.rrd_part_counter += 1
-        rec.set_sinks(stream, rr.FileSink(str(part), write_footer=False))
-    return rec, stream
-
-
-def _merge_rrd_parts(session: Session) -> Path:
-    """Merge this session's footerless callback parts into one valid, compacted RRD.
-
-    The parts are hundreds of tiny per-callback chunks; ``rrd optimize`` re-batches
-    them into fewer, larger chunks and re-derives video keyframes so the download loads fast.
-    """
-    output: Path = RRD_DIR / f"{session.recording_id}.rrd"
-    merged: Path = RRD_DIR / f"{session.recording_id}.merged.rrd"
-    parts: list[Path] = sorted((RRD_DIR / session.recording_id).glob("*.rrd"))
-    subprocess.run(["rerun", "rrd", "merge", "--output", str(merged), *(str(part) for part in parts)], check=True)
-    # --fix-keyframe: the Mp4Reader stream logs is_keyframe=false rows, which blocks GoP rebatching of the video.
-    subprocess.run(["rerun", "rrd", "optimize", "--fix-keyframe", "--output", str(output), str(merged)], check=True)
-    merged.unlink()
-    return output
-
-
-def _viewer_time_s(session: Session, frame_idx: int) -> float:
-    """The viewer's ``video_time`` for a frame — from the logged video stream, never torchcodec pts.
-
-    A clip cut with ``-ss`` carries an edit-list offset (torchcodec frame 0 at 0.033 s
-    while the stream's frame 0 is at 0.0), so overlays stamped with decoder pts
-    land after the cursor and only show up later.
-    """
-    return float(session.frame_timestamps_ns[frame_idx]) / 1e9
-
-
-def _clear_preview(rec: rr.RecordingStream, session: Session) -> None:
-    """Remove the static scrub preview (no-op when none is shown).
-
-    A native Rerun 0.36.2 pixel check confirms that this same-entity static
-    ``Clear`` leaves ``video/preview``'s static scale transform in effect.
-    """
-    if session.preview_visible:
-        rec.log(f"{VIDEO}/preview", rr.Clear(recursive=False), static=True)
-        session.preview_visible = False
-
-
-def _bound_next_frame(rec: rr.RecordingStream, session: Session, entity: str, frame_idx: int, frames_with_data: set[int]) -> None:
-    """Rerun shows the latest logged value until the next one: clear the entity on the following frame unless it has its own data."""
-    nxt: int = frame_idx + 1
-    if nxt < session.tracker.num_frames and nxt not in frames_with_data:
-        rec.set_time(TIMELINE, duration=_viewer_time_s(session, nxt))
-        rec.log(entity, rr.Clear(recursive=False))
-
-
-def _log_points(rec: rr.RecordingStream, session: Session, frame_idx: int) -> None:
-    """Log the frame's points (or a clear) at that frame's time so markers show only where they belong."""
-    entity: str = f"{VIDEO}/points"
-    rec.set_time(TIMELINE, duration=_viewer_time_s(session, frame_idx))
-    points: tuple[Point, ...] = session.tracker.points_on(frame_idx)
-    if not points:
-        session.pointed_frames.discard(frame_idx)
-        rec.log(entity, rr.Clear(recursive=False))
-        return
-    rec.log(
-        entity,
-        rr.Points2D(
-            np.asarray([[p.x, p.y] for p in points], dtype=np.float32),
-            colors=[POSITIVE_COLOR if p.positive else NEGATIVE_COLOR for p in points],
-            radii=6,
-            labels=["+" if p.positive else "−" for p in points],
-        ),
-    )
-    session.pointed_frames.add(frame_idx)
-    _bound_next_frame(rec, session, entity, frame_idx, session.pointed_frames)
-
-
-def _log_mask(rec: rr.RecordingStream, session: Session, mask_hw: UInt8[ndarray, "h w"] | None, frame_idx: int, *, bound: bool = True) -> None:
-    """Log the mask at its frame (or clear it) on the ``video_time`` timeline.
-
-    ``bound`` writes the next-frame Clear that keeps a lone mask on its own frame;
-    dense tracking skips it because the next frame gets its own mask anyway.
-    """
-    entity: str = f"{VIDEO}/mask"
-    rec.set_time(TIMELINE, duration=_viewer_time_s(session, frame_idx))
-    if mask_hw is None:
-        session.masked_frames.discard(frame_idx)
-        rec.log(entity, rr.Clear(recursive=False))
-        return
-    rec.log(entity, rr.SegmentationImage(mask_hw))
-    session.masked_frames.add(frame_idx)
-    if bound:
-        _bound_next_frame(rec, session, entity, frame_idx, session.masked_frames)
-
-
-def _mask_hw(result: MaskResult) -> UInt8[ndarray, "h w"]:
-    """Copy one result mask from the inference device, downsampled for Rerun logging.
-
-    Strided sampling rounds each output dimension up, so a non-multiple of
-    ``MASK_SCALE`` can overhang the full-resolution image by up to three pixels.
-    """
-    return result.mask[::MASK_SCALE, ::MASK_SCALE].cpu().numpy().astype(np.uint8)
-
-
-def _log_confidence(rec: rr.RecordingStream, session: Session, result: MaskResult) -> None:
-    """Log decoder IoU and object-presence confidence at one frame."""
-    rec.set_time(TIMELINE, duration=_viewer_time_s(session, result.frame_idx))
-    rec.log(f"{VIDEO}/confidence", rr.Scalars(result.score))
-    rec.log(f"{VIDEO}/object_score", rr.Scalars(result.object_score))
-
-
-def _invalidate_track(rec: rr.RecordingStream, session: Session) -> bool:
-    """Clear propagated overlays and confidence after a point edit."""
-    if not session.tracked_frame_indices:
-        return False
-    prompted: set[int] = set(session.tracker.prompted_frames())
-    for frame_idx in sorted(session.masked_frames - prompted):
-        rec.set_time(TIMELINE, duration=_viewer_time_s(session, frame_idx))
-        rec.log(f"{VIDEO}/mask", rr.Clear(recursive=False))
-    for frame_idx in sorted(session.tracked_frame_indices):
-        rec.set_time(TIMELINE, duration=_viewer_time_s(session, frame_idx))
-        rec.log(f"{VIDEO}/confidence", rr.Clear(recursive=False))
-        rec.log(f"{VIDEO}/object_score", rr.Clear(recursive=False))
-    session.masked_frames = prompted
-    session.tracked_frame_indices.clear()
-    return True
-
-
-def _status(session: Session, prefix: str) -> str:
-    frames: tuple[int, ...] = session.tracker.prompted_frames()
-    return f"{prefix} {len(session.tracker.points)} point(s) on frame(s) {frames} · viewer at frame {session.current_frame}."
 
 
 # ── callbacks ─────────────────────────────────────────────────────────────
@@ -323,7 +133,7 @@ def load_video(
     video_path: Path = Path(video)
     if variant not in SAM2_VARIANTS:
         raise gr.Error(f"Unknown model {variant!r}.")
-    tracker: ClickTracker = ClickTracker(video_path, _predictor(variant), memory_window_size=int(memory_window))
+    tracker: ClickTracker = ClickTracker(video_path, cached_predictor(variant), memory_window_size=int(memory_window))
     _close_session(previous_session)
     session: Session = Session(
         tracker=tracker,
@@ -611,92 +421,6 @@ def stop_tracking() -> tuple[str, str]:
     """Describe the consistent state left by Gradio cancelling Track at a yield."""
     status: str = "Stopped. The partial result is not downloadable; press Track to run again from scratch."
     return status, status
-
-
-DESCRIPTION: str = (
-    "# posekit: Click to Track\n"
-    "Click an object in the Rerun viewer, refine it on any frame, and propagate the mask through the whole clip. "
-    "The confidence traces help you find frames that need another click."
-)
-
-VIEWER_HEIGHT: str = "calc(100vh - 7rem)"
-"""Viewer frame height: the viewport minus the header/description band, so nothing scrolls."""
-
-# HF Spaces render the default theme in dark mode; do the same here by forcing
-# Gradio's ``__theme=dark`` URL switch before the app mounts (a <head> script —
-# the launch ``js`` hook runs too late to redirect).
-FORCE_DARK_HEAD: str = """
-<script>
-(() => {
-    const url = new URL(window.location);
-    if (url.searchParams.get("__theme") !== "dark") {
-        url.searchParams.set("__theme", "dark");
-        window.location.replace(url.href);
-    }
-})();
-</script>
-"""
-
-APP_CSS: str = """
-html, body, gradio-app, .gradio-container {
-    height: 100%;
-    overflow: hidden;
-}
-.gradio-container {
-    max-width: none !important;
-    padding: 0.6rem 1rem !important;
-}
-#app-description { margin-bottom: 0.35rem; }
-#app-description h1 { margin: 0 0 0.2rem; }
-#app-description p { margin: 0; }
-#main-row {
-    height: calc(100vh - 6.4rem);
-    min-height: 0;
-    overflow: hidden;
-}
-#left-column, #viewer-column { min-height: 0; }
-/* Only the controls scroll on short viewports; the viewer never moves. Reserve the
-   scrollbar gutter so the controls do not shift horizontally when it appears. */
-#left-column { height: 100%; max-height: 100%; overflow-y: auto; scrollbar-gutter: stable; flex-wrap: nowrap; }
-#left-column > * { flex-shrink: 0; }
-#source-video { height: auto !important; }
-#source-video video { max-height: 225px !important; }
-#examples { flex: none; }
-/* Radio-based tab strip: Gradio 6.13 loops in Svelte when this app renders three
-   native Tab components. The panels below are ordinary Columns. */
-#control-tabs { overflow: visible; min-width: 0 !important; }
-#control-tabs .wrap { display: flex; gap: 0; border-bottom: 1px solid var(--border-color-primary); }
-#control-tabs label { flex: 1; justify-content: center; margin: 0; border: 0; border-bottom: 2px solid transparent; border-radius: 0; background: transparent; padding: 0.55rem 0.4rem; color: var(--body-text-color); cursor: pointer; }
-#control-tabs label.selected { border-bottom-color: var(--color-accent); color: var(--color-accent); }
-#control-tabs input { display: none; }
-#control-tabs span { font-weight: 600; }
-/* Click-mode radio as a segmented pill group. */
-#click-mode .wrap { display: flex; gap: 0; border: 1px solid var(--border-color-primary); border-radius: var(--radius-lg); overflow: hidden; }
-#click-mode label { flex: 1; justify-content: center; margin: 0; border-radius: 0; border: 0; background: var(--background-fill-secondary); padding: 0.45rem 0.4rem; cursor: pointer; }
-#click-mode label + label { border-left: 1px solid var(--border-color-primary); }
-#click-mode label.selected { background: var(--color-accent); color: white; }
-#click-mode input { display: none; }
-#click-mode span { font-weight: 600; }
-/* Four small tiles per row with a pager, like the 4DAnyone Space. */
-#examples .gallery { display: flex; flex-wrap: wrap; gap: 0.4rem; }
-#examples .gallery button { flex: none; padding: 0; }
-#examples video, #examples img { height: 64px !important; width: auto !important; max-width: 84px; object-fit: cover; }
-/* The viewer's top edge lines up with the video card beside it. */
-#viewer-column { padding-top: 0; }
-#rerun-viewer { min-height: 0 !important; }
-#run-status {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    min-height: 4.5rem;
-    overflow: visible !important;
-    padding: 0.65rem 0.85rem;
-    border-radius: var(--radius-lg);
-    background: var(--background-fill-secondary);
-}
-#run-status p { font-size: 1.05rem; line-height: 1.4; margin: 0; }
-footer { display: none !important; }
-"""
 
 
 def build_demo(config: AppConfig) -> gr.Blocks:

--- a/packages/posekit/src/posekit/track_ui_theme.py
+++ b/packages/posekit/src/posekit/track_ui_theme.py
@@ -1,0 +1,88 @@
+"""Theme constants for the click-to-track Gradio app."""
+
+DESCRIPTION: str = (
+    "# posekit: Click to Track\n"
+    "Click an object in the Rerun viewer, refine it on any frame, and propagate the mask through the whole clip. "
+    "The confidence traces help you find frames that need another click."
+)
+
+VIEWER_HEIGHT: str = "calc(100vh - 7rem)"
+"""Viewer frame height: the viewport minus the header/description band, so nothing scrolls."""
+
+# HF Spaces render the default theme in dark mode; do the same here by forcing
+# Gradio's ``__theme=dark`` URL switch before the app mounts (a <head> script —
+# the launch ``js`` hook runs too late to redirect).
+FORCE_DARK_HEAD: str = """
+<script>
+(() => {
+    const url = new URL(window.location);
+    if (url.searchParams.get("__theme") !== "dark") {
+        url.searchParams.set("__theme", "dark");
+        window.location.replace(url.href);
+    }
+})();
+</script>
+"""
+
+APP_CSS: str = """
+html, body, gradio-app, .gradio-container {
+    height: 100%;
+    overflow: hidden;
+}
+.gradio-container {
+    max-width: none !important;
+    padding: 0.6rem 1rem !important;
+}
+#app-description { margin-bottom: 0.35rem; }
+#app-description h1 { margin: 0 0 0.2rem; }
+#app-description p { margin: 0; }
+#main-row {
+    height: calc(100vh - 6.4rem);
+    min-height: 0;
+    overflow: hidden;
+}
+#left-column, #viewer-column { min-height: 0; }
+/* Only the controls scroll on short viewports; the viewer never moves. Reserve the
+   scrollbar gutter so the controls do not shift horizontally when it appears. */
+#left-column { height: 100%; max-height: 100%; overflow-y: auto; scrollbar-gutter: stable; flex-wrap: nowrap; }
+#left-column > * { flex-shrink: 0; }
+#source-video { height: auto !important; }
+#source-video video { max-height: 225px !important; }
+#examples { flex: none; }
+/* Radio-based tab strip: Gradio 6.13 loops in Svelte when this app renders three
+   native Tab components. The panels below are ordinary Columns. */
+#control-tabs { overflow: visible; min-width: 0 !important; }
+#control-tabs .wrap { display: flex; gap: 0; border-bottom: 1px solid var(--border-color-primary); }
+#control-tabs label { flex: 1; justify-content: center; margin: 0; border: 0; border-bottom: 2px solid transparent; border-radius: 0; background: transparent; padding: 0.55rem 0.4rem; color: var(--body-text-color); cursor: pointer; }
+#control-tabs label.selected { border-bottom-color: var(--color-accent); color: var(--color-accent); }
+#control-tabs input { display: none; }
+#control-tabs span { font-weight: 600; }
+/* Click-mode radio as a segmented pill group. */
+#click-mode .wrap { display: flex; gap: 0; border: 1px solid var(--border-color-primary); border-radius: var(--radius-lg); overflow: hidden; }
+#click-mode label { flex: 1; justify-content: center; margin: 0; border-radius: 0; border: 0; background: var(--background-fill-secondary); padding: 0.45rem 0.4rem; cursor: pointer; }
+#click-mode label + label { border-left: 1px solid var(--border-color-primary); }
+#click-mode label.selected { background: var(--color-accent); color: white; }
+#click-mode input { display: none; }
+#click-mode span { font-weight: 600; }
+/* Four small tiles per row with a pager, like the 4DAnyone Space. */
+#examples .gallery { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+#examples .gallery button { flex: none; padding: 0; }
+#examples video, #examples img { height: 64px !important; width: auto !important; max-width: 84px; object-fit: cover; }
+/* The viewer's top edge lines up with the video card beside it. */
+#viewer-column { padding-top: 0; }
+#rerun-viewer { min-height: 0 !important; }
+#run-status {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-height: 4.5rem;
+    overflow: visible !important;
+    padding: 0.65rem 0.85rem;
+    border-radius: var(--radius-lg);
+    background: var(--background-fill-secondary);
+}
+#run-status p { font-size: 1.05rem; line-height: 1.4; margin: 0; }
+footer { display: none !important; }
+"""
+
+

--- a/packages/posekit/src/posekit/track_ui_theme.py
+++ b/packages/posekit/src/posekit/track_ui_theme.py
@@ -84,5 +84,3 @@ html, body, gradio-app, .gradio-container {
 #run-status p { font-size: 1.05rem; line-height: 1.4; margin: 0; }
 footer { display: none !important; }
 """
-
-

--- a/packages/posekit/tests/test_track_ui.py
+++ b/packages/posekit/tests/test_track_ui.py
@@ -16,9 +16,10 @@ from gradio_rerun.events import SelectionChange
 from jaxtyping import Int64, UInt8
 from numpy import ndarray
 
+import posekit.apis.track_recording as track_recording
 import posekit.track_ui as track_ui
 from posekit.apis.click_tracker import ClickTracker, MaskResult
-from posekit.track_ui import MASK_SCALE, Session, _close_session, _invalidate_track, _mask_hw, _merge_rrd_parts, _open_recording
+from posekit.apis.track_recording import MASK_SCALE, Session, _close_session, _invalidate_track, _mask_hw, _merge_rrd_parts, _open_recording
 
 CLIP: Path = Path(__file__).resolve().parents[2] / "wilor-nano" / "assets" / "video.mp4"
 SessionWithMock: TypeAlias = tuple[Session, Mock]
@@ -59,7 +60,7 @@ def test_state_delete_callback_closes_tracker_and_removes_rrds(tmp_path: Path, m
     session_with_mock: SessionWithMock = _session("expired")
     session: Session = session_with_mock[0]
     tracker: Mock = session_with_mock[1]
-    monkeypatch.setattr(track_ui, "RRD_DIR", tmp_path)
+    monkeypatch.setattr(track_recording, "RRD_DIR", tmp_path)
     config: track_ui.AppConfig = track_ui.AppConfig(variant="efficienttam-ti-512")
     demo: gr.Blocks = track_ui.build_demo(config)
     states: list[gr.State] = [block for block in demo.blocks.values() if isinstance(block, gr.State)]
@@ -83,7 +84,7 @@ def test_state_delete_callback_closes_tracker_and_removes_rrds(tmp_path: Path, m
 def test_download_recording_contains_video_prompts_masks_and_confidence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     session_with_mock: SessionWithMock = _session("download", prompted=[0])
     session: Session = session_with_mock[0]
-    monkeypatch.setattr(track_ui, "RRD_DIR", tmp_path)
+    monkeypatch.setattr(track_recording, "RRD_DIR", tmp_path)
 
     recording_pair: tuple[rr.RecordingStream, rr.BinaryStream] = _open_recording(session)
     rec: rr.RecordingStream = recording_pair[0]
@@ -174,7 +175,7 @@ def test_load_video_forwards_model_and_memory_config(monkeypatch: pytest.MonkeyP
     stream_mock: Mock = Mock(spec=rr.BinaryStream)
     stream_mock.read.return_value = b"payload"
     monkeypatch.setattr(track_ui, "ClickTracker", FakeClickTracker)
-    monkeypatch.setattr(track_ui, "_predictor", lambda _variant: predictor)
+    monkeypatch.setattr(track_ui, "cached_predictor", lambda _variant: predictor)
     monkeypatch.setattr(track_ui, "_open_recording", lambda _session: (rec_mock, stream_mock))
     monkeypatch.setattr(track_ui, "log_video", fake_log_video)
 
@@ -195,7 +196,7 @@ def test_failed_reload_keeps_previous_session_open(tmp_path: Path, monkeypatch: 
     previous_tracker: Mock = session_with_mock[1]
     corrupt_video: Path = tmp_path / "corrupt.mp4"
     corrupt_video.write_bytes(b"not an mp4")
-    monkeypatch.setattr(track_ui, "_predictor", lambda _variant: object())
+    monkeypatch.setattr(track_ui, "cached_predictor", lambda _variant: object())
 
     with pytest.raises((RuntimeError, ValueError)):
         next(track_ui.load_video(str(corrupt_video), previous_session, "efficienttam-s-512", 10.0))

--- a/packages/posekit/tests/test_track_ui.py
+++ b/packages/posekit/tests/test_track_ui.py
@@ -16,10 +16,10 @@ from gradio_rerun.events import SelectionChange
 from jaxtyping import Int64, UInt8
 from numpy import ndarray
 
-import posekit.apis.track_recording as track_recording
+import posekit.track_recording as track_recording
 import posekit.track_ui as track_ui
 from posekit.apis.click_tracker import ClickTracker, MaskResult
-from posekit.apis.track_recording import MASK_SCALE, Session, _close_session, _invalidate_track, _mask_hw, _merge_rrd_parts, _open_recording
+from posekit.track_recording import MASK_SCALE, Session, _close_session, _invalidate_track, _mask_hw, _merge_rrd_parts, _open_recording
 
 CLIP: Path = Path(__file__).resolve().parents[2] / "wilor-nano" / "assets" / "video.mp4"
 SessionWithMock: TypeAlias = tuple[Session, Mock]


### PR DESCRIPTION
Follow-up to #148, deferred from its review: a pure relocation with no behaviour change.

- `posekit/apis/track_recording.py` (223 lines) — `Session` and the per-session Rerun recording: live stream tee + downloadable `.rrd` parts, overlay logging under the mask scale transform, invalidation. Imports no gradio (checked in a fresh interpreter); it is the part the unit tests exercise.
- `posekit/track_ui_theme.py` (88 lines) — the CSS/HTML/JS strings, verbatim.
- `posekit/models/sam2_video.cached_predictor` — the per-variant cached loader, next to the predictor construction it wraps.
- `posekit/track_ui.py` keeps callbacks, `build_demo`, `launch`: 834 → 558 lines.

Moved function bodies and theme strings were diffed against `main` and are verbatim; tests re-point their imports, no assertion changed.

Verified: lint / typecheck / deadcode, 40 tests (28 s), no-browser Track smoke 299/299 frames, native-viewer render check.