### PR TITLE
posekit: accept clicks on masked pixels again (overlay hit carries the video-space position)

### DIFF
--- a/packages/posekit/src/posekit/track_ui.py
+++ b/packages/posekit/src/posekit/track_ui.py
@@ -454,10 +454,13 @@ def on_select(
     # The viewer fires selection_change on recording open and on every click
     # anywhere; ignored selections must still yield a chunk for the streaming
     # viewer output (gr.skip() there crashes Gradio's end_stream).
-    # A masked pixel can report both the scaled overlay and the source video.
-    # Only the source entity's hit is guaranteed to use video pixel coordinates.
+    # A click on a masked pixel reports the position on the overlay entity
+    # (/video/mask or /video/preview) and lists /video with position=None, so the
+    # first positioned hit under the video is the one to use. Measured on 0.36.2:
+    # the overlays sit under a scale transform, yet their reported position is in
+    # video pixels (preview hit [360.0, 620.0] for a video hit [359.99, 618.69]).
     position: list[float] | None = next(
-        (item.position for item in evt.payload.items if item.type == "entity" and item.entity_path == f"/{VIDEO}" and item.position is not None),
+        (item.position for item in evt.payload.items if item.type == "entity" and item.entity_path.startswith(f"/{VIDEO}") and item.position is not None),
         None,
     )
     if session is None or position is None:

--- a/packages/posekit/tests/test_track_ui.py
+++ b/packages/posekit/tests/test_track_ui.py
@@ -117,7 +117,8 @@ def test_mask_hw_downsamples_by_mask_scale() -> None:
     assert mask_hw.shape == (64 // MASK_SCALE, 96 // MASK_SCALE)
 
 
-def test_click_position_comes_from_video_entity_before_mask(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_click_on_masked_pixel_uses_the_overlay_hit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The viewer reports a masked click on the overlay entity (video pixels) and lists /video without a position."""
     session_with_mock: SessionWithMock = _session("selection")
     session: Session = session_with_mock[0]
     tracker: Mock = session_with_mock[1]
@@ -138,8 +139,8 @@ def test_click_position_comes_from_video_entity_before_mask(monkeypatch: pytest.
             "application_id": "test",
             "recording_id": session.recording_id,
             "items": [
-                {"type": "entity", "entity_path": "/video/mask", "position": [8.0, 9.0]},
-                {"type": "entity", "entity_path": "/video", "position": [80.0, 90.0]},
+                {"type": "entity", "entity_path": "/video/mask", "position": [80.0, 90.0]},
+                {"type": "entity", "entity_path": "/video", "position": None},
             ],
         }
     )


### PR DESCRIPTION
Regression from the review round of #148, found by Pablo in the live app: after the first click on a frame, further clicks on the object — and any click after scrubbing — were silently ignored.

Cause: a click on a pixel covered by the mask or the scrub preview is reported by the viewer on the overlay entity with `/video` listed but `position=None`:

```
bare video:   [('/video', [359.99, 618.69])]
masked pixel: [('/video/mask', [764.1, 332.0]), ('/video', None)]
preview:      [('/video/preview', [360.0, 620.0]), ('/video', None)]
```

The review rule "only the `/video` hit is in video pixel coordinates" was wrong: the overlays sit under a `Transform3D(scale=4)`, yet their reported position is in video pixels (preview `[360.0, 620.0]` vs the video hit `[359.99, 618.69]` for the same click). Restored "first positioned hit under `/video`", with the measurement in the comment; the test now uses the real payload shape.

Verified in the browser (Playwright on the embedded viewer): click at frame 0 → point 1; second click on the masked pixel → point 2; scrub 40 frames, click on the preview → point 3 at (360, 620) on frame 42. posekit lint/typecheck, 40 tests.