### PR TITLE
posekit: atomic reload, single stamp-guarded time_update listener, Undo re-requests the preview

### DIFF
--- a/packages/posekit/src/posekit/track_recording.py
+++ b/packages/posekit/src/posekit/track_recording.py
@@ -51,6 +51,8 @@ class Session:
     """Set by the viewer's play/pause events; clicks while playing have no known frame and are refused."""
     preview_visible: bool = False
     """A static preview mask is currently shown on ``video/preview``."""
+    preview_seq: int = 0
+    """Sequence number folded into ``preview_request`` values (see ``track_ui._preview_request``)."""
     masked_frames: set[int] = field(default_factory=set)
     """Frames that carry a mask; anything else must show none (latest-at would otherwise keep the last one)."""
     pointed_frames: set[int] = field(default_factory=set)

--- a/packages/posekit/src/posekit/track_ui.py
+++ b/packages/posekit/src/posekit/track_ui.py
@@ -25,6 +25,7 @@ import gradio as gr
 import numpy as np
 import rerun as rr
 import tyro
+from beartype.roar import BeartypeException
 from gradio_rerun import Rerun
 from gradio_rerun.events import Pause, Play, SelectionChange, TimeUpdate
 from jaxtyping import UInt8
@@ -59,6 +60,8 @@ from posekit.track_ui_theme import APP_CSS, DESCRIPTION, FORCE_DARK_HEAD, VIEWER
 
 Mode: TypeAlias = Literal["+ Include", "− Exclude", "✕ Remove"]
 MODES: list[Mode] = ["+ Include", "− Exclude", "✕ Remove"]
+PREVIEW_SEQ_STRIDE: int = 1_000_000
+"""``preview_request`` = seq * stride + frame: the sequence number makes every request a new value."""
 TabName: TypeAlias = Literal["Input", "Config", "Outputs"]
 _EXAMPLES_DIR: Path = Path(__file__).resolve().parents[2] / "assets" / "examples"
 EXAMPLE_VIDEOS: list[str] = [
@@ -133,35 +136,44 @@ def load_video(
     video_path: Path = Path(video)
     if variant not in SAM2_VARIANTS:
         raise gr.Error(f"Unknown model {variant!r}.")
+    # The previous session stays live until the replacement is complete: a failure
+    # anywhere below (undecodable clip, transcode error) leaves Gradio holding the
+    # old Session, which must therefore still own an open decoder.
     tracker: ClickTracker = ClickTracker(video_path, cached_predictor(variant), memory_window_size=int(memory_window))
-    _close_session(previous_session)
     session: Session = Session(
         tracker=tracker,
         video_path=video_path,
         recording_id=recording_id,
         frame_timestamps_ns=np.empty(0, dtype=np.int64),
     )
-    recording_pair: RecordingPair = _open_recording(session)
-    rec: rr.RecordingStream = recording_pair[0]
-    stream: rr.BinaryStream = recording_pair[1]
-    rec.send_blueprint(_blueprint())
-    rec.log(
-        VIDEO,
-        rr.AnnotationContext([rr.AnnotationInfo(id=0, label="background", color=(0, 0, 0, 0)), rr.AnnotationInfo(id=1, label="object", color=MASK_COLOR)]),
-        static=True,
-    )
-    for entity in (f"{VIDEO}/mask", f"{VIDEO}/preview"):
-        rec.log(entity, rr.Transform3D(scale=float(MASK_SCALE)), static=True)
-    session.frame_timestamps_ns = log_video(
-        video_path,
-        Path(VIDEO),
-        timeline=TIMELINE,
-        recording=rec,
-        output_codec=rr.VideoCodec.H264,
-    )
-    stream.flush()
-    payload: bytes | None = stream.read()
-    rec.disconnect()
+    try:
+        recording_pair: RecordingPair = _open_recording(session)
+        rec: rr.RecordingStream = recording_pair[0]
+        stream: rr.BinaryStream = recording_pair[1]
+        rec.send_blueprint(_blueprint())
+        rec.log(
+            VIDEO,
+            rr.AnnotationContext([rr.AnnotationInfo(id=0, label="background", color=(0, 0, 0, 0)), rr.AnnotationInfo(id=1, label="object", color=MASK_COLOR)]),
+            static=True,
+        )
+        for entity in (f"{VIDEO}/mask", f"{VIDEO}/preview"):
+            rec.log(entity, rr.Transform3D(scale=float(MASK_SCALE)), static=True)
+        session.frame_timestamps_ns = log_video(
+            video_path,
+            Path(VIDEO),
+            timeline=TIMELINE,
+            recording=rec,
+            output_codec=rr.VideoCodec.H264,
+        )
+        stream.flush()
+        payload: bytes | None = stream.read()
+        rec.disconnect()
+    except BeartypeException:
+        raise
+    except Exception:
+        _close_session(session)
+        raise
+    _close_session(previous_session)
     yield (
         payload,
         session,
@@ -182,20 +194,36 @@ def _reload_video_from_config(
     yield from load_video(video, previous_session, variant, memory_window, selected_tab="Config")
 
 
-def record_time(session: Session | None, stamp: float | None, evt: TimeUpdate) -> None:
-    """Record the viewer's frame instantly (no queue, no outputs) so a click right after a scrub reads the right frame.
+def _preview_request(session: Session, frame_idx: int) -> float:
+    """A fresh ``preview_request`` value for ``frame_idx`` (a repeat of the same frame must still fire ``.change``)."""
+    session.preview_seq += 1
+    return float(session.preview_seq * PREVIEW_SEQ_STRIDE + frame_idx)
 
-    ``stamp`` is the browser's ``performance.now()`` at dispatch (see the ``js`` hook): unqueued
-    requests can complete out of order, so an older event must never overwrite a newer one.
+
+def on_time_update(session: Session | None, stamp: float | None, evt: TimeUpdate) -> tuple[Any, Any, Any]:
+    """Record the viewer's frame instantly, report it, and hand it to ``push_preview``.
+
+    Unqueued and cheap on purpose, and the only listener on time_update: a queued or
+    ``always_last`` listener here re-dispatches the *event* with a stale payload, which
+    made clicks after a playhead drag prompt the frame the drag started from.
+    ``stamp`` is the browser's ``performance.now()`` at dispatch (see the ``js`` hook):
+    unqueued requests complete out of order, so an older event never overwrites a
+    newer one — neither ``current_frame`` nor the status text.
     """
     if session is None:
-        return
+        return gr.skip(), gr.skip(), gr.skip()
     stamp_value: float = float(stamp) if stamp is not None else session.last_stamp + 1.0
     if stamp_value < session.last_stamp:
-        return
+        return gr.skip(), gr.skip(), gr.skip()
     session.last_stamp = stamp_value
-    session.current_frame = frame_at(session.frame_timestamps_ns, float(evt.payload.time))
+    frame_idx: int = frame_at(session.frame_timestamps_ns, float(evt.payload.time))
+    session.current_frame = frame_idx
     session.last_time_update = time.monotonic()
+    if session.playing:
+        # Playback emits ~10 time updates a second; previewing and re-writing the status on each would spam the UI and the GPU.
+        return gr.skip(), gr.skip(), gr.skip()
+    frame_text: str = f"Viewer at frame {frame_idx} — a click prompts this frame."
+    return frame_text, frame_text, _preview_request(session, frame_idx)
 
 
 def on_play(session: Session | None, evt: Play) -> None:
@@ -210,22 +238,6 @@ def on_pause(session: Session | None, evt: Pause) -> None:
         session.playing = False
 
 
-def on_time_update(session: Session | None, evt: TimeUpdate) -> tuple[Any, Any, Any]:
-    """Report the frame under the cursor and hand it to ``push_preview``.
-
-    Unqueued and cheap on purpose. This listener must never use ``trigger_mode="always_last"``:
-    Gradio re-dispatches the coalesced *event* with a stale payload, and that re-dispatch
-    also reaches ``record_time``, which then records a frame the user left long ago.
-    (That is how a click after moving the playhead prompted the wrong frame.)
-    """
-    if session is None or session.playing:
-        # Playback emits ~10 time updates a second; previewing and re-writing the status on each would spam the UI and the GPU.
-        return gr.skip(), gr.skip(), gr.skip()
-    frame_idx: int = frame_at(session.frame_timestamps_ns, float(evt.payload.time))
-    frame_text: str = f"Viewer at frame {frame_idx} — a click prompts this frame."
-    return frame_text, frame_text, float(frame_idx)
-
-
 def push_preview(session: Session | None, request: float | None) -> Iterator[bytes | None]:
     """Preview the memory-conditioned mask on the frame under the cursor once it has rested there.
 
@@ -236,7 +248,7 @@ def push_preview(session: Session | None, request: float | None) -> Iterator[byt
     if session is None or request is None:
         yield b""
         return
-    frame_idx: int = int(request)
+    frame_idx: int = int(request) % PREVIEW_SEQ_STRIDE
     recording_pair: RecordingPair = _open_recording(session, write_part=False)
     rec: rr.RecordingStream = recording_pair[0]
     stream: rr.BinaryStream = recording_pair[1]
@@ -312,7 +324,7 @@ def on_select(
     yield payload, status_text, status_text
 
 
-def undo(session: Session | None) -> Iterator[tuple[bytes | None, str, str]]:
+def undo(session: Session | None) -> Iterator[tuple[bytes | None, str, str, Any]]:
     """Remove the most recently added point."""
     if session is None:
         raise gr.Error("Upload a video first.")
@@ -324,7 +336,7 @@ def undo(session: Session | None) -> Iterator[tuple[bytes | None, str, str]]:
     if edit.point is None:
         rec.disconnect()
         status_text: str = _status(session, "Nothing to undo.")
-        yield b"", status_text, status_text
+        yield b"", status_text, status_text, gr.skip()
         return
     stale: bool = _invalidate_track(rec, session)
     _log_mask(rec, session, _mask_hw(edit.result) if edit.result is not None else None, edit.point.frame_idx)
@@ -336,7 +348,8 @@ def undo(session: Session | None) -> Iterator[tuple[bytes | None, str, str]]:
     if stale:
         prefix += " The previous track is stale — Track again."
     status_text = _status(session, prefix)
-    yield payload, status_text, status_text
+    # The preview under the cursor was cleared above; ask for a fresh one when the cursor's frame has no point of its own.
+    yield payload, status_text, status_text, (_preview_request(session, session.current_frame) if session.tracker.points else gr.skip())
 
 
 def clear(session: Session | None) -> Iterator[tuple[bytes | None, str, str]]:
@@ -507,23 +520,15 @@ def build_demo(config: AppConfig) -> gr.Blocks:
             api_visibility="private",
         )
         # always_last coalesces the flood of time updates while scrubbing/playing into "the latest one".
-        viewer.time_update(
-            fn=record_time,
-            inputs=[recording_state, stamp_in],
-            outputs=None,
-            queue=False,
-            trigger_mode="multiple",
-            js="(session, _stamp) => [session, performance.now()]",
-            api_visibility="private",
-        )
         viewer.play(fn=on_play, inputs=[recording_state], outputs=None, queue=False, trigger_mode="multiple", api_visibility="private")
         viewer.pause(fn=on_pause, inputs=[recording_state], outputs=None, queue=False, trigger_mode="multiple", api_visibility="private")
         viewer.time_update(
             fn=on_time_update,
-            inputs=[recording_state],
+            inputs=[recording_state, stamp_in],
             outputs=[status, status_probe, preview_request],
             queue=False,
             trigger_mode="multiple",
+            js="(session, _stamp) => [session, performance.now()]",
             show_progress="hidden",
             api_visibility="private",
         )
@@ -542,7 +547,7 @@ def build_demo(config: AppConfig) -> gr.Blocks:
             show_progress="hidden",
             api_visibility="private",
         )
-        undo_btn.click(fn=undo, inputs=[recording_state], outputs=[viewer, status, status_probe], api_visibility="private")
+        undo_btn.click(fn=undo, inputs=[recording_state], outputs=[viewer, status, status_probe, preview_request], api_visibility="private")
         clear_btn.click(fn=clear, inputs=[recording_state], outputs=[viewer, status, status_probe], api_visibility="private")
         track_event = track_btn.click(fn=track, inputs=[recording_state], outputs=[viewer, status, status_probe, tabs_radio, download])
         stop_btn.click(fn=stop_tracking, outputs=[status, status_probe], cancels=[track_event], queue=False)

--- a/packages/posekit/tests/test_track_ui.py
+++ b/packages/posekit/tests/test_track_ui.py
@@ -13,7 +13,7 @@ import rerun as rr
 import rerun.experimental as rrx
 import torch
 from gradio_rerun import Rerun
-from gradio_rerun.events import SelectionChange
+from gradio_rerun.events import SelectionChange, TimeUpdate
 from jaxtyping import Int64, UInt8
 from numpy import ndarray
 
@@ -216,9 +216,60 @@ def test_scrub_handler_never_writes_to_the_viewer() -> None:
     demo: gr.Blocks = track_ui.build_demo(track_ui.AppConfig())
     viewer_id: int = next(block._id for block in demo.blocks.values() if isinstance(block, Rerun))
     time_update_fns: list[Any] = [fn for fn in demo.fns.values() if any(t[1] == "time_update" for t in fn.targets)]
-    assert len(time_update_fns) == 2  # record_time (no outputs) + on_time_update
+    assert len(time_update_fns) == 1  # one unqueued, stamp-guarded listener; a queued one would re-dispatch stale events
     for fn in time_update_fns:
         assert viewer_id not in {block._id for block in fn.outputs}
         # always_last re-dispatches the *event* with a stale payload, which also reaches
         # record_time: a click after moving the playhead then prompts the wrong frame.
         assert fn.trigger_mode != "always_last"
+
+
+def test_late_reload_failure_keeps_previous_session_and_closes_the_candidate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failure after the candidate tracker exists (e.g. transcoding) must not close the old session nor leak the new tracker."""
+    previous: Session = _session("previous")[0]
+    candidate_closed: list[bool] = []
+
+    class CandidateClickTracker(ClickTracker):
+        def __init__(self, video_path: Path, actual_predictor: object, *, memory_window_size: int) -> None:
+            pass
+
+        def close(self) -> None:
+            candidate_closed.append(True)
+
+    monkeypatch.setattr(track_ui, "ClickTracker", CandidateClickTracker)
+    monkeypatch.setattr(track_ui, "cached_predictor", lambda _variant: object())
+
+    def failing_log_video(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("injected transcode failure")
+
+    monkeypatch.setattr(track_ui, "log_video", failing_log_video)
+    previous_closed: list[bool] = []
+    monkeypatch.setattr(previous.tracker, "close", lambda: previous_closed.append(True))
+    with pytest.raises(RuntimeError, match="injected"):
+        list(track_ui.load_video("clip.mp4", previous, "efficienttam-s-512", 10.0))
+    assert not previous_closed
+    assert candidate_closed == [True]
+
+
+def test_time_update_ignores_older_stamps_for_status_too() -> None:
+    """Unqueued requests finish out of order: an older event must not roll back the frame or the status text."""
+    session: Session = _session("stamps")[0]
+    session.frame_timestamps_ns = np.arange(0, 300, dtype=np.int64) * 33_366_667
+
+    def event(frame_idx: int) -> TimeUpdate:
+        return TimeUpdate(None, json.dumps({"type": "time_update", "application_id": "t", "recording_id": session.recording_id, "time": int(session.frame_timestamps_ns[frame_idx])}))
+
+    newer: tuple[Any, Any, Any] = track_ui.on_time_update(session, 200.0, event(30))
+    older: tuple[Any, Any, Any] = track_ui.on_time_update(session, 100.0, event(27))
+    assert session.current_frame == 30
+    assert "frame 30" in newer[0]
+    assert all(isinstance(value, type(gr.skip())) for value in older)
+
+
+def test_preview_requests_are_always_fresh_values() -> None:
+    """Re-requesting the same frame (e.g. after Undo) must still trigger preview_request.change."""
+    session: Session = _session("seq")[0]
+    first: float = track_ui._preview_request(session, 42)
+    second: float = track_ui._preview_request(session, 42)
+    assert first != second
+    assert int(first) % track_ui.PREVIEW_SEQ_STRIDE == 42 and int(second) % track_ui.PREVIEW_SEQ_STRIDE == 42

--- a/packages/simplecv/tests/test_log_video.py
+++ b/packages/simplecv/tests/test_log_video.py
@@ -11,6 +11,7 @@ import av
 import numpy as np
 import pytest
 import rerun as rr
+import rerun.experimental as rrx
 from jaxtyping import Int64, UInt8
 from numpy import ndarray
 from pyarrow import ChunkedArray
@@ -180,11 +181,21 @@ def test_log_video_sends_chunks_incrementally(synthetic_h264_mp4: Path, monkeypa
     """The recording receives Mp4Reader's lazy iterator instead of a materialized chunk list."""
     received: list[rr.experimental.Chunk] = []
 
+    exhausted: list[bool] = []
+    real_stream = rrx.Mp4Reader.stream
+
+    def stream_marking_exhaustion(self: rrx.Mp4Reader) -> Iterator[rr.experimental.Chunk]:
+        yield from real_stream(self)
+        exhausted.append(True)
+
+    monkeypatch.setattr(rrx.Mp4Reader, "stream", stream_marking_exhaustion)
+
     def consume_lazily(_recording: rr.RecordingStream, chunks: Iterable[rr.experimental.Chunk]) -> None:
-        assert not isinstance(chunks, list)
         chunk_iterator: Iterator[rr.experimental.Chunk] = iter(chunks)
-        assert chunk_iterator is chunks
-        received.extend(chunks)
+        received.append(next(chunk_iterator))
+        assert not exhausted, "the first chunk must be delivered before the source stream is fully consumed"
+        received.extend(chunk_iterator)
+        assert exhausted
 
     monkeypatch.setattr(rr.RecordingStream, "send_chunks", consume_lazily)
     rec: rr.RecordingStream = rr.RecordingStream(application_id="test-log-video-lazy", recording_id="lazy")


### PR DESCRIPTION
Stacked on #153. Fixes the server-side findings of the adversarial state-machine review (Codex, every claim measured against the running app; report: `/tmp/posekit-adv/report.md` on pablo-dl-server).

- **Reload atomicity** — `load_video` closed the old session right after constructing the candidate tracker; a failure in `log_video` (transcode error) then left Gradio holding a closed session and leaked the candidate. Now the old session is closed only after the replacement is complete, and a failing candidate is closed. Test: injected `log_video` failure → previous tracker open, candidate closed.
- **Stale status text** — `on_time_update` ran unqueued beside `record_time` without the stamp guard, so an out-of-order response could show "frame 27" while the viewer (and the click) were at frame 30 (17/35 precision trials). The two listeners are merged into one stamp-guarded unqueued listener. Test: an older-stamped event yields `gr.skip()` for every output.
- **Undo blanked the preview** — Undo cleared the static preview and only re-logged the edited frame. `preview_request` values now fold in a sequence number (a repeat of the same frame still fires `.change`), and Undo re-requests the preview for the current frame.
- **simplecv test sanity** — `test_log_video_sends_chunks_incrementally` also passed on the materialized version; it now proves the first chunk is delivered before the source stream is exhausted.

Verified: posekit lint/typecheck/deadcode, 44 tests; simplecv 8; the 6-drag browser stress lands every click on the dragged-to frame (157/81/251/119/213/44).

Not fixed here (viewer-side input semantics, documented in the review): a click landing inside the ~100 ms window while the viewer ingests a preview push produces no `selection_change`, and rapid same-entity clicks (<~150 ms apart, i.e. double-click cadence) are coalesced by the viewer; Stop can be followed by a click that was already queued during tracking (state stays consistent).