### PR TITLE
monoprior: FastFoundationStereoPredictor + registry wiring for the stereo tools (add-model PR 2/3)

### DIFF
--- a/packages/monoprior/monopriors/apis/stereo_catalog.py
+++ b/packages/monoprior/monopriors/apis/stereo_catalog.py
@@ -235,7 +235,6 @@ def main(config: StereoCatalogConfig) -> None:
         world_T_rig: Float64[np.ndarray, "4 4"] = world_T_rig_n44[min(int(np.searchsorted(pose_times, np.timedelta64(t_ns, "ns"))), len(pose_times) - 1)]
         left_rect, right_rect = rectify_pair(rect, frame_at(config.left_cam, t_ns), frame_at(config.right_cam, t_ns))
         pred: StereoDepthPrediction = predictor(left_rect, right_rect, K_33=K_rect_32, baseline_m=rect.baseline_m)
-        assert pred.depth_meters is not None
         depth_hw: Float32[np.ndarray, "h w"] = np.where(pred.depth_meters > config.max_depth_m, 0.0, pred.depth_meters).astype(np.float32)
         if config.remove_flying_pixels:
             depth_hw = np.asarray(depth_hw * ~depth_edges_mask(depth_hw, threshold=config.depth_edge_threshold), dtype=np.float32)

--- a/packages/monoprior/monopriors/apis/stereo_catalog.py
+++ b/packages/monoprior/monopriors/apis/stereo_catalog.py
@@ -1,7 +1,7 @@
 """Stream stereo depth + an incremental TSDF mesh for a catalog rig segment into the Rerun viewer.
 
 Reads one exoego:v2 segment straight from the catalog (video packets fetched once per camera, decoded on NVDEC),
-rectifies the fisheye front pair, runs LiteAnyStereo, and logs everything to the ambient recording configured by
+rectifies the fisheye front pair, runs the selected stereo predictor, and logs everything to the ambient recording configured by
 ``RerunTyroConfig`` — the PromptDA Polycam pattern (viewer/save/connect, per-frame logging, mesh re-logged every
 ``mesh_every`` frames so scrubbing shows it grow), on the catalog's own ``video_time`` timeline so the relayed raw
 videos and the slam poses line up. Nothing is registered back to the catalog.
@@ -30,7 +30,7 @@ from simplecv.rig import CameraSensor, Rig, RigCalibration
 from simplecv.rrd_query_utils import first_valid_value
 
 from monopriors.depth_utils import depth_edges_mask
-from monopriors.models.stereo_depth import LiteAnyStereoPredictor, StereoDepthPrediction
+from monopriors.models.stereo_depth import STEREO_PREDICTORS, BaseStereoPredictor, StereoDepthPrediction, get_stereo_predictor
 from monopriors.models.stereo_depth.liteanystereo import LAS2ModelSize
 from monopriors.models.stereo_depth.rectify import StereoRectification, fisheye_stereo_rectify, rectify_pair
 
@@ -72,8 +72,10 @@ class StereoCatalogConfig:
     """Frames per second sampled from the video timeline."""
     max_seconds: float | None = 120.0
     """Only the first N seconds of the segment; None processes it all."""
+    predictor_name: STEREO_PREDICTORS = "LiteAnyStereoPredictor"
+    """Which stereo predictor to use."""
     model_size: LAS2ModelSize = "m"
-    """LiteAnyStereo V2 variant."""
+    """LiteAnyStereo V2 variant; ignored by Fast-FoundationStereo."""
     focal_scale: float = 0.8
     """Rectified focal length as a multiple of the fisheye fx; below 1 keeps more of the wide FOV."""
     max_depth_m: float = 20.0
@@ -218,7 +220,11 @@ def main(config: StereoCatalogConfig) -> None:
         rr.log(f"{RIG}/{cam}/pinhole/video", rr.VideoStream(codec=video_codec), static=True)
         rr.send_columns(f"{RIG}/{cam}/pinhole/video", indexes=[rr.TimeColumn(TIMELINE, duration=times)], columns=rr.VideoStream.columns(sample=samples, is_keyframe=keyframes))
 
-    predictor: LiteAnyStereoPredictor = LiteAnyStereoPredictor(device=config.device, model_size=config.model_size)
+    match config.predictor_name:
+        case "LiteAnyStereoPredictor":
+            predictor: BaseStereoPredictor = get_stereo_predictor(config.predictor_name)(device=config.device, model_size=config.model_size)
+        case "FastFoundationStereoPredictor":
+            predictor = get_stereo_predictor(config.predictor_name)(device=config.device)
     rect_pinhole: str = f"{RIG}/cam_{LEFT_RECT_INDEX}/pinhole"
     output_wh: tuple[int, int] = (left_rect_out.intrinsics.width, left_rect_out.intrinsics.height)
     K_out_33: Float64[np.ndarray, "3 3"] = np.asarray(left_rect_out.intrinsics.k_matrix, dtype=np.float64)

--- a/packages/monoprior/monopriors/apis/stereo_catalog.py
+++ b/packages/monoprior/monopriors/apis/stereo_catalog.py
@@ -7,7 +7,7 @@ rectifies the fisheye front pair, runs the selected stereo predictor, and logs e
 videos and the slam poses line up. Nothing is registered back to the catalog.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal, Protocol
 
 import cv2
@@ -30,8 +30,7 @@ from simplecv.rig import CameraSensor, Rig, RigCalibration
 from simplecv.rrd_query_utils import first_valid_value
 
 from monopriors.depth_utils import depth_edges_mask
-from monopriors.models.stereo_depth import STEREO_PREDICTORS, BaseStereoPredictor, StereoDepthPrediction, get_stereo_predictor
-from monopriors.models.stereo_depth.liteanystereo import LAS2ModelSize
+from monopriors.models.stereo_depth import AnnotatedStereoPredictorUnion, BaseStereoPredictor, LiteAnyStereoConfig, StereoDepthPrediction
 from monopriors.models.stereo_depth.rectify import StereoRectification, fisheye_stereo_rectify, rectify_pair
 
 TIMELINE: str = "video_time"
@@ -72,10 +71,8 @@ class StereoCatalogConfig:
     """Frames per second sampled from the video timeline."""
     max_seconds: float | None = 120.0
     """Only the first N seconds of the segment; None processes it all."""
-    predictor_name: STEREO_PREDICTORS = "LiteAnyStereoPredictor"
-    """Which stereo predictor to use."""
-    model_size: LAS2ModelSize = "m"
-    """LiteAnyStereo V2 variant; ignored by Fast-FoundationStereo."""
+    predictor: AnnotatedStereoPredictorUnion = field(default_factory=LiteAnyStereoConfig)
+    """Stereo model to run; pick with the subcommand, e.g. ``liteanystereo --predictor.model-size h`` or ``fast-foundationstereo``."""
     focal_scale: float = 0.8
     """Rectified focal length as a multiple of the fisheye fx; below 1 keeps more of the wide FOV."""
     max_depth_m: float = 20.0
@@ -220,11 +217,7 @@ def main(config: StereoCatalogConfig) -> None:
         rr.log(f"{RIG}/{cam}/pinhole/video", rr.VideoStream(codec=video_codec), static=True)
         rr.send_columns(f"{RIG}/{cam}/pinhole/video", indexes=[rr.TimeColumn(TIMELINE, duration=times)], columns=rr.VideoStream.columns(sample=samples, is_keyframe=keyframes))
 
-    match config.predictor_name:
-        case "LiteAnyStereoPredictor":
-            predictor: BaseStereoPredictor = get_stereo_predictor(config.predictor_name)(device=config.device, model_size=config.model_size)
-        case "FastFoundationStereoPredictor":
-            predictor = get_stereo_predictor(config.predictor_name)(device=config.device)
+    predictor: BaseStereoPredictor = config.predictor.setup(device=config.device)
     rect_pinhole: str = f"{RIG}/cam_{LEFT_RECT_INDEX}/pinhole"
     output_wh: tuple[int, int] = (left_rect_out.intrinsics.width, left_rect_out.intrinsics.height)
     K_out_33: Float64[np.ndarray, "3 3"] = np.asarray(left_rect_out.intrinsics.k_matrix, dtype=np.float64)

--- a/packages/monoprior/monopriors/apis/stereo_depth.py
+++ b/packages/monoprior/monopriors/apis/stereo_depth.py
@@ -8,7 +8,7 @@ from typing import Literal
 import cv2
 import numpy as np
 import rerun as rr
-from jaxtyping import Float32, UInt8
+from jaxtyping import Bool, Float32, UInt8
 from simplecv.rerun_log_utils import RerunTyroConfig
 
 from monopriors.models.stereo_depth import STEREO_PREDICTORS, BaseStereoPredictor, StereoDepthPrediction, get_stereo_predictor
@@ -65,13 +65,69 @@ def read_rgb(path: Path) -> UInt8[np.ndarray, "h w 3"]:
     return cv2.cvtColor(bgr_hw3, cv2.COLOR_BGR2RGB)
 
 
+def read_pfm(path: Path) -> Float32[np.ndarray, "h w"]:
+    """Read a grayscale PFM disparity image.
+
+    Args:
+        path: PFM file whose first line is ``Pf``.
+
+    Returns:
+        Bottom-to-top corrected disparity, ``Float32[ndarray, "h w"]``.
+    """
+    with path.open("rb") as file:
+        if file.readline().strip() != b"Pf":
+            raise ValueError(f"{path} is not a grayscale PFM")
+        width, height = (int(value) for value in file.readline().split())
+        scale: float = float(file.readline())
+        data: Float32[np.ndarray, "pixels"] = np.fromfile(file, dtype="<f4" if scale < 0.0 else ">f4", count=width * height)
+    return np.flipud(data.reshape(height, width)).astype(np.float32)
+
+
+def stereo_metrics(
+    disparity_hw: Float32[np.ndarray, "h w"],
+    ground_truth_hw: Float32[np.ndarray, "h w"],
+    nonoccluded_hw: UInt8[np.ndarray, "h w"],
+    max_disp: float,
+) -> tuple[float, float]:
+    """Compute ETH3D EPE and bad1 on finite, non-occluded disparities below the model range.
+
+    Args:
+        disparity_hw: Predicted left disparity, ``Float32[ndarray, "h w"]``.
+        ground_truth_hw: Ground-truth left disparity, ``Float32[ndarray, "h w"]``.
+        nonoccluded_hw: ETH3D non-occlusion mask, ``UInt8[ndarray, "h w"]``; 255 marks valid pixels.
+        max_disp: Exclude ground-truth disparities at or above this value.
+
+    Returns:
+        Mean endpoint error in pixels and bad1 percentage.
+    """
+    valid_hw: Bool[np.ndarray, "h w"] = np.isfinite(ground_truth_hw) & (ground_truth_hw < max_disp) & (nonoccluded_hw == 255)
+    error_hw: Float32[np.ndarray, "h w"] = np.abs(disparity_hw - ground_truth_hw)
+    return float(error_hw[valid_hw].mean()), 100.0 * float((error_hw[valid_hw] > 1.0).mean())
+
+
 def main(config: StereoDepthCLIConfig) -> None:
     left_rgb: UInt8[np.ndarray, "h w 3"] = read_rgb(config.scene_dir / "im0.png")
     right_rgb: UInt8[np.ndarray, "h w 3"] = read_rgb(config.scene_dir / "im1.png")
     calibration: MiddleburyCalibration = read_middlebury_calib(config.scene_dir / "calib.txt")
 
-    predictor: BaseStereoPredictor = get_stereo_predictor(config.predictor_name)(device=config.device, model_size=config.model_size)
+    match config.predictor_name:
+        case "LiteAnyStereoPredictor":
+            predictor: BaseStereoPredictor = get_stereo_predictor(config.predictor_name)(device=config.device, model_size=config.model_size)
+        case "FastFoundationStereoPredictor":
+            predictor = get_stereo_predictor(config.predictor_name)(device=config.device)
     stereo_pred: StereoDepthPrediction = predictor(left_rgb, right_rgb, K_33=calibration.K_33, baseline_m=calibration.baseline_m)
+
+    gt_dir: Path = config.scene_dir.parent.with_name(f"{config.scene_dir.parent.name}_gt") / config.scene_dir.name
+    ground_truth_path: Path = gt_dir / "disp0GT.pfm"
+    nonoccluded_path: Path = gt_dir / "mask0nocc.png"
+    if ground_truth_path.is_file() and nonoccluded_path.is_file():
+        ground_truth_hw: Float32[np.ndarray, "h w"] = read_pfm(ground_truth_path)
+        nonoccluded_hw: UInt8[np.ndarray, "h w"] | None = cv2.imread(str(nonoccluded_path), cv2.IMREAD_GRAYSCALE)
+        if nonoccluded_hw is None:
+            raise FileNotFoundError(f"Failed to read image {nonoccluded_path}")
+        max_disp: float = 416.0 if config.predictor_name == "FastFoundationStereoPredictor" else 192.0
+        metrics: tuple[float, float] = stereo_metrics(stereo_pred.disparity, ground_truth_hw, nonoccluded_hw, max_disp=max_disp)
+        print(f"{config.predictor_name} ETH3D: EPE {metrics[0]:.3f} px, bad1 {metrics[1]:.2f}%")
 
     parent_log_path: Path = Path("world")
     rr.send_blueprint(create_stereo_depth_blueprint(parent_log_path))

--- a/packages/monoprior/monopriors/apis/stereo_depth.py
+++ b/packages/monoprior/monopriors/apis/stereo_depth.py
@@ -1,7 +1,7 @@
 """Stereo depth on one rectified pair with Middlebury-style calibration, visualized as an exoego:v2 rig in Rerun."""
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
@@ -11,7 +11,7 @@ import rerun as rr
 from jaxtyping import Bool, Float32, UInt8
 from simplecv.rerun_log_utils import RerunTyroConfig
 
-from monopriors.models.stereo_depth import STEREO_PREDICTORS, BaseStereoPredictor, StereoDepthPrediction, get_stereo_predictor
+from monopriors.models.stereo_depth import AnnotatedStereoPredictorUnion, BaseStereoPredictor, LiteAnyStereoConfig, StereoDepthPrediction
 from monopriors.rr_logging_utils import create_stereo_depth_blueprint, log_stereo_pred
 
 
@@ -44,10 +44,8 @@ class StereoDepthCLIConfig:
     """Rerun logging configuration."""
     scene_dir: Path = Path("data/examples/stereo/eth3d/two_view_training/playground_1l")
     """Directory with ``im0.png`` (left), ``im1.png`` (right) and a Middlebury-style ``calib.txt``."""
-    predictor_name: STEREO_PREDICTORS = "LiteAnyStereoPredictor"
-    """Which stereo predictor to use."""
-    model_size: Literal["s", "m", "l", "h"] = "m"
-    """LiteAnyStereo V2 variant."""
+    predictor: AnnotatedStereoPredictorUnion = field(default_factory=LiteAnyStereoConfig)
+    """Stereo model to run; pick with the subcommand, e.g. ``liteanystereo --predictor.model-size h`` or ``fast-foundationstereo``."""
     device: Literal["cuda", "cpu"] = "cuda"
     """Execution backend."""
     max_depth_m: float = 20.0
@@ -110,11 +108,7 @@ def main(config: StereoDepthCLIConfig) -> None:
     right_rgb: UInt8[np.ndarray, "h w 3"] = read_rgb(config.scene_dir / "im1.png")
     calibration: MiddleburyCalibration = read_middlebury_calib(config.scene_dir / "calib.txt")
 
-    match config.predictor_name:
-        case "LiteAnyStereoPredictor":
-            predictor: BaseStereoPredictor = get_stereo_predictor(config.predictor_name)(device=config.device, model_size=config.model_size)
-        case "FastFoundationStereoPredictor":
-            predictor = get_stereo_predictor(config.predictor_name)(device=config.device)
+    predictor: BaseStereoPredictor = config.predictor.setup(device=config.device)
     stereo_pred: StereoDepthPrediction = predictor(left_rgb, right_rgb, K_33=calibration.K_33, baseline_m=calibration.baseline_m)
 
     gt_dir: Path = config.scene_dir.parent.with_name(f"{config.scene_dir.parent.name}_gt") / config.scene_dir.name
@@ -125,9 +119,9 @@ def main(config: StereoDepthCLIConfig) -> None:
         nonoccluded_hw: UInt8[np.ndarray, "h w"] | None = cv2.imread(str(nonoccluded_path), cv2.IMREAD_GRAYSCALE)
         if nonoccluded_hw is None:
             raise FileNotFoundError(f"Failed to read image {nonoccluded_path}")
-        max_disp: float = 416.0 if config.predictor_name == "FastFoundationStereoPredictor" else 192.0
+        max_disp: float = float(config.predictor.max_disp)
         metrics: tuple[float, float] = stereo_metrics(stereo_pred.disparity, ground_truth_hw, nonoccluded_hw, max_disp=max_disp)
-        print(f"{config.predictor_name} ETH3D: EPE {metrics[0]:.3f} px, bad1 {metrics[1]:.2f}%")
+        print(f"{type(predictor).__name__} ETH3D: EPE {metrics[0]:.3f} px, bad1 {metrics[1]:.2f}%")
 
     parent_log_path: Path = Path("world")
     rr.send_blueprint(create_stereo_depth_blueprint(parent_log_path))

--- a/packages/monoprior/monopriors/apis/stereo_depth.py
+++ b/packages/monoprior/monopriors/apis/stereo_depth.py
@@ -14,6 +14,9 @@ from simplecv.rerun_log_utils import RerunTyroConfig
 from monopriors.models.stereo_depth import AnnotatedStereoPredictorUnion, BaseStereoPredictor, LiteAnyStereoConfig, StereoDepthPrediction
 from monopriors.rr_logging_utils import create_stereo_depth_blueprint, log_stereo_pred
 
+ETH3D_MAX_DISP: float = 192.0
+"""Ground-truth disparity cutoff used for comparable ETH3D metrics across predictors."""
+
 
 @dataclass(slots=True)
 class MiddleburyCalibration:
@@ -87,13 +90,13 @@ def stereo_metrics(
     nonoccluded_hw: UInt8[np.ndarray, "h w"],
     max_disp: float,
 ) -> tuple[float, float]:
-    """Compute ETH3D EPE and bad1 on finite, non-occluded disparities below the model range.
+    """Compute ETH3D EPE and bad1 on finite, non-occluded disparities below an evaluation cutoff.
 
     Args:
         disparity_hw: Predicted left disparity, ``Float32[ndarray, "h w"]``.
         ground_truth_hw: Ground-truth left disparity, ``Float32[ndarray, "h w"]``.
         nonoccluded_hw: ETH3D non-occlusion mask, ``UInt8[ndarray, "h w"]``; 255 marks valid pixels.
-        max_disp: Exclude ground-truth disparities at or above this value.
+        max_disp: Evaluation cutoff; exclude ground-truth disparities at or above this value.
 
     Returns:
         Mean endpoint error in pixels and bad1 percentage.
@@ -119,8 +122,7 @@ def main(config: StereoDepthCLIConfig) -> None:
         nonoccluded_hw: UInt8[np.ndarray, "h w"] | None = cv2.imread(str(nonoccluded_path), cv2.IMREAD_GRAYSCALE)
         if nonoccluded_hw is None:
             raise FileNotFoundError(f"Failed to read image {nonoccluded_path}")
-        max_disp: float = float(config.predictor.max_disp)
-        metrics: tuple[float, float] = stereo_metrics(stereo_pred.disparity, ground_truth_hw, nonoccluded_hw, max_disp=max_disp)
+        metrics: tuple[float, float] = stereo_metrics(stereo_pred.disparity, ground_truth_hw, nonoccluded_hw, max_disp=ETH3D_MAX_DISP)
         print(f"{type(predictor).__name__} ETH3D: EPE {metrics[0]:.3f} px, bad1 {metrics[1]:.2f}%")
 
     parent_log_path: Path = Path("world")

--- a/packages/monoprior/monopriors/gradio_ui/stereo_depth_ui.py
+++ b/packages/monoprior/monopriors/gradio_ui/stereo_depth_ui.py
@@ -1,14 +1,14 @@
 """Stereo depth Gradio app: a rectified left/right pair + calibration in, an exoego:v2 rig in the Rerun viewer out.
 
 Layout follows ``posekit.track_ui`` (inputs + status on the left, Radio-driven Input/Config/Outputs panels, a
-streaming Rerun viewer on the right). One predictor per model selection is kept warm for the process lifetime.
+streaming Rerun viewer on the right). The most recently selected predictor is kept warm.
 """
 
 from __future__ import annotations
 
 import time
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Literal, TypeAlias, get_args
 
@@ -24,7 +24,6 @@ from monopriors.apis.stereo_depth import MiddleburyCalibration, read_middlebury_
 from monopriors.models.stereo_depth import (
     BaseStereoPredictor,
     BaseStereoPredictorConfig,
-    FastFoundationStereoConfig,
     LiteAnyStereoConfig,
     StereoDepthPrediction,
     stereo_predictor_defaults,
@@ -37,8 +36,7 @@ TabName: TypeAlias = Literal["Input", "Config", "Outputs"]
 EXAMPLE_SCENE: Path = Path("data/examples/stereo/eth3d/two_view_training/playground_1l")
 """ETH3D two-view sample fetched by the ``_monoprior-download-stereo`` task (im0/im1 + Middlebury calib.txt)."""
 
-PredictorKey: TypeAlias = tuple[str, LAS2ModelSize | None]
-_PREDICTORS: dict[PredictorKey, BaseStereoPredictor] = {}
+_CACHED_PREDICTOR: tuple[BaseStereoPredictorConfig, BaseStereoPredictor] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -55,17 +53,13 @@ class AppConfig:
 
 
 def _predictor(predictor_name: str, model_size: LAS2ModelSize) -> BaseStereoPredictor:
-    key: PredictorKey = (predictor_name, model_size if predictor_name == "liteanystereo" else None)
-    if key not in _PREDICTORS:
-        match predictor_name:
-            case "liteanystereo":
-                config: BaseStereoPredictorConfig = LiteAnyStereoConfig(model_size=model_size)
-            case "fast-foundationstereo":
-                config = FastFoundationStereoConfig()
-            case _:
-                raise ValueError(f"Unknown stereo predictor: {predictor_name}")
-        _PREDICTORS[key] = config.setup(device="cuda")
-    return _PREDICTORS[key]
+    global _CACHED_PREDICTOR
+    config: BaseStereoPredictorConfig = stereo_predictor_defaults[predictor_name]
+    if isinstance(config, LiteAnyStereoConfig):
+        config = replace(config, model_size=model_size)
+    if _CACHED_PREDICTOR is None or _CACHED_PREDICTOR[0] != config:
+        _CACHED_PREDICTOR = (config, config.setup(device="cuda"))
+    return _CACHED_PREDICTOR[1]
 
 
 def show_control_tab(selected: TabName) -> tuple[gr.Column, gr.Column, gr.Column]:
@@ -111,7 +105,7 @@ def run_stereo(
             depth_edge_threshold=float(depth_edge_threshold),
         )
     valid_hw = stereo_pred.disparity > 0.0
-    model_label: str = f"LAS2-{model_size.upper()}" if predictor_name == "liteanystereo" else "Fast-FoundationStereo"
+    model_label: str = type(predictor).__name__
     status: str = (
         f"{model_label} · {left_rgb.shape[1]}×{left_rgb.shape[0]} · {elapsed_ms:.0f} ms end-to-end · "
         f"disparity {stereo_pred.disparity[valid_hw].min():.1f}–{stereo_pred.disparity[valid_hw].max():.1f} px"

--- a/packages/monoprior/monopriors/gradio_ui/stereo_depth_ui.py
+++ b/packages/monoprior/monopriors/gradio_ui/stereo_depth_ui.py
@@ -1,7 +1,7 @@
 """Stereo depth Gradio app: a rectified left/right pair + calibration in, an exoego:v2 rig in the Rerun viewer out.
 
 Layout follows ``posekit.track_ui`` (inputs + status on the left, Radio-driven Input/Config/Outputs panels, a
-streaming Rerun viewer on the right). One predictor per model size is kept warm for the process lifetime.
+streaming Rerun viewer on the right). One predictor per model selection is kept warm for the process lifetime.
 """
 
 from __future__ import annotations
@@ -21,7 +21,7 @@ from jaxtyping import Float32, UInt8
 from numpy import ndarray
 
 from monopriors.apis.stereo_depth import MiddleburyCalibration, read_middlebury_calib
-from monopriors.models.stereo_depth import LiteAnyStereoPredictor, StereoDepthPrediction
+from monopriors.models.stereo_depth import STEREO_PREDICTORS, BaseStereoPredictor, StereoDepthPrediction, get_stereo_predictor
 from monopriors.models.stereo_depth.liteanystereo import LAS2ModelSize
 from monopriors.rr_logging_utils import create_stereo_depth_blueprint, log_stereo_pred
 
@@ -30,7 +30,8 @@ TabName: TypeAlias = Literal["Input", "Config", "Outputs"]
 EXAMPLE_SCENE: Path = Path("data/examples/stereo/eth3d/two_view_training/playground_1l")
 """ETH3D two-view sample fetched by the ``_monoprior-download-stereo`` task (im0/im1 + Middlebury calib.txt)."""
 
-_PREDICTORS: dict[LAS2ModelSize, LiteAnyStereoPredictor] = {}
+PredictorKey: TypeAlias = tuple[STEREO_PREDICTORS, LAS2ModelSize | None]
+_PREDICTORS: dict[PredictorKey, BaseStereoPredictor] = {}
 
 
 @dataclass(frozen=True, slots=True)
@@ -46,10 +47,15 @@ class AppConfig:
     """Root path when mounted under a reverse-proxy subpath (empty when served at ``/``)."""
 
 
-def _predictor(model_size: LAS2ModelSize) -> LiteAnyStereoPredictor:
-    if model_size not in _PREDICTORS:
-        _PREDICTORS[model_size] = LiteAnyStereoPredictor(device="cuda", model_size=model_size)
-    return _PREDICTORS[model_size]
+def _predictor(predictor_name: STEREO_PREDICTORS, model_size: LAS2ModelSize) -> BaseStereoPredictor:
+    key: PredictorKey = (predictor_name, model_size if predictor_name == "LiteAnyStereoPredictor" else None)
+    if key not in _PREDICTORS:
+        match predictor_name:
+            case "LiteAnyStereoPredictor":
+                _PREDICTORS[key] = get_stereo_predictor(predictor_name)(device="cuda", model_size=model_size)
+            case "FastFoundationStereoPredictor":
+                _PREDICTORS[key] = get_stereo_predictor(predictor_name)(device="cuda")
+    return _PREDICTORS[key]
 
 
 def show_control_tab(selected: TabName) -> tuple[gr.Column, gr.Column, gr.Column]:
@@ -59,6 +65,7 @@ def show_control_tab(selected: TabName) -> tuple[gr.Column, gr.Column, gr.Column
 def run_stereo(
     left_rgb: UInt8[ndarray, "h w 3"] | None,
     right_rgb: UInt8[ndarray, "h w 3"] | None,
+    predictor_name: STEREO_PREDICTORS,
     model_size: LAS2ModelSize,
     fx: float | int,
     cx: float | int,
@@ -75,7 +82,7 @@ def run_stereo(
         raise gr.Error(f"Left {left_rgb.shape[:2]} and right {right_rgb.shape[:2]} images must have the same size (rectified pair).")
     K_33: Float32[ndarray, "3 3"] = np.array([[fx, 0.0, cx], [0.0, fx, cy], [0.0, 0.0, 1.0]], dtype=np.float32)
 
-    predictor: LiteAnyStereoPredictor = _predictor(model_size)
+    predictor: BaseStereoPredictor = _predictor(predictor_name, model_size)
     start: float = time.perf_counter()
     stereo_pred: StereoDepthPrediction = predictor(left_rgb, right_rgb, K_33=K_33, baseline_m=float(baseline_mm) / 1000.0)
     elapsed_ms: float = (time.perf_counter() - start) * 1000.0
@@ -94,8 +101,9 @@ def run_stereo(
             depth_edge_threshold=float(depth_edge_threshold),
         )
     valid_hw = stereo_pred.disparity > 0.0
+    model_label: str = f"LAS2-{model_size.upper()}" if predictor_name == "LiteAnyStereoPredictor" else "Fast-FoundationStereo"
     status: str = (
-        f"LAS2-{model_size.upper()} · {left_rgb.shape[1]}×{left_rgb.shape[0]} · {elapsed_ms:.0f} ms end-to-end · "
+        f"{model_label} · {left_rgb.shape[1]}×{left_rgb.shape[0]} · {elapsed_ms:.0f} ms end-to-end · "
         f"disparity {stereo_pred.disparity[valid_hw].min():.1f}–{stereo_pred.disparity[valid_hw].max():.1f} px"
     )
     yield stream.read(), status, "Outputs"
@@ -104,7 +112,7 @@ def run_stereo(
 def build_demo() -> gr.Blocks:
     example_calibration: MiddleburyCalibration | None = read_middlebury_calib(EXAMPLE_SCENE / "calib.txt") if EXAMPLE_SCENE.is_dir() else None
     with gr.Blocks(title="monoprior: Stereo Depth") as demo:
-        gr.Markdown("**Stereo depth** — a rectified left/right pair + pinhole calibration → LiteAnyStereo V2 disparity, metric depth, and the backprojected cloud as an exoego:v2 rig.")
+        gr.Markdown("**Stereo depth** — a rectified left/right pair + pinhole calibration → selected-model disparity, metric depth, and the backprojected cloud as an exoego:v2 rig.")
         with gr.Row():
             with gr.Column(scale=1):
                 with gr.Row():
@@ -123,7 +131,8 @@ def build_demo() -> gr.Blocks:
                     if example_calibration is not None:
                         gr.Examples(examples=[[str(EXAMPLE_SCENE / "im0.png"), str(EXAMPLE_SCENE / "im1.png")]], inputs=[left_in, right_in], label="ETH3D playground_1l")
                 with gr.Column(visible=False) as config_panel:
-                    model_dd: gr.Dropdown = gr.Dropdown(label="Model", choices=list(get_args(LAS2ModelSize)), value="m")
+                    predictor_dd: gr.Dropdown = gr.Dropdown(label="Model", choices=list(get_args(STEREO_PREDICTORS)), value="LiteAnyStereoPredictor")
+                    model_size_dd: gr.Dropdown = gr.Dropdown(label="LAS2 model size (ignored by Fast-FoundationStereo)", choices=list(get_args(LAS2ModelSize)), value="m")
                     max_depth_slider: gr.Slider = gr.Slider(label="Max depth (m)", minimum=1.0, maximum=100.0, value=20.0, step=1.0)
                     flying_box: gr.Checkbox = gr.Checkbox(label="Remove flying pixels", value=True)
                     edge_slider: gr.Slider = gr.Slider(label="Depth edge threshold (m/px)", minimum=0.05, maximum=5.0, value=0.5, step=0.05)
@@ -136,7 +145,7 @@ def build_demo() -> gr.Blocks:
         tabs_radio.change(fn=show_control_tab, inputs=[tabs_radio], outputs=[input_panel, config_panel, outputs_panel], queue=False, show_progress="hidden", api_visibility="private")
         run_btn.click(
             fn=run_stereo,
-            inputs=[left_in, right_in, model_dd, fx_in, cx_in, cy_in, baseline_in, max_depth_slider, flying_box, edge_slider],
+            inputs=[left_in, right_in, predictor_dd, model_size_dd, fx_in, cx_in, cy_in, baseline_in, max_depth_slider, flying_box, edge_slider],
             outputs=[viewer, status, tabs_radio],
         )
     return demo

--- a/packages/monoprior/monopriors/gradio_ui/stereo_depth_ui.py
+++ b/packages/monoprior/monopriors/gradio_ui/stereo_depth_ui.py
@@ -21,7 +21,14 @@ from jaxtyping import Float32, UInt8
 from numpy import ndarray
 
 from monopriors.apis.stereo_depth import MiddleburyCalibration, read_middlebury_calib
-from monopriors.models.stereo_depth import STEREO_PREDICTORS, BaseStereoPredictor, StereoDepthPrediction, get_stereo_predictor
+from monopriors.models.stereo_depth import (
+    BaseStereoPredictor,
+    BaseStereoPredictorConfig,
+    FastFoundationStereoConfig,
+    LiteAnyStereoConfig,
+    StereoDepthPrediction,
+    stereo_predictor_defaults,
+)
 from monopriors.models.stereo_depth.liteanystereo import LAS2ModelSize
 from monopriors.rr_logging_utils import create_stereo_depth_blueprint, log_stereo_pred
 
@@ -30,7 +37,7 @@ TabName: TypeAlias = Literal["Input", "Config", "Outputs"]
 EXAMPLE_SCENE: Path = Path("data/examples/stereo/eth3d/two_view_training/playground_1l")
 """ETH3D two-view sample fetched by the ``_monoprior-download-stereo`` task (im0/im1 + Middlebury calib.txt)."""
 
-PredictorKey: TypeAlias = tuple[STEREO_PREDICTORS, LAS2ModelSize | None]
+PredictorKey: TypeAlias = tuple[str, LAS2ModelSize | None]
 _PREDICTORS: dict[PredictorKey, BaseStereoPredictor] = {}
 
 
@@ -47,14 +54,17 @@ class AppConfig:
     """Root path when mounted under a reverse-proxy subpath (empty when served at ``/``)."""
 
 
-def _predictor(predictor_name: STEREO_PREDICTORS, model_size: LAS2ModelSize) -> BaseStereoPredictor:
-    key: PredictorKey = (predictor_name, model_size if predictor_name == "LiteAnyStereoPredictor" else None)
+def _predictor(predictor_name: str, model_size: LAS2ModelSize) -> BaseStereoPredictor:
+    key: PredictorKey = (predictor_name, model_size if predictor_name == "liteanystereo" else None)
     if key not in _PREDICTORS:
         match predictor_name:
-            case "LiteAnyStereoPredictor":
-                _PREDICTORS[key] = get_stereo_predictor(predictor_name)(device="cuda", model_size=model_size)
-            case "FastFoundationStereoPredictor":
-                _PREDICTORS[key] = get_stereo_predictor(predictor_name)(device="cuda")
+            case "liteanystereo":
+                config: BaseStereoPredictorConfig = LiteAnyStereoConfig(model_size=model_size)
+            case "fast-foundationstereo":
+                config = FastFoundationStereoConfig()
+            case _:
+                raise ValueError(f"Unknown stereo predictor: {predictor_name}")
+        _PREDICTORS[key] = config.setup(device="cuda")
     return _PREDICTORS[key]
 
 
@@ -65,7 +75,7 @@ def show_control_tab(selected: TabName) -> tuple[gr.Column, gr.Column, gr.Column
 def run_stereo(
     left_rgb: UInt8[ndarray, "h w 3"] | None,
     right_rgb: UInt8[ndarray, "h w 3"] | None,
-    predictor_name: STEREO_PREDICTORS,
+    predictor_name: str,
     model_size: LAS2ModelSize,
     fx: float | int,
     cx: float | int,
@@ -101,7 +111,7 @@ def run_stereo(
             depth_edge_threshold=float(depth_edge_threshold),
         )
     valid_hw = stereo_pred.disparity > 0.0
-    model_label: str = f"LAS2-{model_size.upper()}" if predictor_name == "LiteAnyStereoPredictor" else "Fast-FoundationStereo"
+    model_label: str = f"LAS2-{model_size.upper()}" if predictor_name == "liteanystereo" else "Fast-FoundationStereo"
     status: str = (
         f"{model_label} · {left_rgb.shape[1]}×{left_rgb.shape[0]} · {elapsed_ms:.0f} ms end-to-end · "
         f"disparity {stereo_pred.disparity[valid_hw].min():.1f}–{stereo_pred.disparity[valid_hw].max():.1f} px"
@@ -131,7 +141,7 @@ def build_demo() -> gr.Blocks:
                     if example_calibration is not None:
                         gr.Examples(examples=[[str(EXAMPLE_SCENE / "im0.png"), str(EXAMPLE_SCENE / "im1.png")]], inputs=[left_in, right_in], label="ETH3D playground_1l")
                 with gr.Column(visible=False) as config_panel:
-                    predictor_dd: gr.Dropdown = gr.Dropdown(label="Model", choices=list(get_args(STEREO_PREDICTORS)), value="LiteAnyStereoPredictor")
+                    predictor_dd: gr.Dropdown = gr.Dropdown(label="Model", choices=list(stereo_predictor_defaults), value="liteanystereo")
                     model_size_dd: gr.Dropdown = gr.Dropdown(label="LAS2 model size (ignored by Fast-FoundationStereo)", choices=list(get_args(LAS2ModelSize)), value="m")
                     max_depth_slider: gr.Slider = gr.Slider(label="Max depth (m)", minimum=1.0, maximum=100.0, value=20.0, step=1.0)
                     flying_box: gr.Checkbox = gr.Checkbox(label="Remove flying pixels", value=True)

--- a/packages/monoprior/monopriors/models/stereo_depth/__init__.py
+++ b/packages/monoprior/monopriors/models/stereo_depth/__init__.py
@@ -1,24 +1,38 @@
-from collections.abc import Callable
-from typing import Literal, get_args
+from typing import TYPE_CHECKING
 
-from .base_stereo_depth import BaseStereoPredictor, StereoDepthPrediction, disparity_to_metric_depth
-from .fast_foundationstereo import FastFoundationStereoPredictor
-from .liteanystereo import LiteAnyStereoPredictor
+import tyro
 
-STEREO_PREDICTORS = Literal["LiteAnyStereoPredictor", "FastFoundationStereoPredictor"]
+from monopriors.models.stereo_depth.base_stereo_depth import (
+    BaseStereoPredictor,
+    BaseStereoPredictorConfig,
+    StereoDepthPrediction,
+    disparity_to_metric_depth,
+)
+from monopriors.models.stereo_depth.fast_foundationstereo import FastFoundationStereoConfig, FastFoundationStereoPredictor
+from monopriors.models.stereo_depth.liteanystereo import LiteAnyStereoConfig, LiteAnyStereoPredictor
 
-__all__: list[str] = list(get_args(STEREO_PREDICTORS)) + [
+stereo_predictor_defaults: dict[str, BaseStereoPredictorConfig] = {
+    "liteanystereo": LiteAnyStereoConfig(),
+    "fast-foundationstereo": FastFoundationStereoConfig(),
+}
+
+if TYPE_CHECKING:
+    StereoPredictorUnion = BaseStereoPredictorConfig
+else:
+    StereoPredictorUnion = tyro.extras.subcommand_type_from_defaults(stereo_predictor_defaults, prefix_names=False)
+
+AnnotatedStereoPredictorUnion = tyro.conf.OmitSubcommandPrefixes[StereoPredictorUnion]
+
+__all__: list[str] = [
+    "AnnotatedStereoPredictorUnion",
     "BaseStereoPredictor",
+    "BaseStereoPredictorConfig",
+    "FastFoundationStereoConfig",
+    "FastFoundationStereoPredictor",
+    "LiteAnyStereoConfig",
+    "LiteAnyStereoPredictor",
+    "StereoPredictorUnion",
     "StereoDepthPrediction",
     "disparity_to_metric_depth",
+    "stereo_predictor_defaults",
 ]
-
-
-def get_stereo_predictor(predictor_type: STEREO_PREDICTORS) -> Callable[..., BaseStereoPredictor]:
-    match predictor_type:
-        case "LiteAnyStereoPredictor":
-            return LiteAnyStereoPredictor
-        case "FastFoundationStereoPredictor":
-            return FastFoundationStereoPredictor
-        case _:
-            raise ValueError(f"Unknown predictor type: {predictor_type}")

--- a/packages/monoprior/monopriors/models/stereo_depth/__init__.py
+++ b/packages/monoprior/monopriors/models/stereo_depth/__init__.py
@@ -2,9 +2,10 @@ from collections.abc import Callable
 from typing import Literal, get_args
 
 from .base_stereo_depth import BaseStereoPredictor, StereoDepthPrediction, disparity_to_metric_depth
+from .fast_foundationstereo import FastFoundationStereoPredictor
 from .liteanystereo import LiteAnyStereoPredictor
 
-STEREO_PREDICTORS = Literal["LiteAnyStereoPredictor"]
+STEREO_PREDICTORS = Literal["LiteAnyStereoPredictor", "FastFoundationStereoPredictor"]
 
 __all__: list[str] = list(get_args(STEREO_PREDICTORS)) + [
     "BaseStereoPredictor",
@@ -17,5 +18,7 @@ def get_stereo_predictor(predictor_type: STEREO_PREDICTORS) -> Callable[..., Bas
     match predictor_type:
         case "LiteAnyStereoPredictor":
             return LiteAnyStereoPredictor
+        case "FastFoundationStereoPredictor":
+            return FastFoundationStereoPredictor
         case _:
             raise ValueError(f"Unknown predictor type: {predictor_type}")

--- a/packages/monoprior/monopriors/models/stereo_depth/base_stereo_depth.py
+++ b/packages/monoprior/monopriors/models/stereo_depth/base_stereo_depth.py
@@ -73,9 +73,6 @@ class BaseStereoPredictor(ABC, Generic[ModelT]):
 class BaseStereoPredictorConfig(ABC):
     """Base configuration for a stereo predictor."""
 
-    max_disp: int
-    """Maximum modeled disparity in pixels."""
-
     @abstractmethod
     def setup(self, device: Literal["cpu", "cuda"]) -> BaseStereoPredictor:
         """Build the configured predictor on one device."""

--- a/packages/monoprior/monopriors/models/stereo_depth/base_stereo_depth.py
+++ b/packages/monoprior/monopriors/models/stereo_depth/base_stereo_depth.py
@@ -67,3 +67,16 @@ class BaseStereoPredictor(ABC, Generic[ModelT]):
 
     def set_model_device(self, device: Literal["cpu", "cuda"] = "cuda") -> None:
         self.model.to(device)
+
+
+@dataclass
+class BaseStereoPredictorConfig(ABC):
+    """Base configuration for a stereo predictor."""
+
+    max_disp: int
+    """Maximum modeled disparity in pixels."""
+
+    @abstractmethod
+    def setup(self, device: Literal["cpu", "cuda"]) -> BaseStereoPredictor:
+        """Build the configured predictor on one device."""
+        raise NotImplementedError

--- a/packages/monoprior/monopriors/models/stereo_depth/fast_foundationstereo.py
+++ b/packages/monoprior/monopriors/models/stereo_depth/fast_foundationstereo.py
@@ -1,0 +1,164 @@
+"""Fast-FoundationStereo as a ``BaseStereoPredictor``."""
+
+import copy
+import pickle
+from pathlib import Path
+from typing import Any, Literal, cast
+
+import numpy as np
+import torch
+from einops import rearrange
+from huggingface_hub import hf_hub_download
+from jaxtyping import Float32, UInt8
+from omegaconf import DictConfig, OmegaConf
+from torch import nn
+
+from monopriors.models.stereo_depth.base_stereo_depth import BaseStereoPredictor, StereoDepthPrediction, disparity_to_metric_depth
+from monopriors.third_party.fast_foundationstereo.foundation_stereo import FastFoundationStereo
+from monopriors.third_party.fast_foundationstereo.utils import InputPadder
+
+FAST_FOUNDATIONSTEREO_HF_REPO: str = "nvidia/c-fast-foundationstereo"
+FAST_FOUNDATIONSTEREO_HF_REVISION: str = "9b446878c81ddb27593036767b29b2859d46103e"
+FAST_FOUNDATIONSTEREO_CHECKPOINT: str = "model_best_bp2_serialize.pth"
+FAST_FOUNDATIONSTEREO_CONFIG: str = "cfg.yaml"
+
+
+class _FastFoundationStereoUnpickler(pickle.Unpickler):
+    """Remap upstream ``core.*`` pickle globals onto the vendored package."""
+
+    def find_class(self, module: str, name: str) -> Any:
+        if module.startswith("core."):
+            module = f"monopriors.third_party.fast_foundationstereo.{module.removeprefix('core.')}"
+        elif module.startswith("foundation_stereo_ori."):
+            module = f"monopriors.third_party.fast_foundationstereo.{module.removeprefix('foundation_stereo_ori.')}"
+        return super().find_class(module, name)
+
+
+class _FastFoundationStereoPickleModule:
+    """Module-like adapter accepted by ``torch.load(pickle_module=...)``."""
+
+    Unpickler = _FastFoundationStereoUnpickler
+    load = staticmethod(pickle.load)
+
+
+def download_fast_foundationstereo_checkpoint() -> Path:
+    """Download the released config and pickled module from the pinned Hugging Face revision.
+
+    Returns:
+        Local path to ``model_best_bp2_serialize.pth``; ``cfg.yaml`` is downloaded beside it.
+    """
+    hf_hub_download(repo_id=FAST_FOUNDATIONSTEREO_HF_REPO, filename=FAST_FOUNDATIONSTEREO_CONFIG, revision=FAST_FOUNDATIONSTEREO_HF_REVISION)
+    return Path(hf_hub_download(repo_id=FAST_FOUNDATIONSTEREO_HF_REPO, filename=FAST_FOUNDATIONSTEREO_CHECKPOINT, revision=FAST_FOUNDATIONSTEREO_HF_REVISION))
+
+
+def load_fast_foundationstereo(checkpoint: Path, valid_iters: int = 8, max_disp: int = 416) -> nn.Module:
+    """Remap the released NAS architecture, clone it, and strictly load its state dict.
+
+    Args:
+        checkpoint: Pickled upstream ``FastFoundationStereo`` module with ``cfg.yaml`` beside it.
+        valid_iters: Number of recurrent disparity updates used at inference.
+        max_disp: Maximum modeled disparity in pixels.
+
+    Returns:
+        A fresh evaluation-ready architecture on CPU with the released state loaded strictly.
+
+    Raises:
+        TypeError: If the checkpoint is not a module or the config is not a mapping.
+        FileNotFoundError: If ``cfg.yaml`` is not beside the checkpoint.
+        RuntimeError: If the released state does not strictly match its remapped NAS architecture.
+    """
+    serialized: object = torch.load(checkpoint, map_location="cpu", pickle_module=_FastFoundationStereoPickleModule, weights_only=False)
+    if not isinstance(serialized, nn.Module):
+        raise TypeError(f"Expected a pickled nn.Module in {checkpoint}, got {type(serialized).__name__}")
+    serialized_model: FastFoundationStereo = cast(FastFoundationStereo, serialized)
+    serialized_args: Any = serialized_model.args
+
+    config_path: Path = checkpoint.with_name(FAST_FOUNDATIONSTEREO_CONFIG)
+    if not config_path.is_file():
+        raise FileNotFoundError(f"Fast-FoundationStereo config must be beside the checkpoint: {config_path}")
+    loaded_config: Any = OmegaConf.load(config_path)
+    if not isinstance(loaded_config, DictConfig):
+        raise TypeError(f"Expected a mapping config in {config_path}, got {type(loaded_config).__name__}")
+    for key, value in loaded_config.items():
+        serialized_args[key] = value
+    serialized_args.valid_iters = valid_iters
+    serialized_args.max_disp = max_disp
+    serialized_args.normalize = True
+
+    model: nn.Module = copy.deepcopy(serialized_model)
+    model.load_state_dict(serialized_model.state_dict(), strict=True)
+    return model
+
+
+class FastFoundationStereoPredictor(BaseStereoPredictor[nn.Module]):
+    """Fast-FoundationStereo predictor using the upstream PyTorch cost-volume fallback."""
+
+    def __init__(
+        self,
+        device: Literal["cpu", "cuda"],
+        checkpoint: Path | None = None,
+        valid_iters: int = 8,
+        max_disp: int = 416,
+    ) -> None:
+        """Load Fast-FoundationStereo on one device.
+
+        Args:
+            device: Where the network runs.
+            checkpoint: Local released checkpoint; downloaded from the pinned HF revision when None.
+            valid_iters: Number of recurrent disparity updates.
+            max_disp: Maximum modeled disparity in pixels.
+        """
+        self.valid_iters: int = valid_iters
+        self.max_disp: int = max_disp
+        checkpoint_path: Path = checkpoint or download_fast_foundationstereo_checkpoint()
+        self.model: nn.Module = load_fast_foundationstereo(checkpoint_path, valid_iters=valid_iters, max_disp=max_disp).to(device).eval()
+
+    def infer_disparity(self, left_rgb: UInt8[np.ndarray, "h w 3"], right_rgb: UInt8[np.ndarray, "h w 3"]) -> Float32[np.ndarray, "h w"]:
+        """Predict left-view disparity in pixels at the input resolution.
+
+        Args:
+            left_rgb: Rectified left RGB image, ``UInt8[ndarray, "h w 3"]``.
+            right_rgb: Rectified right RGB image, ``UInt8[ndarray, "h w 3"]``.
+
+        Returns:
+            Non-negative disparity, ``Float32[ndarray, "h w"]``.
+        """
+        device: torch.device = next(self.model.parameters()).device
+        left_13hw: Float32[torch.Tensor, "1 3 h w"] = rearrange(torch.from_numpy(left_rgb).to(device=device, dtype=torch.float32), "h w c -> 1 c h w")
+        right_13hw: Float32[torch.Tensor, "1 3 h w"] = rearrange(torch.from_numpy(right_rgb).to(device=device, dtype=torch.float32), "h w c -> 1 c h w")
+        padder: InputPadder = InputPadder(left_13hw.shape, divis_by=32, force_square=False)
+        padded: list[Float32[torch.Tensor, "1 3 hp wp"]] = padder.pad(left_13hw, right_13hw)
+        with torch.inference_mode(), torch.amp.autocast("cuda", enabled=device.type == "cuda", dtype=torch.float16):
+            disparity_11hw: Float32[torch.Tensor, "1 1 hp wp"] = self.model(
+                padded[0],
+                padded[1],
+                iters=self.valid_iters,
+                test_mode=True,
+                optimize_build_volume="pytorch1",
+            )
+        disparity_hw: Float32[torch.Tensor, "h w"] = rearrange(padder.unpad(disparity_11hw.float()).clamp_min(0.0), "1 1 h w -> h w")
+        return disparity_hw.cpu().numpy()
+
+    def __call__(
+        self,
+        left_rgb: UInt8[np.ndarray, "h w 3"],
+        right_rgb: UInt8[np.ndarray, "h w 3"],
+        K_33: Float32[np.ndarray, "3 3"] | None = None,
+        baseline_m: float | None = None,
+    ) -> StereoDepthPrediction:
+        """Predict disparity and optional metric depth for a rectified RGB pair.
+
+        Args:
+            left_rgb: Rectified left RGB image, ``UInt8[ndarray, "h w 3"]``.
+            right_rgb: Rectified right RGB image, ``UInt8[ndarray, "h w 3"]``.
+            K_33: Shared rectified intrinsics, ``Float32[ndarray, "3 3"]``, when metric depth is wanted.
+            baseline_m: Stereo baseline in metres when metric depth is wanted.
+
+        Returns:
+            Left-view disparity and optional metric depth in a ``StereoDepthPrediction``.
+        """
+        disparity_hw: Float32[np.ndarray, "h w"] = self.infer_disparity(left_rgb, right_rgb)
+        depth_hw: Float32[np.ndarray, "h w"] | None = None
+        if K_33 is not None and baseline_m is not None:
+            depth_hw = disparity_to_metric_depth(disparity_hw, float(K_33[0, 0]), baseline_m)
+        return StereoDepthPrediction(disparity=disparity_hw, depth_meters=depth_hw, K_33=K_33, baseline_m=baseline_m)

--- a/packages/monoprior/monopriors/models/stereo_depth/fast_foundationstereo.py
+++ b/packages/monoprior/monopriors/models/stereo_depth/fast_foundationstereo.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import copy
 import pickle
 from dataclasses import dataclass
 from pathlib import Path
@@ -19,8 +18,6 @@ from torch import nn
 from monopriors.models.stereo_depth.base_stereo_depth import (
     BaseStereoPredictor,
     BaseStereoPredictorConfig,
-    StereoDepthPrediction,
-    disparity_to_metric_depth,
 )
 from monopriors.third_party.fast_foundationstereo.foundation_stereo import FastFoundationStereo
 from monopriors.third_party.fast_foundationstereo.utils import InputPadder
@@ -60,7 +57,11 @@ def download_fast_foundationstereo_checkpoint() -> Path:
 
 
 def load_fast_foundationstereo(checkpoint: Path, valid_iters: int = 8, max_disp: int = 416) -> nn.Module:
-    """Remap the released NAS architecture, clone it, and strictly load its state dict.
+    """Load and remap the released NAS-pruned architecture.
+
+    The pickle is the architecture specification: its per-layer widths cannot be reconstructed from
+    ``cfg.yaml``. ``torch.load`` creates the returned object graph, while the adjacent config supplies runtime
+    arguments that were not serialized with the release.
 
     Args:
         checkpoint: Pickled upstream ``FastFoundationStereo`` module with ``cfg.yaml`` beside it.
@@ -68,12 +69,11 @@ def load_fast_foundationstereo(checkpoint: Path, valid_iters: int = 8, max_disp:
         max_disp: Maximum modeled disparity in pixels.
 
     Returns:
-        A fresh evaluation-ready architecture on CPU with the released state loaded strictly.
+        The remapped serialized architecture on CPU with its runtime arguments updated.
 
     Raises:
         TypeError: If the checkpoint is not a module or the config is not a mapping.
         FileNotFoundError: If ``cfg.yaml`` is not beside the checkpoint.
-        RuntimeError: If the released state does not strictly match its remapped NAS architecture.
     """
     serialized: object = torch.load(checkpoint, map_location="cpu", pickle_module=_FastFoundationStereoPickleModule, weights_only=False)
     if not isinstance(serialized, nn.Module):
@@ -93,9 +93,7 @@ def load_fast_foundationstereo(checkpoint: Path, valid_iters: int = 8, max_disp:
     serialized_args.max_disp = max_disp
     serialized_args.normalize = True
 
-    model: nn.Module = copy.deepcopy(serialized_model)
-    model.load_state_dict(serialized_model.state_dict(), strict=True)
-    return model
+    return serialized_model
 
 
 @dataclass
@@ -162,27 +160,3 @@ class FastFoundationStereoPredictor(BaseStereoPredictor[nn.Module]):
             )
         disparity_hw: Float32[torch.Tensor, "h w"] = rearrange(padder.unpad(disparity_11hw.float()).clamp_min(0.0), "1 1 h w -> h w")
         return disparity_hw.cpu().numpy()
-
-    def __call__(
-        self,
-        left_rgb: UInt8[np.ndarray, "h w 3"],
-        right_rgb: UInt8[np.ndarray, "h w 3"],
-        K_33: Float32[np.ndarray, "3 3"] | None = None,
-        baseline_m: float | None = None,
-    ) -> StereoDepthPrediction:
-        """Predict disparity and optional metric depth for a rectified RGB pair.
-
-        Args:
-            left_rgb: Rectified left RGB image, ``UInt8[ndarray, "h w 3"]``.
-            right_rgb: Rectified right RGB image, ``UInt8[ndarray, "h w 3"]``.
-            K_33: Shared rectified intrinsics, ``Float32[ndarray, "3 3"]``, when metric depth is wanted.
-            baseline_m: Stereo baseline in metres when metric depth is wanted.
-
-        Returns:
-            Left-view disparity and optional metric depth in a ``StereoDepthPrediction``.
-        """
-        disparity_hw: Float32[np.ndarray, "h w"] = self.infer_disparity(left_rgb, right_rgb)
-        depth_hw: Float32[np.ndarray, "h w"] | None = None
-        if K_33 is not None and baseline_m is not None:
-            depth_hw = disparity_to_metric_depth(disparity_hw, float(K_33[0, 0]), baseline_m)
-        return StereoDepthPrediction(disparity=disparity_hw, depth_meters=depth_hw, K_33=K_33, baseline_m=baseline_m)

--- a/packages/monoprior/monopriors/models/stereo_depth/fast_foundationstereo.py
+++ b/packages/monoprior/monopriors/models/stereo_depth/fast_foundationstereo.py
@@ -1,7 +1,10 @@
 """Fast-FoundationStereo as a ``BaseStereoPredictor``."""
 
+from __future__ import annotations
+
 import copy
 import pickle
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, cast
 
@@ -13,7 +16,12 @@ from jaxtyping import Float32, UInt8
 from omegaconf import DictConfig, OmegaConf
 from torch import nn
 
-from monopriors.models.stereo_depth.base_stereo_depth import BaseStereoPredictor, StereoDepthPrediction, disparity_to_metric_depth
+from monopriors.models.stereo_depth.base_stereo_depth import (
+    BaseStereoPredictor,
+    BaseStereoPredictorConfig,
+    StereoDepthPrediction,
+    disparity_to_metric_depth,
+)
 from monopriors.third_party.fast_foundationstereo.foundation_stereo import FastFoundationStereo
 from monopriors.third_party.fast_foundationstereo.utils import InputPadder
 
@@ -88,6 +96,22 @@ def load_fast_foundationstereo(checkpoint: Path, valid_iters: int = 8, max_disp:
     model: nn.Module = copy.deepcopy(serialized_model)
     model.load_state_dict(serialized_model.state_dict(), strict=True)
     return model
+
+
+@dataclass
+class FastFoundationStereoConfig(BaseStereoPredictorConfig):
+    """Configuration for Fast-FoundationStereo."""
+
+    valid_iters: int = 8
+    """Number of recurrent disparity updates used at inference."""
+    max_disp: int = 416
+    """Maximum modeled disparity in pixels."""
+    checkpoint: Path | None = None
+    """Local released checkpoint, or None to download the pinned release."""
+
+    def setup(self, device: Literal["cpu", "cuda"]) -> FastFoundationStereoPredictor:
+        """Build the configured Fast-FoundationStereo predictor on one device."""
+        return FastFoundationStereoPredictor(device=device, checkpoint=self.checkpoint, valid_iters=self.valid_iters, max_disp=self.max_disp)
 
 
 class FastFoundationStereoPredictor(BaseStereoPredictor[nn.Module]):

--- a/packages/monoprior/monopriors/models/stereo_depth/liteanystereo.py
+++ b/packages/monoprior/monopriors/models/stereo_depth/liteanystereo.py
@@ -4,6 +4,9 @@ Preprocessing mirrors upstream ``demo.py``: float RGB in ``[0, 255]`` (no normal
 multiple of 32 with the upstream ``InputPadder``, ``model(left, right, max_disp, test_mode=True)``.
 """
 
+from __future__ import annotations
+
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, TypeAlias
 
@@ -14,10 +17,14 @@ from huggingface_hub import hf_hub_download
 from jaxtyping import Float32, UInt8
 from torch import nn
 
+from monopriors.models.stereo_depth.base_stereo_depth import (
+    BaseStereoPredictor,
+    BaseStereoPredictorConfig,
+    StereoDepthPrediction,
+    disparity_to_metric_depth,
+)
 from monopriors.third_party.liteanystereo.liteanystereov2 import build_liteanystereo
 from monopriors.third_party.liteanystereo.padding import InputPadder
-
-from .base_stereo_depth import BaseStereoPredictor
 
 LAS2ModelSize: TypeAlias = Literal["s", "m", "l", "h"]
 
@@ -41,6 +48,22 @@ def load_liteanystereo(model_size: LAS2ModelSize, checkpoint: Path, max_disp: in
     state = {k.removeprefix("module."): v for k, v in state.items()}
     model.load_state_dict(state, strict=True)
     return model
+
+
+@dataclass
+class LiteAnyStereoConfig(BaseStereoPredictorConfig):
+    """Configuration for LiteAnyStereo V2."""
+
+    model_size: LAS2ModelSize = "m"
+    """LAS2 variant; S/M/L are feed-forward and H uses an iterative ConvGRU."""
+    max_disp: int = 192
+    """Disparity search range in pixels."""
+    checkpoint: Path | None = None
+    """Local weights, or None to download the pinned release checkpoint."""
+
+    def setup(self, device: Literal["cpu", "cuda"]) -> LiteAnyStereoPredictor:
+        """Build the configured LiteAnyStereo predictor on one device."""
+        return LiteAnyStereoPredictor(device=device, model_size=self.model_size, checkpoint=self.checkpoint, max_disp=self.max_disp)
 
 
 class LiteAnyStereoPredictor(BaseStereoPredictor[nn.Module]):

--- a/packages/monoprior/monopriors/models/stereo_depth/liteanystereo.py
+++ b/packages/monoprior/monopriors/models/stereo_depth/liteanystereo.py
@@ -20,8 +20,6 @@ from torch import nn
 from monopriors.models.stereo_depth.base_stereo_depth import (
     BaseStereoPredictor,
     BaseStereoPredictorConfig,
-    StereoDepthPrediction,
-    disparity_to_metric_depth,
 )
 from monopriors.third_party.liteanystereo.liteanystereov2 import build_liteanystereo
 from monopriors.third_party.liteanystereo.padding import InputPadder

--- a/packages/monoprior/tests/test_fast_foundationstereo_eth3d.py
+++ b/packages/monoprior/tests/test_fast_foundationstereo_eth3d.py
@@ -1,0 +1,46 @@
+"""Released Fast-FoundationStereo weights and the ETH3D ``playground_1l`` reference band."""
+
+from pathlib import Path
+
+import cv2
+import numpy as np
+from conftest import requires_cuda, slow_cuda
+from huggingface_hub import snapshot_download
+from jaxtyping import Float32, UInt8
+from torch import nn
+
+from monopriors.apis.stereo_depth import MiddleburyCalibration, read_middlebury_calib, read_pfm, read_rgb, stereo_metrics
+from monopriors.models.stereo_depth import FastFoundationStereoPredictor, StereoDepthPrediction
+from monopriors.models.stereo_depth.fast_foundationstereo import download_fast_foundationstereo_checkpoint, load_fast_foundationstereo
+
+pytestmark = slow_cuda
+
+
+def test_released_checkpoint_remaps_and_loads_all_tensors_strictly() -> None:
+    """The pickled upstream module remaps and strictly fills a fresh clone of its serialized NAS architecture."""
+    checkpoint: Path = download_fast_foundationstereo_checkpoint()
+    model: nn.Module = load_fast_foundationstereo(checkpoint)
+    assert len(model.state_dict()) == 722
+    assert sum(parameter.numel() for parameter in model.parameters()) == 17_654_857
+    assert model.args.normalize is True
+    assert model.args.valid_iters == 8 and model.args.max_disp == 416
+
+
+@requires_cuda
+def test_eth3d_playground_accuracy() -> None:
+    """The released model stays within the measured single-scene baseline: EPE 0.241 px and bad1 0.48%."""
+    root: Path = Path(snapshot_download("pablovela5620/monoprior-example", repo_type="dataset", allow_patterns=["stereo/eth3d/two_view_training*/**"]))
+    scene: Path = root / "stereo/eth3d/two_view_training/playground_1l"
+    gt_dir: Path = root / "stereo/eth3d/two_view_training_gt/playground_1l"
+    calibration: MiddleburyCalibration = read_middlebury_calib(scene / "calib.txt")
+    predictor: FastFoundationStereoPredictor = FastFoundationStereoPredictor(device="cuda")
+    prediction: StereoDepthPrediction = predictor(read_rgb(scene / "im0.png"), read_rgb(scene / "im1.png"), K_33=calibration.K_33, baseline_m=calibration.baseline_m)
+
+    gt_hw: Float32[np.ndarray, "h w"] = read_pfm(gt_dir / "disp0GT.pfm")
+    nocc_hw: UInt8[np.ndarray, "h w"] = cv2.imread(str(gt_dir / "mask0nocc.png"), cv2.IMREAD_GRAYSCALE)
+    metrics: tuple[float, float] = stereo_metrics(prediction.disparity, gt_hw, nocc_hw, max_disp=416.0)
+    epe_px: float = metrics[0]
+    bad1_percent: float = metrics[1]
+    print(f"Fast-FoundationStereo playground_1l: EPE {epe_px:.3f} px, bad1 {bad1_percent:.2f}%")
+    assert epe_px < 0.30
+    assert bad1_percent < 0.8

--- a/packages/monoprior/tests/test_fast_foundationstereo_eth3d.py
+++ b/packages/monoprior/tests/test_fast_foundationstereo_eth3d.py
@@ -9,15 +9,15 @@ from huggingface_hub import snapshot_download
 from jaxtyping import Float32, UInt8
 from torch import nn
 
-from monopriors.apis.stereo_depth import MiddleburyCalibration, read_middlebury_calib, read_pfm, read_rgb, stereo_metrics
+from monopriors.apis.stereo_depth import ETH3D_MAX_DISP, MiddleburyCalibration, read_middlebury_calib, read_pfm, read_rgb, stereo_metrics
 from monopriors.models.stereo_depth import FastFoundationStereoPredictor, StereoDepthPrediction
 from monopriors.models.stereo_depth.fast_foundationstereo import download_fast_foundationstereo_checkpoint, load_fast_foundationstereo
 
 pytestmark = slow_cuda
 
 
-def test_released_checkpoint_remaps_and_loads_all_tensors_strictly() -> None:
-    """The pickled upstream module remaps and strictly fills a fresh clone of its serialized NAS architecture."""
+def test_released_checkpoint_remaps_serialized_architecture() -> None:
+    """The pickled upstream architecture remaps with the released tensor and parameter counts."""
     checkpoint: Path = download_fast_foundationstereo_checkpoint()
     model: nn.Module = load_fast_foundationstereo(checkpoint)
     assert len(model.state_dict()) == 722
@@ -28,7 +28,7 @@ def test_released_checkpoint_remaps_and_loads_all_tensors_strictly() -> None:
 
 @requires_cuda
 def test_eth3d_playground_accuracy() -> None:
-    """The released model stays within the measured single-scene baseline: EPE 0.241 px and bad1 0.48%."""
+    """At the shared 192 px cutoff, the release stays near EPE 0.241 px and bad1 0.48%."""
     root: Path = Path(snapshot_download("pablovela5620/monoprior-example", repo_type="dataset", allow_patterns=["stereo/eth3d/two_view_training*/**"]))
     scene: Path = root / "stereo/eth3d/two_view_training/playground_1l"
     gt_dir: Path = root / "stereo/eth3d/two_view_training_gt/playground_1l"
@@ -38,9 +38,9 @@ def test_eth3d_playground_accuracy() -> None:
 
     gt_hw: Float32[np.ndarray, "h w"] = read_pfm(gt_dir / "disp0GT.pfm")
     nocc_hw: UInt8[np.ndarray, "h w"] = cv2.imread(str(gt_dir / "mask0nocc.png"), cv2.IMREAD_GRAYSCALE)
-    metrics: tuple[float, float] = stereo_metrics(prediction.disparity, gt_hw, nocc_hw, max_disp=416.0)
+    metrics: tuple[float, float] = stereo_metrics(prediction.disparity, gt_hw, nocc_hw, max_disp=ETH3D_MAX_DISP)
     epe_px: float = metrics[0]
     bad1_percent: float = metrics[1]
     print(f"Fast-FoundationStereo playground_1l: EPE {epe_px:.3f} px, bad1 {bad1_percent:.2f}%")
     assert epe_px < 0.30
-    assert bad1_percent < 0.8
+    assert bad1_percent < 0.75

--- a/packages/monoprior/tests/test_fast_foundationstereo_predictor.py
+++ b/packages/monoprior/tests/test_fast_foundationstereo_predictor.py
@@ -1,6 +1,7 @@
 """FastFoundationStereoPredictor registry and stereo prediction contract."""
 
 from collections.abc import Callable
+from dataclasses import fields
 from pathlib import Path
 from typing import Any, cast
 
@@ -14,6 +15,7 @@ from torch import nn
 
 from monopriors.models.stereo_depth import (
     AnnotatedStereoPredictorUnion,
+    BaseStereoPredictorConfig,
     FastFoundationStereoConfig,
     FastFoundationStereoPredictor,
     StereoDepthPrediction,
@@ -51,6 +53,7 @@ class FakeFastFoundationStereo(nn.Module):
 
 
 def test_fast_foundationstereo_config_registered() -> None:
+    assert fields(BaseStereoPredictorConfig) == ()
     assert set(stereo_predictor_defaults) == {"liteanystereo", "fast-foundationstereo"}
     config = stereo_predictor_defaults["fast-foundationstereo"]
     assert isinstance(config, FastFoundationStereoConfig)
@@ -115,7 +118,6 @@ def test_predictor_preprocesses_and_returns_metric_depth(monkeypatch: pytest.Mon
 
     expected_disparity: Float32[np.ndarray, "35 61"] = np.clip(left_rgb[..., 0].astype(np.float32) - 100.0, 0.0, None)
     assert np.array_equal(prediction.disparity, expected_disparity)
-    assert prediction.depth_meters is not None
     valid_hw: Bool[np.ndarray, "35 61"] = expected_disparity > 0.0
     assert np.allclose(prediction.depth_meters[valid_hw], 10.0 / expected_disparity[valid_hw])
     assert np.all(prediction.depth_meters[~valid_hw] == 0.0)

--- a/packages/monoprior/tests/test_fast_foundationstereo_predictor.py
+++ b/packages/monoprior/tests/test_fast_foundationstereo_predictor.py
@@ -2,16 +2,23 @@
 
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, cast, get_args
+from typing import Any, cast
 
 import numpy as np
 import pytest
 import torch
+import tyro
 from jaxtyping import Bool, Float32, UInt8
 from omegaconf import DictConfig, OmegaConf
 from torch import nn
 
-from monopriors.models.stereo_depth import STEREO_PREDICTORS, FastFoundationStereoPredictor, StereoDepthPrediction, get_stereo_predictor
+from monopriors.models.stereo_depth import (
+    AnnotatedStereoPredictorUnion,
+    FastFoundationStereoConfig,
+    FastFoundationStereoPredictor,
+    StereoDepthPrediction,
+    stereo_predictor_defaults,
+)
 from monopriors.models.stereo_depth import fast_foundationstereo as predictor_module
 from monopriors.third_party.fast_foundationstereo import extractor as extractor_module
 from monopriors.third_party.fast_foundationstereo import foundation_stereo as foundation_stereo_module
@@ -43,9 +50,12 @@ class FakeFastFoundationStereo(nn.Module):
         return left_13hw[:, :1] - 100.0 + self.anchor.sum()
 
 
-def test_registered() -> None:
-    assert "FastFoundationStereoPredictor" in get_args(STEREO_PREDICTORS)
-    assert get_stereo_predictor("FastFoundationStereoPredictor") is FastFoundationStereoPredictor
+def test_fast_foundationstereo_config_registered() -> None:
+    assert set(stereo_predictor_defaults) == {"liteanystereo", "fast-foundationstereo"}
+    config = stereo_predictor_defaults["fast-foundationstereo"]
+    assert isinstance(config, FastFoundationStereoConfig)
+    assert config.max_disp == 416
+    assert isinstance(tyro.cli(AnnotatedStereoPredictorUnion, args=["fast-foundationstereo"]), FastFoundationStereoConfig)
 
 
 def test_random_module_runs_tiny_cpu_pair(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/monoprior/tests/test_fast_foundationstereo_predictor.py
+++ b/packages/monoprior/tests/test_fast_foundationstereo_predictor.py
@@ -1,0 +1,112 @@
+"""FastFoundationStereoPredictor registry and stereo prediction contract."""
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast, get_args
+
+import numpy as np
+import pytest
+import torch
+from jaxtyping import Bool, Float32, UInt8
+from omegaconf import DictConfig, OmegaConf
+from torch import nn
+
+from monopriors.models.stereo_depth import STEREO_PREDICTORS, FastFoundationStereoPredictor, StereoDepthPrediction, get_stereo_predictor
+from monopriors.models.stereo_depth import fast_foundationstereo as predictor_module
+from monopriors.third_party.fast_foundationstereo import extractor as extractor_module
+from monopriors.third_party.fast_foundationstereo import foundation_stereo as foundation_stereo_module
+from monopriors.third_party.fast_foundationstereo import submodule as submodule_module
+from monopriors.third_party.fast_foundationstereo.foundation_stereo import FastFoundationStereo
+
+TIMM_CREATE_MODEL: Callable[..., nn.Module] = cast(Callable[..., nn.Module], extractor_module.timm.create_model)
+
+
+class FakeFastFoundationStereo(nn.Module):
+    """Cheap model double that exposes the upstream forward contract at the public predictor seam."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.anchor: nn.Parameter = nn.Parameter(torch.empty(0))
+
+    def forward(
+        self,
+        left_13hw: Float32[torch.Tensor, "1 3 h w"],
+        right_13hw: Float32[torch.Tensor, "1 3 h w"],
+        iters: int,
+        test_mode: bool,
+        optimize_build_volume: str,
+    ) -> Float32[torch.Tensor, "1 1 h w"]:
+        assert left_13hw.shape == right_13hw.shape
+        assert left_13hw.shape[-2] % 32 == 0 and left_13hw.shape[-1] % 32 == 0
+        assert left_13hw.dtype == torch.float32 and 0.0 <= float(left_13hw.min()) <= float(left_13hw.max()) <= 255.0
+        assert iters == 3 and test_mode is True and optimize_build_volume == "pytorch1"
+        return left_13hw[:, :1] - 100.0 + self.anchor.sum()
+
+
+def test_registered() -> None:
+    assert "FastFoundationStereoPredictor" in get_args(STEREO_PREDICTORS)
+    assert get_stereo_predictor("FastFoundationStereoPredictor") is FastFoundationStereoPredictor
+
+
+def test_random_module_runs_tiny_cpu_pair(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A config-built random module runs the PyTorch cost-volume path without CUDA or released weights."""
+
+    def create_model_without_pretrained(model_name: str, *args: Any, **kwargs: Any) -> nn.Module:
+        kwargs["pretrained"] = False
+        return TIMM_CREATE_MODEL(model_name, *args, **kwargs)
+
+    monkeypatch.setattr(extractor_module.timm, "create_model", create_model_without_pretrained)
+    eager_gwc: Callable[..., torch.Tensor] = cast(Callable[..., torch.Tensor], submodule_module.build_gwc_volume_optimized_pytorch1._torchdynamo_orig_callable)
+    eager_concat: Callable[..., torch.Tensor] = cast(Callable[..., torch.Tensor], submodule_module.build_concat_volume_optimized_pytorch1._torchdynamo_orig_callable)
+    monkeypatch.setattr(foundation_stereo_module, "build_gwc_volume_optimized_pytorch1", eager_gwc)
+    monkeypatch.setattr(foundation_stereo_module, "build_concat_volume_optimized_pytorch1", eager_concat)
+    config: DictConfig = OmegaConf.create(
+        {
+            "hidden_dims": [128],
+            "vit_size": "vitl",
+            "n_gru_layers": 1,
+            "n_downsample": 2,
+            "corr_levels": 2,
+            "corr_radius": 4,
+            "mixed_precision": False,
+            "valid_iters": 1,
+            "low_memory": 0,
+            "max_disp": 32,
+            "normalize": True,
+            "cv_group": 8,
+        }
+    )
+    model: FastFoundationStereo = FastFoundationStereo(config).eval()
+    left_13hw: Float32[torch.Tensor, "1 3 32 64"] = torch.rand((1, 3, 32, 64), dtype=torch.float32) * 255.0
+    right_13hw: Float32[torch.Tensor, "1 3 32 64"] = torch.rand((1, 3, 32, 64), dtype=torch.float32) * 255.0
+    with torch.inference_mode():
+        disparity_11hw: Float32[torch.Tensor, "1 1 32 64"] = model(left_13hw, right_13hw, iters=1, test_mode=True, optimize_build_volume="pytorch1")
+    assert disparity_11hw.shape == (1, 1, 32, 64)
+    assert disparity_11hw.dtype == torch.float32
+    assert torch.isfinite(disparity_11hw).all()
+
+
+def test_predictor_preprocesses_and_returns_metric_depth(monkeypatch: pytest.MonkeyPatch) -> None:
+    checkpoint: Path = Path("unused.pth")
+    fake_model: FakeFastFoundationStereo = FakeFastFoundationStereo()
+
+    def fake_load(path: Path, valid_iters: int, max_disp: int) -> nn.Module:
+        assert path == checkpoint and valid_iters == 3 and max_disp == 64
+        return fake_model
+
+    monkeypatch.setattr(predictor_module, "load_fast_foundationstereo", fake_load)
+    monkeypatch.setattr(predictor_module, "download_fast_foundationstereo_checkpoint", lambda: pytest.fail("local checkpoint must bypass download"))
+    predictor: FastFoundationStereoPredictor = FastFoundationStereoPredictor(device="cpu", checkpoint=checkpoint, valid_iters=3, max_disp=64)
+    left_rgb: UInt8[np.ndarray, "35 61 3"] = np.arange(35 * 61 * 3, dtype=np.uint8).reshape(35, 61, 3)
+    right_rgb: UInt8[np.ndarray, "35 61 3"] = np.flip(left_rgb, axis=1).copy()
+    K_33: Float32[np.ndarray, "3 3"] = np.array([[100.0, 0.0, 30.0], [0.0, 100.0, 17.0], [0.0, 0.0, 1.0]], dtype=np.float32)
+
+    prediction: StereoDepthPrediction = predictor(left_rgb, right_rgb, K_33=K_33, baseline_m=0.1)
+
+    expected_disparity: Float32[np.ndarray, "35 61"] = np.clip(left_rgb[..., 0].astype(np.float32) - 100.0, 0.0, None)
+    assert np.array_equal(prediction.disparity, expected_disparity)
+    assert prediction.depth_meters is not None
+    valid_hw: Bool[np.ndarray, "35 61"] = expected_disparity > 0.0
+    assert np.allclose(prediction.depth_meters[valid_hw], 10.0 / expected_disparity[valid_hw])
+    assert np.all(prediction.depth_meters[~valid_hw] == 0.0)
+    assert prediction.K_33 is K_33 and prediction.baseline_m == 0.1

--- a/packages/monoprior/tests/test_liteanystereo_eth3d.py
+++ b/packages/monoprior/tests/test_liteanystereo_eth3d.py
@@ -8,9 +8,9 @@ import numpy as np
 import pytest
 from conftest import requires_cuda, slow_cuda
 from huggingface_hub import snapshot_download
-from jaxtyping import Bool, Float32, UInt8
+from jaxtyping import Float32, UInt8
 
-from monopriors.apis.stereo_depth import read_middlebury_calib, read_rgb
+from monopriors.apis.stereo_depth import ETH3D_MAX_DISP, read_middlebury_calib, read_rgb, stereo_metrics
 from monopriors.models.stereo_depth import LiteAnyStereoPredictor
 
 pytestmark = [slow_cuda, requires_cuda]
@@ -36,8 +36,7 @@ def test_eth3d_playground_bad1(model_size: str, max_bad1_percent: float) -> None
 
     gt_hw: Float32[np.ndarray, "h w"] = _read_pfm(gt_dir / "disp0GT.pfm")
     nocc_hw: UInt8[np.ndarray, "h w"] = cv2.imread(str(gt_dir / "mask0nocc.png"), cv2.IMREAD_GRAYSCALE)
-    valid_hw: Bool[np.ndarray, "h w"] = np.isfinite(gt_hw) & (gt_hw < 192) & (nocc_hw == 255)
-    error_hw = np.abs(pred.disparity - gt_hw)
-    bad1_percent = 100.0 * float((error_hw[valid_hw] > 1.0).mean())
+    epe_px, bad1_percent = stereo_metrics(pred.disparity, gt_hw, nocc_hw, max_disp=ETH3D_MAX_DISP)
+    print(f"LAS2-{model_size.upper()} playground_1l: EPE {epe_px:.3f} px, bad1 {bad1_percent:.2f}%")
     assert bad1_percent < max_bad1_percent, f"LAS2-{model_size.upper()} bad1 {bad1_percent:.2f}%"
     assert np.nanmedian(pred.depth_meters[pred.depth_meters > 0]) < 50.0

--- a/packages/monoprior/tests/test_liteanystereo_predictor.py
+++ b/packages/monoprior/tests/test_liteanystereo_predictor.py
@@ -4,20 +4,23 @@ Runs on CPU against a randomly initialised LAS2-S saved to disk, so no download 
 """
 
 from pathlib import Path
-from typing import get_args
 
 import numpy as np
 import pytest
 import torch
+import tyro
 
-from monopriors.models.stereo_depth import STEREO_PREDICTORS, LiteAnyStereoPredictor, get_stereo_predictor
+from monopriors.models.stereo_depth import AnnotatedStereoPredictorUnion, LiteAnyStereoConfig, LiteAnyStereoPredictor, stereo_predictor_defaults
 from monopriors.models.stereo_depth import liteanystereo as liteanystereo_module
 from monopriors.third_party.liteanystereo.liteanystereov2 import build_liteanystereo
 
 
-def test_registered() -> None:
-    assert "LiteAnyStereoPredictor" in get_args(STEREO_PREDICTORS)
-    assert get_stereo_predictor("LiteAnyStereoPredictor") is LiteAnyStereoPredictor
+def test_liteanystereo_config_registered() -> None:
+    assert set(stereo_predictor_defaults) == {"liteanystereo", "fast-foundationstereo"}
+    config = stereo_predictor_defaults["liteanystereo"]
+    assert isinstance(config, LiteAnyStereoConfig)
+    assert config.max_disp == 192
+    assert isinstance(tyro.cli(AnnotatedStereoPredictorUnion, args=["liteanystereo"]), LiteAnyStereoConfig)
 
 
 @pytest.fixture(scope="module")

--- a/pixi.toml
+++ b/pixi.toml
@@ -438,13 +438,13 @@ cwd = "packages/monoprior"
 cmd = "python tools/demos/stereo_depth.py"
 depends-on = ["_monoprior-download-stereo"]
 cwd = "packages/monoprior"
-description = "LiteAnyStereo V2 on the ETH3D playground_1l stereo pair, shown as an exoego:v2 rig in Rerun"
+description = "Selected stereo predictor on the ETH3D playground_1l pair, shown as an exoego:v2 rig in Rerun"
 
 [feature.monoprior.tasks.monoprior-stereo-depth-app]
 cmd = "python tools/apps/stereo_depth_app.py"
 depends-on = ["_monoprior-download-stereo"]
 cwd = "packages/monoprior"
-description = "Launch the stereo depth Gradio app (LiteAnyStereo V2 + Rerun rig viewer)"
+description = "Launch the multi-model stereo depth Gradio app with a Rerun rig viewer"
 
 [feature.monoprior.tasks.monoprior-relative-depth]
 cmd = "python tools/demos/relative_depth.py --image-path data/examples/single-image/room.jpg"
@@ -560,7 +560,7 @@ torchcodec = "*"
 cmd = "python tools/apps/stereo_catalog.py"
 cwd = "packages/monoprior"
 env = { RERUN_INSECURE_SKIP_HOST_CHECK = "1" }
-description = "Stream LiteAnyStereo V2 depth + an incremental TSDF mesh for a catalog rig segment (robocap front pair on :51235) into the Rerun viewer"
+description = "Stream selected-model stereo depth + an incremental TSDF mesh for a catalog rig segment (robocap front pair on :51235) into the Rerun viewer"
 
 # ═══════════════════════════════════════════════════════════════════════════
 # prompt-da


### PR DESCRIPTION
Stacked on the vendor PR.

- `FastFoundationStereoPredictor(device, checkpoint=None, valid_iters=8, max_disp=416)` implementing `BaseStereoPredictor` → `StereoDepthPrediction`; preprocessing mirrors upstream `run_demo.py` (float RGB, `InputPadder(32)`, fp16 autocast, `test_mode=True`, torch GWC volume).
- Checkpoint: official HF `nvidia/c-fast-foundationstereo` rev `9b446878…` — a **pickled whole module** (no safetensors exists). Loaded with a remapping `Unpickler` (`core.*`/`foundation_stereo_ori.*` → vendored package), deep-copied, strict state-dict reload (722 tensors, 17.66 M params). The checkpoint is NAS-pruned and cannot be rebuilt from `cfg.yaml`; the pickle is the architecture spec. Its `args` lack `normalize`, which `forward()` reads: measured `True` → 0.48 % bad1, `False` → 45 %.
- Registry: `STEREO_PREDICTORS` gains `"FastFoundationStereoPredictor"`; `stereo_depth` demo, `stereo_catalog`, and the Gradio app select by predictor name (small `match`, LAS2 defaults unchanged).
- Tests: fast CPU build-from-config test; slow band: ETH3D playground_1l **EPE 0.241 px / bad1 0.48 %** (LAS2-H 1.12 %) and strict-load of the real checkpoint. Warm timing 5090 fp16: ~83–95 ms/frame at 490×941.

Gates: lint / typecheck / deadcode / tests green (92 passed), slow tests 2 passed.