### PR TITLE
docs: catalog-server fragility and a TensorRT dynamic-batch limitation (stack 8/8)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,41 @@ layer. `arkitscenes-download-serve` uses `ulimit -n 524288`; restart the server
 to inherit it. This is a capacity workaround—the upstream fix is open-on-demand
 files or an LRU descriptor pool.
 
+### The catalog server is in-memory and dies to `pkill -x rerun`
+
+`rerun server` keeps all registrations in memory: any exit — even a graceful
+SIGTERM — loses every dataset, and the whole corpus must be re-registered
+(`register_catalog.py` + `make_gt_subdataset.py` + the `frame_selection`/`promptda`
+layers; ~90 s warm, ~16 min cold). On 2026-08-29 it died three times in one
+evening because **another agent session** cleaned up its headless viewer with
+`pkill -x rerun`, which matches every process named `rerun` on the machine.
+
+Rules for every agent on a shared host:
+
+- **Never kill Rerun by name** (`pkill -x rerun`, `pkill rerun`, `killall rerun`,
+  `pkill -f rerun`). Kill your own viewer by pid, or with a pattern that includes
+  your port: `pkill -f "rerun --headless --port 9877"`.
+- Do not assume a Rerun process is yours because you started one. Check
+  `ss -ltnp | grep 51235` before touching anything named `rerun`.
+
+Short-term hack in place: the shared server on :51235 is launched through a
+symlink named `rerun-catalog` (`~/.local/bin/rerun-catalog` → `rerun_cli/rerun`),
+so its process name is not `rerun` and name-based kills miss it. This hides the
+symptom, not the cause — a session that kills by name is still wrong. The real
+fixes are (a) a persistent catalog store so a restart is not a rebuild, and
+(b) running the server under a supervisor (systemd --user) instead of a shell.
+
+A second, unrelated killer (2026-08-30 00:52): **`paseo.service` has
+`KillMode=control-group`**, and every agent session paseo hosts — plus every
+process those sessions spawn — lives in its cgroup. A paseo restart SIGTERMs all
+of it — and a restart is what systemd does when the kernel OOM-kills *any*
+process in that cgroup (on 2026-08-30 a leaking batch hit 142 GB RSS, got
+OOM-killed, paseo.service was marked `oom-kill` and restarted, and the catalog
+died as collateral). `setsid`/`nohup`/`disown` do not escape a cgroup.
+Long-lived servers and batches started from an agent session must be launched via
+`tmux new-session` (the tmux server lives in the user's SSH session scope, which
+survives paseo restarts; check with `cat /proc/<pid>/cgroup`) or `systemd-run --user`.
+
 ## Testing Rerun builds
 
 **One Rerun version repo-wide — Rust follows Python.** The PyPI `rerun-sdk` pin

--- a/packages/trtkit/README.md
+++ b/packages/trtkit/README.md
@@ -90,6 +90,31 @@ strongly-typed network that takes dtypes from the graph — the escape hatch for
 fp16-overflow-prone ViTs). `allow_tf32=False` disables TF32 for strict-fp32
 models and is part of the cache key (`-notf32`).
 
+## Known TensorRT limitations
+
+**Dynamic batch + Myelin `CHECK(is_const())`.** A graph whose reshape depends on
+the batch symbol can fail to build with `dynamic_batch_max` set:
+
+```
+Could not find any implementation for node {ForeignNode[ONNXTRT_ShapeShuffle_…]}
+MyelinCheckException: value.h:872: CHECK(is_const()) failed
+```
+
+Seen with ZipDepth-base, whose `F.unfold` upsampling head dynamo lowers to a
+gather indexed off `Shape(...)`; head rewrites (`view(-1, …)`, static slices, the
+NPU head) only move the failure earlier, and it reproduces identically on
+TensorRT 10.16.1, 11.0.0, 11.1.0 and 11.2.1 on sm_120 (2026-08-30). It is a
+Myelin limitation on a non-constant leading dim, not a graph bug, and it is not
+in NVIDIA's release notes or tracker. Every other trtkit consumer here (PromptDA,
+MoGe, MammaNet, RTMW, Sapiens) builds fine with a dynamic batch profile.
+
+Workaround: export with `dynamic_batch_max=None` (static batch) and build one
+engine per batch size (`TrtBuildConfig(max_batch_size=b, opt_batch_size=b)`).
+Zero model change; upstream ZipDepth's own `export.py` hardcodes batch 1 for the
+same reason. Related: fp16 via `model.half()`, not autocast — an autocast export
+can leave a float conv kernel beside a half input, which a strongly-typed build
+rejects at parse time.
+
 ## Dev
 
 ```bash


### PR DESCRIPTION
Docs only.

**AGENTS.md** — the shared rerun catalog on :51235 is in-memory and died four times on 2026-08-29/30: three to another agent session's `pkill -x rerun`, once as collateral of an OOM inside its own `paseo.service` cgroup (`KillMode=control-group`). Records the never-kill-Rerun-by-name rule (kill by pid or port pattern), the `rerun-catalog` symlink as an explicit short-term hack, the cgroup mechanism (`setsid`/`nohup` do not escape it; launch long-lived servers/batches via `tmux new-session`), and the real fixes (persistent store, supervisor).

**trtkit README** — new "Known TensorRT limitations": TRT 10.16–11.2 Myelin fails with `CHECK(is_const())` on any graph whose reshape depends on a dynamic batch symbol (ZipDepth-base's `F.unfold` head; verified identical on 10.16.1, 11.0.0, 11.1.0, 11.2.1 on sm_120; head rewrites only move the failure). Not in NVIDIA's release notes or tracker. Workaround: static-batch export, one engine per batch size. Also: fp16 via `model.half()`, not autocast, for strongly-typed builds. Every other trtkit consumer here builds fine with a dynamic profile.
