### PR TITLE
add-model: repo skill for bringing upstream models in (fork+pixify → typed PR stack), Codex + Claude

### DIFF
--- a/.agents/skills/add-model/SKILL.md
+++ b/.agents/skills/add-model/SKILL.md
@@ -32,6 +32,17 @@ Worked examples with every gotcha hit so far: [references/example-liteanystereo.
   (camera dataclasses, `rescale_intri`, `Rig`/`log_rig_static`, `RerunTyroConfig`, `rerun_dataloader`,
   `Open3DFuser`, `log_open3d_mesh`, `rr.VideoCodec`, `scipy.spatial.transform.Rotation`).
   The port ends with an explicit hand-roll audit (validate.md, gate 4).
+- **Rerun geometry rules** (learned on fisheye rigs and people trackers). (a) `DepthImage`/`EncodedDepthImage` unproject only
+  under a distortion-free `Pinhole`: run the model on the *original* fisheye frames, then log **both** the original view and a
+  rectified pinhole twin per camera (`cv2.fisheye.initUndistortRectifyMap` with `R = I` so the z axis is unchanged; remap the
+  frame and the predicted depth with the same maps — that remapped z-depth *is* the twin's pinhole depth) as rig sensors
+  `cam_1i` (`log_rig_static`, never children of `cam_0i`); TSDF runs on the twins. (b) No per-frame `Points3D` clouds in catalog
+  tools (X-Lens: 60 s at 5 fps = 3.4 GB); the viewer unprojects the twin's depth. (c) Per-id entities (`world/people/<id>/…`)
+  persist as latest-at after a track ends → `rr.Clear(recursive=True)` at the id path when the tracker removes it. (d) People
+  render like `sam3d-body`: `posekit.rerun_logging` helpers + `person_color(id)` for 2D, joints as
+  `rr.Points3D(keypoint_ids=…, class_ids=0)` under an `rr.AnnotationContext` with the skeleton's connections (the viewer draws
+  the edges), meshes as `rr.Mesh3D(vertex_normals=…, albedo_factor=(r, g, b, 0.5))`. (e) Sensors that are out of distribution
+  for every model (robocap `cam_02/03` eye cameras look at the wearer) are excluded from all runs; name the rig's cameras.
 - **Python conventions**: beartype via `PIXI_DEV_MODE` claw (never `@beartype`), PEP 526 annotations
   everywhere, jaxtyping dtype+shape on every array, `TypeAlias` not PEP 695, tyro CLIs, `0.0` for float
   defaults, `einops` over reshape/permute chains, dataclass field docstrings, thin `tools/` shims.
@@ -50,6 +61,10 @@ Worked examples with every gotcha hit so far: [references/example-liteanystereo.
 - **Durable execution.** Anything longer than a minute (env solves, catalog runs, Codex jobs) runs in a named tmux
   session with `python -u`, a log file, and a sentinel file on exit; background shells die with the agent session
   and leave half-written `.rrd`s that look complete. Poll the sentinel, never the process name.
+- **Follow-ups resume the job.** A finished Codex job takes corrections on its own session:
+  `codex exec resume -c 'sandbox_mode="danger-full-access"' -c 'model_reasoning_effort="xhigh"' <session-id> - < followup.md`
+  (session id in the log header; `resume` rejects `--sandbox`). New tmux session, own log and sentinel; the prompt names the
+  branch, the commit message and what to re-run.
 - **Feedback loop.** Every delegated run (Codex or subagent) ends its report with a "skill discrepancies" list:
   anything unclear, missing, contradictory, or guessed. Fold each item into this skill before the next phase.
 
@@ -64,6 +79,9 @@ Worked examples with every gotcha hit so far: [references/example-liteanystereo.
 
 1. **License.** MIT/Apache: mirror freely. NVIDIA Source Code License / research-only: allowed to vendor and
    mirror *with the license text*; flag non-commercial in the vendored `__init__.py` docstring, the fork's NOTES.md, and (own mirrors only) the HF card. Weights can carry a different license than the code (e.g. NVIDIA Open Model Agreement vs Source Code License) — record both.
+   Body models are separately licensed assets: SMPL and SMPL-X are not drop-in for each other (24/6890 vs 55/10475), the smplx
+   `transfer_model` converts *poses* not model files, chumpy pickles load without chumpy through a `pickle.Unpickler.find_class`
+   shim, and the file is hosted privately (SMPL forbids redistribution) with its SHA-256 in the loader test.
 2. **Weights.** Is there an official HF repo? Search the Hub (`curl 'https://huggingface.co/api/models?search=<name>'`)
    before mirroring anything. Pin the HF revision SHA (`curl .../api/models/<repo>` → `sha`) and record the file's SHA-256 in the loader test. Is the file a `state_dict` or a pickled module
    (`torch.load(..., weights_only=False)`)? Pickled modules need the unpickler remap recipe in port.md.
@@ -71,9 +89,17 @@ Worked examples with every gotcha hit so far: [references/example-liteanystereo.
    ONNX/TRT, dataset loaders, visualisation utils) stays out.
 4. **Hard deps.** Custom CUDA/Triton kernels (keep only with a pure-torch fallback + parity test), xformers,
    flash-attn, open3d. Check what the model package imports vs what the README says.
+   When an upstream pin blocks the monorepo (rfdetr 1.5.0 → `transformers<5`), check newer releases' `requires_dist` on PyPI
+   and the attributes the upstream wrapper touches before adding a second env lane (rfdetr ≥1.6 needs `transformers>=5.1` and
+   kept `RFDETRNano(pretrain_weights=)`, `.model.model/.postprocess/.resolution`, `optimize_for_inference`).
 5. **Reference number.** Does upstream ship an eval script and a per-dataset number? If not, the monorepo's
    ETH3D `playground_1l` sample (HF `pablovela5620/monoprior-example`, `stereo/eth3d`) is the fallback: record
    the result as a *baseline*, not a reproduction.
+   Non-stereo families define their own numbers: metric depth → abs-rel/δ1 **and** a median-scale-aligned variant (X-Lens on
+   ETH3D: metric abs-rel 0.76 vs scale-aligned 0.15 — the miss was global scale, which EPE alone hides); trackers → counts,
+   per-stage ms, reprojection error of lifted joints, and a **replay fixture** of the exact model inputs/outputs recorded by the
+   fork's demo. The fork owns the fixture layout (NOTES.md table of keys/dtypes/shapes); the port's loader reads that file and
+   never invents its own contract. Report multi-view timing as ms per frameset with view count and resolution.
 6. **Upstream entry points.** Name the demo script (for `demo-upstream`), its preprocessing (scaling, padding divisor, normalisation, AMP dtype), the forward signature (`iters`, `test_mode`, output shape), and the minimum input size the network accepts (fixes the fast test's tiny pair).
 7. **Contract.** Which existing predictor family does it join (`monopriors.models.stereo_depth`,
    `relative_depth`, `normals`, ...)? Joining an existing `Base*Predictor` through its per-model config
@@ -81,6 +107,7 @@ Worked examples with every gotcha hit so far: [references/example-liteanystereo.
    designed first (grill the user).
 8. **Which PRs.** `1-vendor`, `2-predictor`, `3-typed` are always required. `4-app`/`5-catalog` only when the
    family has no app/catalog tool yet — an existing tool gains the new model through the registry.
+   The app PR is optional when the user scopes it out; renumber (`4-catalog`).
 
 Probe commands that answer 1–5 in minutes (run them, do not ask the user for these facts):
 

--- a/.agents/skills/add-model/SKILL.md
+++ b/.agents/skills/add-model/SKILL.md
@@ -43,8 +43,22 @@ Worked examples with every gotcha hit so far: [references/example-liteanystereo.
 - **Process hygiene.** Never `pkill -f`/`pgrep -f` a pattern that appears in the same command line
   (kills the tool's shell, exit 144); use `pkill -x`, a saved PID, `fuser -k <port>/tcp`, or tmux sessions.
   Never start ad-hoc HTTP servers for artifacts; Gradio apps go through `tailscale serve --https`.
-- **Identities.** Forks live under the personal GitHub account (`GH_TOKEN=$(gh auth token --user pablovela5620)`),
-  monorepo PRs use the work account. Check `gh auth status` first. HF mirrors under the personal HF account.
+- **Identities.** Forks live under the personal GitHub account (`GH_TOKEN=$(gh auth token --user pablovela5620) gh …`),
+  monorepo PRs use the work account (`GH_TOKEN=$(gh auth token --user pablo-rerun) gh pr create …` — the active
+  login is often the personal one and `gh pr create` then fails with "must be a collaborator"). HF mirrors under the
+  personal HF account.
+- **Durable execution.** Anything longer than a minute (env solves, catalog runs, Codex jobs) runs in a named tmux
+  session with `python -u`, a log file, and a sentinel file on exit; background shells die with the agent session
+  and leave half-written `.rrd`s that look complete. Poll the sentinel, never the process name.
+- **Feedback loop.** Every delegated run (Codex or subagent) ends its report with a "skill discrepancies" list:
+  anything unclear, missing, contradictory, or guessed. Fold each item into this skill before the next phase.
+
+## Running as Codex (sandbox)
+
+- The sandbox may hide the CUDA virtual package (`CONDA_OVERRIDE_CUDA=13.0` for solves) and make the default pixi
+  cache read-only (`PIXI_CACHE_DIR=/tmp/<job>-pixi-cache`). Neither proves the GPU works: run the GPU gate outside
+  the sandbox or report exactly which command the reviewer must run — never fake numbers.
+- Work in a dedicated git worktree (see port.md "Setup"); never edit the reviewer's checkout.
 
 ## Phase 0 — Scope (write the answers into the fork's `NOTES.md` later)
 
@@ -66,5 +80,22 @@ Worked examples with every gotcha hit so far: [references/example-liteanystereo.
    goal; a new family needs its contract designed first (grill the user).
 8. **Which PRs.** `1-vendor`, `2-predictor`, `3-typed` are always required. `4-app`/`5-catalog` only when the
    family has no app/catalog tool yet — an existing tool gains the new model through the registry.
+
+Probe commands that answer 1–5 in minutes (run them, do not ask the user for these facts):
+
+```bash
+git clone -q --depth 1 https://github.com/<org>/<repo> /tmp/<model>-probe && cd /tmp/<model>-probe && git rev-parse HEAD
+head -40 LICENSE*; grep -n -iE "commercial|research" LICENSE* | head           # code license
+grep -rhoE "^(import|from) [a-zA-Z_0-9.]+" --include=*.py <model-dir> | sort | uniq -c | sort -rn   # real deps
+curl -s 'https://huggingface.co/api/models?search=<name>' | python3 -c 'import sys,json;[print(m["id"]) for m in json.load(sys.stdin)]'
+curl -s https://huggingface.co/api/models/<repo>/tree/main | python3 -c 'import sys,json;[print(f["path"],f.get("size")) for f in json.load(sys.stdin)]'
+curl -s https://huggingface.co/api/models/<repo> | python3 -c 'import sys,json;print(json.load(sys.stdin)["sha"])'
+python - <<'PY'   # is the .pth a state_dict or a pickled module, and which classes does it reference?
+import zipfile,re; z=zipfile.ZipFile('<file>.pth'); d=z.read([n for n in z.namelist() if n.endswith('data.pkl')][0])
+print(sorted(set(re.findall(rb'[A-Za-z_][A-Za-z_0-9]*\.[A-Za-z_0-9.]+', d)))[:60])
+PY
+```
+When `forward()` reads an attribute the checkpoint lacks, A/B each candidate value against the reference sample's
+ground truth (FFS `normalize`: True 0.48 % vs False 45 % bad1) — never pick by reading code alone.
 
 Grill the user on anything ambiguous above (batch the questions, give recommendations) before phase 1.

--- a/.agents/skills/add-model/SKILL.md
+++ b/.agents/skills/add-model/SKILL.md
@@ -10,7 +10,7 @@ description: >
 
 # Add a model to the monorepo
 
-Two phases, four gates. Phase 1 is skippable when a pixified fork already exists.
+Two phases, five gates. Phase 1 is skippable when a pixified fork already exists.
 Every phase reads one reference file; read it fully before starting that phase.
 
 | Phase | Reference | Output |
@@ -47,9 +47,9 @@ Worked example with every gotcha hit so far: [references/example-liteanystereo.m
 ## Phase 0 — Scope (write the answers into the fork's `NOTES.md` later)
 
 1. **License.** MIT/Apache: mirror freely. NVIDIA Source Code License / research-only: allowed to vendor and
-   mirror *with the license text*; flag non-commercial in the vendored `__init__.py` docstring and the HF card.
+   mirror *with the license text*; flag non-commercial in the vendored `__init__.py` docstring, the fork's NOTES.md, and (own mirrors only) the HF card. Weights can carry a different license than the code (e.g. NVIDIA Open Model Agreement vs Source Code License) — record both.
 2. **Weights.** Is there an official HF repo? Search the Hub (`curl 'https://huggingface.co/api/models?search=<name>'`)
-   before mirroring anything. Pin the revision SHA. Is the file a `state_dict` or a pickled module
+   before mirroring anything. Pin the HF revision SHA (`curl .../api/models/<repo>` → `sha`) and record the file's SHA-256 in the loader test. Is the file a `state_dict` or a pickled module
    (`torch.load(..., weights_only=False)`)? Pickled modules need the unpickler remap recipe in port.md.
 3. **Inference subset.** List the modules the demo actually imports. Everything else (training, export,
    ONNX/TRT, dataset loaders, visualisation utils) stays out.
@@ -58,10 +58,11 @@ Worked example with every gotcha hit so far: [references/example-liteanystereo.m
 5. **Reference number.** Does upstream ship an eval script and a per-dataset number? If not, the monorepo's
    ETH3D `playground_1l` sample (HF `pablovela5620/monoprior-example`, `stereo/eth3d`) is the fallback: record
    the result as a *baseline*, not a reproduction.
-6. **Contract.** Which existing predictor family does it join (`monopriors.models.stereo_depth`,
+6. **Upstream entry points.** Name the demo script (for `demo-upstream`), its preprocessing (scaling, padding divisor, normalisation, AMP dtype), the forward signature (`iters`, `test_mode`, output shape), and the minimum input size the network accepts (fixes the fast test's tiny pair).
+7. **Contract.** Which existing predictor family does it join (`monopriors.models.stereo_depth`,
    `relative_depth`, `normals`, ...)? Joining an existing `Base*Predictor` + `get_*_predictor` registry is the
    goal; a new family needs its contract designed first (grill the user).
-7. **Which PRs.** `1-vendor`, `2-predictor`, `3-typed` are always required. `4-app`/`5-catalog` only when the
+8. **Which PRs.** `1-vendor`, `2-predictor`, `3-typed` are always required. `4-app`/`5-catalog` only when the
    family has no app/catalog tool yet — an existing tool gains the new model through the registry.
 
 Grill the user on anything ambiguous above (batch the questions, give recommendations) before phase 1.

--- a/.agents/skills/add-model/SKILL.md
+++ b/.agents/skills/add-model/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: add-model
+description: >
+  Bring an upstream research model (stereo, mono depth, normals, pose, ...) into this monorepo:
+  fork + pixify the upstream repo with a Rerun demo, then port the minimum into a package as a
+  typed, tested, reviewable PR stack that ends with pixel-verified Rerun output. Use when the user
+  says "add/port/bring in <model>", "fork and pixify <repo>", or "make <method> a predictor".
+  Works from Claude Code and Codex; nothing here depends on runtime-specific tools.
+---
+
+# Add a model to the monorepo
+
+Two phases, four gates. Phase 1 is skippable when a pixified fork already exists.
+Every phase reads one reference file; read it fully before starting that phase.
+
+| Phase | Reference | Output |
+|---|---|---|
+| 0. Scope | (this file) | answers to the scope questions, written down |
+| 1. Fork + pixify | [references/fork-and-pixify.md](references/fork-and-pixify.md) | public fork with frozen `main`, `pixi` branch, `pixi run demo`, `NOTES.md` |
+| 2. Port | [references/port.md](references/port.md) | PR stack `1-vendor → 2-predictor → 3-typed (→ 4-app → 5-catalog)` |
+| Gates | [references/validate.md](references/validate.md) | equivalence test, reference number, dev tasks green, viewer pixel evidence |
+
+Worked example with every gotcha hit so far: [references/example-liteanystereo.md](references/example-liteanystereo.md).
+
+## Rules that always bind
+
+- **Pixi only.** Never pip/uv. Pins copy the monorepo (`python 3.12`, `cuda-version 13.0.*`,
+  conda `pytorch-gpu`, `rerun-sdk` at the workspace pin, `timm`, `tyro`), so the port has no env surprises.
+- **Do not hand-roll what exists.** Before writing any helper, look in `simplecv` first
+  (camera dataclasses, `rescale_intri`, `Rig`/`log_rig_static`, `RerunTyroConfig`, `rerun_dataloader`,
+  `Open3DFuser`, `log_open3d_mesh`, `rr.VideoCodec`, `scipy.spatial.transform.Rotation`).
+  The port ends with an explicit hand-roll audit (validate.md, gate 4).
+- **Python conventions**: beartype via `PIXI_DEV_MODE` claw (never `@beartype`), PEP 526 annotations
+  everywhere, jaxtyping dtype+shape on every array, `TypeAlias` not PEP 695, tyro CLIs, `0.0` for float
+  defaults, `einops` over reshape/permute chains, dataclass field docstrings, thin `tools/` shims.
+  (Claude: `python-conventions`, `karpathy-guidelines`, `tdd` skills; Codex has the same rules.)
+- **Minimal diff.** Vendor only the inference subset. No speculative flexibility. Upstream code is
+  untouched in the fork; it is *owned* (typed, trimmed) only in the `3-typed` PR, with an equivalence test.
+- **Rerun output is validated with pixels**, not logs (`rerun-viewer-validation` skill): screenshots of the
+  demo, the app, and the catalog tool; `--rr-config.headless` + `--rr-config.save` in shells without `DISPLAY`.
+- **Process hygiene.** Never `pkill -f`/`pgrep -f` a pattern that appears in the same command line
+  (kills the tool's shell, exit 144); use `pkill -x`, a saved PID, `fuser -k <port>/tcp`, or tmux sessions.
+  Never start ad-hoc HTTP servers for artifacts; Gradio apps go through `tailscale serve --https`.
+- **Identities.** Forks live under the personal GitHub account (`GH_TOKEN=$(gh auth token --user pablovela5620)`),
+  monorepo PRs use the work account. Check `gh auth status` first. HF mirrors under the personal HF account.
+
+## Phase 0 — Scope (write the answers into the fork's `NOTES.md` later)
+
+1. **License.** MIT/Apache: mirror freely. NVIDIA Source Code License / research-only: allowed to vendor and
+   mirror *with the license text*; flag non-commercial in the vendored `__init__.py` docstring and the HF card.
+2. **Weights.** Is there an official HF repo? Search the Hub (`curl 'https://huggingface.co/api/models?search=<name>'`)
+   before mirroring anything. Pin the revision SHA. Is the file a `state_dict` or a pickled module
+   (`torch.load(..., weights_only=False)`)? Pickled modules need the unpickler remap recipe in port.md.
+3. **Inference subset.** List the modules the demo actually imports. Everything else (training, export,
+   ONNX/TRT, dataset loaders, visualisation utils) stays out.
+4. **Hard deps.** Custom CUDA/Triton kernels (keep only with a pure-torch fallback + parity test), xformers,
+   flash-attn, open3d. Check what the model package imports vs what the README says.
+5. **Reference number.** Does upstream ship an eval script and a per-dataset number? If not, the monorepo's
+   ETH3D `playground_1l` sample (HF `pablovela5620/monoprior-example`, `stereo/eth3d`) is the fallback: record
+   the result as a *baseline*, not a reproduction.
+6. **Contract.** Which existing predictor family does it join (`monopriors.models.stereo_depth`,
+   `relative_depth`, `normals`, ...)? Joining an existing `Base*Predictor` + `get_*_predictor` registry is the
+   goal; a new family needs its contract designed first (grill the user).
+7. **Which PRs.** `1-vendor`, `2-predictor`, `3-typed` are always required. `4-app`/`5-catalog` only when the
+   family has no app/catalog tool yet — an existing tool gains the new model through the registry.
+
+Grill the user on anything ambiguous above (batch the questions, give recommendations) before phase 1.

--- a/.agents/skills/add-model/SKILL.md
+++ b/.agents/skills/add-model/SKILL.md
@@ -20,7 +20,9 @@ Every phase reads one reference file; read it fully before starting that phase.
 | 2. Port | [references/port.md](references/port.md) | PR stack `1-vendor → 2-predictor → 3-typed (→ 4-app → 5-catalog)` |
 | Gates | [references/validate.md](references/validate.md) | equivalence test, reference number, dev tasks green, viewer pixel evidence |
 
-Worked example with every gotcha hit so far: [references/example-liteanystereo.md](references/example-liteanystereo.md).
+Worked examples with every gotcha hit so far: [references/example-liteanystereo.md](references/example-liteanystereo.md)
+(the run this skill was distilled from) and [references/example-fast-foundationstereo.md](references/example-fast-foundationstereo.md)
+(the first run *through* the skill: pickled NAS checkpoint, existing family).
 
 ## Rules that always bind
 

--- a/.agents/skills/add-model/SKILL.md
+++ b/.agents/skills/add-model/SKILL.md
@@ -76,8 +76,9 @@ Worked examples with every gotcha hit so far: [references/example-liteanystereo.
    the result as a *baseline*, not a reproduction.
 6. **Upstream entry points.** Name the demo script (for `demo-upstream`), its preprocessing (scaling, padding divisor, normalisation, AMP dtype), the forward signature (`iters`, `test_mode`, output shape), and the minimum input size the network accepts (fixes the fast test's tiny pair).
 7. **Contract.** Which existing predictor family does it join (`monopriors.models.stereo_depth`,
-   `relative_depth`, `normals`, ...)? Joining an existing `Base*Predictor` + `get_*_predictor` registry is the
-   goal; a new family needs its contract designed first (grill the user).
+   `relative_depth`, `normals`, ...)? Joining an existing `Base*Predictor` through its per-model config
+   dataclasses, defaults dict, and Tyro subcommand-union registry is the goal; a new family needs its contract
+   designed first (grill the user).
 8. **Which PRs.** `1-vendor`, `2-predictor`, `3-typed` are always required. `4-app`/`5-catalog` only when the
    family has no app/catalog tool yet — an existing tool gains the new model through the registry.
 

--- a/.agents/skills/add-model/references/example-fast-foundationstereo.md
+++ b/.agents/skills/add-model/references/example-fast-foundationstereo.md
@@ -1,0 +1,52 @@
+# Worked example — Fast-FoundationStereo (2026-08-30), the skill's first run
+
+Second stereo model, done *through* this skill by Codex (phase 1, PRs 1–3) with Claude reviewing and validating.
+Fork: `pablovela5620/Fast-FoundationStereo` (`master` = upstream a290ba0 frozen, `pixi` default).
+Monorepo stack `fast-foundationstereo/1-vendor → 2-predictor → 3-typed` on top of the skill PR (#160).
+No `4-app`/`5-catalog`: the stereo family already had both, and they gained the model through the registry
+(`--predictor-name FastFoundationStereoPredictor`, app dropdown).
+
+## Scope answers that mattered
+
+- License: NVIDIA Source Code License (code, research only) **and** NVIDIA Open Model Agreement (weights) — two licenses.
+- Weights: official HF `nvidia/c-fast-foundationstereo` (rev `9b446878…`), no safetensors, no personal mirror needed.
+  One pickled whole module + `cfg.yaml`; the Drive trio (`23-36-37` …) is not on the Hub and was left out.
+- Inference subset: `core/{foundation_stereo,extractor,update,geometry,submodule,distill_block}.py` +
+  `core/utils/utils.py` (InputPadder **and** the bilinear samplers `geometry.py` needs — not only the padder).
+- Hard deps: `xformers` is in the README but nothing in `core/` imports it; triton GWC kernel has a torch fallback;
+  `open3d`/`turbojpeg` only through `Utils.py`/`frame_utils` → not imported.
+- No eval script → ETH3D `playground_1l` number recorded as a baseline.
+
+## Numbers
+
+ETH3D `playground_1l` (non-occluded, gt < 416): EPE 0.241 px, bad1 **0.48 %** (LAS2-H: 1.12 %, LAS2-M: 2.24 %).
+5090 fp16 autocast, 490×941 (padded 512×960): ~83–95 ms/frame — ~10× slower than LAS2-M at this size.
+Triton vs torch GWC volume: identical metrics.
+
+## Gotchas hit
+
+- Pickled `args` lacks `normalize` (checkpoint predates the code); `True` measured → 0.48 %, `False` → 45 %.
+- The pickle references `core.*` **and** `foundation_stereo_ori.*` class paths, plus `omegaconf` (new dep).
+- The checkpoint is NAS-pruned: 210 tensors only in the pickle, 54 shape changes, `distill_block.ForwardHelper`
+  wrappers — `cfg.yaml` cannot rebuild it, so the loader unpickles + deep-copies + strict-reloads and the typed
+  fork must not rename modules/classes/parameters. Equivalence = fast config-built upstream-vs-owned (CPU,
+  bit-identical) + slow real-checkpoint unpickled onto both packages (deterministic cuDNN, autocast off:
+  CUDA `ConvTranspose2d` otherwise drifts ~2e-5 between identical runs) + triton/torch parity with tolerance.
+- beartype claw cannot decorate a module-level `triton.autotune` object → build the kernel inside a factory;
+  check with `warnings.simplefilter('error', BeartypeClawDecorWarning)`, not `-W error::UserWarning`
+  (that also trips the required PEP 613 `TypeAlias` warnings).
+- `low_memory=False` is the *required* 2D sampler path; only the `low_memory=True` 1D/chunked branch was dead.
+- Codex sandbox: CUDA virtual package hidden (`CONDA_OVERRIDE_CUDA=13.0`), default pixi cache read-only
+  (`PIXI_CACHE_DIR=/tmp/...`); GPU runs verified outside the sandbox.
+- Running pytest from the repo root collects other packages whose envs are absent — run from `packages/monoprior`.
+- The catalog server (`:51235`) keeps registrations in memory: after a restart, `LookupError: No dataset found
+  with name 'robocap'` → `python /mnt/nas/datasets/robocap/rrd/reregister.py` first.
+- A background catalog run launched from the agent session died with the session and left a truncated `.rrd`
+  (video relay covers the whole clip, so the timeline *looks* complete); run long jobs in tmux with `python -u`.
+
+## Skill fixes this run produced
+
+Five gates not four; HF revision + SHA-256; weights vs code license; upstream entry-point scoping in phase 0;
+PR-1 "import paths only"; equivalence vs kernel parity; registry with differing constructors; `PYREFLY_TARGET`
+(which also exposed that the LAS2 typed fork was never typechecked — fixed in #154); frozen default branch may be
+`master`; fresh-clone timing definition; interactive upstream demos; pickled NAS architectures.

--- a/.agents/skills/add-model/references/example-liteanystereo.md
+++ b/.agents/skills/add-model/references/example-liteanystereo.md
@@ -1,0 +1,40 @@
+# Worked example — LiteAnyStereo V2 (2026-08-29)
+
+Fork: `pablovela5620/LiteAnyStereo` (`main` = upstream 8c97bd4, `pixi` default). Monorepo PR stack
+#151 `liteanystereo/1-vendor` → #152 `2-predictor` → #154 `3-typed` → #155 `4-app` → #157 `5-catalog-layer`.
+
+## What landed
+
+- `monopriors/third_party/liteanystereo/` (typed owned fork: `liteanystereov2.py`, `_H.py`, `fnet.py`,
+  `aggregation_fasternet.py`, `submodule.py`, `padding.py`), fixtures under `tests/reference_data/liteanystereo/`.
+- `monopriors/models/stereo_depth/`: `StereoDepthPrediction`, `BaseStereoPredictor`, `disparity_to_metric_depth`,
+  `LiteAnyStereoPredictor(device, model_size="m", checkpoint=None, max_disp=192)`, `rectify.py`
+  (`fisheye_stereo_rectify` on `Fisheye62Parameters` → `StereoRectification` with `PinholeParameters`).
+- `apis/stereo_depth.py` + `tools/demos/stereo_depth.py` (ETH3D demo), `gradio_ui/stereo_depth_ui.py` +
+  `tools/apps/stereo_depth_app.py`, `apis/stereo_catalog.py` + `tools/apps/stereo_catalog.py`
+  (robocap front pair → rectify → stereo → `EncodedDepthImage` + incremental TSDF mesh, streamed to the viewer).
+- simplecv additions: `rig.stereo_rig_calibration`, `rerun_dataloader(codec=)`, `log_open3d_mesh`.
+
+## Numbers
+
+ETH3D `playground_1l` (non-occluded, gt < 192): LAS2-M EPE 0.350 / bad1 2.24 % (paper 2.59), LAS2-H 0.250 / 1.12 %
+(paper 1.83). 5090 fp32 warm 384×1248: S 5.4 / M 6.7 / L 10.4 / H 14.8 ms (launch-bound); 1080p M 28 ms, H 62 ms.
+
+## Gotchas hit (all now encoded in the phase files)
+
+- `simplecv` git dep lacks runtime deps (`av`, `pyarrow`, `einops`) and needs `typing-extensions<4.16`.
+- Upstream S/M/L ignore `max_disp` at build time — tests use 192.
+- Rectified cameras logged as children of `cam_00` double-applied `rig_T_cam` (cloud pointed down); a level TSDF
+  mesh did not catch it. Fix: rectified views are rig sensors (`cam_10`/`cam_11`) with `R_rect @ cam_T_rig`.
+- `cv2.fisheye.stereoRectify`'s estimated `P` is unusable for wide fisheyes (`cx` 2721 px) → own `K_rect`
+  (centre principal point, `focal_scale` 0.8).
+- `$origin/**` in a 3D view pulls 2D-only entities in (error badge); sky disparities streak the cloud (mask > 20 m).
+- Gradio: `np.float32` defaults not JSON-serialisable; int sliders need `float | int`; localhost self-check fails
+  inside the sandbox; plain http on the tailnet breaks the embedded viewer (`crypto.randomUUID`) → tailscale HTTPS.
+- `VideoStream:codec` fourcc endianness → `rr.VideoCodec(value)`. Conda `py-opencv` needs ffmpeg 9 (no ffmpeg pin).
+- Depth colour range 0–20 m hid indoor scenes → default 0–6 m; blueprint overrides via
+  `rr.EncodedDepthImage.from_fields(depth_range=...)`; sending a blueprint after a fresh `rr.init` makes empty
+  recordings → bind the `recording_id`.
+- A process-kill pattern that also appeared in the same command line killed the tool shell four times → a
+  PreToolUse hook now blocks it; use exact names, saved PIDs, `fuser -k <port>/tcp`, or tmux sessions.
+- Live `rr.spawn()` mode of the catalog tool was ~10× slower than headless save + open (unresolved); use save.

--- a/.agents/skills/add-model/references/example-liteanystereo.md
+++ b/.agents/skills/add-model/references/example-liteanystereo.md
@@ -15,6 +15,8 @@ Fork: `pablovela5620/LiteAnyStereo` (`main` = upstream 8c97bd4, `pixi` default).
   (robocap front pair → rectify → stereo → `EncodedDepthImage` + incremental TSDF mesh, streamed to the viewer).
 - simplecv additions: `rig.stereo_rig_calibration`, `rerun_dataloader(codec=)`, `log_open3d_mesh`.
 
+The constructor-flag examples above predate the config-class rework in #162; current tools select predictor config subcommands from the defaults-dict registry.
+
 ## Numbers
 
 ETH3D `playground_1l` (non-occluded, gt < 192): LAS2-M EPE 0.350 / bad1 2.24 % (paper 2.59), LAS2-H 0.250 / 1.12 %

--- a/.agents/skills/add-model/references/example-xlens-lamp.md
+++ b/.agents/skills/add-model/references/example-xlens-lamp.md
@@ -25,7 +25,7 @@ fork (bumped 1.5.0 → 1.9.x for transformers 5). PR stack #196 → #197 → #20
 
 - Numbers: fork on the Aria `test-library` (700 framesets @10 Hz): RF-DETR 8.7 / ViTPose 6.6 / lifter 8.6 / total 28.5 ms,
   lifted-joint reprojection 6.3–7.9 px; port on robocap s29 (four KB4 cameras fed as virtual-pinhole vectors after
-  `cv2.fisheye.undistortPoints`, window 1152–1272 s chosen by a 1 Hz detection scan): 131 ms per frameset, 32 tracks.
+  `cv2.fisheye.undistortPoints`, window 1152–1272 s chosen by a 1 Hz detection scan): 163–170 ms per frameset (detector 38 / pose 28 / tracker 53 / lifter 20), 20 tracks in 30 s, 32 in 120 s; 30 s = 334 MB, 120 s = 1.06 GB with per-frame normals + half-res previews (2.2 GB before).
 - Equivalence: vendored-vs-pristine lifter bit-identical (16 cases); real-fixture seam (lifter I/O + isolated smoothing window)
   bit-identical / 1e-4 m; full-history smoothing off by ≤0.088 m because the fixture lacks merge events (documented limit).
 - Rendering (user request, mirrors `sam3d-body`): posekit `log_person_bbox`/`log_person_points2d` + `person_color` keyed by track id, joints `Points3D(keypoint_ids, class_ids)` under an SMPL-24 `AnnotationContext`, `Mesh3D` with `compute_vertex_normals` + alpha 0.5, `LivePeopleLogger` clears ended tracks, 960×540 previews under `pinhole/preview/` (excluded from the 3D view: a half-res image on the full-res Pinhole plane covers a quarter).

--- a/.agents/skills/add-model/references/example-xlens-lamp.md
+++ b/.agents/skills/add-model/references/example-xlens-lamp.md
@@ -1,0 +1,41 @@
+# Worked example — X-Lens + LAMP (2026-09-02/03), two ports in parallel through Codex
+
+Both runs used this skill end to end with the user asleep: four Codex jobs (two forks, two ports) in tmux with sentinels,
+Claude reviewing, taking the pixel evidence, and sending corrections back through `codex exec resume`.
+
+## X-Lens (calibrated multi-view metric depth, pinhole + fisheye rigs)
+
+Fork `pablovela5620/XLens` (`main` = `e6bdf2f6`, the last Apache-2.0 commit — upstream HEAD relicensed to CC-BY-NC).
+Weights gated CC-BY-NC on `henryzhou998/X-Lens` (rev `1d0c9635`), never mirrored. New monoprior family `rig_depth`
+(`unit_rays` from simplecv cameras, `RigDepthPrediction(depth_m, confidence, mask, scale)`), PR stack #195 → #198 → #199 → #201.
+
+- Numbers: ETH3D `playground_1l` two-view pinhole **baseline** — metric abs-rel 0.76 / EPE 4.47 px, median-scale-aligned
+  abs-rel 0.15 / EPE 1.42 px (a ×1.76 global scale miss: the model normalises translations, so a 6 cm baseline carries no
+  metric cue). 5090 bf16: 6 views 504×798 ≈ 0.9 s, 490×938 pair 168 ms; catalog tool 4 views 896×504 ≈ 1.0 s predict + 1.7 s log (PNG depth + TSDF) per frameset, 60 s @5 fps = 652 MB rrd (the six-camera Points3D version was 3.4 GB). 1120×630 ×4 needs a 4.7 GB attention-bias allocation alone.
+- Gotchas: bare safetensors needs `xlens_vits.yaml` (else ViT-L defaults); upstream `strict=False` hides partial loads → assert
+  empty key lists; beartype claw forced value-preserving annotation fixes in vendored files (PR 2); one-member tyro union;
+  per-frame `Points3D` made a 60-s catalog rrd 3.4 GB → rectified pinhole twins + `EncodedDepthImage`; the two robocap eye
+  cameras are out of distribution → four outward cameras only; upstream URL typo in the vendored docstring caught in review.
+
+## LAMP (4-camera egocentric 3D people tracking, SMPL output)
+
+Fork `pablovela5620/LAMP` (`main` = `db3e4bf9`, CC-BY-NC code + weights). New package `packages/lamp` (`lamptrack`) on
+`common` + `cuda` + `posekit`; 2D stage = posekit RT-DETRv2 + ViTPose-plus-base (upstream's checkpoint); RF-DETR only in the
+fork (bumped 1.5.0 → 1.9.x for transformers 5). PR stack #196 → #197 → #200 → #202.
+
+- Numbers: fork on the Aria `test-library` (700 framesets @10 Hz): RF-DETR 8.7 / ViTPose 6.6 / lifter 8.6 / total 28.5 ms,
+  lifted-joint reprojection 6.3–7.9 px; port on robocap s29 (four KB4 cameras fed as virtual-pinhole vectors after
+  `cv2.fisheye.undistortPoints`, window 1152–1272 s chosen by a 1 Hz detection scan): 131 ms per frameset, 32 tracks.
+- Equivalence: vendored-vs-pristine lifter bit-identical (16 cases); real-fixture seam (lifter I/O + isolated smoothing window)
+  bit-identical / 1e-4 m; full-history smoothing off by ≤0.088 m because the fixture lacks merge events (documented limit).
+- Rendering (user request, mirrors `sam3d-body`): posekit `log_person_bbox`/`log_person_points2d` + `person_color` keyed by track id, joints `Points3D(keypoint_ids, class_ids)` under an SMPL-24 `AnnotationContext`, `Mesh3D` with `compute_vertex_normals` + alpha 0.5, `LivePeopleLogger` clears ended tracks, 960×540 previews under `pinhole/preview/` (excluded from the 3D view: a half-res image on the full-res Pinhole plane covers a quarter).
+- Gotchas: SMPL ≠ SMPL-X (Hub mirror + chumpy `find_class` shim, private hosting); the port invented a fixture contract before
+  the fork produced the real one → the fork owns the layout; ended tracks persist in Rerun without `rr.Clear`; people render
+  like sam3d-body (translucent meshes, annotated joints); `requests` needed explicitly in the isolated catalog lane; measure
+  performance outside the beartype dev env.
+
+## What the runs changed in this skill
+
+Rerun geometry rules (fisheye twins, Clear on track end, no per-frame clouds, sam3d-body people, OOD sensors), non-stereo
+numbers incl. scale-aligned depth metrics and replay fixtures owned by the fork, the follow-up-by-resume pattern, the
+new-package lane, one-member tyro unions, beartype-forced vendored annotation fixes, verbatim ports of frame-convention helpers.

--- a/.agents/skills/add-model/references/fork-and-pixify.md
+++ b/.agents/skills/add-model/references/fork-and-pixify.md
@@ -5,7 +5,8 @@ shows it in Rerun, on the monorepo's pins, with upstream code untouched.
 
 ## Layout of the fork
 
-- `main` = upstream commit, frozen (record the SHA in NOTES.md). Never push to it.
+- Upstream's default branch (`main` or `master` — keep its name) = upstream commit, frozen (record the SHA in
+  NOTES.md). Never push to it.
 - `pixi` = default branch. Change set is limited to: `pixi.toml`, `pixi.lock`, `.gitignore`,
   `demo_rerun.py`, `NOTES.md`, one README section "Run with pixi". Any upstream `.py` edit needs a
   reason under "Upstream edits" in NOTES.md (target: none; `git diff main -- '*.py'` shows only the demo).
@@ -13,7 +14,7 @@ shows it in Rerun, on the monorepo's pins, with upstream code untouched.
 ```bash
 GH_TOKEN=$(gh auth token --user pablovela5620) gh repo fork <org>/<repo> --clone=false
 git clone git@github.com:pablovela5620/<repo> ~/0Dev/forks/<repo>   # personal SSH identity
-git -C ~/0Dev/forks/<repo> checkout main && git -C ~/0Dev/forks/<repo> reset --hard <upstream-sha>   # main == the frozen SHA even if upstream moved
+git -C ~/0Dev/forks/<repo> reset --hard <upstream-sha>   # default branch == the frozen SHA even if upstream moved
 git -C ~/0Dev/forks/<repo> checkout -b pixi
 # after pushing: make pixi the default branch
 GH_TOKEN=$(gh auth token --user pablovela5620) gh repo edit pablovela5620/<repo> --default-branch pixi
@@ -33,7 +34,9 @@ GH_TOKEN=$(gh auth token --user pablovela5620) gh repo edit pablovela5620/<repo>
     skip gitignored files); use `hf download` (never `huggingface-cli`).
   - `demo` (depends-on both downloads) → `python demo_rerun.py`; `demo-upstream` → upstream's own script.
   - `eval` when upstream has an eval script, on the single hosted sample.
-- Verify: `pixi lock --check` clean; fresh clone → `pixi run demo` timing in NOTES.md.
+- Verify: `pixi lock --check` clean; fresh clone → `pixi run demo` timing in NOTES.md (warm pixi package cache,
+  empty env/weights/data — state it). If upstream's demo is interactive (`cv2.imshow`), `demo-upstream` stays
+  interactive; do not patch upstream for it.
 
 ## Weights and sample data
 

--- a/.agents/skills/add-model/references/fork-and-pixify.md
+++ b/.agents/skills/add-model/references/fork-and-pixify.md
@@ -13,6 +13,7 @@ shows it in Rerun, on the monorepo's pins, with upstream code untouched.
 ```bash
 GH_TOKEN=$(gh auth token --user pablovela5620) gh repo fork <org>/<repo> --clone=false
 git clone git@github.com:pablovela5620/<repo> ~/0Dev/forks/<repo>   # personal SSH identity
+git -C ~/0Dev/forks/<repo> checkout main && git -C ~/0Dev/forks/<repo> reset --hard <upstream-sha>   # main == the frozen SHA even if upstream moved
 git -C ~/0Dev/forks/<repo> checkout -b pixi
 # after pushing: make pixi the default branch
 GH_TOKEN=$(gh auth token --user pablovela5620) gh repo edit pablovela5620/<repo> --default-branch pixi

--- a/.agents/skills/add-model/references/fork-and-pixify.md
+++ b/.agents/skills/add-model/references/fork-and-pixify.md
@@ -1,0 +1,58 @@
+# Phase 1 — Fork + pixify
+
+Goal: `git clone <fork> && cd <fork> && pixi run demo` runs upstream inference on one real sample and
+shows it in Rerun, on the monorepo's pins, with upstream code untouched.
+
+## Layout of the fork
+
+- `main` = upstream commit, frozen (record the SHA in NOTES.md). Never push to it.
+- `pixi` = default branch. Change set is limited to: `pixi.toml`, `pixi.lock`, `.gitignore`,
+  `demo_rerun.py`, `NOTES.md`, one README section "Run with pixi". Any upstream `.py` edit needs a
+  reason under "Upstream edits" in NOTES.md (target: none; `git diff main -- '*.py'` shows only the demo).
+
+```bash
+GH_TOKEN=$(gh auth token --user pablovela5620) gh repo fork <org>/<repo> --clone=false
+git clone git@github.com:pablovela5620/<repo> ~/0Dev/forks/<repo>   # personal SSH identity
+git -C ~/0Dev/forks/<repo> checkout -b pixi
+# after pushing: make pixi the default branch
+GH_TOKEN=$(gh auth token --user pablovela5620) gh repo edit pablovela5620/<repo> --default-branch pixi
+```
+
+## pixi.toml
+
+- Channels `conda-forge` only; platforms `linux-64` (+ `osx-arm64` only if it actually solves).
+- Copy pins from the monorepo `pixi.toml` (`common`/`monoprior` features): python, cuda-version, pytorch-gpu,
+  torchvision, rerun-sdk, timm, einops, tyro, numpy, opencv. Keep ranges, not exact pins.
+- `simplecv` as a git PyPI dep on monorepo `main` — it gives `RerunTyroConfig`, camera dataclasses, and
+  `log_rig_static`. It does not carry its runtime deps: add `av`, `pyarrow`, `einops`, and pin
+  `typing-extensions = ">=4.1,<4.16"` (pyserde<0.32).
+- Packages missing from conda-forge go to `[pypi-dependencies]`. Drop upstream's training/export/profiling deps.
+- Tasks (single-line `&&` chains only — pixi collapses multiline `cmd`):
+  - `_download-checkpoints`, `_download-data`: guarded by shell `test -f`/`test -d` (pixi `inputs`/`outputs`
+    skip gitignored files); use `hf download` (never `huggingface-cli`).
+  - `demo` (depends-on both downloads) → `python demo_rerun.py`; `demo-upstream` → upstream's own script.
+  - `eval` when upstream has an eval script, on the single hosted sample.
+- Verify: `pixi lock --check` clean; fresh clone → `pixi run demo` timing in NOTES.md.
+
+## Weights and sample data
+
+- Weights: official HF repo if one exists (pin revision SHA); else mirror the release files unmodified to
+  `pablovela5620/<name>` with the upstream LICENSE in the repo. Non-commercial licenses: say so in the card.
+- Sample: one scene with ground truth, in *upstream's exact dataset layout* so upstream's eval script works
+  unchanged. Stereo: ETH3D two-view `playground_1l` already lives at HF `pablovela5620/monoprior-example`
+  (`stereo/eth3d`, Middlebury-v3 `calib.txt` with baseline in mm).
+
+## demo_rerun.py
+
+- tyro `Config` with a nested `rr_config: RerunTyroConfig` (spawn/save/connect/headless for free).
+- Log an exoego:v2 rig via `simplecv.rerun_rig_logger.log_rig_static` (`/world/rig_00/cam_NN`,
+  `Transform3D(from_parent=True)`, `Pinhole`, image + depth under `pinhole/`). Camera params are simplecv
+  `PinholeParameters` (`Intrinsics.from_k_matrix`, `Extrinsics`).
+- Depth from disparity: `fx * B / (d + doffs)`; mask `depth > max_depth_m` (sky sub-pixel disparities
+  streak the cloud). Keep 2D-only entities (disparity/GT/error) out of the 3D view's contents.
+- Print the metric against GT in-script (EPE, bad-N) and check it equals upstream's eval to the printed digit.
+
+## NOTES.md (mandatory — it is what feeds this skill back)
+
+Sections: Decisions, Commands (fork, sample prep, upload), Upstream edits, Gotchas found,
+Reproduction table (ours vs paper), fresh-clone timing.

--- a/.agents/skills/add-model/references/fork-and-pixify.md
+++ b/.agents/skills/add-model/references/fork-and-pixify.md
@@ -28,12 +28,17 @@ GH_TOKEN=$(gh auth token --user pablovela5620) gh repo edit pablovela5620/<repo>
 - `simplecv` as a git PyPI dep on monorepo `main` — it gives `RerunTyroConfig`, camera dataclasses, and
   `log_rig_static`. It does not carry its runtime deps: add `av`, `pyarrow`, `einops`, and pin
   `typing-extensions = ">=4.1,<4.16"` (pyserde<0.32).
+- The git `simplecv` package now declares most runtime deps (including `opencv-python`, `matplotlib`); still add `av`, `pyarrow`
+  and `typing-extensions>=4.1,<4.16` explicitly. Frozen upstream code may already use PEP 695 (`type X = …`) — fine on 3.12;
+  the ban applies to new code only.
 - Packages missing from conda-forge go to `[pypi-dependencies]`. Drop upstream's training/export/profiling deps.
 - Tasks (single-line `&&` chains only — pixi collapses multiline `cmd`):
   - `_download-checkpoints`, `_download-data`: guarded by shell `test -f`/`test -d` (pixi `inputs`/`outputs`
     skip gitignored files); use `hf download` (never `huggingface-cli`).
   - `demo` (depends-on both downloads) → `python demo_rerun.py`; `demo-upstream` → upstream's own script.
   - `eval` when upstream has an eval script, on the single hosted sample.
+- `demo`/`demo-<scene>` default to headless save (`mkdir -p out && python -u demo_rerun.py --rr-config.headless --rr-config.save out/<scene>.rrd`);
+  explicit `--rr-config.*` flags override. Foreground `python -u` + tee logs inside the (already durable) tmux job.
 - Verify: `pixi lock --check` clean; fresh clone → `pixi run demo` timing in NOTES.md (warm pixi package cache,
   empty env/weights/data — state it). If upstream's demo is interactive (`cv2.imshow`), `demo-upstream` stays
   interactive; do not patch upstream for it.
@@ -60,3 +65,5 @@ GH_TOKEN=$(gh auth token --user pablovela5620) gh repo edit pablovela5620/<repo>
 
 Sections: Decisions, Commands (fork, sample prep, upload), Upstream edits, Gotchas found,
 Reproduction table (ours vs paper), fresh-clone timing.
+When the demo records a replay fixture, NOTES.md carries its layout as a table (key, dtype, shape, meaning) — the port reads
+this file; the Middlebury `doffs` convention used (`disp = fx·B/depth + doffs`) is stated even when the sample has `doffs = 0`.

--- a/.agents/skills/add-model/references/port.md
+++ b/.agents/skills/add-model/references/port.md
@@ -3,6 +3,17 @@
 Target package is normally `packages/monoprior` (`monopriors`). Branch names `<model>/<n>-<stage>`;
 each PR bases on the previous one. Keep every PR reviewable on its own.
 
+## Setup (once per port)
+
+```bash
+git worktree add /tmp/<model>/wt -b <model>/1-vendor <base-branch>
+cd /tmp/<model>/wt && pixi install -e <pkg>-dev          # editable installs must point at THIS tree — do not symlink .pixi
+pixi run -e <pkg>-dev python -c "import <module>; print(<module>.__file__)"   # must print /tmp/<model>/wt/...
+ln -s <main-checkout>/packages/<pkg>/data/examples/<family> packages/<pkg>/data/examples/<family>   # gitignored samples
+```
+Run pytest from `packages/<pkg>` (root collection pulls in packages whose envs are absent). Use
+`pixi run --frozen` after the first install; re-run `pixi install` only after changing deps.
+
 ## PR 1 — `1-vendor`: upstream inference subset, as-is
 
 - Copy only the inference modules to `monopriors/third_party/<model>/` plus the upstream `LICENSE`.
@@ -85,9 +96,20 @@ Follow `monopriors/apis/stereo_catalog.py` / `promptda_polycam`: read cameras + 
 (`Fisheye62Parameters`, `PinholeParameters`), rectify with `models/stereo_depth/rectify.py`, log the rig with
 `log_rig_static`, relay video with `send_columns`, `EncodedDepthImage` (16-bit mm, `depth_range`) for depth,
 `Open3DFuser` + `log_open3d_mesh` for incremental TSDF, `RerunTyroConfig` for the sink. Stream to the viewer;
-do not register a layer unless asked.
+do not register a layer unless asked. Catalog registrations are in-memory: after a server restart the dataset is
+gone (`LookupError: No dataset found with name 'robocap'`) — re-register (`/mnt/nas/datasets/robocap/rrd/reregister.py`)
+before blaming the tool.
+
+## PR description (every PR)
+
+Stacked-on line; what the PR adds in 3–6 bullets; **numbers** (reference metric vs paper/incumbent, warm ms/frame,
+resolution); **gates** as run (lint/typecheck/deadcode/tests counts, slow tests); licenses when non-permissive;
+for the last PR the evidence directory and the key screenshots (frusta, depth, mesh, same-frame comparison).
 
 ## Stacking and merging
 
-Open PRs bottom-up with `--base` on the previous branch. When merging: merge with a merge commit in order,
+Open PRs bottom-up with `--base` on the previous branch. A fix that belongs to a lower PR goes on that PR's branch
+(cherry-pick), then replay everything above it (`git rebase <lower>` per branch, or `git rebase --onto` for
+worktrees based on an old tip) and `git push --force-with-lease` — a fix on the top branch hides the defect in the
+reviewed PR. When merging: merge with a merge commit in order,
 retarget each next PR to `main` (`gh pr edit N --base main`) right before merging it, delete branches after.

--- a/.agents/skills/add-model/references/port.md
+++ b/.agents/skills/add-model/references/port.md
@@ -38,8 +38,12 @@ Run pytest from `packages/<pkg>` (root collection pulls in packages whose envs a
 - Register: `<FAMILY>_PREDICTORS` Literal + `get_<family>_predictor` in `models/<family>/__init__.py`.
   Existing demos/apps/catalog tools select by `predictor_name`; if one still hardcodes a class, switch it to
   the registry in this PR (that is how the tools gain the model). Constructors differ per model (one has
-  `model_size`, another `valid_iters`); tools keep a small `match predictor_name` at the construction site — no
-  config abstraction, no kwargs plumbing for options a model does not have.
+  `model_size`, another `valid_iters`): model-specific options live in a per-model config dataclass next to the
+  predictor (`LiteAnyStereoConfig(model_size=...)`, `FastFoundationStereoConfig(valid_iters=...)`, each with
+  `setup(device) -> Predictor`), combined into a tyro subcommand union exactly like
+  `simplecv/configs/exoego_dataset_configs.py` (defaults dict → `tyro.extras.subcommand_type_from_defaults` →
+  `tyro.conf.OmitSubcommandPrefixes`); tools take one `predictor:` union field. Never put a model-specific flag
+  (a `model_size`, an iteration count) flat on a tool's config — review feedback on FFS PR #162.
 - Tests: fast CPU test that builds the model from config and runs a tiny random pair (shape/dtype/finite);
   slow band (`pytestmark = [slow_cuda, requires_cuda]`) that downloads the checkpoint and checks the
   reference number on the ETH3D sample (validate.md gate 2). Default `pytest -q` must stay seconds.

--- a/.agents/skills/add-model/references/port.md
+++ b/.agents/skills/add-model/references/port.md
@@ -1,0 +1,75 @@
+# Phase 2 — Port into the monorepo
+
+Target package is normally `packages/monoprior` (`monopriors`). Branch names `<model>/<n>-<stage>`;
+each PR bases on the previous one. Keep every PR reviewable on its own.
+
+## PR 1 — `1-vendor`: upstream inference subset, as-is
+
+- Copy only the inference modules to `monopriors/third_party/<model>/` plus the upstream `LICENSE`.
+  Docstring in `__init__.py`: upstream URL, license (flag non-commercial), fork + SHA, file mapping
+  (`ours.py <- upstream/path.py`), "Local changes: none yet".
+- Make it importable: absolute imports, drop `sys.path` hacks; nothing else changes.
+- Register the vendor dir as *unowned* in `pyrefly.toml` (`project-excludes`) and in the package
+  `pyproject.toml` (ruff `extend-exclude`, vulture `exclude`, package-data for LICENSE).
+- Deps: add to the package feature in root `pixi.toml` (conda first, PyPI second); keep `platforms`
+  explicit. `pixi install -e <pkg>-dev` then commit `pixi.lock`.
+- Copy the same upstream files a second time to `tests/reference_data/<model>/upstream_*.py` — pristine
+  fixtures for the equivalence test in PR 3 (also excluded from lint/typecheck).
+
+## PR 2 — `2-predictor`: the contract
+
+- `monopriors/models/<family>/<model>.py`: `<Model>Predictor(Base<Family>Predictor)` with
+  `__init__(device, model_size=..., checkpoint: Path | None = None, ...)`, checkpoint download from the pinned
+  HF revision, strict `load_state_dict`, preprocessing mirroring upstream's demo exactly (padding, scaling,
+  normalisation, `iters`/`test_mode`), and `__call__` returning the family's prediction dataclass
+  (stereo: `StereoDepthPrediction(disparity, depth_meters, K_33, baseline_m)` via `disparity_to_metric_depth`).
+- Register: `<FAMILY>_PREDICTORS` Literal + `get_<family>_predictor` in `models/<family>/__init__.py`.
+  Existing demos/apps/catalog tools select by `predictor_name`; if one still hardcodes a class, switch it to
+  the registry in this PR (that is how the tools gain the model).
+- Tests: fast CPU test that builds the model from config and runs a tiny random pair (shape/dtype/finite);
+  slow band (`pytestmark = [slow_cuda, requires_cuda]`) that downloads the checkpoint and checks the
+  reference number on the ETH3D sample (validate.md gate 2). Default `pytest -q` must stay seconds.
+- Demo: if the family has no `tools/demos/<family>.py`, add one (thin shim over `monopriors/apis/<family>.py`
+  with `RerunTyroConfig`) plus a `pixi.toml` task with a `_download` dependency.
+
+### Pickled-module checkpoints (`torch.load(..., weights_only=False)` on a whole `nn.Module`)
+
+Do not import upstream at its original path and do not re-host converted files. Load with a custom
+`pickle.Unpickler` whose `find_class` remaps upstream module paths (`core.foundation_stereo` →
+`monopriors.third_party.<model>.foundation_stereo`, `Utils` → ...) onto the vendored modules, then take
+`.state_dict()` and load it strictly into a freshly built module. Cover it with a test on the real file (slow).
+
+## PR 3 — `3-typed`: owned fork
+
+- Apply python-conventions to the vendored subset: jaxtyping shapes on tensors, TypedDict/dataclass configs,
+  Google docstrings, absolute imports, remove training-only paths, dead code, unused helpers.
+- Module/parameter names and `state_dict` keys must not change.
+- `tests/test_<model>_upstream_equivalence.py`: load the pristine fixtures as a synthetic package
+  (`importlib.util.spec_from_file_location` under a fake package name), build upstream and ours from the same
+  config, copy the state dict, assert bit-identical outputs on seeded random pairs for every variant and
+  every optional path (e.g. triton kernel vs torch fallback, hierarchical vs plain).
+- Flip the vendor dir to *owned*: remove it from `pyrefly.toml`/ruff/vulture excludes; add vulture
+  `ignore_names` for framework-read config keys instead of reworking code.
+- Update the `__init__.py` docstring: "Local changes vs upstream" + the re-sync recipe (copy upstream to
+  fixtures, re-apply annotations, run the equivalence test).
+
+## PR 4 — `4-app` (only if the family has no Gradio app)
+
+Follow `posekit`/`stereo_depth_ui.py`: Radio-driven panels, `gradio_rerun` streaming viewer, ints typed
+`float | int`, no `np.float32` defaults (not JSON-serialisable), `--host` default `127.0.0.1`, launched with the
+sandbox off and exposed with `tailscale serve --bg --https=<port> http://127.0.0.1:<port-1>` (the embedded
+viewer needs a secure context).
+
+## PR 5 — `5-catalog` (only if the family has no catalog tool)
+
+Follow `monopriors/apis/stereo_catalog.py` / `promptda_polycam`: read cameras + poses from the catalog with
+`simplecv.rerun_dataloader` (`open_segment_decoder`, NVDEC), build simplecv camera dataclasses
+(`Fisheye62Parameters`, `PinholeParameters`), rectify with `models/stereo_depth/rectify.py`, log the rig with
+`log_rig_static`, relay video with `send_columns`, `EncodedDepthImage` (16-bit mm, `depth_range`) for depth,
+`Open3DFuser` + `log_open3d_mesh` for incremental TSDF, `RerunTyroConfig` for the sink. Stream to the viewer;
+do not register a layer unless asked.
+
+## Stacking and merging
+
+Open PRs bottom-up with `--base` on the previous branch. When merging: merge with a merge commit in order,
+retarget each next PR to `main` (`gh pr edit N --base main`) right before merging it, delete branches after.

--- a/.agents/skills/add-model/references/port.md
+++ b/.agents/skills/add-model/references/port.md
@@ -35,14 +35,12 @@ Run pytest from `packages/<pkg>` (root collection pulls in packages whose envs a
   HF revision, strict `load_state_dict`, preprocessing mirroring upstream's demo exactly (padding, scaling,
   normalisation, `iters`/`test_mode`), and `__call__` returning the family's prediction dataclass
   (stereo: `StereoDepthPrediction(disparity, depth_meters, K_33, baseline_m)` via `disparity_to_metric_depth`).
-- Register: `<FAMILY>_PREDICTORS` Literal + `get_<family>_predictor` in `models/<family>/__init__.py`.
-  Existing demos/apps/catalog tools select by `predictor_name`; if one still hardcodes a class, switch it to
-  the registry in this PR (that is how the tools gain the model). Constructors differ per model (one has
-  `model_size`, another `valid_iters`): model-specific options live in a per-model config dataclass next to the
+- Register model-specific options in a per-model config dataclass next to the
   predictor (`LiteAnyStereoConfig(model_size=...)`, `FastFoundationStereoConfig(valid_iters=...)`, each with
   `setup(device) -> Predictor`), combined into a tyro subcommand union exactly like
   `simplecv/configs/exoego_dataset_configs.py` (defaults dict → `tyro.extras.subcommand_type_from_defaults` →
-  `tyro.conf.OmitSubcommandPrefixes`); tools take one `predictor:` union field. Never put a model-specific flag
+  `tyro.conf.OmitSubcommandPrefixes`); tools take one `predictor:` union field, and existing demos/apps/catalog
+  tools gain the model through that registry. Never put a model-specific flag
   (a `model_size`, an iteration count) flat on a tool's config — review feedback on FFS PR #162.
 - Tests: fast CPU test that builds the model from config and runs a tiny random pair (shape/dtype/finite);
   slow band (`pytestmark = [slow_cuda, requires_cuda]`) that downloads the checkpoint and checks the

--- a/.agents/skills/add-model/references/port.md
+++ b/.agents/skills/add-model/references/port.md
@@ -7,14 +7,15 @@ each PR bases on the previous one. Keep every PR reviewable on its own.
 
 - Copy only the inference modules to `monopriors/third_party/<model>/` plus the upstream `LICENSE`.
   Docstring in `__init__.py`: upstream URL, license (flag non-commercial), fork + SHA, file mapping
-  (`ours.py <- upstream/path.py`), "Local changes: none yet".
+  (`ours.py <- upstream/path.py`), "Local changes: import paths only" (absolute imports, no `sys.path` hacks, export/TRT-only classes dropped — nothing behavioural).
 - Make it importable: absolute imports, drop `sys.path` hacks; nothing else changes.
 - Register the vendor dir as *unowned* in `pyrefly.toml` (`project-excludes`) and in the package
   `pyproject.toml` (ruff `extend-exclude`, vulture `exclude`, package-data for LICENSE).
 - Deps: add to the package feature in root `pixi.toml` (conda first, PyPI second); keep `platforms`
   explicit. `pixi install -e <pkg>-dev` then commit `pixi.lock`.
 - Copy the same upstream files a second time to `tests/reference_data/<model>/upstream_*.py` — pristine
-  fixtures for the equivalence test in PR 3 (also excluded from lint/typecheck).
+  fixtures (excluded from lint/typecheck) — and add `tests/test_<model>_upstream_equivalence.py` already here
+  (it passes trivially against the as-is copy); PR 3 must keep it passing.
 
 ## PR 2 — `2-predictor`: the contract
 
@@ -25,7 +26,9 @@ each PR bases on the previous one. Keep every PR reviewable on its own.
   (stereo: `StereoDepthPrediction(disparity, depth_meters, K_33, baseline_m)` via `disparity_to_metric_depth`).
 - Register: `<FAMILY>_PREDICTORS` Literal + `get_<family>_predictor` in `models/<family>/__init__.py`.
   Existing demos/apps/catalog tools select by `predictor_name`; if one still hardcodes a class, switch it to
-  the registry in this PR (that is how the tools gain the model).
+  the registry in this PR (that is how the tools gain the model). Constructors differ per model (one has
+  `model_size`, another `valid_iters`); tools keep a small `match predictor_name` at the construction site — no
+  config abstraction, no kwargs plumbing for options a model does not have.
 - Tests: fast CPU test that builds the model from config and runs a tiny random pair (shape/dtype/finite);
   slow band (`pytestmark = [slow_cuda, requires_cuda]`) that downloads the checkpoint and checks the
   reference number on the ETH3D sample (validate.md gate 2). Default `pytest -q` must stay seconds.
@@ -35,7 +38,8 @@ each PR bases on the previous one. Keep every PR reviewable on its own.
 ### Pickled-module checkpoints (`torch.load(..., weights_only=False)` on a whole `nn.Module`)
 
 Do not import upstream at its original path and do not re-host converted files. Load with a custom
-`pickle.Unpickler` whose `find_class` remaps upstream module paths (`core.foundation_stereo` →
+`pickle.Unpickler` subclass (wrapped in a module-like namespace for `torch.load(..., pickle_module=...)`) whose
+`find_class` remaps upstream module paths (`core.foundation_stereo` →
 `monopriors.third_party.<model>.foundation_stereo`, `Utils` → ...) onto the vendored modules, then take
 `.state_dict()` and load it strictly into a freshly built module. Cover it with a test on the real file (slow).
 Inspect the pickle first (`zipfile` + `re.findall(rb'core\.[A-Za-z_.]+', data.pkl)`): it also references the
@@ -50,10 +54,14 @@ against the reference sample instead of guessing (FFS: `args.normalize` missing;
 - Module/parameter names and `state_dict` keys must not change.
 - `tests/test_<model>_upstream_equivalence.py`: load the pristine fixtures as a synthetic package
   (`importlib.util.spec_from_file_location` under a fake package name), build upstream and ours from the same
-  config, copy the state dict, assert bit-identical outputs on seeded random pairs for every variant and
-  every optional path (e.g. triton kernel vs torch fallback, hierarchical vs plain).
-- Flip the vendor dir to *owned*: remove it from `pyrefly.toml`/ruff/vulture excludes; add vulture
-  `ignore_names` for framework-read config keys instead of reworking code.
+  config, copy the state dict, assert bit-identical outputs (fp32, no autocast) on seeded random pairs for every
+  checkpoint/config variant and every code path that has both an upstream and an owned implementation
+  (hierarchical vs plain, iteration counts). Alternative kernels (triton vs torch volume) are *parity* checks
+  with a tolerance, not bit-identity, and are asserted separately.
+- Flip the vendor dir to *owned*: remove it from `pyrefly.toml`/ruff/vulture excludes **and add it to the
+  package's `PYREFLY_TARGET` list in root `pixi.toml`** (monoprior enumerates its typechecked paths; a path
+  missing there is silently never checked); add vulture `ignore_names` for framework-read config keys instead of
+  reworking code.
 - Update the `__init__.py` docstring: "Local changes vs upstream" + the re-sync recipe (copy upstream to
   fixtures, re-apply annotations, run the equivalence test).
 

--- a/.agents/skills/add-model/references/port.md
+++ b/.agents/skills/add-model/references/port.md
@@ -38,6 +38,10 @@ Do not import upstream at its original path and do not re-host converted files. 
 `pickle.Unpickler` whose `find_class` remaps upstream module paths (`core.foundation_stereo` →
 `monopriors.third_party.<model>.foundation_stereo`, `Utils` → ...) onto the vendored modules, then take
 `.state_dict()` and load it strictly into a freshly built module. Cover it with a test on the real file (slow).
+Inspect the pickle first (`zipfile` + `re.findall(rb'core\.[A-Za-z_.]+', data.pkl)`): it also references the
+config classes the module holds (e.g. `omegaconf.dictconfig`), which then become a dependency, and a checkpoint
+serialised by older code may lack attributes the current `forward()` reads — measure each candidate default
+against the reference sample instead of guessing (FFS: `args.normalize` missing; True → 0.48 % bad1, False → 45 %).
 
 ## PR 3 — `3-typed`: owned fork
 

--- a/.agents/skills/add-model/references/port.md
+++ b/.agents/skills/add-model/references/port.md
@@ -20,6 +20,9 @@ Run pytest from `packages/<pkg>` (root collection pulls in packages whose envs a
   Docstring in `__init__.py`: upstream URL, license (flag non-commercial), fork + SHA, file mapping
   (`ours.py <- upstream/path.py`), "Local changes: import paths only" (absolute imports, no `sys.path` hacks, export/TRT-only classes dropped — nothing behavioural).
 - Make it importable: absolute imports, drop `sys.path` hacks; nothing else changes.
+- Exception forced by the beartype claw (it instruments `third_party/` too): annotations that lie (`mlp_ratio: int = 4` used as
+  a float, `size: Tuple[int, int] = None`) get value-preserving fixes (`4.0`, `Optional[...]`) in PR 1 or PR 2, listed in the
+  docstring as "beartype-compatible annotation fixes, values unchanged".
 - Register the vendor dir as *unowned* in `pyrefly.toml` (`project-excludes`) and in the package
   `pyproject.toml` (ruff `extend-exclude`, vulture `exclude`, package-data for LICENSE).
 - Deps: add to the package feature in root `pixi.toml` (conda first, PyPI second); keep `platforms`
@@ -42,6 +45,13 @@ Run pytest from `packages/<pkg>` (root collection pulls in packages whose envs a
   `tyro.conf.OmitSubcommandPrefixes`); tools take one `predictor:` union field, and existing demos/apps/catalog
   tools gain the model through that registry. Never put a model-specific flag
   (a `model_size`, an iteration count) flat on a tool's config — review feedback on FFS PR #162.
+- A family's first model: tyro cannot build a subcommand union from a one-entry defaults dict — alias the union to that config
+  at runtime (base class under `TYPE_CHECKING`) and switch to `subcommand_type_from_defaults` when the second model lands.
+- Upstream private helpers that fix a frame convention (LAMP `MpsLoader._compute_T_gravityWorld_world`) are ported verbatim
+  with a parity test against the pristine fixture — never re-derived.
+- New package instead of a family (LAMP → `packages/lamp`, module `lamptrack`): its env composes `common` + `cuda` + the
+  package feature (+ `posekit` for 2D people stages); a `<pkg>-catalog` lane mirrors `monoprior-catalog`; the two catalog rig
+  readers are copied from `monopriors/apis/stereo_catalog.py` (no monoprior dependency) pending a shared simplecv reader.
 - Tests: fast CPU test that builds the model from config and runs a tiny random pair (shape/dtype/finite);
   slow band (`pytestmark = [slow_cuda, requires_cuda]`) that downloads the checkpoint and checks the
   reference number on the ETH3D sample (validate.md gate 2). Default `pytest -q` must stay seconds.
@@ -101,6 +111,11 @@ Follow `monopriors/apis/stereo_catalog.py` / `promptda_polycam`: read cameras + 
 do not register a layer unless asked. Catalog registrations are in-memory: after a server restart the dataset is
 gone (`LookupError: No dataset found with name 'robocap'`) — re-register (`/mnt/nas/datasets/robocap/rrd/reregister.py`)
 before blaming the tool.
+
+Catalog-tool rules added by the X-Lens/LAMP runs: fisheye rigs get rectified pinhole twins for depth (SKILL.md "Rerun geometry
+rules"); `start_s` is absolute `video_time` seconds (say so in the field docstring); decoded+resized fisheye frames are logged
+as `rr.Image(...).compress(...)` (the `send_columns` relay is for untouched pinhole streams); print ms per frameset with
+views × resolution; ended tracks are cleared; the 60-s evidence rrd stays well under 500 MB.
 
 ## PR description (every PR)
 

--- a/.agents/skills/add-model/references/port.md
+++ b/.agents/skills/add-model/references/port.md
@@ -52,6 +52,9 @@ Run pytest from `packages/<pkg>` (root collection pulls in packages whose envs a
 - New package instead of a family (LAMP → `packages/lamp`, module `lamptrack`): its env composes `common` + `cuda` + the
   package feature (+ `posekit` for 2D people stages); a `<pkg>-catalog` lane mirrors `monoprior-catalog`; the two catalog rig
   readers are copied from `monopriors/apis/stereo_catalog.py` (no monoprior dependency) pending a shared simplecv reader.
+  A lane solved in isolation may need deps its imports pull transitively (`requests` via posekit/simplecv): add them to the
+  lane explicitly. When the fork runs in parallel, PR 2 ships clear skip/fail behaviour for the missing fixture and PR 3
+  integrates it after a second check.
 - Tests: fast CPU test that builds the model from config and runs a tiny random pair (shape/dtype/finite);
   slow band (`pytestmark = [slow_cuda, requires_cuda]`) that downloads the checkpoint and checks the
   reference number on the ETH3D sample (validate.md gate 2). Default `pytest -q` must stay seconds.

--- a/.agents/skills/add-model/references/port.md
+++ b/.agents/skills/add-model/references/port.md
@@ -46,6 +46,12 @@ Inspect the pickle first (`zipfile` + `re.findall(rb'core\.[A-Za-z_.]+', data.pk
 config classes the module holds (e.g. `omegaconf.dictconfig`), which then become a dependency, and a checkpoint
 serialised by older code may lack attributes the current `forward()` reads — measure each candidate default
 against the reference sample instead of guessing (FFS: `args.normalize` missing; True → 0.48 % bad1, False → 45 %).
+Compare the unpickled module's `state_dict` against a config-built module before promising "build from config +
+strict load": a NAS-pruned / distilled release (FFS: 210 tensors only in the pickle, 54 shape changes, distillation
+wrapper modules) cannot be described by its `cfg.yaml`. Then the pickle *is* the architecture spec: the loader
+unpickles + deep-copies + strictly reloads, the typed fork types the classes without renaming modules, classes or
+parameters (the remap and the state_dict keys depend on them), the fast equivalence test compares config-built
+upstream vs owned nets, and a slow test unpickles the real file onto both packages and compares outputs.
 
 ## PR 3 — `3-typed`: owned fork
 

--- a/.agents/skills/add-model/references/validate.md
+++ b/.agents/skills/add-model/references/validate.md
@@ -1,0 +1,49 @@
+# Gates
+
+A phase is not done until its gate passes. Report failures as failures.
+
+## Gate 1 — Fork runs (end of phase 1)
+
+- Fresh `git clone` → `pixi run demo` succeeds; `pixi lock --check` clean.
+- Rerun demo screenshot: rig frusta with images, depth/cloud in the 3D view, no red error badges.
+- In-script metric equals upstream eval on the same sample (or is recorded as baseline when upstream has none).
+
+## Gate 2 — Reference number (PR 2)
+
+- Slow GPU test loads the released checkpoint and reproduces the fork's number on the ETH3D sample.
+  Stereo: EPE + bad1 on non-occluded pixels with `gt < max_disp`; compare to paper (dataset mean — a single
+  scene lands near, not on, it) and record both in the test docstring.
+- Warm timing: `torch.cuda.synchronize()` around 50 forwards after 10 warm-ups, at the demo resolution;
+  record ms/frame in the PR description.
+
+## Gate 3 — Equivalence + dev tasks (PR 3, and every PR)
+
+- `tests/test_<model>_upstream_equivalence.py` passes (bit-identical outputs, all variants, all optional paths).
+- From repo root: `pixi run -e <pkg>-dev --frozen lint`, `typecheck`, `deadcode`, `tests` all green.
+- Default `pytest -q` runtime stays in seconds; checkpoint tests are `-m slow`.
+
+## Gate 4 — Hand-roll audit (last PR before pushing)
+
+Grep the diff for the usual suspects and replace with the shared implementation:
+
+| hand-rolled | use instead |
+|---|---|
+| quaternion → matrix | `scipy.spatial.transform.Rotation.from_quat` (xyzw) |
+| K scaling for resized images | `simplecv.camera_parameters.rescale_intri` |
+| camera dicts / ad-hoc `K, D, R, t` tuples | `PinholeParameters`, `Fisheye62Parameters`, `Intrinsics.from_k_matrix`, `Extrinsics` |
+| rig entity paths + transforms by hand | `simplecv.rig.Rig` + `log_rig_static` |
+| fourcc / codec ints | `rr.VideoCodec(value)` |
+| open3d mesh → `rr.Mesh3D` | `simplecv.rerun_log_utils.log_open3d_mesh` |
+| own `rr.init`/spawn/save flags | `RerunTyroConfig` |
+| TSDF loop | `simplecv.ops.tsdf_depth_fuser.Open3DFuser` |
+| video decode | `simplecv.rerun_dataloader` / `SegmentNvdecDecoder` |
+
+Keep a hand-rolled version only when no shared helper fits, and say so in the PR.
+
+## Gate 5 — Viewer pixel evidence (before "done")
+
+Use the `rerun-viewer-validation` skill: run with `--rr-config.headless --rr-config.save <rrd>`, open the
+`.rrd` in a viewer, take screenshots that show the actual claim (frusta orientation, depth pointing out of the
+right camera, mesh faces visible from inside, no error badges), and note the evidence directory in the PR.
+Watch for: child `Transform3D` is relative to its *parent*, not the rig (a level mesh does not prove the tree);
+`EncodedDepthImage` needs `depth_range` or renders purple; colour range 0–6 m for indoor scenes.

--- a/.agents/skills/add-model/references/validate.md
+++ b/.agents/skills/add-model/references/validate.md
@@ -6,6 +6,10 @@ A phase is not done until its gate passes. Report failures as failures.
 
 - Fresh `git clone` → `pixi run demo` succeeds; `pixi lock --check` clean.
 - Rerun demo screenshot: rig frusta with images, depth/cloud in the 3D view, no red error badges.
+- No display: the producer saves `.rrd`s (`mkdir -p out && python -u demo_rerun.py --rr-config.headless --rr-config.save out/<scene>.rrd`
+  — `RerunTyroConfig` opens the sink in `__post_init__`, so the directory must exist), then takes the screenshot from a headless
+  viewer (`ViewerClient.spawn(headless=True)` or `rerun --headless` + `rerun viewer-mcp`), or the reviewer does; reviewer
+  evidence lives in `/tmp/rerun-viewer-validation/<date>-<model>/`.
 - In-script metric equals upstream eval on the same sample (or is recorded as baseline when upstream has none).
 
 ## Gate 2 — Reference number (PR 2)
@@ -13,6 +17,9 @@ A phase is not done until its gate passes. Report failures as failures.
 - Slow GPU test loads the released checkpoint and reproduces the fork's number on the ETH3D sample.
   Stereo: EPE + bad1 on non-occluded pixels with `gt < max_disp`; compare to paper (dataset mean — a single
   scene lands near, not on, it) and record both in the test docstring.
+- Non-stereo families use the numbers defined in Phase 0 item 5 (metric + scale-aligned depth metrics; tracker counts, per-stage
+  ms, reprojection error, fixture replay within a stated tolerance — upstream BF16/CUDA-graph outputs are not bit-identical to
+  an fp32 eager replay; bit-identity is for vendored-vs-pristine on synthetic inputs).
 - Warm timing: `torch.cuda.synchronize()` around 50 forwards after 10 warm-ups, at the demo resolution;
   record ms/frame in the PR description.
 

--- a/.agents/skills/add-model/references/validate.md
+++ b/.agents/skills/add-model/references/validate.md
@@ -16,10 +16,12 @@ A phase is not done until its gate passes. Report failures as failures.
 - Warm timing: `torch.cuda.synchronize()` around 50 forwards after 10 warm-ups, at the demo resolution;
   record ms/frame in the PR description.
 
-## Gate 3 — Equivalence + dev tasks (PR 3, and every PR)
+## Gate 3 — Equivalence + dev tasks
 
-- `tests/test_<model>_upstream_equivalence.py` passes (bit-identical outputs, all variants, all optional paths).
-- From repo root: `pixi run -e <pkg>-dev --frozen lint`, `typecheck`, `deadcode`, `tests` all green.
+- Every PR: the dev tasks below. From PR 1 on: `tests/test_<model>_upstream_equivalence.py` passes (bit-identical
+  fp32 outputs for all variants and shared code paths; kernel alternatives with tolerance).
+- From repo root: `pixi run -e <pkg>-dev --frozen lint`, `typecheck`, `deadcode`, `tests` all green — and confirm
+  the new paths are actually inside the package's `PYREFLY_TARGET` (root `pixi.toml`), else typecheck is vacuous.
 - Default `pytest -q` runtime stays in seconds; checkpoint tests are `-m slow`.
 
 ## Gate 4 — Hand-roll audit (last PR before pushing)
@@ -44,6 +46,8 @@ Keep a hand-rolled version only when no shared helper fits, and say so in the PR
 
 Use the `rerun-viewer-validation` skill: run with `--rr-config.headless --rr-config.save <rrd>`, open the
 `.rrd` in a viewer, take screenshots that show the actual claim (frusta orientation, depth pointing out of the
-right camera, mesh faces visible from inside, no error badges), and note the evidence directory in the PR.
+right camera, mesh faces visible from inside, no error badges). Evidence lives in
+`/tmp/rerun-viewer-validation/<date>-<model>/` (screenshots + the `.rrd`); the PR description links the
+directory and embeds the key screenshots.
 Watch for: child `Transform3D` is relative to its *parent*, not the rig (a level mesh does not prove the tree);
 `EncodedDepthImage` needs `depth_range` or renders purple; colour range 0–6 m for indoor scenes.

--- a/.agents/skills/add-model/references/validate.md
+++ b/.agents/skills/add-model/references/validate.md
@@ -49,5 +49,8 @@ Use the `rerun-viewer-validation` skill: run with `--rr-config.headless --rr-con
 right camera, mesh faces visible from inside, no error badges). Evidence lives in
 `/tmp/rerun-viewer-validation/<date>-<model>/` (screenshots + the `.rrd`); the PR description links the
 directory and embeds the key screenshots.
+For a model joining an existing family, add a **same-frame comparison** against the incumbent (open both `.rrd`s,
+`set_time` to the same `video_time`, screenshot both) — that, not the absolute look, is what the reviewer asks about.
+Before a catalog-backed run, confirm the dataset is registered (see port.md PR 5).
 Watch for: child `Transform3D` is relative to its *parent*, not the rig (a level mesh does not prove the tree);
 `EncodedDepthImage` needs `depth_range` or renders purple; colour range 0–6 m for indoor scenes.

--- a/.agents/skills/add-model/references/validate.md
+++ b/.agents/skills/add-model/references/validate.md
@@ -30,6 +30,9 @@ A phase is not done until its gate passes. Report failures as failures.
 - From repo root: `pixi run -e <pkg>-dev --frozen lint`, `typecheck`, `deadcode`, `tests` all green — and confirm
   the new paths are actually inside the package's `PYREFLY_TARGET` (root `pixi.toml`), else typecheck is vacuous.
 - Default `pytest -q` runtime stays in seconds; checkpoint tests are `-m slow`.
+- Measure performance evidence in the non-dev env (`<pkg>` or `<pkg>-catalog`): the beartype claw instruments hot per-frame
+  loops in `-dev`. Evidence rrds above ~1.5 GB cannot be browser-embedded — validate the quick rrd in the native headless
+  viewer and keep the full one for `rrd verify` only.
 
 ## Gate 4 — Hand-roll audit (last PR before pushing)
 

--- a/.agents/skills/add-model/references/validate.md
+++ b/.agents/skills/add-model/references/validate.md
@@ -52,6 +52,10 @@ Grep the diff for the usual suspects and replace with the shared implementation:
 
 Keep a hand-rolled version only when no shared helper fits, and say so in the PR.
 
+## Gate 4b — Profile the streaming path
+
+Before calling a catalog/streaming tool done, profile one short run: `pixi exec py-spy record -n --rate 250 --format raw -o out.raw -- <env>/bin/python -u tools/apps/<tool>.py …` (child mode — `ptrace_scope=1` blocks attaching to a live process without sudo), then aggregate the folded stacks by leaf and by inclusive function. Report predict vs log time per frameset. X-Lens: depth PNGs at zlib level 9 were 60 % of wall time (2.5–3 s per frameset); level 1 is 20× faster for ~6 % larger files. Any encoder or fusion flag chosen for size needs a timing number next to it.
+
 ## Gate 5 — Viewer pixel evidence (before "done")
 
 Use the `rerun-viewer-validation` skill: run with `--rr-config.headless --rr-config.save <rrd>`, open the

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,12 @@ packages/<name>/
   tests/
 ```
 
+## Adding a model
+
+Bringing an upstream research model in (fork + pixify, then a vendor → predictor → typed PR stack with
+Rerun pixel evidence) follows the repo skill `add-model` (`.agents/skills/add-model/SKILL.md`, also visible to
+Claude Code through `.claude/skills`). Both Codex and Claude Code load it when asked to "add/port <model>".
+
 ## Adding a new package
 
 1. Create `packages/<name>/` with `pyproject.toml`, the source module, `tools/`, and `tests/` (structure above). If it imports another workspace package, list that name in `[project].dependencies` **and** pin it in `[tool.uv.sources]` (`name = { path = "../<dir>", editable = true }`); `packages/simplecv/tests/test_workspace_sources.py` checks both and fails if the lock ever resolves a workspace name from PyPI.


### PR DESCRIPTION
Stacked on #157.

Turns the LiteAnyStereo run (#151→#157) into a repo skill both runtimes load: `.agents/skills/add-model/` (Codex) with `.claude/skills -> ../.agents/skills` (Claude Code), plus an AGENTS.md pointer.

- `SKILL.md`: rules that always bind (pixi only, no hand-rolling over simplecv, python-conventions, minimal diff, pixel evidence, process hygiene, identities) + Phase 0 scope questions.
- `references/fork-and-pixify.md`: frozen `main` + `pixi` branch, pins, tasks, weights/sample hosting, `demo_rerun.py`, NOTES.md.
- `references/port.md`: PR stack `1-vendor → 2-predictor → 3-typed (→ 4-app → 5-catalog)`, pickled-checkpoint recipe, registry guidance, merge order.
- `references/validate.md`: five gates (fork runs, reference number, equivalence + dev tasks, hand-roll audit, viewer pixel evidence).
- `references/example-liteanystereo.md`: what landed, numbers, every gotcha.

Acceptance test: a fresh Codex session read only the skill and planned the Fast-FoundationStereo port; its 20 findings (HF pin + sha256, weights vs code license, PR-1 wording, equivalence vs kernel parity, registry constructors, `PYREFLY_TARGET`, frozen-main reset, evidence dir) are folded in. That dry run also exposed that `monopriors/third_party/liteanystereo` was missing from monoprior's `PYREFLY_TARGET` — fixed in #154's branch (pyrefly: 0 errors on the fork).

Fast-FoundationStereo is being ported through this skill next (separate stack on top).