### PR TITLE
prompt-da: return TSDF arena pages to the OS at each segment boundary (stack 7/8)

### DIFF
--- a/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_arkitscenes.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_arkitscenes.py
@@ -5,6 +5,8 @@ local Rerun catalog, completes depth frame-by-frame, fuses a final TSDF mesh,
 and writes a replaceable ``promptda`` layer back to the dataset.
 """
 
+import ctypes
+import gc
 from collections.abc import Iterable, Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
@@ -49,6 +51,11 @@ from rerun_prompt_da.promptda_stream import PromptDABatch, PromptDACollate, prom
 from rerun_prompt_da.trt_predictor import PromptDATrtPredictor
 
 PROMPTDA_LAYER = "promptda"
+
+_MALLOC_TRIM = ctypes.CDLL(None).malloc_trim
+"""glibc ``malloc_trim``; Linux-only, like the rest of this pipeline (NVDEC, TensorRT)."""
+_MALLOC_TRIM.argtypes = [ctypes.c_size_t]
+_MALLOC_TRIM.restype = ctypes.c_int
 
 
 @dataclass
@@ -305,6 +312,11 @@ def run_segment(
                 make_blueprint(portrait=portrait, framing=mesh_bounding_geometry(vertices), include_promptda=True),
                 recording=recording,
             )
+    # Open3D's TSDF churn leaves ~0.6 GB of freed native pages per segment resident in
+    # glibc arenas (measured: OOM at 142 GB after 234 segments). The fuser, executor and
+    # recording are out of scope here, so return those pages to the OS at the boundary.
+    gc.collect()
+    _MALLOC_TRIM(0)
     skipped_decodes: int = 0 if expected_frames is None else expected_frames - inferred_frames
     return SegmentResult(rrd_path=rrd_path, inferred_frames=inferred_frames, skipped_decodes=skipped_decodes)
 


### PR DESCRIPTION
Stacked on the GPU-transfer PR. Fixes the ~0.6 GB/segment host-memory growth that OOM-killed the corpus batch at 142 GB anon-rss after 234 segments (2026-08-30 00:52) — and, because the process lived in `paseo.service`'s cgroup, took the catalog server down with it.

**Root cause (bisected by ablation on real segments):** not Rerun (file sink plateaus at ~550 MB), not the NVDEC decoder, not Arrow. Open3D's `ScalableTSDFVolume` churn on the writer thread frees hundreds of MB per segment that glibc keeps resident in per-thread arenas — used space flat at ~484 MiB while free arena space grew to 3.6 GiB over six segments. `gc.collect()` alone does nothing; `malloc_trim(0)` returns ~1 GB per segment.

**Change:** `gc.collect()` + `malloc_trim(0)` (via `ctypes.CDLL(None)`) at the end of `run_segment()`, where the fuser, executor and recording are out of scope. Linux-only, like NVDEC/TensorRT.

**Verified:** full pipeline smoke +0.2 GB over 3 segments (peak 3.8 GB) vs +0.5–1.1 GB/segment before; in production RSS stayed 4–8 GB across 570 segments (was 36 GB after 50 on the unpatched code).

Gates: ruff, pyrefly (0 errors), vulture, 23 passed / 3 skipped.
