### PR TITLE
prompt-da: cast depth to uint16 and downscale fusion RGB on the GPU (stack 6/8)

### DIFF
--- a/packages/prompt-da/src/rerun_prompt_da/apis/arkitscenes_shared.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/arkitscenes_shared.py
@@ -7,6 +7,7 @@ import cv2
 import numpy as np
 import open3d as o3d
 import rerun as rr
+import torch
 from arkitscenes_download.ingest.depth import ArkitDepthConfidence
 from beartype.roar import BeartypeException
 from einops import rearrange
@@ -137,10 +138,15 @@ def run_promptda_batch(
     image_b3hw, prompt_b1hw = preprocess_batch(rgb_bhw3, prompt_bhw, predictor.image_hw)
     depth_model_b1hw: Float32[Tensor, "b 1 nh nw"] = predictor.runtime({"image": image_b3hw, "prompt_depth": prompt_b1hw})["depth"]
     depth_bhw: Float32[Tensor, "b oh ow"] = postprocess_depth(depth_model_b1hw, output_hw)
-    depth_mm_bhw: UInt16[ndarray, "b oh ow"] = (depth_bhw.cpu().numpy() * 1000.0).astype(np.uint16)
+    # Scale and cast on the GPU: halves the device-to-host copy and drops two full-size host passes.
+    depth_mm_bhw: UInt16[ndarray, "b oh ow"] = (depth_bhw * 1000.0).clamp(0.0, 65535.0).to(torch.uint16).cpu().numpy()
     depth_model_mm_bhw: UInt16[ndarray, "b nh nw"] = (
-        rearrange(depth_model_b1hw, "b 1 h w -> b h w").cpu().numpy() * 1000.0  # pyrefly: ignore  # bad-argument-type — einops stub false positive
-    ).astype(np.uint16)
+        (rearrange(depth_model_b1hw, "b 1 h w -> b h w") * 1000.0)  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+        .clamp(0.0, 65535.0)
+        .to(torch.uint16)
+        .cpu()
+        .numpy()
+    )
     return depth_mm_bhw, depth_model_mm_bhw
 
 

--- a/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_arkitscenes.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_arkitscenes.py
@@ -10,18 +10,19 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 
-import cv2
 import numpy as np
 import open3d as o3d
 import pyarrow as pa
 import rerun as rr
 import torch
+import torch.nn.functional as F
 from arkitscenes_download.ingest.blueprint import DEPTH_RANGE_MM, make_blueprint
 from arkitscenes_download.ingest.catalog import DEFAULT_CATALOG_URL
 from arkitscenes_download.ingest.cells import landscape_quarter_turns, portrait_from_segment_row
 from arkitscenes_download.ingest.depth import encode_depth_png
 from arkitscenes_download.ingest.paths import DEPTH_PROMPTDA, PROMPTDA_MESH, TIMELINE
 from arkitscenes_download.ingest.recording import atomic_recording
+from einops import rearrange
 from jaxtyping import Float, UInt8, UInt16
 from numpy import ndarray
 from rerun.catalog import CatalogClient, DatasetEntry, OnDuplicateSegmentLayer, RegistrationHandle
@@ -29,6 +30,7 @@ from rerun.experimental.dataloader import RerunIterableDataset
 from simplecv.camera_parameters import Intrinsics, rescale_intri
 from simplecv.ops.tsdf_depth_fuser import Open3DFuser
 from simplecv.rerun_log_utils import mesh_bounding_geometry
+from torch import Tensor
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
@@ -106,8 +108,8 @@ class CompletedPromptDABatch:
     """Full-resolution predicted depth in millimetres, in inference orientation."""
     depth_model_mm_bhw: UInt16[ndarray, "b nh nw"]
     """Network-resolution predicted depth in millimetres, in inference orientation."""
-    rgb_stored_bhw3: UInt8[ndarray, "b stored_h stored_w 3"]
-    """RGB frames restored to catalog orientation."""
+    rgb_stored_bhw3: UInt8[ndarray, "b fh fw 3"]
+    """RGB frames at the fusion (network) resolution, restored to catalog orientation."""
     confidence_bhw: UInt8[ndarray, "b stored_prompt_h stored_prompt_w"]
     """ARKit confidence in catalog orientation."""
     K_native_b33: Float[ndarray, "b 3 3"]
@@ -160,16 +162,14 @@ def fuse_and_log_batch(
         predicted_depth_hw: UInt16[ndarray, "h w"] = np.ascontiguousarray(np.rot90(batch.depth_mm_bhw[row], -batch.quarter_turns))
         fusion_depth_hw: UInt16[ndarray, "fh fw"] = np.ascontiguousarray(np.rot90(batch.depth_model_mm_bhw[row], -batch.quarter_turns))
         confidence_hw: UInt8[ndarray, "h2 w2"] = batch.confidence_bhw[row]
-        rgb_hw3: UInt8[ndarray, "h w 3"] = batch.rgb_stored_bhw3[row]
         log_promptda_frame(recording, timestamp_ns, predicted_depth_hw)
         filtered_depth_hw: UInt16[ndarray, "h w"] = filter_depth_for_fusion(
             fusion_depth_hw,
             confidence_hw,
             max_depth_meter,
         )
-        rgb_fusion_hw3: UInt8[ndarray, "fh fw 3"] = np.asarray(
-            cv2.resize(rgb_hw3, (fusion_depth_hw.shape[1], fusion_depth_hw.shape[0]), interpolation=cv2.INTER_AREA), dtype=np.uint8
-        )
+        # Already at the fusion resolution and catalog orientation — downscaled on the GPU.
+        rgb_fusion_hw3: UInt8[ndarray, "fh fw 3"] = batch.rgb_stored_bhw3[row]
         stored_k_33: Float[ndarray, "3 3"] = batch.K_native_b33[row]
         stored_intrinsics: Intrinsics = Intrinsics.from_k_matrix(
             camera_conventions="RDF",
@@ -257,9 +257,22 @@ def run_segment(
                 batch.prompt_bhw,
                 (batch.rgb_bhw3.shape[1], batch.rgb_bhw3.shape[2]),
             )
-            rgb_stored_bhw3: UInt8[ndarray, "b stored_h stored_w 3"] = np.asarray(
-                torch.rot90(batch.rgb_bhw3, -batch.quarter_turns, dims=(1, 2)).cpu().numpy(),
-                dtype=np.uint8,
+            # Fusion only needs colour at the network resolution, so downscale on the
+            # GPU and keep the full-resolution frame off the bus entirely.
+            fusion_hw: tuple[int, int] = (inference_result[1].shape[1], inference_result[1].shape[2])
+            rgb_fusion_b3hw: Float[Tensor, "b 3 fh fw"] = F.interpolate(
+                rearrange(batch.rgb_bhw3, "b h w c -> b c h w").float(),  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+                size=fusion_hw,
+                mode="bilinear",
+                antialias=True,
+            )
+            rgb_stored_bhw3: UInt8[ndarray, "b fh fw 3"] = np.ascontiguousarray(
+                rearrange(torch.rot90(rgb_fusion_b3hw, -batch.quarter_turns, dims=(2, 3)), "b c h w -> b h w c")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+                .round()
+                .clamp(0.0, 255.0)
+                .to(torch.uint8)
+                .cpu()
+                .numpy()
             )
             if pending_batch is not None:
                 inferred_frames += pending_batch.result()


### PR DESCRIPTION
Stacked on #129 (zipdepth catalog stack). Throughput-only change to the chosen-frame PromptDA batch tool; stored bytes, layer contract and fused mesh are unchanged.

**What was dumb:** every frame shipped float32 depth (11 MB full-res + 3 MB net-res) and the full 1440×1920 RGB (8.3 MB) over PCIe, then did the scale/cast and the fusion downscale on the host — and fusion only ever used the RGB at network resolution.

**Change:** scale+clamp+cast to uint16 on the device before `.cpu()`; `F.interpolate` the RGB to the fusion size on the device; the writer thread loses its `cv2.resize` (and `cv2` import).

**Measured** (live 5090 batch, 243 vs 12-segment samples, uncontended): 17.3 → 21.6 frames/s (+25%); per-frame D2H 22.4 MB → 6.3 MB; A/B on one segment: identical mesh vertex count, RRD 375 → 374 MB (uint16 cast now truncates a float32 product instead of float64 — occasional ±1 mm).

Gates: ruff, pyrefly (0 errors), vulture, 23 passed / 3 skipped.
