### PR TITLE
monoprior: LiteAnyStereoPredictor, StereoDepthPrediction, exoego:v2 stereo rig demo

### DIFF
--- a/packages/monoprior/monopriors/apis/stereo_depth.py
+++ b/packages/monoprior/monopriors/apis/stereo_depth.py
@@ -1,0 +1,74 @@
+"""Stereo depth on one rectified pair with Middlebury-style calibration, visualized as an exoego:v2 rig in Rerun."""
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import cv2
+import numpy as np
+import rerun as rr
+from jaxtyping import Float32, UInt8
+from simplecv.rerun_log_utils import RerunTyroConfig
+
+from monopriors.models.stereo_depth import STEREO_PREDICTORS, BaseStereoPredictor, StereoDepthPrediction, get_stereo_predictor
+from monopriors.rr_logging_utils import create_stereo_depth_blueprint, log_stereo_pred
+
+
+@dataclass(slots=True)
+class MiddleburyCalibration:
+    """The subset of a Middlebury v3 ``calib.txt`` a rectified pair needs (ETH3D two-view uses the same format)."""
+
+    K_33: Float32[np.ndarray, "3 3"]
+    """``cam0`` intrinsics."""
+    baseline_m: float
+    """``baseline`` (stored in millimetres in the file) converted to metres."""
+
+
+def read_middlebury_calib(path: Path) -> MiddleburyCalibration:
+    """Parse ``cam0=[fx 0 cx; 0 fy cy; 0 0 1]`` and ``baseline=<mm>`` from a Middlebury v3 ``calib.txt``."""
+    text: str = path.read_text()
+    cam0_match: re.Match[str] | None = re.search(r"cam0=\[(.*?)\]", text)
+    baseline_match: re.Match[str] | None = re.search(r"baseline=([\d.]+)", text)
+    if cam0_match is None or baseline_match is None:
+        raise ValueError(f"{path} lacks cam0/baseline entries")
+    K_33: Float32[np.ndarray, "3 3"] = np.array([[float(v) for v in row.split()] for row in cam0_match.group(1).split(";")], dtype=np.float32)
+    return MiddleburyCalibration(K_33=K_33, baseline_m=float(baseline_match.group(1)) / 1000.0)
+
+
+@dataclass
+class StereoDepthCLIConfig:
+    """CLI configuration for stereo depth estimation."""
+
+    rr_config: RerunTyroConfig
+    """Rerun logging configuration."""
+    scene_dir: Path = Path("data/examples/stereo/eth3d/two_view_training/playground_1l")
+    """Directory with ``im0.png`` (left), ``im1.png`` (right) and a Middlebury-style ``calib.txt``."""
+    predictor_name: STEREO_PREDICTORS = "LiteAnyStereoPredictor"
+    """Which stereo predictor to use."""
+    model_size: Literal["s", "m", "l", "h"] = "m"
+    """LiteAnyStereo V2 variant."""
+    device: Literal["cuda", "cpu"] = "cuda"
+    """Execution backend."""
+    max_depth_m: float = 20.0
+    """Depth beyond this is dropped from the logged depth image / point cloud."""
+
+
+def read_rgb(path: Path) -> UInt8[np.ndarray, "h w 3"]:
+    bgr_hw3: UInt8[np.ndarray, "h w 3"] | None = cv2.imread(str(path), cv2.IMREAD_COLOR)
+    if bgr_hw3 is None:
+        raise FileNotFoundError(f"Failed to read image {path}")
+    return cv2.cvtColor(bgr_hw3, cv2.COLOR_BGR2RGB)
+
+
+def main(config: StereoDepthCLIConfig) -> None:
+    left_rgb: UInt8[np.ndarray, "h w 3"] = read_rgb(config.scene_dir / "im0.png")
+    right_rgb: UInt8[np.ndarray, "h w 3"] = read_rgb(config.scene_dir / "im1.png")
+    calibration: MiddleburyCalibration = read_middlebury_calib(config.scene_dir / "calib.txt")
+
+    predictor: BaseStereoPredictor = get_stereo_predictor(config.predictor_name)(device=config.device, model_size=config.model_size)
+    stereo_pred: StereoDepthPrediction = predictor(left_rgb, right_rgb, K_33=calibration.K_33, baseline_m=calibration.baseline_m)
+
+    parent_log_path: Path = Path("world")
+    rr.send_blueprint(create_stereo_depth_blueprint(parent_log_path))
+    log_stereo_pred(parent_log_path, stereo_pred, left_rgb, right_rgb, max_depth_m=config.max_depth_m)

--- a/packages/monoprior/monopriors/models/stereo_depth/__init__.py
+++ b/packages/monoprior/monopriors/models/stereo_depth/__init__.py
@@ -1,0 +1,21 @@
+from collections.abc import Callable
+from typing import Literal, get_args
+
+from .base_stereo_depth import BaseStereoPredictor, StereoDepthPrediction, disparity_to_metric_depth
+from .liteanystereo import LiteAnyStereoPredictor
+
+STEREO_PREDICTORS = Literal["LiteAnyStereoPredictor"]
+
+__all__: list[str] = list(get_args(STEREO_PREDICTORS)) + [
+    "BaseStereoPredictor",
+    "StereoDepthPrediction",
+    "disparity_to_metric_depth",
+]
+
+
+def get_stereo_predictor(predictor_type: STEREO_PREDICTORS) -> Callable[..., BaseStereoPredictor]:
+    match predictor_type:
+        case "LiteAnyStereoPredictor":
+            return LiteAnyStereoPredictor
+        case _:
+            raise ValueError(f"Unknown predictor type: {predictor_type}")

--- a/packages/monoprior/monopriors/models/stereo_depth/base_stereo_depth.py
+++ b/packages/monoprior/monopriors/models/stereo_depth/base_stereo_depth.py
@@ -1,0 +1,59 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Generic, Literal, TypeVar
+
+import numpy as np
+from jaxtyping import Float32, UInt8
+
+from monopriors.models._protocols import DeviceMovable
+
+ModelT = TypeVar("ModelT", bound=DeviceMovable)
+
+
+@dataclass(slots=True)
+class StereoDepthPrediction:
+    """Output of a rectified stereo matcher for the left view."""
+
+    disparity: Float32[np.ndarray, "h w"]
+    """Left-view disparity in pixels (the network's native output); ``<= 0`` marks invalid pixels."""
+    depth_meters: Float32[np.ndarray, "h w"] | None
+    """``fx * baseline / disparity`` when intrinsics and baseline were given, ``0`` where disparity is invalid; else None."""
+    K_33: Float32[np.ndarray, "3 3"] | None
+    """Rectified pinhole intrinsics shared by both views, when given."""
+    baseline_m: float | None
+    """Stereo baseline in metres, when given."""
+
+
+def disparity_to_metric_depth(disparity_hw: Float32[np.ndarray, "h w"], fx: float, baseline_m: float) -> Float32[np.ndarray, "h w"]:
+    """Convert disparity to metric depth, leaving invalid (``<= 0``) disparities at ``0`` depth.
+
+    Args:
+        disparity_hw: Left-view disparity in pixels, ``Float32[ndarray, "h w"]``.
+        fx: Horizontal focal length in pixels.
+        baseline_m: Stereo baseline in metres.
+
+    Returns:
+        Depth in metres, ``Float32[ndarray, "h w"]``.
+    """
+    valid_hw: np.ndarray = disparity_hw > 0.0
+    depth_hw: Float32[np.ndarray, "h w"] = np.zeros_like(disparity_hw)
+    depth_hw[valid_hw] = fx * baseline_m / disparity_hw[valid_hw]
+    return depth_hw
+
+
+class BaseStereoPredictor(ABC, Generic[ModelT]):
+    model: ModelT
+
+    @abstractmethod
+    def __call__(
+        self,
+        left_rgb: UInt8[np.ndarray, "h w 3"],
+        right_rgb: UInt8[np.ndarray, "h w 3"],
+        K_33: Float32[np.ndarray, "3 3"] | None = None,
+        baseline_m: float | None = None,
+    ) -> StereoDepthPrediction:
+        """Predict left-view disparity for a rectified pair; metric depth is filled when ``K_33`` and ``baseline_m`` are given."""
+        raise NotImplementedError
+
+    def set_model_device(self, device: Literal["cpu", "cuda"] = "cuda") -> None:
+        self.model.to(device)

--- a/packages/monoprior/monopriors/models/stereo_depth/base_stereo_depth.py
+++ b/packages/monoprior/monopriors/models/stereo_depth/base_stereo_depth.py
@@ -16,12 +16,12 @@ class StereoDepthPrediction:
 
     disparity: Float32[np.ndarray, "h w"]
     """Left-view disparity in pixels (the network's native output); ``<= 0`` marks invalid pixels."""
-    depth_meters: Float32[np.ndarray, "h w"] | None
-    """``fx * baseline / disparity`` when intrinsics and baseline were given, ``0`` where disparity is invalid; else None."""
-    K_33: Float32[np.ndarray, "3 3"] | None
-    """Rectified pinhole intrinsics shared by both views, when given."""
-    baseline_m: float | None
-    """Stereo baseline in metres, when given."""
+    depth_meters: Float32[np.ndarray, "h w"]
+    """``fx * baseline / disparity``, with ``0`` where disparity is invalid."""
+    K_33: Float32[np.ndarray, "3 3"]
+    """Rectified pinhole intrinsics shared by both views."""
+    baseline_m: float
+    """Stereo baseline in metres."""
 
 
 def disparity_to_metric_depth(disparity_hw: Float32[np.ndarray, "h w"], fx: float, baseline_m: float) -> Float32[np.ndarray, "h w"]:
@@ -45,15 +45,25 @@ class BaseStereoPredictor(ABC, Generic[ModelT]):
     model: ModelT
 
     @abstractmethod
+    def infer_disparity(
+        self,
+        left_rgb: UInt8[np.ndarray, "h w 3"],
+        right_rgb: UInt8[np.ndarray, "h w 3"],
+    ) -> Float32[np.ndarray, "h w"]:
+        """Predict left-view disparity in pixels for a rectified stereo pair."""
+        raise NotImplementedError
+
     def __call__(
         self,
         left_rgb: UInt8[np.ndarray, "h w 3"],
         right_rgb: UInt8[np.ndarray, "h w 3"],
-        K_33: Float32[np.ndarray, "3 3"] | None = None,
-        baseline_m: float | None = None,
+        K_33: Float32[np.ndarray, "3 3"],
+        baseline_m: float,
     ) -> StereoDepthPrediction:
-        """Predict left-view disparity for a rectified pair; metric depth is filled when ``K_33`` and ``baseline_m`` are given."""
-        raise NotImplementedError
+        """Predict calibrated left-view disparity and metric depth for a rectified stereo pair."""
+        disparity_hw: Float32[np.ndarray, "h w"] = self.infer_disparity(left_rgb, right_rgb)
+        depth_hw: Float32[np.ndarray, "h w"] = disparity_to_metric_depth(disparity_hw, float(K_33[0, 0]), baseline_m)
+        return StereoDepthPrediction(disparity=disparity_hw, depth_meters=depth_hw, K_33=K_33, baseline_m=baseline_m)
 
     def set_model_device(self, device: Literal["cpu", "cuda"] = "cuda") -> None:
         self.model.to(device)

--- a/packages/monoprior/monopriors/models/stereo_depth/liteanystereo.py
+++ b/packages/monoprior/monopriors/models/stereo_depth/liteanystereo.py
@@ -1,0 +1,86 @@
+"""LiteAnyStereo V2 (LAS2 S/M/L/H) as a ``BaseStereoPredictor``.
+
+Preprocessing mirrors upstream ``demo.py``: float RGB in ``[0, 255]`` (no normalisation), padded to a
+multiple of 32 with the upstream ``InputPadder``, ``model(left, right, max_disp, test_mode=True)``.
+"""
+
+from pathlib import Path
+from typing import Literal, TypeAlias
+
+import numpy as np
+import torch
+from einops import rearrange
+from huggingface_hub import hf_hub_download
+from jaxtyping import Float32, UInt8
+from torch import nn
+
+from monopriors.third_party.liteanystereo.liteanystereov2 import build_liteanystereo
+from monopriors.third_party.liteanystereo.padding import InputPadder
+
+from .base_stereo_depth import BaseStereoPredictor, StereoDepthPrediction, disparity_to_metric_depth
+
+LAS2ModelSize: TypeAlias = Literal["s", "m", "l", "h"]
+
+LITEANYSTEREO_HF_REPO = "pablovela5620/liteanystereo"
+"""Unmodified mirror of ``tomtomtommi/LiteAnyStereoV2`` (LAS2_{S,M,L,H}.pth)."""
+LITEANYSTEREO_HF_REVISION = "19870ad07fe89fe6e5a7c11c69348e13936adbe7"
+
+
+def download_liteanystereo_checkpoint(model_size: LAS2ModelSize) -> Path:
+    """Released LAS2 weights for one model size, from the pinned HF mirror."""
+    return Path(hf_hub_download(repo_id=LITEANYSTEREO_HF_REPO, filename=f"LAS2_{model_size.upper()}.pth", revision=LITEANYSTEREO_HF_REVISION))
+
+
+def load_liteanystereo(model_size: LAS2ModelSize, checkpoint: Path, max_disp: int = 192) -> nn.Module:
+    """Build a LAS2 network and strictly load a released checkpoint (bare state dict or ``{"model"|"state_dict": ...}``)."""
+    model: nn.Module = build_liteanystereo(model_size=model_size, fnet_pretrained=False, max_disp=max_disp)
+    state: dict = torch.load(checkpoint, map_location="cpu")
+    for key in ("model", "state_dict"):
+        if key in state:
+            state = state[key]
+    state = {k.removeprefix("module."): v for k, v in state.items()}
+    model.load_state_dict(state, strict=True)
+    return model
+
+
+class LiteAnyStereoPredictor(BaseStereoPredictor[nn.Module]):
+    def __init__(
+        self,
+        device: Literal["cpu", "cuda"],
+        model_size: LAS2ModelSize = "m",
+        checkpoint: Path | None = None,
+        max_disp: int = 192,
+    ) -> None:
+        """
+        Args:
+            device: Where the network runs.
+            model_size: LAS2 variant; ``s``/``m``/``l`` are feed-forward, ``h`` is the iterative ConvGRU model.
+            checkpoint: Local weights; downloaded from the pinned HF mirror when None.
+            max_disp: Disparity search range in pixels. Upstream S/M/L are built for 192 regardless; ``h`` is built for this value.
+        """
+        self.max_disp: int = max_disp
+        self.model: nn.Module = load_liteanystereo(model_size, checkpoint or download_liteanystereo_checkpoint(model_size), max_disp).to(device).eval()
+
+    def infer_disparity(self, left_rgb: UInt8[np.ndarray, "h w 3"], right_rgb: UInt8[np.ndarray, "h w 3"]) -> Float32[np.ndarray, "h w"]:
+        """Left-view disparity in pixels at input resolution."""
+        device: torch.device = next(self.model.parameters()).device
+        left_13hw: Float32[torch.Tensor, "1 3 h w"] = rearrange(torch.from_numpy(left_rgb).to(device).float(), "h w c -> 1 c h w")
+        right_13hw: Float32[torch.Tensor, "1 3 h w"] = rearrange(torch.from_numpy(right_rgb).to(device).float(), "h w c -> 1 c h w")
+        padder: InputPadder = InputPadder(left_13hw.shape, divis_by=32)
+        padded: list[Float32[torch.Tensor, "1 3 hp wp"]] = padder.pad(left_13hw, right_13hw)
+        with torch.no_grad():
+            disparity_11hw: Float32[torch.Tensor, "1 1 hp wp"] = self.model(padded[0], padded[1], max_disp=self.max_disp, test_mode=True)
+        return rearrange(padder.unpad(disparity_11hw.float()), "1 1 h w -> h w").cpu().numpy()
+
+    def __call__(
+        self,
+        left_rgb: UInt8[np.ndarray, "h w 3"],
+        right_rgb: UInt8[np.ndarray, "h w 3"],
+        K_33: Float32[np.ndarray, "3 3"] | None = None,
+        baseline_m: float | None = None,
+    ) -> StereoDepthPrediction:
+        disparity_hw: Float32[np.ndarray, "h w"] = self.infer_disparity(left_rgb, right_rgb)
+        depth_hw: Float32[np.ndarray, "h w"] | None = None
+        if K_33 is not None and baseline_m is not None:
+            depth_hw = disparity_to_metric_depth(disparity_hw, float(K_33[0, 0]), baseline_m)
+        return StereoDepthPrediction(disparity=disparity_hw, depth_meters=depth_hw, K_33=K_33, baseline_m=baseline_m)

--- a/packages/monoprior/monopriors/models/stereo_depth/liteanystereo.py
+++ b/packages/monoprior/monopriors/models/stereo_depth/liteanystereo.py
@@ -17,7 +17,7 @@ from torch import nn
 from monopriors.third_party.liteanystereo.liteanystereov2 import build_liteanystereo
 from monopriors.third_party.liteanystereo.padding import InputPadder
 
-from .base_stereo_depth import BaseStereoPredictor, StereoDepthPrediction, disparity_to_metric_depth
+from .base_stereo_depth import BaseStereoPredictor
 
 LAS2ModelSize: TypeAlias = Literal["s", "m", "l", "h"]
 
@@ -71,16 +71,3 @@ class LiteAnyStereoPredictor(BaseStereoPredictor[nn.Module]):
         with torch.no_grad():
             disparity_11hw: Float32[torch.Tensor, "1 1 hp wp"] = self.model(padded[0], padded[1], max_disp=self.max_disp, test_mode=True)
         return rearrange(padder.unpad(disparity_11hw.float()), "1 1 h w -> h w").cpu().numpy()
-
-    def __call__(
-        self,
-        left_rgb: UInt8[np.ndarray, "h w 3"],
-        right_rgb: UInt8[np.ndarray, "h w 3"],
-        K_33: Float32[np.ndarray, "3 3"] | None = None,
-        baseline_m: float | None = None,
-    ) -> StereoDepthPrediction:
-        disparity_hw: Float32[np.ndarray, "h w"] = self.infer_disparity(left_rgb, right_rgb)
-        depth_hw: Float32[np.ndarray, "h w"] | None = None
-        if K_33 is not None and baseline_m is not None:
-            depth_hw = disparity_to_metric_depth(disparity_hw, float(K_33[0, 0]), baseline_m)
-        return StereoDepthPrediction(disparity=disparity_hw, depth_meters=depth_hw, K_33=K_33, baseline_m=baseline_m)

--- a/packages/monoprior/monopriors/rr_logging_utils.py
+++ b/packages/monoprior/monopriors/rr_logging_utils.py
@@ -324,8 +324,6 @@ def log_stereo_pred(
     from simplecv.rerun_rig_logger import log_rig_static
     from simplecv.rig import Rig, stereo_rig_calibration
 
-    if stereo_pred.K_33 is None or stereo_pred.baseline_m is None or stereo_pred.depth_meters is None:
-        raise ValueError("log_stereo_pred needs a calibrated prediction (K_33, baseline_m, depth_meters)")
     height: int = left_rgb.shape[0]
     width: int = left_rgb.shape[1]
     rig: Rig = Rig(index=0, calibration=stereo_rig_calibration(stereo_pred.K_33, stereo_pred.baseline_m, width, height), image_plane_distance=0.5)

--- a/packages/monoprior/monopriors/rr_logging_utils.py
+++ b/packages/monoprior/monopriors/rr_logging_utils.py
@@ -9,6 +9,7 @@ from jaxtyping import Bool, Float32, Float64, UInt8
 from monopriors.depth_utils import clip_disparity, depth_edges_mask, depth_to_disparity, depth_to_points
 from monopriors.models.metric_depth import METRIC_PREDICTORS, MetricDepthPrediction
 from monopriors.models.relative_depth import RELATIVE_PREDICTORS, RelativeDepthPrediction
+from monopriors.models.stereo_depth import StereoDepthPrediction
 from monopriors.models.surface_normal.base_normal_model import SurfaceNormalPrediction
 
 CONFIDENCE_THRESHOLD: float = 0.5
@@ -278,3 +279,62 @@ def log_normal_pred(
 
     confidence_hw1: Float32[np.ndarray, "h w 1"] = normal_pred.confidence_hw1
     rr.log(f"{pinhole_path}/confidence", rr.Image((confidence_hw1 * 255).astype(np.uint8)))
+
+
+def create_stereo_depth_blueprint(parent_log_path: Path) -> rrb.Blueprint:
+    """3D rig + cloud beside the stereo pair, metric depth, and disparity (matches ``log_stereo_pred``)."""
+    left_path: Path = parent_log_path / "rig_00" / "cam_00"
+    right_path: Path = parent_log_path / "rig_00" / "cam_01"
+    return rrb.Blueprint(
+        rrb.Horizontal(
+            rrb.Spatial3DView(origin=f"{parent_log_path}", contents=["$origin/**", f"- {left_path}/pinhole/image", f"- {right_path}/pinhole/image", f"- {left_path}/disparity"]),
+            rrb.Vertical(
+                rrb.Horizontal(rrb.Spatial2DView(origin=f"{left_path}/pinhole/image", name="left"), rrb.Spatial2DView(origin=f"{right_path}/pinhole/image", name="right")),
+                rrb.Spatial2DView(origin=f"{left_path}/pinhole/depth", name="depth (m)"),
+                rrb.Spatial2DView(origin=f"{left_path}/disparity", name="disparity (px)"),
+            ),
+            column_shares=[3, 2],
+        ),
+        collapse_panels=True,
+    )
+
+
+def log_stereo_pred(
+    parent_log_path: Path,
+    stereo_pred: StereoDepthPrediction,
+    left_rgb: UInt8[np.ndarray, "h w 3"],
+    right_rgb: UInt8[np.ndarray, "h w 3"],
+    max_depth_m: float = 20.0,
+    jpeg_quality: int = 90,
+) -> None:
+    """Log a calibrated stereo prediction as an exoego:v2 rig.
+
+    ``rig_00/cam_00`` is the left (reference) camera, ``cam_01`` the right one at ``+baseline`` along x. Metric depth goes
+    under the left pinhole (``cam_00/pinhole/depth``) so the viewer backprojects it; disparity is logged beside the pinhole
+    (``cam_00/disparity``) so it is not. Depth beyond ``max_depth_m`` is dropped: sub-pixel disparities explode to kilometres.
+
+    Args:
+        parent_log_path: World entity path; the rig is logged at ``<parent>/rig_00``.
+        stereo_pred: Prediction with ``K_33``, ``baseline_m``, and ``depth_meters`` filled.
+        left_rgb: Left image, ``UInt8[ndarray, "h w 3"]``.
+        right_rgb: Right image, ``UInt8[ndarray, "h w 3"]``.
+        max_depth_m: Depth cut-off for the logged depth image.
+        jpeg_quality: JPEG quality for the two images.
+    """
+    from simplecv.rerun_rig_logger import log_rig_static
+    from simplecv.rig import Rig, stereo_rig_calibration
+
+    if stereo_pred.K_33 is None or stereo_pred.baseline_m is None or stereo_pred.depth_meters is None:
+        raise ValueError("log_stereo_pred needs a calibrated prediction (K_33, baseline_m, depth_meters)")
+    height: int = left_rgb.shape[0]
+    width: int = left_rgb.shape[1]
+    rig: Rig = Rig(index=0, calibration=stereo_rig_calibration(stereo_pred.K_33, stereo_pred.baseline_m, width, height), image_plane_distance=0.5)
+    rr.log(f"{parent_log_path}", rr.ViewCoordinates.RDF, static=True)
+    log_rig_static(rig, world_path=str(parent_log_path))
+    left_path: Path = parent_log_path / "rig_00" / "cam_00"
+    right_path: Path = parent_log_path / "rig_00" / "cam_01"
+    rr.log(f"{left_path}/pinhole/image", rr.Image(left_rgb).compress(jpeg_quality=jpeg_quality), static=True)
+    rr.log(f"{right_path}/pinhole/image", rr.Image(right_rgb).compress(jpeg_quality=jpeg_quality), static=True)
+    depth_hw: Float32[np.ndarray, "h w"] = np.where(stereo_pred.depth_meters > max_depth_m, 0.0, stereo_pred.depth_meters).astype(np.float32)
+    rr.log(f"{left_path}/pinhole/depth", rr.DepthImage(depth_hw, meter=1.0, depth_range=(0.0, max_depth_m)), static=True)
+    rr.log(f"{left_path}/disparity", rr.DepthImage(stereo_pred.disparity), static=True)

--- a/packages/monoprior/tests/test_liteanystereo_eth3d.py
+++ b/packages/monoprior/tests/test_liteanystereo_eth3d.py
@@ -40,4 +40,4 @@ def test_eth3d_playground_bad1(model_size: str, max_bad1_percent: float) -> None
     error_hw = np.abs(pred.disparity - gt_hw)
     bad1_percent = 100.0 * float((error_hw[valid_hw] > 1.0).mean())
     assert bad1_percent < max_bad1_percent, f"LAS2-{model_size.upper()} bad1 {bad1_percent:.2f}%"
-    assert pred.depth_meters is not None and np.nanmedian(pred.depth_meters[pred.depth_meters > 0]) < 50.0
+    assert np.nanmedian(pred.depth_meters[pred.depth_meters > 0]) < 50.0

--- a/packages/monoprior/tests/test_liteanystereo_eth3d.py
+++ b/packages/monoprior/tests/test_liteanystereo_eth3d.py
@@ -1,0 +1,43 @@
+"""Released LAS2 weights on the ETH3D ``playground_1l`` sample must land near the numbers recorded on the fork
+(M: EPE 0.350 / bad1 2.24 %, H: 0.250 / 1.12 %; paper dataset means 2.59 / 1.83). Downloads weights + data."""
+
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+from conftest import requires_cuda, slow_cuda
+from huggingface_hub import snapshot_download
+from jaxtyping import Bool, Float32, UInt8
+
+from monopriors.apis.stereo_depth import read_middlebury_calib, read_rgb
+from monopriors.models.stereo_depth import LiteAnyStereoPredictor
+
+pytestmark = [slow_cuda, requires_cuda]
+
+
+def _read_pfm(path: Path) -> Float32[np.ndarray, "h w"]:
+    with path.open("rb") as f:
+        assert f.readline().strip() == b"Pf"
+        width, height = (int(v) for v in f.readline().split())
+        scale = float(f.readline())
+        data = np.fromfile(f, dtype="<f4" if scale < 0 else ">f4", count=width * height)
+    return np.flipud(data.reshape(height, width)).astype(np.float32)
+
+
+@pytest.mark.parametrize(("model_size", "max_bad1_percent"), [("m", 3.5), ("h", 2.0)])
+def test_eth3d_playground_bad1(model_size: str, max_bad1_percent: float) -> None:
+    root = Path(snapshot_download("pablovela5620/monoprior-example", repo_type="dataset", allow_patterns=["stereo/eth3d/two_view_training*/**"]))
+    scene = root / "stereo/eth3d/two_view_training/playground_1l"
+    gt_dir = root / "stereo/eth3d/two_view_training_gt/playground_1l"
+    calibration = read_middlebury_calib(scene / "calib.txt")
+    predictor = LiteAnyStereoPredictor(device="cuda", model_size=model_size)
+    pred = predictor(read_rgb(scene / "im0.png"), read_rgb(scene / "im1.png"), K_33=calibration.K_33, baseline_m=calibration.baseline_m)
+
+    gt_hw: Float32[np.ndarray, "h w"] = _read_pfm(gt_dir / "disp0GT.pfm")
+    nocc_hw: UInt8[np.ndarray, "h w"] = cv2.imread(str(gt_dir / "mask0nocc.png"), cv2.IMREAD_GRAYSCALE)
+    valid_hw: Bool[np.ndarray, "h w"] = np.isfinite(gt_hw) & (gt_hw < 192) & (nocc_hw == 255)
+    error_hw = np.abs(pred.disparity - gt_hw)
+    bad1_percent = 100.0 * float((error_hw[valid_hw] > 1.0).mean())
+    assert bad1_percent < max_bad1_percent, f"LAS2-{model_size.upper()} bad1 {bad1_percent:.2f}%"
+    assert pred.depth_meters is not None and np.nanmedian(pred.depth_meters[pred.depth_meters > 0]) < 50.0

--- a/packages/monoprior/tests/test_liteanystereo_predictor.py
+++ b/packages/monoprior/tests/test_liteanystereo_predictor.py
@@ -40,19 +40,17 @@ def test_local_checkpoint_bypasses_download(monkeypatch: pytest.MonkeyPatch, rel
     LiteAnyStereoPredictor(device="cpu", model_size="s", checkpoint=released_style_checkpoint)
 
 
-def test_call_contract_without_calibration(predictor: LiteAnyStereoPredictor) -> None:
-    rng = np.random.default_rng(0)
-    left = rng.integers(0, 255, (50, 70, 3), dtype=np.uint8)  # not a multiple of 32: exercises the padder
-    pred = predictor(left, left)
-    assert pred.disparity.shape == (50, 70) and pred.disparity.dtype == np.float32 and np.isfinite(pred.disparity).all()
-    assert pred.depth_meters is None and pred.K_33 is None and pred.baseline_m is None
+def test_call_requires_calibration(predictor: LiteAnyStereoPredictor) -> None:
+    left = np.zeros((64, 96, 3), dtype=np.uint8)
+    with pytest.raises(TypeError):
+        predictor(left, left)
 
 
 def test_call_contract_with_calibration(predictor: LiteAnyStereoPredictor) -> None:
     left = np.zeros((64, 96, 3), dtype=np.uint8)
     K_33 = np.array([[100.0, 0, 48], [0, 100.0, 32], [0, 0, 1]], dtype=np.float32)
     pred = predictor(left, left, K_33=K_33, baseline_m=0.1)
-    assert pred.depth_meters is not None and pred.depth_meters.shape == (64, 96) and pred.depth_meters.dtype == np.float32
+    assert pred.depth_meters.shape == (64, 96) and pred.depth_meters.dtype == np.float32
     valid = pred.disparity > 0.0
     assert np.allclose(pred.depth_meters[valid], 100.0 * 0.1 / pred.disparity[valid])
     assert (pred.depth_meters[~valid] == 0.0).all()

--- a/packages/monoprior/tests/test_liteanystereo_predictor.py
+++ b/packages/monoprior/tests/test_liteanystereo_predictor.py
@@ -1,0 +1,59 @@
+"""LiteAnyStereoPredictor: registration, checkpoint loading, and the StereoDepthPrediction contract.
+
+Runs on CPU against a randomly initialised LAS2-S saved to disk, so no download or GPU is needed.
+"""
+
+from pathlib import Path
+from typing import get_args
+
+import numpy as np
+import pytest
+import torch
+
+from monopriors.models.stereo_depth import STEREO_PREDICTORS, LiteAnyStereoPredictor, get_stereo_predictor
+from monopriors.models.stereo_depth import liteanystereo as liteanystereo_module
+from monopriors.third_party.liteanystereo.liteanystereov2 import build_liteanystereo
+
+
+def test_registered() -> None:
+    assert "LiteAnyStereoPredictor" in get_args(STEREO_PREDICTORS)
+    assert get_stereo_predictor("LiteAnyStereoPredictor") is LiteAnyStereoPredictor
+
+
+@pytest.fixture(scope="module")
+def released_style_checkpoint(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A checkpoint in the released format: DDP-prefixed keys under a ``model`` entry."""
+    torch.manual_seed(0)
+    model = build_liteanystereo(model_size="s", fnet_pretrained=False)
+    path = tmp_path_factory.mktemp("ckpt") / "LAS2_S.pth"
+    torch.save({"model": {"module." + k: v for k, v in model.state_dict().items()}}, path)
+    return path
+
+
+@pytest.fixture(scope="module")
+def predictor(released_style_checkpoint: Path) -> LiteAnyStereoPredictor:
+    return LiteAnyStereoPredictor(device="cpu", model_size="s", checkpoint=released_style_checkpoint)
+
+
+def test_local_checkpoint_bypasses_download(monkeypatch: pytest.MonkeyPatch, released_style_checkpoint: Path) -> None:
+    monkeypatch.setattr(liteanystereo_module, "download_liteanystereo_checkpoint", lambda model_size: pytest.fail("should not download"))
+    LiteAnyStereoPredictor(device="cpu", model_size="s", checkpoint=released_style_checkpoint)
+
+
+def test_call_contract_without_calibration(predictor: LiteAnyStereoPredictor) -> None:
+    rng = np.random.default_rng(0)
+    left = rng.integers(0, 255, (50, 70, 3), dtype=np.uint8)  # not a multiple of 32: exercises the padder
+    pred = predictor(left, left)
+    assert pred.disparity.shape == (50, 70) and pred.disparity.dtype == np.float32 and np.isfinite(pred.disparity).all()
+    assert pred.depth_meters is None and pred.K_33 is None and pred.baseline_m is None
+
+
+def test_call_contract_with_calibration(predictor: LiteAnyStereoPredictor) -> None:
+    left = np.zeros((64, 96, 3), dtype=np.uint8)
+    K_33 = np.array([[100.0, 0, 48], [0, 100.0, 32], [0, 0, 1]], dtype=np.float32)
+    pred = predictor(left, left, K_33=K_33, baseline_m=0.1)
+    assert pred.depth_meters is not None and pred.depth_meters.shape == (64, 96) and pred.depth_meters.dtype == np.float32
+    valid = pred.disparity > 0.0
+    assert np.allclose(pred.depth_meters[valid], 100.0 * 0.1 / pred.disparity[valid])
+    assert (pred.depth_meters[~valid] == 0.0).all()
+    assert pred.baseline_m == 0.1 and pred.K_33 is K_33

--- a/packages/monoprior/tools/demos/stereo_depth.py
+++ b/packages/monoprior/tools/demos/stereo_depth.py
@@ -1,0 +1,6 @@
+import tyro
+
+from monopriors.apis.stereo_depth import StereoDepthCLIConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(StereoDepthCLIConfig))

--- a/packages/simplecv/simplecv/rig.py
+++ b/packages/simplecv/simplecv/rig.py
@@ -33,7 +33,7 @@ import numpy as np
 from jaxtyping import Bool, Float
 from numpy import ndarray
 
-from simplecv.camera_parameters import Extrinsics, Fisheye62Parameters, PinholeParameters
+from simplecv.camera_parameters import Extrinsics, Fisheye62Parameters, Intrinsics, PinholeParameters
 
 #: Reserved sensor kinds describing image *content* (not projection model — a
 #: fisheye RGB camera is still ``"rgb"``). Only ``rgb``/``grayscale`` cameras are
@@ -181,3 +181,23 @@ def rebuild_camera_with_extrinsics(
     and re-runs ``__post_init__`` so the derived ``projection_matrix`` is rebuilt.
     """
     return replace(camera, extrinsics=extrinsics)
+
+
+def stereo_rig_calibration(K_33: Float[ndarray, "3 3"], baseline_m: float, width: int, height: int) -> RigCalibration:
+    """Calibration for a rectified stereo pair: ``cam_00`` = left (reference, identity), ``cam_01`` = right at ``+baseline_m`` along x.
+
+    Args:
+        K_33: Shared pinhole intrinsics of the rectified pair, ``Float[ndarray, "3 3"]``.
+        baseline_m: Distance between the optical centres in metres.
+        width: Image width in pixels.
+        height: Image height in pixels.
+
+    Returns:
+        A two-camera :class:`RigCalibration` with the left camera as reference.
+    """
+    cameras: list[CameraSensor] = []
+    for index, name, t_x in ((0, "left", 0.0), (1, "right", baseline_m)):
+        intrinsics: Intrinsics = Intrinsics(camera_conventions="RDF", height=height, width=width, k_matrix=K_33)
+        extrinsics: Extrinsics = Extrinsics(world_R_cam=np.eye(3), world_t_cam=np.array([t_x, 0.0, 0.0]))
+        cameras.append(CameraSensor(index=index, name=name, kind="rgb", pinhole=PinholeParameters(name=name, extrinsics=extrinsics, intrinsics=intrinsics)))
+    return RigCalibration(cameras=cameras, reference_index=0)

--- a/pixi.toml
+++ b/pixi.toml
@@ -427,6 +427,16 @@ cmd = "test -d data/examples/polycam || hf download pablovela5620/monoprior-exam
 cwd = "packages/monoprior"
 
 # ── Demo tasks ───────────────────────────────────────────────────────────
+[feature.monoprior.tasks._monoprior-download-stereo]
+cmd = "test -d data/examples/stereo/eth3d || hf download pablovela5620/monoprior-example --include 'stereo/eth3d/two_view_training*/**' --repo-type dataset --local-dir data/examples/"
+cwd = "packages/monoprior"
+
+[feature.monoprior.tasks.monoprior-stereo-depth]
+cmd = "python tools/demos/stereo_depth.py"
+depends-on = ["_monoprior-download-stereo"]
+cwd = "packages/monoprior"
+description = "LiteAnyStereo V2 on the ETH3D playground_1l stereo pair, shown as an exoego:v2 rig in Rerun"
+
 [feature.monoprior.tasks.monoprior-relative-depth]
 cmd = "python tools/demos/relative_depth.py --image-path data/examples/single-image/room.jpg"
 depends-on = ["_monoprior-download-single-image"]


### PR DESCRIPTION
PR 2/3 of the LiteAnyStereo V2 stereo port (base: #1 vendor).

- `models/stereo_depth/`: `StereoDepthPrediction(disparity, depth_meters|None, K_33|None, baseline_m|None)`, `BaseStereoPredictor`, `LiteAnyStereoPredictor(device, model_size, checkpoint=None, max_disp=192)` — weights from the pinned mirror `pablovela5620/liteanystereo`; preprocessing mirrors upstream `demo.py`.
- `simplecv.rig.stereo_rig_calibration` + `rr_logging_utils.log_stereo_pred`/`create_stereo_depth_blueprint`: exoego:v2 rig (`rig_00/cam_00` left reference, `cam_01` right at +baseline), metric depth under the left pinhole, disparity beside it.
- `apis/stereo_depth.py` + `tools/demos/stereo_depth.py`; task `pixi run -e monoprior monoprior-stereo-depth` (ETH3D `playground_1l` sample from `pablovela5620/monoprior-example`).
- Tests: CPU contract tests on a random-init LAS2-S; `-m slow` GPU ETH3D bad1 band for M (<3.5 %) and H (<2 %) — measured 2.24 % / 1.12 % (paper dataset means 2.59 / 1.83).

Viewer-validated (headless 0.36.2 screenshots + embedded rrds): https://pablos-4800gt.ilish-ruler.ts.net:8768/liteanystereo/las-fork-tracker.html