### PR TITLE
zipdepth: ZipDepth-PromptDA — prompted metric depth distilled from PromptDA (stack 9/9)

### DIFF
--- a/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt.py
+++ b/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt.py
@@ -180,6 +180,10 @@ def load_zipdepth_prompt(checkpoint: Path) -> ZipDepthPrompt:
     checkpoint_data: dict[str, Any] = torch.load(checkpoint, map_location="cpu", weights_only=True)
     raw_state_dict: StateDict = checkpoint_data.get("model_state_dict", checkpoint_data)
     state_dict: StateDict = strip_state_dict_prefixes(raw_state_dict)
+    if any(key.startswith("backbone.") for key in state_dict):
+        prompted_model: ZipDepthPrompt = ZipDepthPrompt()
+        prompted_model.load_state_dict(state_dict, strict=True)
+        return prompted_model
     backbone: ZipDepth = create_model(variant="base")
     backbone.load_state_dict(state_dict, strict=True)
     return ZipDepthPrompt(backbone)

--- a/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt.py
+++ b/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt.py
@@ -85,12 +85,30 @@ class ZipDepthPrompt(nn.Module):
 
         Returns:
             Float metric depth in metres with shape
-            ``(batch, 1, height, width)``.
+                ``(batch, 1, height, width)``.
+        """
+        metric_depth_b1hw: Float[Tensor, "b 1 h w"]
+        metric_depth_b1hw, _, _ = self.forward_with_range(image, prompt_depth)
+        return metric_depth_b1hw
+
+    def forward_with_range(
+        self,
+        image: UInt8[Tensor, "b 3 h w"] | Float[Tensor, "b 3 h w"],
+        prompt_depth: Float32[Tensor, "b 1 192 256"],
+    ) -> tuple[
+        Float[Tensor, "b 1 h w"],
+        Float32[Tensor, "b 1 1 1"],
+        Float32[Tensor, "b 1 1 1"],
+    ]:
+        """Predict metric depth and expose the prompt range for TRT export.
+
+        The two scalar outputs force TensorRT to materialize the input-derived
+        reductions. Normal callers use :meth:`forward` and receive depth only.
         """
         if image.dtype == torch.uint8:
-            image_b3hw: Float32[Tensor, "b 3 h w"] = image.to(dtype=torch.float32) / 255.0
+            image_b3hw: Float[Tensor, "b 3 h w"] = image.to(dtype=self.backbone.mean.dtype) / 255.0
         else:
-            image_b3hw = image.to(dtype=torch.float32)
+            image_b3hw = image.to(dtype=self.backbone.mean.dtype)
 
         valid_b1hw: torch.Tensor = (
             torch.isfinite(prompt_depth)
@@ -117,7 +135,7 @@ class ZipDepthPrompt(nn.Module):
             torch.zeros_like(prompt_depth),
         )
 
-        normalized_image_b3hw: Float32[Tensor, "b 3 h w"] = (image_b3hw - self.backbone.mean) / self.backbone.std
+        normalized_image_b3hw: Float[Tensor, "b 3 h w"] = (image_b3hw - self.backbone.mean) / self.backbone.std
         encoder_output: EncoderOutput = self.backbone.encoder(normalized_image_b3hw)
         stem_half_bchw: Float[Tensor, "b c_half h_half w_half"] = encoder_output[0]
         encoder_features: FeaturePyramid = encoder_output[1]
@@ -128,27 +146,27 @@ class ZipDepthPrompt(nn.Module):
 
         decoder = self.backbone.decoder
         f4_bchw: Float[Tensor, "b 288 h_thirtysecond w_thirtysecond"] = decoder.proj4(c4_bchw)
-        prompt4_b1hw: Float32[Tensor, "b 1 h_thirtysecond w_thirtysecond"] = F.interpolate(
+        prompt4_b1hw: Float[Tensor, "b 1 h_thirtysecond w_thirtysecond"] = F.interpolate(
             normalized_prompt_b1hw, size=f4_bchw.shape[-2:], mode="bilinear", align_corners=False
-        )
+        ).to(dtype=f4_bchw.dtype)
         f4_bchw = f4_bchw + self.prompt_branches[0](prompt4_b1hw)
 
         f3_bchw: Float[Tensor, "b 192 h_sixteenth w_sixteenth"] = decoder.fuse3(c3_bchw, f4_bchw)
-        prompt3_b1hw: Float32[Tensor, "b 1 h_sixteenth w_sixteenth"] = F.interpolate(
+        prompt3_b1hw: Float[Tensor, "b 1 h_sixteenth w_sixteenth"] = F.interpolate(
             normalized_prompt_b1hw, size=f3_bchw.shape[-2:], mode="bilinear", align_corners=False
-        )
+        ).to(dtype=f3_bchw.dtype)
         f3_bchw = f3_bchw + self.prompt_branches[1](prompt3_b1hw)
 
         f2_bchw: Float[Tensor, "b 144 h_eighth w_eighth"] = decoder.fuse2(c2_bchw, f3_bchw)
-        prompt2_b1hw: Float32[Tensor, "b 1 h_eighth w_eighth"] = F.interpolate(
+        prompt2_b1hw: Float[Tensor, "b 1 h_eighth w_eighth"] = F.interpolate(
             normalized_prompt_b1hw, size=f2_bchw.shape[-2:], mode="bilinear", align_corners=False
-        )
+        ).to(dtype=f2_bchw.dtype)
         f2_bchw = f2_bchw + self.prompt_branches[2](prompt2_b1hw)
 
         f1_bchw: Float[Tensor, "b 96 h_quarter w_quarter"] = decoder.fuse1(c1_bchw, f2_bchw)
-        prompt1_b1hw: Float32[Tensor, "b 1 h_quarter w_quarter"] = F.interpolate(
+        prompt1_b1hw: Float[Tensor, "b 1 h_quarter w_quarter"] = F.interpolate(
             normalized_prompt_b1hw, size=f1_bchw.shape[-2:], mode="bilinear", align_corners=False
-        )
+        ).to(dtype=f1_bchw.dtype)
         f1_bchw = f1_bchw + self.prompt_branches[3](prompt1_b1hw)
 
         f_half_bchw: Float[Tensor, "b 32 h_half w_half"] = decoder.fuse_half(stem_half_bchw, f1_bchw)
@@ -156,7 +174,7 @@ class ZipDepthPrompt(nn.Module):
         depth_logits_b1hw: Float[Tensor, "b 1 h w"] = decoder.convex_up._forward_unfold(f_half_bchw, depth_logits_half_b1hw)
         normalized_depth_b1hw: Float[Tensor, "b 1 h w"] = torch.sigmoid(depth_logits_b1hw)
         metric_depth_b1hw: Float[Tensor, "b 1 h w"] = normalized_depth_b1hw * span_b111 + min_depth_b111
-        return metric_depth_b1hw
+        return metric_depth_b1hw, min_depth_b111, max_depth_b111
 
     def fuse_for_inference(self) -> Self:
         """Fuse the released ZipDepth backbone in place and enter eval mode."""

--- a/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt.py
+++ b/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt.py
@@ -1,0 +1,185 @@
+"""Prompt-conditioned metric ZipDepth model.
+
+The wrapper keeps the vendored ZipDepth-base tensors unchanged, injects a
+normalized metric prompt into all four decoder stages, and returns depth in the
+same units as the prompt (metres for the public API).
+"""
+
+from pathlib import Path
+from typing import Any, Self
+
+import torch
+import torch.nn.functional as F
+from jaxtyping import Float, Float32, UInt8
+from torch import Tensor, nn
+
+from monopriors.third_party.zipdepth.architecture import EncoderOutput, FeaturePyramid, ZipDepth, create_model
+from monopriors.third_party.zipdepth.model_utils import StateDict, strip_state_dict_prefixes
+
+PROMPT_HEIGHT: int = 192
+PROMPT_WIDTH: int = 256
+MIN_PROMPT_DEPTH_M: float = 0.1
+MAX_PROMPT_DEPTH_M: float = 4.0
+MIN_PROMPT_SPAN_M: float = 1.0e-6
+
+
+def _make_prompt_branch(channels: int) -> nn.Sequential:
+    """Build one PromptDA-style depthwise-separable prompt branch.
+
+    Args:
+        channels: Decoder-stage channel count.
+
+    Returns:
+        A branch mapping float normalized prompt depth with shape
+        ``(batch, 1, height, width)`` to float features with shape
+        ``(batch, channels, height, width)``. The last pointwise convolution is
+        exactly zero-initialized, so the branch initially contributes zero.
+    """
+    input_conv: nn.Conv2d = nn.Conv2d(1, channels, kernel_size=3, padding=1)
+    depthwise_conv: nn.Conv2d = nn.Conv2d(channels, channels, kernel_size=3, padding=1, groups=channels)
+    final_conv: nn.Conv2d = nn.Conv2d(channels, channels, kernel_size=1)
+    branch: nn.Sequential = nn.Sequential(
+        input_conv,
+        nn.ReLU(inplace=True),
+        depthwise_conv,
+        nn.ReLU(inplace=True),
+        final_conv,
+    )
+    nn.init.zeros_(final_conv.weight)
+    if final_conv.bias is not None:
+        nn.init.zeros_(final_conv.bias)
+    return branch
+
+
+class ZipDepthPrompt(nn.Module):
+    """ZipDepth-base with PromptDA-style multi-scale metric conditioning."""
+
+    def __init__(self, backbone: ZipDepth | None = None) -> None:
+        super().__init__()
+        self.backbone: ZipDepth = create_model(variant="base") if backbone is None else backbone
+        if self.backbone.variant != "base":
+            raise ValueError(f"ZipDepthPrompt requires the base variant, got {self.backbone.variant!r}")
+        if not self.backbone.decoder.convex_up.use_unfold:
+            raise ValueError("ZipDepthPrompt currently requires ZipDepth's unfold-based convex head")
+        self.prompt_branches: nn.ModuleList = nn.ModuleList(
+            [_make_prompt_branch(channels) for channels in (288, 192, 144, 96)]
+        )
+
+    def forward(
+        self,
+        image: UInt8[Tensor, "b 3 h w"] | Float[Tensor, "b 3 h w"],
+        prompt_depth: Float32[Tensor, "b 1 192 256"],
+    ) -> Float[Tensor, "b 1 h w"]:
+        """Predict metric depth from RGB and a low-resolution metric prompt.
+
+        Confidence-invalid prompt pixels must be zeroed by the caller. This
+        method also rejects non-finite values and depths outside 0.1--4.0 m
+        when computing the per-image prompt range.
+
+        Args:
+            image: UInt8 RGB or float RGB tensor with shape
+                ``(batch, 3, height, width)``. UInt8 values are scaled to
+                ``[0, 1]``; float values are already expected in that range.
+            prompt_depth: Float32 metric prompt in metres with shape
+                ``(batch, 1, 192, 256)``. Invalid pixels are zero.
+
+        Returns:
+            Float metric depth in metres with shape
+            ``(batch, 1, height, width)``.
+        """
+        if image.dtype == torch.uint8:
+            image_b3hw: Float32[Tensor, "b 3 h w"] = image.to(dtype=torch.float32) / 255.0
+        else:
+            image_b3hw = image.to(dtype=torch.float32)
+
+        valid_b1hw: torch.Tensor = (
+            torch.isfinite(prompt_depth)
+            & (prompt_depth >= MIN_PROMPT_DEPTH_M)
+            & (prompt_depth <= MAX_PROMPT_DEPTH_M)
+        )
+        valid_any_b111: torch.Tensor = valid_b1hw.any(dim=(1, 2, 3), keepdim=True)
+        masked_min_b111: Float32[Tensor, "b 1 1 1"] = torch.where(
+            valid_b1hw, prompt_depth, torch.full_like(prompt_depth, torch.inf)
+        ).amin(dim=(1, 2, 3), keepdim=True)
+        masked_max_b111: Float32[Tensor, "b 1 1 1"] = torch.where(
+            valid_b1hw, prompt_depth, torch.full_like(prompt_depth, -torch.inf)
+        ).amax(dim=(1, 2, 3), keepdim=True)
+        min_depth_b111: Float32[Tensor, "b 1 1 1"] = torch.where(
+            valid_any_b111, masked_min_b111, torch.full_like(masked_min_b111, MIN_PROMPT_DEPTH_M)
+        )
+        max_depth_b111: Float32[Tensor, "b 1 1 1"] = torch.where(
+            valid_any_b111, masked_max_b111, torch.full_like(masked_max_b111, MAX_PROMPT_DEPTH_M)
+        )
+        span_b111: Float32[Tensor, "b 1 1 1"] = (max_depth_b111 - min_depth_b111).clamp_min(MIN_PROMPT_SPAN_M)
+        normalized_prompt_b1hw: Float32[Tensor, "b 1 192 256"] = torch.where(
+            valid_b1hw,
+            (prompt_depth - min_depth_b111) / span_b111,
+            torch.zeros_like(prompt_depth),
+        )
+
+        normalized_image_b3hw: Float32[Tensor, "b 3 h w"] = (image_b3hw - self.backbone.mean) / self.backbone.std
+        encoder_output: EncoderOutput = self.backbone.encoder(normalized_image_b3hw)
+        stem_half_bchw: Float[Tensor, "b c_half h_half w_half"] = encoder_output[0]
+        encoder_features: FeaturePyramid = encoder_output[1]
+        c1_bchw: Float[Tensor, "b c1 h_quarter w_quarter"] = encoder_features[0]
+        c2_bchw: Float[Tensor, "b c2 h_eighth w_eighth"] = encoder_features[1]
+        c3_bchw: Float[Tensor, "b c3 h_sixteenth w_sixteenth"] = encoder_features[2]
+        c4_bchw: Float[Tensor, "b c4 h_thirtysecond w_thirtysecond"] = encoder_features[3]
+
+        decoder = self.backbone.decoder
+        f4_bchw: Float[Tensor, "b 288 h_thirtysecond w_thirtysecond"] = decoder.proj4(c4_bchw)
+        prompt4_b1hw: Float32[Tensor, "b 1 h_thirtysecond w_thirtysecond"] = F.interpolate(
+            normalized_prompt_b1hw, size=f4_bchw.shape[-2:], mode="bilinear", align_corners=False
+        )
+        f4_bchw = f4_bchw + self.prompt_branches[0](prompt4_b1hw)
+
+        f3_bchw: Float[Tensor, "b 192 h_sixteenth w_sixteenth"] = decoder.fuse3(c3_bchw, f4_bchw)
+        prompt3_b1hw: Float32[Tensor, "b 1 h_sixteenth w_sixteenth"] = F.interpolate(
+            normalized_prompt_b1hw, size=f3_bchw.shape[-2:], mode="bilinear", align_corners=False
+        )
+        f3_bchw = f3_bchw + self.prompt_branches[1](prompt3_b1hw)
+
+        f2_bchw: Float[Tensor, "b 144 h_eighth w_eighth"] = decoder.fuse2(c2_bchw, f3_bchw)
+        prompt2_b1hw: Float32[Tensor, "b 1 h_eighth w_eighth"] = F.interpolate(
+            normalized_prompt_b1hw, size=f2_bchw.shape[-2:], mode="bilinear", align_corners=False
+        )
+        f2_bchw = f2_bchw + self.prompt_branches[2](prompt2_b1hw)
+
+        f1_bchw: Float[Tensor, "b 96 h_quarter w_quarter"] = decoder.fuse1(c1_bchw, f2_bchw)
+        prompt1_b1hw: Float32[Tensor, "b 1 h_quarter w_quarter"] = F.interpolate(
+            normalized_prompt_b1hw, size=f1_bchw.shape[-2:], mode="bilinear", align_corners=False
+        )
+        f1_bchw = f1_bchw + self.prompt_branches[3](prompt1_b1hw)
+
+        f_half_bchw: Float[Tensor, "b 32 h_half w_half"] = decoder.fuse_half(stem_half_bchw, f1_bchw)
+        depth_logits_half_b1hw: Float[Tensor, "b 1 h_half w_half"] = decoder.head_half(f_half_bchw)
+        depth_logits_b1hw: Float[Tensor, "b 1 h w"] = decoder.convex_up._forward_unfold(f_half_bchw, depth_logits_half_b1hw)
+        normalized_depth_b1hw: Float[Tensor, "b 1 h w"] = torch.sigmoid(depth_logits_b1hw)
+        metric_depth_b1hw: Float[Tensor, "b 1 h w"] = normalized_depth_b1hw * span_b111 + min_depth_b111
+        return metric_depth_b1hw
+
+    def fuse_for_inference(self) -> Self:
+        """Fuse the released ZipDepth backbone in place and enter eval mode."""
+        self.backbone.fuse_for_inference()
+        self.eval()
+        return self
+
+
+def load_zipdepth_prompt(checkpoint: Path) -> ZipDepthPrompt:
+    """Load a complete released ZipDepth-base checkpoint into the wrapper.
+
+    Args:
+        checkpoint: Bare ZipDepth state dict or trainer checkpoint containing
+            ``model_state_dict``. DDP and ``torch.compile`` prefixes are
+            accepted.
+
+    Returns:
+        A trainable prompted model. Every released tensor is loaded strictly;
+        prompt-branch tensors retain their zero-output initialization.
+    """
+    checkpoint_data: dict[str, Any] = torch.load(checkpoint, map_location="cpu", weights_only=True)
+    raw_state_dict: StateDict = checkpoint_data.get("model_state_dict", checkpoint_data)
+    state_dict: StateDict = strip_state_dict_prefixes(raw_state_dict)
+    backbone: ZipDepth = create_model(variant="base")
+    backbone.load_state_dict(state_dict, strict=True)
+    return ZipDepthPrompt(backbone)

--- a/packages/prompt-da/src/rerun_prompt_da/apis/arkitscenes_shared.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/arkitscenes_shared.py
@@ -5,8 +5,6 @@ from typing import Any
 
 import cv2
 import numpy as np
-import open3d as o3d
-import rerun as rr
 import torch
 from arkitscenes_download.ingest.depth import ArkitDepthConfidence
 from beartype.roar import BeartypeException
@@ -150,21 +148,3 @@ def run_promptda_batch(
     return depth_mm_bhw, depth_model_mm_bhw
 
 
-def log_fused_mesh(recording: rr.RecordingStream, entity_path: str, mesh: o3d.geometry.TriangleMesh) -> None:
-    """Log a fused TSDF mesh statically.
-
-    Same see-through treatment as the ARKit mesh: cull back-facing walls so the
-    3D view looks into the room from outside.
-    """
-    rr.log(
-        entity_path,
-        rr.Mesh3D(
-            vertex_positions=np.asarray(mesh.vertices),
-            triangle_indices=np.asarray(mesh.triangles),
-            vertex_normals=np.asarray(mesh.vertex_normals),
-            vertex_colors=np.asarray(mesh.vertex_colors),
-            face_rendering=rr.components.MeshFaceRendering.Front,
-        ),
-        static=True,
-        recording=recording,
-    )

--- a/packages/prompt-da/src/rerun_prompt_da/apis/polycam_compare.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/polycam_compare.py
@@ -1,0 +1,218 @@
+"""Side-by-side PromptDA teacher vs ZipDepth-PromptDA student on a Polycam capture.
+
+Runs both depth models over the same frames with the same LiDAR prompt and logs
+RGB, both predictions, and their absolute difference to Rerun for visual
+inspection. The student is the distilled 6.14 M-parameter model; the teacher is
+the 340 M-parameter PromptDA-large TensorRT engine that produced its training
+labels.
+
+Preprocessing mirrors the training pipeline exactly: RGB is resized with
+``cv2.INTER_LINEAR`` and prompt pixels failing the confidence or range test are
+zeroed before the student sees them.
+"""
+
+import time
+from dataclasses import dataclass, field
+from itertools import batched, chain
+from pathlib import Path
+
+import cv2
+import numpy as np
+import rerun as rr
+import rerun.blueprint as rrb
+import torch
+from jaxtyping import Bool, Float32, UInt8, UInt16
+from monopriors.models.depth_completion.zipdepth_prompt import ZipDepthPrompt, load_zipdepth_prompt
+from numpy import ndarray
+from simplecv.data.polycam import PolycamData, PolycamDataset, load_polycam_data
+from simplecv.rerun_log_utils import RerunTyroConfig
+from torch import Tensor
+from tqdm import tqdm
+
+from rerun_prompt_da.apis.prompt_da_trt_polycam import network_image_hw
+from rerun_prompt_da.trt_predictor import PromptDATrtPredictor
+
+PROMPT_MIN_DEPTH_MM: int = 100
+"""Shortest prompt depth the student was trained to trust, in millimetres."""
+PROMPT_MAX_DEPTH_MM: int = 4000
+"""Furthest prompt depth the student was trained to trust, in millimetres."""
+
+
+@dataclass
+class PolycamCompareConfig:
+    """Runtime configuration for the teacher-versus-student Polycam comparison."""
+
+    polycam_zip_path: Path
+    """Polycam capture zip (or extracted directory) to process."""
+    zipdepth_checkpoint: Path
+    """Trained ZipDepth-PromptDA checkpoint to evaluate against the teacher."""
+    rr_config: RerunTyroConfig = field(default_factory=RerunTyroConfig)
+    """Rerun viewer/save/connect behavior."""
+    batch_size: int = 8
+    """Frames per model batch."""
+    max_image_size: int = 1008
+    """Longest teacher network image side; 14-aligned from the capture resolution."""
+    student_height: int = 768
+    """Student network input height; 768 matches the training resolution."""
+    student_width: int = 1024
+    """Student network input width; 1024 matches the training resolution."""
+    max_frames: int | None = None
+    """Optional cap on processed frames, for a quick visual check."""
+
+
+def masked_prompt_metres(polycam_data: PolycamData) -> Float32[ndarray, "192 256"]:
+    """Return the LiDAR prompt in metres with untrusted pixels zeroed.
+
+    Mirrors ``zipdepth.catalog.targets._prompt_tensors`` so the student sees the
+    same prompt distribution it was trained on: confidence above LOW, depth
+    inside 0.1--4.0 m, everything else zero.
+
+    Args:
+        polycam_data: One decoded Polycam frame.
+
+    Returns:
+        Float32 prompt depth in metres with shape ``(192, 256)``.
+    """
+    prompt_depth_mm_hw: UInt16[ndarray, "192 256"] = polycam_data.original_depth_hw
+    prompt_confidence_hw: UInt8[ndarray, "192 256"] = polycam_data.original_confidence_hw
+    prompt_valid_hw: Bool[ndarray, "192 256"] = (
+        (prompt_confidence_hw >= 1) & (prompt_depth_mm_hw >= PROMPT_MIN_DEPTH_MM) & (prompt_depth_mm_hw <= PROMPT_MAX_DEPTH_MM)
+    )
+    prompt_depth_m_hw: Float32[ndarray, "192 256"] = prompt_depth_mm_hw.astype(np.float32) / 1000.0
+    return np.where(prompt_valid_hw, prompt_depth_m_hw, np.float32(0.0))
+
+
+def create_compare_blueprint(parent_log_path: Path) -> rrb.Blueprint:
+    """Lay out RGB, both predictions, and their difference for visual comparison."""
+    pinhole_path: Path = parent_log_path / "cam" / "pinhole"
+    return rrb.Blueprint(
+        rrb.Vertical(
+            rrb.Horizontal(
+                rrb.Spatial2DView(origin=str(pinhole_path / "rgb"), name="RGB"),
+                rrb.Spatial2DView(origin=str(pinhole_path / "abs_diff"), name="|teacher - student|"),
+            ),
+            rrb.Horizontal(
+                rrb.Spatial2DView(origin=str(pinhole_path / "teacher_depth"), name="PromptDA-large (teacher)"),
+                rrb.Spatial2DView(origin=str(pinhole_path / "student_depth"), name="ZipDepth-PromptDA (student)"),
+            ),
+        ),
+        collapse_panels=True,
+    )
+
+
+def polycam_compare(config: PolycamCompareConfig) -> None:
+    """Run teacher and student over one Polycam capture and stream both to Rerun."""
+    parent_log_path: Path = Path("world")
+    pinhole_path: Path = parent_log_path / "cam" / "pinhole"
+    rr.log("/", rr.ViewCoordinates.RUB, static=True)
+    rr.send_blueprint(create_compare_blueprint(parent_log_path))
+
+    polycam_dataset: PolycamDataset = load_polycam_data(polycam_zip_or_directory_path=config.polycam_zip_path)
+    student_hw: tuple[int, int] = (config.student_height, config.student_width)
+
+    batches = batched(polycam_dataset, config.batch_size)
+    first_batch: tuple[PolycamData, ...] | None = next(batches, None)
+    if first_batch is None:
+        raise ValueError(f"Polycam capture {config.polycam_zip_path} contains no frames.")
+
+    teacher_hw: tuple[int, int] = network_image_hw(first_batch[0].rgb_hw3.shape[:2], config.max_image_size)
+    teacher = PromptDATrtPredictor(model_type="large", image_hw=teacher_hw, batch_size=config.batch_size)
+    student: ZipDepthPrompt = load_zipdepth_prompt(config.zipdepth_checkpoint).cuda().eval()
+
+    frame_budget: int = config.max_frames if config.max_frames is not None else len(polycam_dataset)
+    total_batches: int = -(-min(frame_budget, len(polycam_dataset)) // config.batch_size)
+
+    n_frames: int = 0
+    teacher_seconds: float = 0.0
+    student_seconds: float = 0.0
+    abs_diff_sum: float = 0.0
+    abs_diff_count: int = 0
+    wall_start: float = time.perf_counter()
+
+    progress = tqdm(chain([first_batch], batches), desc="Comparing", total=total_batches)
+    batch: tuple[PolycamData, ...]
+    for batch in progress:
+        if n_frames >= frame_budget:
+            break
+        batch_start: int = n_frames
+        n_frames += len(batch)
+
+        # The teacher gets the RAW prompt and the student the confidence-masked
+        # one. PromptDA normalizes by the prompt's own min/max with no mask and
+        # no epsilon, so zeroed holes drag its minimum to 0 and corrupt the
+        # prediction; the student was trained on the masked prompt and expects it.
+        raw_prompt_bhw: Float32[Tensor, "b 192 256"] = torch.from_numpy(
+            np.stack([data.original_depth_hw for data in batch]).astype(np.float32) / 1000.0
+        ).cuda()
+        masked_prompt_bhw: Float32[Tensor, "b 192 256"] = torch.from_numpy(
+            np.stack([masked_prompt_metres(data) for data in batch])
+        ).cuda()
+        rgb_bhw3: UInt8[Tensor, "b h w 3"] = torch.from_numpy(np.stack([data.rgb_hw3 for data in batch])).cuda()
+
+        torch.cuda.synchronize()
+        teacher_start: float = time.perf_counter()
+        teacher_depth_bhw: Float32[Tensor, "b th tw"] = teacher(rgb_bhw3, raw_prompt_bhw)
+        torch.cuda.synchronize()
+        teacher_seconds += time.perf_counter() - teacher_start
+
+        # The student runs at its training resolution; RGB is resized the same
+        # way the training transform did, on the host with cv2.INTER_LINEAR.
+        student_rgb_b3hw: UInt8[Tensor, "b 3 sh sw"] = torch.from_numpy(
+            np.ascontiguousarray(
+                np.stack([cv2.resize(data.rgb_hw3, (student_hw[1], student_hw[0]), interpolation=cv2.INTER_LINEAR) for data in batch]).transpose(
+                    0, 3, 1, 2
+                )
+            )
+        ).cuda()
+
+        torch.cuda.synchronize()
+        student_start: float = time.perf_counter()
+        with torch.inference_mode():
+            student_depth_b1hw: Float32[Tensor, "b 1 sh sw"] = student(student_rgb_b3hw, masked_prompt_bhw.unsqueeze(1))
+        torch.cuda.synchronize()
+        student_seconds += time.perf_counter() - student_start
+
+        # Compare on the student's grid: resize the teacher down rather than
+        # upsampling the student, so the student is never flattered by interpolation.
+        teacher_on_student_b1hw: Float32[Tensor, "b 1 sh sw"] = torch.nn.functional.interpolate(
+            teacher_depth_bhw.unsqueeze(1), size=student_hw, mode="bilinear", align_corners=False
+        )
+        abs_diff_b1hw: Float32[Tensor, "b 1 sh sw"] = (teacher_on_student_b1hw - student_depth_b1hw).abs()
+        abs_diff_sum += float(abs_diff_b1hw.sum().item())
+        abs_diff_count += int(abs_diff_b1hw.numel())
+
+        teacher_mm_bhw: UInt16[ndarray, "b sh sw"] = (
+            (teacher_on_student_b1hw.squeeze(1) * 1000.0).clamp(0.0, 65535.0).to(torch.uint16).cpu().numpy()
+        )
+        student_mm_bhw: UInt16[ndarray, "b sh sw"] = (
+            (student_depth_b1hw.squeeze(1) * 1000.0).clamp(0.0, 65535.0).to(torch.uint16).cpu().numpy()
+        )
+        diff_mm_bhw: UInt16[ndarray, "b sh sw"] = (abs_diff_b1hw.squeeze(1) * 1000.0).clamp(0.0, 65535.0).to(torch.uint16).cpu().numpy()
+
+        frame_offset: int
+        for frame_offset in range(len(batch)):
+            rr.set_time("frame_idx", sequence=batch_start + frame_offset)
+            rr.log(
+                str(pinhole_path / "rgb"),
+                rr.Image(cv2.resize(batch[frame_offset].rgb_hw3, (student_hw[1], student_hw[0]), interpolation=cv2.INTER_LINEAR)),
+            )
+            rr.log(str(pinhole_path / "teacher_depth"), rr.DepthImage(teacher_mm_bhw[frame_offset], meter=1000.0, colormap="Viridis"))
+            rr.log(str(pinhole_path / "student_depth"), rr.DepthImage(student_mm_bhw[frame_offset], meter=1000.0, colormap="Viridis"))
+            rr.log(
+                str(pinhole_path / "abs_diff"),
+                rr.DepthImage(diff_mm_bhw[frame_offset], meter=1000.0, colormap="Inferno", depth_range=(0.0, 250.0)),
+            )
+
+    wall_seconds: float = time.perf_counter() - wall_start
+    mean_abs_diff_m: float = abs_diff_sum / abs_diff_count if abs_diff_count else 0.0
+    print(f"frames                {n_frames}")
+    print(f"teacher (PromptDA-L)  {1000.0 * teacher_seconds / n_frames:.2f} ms/frame")
+    print(f"student (ZipDepth-PDA){1000.0 * student_seconds / n_frames:.2f} ms/frame")
+    print(f"speedup               {teacher_seconds / student_seconds:.1f}x")
+    print(f"mean |teacher-student| {1000.0 * mean_abs_diff_m:.1f} mm")
+    print(f"wall                  {wall_seconds:.1f} s")
+
+
+def main(config: PolycamCompareConfig) -> None:
+    """Entry point for the Polycam teacher-versus-student comparison."""
+    polycam_compare(config)

--- a/packages/prompt-da/src/rerun_prompt_da/apis/polycam_compare.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/polycam_compare.py
@@ -64,11 +64,15 @@ def create_compare_blueprint(parent_log_path: Path) -> rrb.Blueprint:
             rrb.Horizontal(
                 rrb.Spatial2DView(origin=str(pinhole_path / "rgb"), name="RGB (768x1024)"),
                 rrb.Spatial2DView(origin=str(pinhole_path / "lidar_prompt"), name="LiDAR prompt (192x256)"),
-                rrb.Spatial2DView(origin=str(pinhole_path / "abs_diff"), name="|teacher - student|"),
             ),
             rrb.Horizontal(
-                rrb.Spatial2DView(origin=str(pinhole_path / "teacher_depth"), name="PromptDA-large (teacher)"),
-                rrb.Spatial2DView(origin=str(pinhole_path / "student_depth"), name="ZipDepth-PromptDA (student)"),
+                rrb.Spatial2DView(origin=str(pinhole_path / "teacher_depth"), name="PromptDA-large (teacher, 340M)"),
+                rrb.Spatial2DView(origin=str(pinhole_path / "student_depth"), name="ZipDepth-PromptDA (student, 6.95M)"),
+                rrb.Spatial2DView(origin=str(pinhole_path / "bilinear_depth"), name="bilinear upsample (0 params)"),
+            ),
+            rrb.Horizontal(
+                rrb.Spatial2DView(origin=str(pinhole_path / "abs_diff"), name="|teacher - student|"),
+                rrb.Spatial2DView(origin=str(pinhole_path / "abs_diff_bilinear"), name="|teacher - bilinear|"),
             ),
         ),
         collapse_panels=True,
@@ -101,6 +105,7 @@ def polycam_compare(config: PolycamCompareConfig) -> None:
     teacher_seconds: float = 0.0
     student_seconds: float = 0.0
     abs_diff_sum: float = 0.0
+    bilinear_sum: float = 0.0
     abs_diff_count: int = 0
     wall_start: float = time.perf_counter()
 
@@ -149,7 +154,14 @@ def polycam_compare(config: PolycamCompareConfig) -> None:
         teacher_on_student_b1hw: Float32[Tensor, "b 1 sh sw"] = torch.nn.functional.interpolate(
             teacher_depth_bhw.unsqueeze(1), size=student_hw, mode="bilinear", align_corners=False
         )
+        # Zero-parameter control: bilinearly upsample the same raw prompt. Logged beside
+        # the student so the difference the network actually buys is visible, not asserted.
+        bilinear_b1hw: Float32[Tensor, "b 1 sh sw"] = torch.nn.functional.interpolate(
+            raw_prompt_bhw.unsqueeze(1), size=student_hw, mode="bilinear", align_corners=False
+        )
         abs_diff_b1hw: Float32[Tensor, "b 1 sh sw"] = (teacher_on_student_b1hw - student_depth_b1hw).abs()
+        abs_diff_bilinear_b1hw: Float32[Tensor, "b 1 sh sw"] = (teacher_on_student_b1hw - bilinear_b1hw).abs()
+        bilinear_sum += float(abs_diff_bilinear_b1hw.sum().item())
         abs_diff_sum += float(abs_diff_b1hw.sum().item())
         abs_diff_count += int(abs_diff_b1hw.numel())
 
@@ -160,6 +172,10 @@ def polycam_compare(config: PolycamCompareConfig) -> None:
             (student_depth_b1hw.squeeze(1) * 1000.0).clamp(0.0, 65535.0).to(torch.uint16).cpu().numpy()
         )
         diff_mm_bhw: UInt16[ndarray, "b sh sw"] = (abs_diff_b1hw.squeeze(1) * 1000.0).clamp(0.0, 65535.0).to(torch.uint16).cpu().numpy()
+        bilinear_mm_bhw: UInt16[ndarray, "b sh sw"] = (bilinear_b1hw.squeeze(1) * 1000.0).clamp(0.0, 65535.0).to(torch.uint16).cpu().numpy()
+        diff_bil_mm_bhw: UInt16[ndarray, "b sh sw"] = (
+            (abs_diff_bilinear_b1hw.squeeze(1) * 1000.0).clamp(0.0, 65535.0).to(torch.uint16).cpu().numpy()
+        )
         # The raw prompt is what the teacher sees; it is the model's only source
         # of metric scale, so log it at its native 192x256 beside the predictions.
         prompt_mm_bhw: UInt16[ndarray, "b 192 256"] = np.stack([data.original_depth_hw for data in batch])
@@ -178,8 +194,16 @@ def polycam_compare(config: PolycamCompareConfig) -> None:
             rr.log(str(pinhole_path / "teacher_depth"), rr.DepthImage(teacher_mm_bhw[frame_offset], meter=1000.0, colormap="Viridis"))
             rr.log(str(pinhole_path / "student_depth"), rr.DepthImage(student_mm_bhw[frame_offset], meter=1000.0, colormap="Viridis"))
             rr.log(
+                str(pinhole_path / "bilinear_depth"),
+                rr.DepthImage(bilinear_mm_bhw[frame_offset], meter=1000.0, colormap="Viridis"),
+            )
+            rr.log(
                 str(pinhole_path / "abs_diff"),
                 rr.DepthImage(diff_mm_bhw[frame_offset], meter=1000.0, colormap="Inferno", depth_range=(0.0, 250.0)),
+            )
+            rr.log(
+                str(pinhole_path / "abs_diff_bilinear"),
+                rr.DepthImage(diff_bil_mm_bhw[frame_offset], meter=1000.0, colormap="Inferno", depth_range=(0.0, 250.0)),
             )
 
     wall_seconds: float = time.perf_counter() - wall_start
@@ -188,7 +212,8 @@ def polycam_compare(config: PolycamCompareConfig) -> None:
     print(f"teacher (PromptDA-L)  {1000.0 * teacher_seconds / n_frames:.2f} ms/frame")
     print(f"student (ZipDepth-PDA){1000.0 * student_seconds / n_frames:.2f} ms/frame")
     print(f"speedup               {teacher_seconds / student_seconds:.1f}x")
-    print(f"mean |teacher-student| {1000.0 * mean_abs_diff_m:.1f} mm")
+    print(f"mean |teacher-student|  {1000.0 * mean_abs_diff_m:.1f} mm")
+    print(f"mean |teacher-bilinear| {1000.0 * bilinear_sum / abs_diff_count:.1f} mm  (zero-parameter control)")
     print(f"wall                  {wall_seconds:.1f} s")
 
 

--- a/packages/prompt-da/src/rerun_prompt_da/apis/polycam_compare.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/polycam_compare.py
@@ -83,12 +83,13 @@ def masked_prompt_metres(polycam_data: PolycamData) -> Float32[ndarray, "192 256
 
 
 def create_compare_blueprint(parent_log_path: Path) -> rrb.Blueprint:
-    """Lay out RGB, both predictions, and their difference for visual comparison."""
+    """Lay out RGB, the LiDAR prompt, both predictions, and their difference."""
     pinhole_path: Path = parent_log_path / "cam" / "pinhole"
     return rrb.Blueprint(
         rrb.Vertical(
             rrb.Horizontal(
-                rrb.Spatial2DView(origin=str(pinhole_path / "rgb"), name="RGB"),
+                rrb.Spatial2DView(origin=str(pinhole_path / "rgb"), name="RGB (768x1024)"),
+                rrb.Spatial2DView(origin=str(pinhole_path / "lidar_prompt"), name="LiDAR prompt (192x256)"),
                 rrb.Spatial2DView(origin=str(pinhole_path / "abs_diff"), name="|teacher - student|"),
             ),
             rrb.Horizontal(
@@ -188,6 +189,9 @@ def polycam_compare(config: PolycamCompareConfig) -> None:
             (student_depth_b1hw.squeeze(1) * 1000.0).clamp(0.0, 65535.0).to(torch.uint16).cpu().numpy()
         )
         diff_mm_bhw: UInt16[ndarray, "b sh sw"] = (abs_diff_b1hw.squeeze(1) * 1000.0).clamp(0.0, 65535.0).to(torch.uint16).cpu().numpy()
+        # The raw prompt is what the teacher sees; it is the model's only source
+        # of metric scale, so log it at its native 192x256 beside the predictions.
+        prompt_mm_bhw: UInt16[ndarray, "b 192 256"] = np.stack([data.original_depth_hw for data in batch])
 
         frame_offset: int
         for frame_offset in range(len(batch)):
@@ -195,6 +199,10 @@ def polycam_compare(config: PolycamCompareConfig) -> None:
             rr.log(
                 str(pinhole_path / "rgb"),
                 rr.Image(cv2.resize(batch[frame_offset].rgb_hw3, (student_hw[1], student_hw[0]), interpolation=cv2.INTER_LINEAR)),
+            )
+            rr.log(
+                str(pinhole_path / "lidar_prompt"),
+                rr.DepthImage(prompt_mm_bhw[frame_offset], meter=1000.0, colormap="Viridis"),
             )
             rr.log(str(pinhole_path / "teacher_depth"), rr.DepthImage(teacher_mm_bhw[frame_offset], meter=1000.0, colormap="Viridis"))
             rr.log(str(pinhole_path / "student_depth"), rr.DepthImage(student_mm_bhw[frame_offset], meter=1000.0, colormap="Viridis"))

--- a/packages/prompt-da/src/rerun_prompt_da/apis/polycam_compare.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/polycam_compare.py
@@ -6,9 +6,9 @@ inspection. The student is the distilled 6.14 M-parameter model; the teacher is
 the 340 M-parameter PromptDA-large TensorRT engine that produced its training
 labels.
 
-Preprocessing mirrors the training pipeline exactly: RGB is resized with
-``cv2.INTER_LINEAR`` and prompt pixels failing the confidence or range test are
-zeroed before the student sees them.
+Both models receive the same raw LiDAR prompt -- distillation is only meaningful
+when student and teacher see identical input. RGB resizing mirrors the training
+transform (``cv2.INTER_LINEAR``).
 """
 
 import time
@@ -21,7 +21,7 @@ import numpy as np
 import rerun as rr
 import rerun.blueprint as rrb
 import torch
-from jaxtyping import Bool, Float32, UInt8, UInt16
+from jaxtyping import Float32, UInt8, UInt16
 from monopriors.models.depth_completion.zipdepth_prompt import ZipDepthPrompt, load_zipdepth_prompt
 from numpy import ndarray
 from simplecv.data.polycam import PolycamData, PolycamDataset, load_polycam_data
@@ -31,11 +31,6 @@ from tqdm import tqdm
 
 from rerun_prompt_da.apis.prompt_da_trt_polycam import network_image_hw
 from rerun_prompt_da.trt_predictor import PromptDATrtPredictor
-
-PROMPT_MIN_DEPTH_MM: int = 100
-"""Shortest prompt depth the student was trained to trust, in millimetres."""
-PROMPT_MAX_DEPTH_MM: int = 4000
-"""Furthest prompt depth the student was trained to trust, in millimetres."""
 
 
 @dataclass
@@ -59,27 +54,6 @@ class PolycamCompareConfig:
     max_frames: int | None = None
     """Optional cap on processed frames, for a quick visual check."""
 
-
-def masked_prompt_metres(polycam_data: PolycamData) -> Float32[ndarray, "192 256"]:
-    """Return the LiDAR prompt in metres with untrusted pixels zeroed.
-
-    Mirrors ``zipdepth.catalog.targets._prompt_tensors`` so the student sees the
-    same prompt distribution it was trained on: confidence above LOW, depth
-    inside 0.1--4.0 m, everything else zero.
-
-    Args:
-        polycam_data: One decoded Polycam frame.
-
-    Returns:
-        Float32 prompt depth in metres with shape ``(192, 256)``.
-    """
-    prompt_depth_mm_hw: UInt16[ndarray, "192 256"] = polycam_data.original_depth_hw
-    prompt_confidence_hw: UInt8[ndarray, "192 256"] = polycam_data.original_confidence_hw
-    prompt_valid_hw: Bool[ndarray, "192 256"] = (
-        (prompt_confidence_hw >= 1) & (prompt_depth_mm_hw >= PROMPT_MIN_DEPTH_MM) & (prompt_depth_mm_hw <= PROMPT_MAX_DEPTH_MM)
-    )
-    prompt_depth_m_hw: Float32[ndarray, "192 256"] = prompt_depth_mm_hw.astype(np.float32) / 1000.0
-    return np.where(prompt_valid_hw, prompt_depth_m_hw, np.float32(0.0))
 
 
 def create_compare_blueprint(parent_log_path: Path) -> rrb.Blueprint:
@@ -138,15 +112,12 @@ def polycam_compare(config: PolycamCompareConfig) -> None:
         batch_start: int = n_frames
         n_frames += len(batch)
 
-        # The teacher gets the RAW prompt and the student the confidence-masked
-        # one. PromptDA normalizes by the prompt's own min/max with no mask and
-        # no epsilon, so zeroed holes drag its minimum to 0 and corrupt the
-        # prediction; the student was trained on the masked prompt and expects it.
+        # Both models get the same RAW prompt. Distillation only makes sense when
+        # student and teacher see identical input, and PromptDA normalizes by the
+        # prompt's own min/max with no mask -- zeroed holes would drag its minimum
+        # to 0 and corrupt the teacher.
         raw_prompt_bhw: Float32[Tensor, "b 192 256"] = torch.from_numpy(
             np.stack([data.original_depth_hw for data in batch]).astype(np.float32) / 1000.0
-        ).cuda()
-        masked_prompt_bhw: Float32[Tensor, "b 192 256"] = torch.from_numpy(
-            np.stack([masked_prompt_metres(data) for data in batch])
         ).cuda()
         rgb_bhw3: UInt8[Tensor, "b h w 3"] = torch.from_numpy(np.stack([data.rgb_hw3 for data in batch])).cuda()
 
@@ -169,7 +140,7 @@ def polycam_compare(config: PolycamCompareConfig) -> None:
         torch.cuda.synchronize()
         student_start: float = time.perf_counter()
         with torch.inference_mode():
-            student_depth_b1hw: Float32[Tensor, "b 1 sh sw"] = student(student_rgb_b3hw, masked_prompt_bhw.unsqueeze(1))
+            student_depth_b1hw: Float32[Tensor, "b 1 sh sw"] = student(student_rgb_b3hw, raw_prompt_bhw.unsqueeze(1))
         torch.cuda.synchronize()
         student_seconds += time.perf_counter() - student_start
 

--- a/packages/prompt-da/src/rerun_prompt_da/apis/polycam_trio.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/polycam_trio.py
@@ -1,0 +1,372 @@
+"""Three-way Polycam comparison: raw ARKit LiDAR, PromptDA-large, and ZipDepth-PromptDA.
+
+Runs both depth models over the same frames with the same raw prompt and fuses
+each depth source into its own TSDF volume, so the three reconstructions can be
+compared as geometry rather than only as depth images. Accumulated depth error
+shows up in a mesh in ways a per-frame depth view hides.
+
+The raw ARKit stream is the device's own upsampled depth -- the baseline any
+phone gives you for free, and the thing both models have to beat.
+"""
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from itertools import batched, chain
+from pathlib import Path
+
+import cv2
+import numpy as np
+import rerun as rr
+import rerun.blueprint as rrb
+import torch
+from einops import rearrange
+from jaxtyping import Float32, UInt8, UInt16
+from monopriors.models.depth_completion.zipdepth_prompt import ZipDepthPrompt, load_zipdepth_prompt
+from numpy import ndarray
+from simplecv.camera_parameters import rescale_intri
+from simplecv.data.polycam import DepthConfidenceLevel, PolycamData, PolycamDataset, load_polycam_data
+from simplecv.ops.tsdf_depth_fuser import Open3DFuser
+from simplecv.rerun_log_utils import RerunTyroConfig, log_pinhole
+from torch import Tensor
+from tqdm import tqdm
+
+from rerun_prompt_da.apis.prompt_da_polycam import filter_depth
+from rerun_prompt_da.apis.prompt_da_trt_polycam import network_image_hw
+from rerun_prompt_da.mesh_logging import log_fused_mesh
+from rerun_prompt_da.trt_predictor import PromptDATrtPredictor
+
+SOURCES: tuple[str, str, str] = ("arkit", "promptda", "zipdepth")
+"""Depth sources compared, in increasing order of expected quality."""
+
+
+@dataclass
+class PolycamTrioConfig:
+    """Runtime configuration for the three-way Polycam comparison."""
+
+    polycam_zip_path: Path
+    """Polycam capture zip (or extracted directory) to process."""
+    zipdepth_checkpoint: Path
+    """Trained ZipDepth-PromptDA checkpoint; also the PyTorch fallback when no engine is given."""
+    zipdepth_engine: Path | None = None
+    """Static-batch TensorRT fp16 engine for the student, built by ``zipdepth-export-prompted-trt``.
+
+    Parity against PyTorch is 0.003 mm at the 95th percentile -- four orders of magnitude
+    below the model's own ~22 mm error -- so running the engine costs nothing in fidelity
+    and makes the timing comparison against the TensorRT teacher apples-to-apples."""
+    rr_config: RerunTyroConfig = field(default_factory=RerunTyroConfig)
+    """Rerun viewer/save/connect behavior."""
+    batch_size: int = 8
+    """Frames per model batch."""
+    max_image_size: int = 1008
+    """Longest PromptDA network image side; 14-aligned from the capture resolution."""
+    max_depth_range_meter: float = 4.0
+    """Depth beyond this is dropped before TSDF fusion."""
+    depth_fusion_resolution: float = 0.04
+    """TSDF voxel size in metres."""
+    max_frames: int | None = None
+    """Optional cap on processed frames."""
+    log_incremental_mesh: bool = False
+    """Log all three fused meshes after every batch instead of only at the end.
+
+    Shows the reconstructions growing as the capture is walked, which makes it obvious
+    where each source starts accumulating drift. Costs one mesh upload per source per
+    batch, so the recording is substantially larger."""
+
+
+ERROR_RANGE_MM: tuple[float, float] = (0.0, 250.0)
+"""Shared colour range for both error panes, so they read against each other."""
+SPIN_SPEED: float = 0.25
+"""Orbital spin applied to every mesh view, so all three rotate together and the
+reconstructions can be compared from the same angle without manual navigation."""
+
+
+def create_trio_blueprint(parent_log_path: Path) -> rrb.Blueprint:
+    """Lay out the fused meshes, plus a tab comparing each source against the teacher."""
+    pinhole_path: Path = parent_log_path / "cam" / "pinhole"
+    lowres_path: Path = parent_log_path / "cam" / "pinhole_lowres"
+    return rrb.Blueprint(
+        rrb.Tabs(
+            _mesh_tab(parent_log_path, pinhole_path, lowres_path),
+            _comparison_tab(pinhole_path, lowres_path),
+        ),
+        collapse_panels=True,
+    )
+
+
+def _comparison_tab(pinhole_path: Path, lowres_path: Path) -> rrb.Vertical:
+    """Two rows against a common reference: the teacher.
+
+    Row 2 is the size of the problem -- everything PromptDA changes about the raw ARKit
+    depth. Row 1 is the student's residual -- the part of that correction it did not
+    reproduce. Both error panes share one scale, so they read directly against each other.
+    """
+    return rrb.Vertical(
+        rrb.Horizontal(
+            rrb.Spatial2DView(origin=str(lowres_path / "arkit_depth"), name="raw ARKit LiDAR (192x256, native)"),
+            rrb.Spatial2DView(origin=str(pinhole_path / "zipdepth_depth"), name="ZipDepth-PromptDA (6.95M)"),
+            rrb.Spatial2DView(origin=str(pinhole_path / "err_student"), name="|ZipDepth - PromptDA|  (student residual)"),
+        ),
+        rrb.Horizontal(
+            rrb.Spatial2DView(origin=str(lowres_path / "arkit_depth"), name="raw ARKit LiDAR (192x256, native)"),
+            rrb.Spatial2DView(origin=str(pinhole_path / "promptda_depth"), name="PromptDA-large (DAv2, 340M)"),
+            rrb.Spatial2DView(origin=str(lowres_path / "err_arkit"), name="|ARKit - PromptDA|  (what the teacher fixes)"),
+        ),
+        name="side by side",
+    )
+
+
+def _mesh_tab(parent_log_path: Path, pinhole_path: Path, lowres_path: Path) -> rrb.Horizontal:
+    """The fused reconstructions beside the raw depth streams."""
+    return rrb.Horizontal(
+            rrb.Vertical(
+                rrb.Spatial3DView(
+                    origin=str(parent_log_path / "arkit"),
+                    contents=["$origin/**", str(parent_log_path / "cam") + "/**"],
+                    name="mesh: raw ARKit LiDAR (192x256)",
+                    eye_controls=rrb.EyeControls3D(kind=rrb.Eye3DKind.Orbital, spin_speed=SPIN_SPEED),
+                ),
+                rrb.Spatial3DView(
+                    origin=str(parent_log_path / "promptda"),
+                    contents=["$origin/**", str(parent_log_path / "cam") + "/**"],
+                    name="mesh: PromptDA-large (DAv2, 340M)",
+                    eye_controls=rrb.EyeControls3D(kind=rrb.Eye3DKind.Orbital, spin_speed=SPIN_SPEED),
+                ),
+                rrb.Spatial3DView(
+                    origin=str(parent_log_path / "zipdepth"),
+                    contents=["$origin/**", str(parent_log_path / "cam") + "/**"],
+                    name="mesh: ZipDepth-PromptDA (6.95M)",
+                    eye_controls=rrb.EyeControls3D(kind=rrb.Eye3DKind.Orbital, spin_speed=SPIN_SPEED),
+                ),
+            ),
+            rrb.Vertical(
+                rrb.Spatial2DView(origin=str(pinhole_path / "image"), name="RGB"),
+                rrb.Spatial2DView(origin=str(lowres_path / "confidence"), name="ARKit confidence (192x256)"),
+                rrb.Spatial2DView(origin=str(lowres_path / "arkit_depth"), name="raw ARKit LiDAR (192x256, native)"),
+                rrb.Spatial2DView(origin=str(pinhole_path / "promptda_depth"), name="PromptDA-large"),
+                rrb.Spatial2DView(origin=str(pinhole_path / "zipdepth_depth"), name="ZipDepth-PromptDA"),
+            ),
+        column_shares=[3, 2],
+        name="meshes",
+    )
+
+
+def _log_source_mesh(parent_log_path: Path, source: str, fuser: Open3DFuser) -> None:
+    """Log one source's fused TSDF mesh under its own entity, at the current time."""
+    mesh = fuser.get_mesh()
+    mesh.compute_vertex_normals()
+    log_fused_mesh(None, str(parent_log_path / source / "mesh"), mesh, static=False)
+
+
+def polycam_trio(config: PolycamTrioConfig) -> None:
+    """Fuse and log raw ARKit, PromptDA, and ZipDepth-PromptDA depth for one capture."""
+    parent_log_path: Path = Path("world")
+    pinhole_path: Path = parent_log_path / "cam" / "pinhole"
+    lowres_path: Path = parent_log_path / "cam" / "pinhole_lowres"
+    rr.log("/", rr.ViewCoordinates.RUB, static=True)
+    rr.send_blueprint(create_trio_blueprint(parent_log_path))
+    rr.log(
+        str(lowres_path / "confidence"),
+        rr.AnnotationContext(
+            [
+                rr.AnnotationInfo(id=0, label="low", color=(220, 40, 40)),
+                rr.AnnotationInfo(id=1, label="medium", color=(235, 200, 40)),
+                rr.AnnotationInfo(id=2, label="high", color=(60, 200, 90)),
+            ]
+        ),
+        static=True,
+    )
+
+    dataset: PolycamDataset = load_polycam_data(polycam_zip_or_directory_path=config.polycam_zip_path)
+    fusers: dict[str, Open3DFuser] = {
+        source: Open3DFuser(fusion_resolution=config.depth_fusion_resolution, max_fusion_depth=config.max_depth_range_meter)
+        for source in SOURCES
+    }
+
+    batches = batched(dataset, config.batch_size)
+    first_batch: tuple[PolycamData, ...] | None = next(batches, None)
+    if first_batch is None:
+        raise ValueError(f"Polycam capture {config.polycam_zip_path} contains no frames.")
+
+    # The raw LiDAR is a fixed 192x256 per PolycamData; one static scale transform maps
+    # its 2D frame onto the full-res image (the posekit SAM2-mask pattern, track_ui.py).
+    native_hw: tuple[int, int] = first_batch[0].original_depth_hw.shape
+    native_scale: float = first_batch[0].rgb_hw3.shape[1] / native_hw[1]
+    rr.log(str(lowres_path), rr.Transform3D(scale=native_scale), static=True)
+
+    capture_hw: tuple[int, int] = first_batch[0].rgb_hw3.shape[:2]
+    teacher = PromptDATrtPredictor(
+        model_type="large",
+        image_hw=network_image_hw(capture_hw, config.max_image_size),
+        batch_size=config.batch_size,
+    )
+    # Both closures take BHW3 and do their own layout work INSIDE, so the timing
+    # brackets measure the same preprocessing for student and teacher alike.
+    student_backend: str
+    predict_student: Callable[[UInt8[Tensor, "b h w 3"], Float32[Tensor, "b 1 192 256"]], Float32[Tensor, "b 1 h w"]]
+    if config.zipdepth_engine is None:
+        # fuse_for_inference folds the RepVGG branches, matching how eval_catalog.py
+        # and the TRT export run the model; unfused eager understates its speed.
+        student: ZipDepthPrompt = load_zipdepth_prompt(config.zipdepth_checkpoint).cuda().fuse_for_inference()
+
+        def predict_student(rgb_bhw3: UInt8[Tensor, "b h w 3"], prompt_b1hw: Float32[Tensor, "b 1 192 256"]) -> Float32[Tensor, "b 1 h w"]:
+            image_b3hw: UInt8[Tensor, "b 3 h w"] = rearrange(rgb_bhw3, "b h w c -> b c h w").contiguous()  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+            with torch.inference_mode():
+                return student(image_b3hw, prompt_b1hw)
+
+        student_backend = "PyTorch eager"
+    else:
+        from trtkit import TensorRtRuntime
+
+        runtime = TensorRtRuntime(config.zipdepth_engine)
+
+        def predict_student(rgb_bhw3: UInt8[Tensor, "b h w 3"], prompt_b1hw: Float32[Tensor, "b 1 192 256"]) -> Float32[Tensor, "b 1 h w"]:
+            # The engine bakes the uint8->[0,1] scaling the wrapper does in torch.
+            image_b3hw: Float32[Tensor, "b 3 h w"] = rearrange(rgb_bhw3, "b h w c -> b c h w").contiguous().float() / 255.0  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+            outputs = runtime({"image": image_b3hw, "prompt_depth": prompt_b1hw})
+            return outputs["depth"].clone()
+
+        student_backend = "TensorRT fp16"
+
+    frame_budget: int = config.max_frames if config.max_frames is not None else len(dataset)
+    n_frames: int = 0
+    seconds: dict[str, float] = {"promptda": 0.0, "zipdepth": 0.0}
+    wall_start: float = time.perf_counter()
+
+    progress = tqdm(chain([first_batch], batches), desc="Trio", total=-(-min(frame_budget, len(dataset)) // config.batch_size))
+    batch: tuple[PolycamData, ...]
+    for batch in progress:
+        if n_frames >= frame_budget:
+            break
+        batch_start: int = n_frames
+        n_frames += len(batch)
+
+        # Both models see the same RAW prompt: PromptDA normalizes by its own min/max
+        # with no mask, and the student was trained on the raw prompt to match.
+        prompt_bhw: Float32[Tensor, "b 192 256"] = torch.from_numpy(
+            np.stack([data.original_depth_hw for data in batch]).astype(np.float32) / 1000.0
+        ).cuda()
+        rgb_bhw3: UInt8[Tensor, "b h w 3"] = torch.from_numpy(np.stack([data.rgb_hw3 for data in batch])).cuda()
+
+        torch.cuda.synchronize()
+        started: float = time.perf_counter()
+        teacher_bhw: Float32[Tensor, "b h w"] = teacher(rgb_bhw3, prompt_bhw)
+        torch.cuda.synchronize()
+        seconds["promptda"] += time.perf_counter() - started
+
+        torch.cuda.synchronize()
+        started = time.perf_counter()
+        student_bhw: Float32[Tensor, "b h w"] = predict_student(rgb_bhw3, prompt_bhw.unsqueeze(1)).squeeze(1)
+        torch.cuda.synchronize()
+        seconds["zipdepth"] += time.perf_counter() - started
+
+        predicted_mm: dict[str, UInt16[ndarray, "b h w"]] = {
+            "promptda": (teacher_bhw * 1000.0).clamp(0.0, 65535.0).to(torch.uint16).cpu().numpy(),
+            "zipdepth": (student_bhw * 1000.0).clamp(0.0, 65535.0).to(torch.uint16).cpu().numpy(),
+        }
+
+        frame_offset: int
+        polycam_data: PolycamData
+        for frame_offset, polycam_data in enumerate(batch):
+            rr.set_time("frame_idx", sequence=batch_start + frame_offset)
+            k_matrix: Float32[ndarray, "3 3"] | None = polycam_data.pinhole_params.intrinsics.k_matrix
+            if k_matrix is None:
+                raise ValueError("Polycam pinhole intrinsics must include a 3x3 k_matrix for TSDF fusion.")
+
+            log_pinhole(camera=polycam_data.pinhole_params, cam_log_path=parent_log_path / "cam")
+            rr.log(str(pinhole_path / "image"), rr.Image(polycam_data.rgb_hw3).compress(jpeg_quality=75))
+
+            # The raw LiDAR is 192x256. Log and fuse it at that size -- upsampling it first
+            # would flatter the sensor and hide the 16x resolution gap the models close.
+            # A static Transform3D scales its 2D frame onto the full-res image, the same
+            # pattern posekit uses for SAM2 masks (track_ui.py:160).
+            rr.log(
+                str(lowres_path / "arkit_depth"),
+                rr.DepthImage(polycam_data.original_depth_hw, meter=1000.0, colormap="Viridis"),
+            )
+            # Polycam stores confidence as 0/54/255; compact to class ids 0/1/2 so the
+            # annotation context colors apply (red = low, yellow = medium, green = high).
+            confidence_class_hw: UInt8[ndarray, "nh nw"] = (
+                (polycam_data.original_confidence_hw >= DepthConfidenceLevel.MEDIUM).astype(np.uint8)
+                + (polycam_data.original_confidence_hw >= DepthConfidenceLevel.HIGH).astype(np.uint8)
+            )
+            rr.log(str(lowres_path / "confidence"), rr.SegmentationImage(confidence_class_hw))
+
+            # Errors share one reference -- the teacher -- so the two panes read against
+            # each other: row 2 is the correction PromptDA makes to the raw sensor, row 1
+            # is the part of that correction the student did not reproduce. Row 2 is
+            # measured at the sensor's own resolution by pooling the teacher down to it.
+            teacher_full_hw: Float32[ndarray, "h w"] = predicted_mm["promptda"][frame_offset].astype(np.float32)
+            student_error_hw: UInt16[ndarray, "h w"] = (
+                np.abs(predicted_mm["zipdepth"][frame_offset].astype(np.float32) - teacher_full_hw).clip(0.0, 65535.0).astype(np.uint16)
+            )
+            rr.log(
+                str(pinhole_path / "err_student"),
+                rr.DepthImage(student_error_hw, meter=1000.0, colormap="Inferno", depth_range=ERROR_RANGE_MM),
+            )
+            teacher_native_hw: Float32[ndarray, "nh nw"] = cv2.resize(
+                teacher_full_hw, (native_hw[1], native_hw[0]), interpolation=cv2.INTER_AREA
+            )
+            arkit_error_hw: UInt16[ndarray, "nh nw"] = (
+                np.abs(polycam_data.original_depth_hw.astype(np.float32) - teacher_native_hw).clip(0.0, 65535.0).astype(np.uint16)
+            )
+            rr.log(
+                str(lowres_path / "err_arkit"),
+                rr.DepthImage(arkit_error_hw, meter=1000.0, colormap="Inferno", depth_range=ERROR_RANGE_MM),
+            )
+
+            # Each source fuses on its own grid: the models at full resolution, the raw
+            # sensor at 192x256 with matching RGB and rescaled intrinsics, so the ARKit
+            # mesh shows what the LiDAR alone actually reconstructs.
+            native_rgb_hw3: UInt8[ndarray, "nh nw 3"] = cv2.resize(
+                polycam_data.rgb_hw3, (native_hw[1], native_hw[0]), interpolation=cv2.INTER_AREA
+            )
+            native_k_33: Float32[ndarray, "3 3"] | None = rescale_intri(
+                camera_intrinsics=polycam_data.pinhole_params.intrinsics,
+                target_height=native_hw[0],
+                target_width=native_hw[1],
+            ).k_matrix
+            if native_k_33 is None:
+                raise ValueError("rescaled Polycam intrinsics must include a 3x3 k_matrix for native-resolution fusion.")
+            fuse_inputs: dict[str, tuple[UInt16[ndarray, "h w"], UInt8[ndarray, "h w"], Float32[ndarray, "3 3"], UInt8[ndarray, "h w 3"]]] = {
+                "arkit": (polycam_data.original_depth_hw, polycam_data.original_confidence_hw, native_k_33, native_rgb_hw3),
+                "promptda": (predicted_mm["promptda"][frame_offset], polycam_data.confidence_hw, k_matrix, polycam_data.rgb_hw3),
+                "zipdepth": (predicted_mm["zipdepth"][frame_offset], polycam_data.confidence_hw, k_matrix, polycam_data.rgb_hw3),
+            }
+            source: str
+            for source in SOURCES:
+                depth_mm, source_confidence, source_k_33, source_rgb = fuse_inputs[source]
+                if source != "arkit":
+                    rr.log(str(pinhole_path / f"{source}_depth"), rr.DepthImage(depth_mm, meter=1000.0, colormap="Viridis"))
+                fusers[source].fuse_frames(
+                    depth_hw=filter_depth(
+                        depth_mm=depth_mm,
+                        confidence=source_confidence,
+                        confidence_threshold=DepthConfidenceLevel.MEDIUM,
+                        max_depth_meter=config.max_depth_range_meter,
+                    ),
+                    K_33=source_k_33,
+                    cam_T_world_44=polycam_data.pinhole_params.extrinsics.cam_T_world,
+                    rgb_hw3=source_rgb,
+                )
+
+        if config.log_incremental_mesh:
+            for source in SOURCES:
+                _log_source_mesh(parent_log_path, source, fusers[source])
+
+    if not config.log_incremental_mesh:
+        # The incremental path already logged the final state after the last batch.
+        for source in SOURCES:
+            _log_source_mesh(parent_log_path, source, fusers[source])
+
+    wall_seconds: float = time.perf_counter() - wall_start
+    print(f"frames                {n_frames}")
+    print(f"PromptDA-large        {1000.0 * seconds['promptda'] / n_frames:.2f} ms/frame  (TensorRT fp16)")
+    print(f"ZipDepth-PromptDA     {1000.0 * seconds['zipdepth'] / n_frames:.2f} ms/frame  ({student_backend})")
+    print(f"speedup               {seconds['promptda'] / seconds['zipdepth']:.1f}x")
+    print(f"wall                  {wall_seconds:.1f} s  (three TSDF volumes)")
+
+
+def main(config: PolycamTrioConfig) -> None:
+    """Entry point for the three-way Polycam comparison."""
+    polycam_trio(config)

--- a/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_arkitscenes.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_arkitscenes.py
@@ -41,12 +41,12 @@ from rerun_prompt_da.apis.arkitscenes_shared import (
     NATIVE_FPS,
     connect_catalog,
     filter_depth_for_fusion,
-    log_fused_mesh,
     run_promptda_batch,
     segments_to_process,
     stride_for,
 )
 from rerun_prompt_da.apis.prompt_da_trt_polycam import network_image_hw
+from rerun_prompt_da.mesh_logging import log_fused_mesh
 from rerun_prompt_da.promptda_stream import PromptDABatch, PromptDACollate, promptda_dataset
 from rerun_prompt_da.trt_predictor import PromptDATrtPredictor
 

--- a/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_arkitscenes_raw.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_arkitscenes_raw.py
@@ -50,13 +50,13 @@ from rerun_prompt_da.apis.arkitscenes_shared import (
     NATIVE_FPS,
     connect_catalog,
     filter_depth_for_fusion,
-    log_fused_mesh,
     run_promptda_batch,
     segments_to_process,
     stride_for,
     world_t_cam_from_pose,
 )
 from rerun_prompt_da.apis.prompt_da_trt_polycam import network_image_hw
+from rerun_prompt_da.mesh_logging import log_fused_mesh
 from rerun_prompt_da.trt_predictor import PromptDATrtPredictor
 
 PROMPTDA_RAW_LAYER = "promptda_raw"

--- a/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_trt_polycam.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_trt_polycam.py
@@ -15,7 +15,6 @@ import numpy as np
 import rerun as rr
 import torch
 from jaxtyping import Float32, UInt8, UInt16
-from monopriors.models.depth_completion.prompt_da import ensure_multiple_of
 from numpy import ndarray
 from simplecv.data.polycam import (
     DepthConfidenceLevel,
@@ -29,7 +28,7 @@ from torch import Tensor
 from tqdm import tqdm
 
 from rerun_prompt_da.apis.prompt_da_polycam import _log_mesh, create_blueprint, filter_depth, log_polycam_data
-from rerun_prompt_da.trt_predictor import PromptDATrtPredictor
+from rerun_prompt_da.trt_predictor import PromptDATrtPredictor, network_image_hw
 
 
 @dataclass
@@ -52,22 +51,6 @@ class PDATrtPolycamConfig:
     """Log the fused mesh after every batch instead of only at the end."""
 
 
-def network_image_hw(capture_hw: tuple[int, int], max_image_size: int) -> tuple[int, int]:
-    """14-align the capture resolution scaled to fit ``max_image_size``.
-
-    Mirrors the torch predictor's preprocessing policy so both backends run
-    the network at the same resolution.
-
-    Args:
-        capture_hw: Native capture (height, width).
-        max_image_size: Longest allowed network side.
-
-    Returns:
-        Network (height, width), each a multiple of 14.
-    """
-    height, width = capture_hw
-    scale: float = min(1.0, max_image_size / max(height, width))
-    return (ensure_multiple_of(height * scale), ensure_multiple_of(width * scale))
 
 
 def pda_trt_polycam_inference(config: PDATrtPolycamConfig) -> None:
@@ -89,11 +72,7 @@ def pda_trt_polycam_inference(config: PDATrtPolycamConfig) -> None:
     if first_batch is None:
         raise ValueError(f"Polycam capture {config.polycam_zip_path} contains no frames.")
     image_hw: tuple[int, int] = network_image_hw(first_batch[0].rgb_hw3.shape[:2], config.max_image_size)
-    predictor = PromptDATrtPredictor(
-        model_type="large",
-        image_hw=image_hw,
-        batch_size=config.batch_size,
-    )
+    predictor = PromptDATrtPredictor(model_type="large", image_hw=image_hw, batch_size=config.batch_size)
 
     n_frames: int = 0
     model_seconds: float = 0.0

--- a/packages/prompt-da/src/rerun_prompt_da/mesh_logging.py
+++ b/packages/prompt-da/src/rerun_prompt_da/mesh_logging.py
@@ -1,0 +1,38 @@
+"""Fused-TSDF-mesh logging shared by the catalog and demo tools.
+
+Kept dependency-light (rerun, numpy, open3d only) because it is imported from
+both the catalog lane and the demo env, which do not share heavier deps such
+as ``arkitscenes_download``.
+"""
+
+import numpy as np
+import open3d as o3d
+import rerun as rr
+
+
+def log_fused_mesh(
+    recording: rr.RecordingStream | None,
+    entity_path: str,
+    mesh: o3d.geometry.TriangleMesh,
+    *,
+    static: bool = True,
+) -> None:
+    """Log a fused TSDF mesh, statically by default.
+
+    Same see-through treatment as the ARKit mesh: cull back-facing walls so the
+    3D view looks into the room from outside. Pass ``static=False`` to log the
+    mesh at the current time instead (incremental reconstruction views), and
+    ``recording=None`` to use the global recording stream.
+    """
+    rr.log(
+        entity_path,
+        rr.Mesh3D(
+            vertex_positions=np.asarray(mesh.vertices),
+            triangle_indices=np.asarray(mesh.triangles),
+            vertex_normals=np.asarray(mesh.vertex_normals),
+            vertex_colors=np.asarray(mesh.vertex_colors),
+            face_rendering=rr.components.MeshFaceRendering.Front,
+        ),
+        static=static,
+        recording=recording,
+    )

--- a/packages/prompt-da/src/rerun_prompt_da/trt_predictor.py
+++ b/packages/prompt-da/src/rerun_prompt_da/trt_predictor.py
@@ -15,6 +15,7 @@ import torch
 import torch.nn.functional as F
 from einops import rearrange
 from jaxtyping import Float32, UInt8
+from monopriors.models.depth_completion.prompt_da import ensure_multiple_of
 from torch import Tensor
 
 from rerun_prompt_da.trt_engine import (
@@ -24,6 +25,24 @@ from rerun_prompt_da.trt_engine import (
     ensure_engine,
     export_promptda_onnx,
 )
+
+
+def network_image_hw(capture_hw: tuple[int, int], max_image_size: int) -> tuple[int, int]:
+    """14-align the capture resolution scaled to fit ``max_image_size``.
+
+    Lives beside ``preprocess_batch`` because it is the other half of the same
+    resolution policy: the size this returns is what the predictor resizes to.
+
+    Args:
+        capture_hw: Native capture (height, width).
+        max_image_size: Longest allowed network side.
+
+    Returns:
+        Network (height, width), each a multiple of 14.
+    """
+    height, width = capture_hw
+    scale: float = min(1.0, max_image_size / max(height, width))
+    return (ensure_multiple_of(height * scale), ensure_multiple_of(width * scale))
 
 
 def preprocess_batch(

--- a/packages/prompt-da/tests/test_prompt_da_arkitscenes.py
+++ b/packages/prompt-da/tests/test_prompt_da_arkitscenes.py
@@ -25,7 +25,6 @@ from simplecv.rerun_dataloader import SegmentNvdecDecoder  # noqa: E402
 
 from rerun_prompt_da.apis.arkitscenes_shared import (  # noqa: E402
     filter_depth_for_fusion,
-    log_fused_mesh,
     segments_to_process,
     stride_for,
     world_t_cam_from_pose,
@@ -36,6 +35,7 @@ from rerun_prompt_da.apis.prompt_da_arkitscenes import (  # noqa: E402
     fuse_and_log_batch,
     log_promptda_frame,
 )
+from rerun_prompt_da.mesh_logging import log_fused_mesh  # noqa: E402
 from rerun_prompt_da.promptda_stream import PromptDACollate, promptda_dataset  # noqa: E402
 
 

--- a/packages/prompt-da/tools/polycam_compare.py
+++ b/packages/prompt-da/tools/polycam_compare.py
@@ -1,0 +1,8 @@
+"""Thin CLI shim for the PromptDA-versus-ZipDepth-PromptDA Polycam comparison."""
+
+import tyro
+
+from rerun_prompt_da.apis.polycam_compare import PolycamCompareConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(PolycamCompareConfig))

--- a/packages/prompt-da/tools/polycam_trio.py
+++ b/packages/prompt-da/tools/polycam_trio.py
@@ -1,0 +1,8 @@
+"""Thin CLI shim for the three-way ARKit / PromptDA / ZipDepth-PromptDA Polycam comparison."""
+
+import tyro
+
+from rerun_prompt_da.apis.polycam_trio import PolycamTrioConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(PolycamTrioConfig))

--- a/packages/zipdepth/tests/test_catalog_dataset.py
+++ b/packages/zipdepth/tests/test_catalog_dataset.py
@@ -20,7 +20,7 @@ from rerun.catalog import DatasetEntry  # noqa: E402
 
 from zipdepth.apis.catalog_throughput import CatalogThroughputConfig  # noqa: E402
 from zipdepth.catalog.builders import CpuSampleBuilder  # noqa: E402
-from zipdepth.catalog.dataset import CatalogPromptDepthDataset, ShuffleBuffer, _ProducerSlot, promptda_blob_views  # noqa: E402
+from zipdepth.catalog.dataset import CatalogPromptDepthDataset, ShuffleBuffer, _ProducerSlot, component_u8_views, promptda_blob_views  # noqa: E402
 from zipdepth.catalog.stats import CatalogDatasetStats  # noqa: E402
 from zipdepth.catalog.targets import build_eval_transform  # noqa: E402
 
@@ -108,16 +108,59 @@ def test_cpu_sample_builder_decodes_and_reports_local_stats() -> None:
     rgb_chw: UInt8[torch.Tensor, "3 h w"] = torch.arange(3 * 6 * 8, dtype=torch.uint8).reshape(3, 6, 8)
     depth_mm_hw: UInt16[ndarray, "h w"] = np.arange(6 * 8, dtype=np.uint16).reshape(6, 8) + 100
     blob_u8: UInt8[ndarray, "n"] = np.frombuffer(encode_depth_png(depth_mm_hw), dtype=np.uint8)
+    prompt_mm_hw: UInt16[ndarray, "192 256"] = np.full((192, 256), 1250, dtype=np.uint16)
+    prompt_blob_u8: UInt8[ndarray, "prompt_n"] = np.frombuffer(encode_depth_png(prompt_mm_hw), dtype=np.uint8)
+    confidence_hw: UInt8[ndarray, "192 256"] = np.full((192, 256), 2, dtype=np.uint8)
+    confidence_u8: UInt8[ndarray, "confidence_n"] = confidence_hw.reshape(-1)
     builder: CpuSampleBuilder = CpuSampleBuilder(build_eval_transform(6, 8), min_depth_span=0.0)
 
-    sample: dict[str, torch.Tensor] | None = builder(rgb_chw, blob_u8, quarter_turns=0, sample_seed=17)
+    sample: dict[str, torch.Tensor] | None = builder(
+        rgb_chw,
+        blob_u8,
+        prompt_blob_u8,
+        confidence_u8,
+        quarter_turns=0,
+        sample_seed=17,
+    )
 
     assert sample is not None
     assert sample["image"].shape == (3, 6, 8)
+    assert sample["depth"].dtype == torch.uint16
+    assert sample["prompt_depth"].shape == (1, 192, 256)
+    assert sample["prompt_valid"].all()
     assert builder.stats.samples_built == 1
     assert builder.stats.png_fallbacks == 0
     assert builder.stats.blob_decode > 0.0
     assert builder.stats.augment > 0.0
+
+
+def test_cpu_metric_builder_orients_prompt_and_confidence_with_rgb_and_target() -> None:
+    """Apply one counter-clockwise turn to every spatial catalog input."""
+    rgb_chw: UInt8[torch.Tensor, "3 stored_h stored_w"] = torch.arange(3 * 8 * 6, dtype=torch.uint8).reshape(3, 8, 6)
+    target_mm_hw: UInt16[ndarray, "stored_h stored_w"] = np.full((8, 6), 2000, dtype=np.uint16)
+    target_blob_u8: UInt8[ndarray, "target_n"] = np.frombuffer(encode_depth_png(target_mm_hw), dtype=np.uint8)
+    prompt_stored_mm_hw: UInt16[ndarray, "256 192"] = np.full((256, 192), 1000, dtype=np.uint16)
+    prompt_stored_mm_hw[:, :96] = 3000
+    prompt_blob_u8: UInt8[ndarray, "prompt_n"] = np.frombuffer(encode_depth_png(prompt_stored_mm_hw), dtype=np.uint8)
+    confidence_stored_hw: UInt8[ndarray, "256 192"] = np.full((256, 192), 2, dtype=np.uint8)
+    confidence_stored_hw[:128] = 0
+    builder: CpuSampleBuilder = CpuSampleBuilder(build_eval_transform(6, 8), min_depth_span=0.0, target_mode="metric")
+
+    sample: dict[str, torch.Tensor] | None = builder(
+        rgb_chw,
+        target_blob_u8,
+        prompt_blob_u8,
+        confidence_stored_hw.reshape(-1),
+        quarter_turns=1,
+        sample_seed=23,
+    )
+
+    assert sample is not None
+    assert set(sample) == {"image", "target_depth", "target_valid", "prompt_depth", "prompt_valid"}
+    assert sample["image"].shape == (3, 6, 8)
+    assert_array_equal(sample["prompt_depth"].numpy()[0], np.rot90(prompt_stored_mm_hw, 1) / 1000.0)
+    expected_valid_hw: ndarray = np.rot90((confidence_stored_hw >= 1) & (prompt_stored_mm_hw >= 100) & (prompt_stored_mm_hw <= 4000), 1)
+    assert_array_equal(sample["prompt_valid"].numpy()[0], expected_valid_hw)
 
 
 @pytest.mark.parametrize(("num_producers", "prefetch_samples"), [(0, 64), (1, 0)])
@@ -151,6 +194,15 @@ def test_promptda_blob_views_extract_one_instance_per_row_without_python_lists()
     for view, python_row in zip(views, column.to_pylist(), strict=True):
         assert not view.flags.owndata
         assert_array_equal(view, python_row[0])
+
+
+def test_component_u8_views_handles_prompt_and_confidence_columns() -> None:
+    """Extract generic uint8 component cells without PromptDA-specific errors."""
+    column = pa.chunked_array([pa.array([[[1, 2]], [[3, 4, 5]]], type=pa.list_(pa.list_(pa.uint8())))])
+
+    views: list[ndarray] = component_u8_views(column, "/confidence:SegmentationImage:buffer")
+
+    assert [view.tolist() for view in views] == [[1, 2], [3, 4, 5]]
 
 
 def test_promptda_blob_views_rejects_sliced_outer_arrays() -> None:

--- a/packages/zipdepth/tests/test_catalog_targets.py
+++ b/packages/zipdepth/tests/test_catalog_targets.py
@@ -11,6 +11,7 @@ from zipdepth.catalog.targets import (
     INV_DEPTH_SCALE,
     AugmentPolicy,
     build_eval_transform,
+    build_metric_training_sample,
     build_train_transform,
     build_training_sample,
     build_training_sample_cuda,
@@ -214,3 +215,44 @@ def test_build_train_transform_is_the_eval_resize_with_optional_mirroring() -> N
     for key in ("image", "depth", "mask"):
         assert torch.equal(actual[key], expected[key])
         assert_array_equal(flipped[key].numpy(), np.flip(expected[key].numpy(), axis=-1))
+
+
+def test_metric_training_sample_emits_metres_and_flips_every_spatial_input() -> None:
+    """Keep metric target and prompt aligned while preserving the native prompt grid."""
+    rgb_hw3: UInt8[ndarray, "4 6 3"] = np.arange(4 * 6 * 3, dtype=np.uint8).reshape(4, 6, 3)
+    target_mm_hw: UInt16[ndarray, "4 6"] = np.array(
+        [
+            [0, 100, 500, 1000, 4000, 4001],
+            [1000, 1000, 1000, 1000, 1000, 1000],
+            [2000, 2000, 2000, 2000, 2000, 2000],
+            [3000, 3000, 3000, 3000, 3000, 3000],
+        ],
+        dtype=np.uint16,
+    )
+    prompt_mm_hw: UInt16[ndarray, "192 256"] = np.full((192, 256), 1500, dtype=np.uint16)
+    prompt_mm_hw[:, :128] = 500
+    confidence_hw: UInt8[ndarray, "192 256"] = np.full((192, 256), 2, dtype=np.uint8)
+    confidence_hw[:, :64] = 0
+    mirror: AugmentPolicy = AugmentPolicy(flip_p=1.0, channel_shuffle_p=0.0, gray_p=0.0)
+
+    sample: dict[str, torch.Tensor] = build_metric_training_sample(
+        rgb_hw3,
+        target_mm_hw,
+        prompt_mm_hw,
+        confidence_hw,
+        build_train_transform(4, 6, mirror),
+    )
+
+    assert set(sample) == {"image", "target_depth", "target_valid", "prompt_depth", "prompt_valid"}
+    assert sample["target_depth"].shape == (1, 4, 6)
+    assert sample["target_depth"].dtype == torch.float32
+    assert sample["target_valid"].dtype == torch.bool
+    assert sample["prompt_depth"].shape == (1, 192, 256)
+    assert sample["prompt_depth"].dtype == torch.float32
+    assert sample["prompt_valid"].shape == (1, 192, 256)
+    assert sample["prompt_valid"].dtype == torch.bool
+    assert_array_equal(sample["target_valid"].numpy()[0], np.flip((target_mm_hw >= 100) & (target_mm_hw <= 4000), axis=-1))
+    assert_allclose(sample["target_depth"].numpy()[0], np.flip(np.where((target_mm_hw >= 100) & (target_mm_hw <= 4000), target_mm_hw / 1000.0, 0.0), axis=-1))
+    assert_allclose(sample["prompt_depth"].numpy()[0], np.flip(prompt_mm_hw / 1000.0, axis=-1))
+    expected_prompt_valid_hw: np.ndarray = (confidence_hw >= 1) & (prompt_mm_hw >= 100) & (prompt_mm_hw <= 4000)
+    assert_array_equal(sample["prompt_valid"].numpy()[0], np.flip(expected_prompt_valid_hw, axis=-1))

--- a/packages/zipdepth/tests/test_catalog_train.py
+++ b/packages/zipdepth/tests/test_catalog_train.py
@@ -4,6 +4,7 @@ import pytest
 from torch import nn, optim
 
 from zipdepth.apis.train_catalog import TrainCatalogConfig, pin_batchnorm_eval, resolve_max_lr, split_holdout_segments
+from zipdepth.loss import MetricDepthLoss, ZipDepthLoss
 from zipdepth.training.trainer import ZipDepthTrainer
 
 
@@ -16,6 +17,24 @@ def test_catalog_training_defaults_to_parallel_segment_producers() -> None:
     assert config.prefetch_samples == 256
     assert not hasattr(config, "prefetch")
     assert not hasattr(config, "gpu_augment")
+
+
+def test_catalog_training_defaults_to_metric_with_an_explicit_ssi_lane() -> None:
+    """Make prompted metric distillation the default without removing relative training."""
+    assert TrainCatalogConfig().target_mode == "metric"
+    assert TrainCatalogConfig(target_mode="ssi").target_mode == "ssi"
+
+
+def test_trainer_selects_the_objective_without_mixing_ssi_into_metric() -> None:
+    """Use the fixed metric criterion only for the prompted lane."""
+    model: nn.Linear = nn.Linear(1, 1)
+    optimizer: optim.SGD = optim.SGD(model.parameters(), lr=0.1)
+
+    ssi_trainer: ZipDepthTrainer = ZipDepthTrainer(model, [], optimizer, None, "cpu", use_amp=False, target_mode="ssi")
+    metric_trainer: ZipDepthTrainer = ZipDepthTrainer(model, [], optimizer, None, "cpu", use_amp=False, target_mode="metric")
+
+    assert isinstance(ssi_trainer.criterion, ZipDepthLoss)
+    assert isinstance(metric_trainer.criterion, MetricDepthLoss)
 
 
 def test_catalog_training_uses_one_explicit_optimizer_step_schedule() -> None:
@@ -106,5 +125,4 @@ def test_pin_batchnorm_eval_overrides_only_the_model_root_train_method() -> None
     assert batchnorms[0].training is True
     model.train(True)
     assert all(not module.training for module in batchnorms)
-
 

--- a/packages/zipdepth/tests/test_eval_catalog.py
+++ b/packages/zipdepth/tests/test_eval_catalog.py
@@ -5,7 +5,14 @@ import pytest
 from jaxtyping import Bool, Float32
 from numpy import ndarray
 
-from zipdepth.apis.eval_catalog import CatalogDepthMetrics, align_and_score_inverse_depth
+from zipdepth.apis.eval_catalog import (
+    CatalogDepthMetrics,
+    MetricCatalogDepthMetrics,
+    affine_reference_depth,
+    align_and_score_inverse_depth,
+    aligned_inverse_diagnostic,
+    score_metric_depth,
+)
 
 
 def test_inverse_depth_alignment_recovers_affine_prediction_and_excludes_masked_pixels() -> None:
@@ -20,3 +27,48 @@ def test_inverse_depth_alignment_recovers_affine_prediction_and_excludes_masked_
 
     assert metrics.abs_rel == pytest.approx(0.0, abs=1e-6)
     assert metrics.delta1 == 1.0
+
+
+def test_direct_metric_scoring_reports_unaligned_absrel_delta1_and_mae() -> None:
+    """Measure metre predictions directly and ignore invalid teacher pixels."""
+    target_hw: Float32[ndarray, "4 4"] = np.ones((4, 4), dtype=np.float32)
+    prediction_hw: Float32[ndarray, "4 4"] = np.full((4, 4), 2.0, dtype=np.float32)
+    valid_hw: Bool[ndarray, "4 4"] = np.ones((4, 4), dtype=bool)
+    target_hw[0, 0] = 0.0
+    prediction_hw[0, 0] = 1000.0
+
+    metrics: MetricCatalogDepthMetrics = score_metric_depth(prediction_hw, target_hw, valid_hw)
+
+    assert metrics.abs_rel == pytest.approx(1.0)
+    assert metrics.delta1 == pytest.approx(0.0)
+    assert metrics.mae == pytest.approx(1.0)
+
+
+def test_affine_reference_fits_inverse_depth_to_valid_lidar() -> None:
+    """Turn released relative inverse depth into metric depth only for the reference row."""
+    relative_inverse_hw: Float32[ndarray, "192 256"] = np.linspace(0.2, 0.8, 192 * 256, dtype=np.float32).reshape(192, 256)
+    expected_inverse_hw: Float32[ndarray, "192 256"] = 2.0 * relative_inverse_hw + 0.5
+    prompt_depth_hw: Float32[ndarray, "192 256"] = 1.0 / expected_inverse_hw
+    prompt_valid_hw: Bool[ndarray, "192 256"] = np.ones((192, 256), dtype=bool)
+    prompt_valid_hw[40:80, 60:120] = False
+
+    depth_hw: Float32[ndarray, "192 256"] = affine_reference_depth(
+        relative_inverse_hw,
+        prompt_depth_hw,
+        prompt_valid_hw,
+    )
+
+    np.testing.assert_allclose(depth_hw, 1.0 / expected_inverse_hw, rtol=1e-5, atol=1e-6)
+
+
+def test_aligned_inverse_result_is_named_as_a_diagnostic() -> None:
+    """Keep affine alignment separate from direct metric accuracy."""
+    target_depth_hw: Float32[ndarray, "4 4"] = np.linspace(0.5, 2.0, 16, dtype=np.float32).reshape(4, 4)
+    prediction_depth_hw: Float32[ndarray, "4 4"] = 1.0 / (3.0 / target_depth_hw + 7.0)
+    valid_hw: Bool[ndarray, "4 4"] = np.ones((4, 4), dtype=bool)
+
+    metrics: MetricCatalogDepthMetrics = aligned_inverse_diagnostic(prediction_depth_hw, target_depth_hw, valid_hw)
+
+    assert metrics.abs_rel == pytest.approx(0.0, abs=1e-6)
+    assert metrics.delta1 == pytest.approx(1.0)
+    assert metrics.mae == pytest.approx(0.0, abs=1e-6)

--- a/packages/zipdepth/tests/test_metric_depth_loss.py
+++ b/packages/zipdepth/tests/test_metric_depth_loss.py
@@ -1,0 +1,35 @@
+"""Metric distillation-loss behavior tests."""
+
+import pytest
+import torch
+from jaxtyping import Bool, Float32
+from torch import Tensor
+
+from zipdepth.loss.metric_depth_loss import MetricDepthLoss
+
+
+def test_metric_depth_loss_is_masked_l1_plus_half_gradient() -> None:
+    """Use metre-space errors directly, without SSI normalization."""
+    prediction_b1hw: Float32[Tensor, "1 1 2 2"] = torch.tensor([[[[1.0, 2.0], [1.0, 2.0]]]])
+    target_b1hw: Float32[Tensor, "1 1 2 2"] = torch.ones(1, 1, 2, 2)
+    valid_b1hw: Bool[Tensor, "1 1 2 2"] = torch.ones(1, 1, 2, 2, dtype=torch.bool)
+    criterion: MetricDepthLoss = MetricDepthLoss(grad_scales=1)
+
+    loss: Tensor
+    parts: dict[str, float]
+    loss, parts = criterion(prediction_b1hw, target_b1hw, valid_b1hw)
+
+    assert float(loss) == pytest.approx(0.75)
+    assert parts == {"l1": pytest.approx(0.5), "grad": pytest.approx(0.5)}
+
+
+def test_metric_depth_loss_applies_teacher_range_and_explicit_mask() -> None:
+    """Supervise only explicit finite teacher pixels in the 0.1--4 m lane."""
+    prediction_b1hw: Float32[Tensor, "1 1 1 5"] = torch.tensor([[[[2.0, 2.0, 2.0, 2.0, 2.0]]]])
+    target_b1hw: Float32[Tensor, "1 1 1 5"] = torch.tensor([[[[0.0, 1.0, 3.0, 5.0, float("nan")]]]])
+    valid_b1hw: Bool[Tensor, "1 1 1 5"] = torch.tensor([[[[True, True, False, True, True]]]])
+    criterion: MetricDepthLoss = MetricDepthLoss(grad_scales=1)
+
+    loss: Tensor = criterion(prediction_b1hw, target_b1hw, valid_b1hw)[0]
+
+    assert float(loss) == pytest.approx(1.0)

--- a/packages/zipdepth/tests/test_prompted_model.py
+++ b/packages/zipdepth/tests/test_prompted_model.py
@@ -1,0 +1,71 @@
+"""Behavior tests for the prompted metric ZipDepth wrapper."""
+
+from pathlib import Path
+
+import torch
+from jaxtyping import Float32, UInt8
+from monopriors.models.depth_completion.zipdepth_prompt import ZipDepthPrompt, load_zipdepth_prompt
+from monopriors.third_party.zipdepth.architecture import ZipDepth, create_model
+from torch import Tensor
+
+
+def _prompt_with_fixed_range(*, flip: bool = False) -> Float32[Tensor, "1 1 192 256"]:
+    prompt_b1hw: Float32[Tensor, "1 1 192 256"] = torch.linspace(0.2, 3.8, 192 * 256, dtype=torch.float32).reshape(1, 1, 192, 256)
+    if flip:
+        prompt_b1hw = torch.flip(prompt_b1hw, dims=(-1,))
+    prompt_b1hw[:, :, 40:80, 60:120] = 0.0
+    return prompt_b1hw
+
+
+def test_zero_initialized_prompt_injection_has_no_spatial_contribution() -> None:
+    model: ZipDepthPrompt = ZipDepthPrompt().eval()
+    image_b3hw: Float32[Tensor, "1 3 64 96"] = torch.rand(1, 3, 64, 96)
+
+    with torch.inference_mode():
+        first_b1hw: Float32[Tensor, "1 1 64 96"] = model(image_b3hw, _prompt_with_fixed_range())
+        second_b1hw: Float32[Tensor, "1 1 64 96"] = model(image_b3hw, _prompt_with_fixed_range(flip=True))
+
+    assert torch.equal(first_b1hw, second_b1hw)
+
+
+def test_prompted_model_accepts_uint8_and_float_rgb() -> None:
+    model: ZipDepthPrompt = ZipDepthPrompt().eval()
+    image_u8_b3hw: UInt8[Tensor, "1 3 64 96"] = torch.randint(0, 256, (1, 3, 64, 96), dtype=torch.uint8)
+    image_f32_b3hw: Float32[Tensor, "1 3 64 96"] = image_u8_b3hw.to(dtype=torch.float32) / 255.0
+    prompt_b1hw: Float32[Tensor, "1 1 192 256"] = _prompt_with_fixed_range()
+
+    with torch.inference_mode():
+        uint8_depth_b1hw: Float32[Tensor, "1 1 64 96"] = model(image_u8_b3hw, prompt_b1hw)
+        float_depth_b1hw: Float32[Tensor, "1 1 64 96"] = model(image_f32_b3hw, prompt_b1hw)
+
+    assert uint8_depth_b1hw.shape == (1, 1, 64, 96)
+    torch.testing.assert_close(uint8_depth_b1hw, float_depth_b1hw, rtol=0.0, atol=0.0)
+    assert float(uint8_depth_b1hw.min()) >= 0.2
+    assert float(uint8_depth_b1hw.max()) <= 3.8
+
+
+def test_degenerate_prompts_produce_finite_metric_depth() -> None:
+    model: ZipDepthPrompt = ZipDepthPrompt().eval()
+    image_b3hw: Float32[Tensor, "2 3 64 96"] = torch.rand(2, 3, 64, 96)
+    prompt_b1hw: Float32[Tensor, "2 1 192 256"] = torch.zeros(2, 1, 192, 256)
+    prompt_b1hw[0] = 1.25
+
+    with torch.inference_mode():
+        depth_b1hw: Float32[Tensor, "2 1 64 96"] = model(image_b3hw, prompt_b1hw)
+
+    assert depth_b1hw.shape == (2, 1, 64, 96)
+    assert torch.isfinite(depth_b1hw).all()
+
+
+def test_released_zipdepth_state_loads_strictly_into_backbone(tmp_path: Path) -> None:
+    released: ZipDepth = create_model(variant="base")
+    checkpoint: Path = tmp_path / "zipdepth_base.pth"
+    torch.save(released.state_dict(), checkpoint)
+
+    prompted: ZipDepthPrompt = load_zipdepth_prompt(checkpoint)
+
+    prompted_backbone_state: dict[str, Tensor] = prompted.backbone.state_dict()
+    released_state: dict[str, Tensor] = released.state_dict()
+    assert prompted_backbone_state.keys() == released_state.keys()
+    for key, released_tensor in released_state.items():
+        assert torch.equal(prompted_backbone_state[key], released_tensor), key

--- a/packages/zipdepth/tests/test_prompted_trt.py
+++ b/packages/zipdepth/tests/test_prompted_trt.py
@@ -1,0 +1,115 @@
+"""Static-batch ONNX/TensorRT export tests for ZipDepth-PromptDA."""
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+from monopriors.models.depth_completion.zipdepth_prompt import load_zipdepth_prompt
+from monopriors.models.relative_depth.zipdepth import download_zipdepth_checkpoint
+from torch import Tensor, nn
+
+from zipdepth.apis.prompted_trt import (
+    IMAGE_INPUT_NAME,
+    PROMPT_INPUT_NAME,
+    export_zipdepth_prompt_onnx,
+    prepare_zipdepth_prompt_for_export,
+)
+
+
+class _FakePromptModel(nn.Module):
+    """Small model double exposing the prompted export contract."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(()))
+        self.fused = False
+
+    def fuse_for_inference(self) -> "_FakePromptModel":
+        self.fused = True
+        return self
+
+    def forward_with_range(self, image: Tensor, prompt_depth: Tensor) -> tuple[Tensor, Tensor, Tensor]:
+        depth: Tensor = image[:, :1] * self.weight
+        return depth, prompt_depth.amin(dim=(1, 2, 3), keepdim=True), prompt_depth.amax(dim=(1, 2, 3), keepdim=True)
+
+
+def test_export_uses_two_fp32_inputs_and_static_batch_eight(tmp_path: Path) -> None:
+    checkpoint: Path = tmp_path / "zipdepth_base.pth"
+    checkpoint.write_bytes(b"released")
+    fake_model = _FakePromptModel()
+    calls: list[dict[str, Any]] = []
+
+    def fake_export(model: nn.Module, example_inputs: tuple[Tensor, ...], out_path: Path, **kwargs: Any) -> None:
+        calls.append({"model": model, "inputs": example_inputs, "out_path": out_path, **kwargs})
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_bytes(b"onnx")
+
+    onnx_path: Path = export_zipdepth_prompt_onnx(
+        checkpoint=checkpoint,
+        image_hw=(768, 1024),
+        batch_size=8,
+        cache_dir=tmp_path / "cache",
+        model_loader=lambda _checkpoint: fake_model,
+        export_fn=fake_export,
+        device="cpu",
+    )
+
+    call: dict[str, Any] = calls[0]
+    assert onnx_path == call["out_path"]
+    assert "768x1024_b8_fp16" in onnx_path.name
+    assert call["input_names"] == [IMAGE_INPUT_NAME, PROMPT_INPUT_NAME]
+    assert call["output_names"] == ["depth", "min_depth", "max_depth"]
+    assert "dynamic_batch_max" not in call or call["dynamic_batch_max"] is None
+    assert [tuple(tensor.shape) for tensor in call["inputs"]] == [(8, 3, 768, 1024), (8, 1, 192, 256)]
+    assert all(tensor.dtype == torch.float32 for tensor in call["inputs"])
+    assert fake_model.fused
+    assert fake_model.weight.dtype == torch.float16
+
+
+trt_parity = pytest.mark.skipif(
+    os.environ.get("ZIPDEPTH_TRT_PARITY") != "1" or not torch.cuda.is_available(),
+    reason="set ZIPDEPTH_TRT_PARITY=1 on a CUDA/TensorRT host",
+)
+
+
+def _parity_prompts(batch_size: int, device: torch.device) -> Tensor:
+    """Build alternating holey and narrow-range metric prompts."""
+    wide: Tensor = torch.linspace(0.2, 3.8, 192 * 256, device=device).reshape(1, 1, 192, 256)
+    wide[:, :, 24:160:3, 32:224:4] = 0.0
+    narrow: Tensor = torch.linspace(1.500, 1.503, 192 * 256, device=device).reshape(1, 1, 192, 256)
+    prompts: Tensor = torch.cat([wide, narrow] * (batch_size // 2), dim=0)
+    return prompts.contiguous()
+
+
+@trt_parity
+def test_holey_and_narrow_prompt_torch_onnx_trt_parity() -> None:
+    """Compare the real fp16 graph across Torch, ONNX Runtime, and TensorRT."""
+    from trtkit import OnnxCudaRuntime, TensorRtRuntime, TrtBuildConfig, ensure_engine, onnx_static_batch_size
+
+    batch_size: int = 8
+    cache_dir: Path = Path(os.environ.get("ZIPDEPTH_PROMPT_TRT_CACHE", "/tmp/zd-pda-research/trt"))
+    checkpoint: Path = download_zipdepth_checkpoint()
+    onnx_path: Path = export_zipdepth_prompt_onnx(checkpoint=checkpoint, batch_size=batch_size, cache_dir=cache_dir)
+    assert onnx_static_batch_size(onnx_path) == batch_size
+    engine_path: Path = ensure_engine(
+        onnx_path,
+        TrtBuildConfig(max_batch_size=batch_size, opt_batch_size=batch_size),
+        cache_dir=cache_dir / "engines",
+    )
+
+    model: nn.Module = prepare_zipdepth_prompt_for_export(load_zipdepth_prompt(checkpoint), (768, 1024), torch.device("cuda"))
+    image: Tensor = torch.rand((batch_size, 3, 768, 1024), dtype=torch.float32, device="cuda")
+    prompt: Tensor = _parity_prompts(batch_size, torch.device("cuda"))
+    with torch.inference_mode():
+        torch_depth: Tensor = model(image, prompt).clone()
+    inputs: dict[str, Tensor] = {IMAGE_INPUT_NAME: image, PROMPT_INPUT_NAME: prompt}
+    onnx_depth: Tensor = OnnxCudaRuntime(onnx_path)(inputs)["depth"].clone()
+    trt_depth: Tensor = TensorRtRuntime(engine_path)(inputs)["depth"].clone()
+
+    for case_name, rows in (("holey", slice(0, None, 2)), ("narrow", slice(1, None, 2))):
+        for backend_name, actual in (("onnx", onnx_depth), ("trt", trt_depth)):
+            error: Tensor = (actual[rows] - torch_depth[rows]).abs()
+            assert float(error.median()) < 0.003, f"{backend_name}:{case_name} median"
+            assert float(error.max()) < 0.02, f"{backend_name}:{case_name} max"

--- a/packages/zipdepth/tools/export_prompted_trt.py
+++ b/packages/zipdepth/tools/export_prompted_trt.py
@@ -1,0 +1,8 @@
+"""Tyro shim for static-batch ZipDepth-PromptDA TensorRT export."""
+
+import tyro
+
+from zipdepth.apis.prompted_trt import TrtExportConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(TrtExportConfig))

--- a/packages/zipdepth/zipdepth/apis/catalog_throughput.py
+++ b/packages/zipdepth/zipdepth/apis/catalog_throughput.py
@@ -40,6 +40,8 @@ class CatalogThroughputConfig:
     """Whole-segment producer threads, each with its own video decoder."""
     prefetch_samples: int = 256
     """Maximum completed samples buffered across segment producers."""
+    load_confidence: bool = True
+    """Fetch the ARKit confidence column; training skips it."""
     min_depth_span: float = 1.25
     """Minimum valid-depth p95/p5 ratio; zero disables flat-frame filtering."""
     max_batches: int | None = None

--- a/packages/zipdepth/zipdepth/apis/eval_catalog.py
+++ b/packages/zipdepth/zipdepth/apis/eval_catalog.py
@@ -292,6 +292,7 @@ def main(config: EvalCatalogConfig) -> Path:
         segment_diagnostic_abs_rel: list[float] = []
         segment_diagnostic_delta1: list[float] = []
         segment_diagnostic_mae: list[float] = []
+        skipped_frame_count: int = 0
         batch: dict[str, Tensor]
         for batch in loader:
             image_chw: UInt8[ndarray, "3 h w"] = batch["image"][0].numpy()
@@ -315,7 +316,12 @@ def main(config: EvalCatalogConfig) -> Path:
                     raise RuntimeError("relative predictor was not initialized")
                 relative_inverse_hw: Float32[ndarray, "h w"] = relative_predictor(rgb_hw3, None).disparity
                 if config.evaluation == "affine-reference":
-                    prediction_depth_hw = affine_reference_depth(relative_inverse_hw, prompt_depth_hw, prompt_valid_hw)
+                    try:
+                        prediction_depth_hw = affine_reference_depth(relative_inverse_hw, prompt_depth_hw, prompt_valid_hw)
+                    except ValueError as error:
+                        print(f"{segment_id}: skipping frame without a solvable LiDAR fit ({error})")
+                        skipped_frame_count += 1
+                        continue
                 else:
                     prediction_depth_hw = np.reciprocal(np.clip(relative_inverse_hw, 1.0e-6, None)).astype(np.float32)
 
@@ -334,12 +340,13 @@ def main(config: EvalCatalogConfig) -> Path:
             segment_diagnostic_mae.append(diagnostic.mae)
 
         if not segment_diagnostic_abs_rel:
-            print(f"{segment_id}: no frames")
+            print(f"{segment_id}: no scorable frames (skipped={skipped_frame_count})")
             continue
         frame_count: int = len(segment_diagnostic_abs_rel)
         segment_report: dict[str, float | int | str] = {
             "segment_id": segment_id,
             "frame_count": frame_count,
+            "skipped_frame_count": skipped_frame_count,
             "aligned_inverse_diagnostic_abs_rel": float(np.mean(segment_diagnostic_abs_rel)),
             "aligned_inverse_diagnostic_delta1": float(np.mean(segment_diagnostic_delta1)),
             "aligned_inverse_diagnostic_mae": float(np.mean(segment_diagnostic_mae)),

--- a/packages/zipdepth/zipdepth/apis/eval_catalog.py
+++ b/packages/zipdepth/zipdepth/apis/eval_catalog.py
@@ -38,8 +38,9 @@ class EvalCatalogConfig:
     """Explicit evaluation segment identifiers; overrides the saved holdout manifest."""
     checkpoint: Path | None = None
     """Checkpoint to evaluate; None uses released ZipDepth-base weights."""
-    evaluation: Literal["metric", "affine-reference", "aligned-relative"] = "metric"
-    """Direct prompted model, closed-form untrained reference, or legacy aligned diagnostic."""
+    evaluation: Literal["metric", "affine-reference", "aligned-relative", "prompt-upsample"] = "metric"
+    """Direct prompted model, closed-form untrained reference, legacy aligned diagnostic, or the
+    zero-parameter bilinear prompt upsample -- the floor any trained student must beat."""
     height: int = 768
     """Deterministic evaluation image height."""
     width: int = 1024
@@ -78,6 +79,41 @@ class MetricCatalogDepthMetrics:
     """Fraction of valid depth ratios below 1.25."""
     mae: float
     """Mean absolute error in metres."""
+
+
+def prompt_upsample_depth(
+    prompt_depth_hw: Float32[ndarray, "192 256"],
+    prompt_valid_hw: Bool[ndarray, "192 256"],
+    *,
+    height: int,
+    width: int,
+) -> Float32[ndarray, "h w"]:
+    """Bilinearly upsample the LiDAR prompt to full resolution, ignoring holes.
+
+    The zero-parameter control every trained student must beat. Invalid prompt
+    pixels are excluded rather than treated as zero depth: depth and validity are
+    resized together and divided, which is a normalized-convolution fill. Pixels
+    with no valid support anywhere nearby take the frame's median valid depth, so
+    the prediction is dense and is scored on the same pixels as a model's.
+
+    Args:
+        prompt_depth_hw: Prompt depth in metres with shape ``(192, 256)``.
+        prompt_valid_hw: Prompt validity with shape ``(192, 256)``.
+        height: Output height.
+        width: Output width.
+
+    Returns:
+        Dense float32 depth in metres with shape ``(height, width)``.
+    """
+    valid_f32_hw: Float32[ndarray, "192 256"] = prompt_valid_hw.astype(np.float32)
+    weighted_hw: Float32[ndarray, "192 256"] = (prompt_depth_hw * valid_f32_hw).astype(np.float32)
+    weighted_up_hw: Float32[ndarray, "h w"] = cv2.resize(weighted_hw, (width, height), interpolation=cv2.INTER_LINEAR)
+    weight_up_hw: Float32[ndarray, "h w"] = cv2.resize(valid_f32_hw, (width, height), interpolation=cv2.INTER_LINEAR)
+    supported_hw: Bool[ndarray, "h w"] = weight_up_hw > 1.0e-3
+    fallback: float = float(np.median(prompt_depth_hw[prompt_valid_hw])) if bool(prompt_valid_hw.any()) else 1.0
+    upsampled_hw: Float32[ndarray, "h w"] = np.full((height, width), fallback, dtype=np.float32)
+    upsampled_hw[supported_hw] = weighted_up_hw[supported_hw] / weight_up_hw[supported_hw]
+    return upsampled_hw
 
 
 def score_metric_depth(
@@ -254,7 +290,8 @@ def main(config: EvalCatalogConfig) -> Path:
     relative_predictor: ZipDepthPredictor | None = None
     if config.evaluation == "metric":
         prompted_model = load_zipdepth_prompt(checkpoint).to(device).fuse_for_inference()
-    else:
+    elif config.evaluation != "prompt-upsample":
+        # The prompt-upsample control needs no network at all.
         relative_predictor = ZipDepthPredictor(
             device="cuda" if device.type == "cuda" else "cpu",
             checkpoint=checkpoint,
@@ -302,15 +339,19 @@ def main(config: EvalCatalogConfig) -> Path:
             prompt_depth_hw: Float32[ndarray, "192 256"] = batch["prompt_depth"][0, 0].numpy().astype(np.float32, copy=False)
             prompt_valid_hw: Bool[ndarray, "192 256"] = batch["prompt_valid"][0, 0].numpy().astype(bool, copy=False)
 
-            if prompted_model is not None:
+            if config.evaluation == "prompt-upsample":
+                # Zero-parameter control: bilinearly resize the confidence-masked
+                # LiDAR prompt to full resolution. A trained student that does not
+                # beat this has learned nothing beyond upsampling its own input.
+                prediction_depth_hw: Float32[ndarray, "h w"] = prompt_upsample_depth(
+                    prompt_depth_hw, prompt_valid_hw, height=config.height, width=config.width
+                )
+            elif prompted_model is not None:
                 image_b3hw: Tensor = batch["image"].to(device=device, non_blocking=True)
+                # Raw prompt, matching both training and the teacher's own input.
                 prompt_depth_b1hw: Tensor = batch["prompt_depth"].to(device=device, non_blocking=True)
-                prompt_valid_b1hw: Tensor = batch["prompt_valid"].to(device=device, non_blocking=True)
-                masked_prompt_b1hw: Tensor = torch.where(prompt_valid_b1hw, prompt_depth_b1hw, torch.zeros_like(prompt_depth_b1hw))
                 with torch.inference_mode():
-                    prediction_depth_hw: Float32[ndarray, "h w"] = (
-                        prompted_model(image_b3hw, masked_prompt_b1hw)[0, 0].float().cpu().numpy()
-                    )
+                    prediction_depth_hw = prompted_model(image_b3hw, prompt_depth_b1hw)[0, 0].float().cpu().numpy()
             else:
                 if relative_predictor is None:
                     raise RuntimeError("relative predictor was not initialized")

--- a/packages/zipdepth/zipdepth/apis/eval_catalog.py
+++ b/packages/zipdepth/zipdepth/apis/eval_catalog.py
@@ -1,21 +1,25 @@
-"""Evaluate ZipDepth inverse depth on held-out catalog PromptDA targets."""
+"""Evaluate metric ZipDepth-PromptDA and explicit reference diagnostics."""
 
 from __future__ import annotations
 
 import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from random import Random
+from typing import Literal
 
+import cv2
 import numpy as np
 import torch
 from jaxtyping import Bool, Float, Float32, UInt8
+from monopriors.models.depth_completion.zipdepth_prompt import ZipDepthPrompt, load_zipdepth_prompt
 from monopriors.models.relative_depth.zipdepth import ZipDepthPredictor, download_zipdepth_checkpoint
 from numpy import ndarray
 from torch import Tensor
 from torch.utils.data import DataLoader
 
 from zipdepth.catalog.segments import DEFAULT_CATALOG_URL, PromptDACatalog, load_promptda_catalog
-from zipdepth.catalog.targets import INV_DEPTH_SCALE, build_eval_transform
+from zipdepth.catalog.targets import build_eval_transform
 from zipdepth.data.transforms import AlbumentationsWrapper
 from zipdepth.evaluation.metrics import abs_relative_difference, align_depth_least_square, delta1_acc, disparity2depth
 
@@ -33,19 +37,25 @@ class EvalCatalogConfig:
     segment_ids: list[str] | None = None
     """Explicit evaluation segment identifiers; overrides the saved holdout manifest."""
     checkpoint: Path | None = None
-    """Trainable checkpoint to evaluate; None uses released ZipDepth-base weights."""
+    """Checkpoint to evaluate; None uses released ZipDepth-base weights."""
+    evaluation: Literal["metric", "affine-reference", "aligned-relative"] = "metric"
+    """Direct prompted model, closed-form untrained reference, or legacy aligned diagnostic."""
     height: int = 768
     """Deterministic evaluation image height."""
     width: int = 1024
     """Deterministic evaluation image width."""
     frame_stride: int = 10
     """Evaluate every Nth chosen PromptDA frame within each segment."""
-    input_size: int = 384
+    input_size: int = 768
     """Shorter image side the network runs at (``ZipDepthPredictor`` resizes to it, then upsamples the disparity).
     384 is the released model's training size; catalog fine-tunes train the network directly at ``height`` x ``width``,
     so score those with ``input_size=height`` to avoid a train/eval resolution mismatch."""
     max_segments: int | None = None
     """Optional limit on the selected evaluation segments."""
+    holdout_count: int = 20
+    """Deterministic fallback holdout size when no saved manifest exists."""
+    holdout_seed: int = 0
+    """Deterministic fallback holdout seed."""
 
 
 @dataclass(slots=True, frozen=True)
@@ -56,6 +66,111 @@ class CatalogDepthMetrics:
     """Mean absolute relative depth error over valid pixels."""
     delta1: float
     """Fraction of valid depth ratios below 1.25."""
+
+
+@dataclass(slots=True, frozen=True)
+class MetricCatalogDepthMetrics:
+    """Unaligned or explicitly diagnostic metric-depth scores."""
+
+    abs_rel: float
+    """Mean absolute relative depth error over valid pixels."""
+    delta1: float
+    """Fraction of valid depth ratios below 1.25."""
+    mae: float
+    """Mean absolute error in metres."""
+
+
+def score_metric_depth(
+    prediction_depth_hw: Float[ndarray, "h w"],
+    target_depth_hw: Float[ndarray, "h w"],
+    valid_hw: Bool[ndarray, "h w"],
+) -> MetricCatalogDepthMetrics:
+    """Score metric depth directly, without any scale or shift alignment."""
+    if prediction_depth_hw.shape != target_depth_hw.shape or valid_hw.shape != target_depth_hw.shape:
+        raise ValueError("prediction, target, and validity mask must have equal shapes")
+    metric_valid_hw: Bool[ndarray, "h w"] = (
+        valid_hw
+        & np.isfinite(prediction_depth_hw)
+        & np.isfinite(target_depth_hw)
+        & (prediction_depth_hw > 0.0)
+        & (target_depth_hw >= 0.1)
+        & (target_depth_hw <= 4.0)
+    )
+    if int(np.count_nonzero(metric_valid_hw)) < 10:
+        raise ValueError("at least ten valid metric-depth pixels are required")
+    return MetricCatalogDepthMetrics(
+        abs_rel=abs_relative_difference(prediction_depth_hw, target_depth_hw, metric_valid_hw),
+        delta1=delta1_acc(prediction_depth_hw, target_depth_hw, metric_valid_hw),
+        mae=float(np.mean(np.abs(prediction_depth_hw[metric_valid_hw] - target_depth_hw[metric_valid_hw]))),
+    )
+
+
+def affine_reference_depth(
+    relative_inverse_depth_hw: Float32[ndarray, "h w"],
+    prompt_depth_hw: Float32[ndarray, "192 256"],
+    prompt_valid_hw: Bool[ndarray, "192 256"],
+) -> Float32[ndarray, "h w"]:
+    """Fit released relative inverse depth to valid LiDAR and return metres.
+
+    This is the untrained reference only. It is not the prompted model.
+    """
+    if prompt_depth_hw.shape != (192, 256) or prompt_valid_hw.shape != (192, 256):
+        raise ValueError("prompt depth and validity must both have shape 192x256")
+    relative_prompt_hw: Float32[ndarray, "192 256"] = cv2.resize(
+        relative_inverse_depth_hw,
+        (256, 192),
+        interpolation=cv2.INTER_LINEAR,
+    ).astype(np.float32)
+    fit_hw: Bool[ndarray, "192 256"] = (
+        prompt_valid_hw
+        & np.isfinite(relative_prompt_hw)
+        & np.isfinite(prompt_depth_hw)
+        & (prompt_depth_hw >= 0.1)
+        & (prompt_depth_hw <= 4.0)
+    )
+    if int(np.count_nonzero(fit_hw)) < 10:
+        raise ValueError("at least ten valid LiDAR prompt pixels are required")
+    x_n: Float[ndarray, "n"] = relative_prompt_hw[fit_hw].astype(np.float64)
+    y_n: Float[ndarray, "n"] = (1.0 / prompt_depth_hw[fit_hw]).astype(np.float64)
+    x_mean: float = float(np.mean(x_n))
+    y_mean: float = float(np.mean(y_n))
+    centered_x_n: Float[ndarray, "n"] = x_n - x_mean
+    variance: float = float(np.sum(centered_x_n * centered_x_n))
+    if variance <= 1.0e-12:
+        raise ValueError("relative inverse depth is constant over the valid LiDAR prompt")
+    scale: float = float(np.sum(centered_x_n * (y_n - y_mean)) / variance)
+    shift: float = y_mean - scale * x_mean
+    aligned_inverse_hw: Float32[ndarray, "h w"] = np.clip(
+        scale * relative_inverse_depth_hw.astype(np.float64) + shift,
+        0.25,
+        10.0,
+    ).astype(np.float32)
+    return np.reciprocal(aligned_inverse_hw).astype(np.float32)
+
+
+def aligned_inverse_diagnostic(
+    prediction_depth_hw: Float[ndarray, "h w"],
+    target_depth_hw: Float[ndarray, "h w"],
+    valid_hw: Bool[ndarray, "h w"],
+) -> MetricCatalogDepthMetrics:
+    """Score after affine inverse-depth alignment, explicitly as a diagnostic."""
+    fit_hw: Bool[ndarray, "h w"] = (
+        valid_hw
+        & np.isfinite(prediction_depth_hw)
+        & np.isfinite(target_depth_hw)
+        & (prediction_depth_hw > 0.0)
+        & (target_depth_hw >= 0.1)
+        & (target_depth_hw <= 4.0)
+    )
+    if int(np.count_nonzero(fit_hw)) < 10:
+        raise ValueError("at least ten valid metric-depth pixels are required")
+    prediction_inverse_hw: Float[ndarray, "h w"] = np.zeros_like(prediction_depth_hw)
+    target_inverse_hw: Float[ndarray, "h w"] = np.zeros_like(target_depth_hw)
+    prediction_inverse_hw[fit_hw] = 1.0 / prediction_depth_hw[fit_hw]
+    target_inverse_hw[fit_hw] = 1.0 / target_depth_hw[fit_hw]
+    aligned_inverse_hw: Float[ndarray, "h w"] = align_depth_least_square(target_inverse_hw, prediction_inverse_hw, fit_hw)
+    aligned_depth_hw: Float[ndarray, "h w"] = disparity2depth(aligned_inverse_hw)
+    return score_metric_depth(aligned_depth_hw, target_depth_hw, fit_hw)
 
 
 def align_and_score_inverse_depth(
@@ -101,13 +216,17 @@ def _selected_segments(config: EvalCatalogConfig, catalog: PromptDACatalog) -> l
     """Resolve explicit segments or the saved training holdout manifest."""
     if config.segment_ids is None:
         manifest: Path = config.save_dir / "holdout_segments.json"
-        if not manifest.is_file():
-            raise FileNotFoundError(manifest)
-        with manifest.open() as file:
-            loaded: object = json.load(file)
-        if not isinstance(loaded, list) or not all(isinstance(value, str) for value in loaded):
-            raise ValueError(f"holdout manifest must contain a JSON string list: {manifest}")
-        segment_ids: list[str] = list(loaded)
+        if manifest.is_file():
+            with manifest.open() as file:
+                loaded: object = json.load(file)
+            if not isinstance(loaded, list) or not all(isinstance(value, str) for value in loaded):
+                raise ValueError(f"holdout manifest must contain a JSON string list: {manifest}")
+            segment_ids: list[str] = list(loaded)
+        else:
+            if not 0 < config.holdout_count <= len(catalog.segment_ids):
+                raise ValueError(f"holdout_count must be in [1, {len(catalog.segment_ids)}]")
+            holdout_set: set[str] = set(Random(config.holdout_seed).sample(sorted(catalog.segment_ids), config.holdout_count))
+            segment_ids = sorted(holdout_set)
     else:
         segment_ids = list(config.segment_ids)
     catalog.require_segments(segment_ids)
@@ -121,25 +240,38 @@ def _selected_segments(config: EvalCatalogConfig, catalog: PromptDACatalog) -> l
 
 
 def main(config: EvalCatalogConfig) -> Path:
-    """Evaluate selected segments, print summaries, and write a JSON report."""
+    """Evaluate selected segments, print explicit metric/diagnostic summaries, and write JSON."""
     if config.frame_stride <= 0:
         raise ValueError("frame_stride must be positive")
+    if config.height <= 0 or config.width <= 0 or config.input_size <= 0:
+        raise ValueError("height, width, and input_size must be positive")
     catalog: PromptDACatalog = load_promptda_catalog(config.catalog_url, config.dataset_name)
     segment_ids: list[str] = _selected_segments(config, catalog)
     transform: AlbumentationsWrapper = build_eval_transform(config.height, config.width)
     device: torch.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     checkpoint: Path = config.checkpoint or download_zipdepth_checkpoint()
-    predictor: ZipDepthPredictor = ZipDepthPredictor(
-        device="cuda" if device.type == "cuda" else "cpu", checkpoint=checkpoint, input_size=config.input_size
-    )
+    prompted_model: ZipDepthPrompt | None = None
+    relative_predictor: ZipDepthPredictor | None = None
+    if config.evaluation == "metric":
+        prompted_model = load_zipdepth_prompt(checkpoint).to(device).fuse_for_inference()
+    else:
+        relative_predictor = ZipDepthPredictor(
+            device="cuda" if device.type == "cuda" else "cpu",
+            checkpoint=checkpoint,
+            input_size=config.input_size,
+        )
 
-    # Catalog-only import stays local so pure metric tests run in zipdepth-dev.
+    # Catalog-only imports stay local so pure metric tests run outside the catalog lane.
     from zipdepth.catalog.builders import CpuSampleBuilder
     from zipdepth.catalog.dataset import CatalogPromptDepthDataset
 
     per_segment: list[dict[str, float | int | str]] = []
-    all_abs_rel: list[float] = []
-    all_delta1: list[float] = []
+    all_metric_abs_rel: list[float] = []
+    all_metric_delta1: list[float] = []
+    all_metric_mae: list[float] = []
+    all_diagnostic_abs_rel: list[float] = []
+    all_diagnostic_delta1: list[float] = []
+    all_diagnostic_mae: list[float] = []
     segment_id: str
     for segment_id in segment_ids:
         dataset: CatalogPromptDepthDataset = CatalogPromptDepthDataset(
@@ -147,49 +279,127 @@ def main(config: EvalCatalogConfig) -> Path:
             [segment_id],
             catalog.row_by_id,
             device=device,
-            builder_factory=lambda: CpuSampleBuilder(transform, min_depth_span=1.25),
+            builder_factory=lambda: CpuSampleBuilder(transform, min_depth_span=0.0, target_mode="metric"),
             shuffle_buffer_size=1,
             frame_stride=config.frame_stride,
             num_producers=1,
             prefetch_samples=4,
         )
         loader: DataLoader[dict[str, Tensor]] = DataLoader(dataset, batch_size=1, num_workers=0)
-        segment_abs_rel: list[float] = []
-        segment_delta1: list[float] = []
+        segment_metric_abs_rel: list[float] = []
+        segment_metric_delta1: list[float] = []
+        segment_metric_mae: list[float] = []
+        segment_diagnostic_abs_rel: list[float] = []
+        segment_diagnostic_delta1: list[float] = []
+        segment_diagnostic_mae: list[float] = []
         batch: dict[str, Tensor]
         for batch in loader:
             image_chw: UInt8[ndarray, "3 h w"] = batch["image"][0].numpy()
             rgb_hw3: UInt8[ndarray, "h w 3"] = np.ascontiguousarray(np.moveaxis(image_chw, 0, -1))
-            target_hw: Float32[ndarray, "h w"] = batch["depth"][0, 0].numpy().astype(np.float32) / INV_DEPTH_SCALE
-            valid_hw: Bool[ndarray, "h w"] = batch["mask"][0, 0].numpy().astype(bool, copy=False)
-            prediction_hw: Float32[ndarray, "h w"] = predictor(rgb_hw3, None).disparity
-            metrics: CatalogDepthMetrics = align_and_score_inverse_depth(prediction_hw, target_hw, valid_hw)
-            segment_abs_rel.append(metrics.abs_rel)
-            segment_delta1.append(metrics.delta1)
-        if not segment_abs_rel:
+            target_depth_hw: Float32[ndarray, "h w"] = batch["target_depth"][0, 0].numpy().astype(np.float32, copy=False)
+            target_valid_hw: Bool[ndarray, "h w"] = batch["target_valid"][0, 0].numpy().astype(bool, copy=False)
+            prompt_depth_hw: Float32[ndarray, "192 256"] = batch["prompt_depth"][0, 0].numpy().astype(np.float32, copy=False)
+            prompt_valid_hw: Bool[ndarray, "192 256"] = batch["prompt_valid"][0, 0].numpy().astype(bool, copy=False)
+
+            if prompted_model is not None:
+                image_b3hw: Tensor = batch["image"].to(device=device, non_blocking=True)
+                prompt_depth_b1hw: Tensor = batch["prompt_depth"].to(device=device, non_blocking=True)
+                prompt_valid_b1hw: Tensor = batch["prompt_valid"].to(device=device, non_blocking=True)
+                masked_prompt_b1hw: Tensor = torch.where(prompt_valid_b1hw, prompt_depth_b1hw, torch.zeros_like(prompt_depth_b1hw))
+                with torch.inference_mode():
+                    prediction_depth_hw: Float32[ndarray, "h w"] = (
+                        prompted_model(image_b3hw, masked_prompt_b1hw)[0, 0].float().cpu().numpy()
+                    )
+            else:
+                if relative_predictor is None:
+                    raise RuntimeError("relative predictor was not initialized")
+                relative_inverse_hw: Float32[ndarray, "h w"] = relative_predictor(rgb_hw3, None).disparity
+                if config.evaluation == "affine-reference":
+                    prediction_depth_hw = affine_reference_depth(relative_inverse_hw, prompt_depth_hw, prompt_valid_hw)
+                else:
+                    prediction_depth_hw = np.reciprocal(np.clip(relative_inverse_hw, 1.0e-6, None)).astype(np.float32)
+
+            if config.evaluation != "aligned-relative":
+                metric: MetricCatalogDepthMetrics = score_metric_depth(prediction_depth_hw, target_depth_hw, target_valid_hw)
+                segment_metric_abs_rel.append(metric.abs_rel)
+                segment_metric_delta1.append(metric.delta1)
+                segment_metric_mae.append(metric.mae)
+            diagnostic: MetricCatalogDepthMetrics = aligned_inverse_diagnostic(
+                prediction_depth_hw,
+                target_depth_hw,
+                target_valid_hw,
+            )
+            segment_diagnostic_abs_rel.append(diagnostic.abs_rel)
+            segment_diagnostic_delta1.append(diagnostic.delta1)
+            segment_diagnostic_mae.append(diagnostic.mae)
+
+        if not segment_diagnostic_abs_rel:
             print(f"{segment_id}: no frames")
             continue
-        mean_abs_rel: float = float(np.mean(segment_abs_rel))
-        mean_delta1: float = float(np.mean(segment_delta1))
-        frame_count: int = len(segment_abs_rel)
-        print(f"{segment_id}: AbsRel={mean_abs_rel:.6f} delta1={mean_delta1:.6f} frames={frame_count}")
-        per_segment.append({"segment_id": segment_id, "abs_rel": mean_abs_rel, "delta1": mean_delta1, "frame_count": frame_count})
-        all_abs_rel.extend(segment_abs_rel)
-        all_delta1.extend(segment_delta1)
+        frame_count: int = len(segment_diagnostic_abs_rel)
+        segment_report: dict[str, float | int | str] = {
+            "segment_id": segment_id,
+            "frame_count": frame_count,
+            "aligned_inverse_diagnostic_abs_rel": float(np.mean(segment_diagnostic_abs_rel)),
+            "aligned_inverse_diagnostic_delta1": float(np.mean(segment_diagnostic_delta1)),
+            "aligned_inverse_diagnostic_mae": float(np.mean(segment_diagnostic_mae)),
+        }
+        if segment_metric_abs_rel:
+            segment_report.update(
+                {
+                    "metric_abs_rel": float(np.mean(segment_metric_abs_rel)),
+                    "metric_delta1": float(np.mean(segment_metric_delta1)),
+                    "metric_mae": float(np.mean(segment_metric_mae)),
+                }
+            )
+            print(
+                f"{segment_id}: metric AbsRel={segment_report['metric_abs_rel']:.6f} "
+                f"delta1={segment_report['metric_delta1']:.6f} MAE={segment_report['metric_mae']:.6f}m frames={frame_count}"
+            )
+            all_metric_abs_rel.extend(segment_metric_abs_rel)
+            all_metric_delta1.extend(segment_metric_delta1)
+            all_metric_mae.extend(segment_metric_mae)
+        else:
+            print(
+                f"{segment_id}: aligned_inverse_diagnostic AbsRel={segment_report['aligned_inverse_diagnostic_abs_rel']:.6f} "
+                f"delta1={segment_report['aligned_inverse_diagnostic_delta1']:.6f} frames={frame_count}"
+            )
+        per_segment.append(segment_report)
+        all_diagnostic_abs_rel.extend(segment_diagnostic_abs_rel)
+        all_diagnostic_delta1.extend(segment_diagnostic_delta1)
+        all_diagnostic_mae.extend(segment_diagnostic_mae)
 
-    if not all_abs_rel:
+    if not all_diagnostic_abs_rel:
         raise RuntimeError("evaluation yielded no valid frames")
-    overall_abs_rel: float = float(np.mean(all_abs_rel))
-    overall_delta1: float = float(np.mean(all_delta1))
-    overall_frames: int = len(all_abs_rel)
-    print(f"overall: AbsRel={overall_abs_rel:.6f} delta1={overall_delta1:.6f} frames={overall_frames}")
+    overall: dict[str, float | int] = {
+        "frame_count": len(all_diagnostic_abs_rel),
+        "aligned_inverse_diagnostic_abs_rel": float(np.mean(all_diagnostic_abs_rel)),
+        "aligned_inverse_diagnostic_delta1": float(np.mean(all_diagnostic_delta1)),
+        "aligned_inverse_diagnostic_mae": float(np.mean(all_diagnostic_mae)),
+    }
+    if all_metric_abs_rel:
+        overall.update(
+            {
+                "metric_abs_rel": float(np.mean(all_metric_abs_rel)),
+                "metric_delta1": float(np.mean(all_metric_delta1)),
+                "metric_mae": float(np.mean(all_metric_mae)),
+            }
+        )
+        print(
+            f"overall metric: AbsRel={overall['metric_abs_rel']:.6f} delta1={overall['metric_delta1']:.6f} "
+            f"MAE={overall['metric_mae']:.6f}m frames={overall['frame_count']}"
+        )
+    print(
+        f"overall aligned_inverse_diagnostic: AbsRel={overall['aligned_inverse_diagnostic_abs_rel']:.6f} "
+        f"delta1={overall['aligned_inverse_diagnostic_delta1']:.6f} MAE={overall['aligned_inverse_diagnostic_mae']:.6f}m"
+    )
 
     config.save_dir.mkdir(parents=True, exist_ok=True)
-    output: Path = config.save_dir / f"eval_{checkpoint.stem}_net{config.input_size}.json"
+    output: Path = config.save_dir / f"eval_{config.evaluation}_{checkpoint.stem}_net{config.input_size}.json"
     report: dict[str, object] = {
-        "config": {**asdict(config), "checkpoint": str(checkpoint)},
+        "config": {**asdict(config), "checkpoint": str(checkpoint), "segment_ids": segment_ids},
         "per_segment": per_segment,
-        "overall": {"abs_rel": overall_abs_rel, "delta1": overall_delta1, "frame_count": overall_frames},
+        "overall": overall,
     }
     with output.open("w") as file:
         json.dump(report, file, indent=2, default=str)

--- a/packages/zipdepth/zipdepth/apis/prompted_trt.py
+++ b/packages/zipdepth/zipdepth/apis/prompted_trt.py
@@ -1,0 +1,279 @@
+"""Static-batch fp16 ONNX/TensorRT export for ZipDepth-PromptDA."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import torch
+from monopriors.models.depth_completion.zipdepth_prompt import load_zipdepth_prompt
+from monopriors.models.relative_depth.zipdepth import download_zipdepth_checkpoint
+from torch import Tensor, nn
+
+IMAGE_INPUT_NAME: str = "image"
+PROMPT_INPUT_NAME: str = "prompt_depth"
+DEPTH_OUTPUT_NAME: str = "depth"
+ONNX_EXPORT_VERSION: int = 1
+DEFAULT_CACHE_DIR: Path = Path(os.environ.get("ZIPDEPTH_PROMPT_TRT_CACHE", "~/.cache/zipdepth-promptda")).expanduser()
+
+ModelLoader = Callable[[Path], Any]
+ExportFn = Callable[..., None]
+
+
+class _ExportOutputs(nn.Module):
+    """Expose the prompt min/max reductions as TRT fusion barriers."""
+
+    def __init__(self, model: nn.Module) -> None:
+        super().__init__()
+        self.model = model
+
+    def forward(self, image: Tensor, prompt_depth: Tensor) -> tuple[Tensor, Tensor, Tensor]:
+        prompt_model: Any = self.model
+        return cast(tuple[Tensor, Tensor, Tensor], prompt_model.forward_with_range(image, prompt_depth))
+
+
+@dataclass(frozen=True, slots=True)
+class TrtExportConfig:
+    """Export, parity-check, and benchmark configuration."""
+
+    checkpoint: Path | None = None
+    """Prompted trainer checkpoint; None uses released ZipDepth-base with a zero branch."""
+    cache_dir: Path = DEFAULT_CACHE_DIR
+    """Portable ONNX, machine-local engine, and result cache root."""
+    height: int = 768
+    """Static image height."""
+    width: int = 1024
+    """Static image width."""
+    batch_size: int = 8
+    """Batch baked into both ONNX and TensorRT artifacts."""
+    warmup: int = 10
+    """Unmeasured TensorRT calls before timing."""
+    iterations: int = 50
+    """Measured TensorRT calls."""
+    result_path: Path = Path("/tmp/zd-pda-research/trt-parity-latency.json")
+    """JSON report containing artifact paths, parity errors, and CUDA-event latency."""
+
+
+def _checkpoint_tag(checkpoint: Path) -> str:
+    """Return a stable short identity for released and locally trained weights."""
+    parts: tuple[str, ...] = checkpoint.parts
+    if "snapshots" in parts:
+        return parts[parts.index("snapshots") + 1][:8]
+    digest = hashlib.sha256()
+    with checkpoint.open("rb") as file:
+        while block := file.read(1024 * 1024):
+            digest.update(block)
+    return digest.hexdigest()[:8]
+
+
+def prepare_zipdepth_prompt_for_export(
+    model: Any,
+    image_hw: tuple[int, int],
+    device: torch.device,
+) -> nn.Module:
+    """Fuse and convert a prompted model for a static fp16 graph."""
+    height, width = image_hw
+    if height <= 0 or width <= 0 or height % 32 != 0 or width % 32 != 0:
+        raise ValueError(f"ZipDepth image dimensions must be positive multiples of 32, got {image_hw}")
+    fused_model = cast(nn.Module, model.fuse_for_inference())
+    return fused_model.to(device).half()
+
+
+def export_zipdepth_prompt_onnx(
+    *,
+    checkpoint: Path | None = None,
+    image_hw: tuple[int, int] = (768, 1024),
+    batch_size: int = 8,
+    cache_dir: Path = DEFAULT_CACHE_DIR,
+    model_loader: ModelLoader = load_zipdepth_prompt,
+    export_fn: ExportFn | None = None,
+    device: str = "cuda",
+) -> Path:
+    """Export a two-input fp16-compute ONNX graph with a fixed batch.
+
+    Static batch is required because TensorRT Myelin cannot build ZipDepth's
+    unfold head when its leading dimension is symbolic. The graph keeps fp32
+    image, prompt, and depth I/O while the network weights and convolutions are
+    fp16.
+    """
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+    height, width = image_hw
+    resolved_checkpoint: Path = checkpoint or download_zipdepth_checkpoint()
+    tag: str = _checkpoint_tag(resolved_checkpoint)
+    onnx_dir: Path = cache_dir / "onnx"
+    onnx_path: Path = onnx_dir / f"zipdepth-prompt_{height}x{width}_b{batch_size}_fp16_v{ONNX_EXPORT_VERSION}_{tag}.onnx"
+    if onnx_path.is_file():
+        return onnx_path
+
+    resolved_device = torch.device(device)
+    if resolved_device.type == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for the fp16 ZipDepth ONNX export")
+    model: nn.Module = prepare_zipdepth_prompt_for_export(model_loader(resolved_checkpoint), image_hw, resolved_device)
+    wrapper = _ExportOutputs(model).eval()
+    dummy_image = torch.rand((batch_size, 3, height, width), dtype=torch.float32, device=resolved_device)
+    dummy_prompt = torch.linspace(0.2, 3.8, 192 * 256, dtype=torch.float32, device=resolved_device).reshape(1, 1, 192, 256)
+    dummy_prompt = dummy_prompt.expand(batch_size, -1, -1, -1).contiguous()
+    dummy_prompt[:, :, 24:160:3, 32:224:4] = 0.0
+
+    if export_fn is None:
+        from trtkit import export_onnx
+
+        export_fn = export_onnx
+    export_fn(
+        wrapper,
+        (dummy_image, dummy_prompt),
+        onnx_path,
+        input_names=[IMAGE_INPUT_NAME, PROMPT_INPUT_NAME],
+        output_names=[DEPTH_OUTPUT_NAME, "min_depth", "max_depth"],
+        compute_dtype=None,
+        dynamic_batch_max=None,
+    )
+    del wrapper, model
+    if resolved_device.type == "cuda":
+        torch.cuda.empty_cache()
+    return onnx_path
+
+
+def _parity_inputs(batch_size: int, image_hw: tuple[int, int], device: torch.device) -> dict[str, Tensor]:
+    """Create deterministic image plus alternating holey/narrow prompts."""
+    generator = torch.Generator(device=device).manual_seed(7)
+    image = torch.rand((batch_size, 3, *image_hw), generator=generator, dtype=torch.float32, device=device)
+    wide = torch.linspace(0.2, 3.8, 192 * 256, dtype=torch.float32, device=device).reshape(1, 1, 192, 256)
+    wide[:, :, 24:160:3, 32:224:4] = 0.0
+    narrow = torch.linspace(1.500, 1.503, 192 * 256, dtype=torch.float32, device=device).reshape(1, 1, 192, 256)
+    prompt_rows: list[Tensor] = [wide if index % 2 == 0 else narrow for index in range(batch_size)]
+    return {IMAGE_INPUT_NAME: image, PROMPT_INPUT_NAME: torch.cat(prompt_rows, dim=0).contiguous()}
+
+
+def _error_summary(actual: Tensor, expected: Tensor, rows: slice) -> dict[str, float]:
+    """Summarize absolute metric-depth parity error for selected rows."""
+    error: Tensor = (actual[rows] - expected[rows]).abs()
+    return {"median_abs_m": float(error.median()), "max_abs_m": float(error.max())}
+
+
+def verify_three_backend_parity(
+    checkpoint: Path,
+    onnx_path: Path,
+    engine_path: Path,
+    image_hw: tuple[int, int],
+    batch_size: int,
+) -> dict[str, dict[str, dict[str, float]]]:
+    """Measure Torch-vs-ONNX-vs-TRT error for holey and narrow prompts."""
+    from trtkit import OnnxCudaRuntime, TensorRtRuntime
+
+    device = torch.device("cuda")
+    inputs: dict[str, Tensor] = _parity_inputs(batch_size, image_hw, device)
+    model: nn.Module = prepare_zipdepth_prompt_for_export(load_zipdepth_prompt(checkpoint), image_hw, device)
+    with torch.inference_mode():
+        expected: Tensor = model(inputs[IMAGE_INPUT_NAME], inputs[PROMPT_INPUT_NAME]).clone()
+    onnx_depth: Tensor = OnnxCudaRuntime(onnx_path)(inputs)[DEPTH_OUTPUT_NAME].clone()
+    trt_depth: Tensor = TensorRtRuntime(engine_path)(inputs)[DEPTH_OUTPUT_NAME].clone()
+    result: dict[str, dict[str, dict[str, float]]] = {}
+    for case_name, rows in (("holey", slice(0, None, 2)), ("narrow", slice(1, None, 2))):
+        result[case_name] = {
+            "onnx_vs_torch": _error_summary(onnx_depth, expected, rows),
+            "trt_vs_torch": _error_summary(trt_depth, expected, rows),
+        }
+    del model
+    torch.cuda.empty_cache()
+    return result
+
+
+def benchmark_tensorrt(
+    engine_path: Path,
+    image_hw: tuple[int, int],
+    batch_size: int,
+    warmup: int,
+    iterations: int,
+) -> dict[str, float | int]:
+    """Measure engine-call latency with CUDA events, including input copies."""
+    from trtkit import TensorRtRuntime
+
+    if warmup < 0 or iterations <= 0:
+        raise ValueError("warmup must be nonnegative and iterations must be positive")
+    runtime = TensorRtRuntime(engine_path)
+    inputs: dict[str, Tensor] = _parity_inputs(batch_size, image_hw, torch.device("cuda"))
+    for _ in range(warmup):
+        runtime(inputs)
+    torch.cuda.synchronize()
+    elapsed_ms: list[float] = []
+    for _ in range(iterations):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        runtime(inputs)
+        end.record()
+        end.synchronize()
+        elapsed_ms.append(float(start.elapsed_time(end)))
+    median_ms: float = float(np.median(elapsed_ms))
+    return {
+        "batch_size": batch_size,
+        "warmup": warmup,
+        "iterations": iterations,
+        "median_ms_per_batch": median_ms,
+        "p95_ms_per_batch": float(np.percentile(elapsed_ms, 95)),
+        "median_ms_per_frame": median_ms / batch_size,
+        "frames_per_second": 1000.0 * batch_size / median_ms,
+    }
+
+
+def main(config: TrtExportConfig) -> Path:
+    """Export, build, verify parity, benchmark, and write a JSON report."""
+    if not torch.cuda.is_available():
+        raise RuntimeError("ZipDepth TensorRT export requires CUDA")
+    checkpoint: Path = config.checkpoint or download_zipdepth_checkpoint()
+    image_hw: tuple[int, int] = (config.height, config.width)
+    onnx_path: Path = export_zipdepth_prompt_onnx(
+        checkpoint=checkpoint,
+        image_hw=image_hw,
+        batch_size=config.batch_size,
+        cache_dir=config.cache_dir,
+    )
+    from trtkit import TrtBuildConfig, ensure_engine, onnx_static_batch_size
+
+    static_batch: int | None = onnx_static_batch_size(onnx_path)
+    if static_batch != config.batch_size:
+        raise RuntimeError(f"ONNX batch must be static {config.batch_size}, got {static_batch}")
+    engine_path: Path = ensure_engine(
+        onnx_path,
+        TrtBuildConfig(max_batch_size=config.batch_size, opt_batch_size=config.batch_size),
+        cache_dir=config.cache_dir / "engines",
+    )
+    parity: dict[str, dict[str, dict[str, float]]] = verify_three_backend_parity(
+        checkpoint,
+        onnx_path,
+        engine_path,
+        image_hw,
+        config.batch_size,
+    )
+    for case_name, backends in parity.items():
+        for backend_name, errors in backends.items():
+            if errors["median_abs_m"] >= 0.003 or errors["max_abs_m"] >= 0.02:
+                raise RuntimeError(f"parity failed for {backend_name}:{case_name}: {errors}")
+    latency: dict[str, float | int] = benchmark_tensorrt(
+        engine_path,
+        image_hw,
+        config.batch_size,
+        config.warmup,
+        config.iterations,
+    )
+    report: dict[str, Any] = {
+        "config": {**asdict(config), "checkpoint": str(checkpoint), "cache_dir": str(config.cache_dir), "result_path": str(config.result_path)},
+        "onnx_path": str(onnx_path),
+        "engine_path": str(engine_path),
+        "static_batch": static_batch,
+        "parity": parity,
+        "latency": latency,
+        "gpu": torch.cuda.get_device_name(),
+    }
+    config.result_path.parent.mkdir(parents=True, exist_ok=True)
+    config.result_path.write_text(json.dumps(report, indent=2) + "\n")
+    print(json.dumps(report, indent=2))
+    return config.result_path

--- a/packages/zipdepth/zipdepth/apis/train_catalog.py
+++ b/packages/zipdepth/zipdepth/apis/train_catalog.py
@@ -69,6 +69,11 @@ class TrainCatalogConfig:
     """Minimum valid-depth p95/p5 ratio; zero disables flat-frame filtering."""
     from_scratch: bool = False
     """Start with random weights instead of the released ZipDepth-base weights."""
+    metric_gradient_weight: float = 0.5
+    """Weight on the multi-scale gradient term in the metric loss (L1 + w * grad).
+    At 0.5 the term supplies only ~9% of the objective; upstream ZipDepth weights its
+    equivalent term at 2.0. Raising it targets depth-discontinuity error, where the model
+    beats a bilinear prompt upsample by the smallest margin."""
     freeze_bn: bool = True
     """Pin BatchNorm to eval mode while fine-tuning: forwards use the released running
     stats instead of batch statistics, and the stats never drift toward the new data.
@@ -463,6 +468,7 @@ def main(
             alpha_ssi=float(loss_config.get("alpha_ssi", 1.0)),
             alpha_grad=float(loss_config.get("alpha_grad", 2.0)),
             target_mode=config.target_mode,
+            metric_gradient_weight=config.metric_gradient_weight,
         )
         if step_loss_callback is not None:
             trainer.criterion = cast(Any, _LossObserver(trainer.criterion, step_loss_callback))

--- a/packages/zipdepth/zipdepth/apis/train_catalog.py
+++ b/packages/zipdepth/zipdepth/apis/train_catalog.py
@@ -13,6 +13,7 @@ from typing import Any, cast
 
 import torch
 import torch.distributed as dist
+from monopriors.models.depth_completion.zipdepth_prompt import ZipDepthPrompt, load_zipdepth_prompt
 from monopriors.models.relative_depth.zipdepth import download_zipdepth_checkpoint
 from monopriors.third_party.zipdepth.architecture import ZipDepth, create_model
 from monopriors.third_party.zipdepth.model_utils import StateDict, strip_state_dict_prefixes
@@ -23,7 +24,7 @@ from torch.utils.tensorboard import SummaryWriter
 
 from zipdepth.catalog.instrument import InstrumentedLoader
 from zipdepth.catalog.segments import DEFAULT_CATALOG_URL, PromptDACatalog, load_promptda_catalog
-from zipdepth.catalog.targets import AugmentPolicy
+from zipdepth.catalog.targets import AugmentPolicy, TargetMode
 from zipdepth.training.distributed import barrier, cleanup_distributed, fix_state_dict_prefix, print_main, setup_distributed
 from zipdepth.training.trainer import ZipDepthTrainer
 
@@ -50,6 +51,8 @@ class TrainCatalogConfig:
     """Training image width after augmentation."""
     batch_size: int = 8
     """Samples per rank and optimizer step."""
+    target_mode: TargetMode = "metric"
+    """Prompted metric distillation by default; ``ssi`` retains the legacy RGB-only lane."""
     total_steps: int = 70_000
     """Optimizer steps in the run; the OneCycle schedule spans exactly this many. 70k is about one pass over the 875-segment train split at batch 8 (70.5k steps measured 2026-08-28)."""
     shuffle_buffer_size: int = 256
@@ -323,6 +326,8 @@ def main(
             raise ValueError("num_producers and prefetch_samples must be positive")
         if config.save_every_steps < 0:
             raise ValueError("save_every_steps must be non-negative")
+        if config.target_mode not in ("ssi", "metric"):
+            raise ValueError(f"unknown target mode {config.target_mode!r}")
         torch.backends.cudnn.benchmark = True
         torch.backends.cuda.matmul.allow_tf32 = True
         torch.backends.cudnn.allow_tf32 = True
@@ -381,6 +386,7 @@ def main(
                 AugmentPolicy(),
                 config.min_depth_span,
                 device,
+                target_mode=config.target_mode,
             ),
             shuffle_buffer_size=config.shuffle_buffer_size,
             seed=config.seed,
@@ -403,20 +409,31 @@ def main(
             writer=writer if is_main else None,
         )
 
-        model: ZipDepth = create_model(variant="base", upsample_unfold=bool(model_config.get("upsample_unfold", True)))
         initialization: Path | None = config.init_checkpoint
         if initialization is None and not config.from_scratch and config.resume is None:
             initialization = download_zipdepth_checkpoint()
-        if initialization is not None:
-            print_main(f"Loading trainable initialization: {initialization}", rank)
-            load_trainable_checkpoint(model, initialization)
+        if config.target_mode == "metric":
+            if initialization is not None:
+                print_main(f"Loading prompted trainable initialization: {initialization}", rank)
+                model: nn.Module = load_zipdepth_prompt(initialization)
+            else:
+                model = ZipDepthPrompt(
+                    create_model(variant="base", upsample_unfold=bool(model_config.get("upsample_unfold", True)))
+                )
+                print_main("Training ZipDepth-PromptDA from scratch", rank)
         else:
-            print_main("Training ZipDepth-base from scratch", rank)
+            relative_model: ZipDepth = create_model(variant="base", upsample_unfold=bool(model_config.get("upsample_unfold", True)))
+            if initialization is not None:
+                print_main(f"Loading trainable initialization: {initialization}", rank)
+                load_trainable_checkpoint(relative_model, initialization)
+            else:
+                print_main("Training ZipDepth-base from scratch", rank)
+            model = relative_model
         if config.freeze_bn and not config.from_scratch:
             pinned: int = pin_batchnorm_eval(model)
             print_main(f"Pinned {pinned} BatchNorm modules to eval (released running stats)", rank)
         model = model.to(device)
-        wrapped_model: ZipDepth | DDP = (
+        wrapped_model: nn.Module | DDP = (
             DDP(model, device_ids=[local_rank], output_device=local_rank, find_unused_parameters=False) if is_distributed else model
         )
 
@@ -441,6 +458,7 @@ def main(
             amp_dtype=str(amp_config.get("dtype", "bfloat16")),
             alpha_ssi=float(loss_config.get("alpha_ssi", 1.0)),
             alpha_grad=float(loss_config.get("alpha_grad", 2.0)),
+            target_mode=config.target_mode,
         )
         if step_loss_callback is not None:
             trainer.criterion = cast(Any, _LossObserver(trainer.criterion, step_loss_callback))

--- a/packages/zipdepth/zipdepth/apis/train_catalog.py
+++ b/packages/zipdepth/zipdepth/apis/train_catalog.py
@@ -394,6 +394,10 @@ def main(
             world_size=world_size,
             num_producers=config.num_producers,
             prefetch_samples=config.prefetch_samples,
+            # Training ignores confidence: the student takes the raw prompt and the model
+            # range-gates internally. Skipping the column drops a column and ~48 KB/frame
+            # off every segment query.
+            load_confidence=False
         )
         data_loader: DataLoader[dict[str, Tensor]] = DataLoader(
             dataset,

--- a/packages/zipdepth/zipdepth/apis/train_catalog_smoke.py
+++ b/packages/zipdepth/zipdepth/apis/train_catalog_smoke.py
@@ -146,6 +146,7 @@ def main(config: TrainCatalogSmokeConfig) -> None:
         height=768,
         width=1024,
         batch_size=4,
+        target_mode="ssi",
         total_steps=config.total_steps,
         shuffle_buffer_size=32,
         num_producers=1,

--- a/packages/zipdepth/zipdepth/catalog/builders.py
+++ b/packages/zipdepth/zipdepth/catalog/builders.py
@@ -23,6 +23,9 @@ from zipdepth.catalog.targets import (
 )
 from zipdepth.data.transforms import AlbumentationsWrapper
 
+ARKIT_CONFIDENCE_HIGH: int = 2
+"""ARKit HIGH confidence; stood in when the confidence column is not fetched."""
+
 
 @runtime_checkable
 class SampleBuilder(Protocol):
@@ -36,7 +39,7 @@ class SampleBuilder(Protocol):
         frame_chw: UInt8[Tensor, "3 h w"],
         target_blob_u8: UInt8[ndarray, "target_n"],
         prompt_blob_u8: UInt8[ndarray, "prompt_n"],
-        confidence_u8: UInt8[ndarray, "confidence_n"],
+        confidence_u8: UInt8[ndarray, "confidence_n"] | None,
         quarter_turns: int,
         sample_seed: int,
     ) -> dict[str, Tensor] | None:
@@ -63,7 +66,7 @@ class CpuSampleBuilder:
         frame_chw: UInt8[Tensor, "3 h w"],
         target_blob_u8: UInt8[ndarray, "target_n"],
         prompt_blob_u8: UInt8[ndarray, "prompt_n"],
-        confidence_u8: UInt8[ndarray, "confidence_n"],
+        confidence_u8: UInt8[ndarray, "confidence_n"] | None,
         quarter_turns: int,
         sample_seed: int,
     ) -> dict[str, Tensor] | None:
@@ -78,9 +81,14 @@ class CpuSampleBuilder:
         if prompt_depth_mm_hw is None:
             prompt_depth_mm_hw = decode_depth_png(prompt_blob_u8)
             self.stats.png_fallbacks += 1
-        if confidence_u8.size != prompt_depth_mm_hw.size:
-            raise ValueError(f"prompt confidence has {confidence_u8.size} values for prompt shape {prompt_depth_mm_hw.shape}")
-        prompt_confidence_hw: UInt8[ndarray, "prompt_h prompt_w"] = confidence_u8.reshape(prompt_depth_mm_hw.shape)
+        if confidence_u8 is None:
+            # Confidence was not fetched: trust every prompt pixel and let the model's
+            # own 0.1-4 m range gate do the filtering.
+            prompt_confidence_hw: UInt8[ndarray, "prompt_h prompt_w"] = np.full(prompt_depth_mm_hw.shape, ARKIT_CONFIDENCE_HIGH, dtype=np.uint8)
+        else:
+            if confidence_u8.size != prompt_depth_mm_hw.size:
+                raise ValueError(f"prompt confidence has {confidence_u8.size} values for prompt shape {prompt_depth_mm_hw.shape}")
+            prompt_confidence_hw = confidence_u8.reshape(prompt_depth_mm_hw.shape)
         if self._min_depth_span > 0.0 and depth_span_ratio(depth_mm_hw) < self._min_depth_span:
             self.stats.blob_decode += perf_counter() - started
             self.stats.skipped_flat_frames += 1
@@ -150,7 +158,7 @@ class CudaSampleBuilder:
         frame_chw: UInt8[Tensor, "3 h w"],
         target_blob_u8: UInt8[ndarray, "target_n"],
         prompt_blob_u8: UInt8[ndarray, "prompt_n"],
-        confidence_u8: UInt8[ndarray, "confidence_n"],
+        confidence_u8: UInt8[ndarray, "confidence_n"] | None,
         quarter_turns: int,
         sample_seed: int,
     ) -> dict[str, Tensor] | None:
@@ -179,6 +187,10 @@ class CudaSampleBuilder:
             if prompt_depth_mm_hw is None:
                 prompt_depth_mm_hw = decode_depth_png(prompt_blob_u8)
                 self.stats.png_fallbacks += 1
+            if confidence_u8 is None:
+                # Confidence was not fetched: trust every prompt pixel and let the
+                # model's own 0.1-4 m range gate do the filtering.
+                confidence_u8 = np.full(prompt_depth_mm_hw.size, ARKIT_CONFIDENCE_HIGH, dtype=np.uint8)
             if confidence_u8.size != prompt_depth_mm_hw.size:
                 raise ValueError(f"prompt confidence has {confidence_u8.size} values for prompt shape {prompt_depth_mm_hw.shape}")
             prompt_depth_cuda_hw: Int32[Tensor, "prompt_h prompt_w"] = torch.from_numpy(prompt_depth_mm_hw).to(

--- a/packages/zipdepth/zipdepth/catalog/builders.py
+++ b/packages/zipdepth/zipdepth/catalog/builders.py
@@ -14,6 +14,8 @@ from zipdepth.catalog.png import unfilter_up_cuda
 from zipdepth.catalog.stats import BuilderStats
 from zipdepth.catalog.targets import (
     AugmentPolicy,
+    TargetMode,
+    build_metric_training_sample,
     build_training_sample,
     build_training_sample_cuda,
     depth_span_ratio,
@@ -32,7 +34,9 @@ class SampleBuilder(Protocol):
     def __call__(
         self,
         frame_chw: UInt8[Tensor, "3 h w"],
-        blob_u8: UInt8[ndarray, "n"],
+        target_blob_u8: UInt8[ndarray, "target_n"],
+        prompt_blob_u8: UInt8[ndarray, "prompt_n"],
+        confidence_u8: UInt8[ndarray, "confidence_n"],
         quarter_turns: int,
         sample_seed: int,
     ) -> dict[str, Tensor] | None:
@@ -42,29 +46,41 @@ class SampleBuilder(Protocol):
 class CpuSampleBuilder:
     """Decode depth and build samples on the CPU."""
 
-    def __init__(self, transform: AlbumentationsWrapper, min_depth_span: float) -> None:
+    def __init__(self, transform: AlbumentationsWrapper, min_depth_span: float, target_mode: TargetMode = "ssi") -> None:
         """Configure deterministic transform and optional flat-depth filtering."""
         if min_depth_span < 0.0:
             raise ValueError("min_depth_span must be non-negative")
+        if target_mode not in ("ssi", "metric"):
+            raise ValueError(f"unknown target mode {target_mode!r}")
         self._transform: AlbumentationsWrapper = transform
         self._min_depth_span: float = min_depth_span
+        self._target_mode: TargetMode = target_mode
         self.stats: BuilderStats = BuilderStats()
         """Counters local to this builder."""
 
     def __call__(
         self,
         frame_chw: UInt8[Tensor, "3 h w"],
-        blob_u8: UInt8[ndarray, "n"],
+        target_blob_u8: UInt8[ndarray, "target_n"],
+        prompt_blob_u8: UInt8[ndarray, "prompt_n"],
+        confidence_u8: UInt8[ndarray, "confidence_n"],
         quarter_turns: int,
         sample_seed: int,
     ) -> dict[str, Tensor] | None:
         """Decode, orient, filter, and transform one CPU sample."""
         del sample_seed
         started: float = perf_counter()
-        depth_mm_hw: UInt16[ndarray, "h w"] | None = decode_depth_png_fast(blob_u8)
+        depth_mm_hw: UInt16[ndarray, "h w"] | None = decode_depth_png_fast(target_blob_u8)
         if depth_mm_hw is None:
-            depth_mm_hw = decode_depth_png(blob_u8)
+            depth_mm_hw = decode_depth_png(target_blob_u8)
             self.stats.png_fallbacks += 1
+        prompt_depth_mm_hw: UInt16[ndarray, "prompt_h prompt_w"] | None = decode_depth_png_fast(prompt_blob_u8)
+        if prompt_depth_mm_hw is None:
+            prompt_depth_mm_hw = decode_depth_png(prompt_blob_u8)
+            self.stats.png_fallbacks += 1
+        if confidence_u8.size != prompt_depth_mm_hw.size:
+            raise ValueError(f"prompt confidence has {confidence_u8.size} values for prompt shape {prompt_depth_mm_hw.shape}")
+        prompt_confidence_hw: UInt8[ndarray, "prompt_h prompt_w"] = confidence_u8.reshape(prompt_depth_mm_hw.shape)
         if self._min_depth_span > 0.0 and depth_span_ratio(depth_mm_hw) < self._min_depth_span:
             self.stats.blob_decode += perf_counter() - started
             self.stats.skipped_flat_frames += 1
@@ -76,7 +92,24 @@ class CpuSampleBuilder:
         rgb_hw3: UInt8[ndarray, "h w 3"] = np.moveaxis(rgb_chw, 0, -1)
         rgb_landscape_hw3: UInt8[ndarray, "landscape_h landscape_w 3"] = np.ascontiguousarray(np.rot90(rgb_hw3, quarter_turns))
         depth_landscape_mm_hw: UInt16[ndarray, "landscape_h landscape_w"] = np.ascontiguousarray(np.rot90(depth_mm_hw, quarter_turns))
-        sample: dict[str, Tensor] = build_training_sample(rgb_landscape_hw3, depth_landscape_mm_hw, self._transform)
+        prompt_landscape_mm_hw: UInt16[ndarray, "192 256"] = np.ascontiguousarray(np.rot90(prompt_depth_mm_hw, quarter_turns))
+        confidence_landscape_hw: UInt8[ndarray, "192 256"] = np.ascontiguousarray(np.rot90(prompt_confidence_hw, quarter_turns))
+        if self._target_mode == "metric":
+            sample: dict[str, Tensor] = build_metric_training_sample(
+                rgb_landscape_hw3,
+                depth_landscape_mm_hw,
+                prompt_landscape_mm_hw,
+                confidence_landscape_hw,
+                self._transform,
+            )
+        else:
+            sample = build_training_sample(
+                rgb_landscape_hw3,
+                depth_landscape_mm_hw,
+                self._transform,
+                prompt_depth_mm_hw=prompt_landscape_mm_hw,
+                prompt_confidence_hw=confidence_landscape_hw,
+            )
         self.stats.augment += perf_counter() - started
         self.stats.samples_built += 1
         return sample
@@ -85,7 +118,14 @@ class CpuSampleBuilder:
 class CudaSampleBuilder:
     """Inflate depth and build samples on one producer-owned CUDA stream."""
 
-    def __init__(self, out_hw: tuple[int, int], policy: AugmentPolicy, min_depth_span: float, device: torch.device) -> None:
+    def __init__(
+        self,
+        out_hw: tuple[int, int],
+        policy: AugmentPolicy,
+        min_depth_span: float,
+        device: torch.device,
+        target_mode: TargetMode = "ssi",
+    ) -> None:
         """Configure output shape, augmentation, filtering, and CUDA state."""
         if out_hw[0] <= 0 or out_hw[1] <= 0:
             raise ValueError("output height and width must be positive")
@@ -93,10 +133,13 @@ class CudaSampleBuilder:
             raise ValueError("min_depth_span must be non-negative")
         if device.type != "cuda":
             raise ValueError("CudaSampleBuilder requires a CUDA device")
+        if target_mode not in ("ssi", "metric"):
+            raise ValueError(f"unknown target mode {target_mode!r}")
         self._out_hw: tuple[int, int] = out_hw
         self._policy: AugmentPolicy = policy
         self._min_depth_span: float = min_depth_span
         self._device: torch.device = device
+        self._target_mode: TargetMode = target_mode
         self._generator: torch.Generator = torch.Generator()
         self._stream: torch.cuda.Stream = torch.cuda.Stream(device=device)
         self.stats: BuilderStats = BuilderStats()
@@ -105,7 +148,9 @@ class CudaSampleBuilder:
     def __call__(
         self,
         frame_chw: UInt8[Tensor, "3 h w"],
-        blob_u8: UInt8[ndarray, "n"],
+        target_blob_u8: UInt8[ndarray, "target_n"],
+        prompt_blob_u8: UInt8[ndarray, "prompt_n"],
+        confidence_u8: UInt8[ndarray, "confidence_n"],
         quarter_turns: int,
         sample_seed: int,
     ) -> dict[str, Tensor] | None:
@@ -114,9 +159,9 @@ class CudaSampleBuilder:
         frame_chw.record_stream(self._stream)
         started: float = perf_counter()
         with torch.cuda.stream(self._stream):
-            inflated: tuple[UInt8[ndarray, "h row_bytes"], tuple[int, int]] | None = inflate_depth_png_rows(blob_u8)
+            inflated: tuple[UInt8[ndarray, "h row_bytes"], tuple[int, int]] | None = inflate_depth_png_rows(target_blob_u8)
             if inflated is None:
-                depth_mm_hw: UInt16[ndarray, "h w"] = decode_depth_png(blob_u8)
+                depth_mm_hw: UInt16[ndarray, "h w"] = decode_depth_png(target_blob_u8)
                 depth_mm_cuda_hw: Int32[Tensor, "h w"] = torch.from_numpy(depth_mm_hw).to(
                     device=self._device,
                     dtype=torch.int32,
@@ -130,6 +175,20 @@ class CudaSampleBuilder:
                     non_blocking=True,
                 )
                 depth_mm_cuda_hw = unfilter_up_cuda(filtered_cuda_hwb)
+            prompt_depth_mm_hw: UInt16[ndarray, "prompt_h prompt_w"] | None = decode_depth_png_fast(prompt_blob_u8)
+            if prompt_depth_mm_hw is None:
+                prompt_depth_mm_hw = decode_depth_png(prompt_blob_u8)
+                self.stats.png_fallbacks += 1
+            if confidence_u8.size != prompt_depth_mm_hw.size:
+                raise ValueError(f"prompt confidence has {confidence_u8.size} values for prompt shape {prompt_depth_mm_hw.shape}")
+            prompt_depth_cuda_hw: Int32[Tensor, "prompt_h prompt_w"] = torch.from_numpy(prompt_depth_mm_hw).to(
+                device=self._device,
+                dtype=torch.int32,
+                non_blocking=True,
+            )
+            prompt_confidence_cuda_hw: UInt8[Tensor, "prompt_h prompt_w"] = torch.from_numpy(
+                confidence_u8.reshape(prompt_depth_mm_hw.shape)
+            ).to(device=self._device, non_blocking=True)
             span_ratio: Float32[Tensor, ""] = depth_span_ratio_cuda(depth_mm_cuda_hw)
         self.stats.blob_decode += perf_counter() - started
 
@@ -143,6 +202,9 @@ class CudaSampleBuilder:
                 self._out_hw,
                 self._generator,
                 self._policy,
+                prompt_depth_mm_hw=prompt_depth_cuda_hw,
+                prompt_confidence_hw=prompt_confidence_cuda_hw,
+                target_mode=self._target_mode,
             )
             self._stream.synchronize()
         self.stats.augment += perf_counter() - started

--- a/packages/zipdepth/zipdepth/catalog/dataset.py
+++ b/packages/zipdepth/zipdepth/catalog/dataset.py
@@ -162,6 +162,7 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
         frame_stride: int = 1,
         num_producers: int = 6,
         prefetch_samples: int = 256,
+        load_confidence: bool = True,
     ) -> None:
         """Configure catalog streaming without opening the server or decoder.
 
@@ -178,6 +179,11 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
             frame_stride: Keep every Nth chosen PromptDA row within each segment.
             num_producers: Whole-segment producer threads. One preserves order.
             prefetch_samples: Maximum completed samples queued by producers.
+            load_confidence: Fetch the ARKit confidence column. Training ignores it --
+                the student takes the raw prompt and the model range-gates internally --
+                so leaving it out drops a column and ~48 KB/frame off every segment
+                query. Evaluation keeps it for the affine-reference and prompt-upsample
+                diagnostics, which do consume ``prompt_valid``.
 
         Raises:
             ValueError: If sizes or distributed shard settings are invalid.
@@ -197,6 +203,7 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
         self._row_by_id: dict[str, dict[str, Any]] = row_by_id
         self._device: torch.device = device
         self._builder_factory: Callable[[], SampleBuilder] = builder_factory
+        self._load_confidence: bool = load_confidence
         self._shuffle_buffer_size: int = shuffle_buffer_size
         self._seed: int = seed
         self._rank: int = rank
@@ -236,12 +243,17 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
     ) -> Generator[dict[str, Tensor], None, None]:
         """Run the complete query, decode, filter, and build pipeline for one segment."""
         started: float = perf_counter()
+        contents: list[str] = [f"/{DEPTH_PROMPTDA}", f"/{DEPTH}"]
+        columns: list[str] = [TIMELINE, PROMPTDA_BLOB_COLUMN, PROMPT_BLOB_COLUMN]
+        if self._load_confidence:
+            contents.append(f"/{CONFIDENCE}")
+            columns.append(CONFIDENCE_COLUMN)
         table: pa.Table = (
             self._dataset_entry.filter_segments(segment_id)
-            .filter_contents([f"/{DEPTH_PROMPTDA}", f"/{DEPTH}", f"/{CONFIDENCE}"])
+            .filter_contents(contents)
             .reader(index=TIMELINE, fill_latest_at=True)
             .filter(col(f'"{PROMPTDA_BLOB_COLUMN}"').is_not_null())
-            .select(TIMELINE, PROMPTDA_BLOB_COLUMN, PROMPT_BLOB_COLUMN, CONFIDENCE_COLUMN)
+            .select(*columns)
             .sort(TIMELINE)
             .to_arrow_table()
         )
@@ -257,9 +269,13 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
         prompt_blobs: list[UInt8[ndarray, "prompt_n_bytes"]] = component_u8_views(table.column(PROMPT_BLOB_COLUMN), PROMPT_BLOB_COLUMN)[
             :: self._frame_stride
         ]
-        confidences: list[UInt8[ndarray, "confidence_n_values"]] = component_u8_views(table.column(CONFIDENCE_COLUMN), CONFIDENCE_COLUMN)[
-            :: self._frame_stride
-        ]
+        confidences: list[UInt8[ndarray, "confidence_n_values"] | None]
+        if self._load_confidence:
+            confidences = list(component_u8_views(table.column(CONFIDENCE_COLUMN), CONFIDENCE_COLUMN)[:: self._frame_stride])
+        else:
+            # Not fetched: the builder stands in an all-trusted mask once it knows the
+            # decoded prompt shape. The model range-gates the prompt itself.
+            confidences = [None] * len(prompt_blobs)
 
         started = perf_counter()
         decoder_result: tuple[Shaped[ndarray, "n_packets"], list[bytes], list[bool], VideoDecoder] = open_segment_decoder(
@@ -285,7 +301,7 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
 
         target_blob_u8: UInt8[ndarray, "target_n_bytes"]
         prompt_blob_u8: UInt8[ndarray, "prompt_n_bytes"]
-        confidence_u8: UInt8[ndarray, "confidence_n_values"]
+        confidence_u8: UInt8[ndarray, "confidence_n_values"] | None
         packet_index: np.int64
         first_decode_error_reported: bool = False
         sample_inputs = zip(target_blobs, prompt_blobs, confidences, packet_indices_n, strict=True)

--- a/packages/zipdepth/zipdepth/catalog/dataset.py
+++ b/packages/zipdepth/zipdepth/catalog/dataset.py
@@ -14,7 +14,7 @@ import numpy as np
 import pyarrow as pa
 import torch
 from arkitscenes_download.ingest.cells import landscape_quarter_turns
-from arkitscenes_download.ingest.paths import DEPTH_PROMPTDA, TIMELINE, VIDEO_WIDE
+from arkitscenes_download.ingest.paths import CONFIDENCE, DEPTH, DEPTH_PROMPTDA, TIMELINE, VIDEO_WIDE
 from arkitscenes_download.ingest.timestamps import match_exact_timestamps, table_timestamps
 from beartype.roar import BeartypeException
 from datafusion import col
@@ -32,6 +32,10 @@ from zipdepth.catalog.threaded import iter_threaded
 
 PROMPTDA_BLOB_COLUMN: str = f"/{DEPTH_PROMPTDA}:EncodedDepthImage:blob"
 """Catalog column containing uint16 PromptDA PNG blobs."""
+PROMPT_BLOB_COLUMN: str = f"/{DEPTH}:EncodedDepthImage:blob"
+"""Catalog column containing uint16 ARKit LiDAR prompt PNG blobs."""
+CONFIDENCE_COLUMN: str = f"/{CONFIDENCE}:SegmentationImage:buffer"
+"""Catalog column containing flattened uint8 ARKit depth confidence."""
 NATIVE_VIDEO_FPS: int = 60
 """Nominal frame rate used when wrapping the segment's encoded AV1 packets."""
 ItemT = TypeVar("ItemT")
@@ -78,12 +82,13 @@ class _ProducerSlot:
     """Producer thread currently driving this builder; None when idle."""
 
 
-def promptda_blob_views(column: pa.ChunkedArray) -> list[UInt8[ndarray, "n_bytes"]]:
-    """Return byte views into each Arrow chunk for one blob instance per row.
+def component_u8_views(column: pa.ChunkedArray, column_name: str) -> list[UInt8[ndarray, "n_bytes"]]:
+    """Return byte views into each Arrow chunk for one uint8 component instance per row.
 
     Args:
-        column: PromptDA ``list<list<uint8>>`` component column. Each outer row
+        column: Rerun ``list<list<uint8>>`` component column. Each outer row
             must contain exactly one component instance.
+        column_name: Fully-qualified column name used in validation errors.
 
     Returns:
         One zero-copy uint8 view into its source chunk's values buffer per row.
@@ -92,30 +97,30 @@ def promptda_blob_views(column: pa.ChunkedArray) -> list[UInt8[ndarray, "n_bytes
     chunk: pa.Array
     for chunk in column.chunks:
         if not isinstance(chunk, pa.ListArray):
-            raise ValueError(f"{PROMPTDA_BLOB_COLUMN}: expected list rows, got {chunk.type}")
+            raise ValueError(f"{column_name}: expected list rows, got {chunk.type}")
         if chunk.offset != 0:
-            raise ValueError(f"{PROMPTDA_BLOB_COLUMN}: outer chunk offset must be zero, got {chunk.offset}")
+            raise ValueError(f"{column_name}: outer chunk offset must be zero, got {chunk.offset}")
         if chunk.null_count != 0:
-            raise ValueError(f"{PROMPTDA_BLOB_COLUMN}: outer rows must not be null")
+            raise ValueError(f"{column_name}: outer rows must not be null")
         outer_offsets: Shaped[ndarray, "n_rows_plus_one"] = chunk.offsets.to_numpy()
         if not bool(np.all(np.diff(outer_offsets) == 1)):
-            raise ValueError(f"{PROMPTDA_BLOB_COLUMN}: each row must contain exactly one blob instance")
+            raise ValueError(f"{column_name}: each row must contain exactly one component instance")
 
         inner: pa.Array = chunk.values
         if not isinstance(inner, pa.ListArray):
-            raise ValueError(f"{PROMPTDA_BLOB_COLUMN}: expected list blob instances, got {inner.type}")
+            raise ValueError(f"{column_name}: expected list component instances, got {inner.type}")
         if inner.offset != 0:
-            raise ValueError(f"{PROMPTDA_BLOB_COLUMN}: inner array offset must be zero, got {inner.offset}")
+            raise ValueError(f"{column_name}: inner array offset must be zero, got {inner.offset}")
         if inner.null_count != 0:
-            raise ValueError(f"{PROMPTDA_BLOB_COLUMN}: blob instances must not be null")
+            raise ValueError(f"{column_name}: component instances must not be null")
         data: pa.Array = inner.values
         if not pa.types.is_uint8(data.type):
-            raise ValueError(f"{PROMPTDA_BLOB_COLUMN}: expected uint8 blob values, got {data.type}")
+            raise ValueError(f"{column_name}: expected uint8 component values, got {data.type}")
         if data.null_count != 0:
-            raise ValueError(f"{PROMPTDA_BLOB_COLUMN}: blob values must not be null")
+            raise ValueError(f"{column_name}: component values must not be null")
         data_buffer: pa.Buffer | None = data.buffers()[1]
         if data_buffer is None:
-            raise ValueError(f"{PROMPTDA_BLOB_COLUMN}: blob values have no Arrow data buffer")
+            raise ValueError(f"{column_name}: component values have no Arrow data buffer")
         all_bytes_n: UInt8[ndarray, "all_bytes"] = np.frombuffer(data_buffer, dtype=np.uint8, offset=data.offset, count=len(data))
         inner_offsets: Shaped[ndarray, "n_instances_plus_one"] = inner.offsets.to_numpy()
         row: int
@@ -125,6 +130,11 @@ def promptda_blob_views(column: pa.ChunkedArray) -> list[UInt8[ndarray, "n_bytes
             end: int = int(inner_offsets[instance + 1]) - data.offset
             views.append(all_bytes_n[start:end])
     return views
+
+
+def promptda_blob_views(column: pa.ChunkedArray) -> list[UInt8[ndarray, "n_bytes"]]:
+    """Return zero-copy PromptDA blob views, retaining the established public helper."""
+    return component_u8_views(column, PROMPTDA_BLOB_COLUMN)
 
 
 class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
@@ -228,9 +238,10 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
         started: float = perf_counter()
         table: pa.Table = (
             self._dataset_entry.filter_segments(segment_id)
+            .filter_contents([f"/{DEPTH_PROMPTDA}", f"/{DEPTH}", f"/{CONFIDENCE}"])
             .reader(index=TIMELINE, fill_latest_at=True)
             .filter(col(f'"{PROMPTDA_BLOB_COLUMN}"').is_not_null())
-            .select(TIMELINE, PROMPTDA_BLOB_COLUMN)
+            .select(TIMELINE, PROMPTDA_BLOB_COLUMN, PROMPT_BLOB_COLUMN, CONFIDENCE_COLUMN)
             .sort(TIMELINE)
             .to_arrow_table()
         )
@@ -240,8 +251,15 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
 
         all_times_n: Shaped[ndarray, "n_rows"] = table_timestamps(table)
         chosen_times_n: Shaped[ndarray, "n_chosen"] = all_times_n[:: self._frame_stride]
-        all_blobs: list[UInt8[ndarray, "n_bytes"]] = promptda_blob_views(table.column(PROMPTDA_BLOB_COLUMN))
-        chosen_blobs: list[UInt8[ndarray, "n_bytes"]] = all_blobs[:: self._frame_stride]
+        target_blobs: list[UInt8[ndarray, "target_n_bytes"]] = component_u8_views(table.column(PROMPTDA_BLOB_COLUMN), PROMPTDA_BLOB_COLUMN)[
+            :: self._frame_stride
+        ]
+        prompt_blobs: list[UInt8[ndarray, "prompt_n_bytes"]] = component_u8_views(table.column(PROMPT_BLOB_COLUMN), PROMPT_BLOB_COLUMN)[
+            :: self._frame_stride
+        ]
+        confidences: list[UInt8[ndarray, "confidence_n_values"]] = component_u8_views(table.column(CONFIDENCE_COLUMN), CONFIDENCE_COLUMN)[
+            :: self._frame_stride
+        ]
 
         started = perf_counter()
         decoder_result: tuple[Shaped[ndarray, "n_packets"], list[bytes], list[bool], VideoDecoder] = open_segment_decoder(
@@ -265,10 +283,13 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
             + self._segment_seed_index[segment_id] * 100_000_007
         )
 
-        blob_u8: UInt8[ndarray, "n_bytes"]
+        target_blob_u8: UInt8[ndarray, "target_n_bytes"]
+        prompt_blob_u8: UInt8[ndarray, "prompt_n_bytes"]
+        confidence_u8: UInt8[ndarray, "confidence_n_values"]
         packet_index: np.int64
         first_decode_error_reported: bool = False
-        for sample_index, (blob_u8, packet_index) in enumerate(zip(chosen_blobs, packet_indices_n, strict=True)):
+        sample_inputs = zip(target_blobs, prompt_blobs, confidences, packet_indices_n, strict=True)
+        for sample_index, (target_blob_u8, prompt_blob_u8, confidence_u8, packet_index) in enumerate(sample_inputs):
             try:
                 started = perf_counter()
                 frame_chw: UInt8[Tensor, "3 stored_h stored_w"] = decoder.get_frame_at(int(packet_index)).data
@@ -284,7 +305,9 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
                 continue
             sample: dict[str, Tensor] | None = builder(
                 frame_chw,
-                blob_u8,
+                target_blob_u8,
+                prompt_blob_u8,
+                confidence_u8,
                 quarter_turns,
                 (segment_seed + sample_index) % (2**63 - 1),
             )

--- a/packages/zipdepth/zipdepth/catalog/targets.py
+++ b/packages/zipdepth/zipdepth/catalog/targets.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TypeAlias
+from typing import Any, Literal, TypeAlias
 
 import albumentations as A
 import cv2
@@ -30,6 +30,7 @@ _DepthTransform: TypeAlias = Callable[
     [UInt8[ndarray, "h w 3"], Float32[ndarray, "h w"]],
     tuple[UInt8[ndarray, "out_h out_w 3"], Float32[ndarray, "out_h out_w"] | None],
 ]
+TargetMode: TypeAlias = Literal["ssi", "metric"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -90,7 +91,7 @@ def build_train_transform(height: int, width: int, policy: AugmentPolicy) -> Alb
     color augmentation but resizes deterministically to the training size.
     """
     return AlbumentationsWrapper(
-        A.Compose(
+        A.ReplayCompose(
             [
                 A.Resize(height=height, width=width, interpolation=cv2.INTER_LINEAR),
                 A.HorizontalFlip(p=policy.flip_p),
@@ -106,11 +107,74 @@ def build_eval_transform(height: int, width: int) -> AlbumentationsWrapper:
     """Build deterministic aligned RGB/mask resizing for evaluation."""
     if height <= 0 or width <= 0:
         raise ValueError("evaluation height and width must be positive")
-    transform: A.Compose = A.Compose(
+    transform: A.ReplayCompose = A.ReplayCompose(
         [A.Resize(height=height, width=width, interpolation=cv2.INTER_LINEAR, mask_interpolation=cv2.INTER_NEAREST)],
         additional_targets={"mask": "mask"},
     )
     return AlbumentationsWrapper(transform)
+
+
+def _replay_applied_horizontal_flip(replay: dict[str, Any]) -> bool:
+    """Return whether an Albumentations replay applied a horizontal flip."""
+    transforms: Any = replay.get("transforms", [])
+    if not isinstance(transforms, list):
+        return False
+    transform: Any
+    for transform in transforms:
+        if not isinstance(transform, dict):
+            continue
+        class_name: str = str(transform.get("__class_fullname__", ""))
+        if class_name.endswith("HorizontalFlip") and bool(transform.get("applied", False)):
+            return True
+        if _replay_applied_horizontal_flip(transform):
+            return True
+    return False
+
+
+def _transform_with_flip_state(
+    rgb_hw3: UInt8[ndarray, "h w 3"],
+    target_hw: Float32[ndarray, "h w"],
+    transform: _DepthTransform,
+) -> tuple[UInt8[ndarray, "out_h out_w 3"], Float32[ndarray, "out_h out_w"], bool]:
+    """Apply RGB/target augmentation and report the replayed horizontal flip."""
+    if not isinstance(transform, AlbumentationsWrapper) or not isinstance(transform.transform, A.ReplayCompose):
+        transformed: tuple[UInt8[ndarray, "out_h out_w 3"], Float32[ndarray, "out_h out_w"] | None] = transform(rgb_hw3, target_hw)
+        if transformed[1] is None:
+            raise RuntimeError("training transform dropped the depth target")
+        return transformed[0], transformed[1], False
+    result: dict[str, Any] = transform.transform(image=rgb_hw3, mask=target_hw)
+    augmented_rgb_hw3: UInt8[ndarray, "out_h out_w 3"] = result["image"]
+    augmented_target_hw: Float32[ndarray, "out_h out_w"] = result["mask"]
+    replay: Any = result.get("replay")
+    if not isinstance(replay, dict):
+        raise RuntimeError("ReplayCompose did not return augmentation metadata")
+    return augmented_rgb_hw3, augmented_target_hw, _replay_applied_horizontal_flip(replay)
+
+
+def _prompt_tensors(
+    prompt_depth_mm_hw: UInt16[ndarray, "192 256"],
+    prompt_confidence_hw: UInt8[ndarray, "192 256"],
+    *,
+    flipped: bool,
+) -> dict[str, Tensor]:
+    """Convert one oriented native-grid LiDAR prompt to collatable tensors."""
+    if prompt_depth_mm_hw.shape != (192, 256) or prompt_confidence_hw.shape != (192, 256):
+        raise ValueError(
+            f"oriented prompt depth and confidence must both be 192x256, got {prompt_depth_mm_hw.shape} and {prompt_confidence_hw.shape}"
+        )
+    prompt_depth_m_hw: Float32[ndarray, "192 256"] = prompt_depth_mm_hw.astype(np.float32) / 1000.0
+    prompt_valid_hw: Bool[ndarray, "192 256"] = (
+        (prompt_confidence_hw >= 1) & (prompt_depth_mm_hw >= MIN_DEPTH_MM) & (prompt_depth_mm_hw <= MAX_DEPTH_MM)
+    )
+    if flipped:
+        prompt_depth_m_hw = np.flip(prompt_depth_m_hw, axis=-1)
+        prompt_valid_hw = np.flip(prompt_valid_hw, axis=-1)
+    prompt_depth_1hw: Float32[ndarray, "1 192 256"] = np.ascontiguousarray(prompt_depth_m_hw[None])
+    prompt_valid_1hw: Bool[ndarray, "1 192 256"] = np.ascontiguousarray(prompt_valid_hw[None])
+    return {
+        "prompt_depth": torch.from_numpy(prompt_depth_1hw),
+        "prompt_valid": torch.from_numpy(prompt_valid_1hw),
+    }
 
 
 def depth_span_ratio(depth_mm_hw: UInt16[ndarray, "h w"]) -> float:
@@ -170,7 +234,12 @@ def depth_span_ratio_cuda(depth_mm_hw: Shaped[Tensor, "h w"]) -> Float32[Tensor,
 
 
 def build_training_sample(
-    rgb_hw3: UInt8[ndarray, "h w 3"], depth_mm_hw: UInt16[ndarray, "h w"], transform: _DepthTransform
+    rgb_hw3: UInt8[ndarray, "h w 3"],
+    depth_mm_hw: UInt16[ndarray, "h w"],
+    transform: _DepthTransform,
+    *,
+    prompt_depth_mm_hw: UInt16[ndarray, "192 256"] | None = None,
+    prompt_confidence_hw: UInt8[ndarray, "192 256"] | None = None,
 ) -> dict[str, Tensor]:
     """Augment aligned RGB and inverse depth, then build one collatable sample.
 
@@ -191,11 +260,11 @@ def build_training_sample(
         RuntimeError: If the transform drops the depth target.
     """
     inverse_depth_hw: Float32[ndarray, "h w"] = inverse_depth_from_mm(depth_mm_hw)
-    transformed: tuple[UInt8[ndarray, "out_h out_w 3"], Float32[ndarray, "out_h out_w"] | None] = transform(rgb_hw3, inverse_depth_hw)
+    transformed: tuple[UInt8[ndarray, "out_h out_w 3"], Float32[ndarray, "out_h out_w"], bool] = _transform_with_flip_state(
+        rgb_hw3, inverse_depth_hw, transform
+    )
     augmented_rgb_hw3: UInt8[ndarray, "out_h out_w 3"] = transformed[0]
-    augmented_inverse_depth_hw: Float32[ndarray, "out_h out_w"] | None = transformed[1]
-    if augmented_inverse_depth_hw is None:
-        raise RuntimeError("training transform dropped the inverse-depth target")
+    augmented_inverse_depth_hw: Float32[ndarray, "out_h out_w"] = transformed[1]
     quantized_hw: UInt16[ndarray, "out_h out_w"] = quantize_inverse_depth(augmented_inverse_depth_hw)
     image_chw: UInt8[ndarray, "3 out_h out_w"] = np.ascontiguousarray(np.moveaxis(augmented_rgb_hw3, -1, 0))
     depth_1hw: UInt16[ndarray, "1 out_h out_w"] = np.ascontiguousarray(quantized_hw[None])
@@ -203,7 +272,60 @@ def build_training_sample(
     image_tensor: UInt8[Tensor, "3 out_h out_w"] = torch.from_numpy(image_chw)
     depth_tensor: UInt16[Tensor, "1 out_h out_w"] = torch.from_numpy(depth_1hw)
     mask_tensor: Bool[Tensor, "1 out_h out_w"] = torch.from_numpy(mask_1hw)
-    return {"image": image_tensor, "depth": depth_tensor, "mask": mask_tensor}
+    sample: dict[str, Tensor] = {"image": image_tensor, "depth": depth_tensor, "mask": mask_tensor}
+    if (prompt_depth_mm_hw is None) != (prompt_confidence_hw is None):
+        raise ValueError("prompt depth and confidence must be provided together")
+    if prompt_depth_mm_hw is not None and prompt_confidence_hw is not None:
+        sample.update(_prompt_tensors(prompt_depth_mm_hw, prompt_confidence_hw, flipped=transformed[2]))
+    return sample
+
+
+def build_metric_training_sample(
+    rgb_hw3: UInt8[ndarray, "h w 3"],
+    target_depth_mm_hw: UInt16[ndarray, "h w"],
+    prompt_depth_mm_hw: UInt16[ndarray, "192 256"],
+    prompt_confidence_hw: UInt8[ndarray, "192 256"],
+    transform: _DepthTransform,
+) -> dict[str, Tensor]:
+    """Build a metric prompted sample without inverse-depth quantization.
+
+    Args:
+        rgb_hw3: Oriented uint8 RGB with shape ``(H, W, 3)``.
+        target_depth_mm_hw: Oriented dense PromptDA depth in millimetres with
+            shape ``(H, W)``.
+        prompt_depth_mm_hw: Oriented ARKit LiDAR depth in millimetres with
+            native shape ``(192, 256)``.
+        prompt_confidence_hw: Oriented ARKit confidence with native shape
+            ``(192, 256)``.
+        transform: Replayable aligned RGB/target augmentation.
+
+    Returns:
+        A dictionary with uint8 ``image``; float32 metre ``target_depth`` and
+        ``prompt_depth``; and bool ``target_valid`` and ``prompt_valid``.
+    """
+    target_valid_hw: Bool[ndarray, "h w"] = (target_depth_mm_hw >= MIN_DEPTH_MM) & (target_depth_mm_hw <= MAX_DEPTH_MM)
+    target_depth_m_hw: Float32[ndarray, "h w"] = np.where(
+        target_valid_hw,
+        target_depth_mm_hw.astype(np.float32) / 1000.0,
+        0.0,
+    ).astype(np.float32)
+    transformed: tuple[UInt8[ndarray, "out_h out_w 3"], Float32[ndarray, "out_h out_w"], bool] = _transform_with_flip_state(
+        rgb_hw3, target_depth_m_hw, transform
+    )
+    augmented_rgb_hw3: UInt8[ndarray, "out_h out_w 3"] = transformed[0]
+    augmented_target_depth_hw: Float32[ndarray, "out_h out_w"] = transformed[1]
+    image_chw: UInt8[ndarray, "3 out_h out_w"] = np.ascontiguousarray(np.moveaxis(augmented_rgb_hw3, -1, 0))
+    target_depth_1hw: Float32[ndarray, "1 out_h out_w"] = np.ascontiguousarray(augmented_target_depth_hw[None])
+    target_valid_1hw: Bool[ndarray, "1 out_h out_w"] = np.ascontiguousarray(
+        (target_depth_1hw >= MIN_DEPTH_MM / 1000.0) & (target_depth_1hw <= MAX_DEPTH_MM / 1000.0)
+    )
+    sample: dict[str, Tensor] = {
+        "image": torch.from_numpy(image_chw),
+        "target_depth": torch.from_numpy(target_depth_1hw),
+        "target_valid": torch.from_numpy(target_valid_1hw),
+    }
+    sample.update(_prompt_tensors(prompt_depth_mm_hw, prompt_confidence_hw, flipped=transformed[2]))
+    return sample
 
 
 def build_training_sample_cuda(
@@ -213,6 +335,10 @@ def build_training_sample_cuda(
     out_hw: tuple[int, int],
     generator: torch.Generator,
     policy: AugmentPolicy,
+    *,
+    prompt_depth_mm_hw: Shaped[Tensor, "prompt_h prompt_w"] | None = None,
+    prompt_confidence_hw: UInt8[Tensor, "prompt_h prompt_w"] | None = None,
+    target_mode: TargetMode = "ssi",
 ) -> dict[str, Tensor]:
     """Build one augmented training sample without leaving CUDA.
 
@@ -253,9 +379,13 @@ def build_training_sample_cuda(
     rotated_depth_mm_hw: Shaped[Tensor, "rotated_h rotated_w"] = torch.rot90(depth_mm_hw, turns, dims=(-2, -1))
     depth_float_hw: Float32[Tensor, "rotated_h rotated_w"] = rotated_depth_mm_hw.to(dtype=torch.float32)
     valid_hw: Bool[Tensor, "rotated_h rotated_w"] = (depth_float_hw >= MIN_DEPTH_MM) & (depth_float_hw <= MAX_DEPTH_MM)
-    inverse_depth_hw: Float32[Tensor, "rotated_h rotated_w"] = torch.where(
+    if target_mode not in ("ssi", "metric"):
+        raise ValueError(f"unknown target mode {target_mode!r}")
+    if (prompt_depth_mm_hw is None) != (prompt_confidence_hw is None):
+        raise ValueError("prompt depth and confidence must be provided together")
+    target_hw: Float32[Tensor, "rotated_h rotated_w"] = torch.where(
         valid_hw,
-        1000.0 / depth_float_hw,
+        1000.0 / depth_float_hw if target_mode == "ssi" else depth_float_hw / 1000.0,
         torch.zeros_like(depth_float_hw),
     )
     resized_rgb_float_chw: Float32[Tensor, "3 out_h out_w"] = F.interpolate(
@@ -266,18 +396,40 @@ def build_training_sample_cuda(
         antialias=False,
     ).squeeze(0)
     resized_rgb_chw: UInt8[Tensor, "3 out_h out_w"] = torch.round(resized_rgb_float_chw).clamp_(0.0, 255.0).to(dtype=torch.uint8)
-    resized_inverse_depth_hw: Float32[Tensor, "out_h out_w"] = F.interpolate(
-        inverse_depth_hw.unsqueeze(0).unsqueeze(0),
+    resized_target_hw: Float32[Tensor, "out_h out_w"] = F.interpolate(
+        target_hw.unsqueeze(0).unsqueeze(0),
         size=(out_height, out_width),
         mode="nearest",
     ).squeeze(0).squeeze(0)
+    prompt_depth_m_hw: Float32[Tensor, "192 256"] | None = None
+    prompt_valid_hw: Bool[Tensor, "192 256"] | None = None
+    if prompt_depth_mm_hw is not None and prompt_confidence_hw is not None:
+        rotated_prompt_mm_hw: Shaped[Tensor, "oriented_prompt_h oriented_prompt_w"] = torch.rot90(
+            prompt_depth_mm_hw, turns, dims=(-2, -1)
+        )
+        rotated_confidence_hw: UInt8[Tensor, "oriented_prompt_h oriented_prompt_w"] = torch.rot90(
+            prompt_confidence_hw, turns, dims=(-2, -1)
+        )
+        if tuple(rotated_prompt_mm_hw.shape) != (192, 256) or tuple(rotated_confidence_hw.shape) != (192, 256):
+            raise ValueError(
+                f"oriented prompt depth and confidence must both be 192x256, got {tuple(rotated_prompt_mm_hw.shape)} and {tuple(rotated_confidence_hw.shape)}"
+            )
+        prompt_depth_m_hw = rotated_prompt_mm_hw.to(dtype=torch.float32) / 1000.0
+        prompt_valid_hw = (
+            (rotated_confidence_hw >= 1)
+            & (rotated_prompt_mm_hw >= MIN_DEPTH_MM)
+            & (rotated_prompt_mm_hw <= MAX_DEPTH_MM)
+        )
 
     random_values_n: Float32[Tensor, "3"] = torch.rand(3, device=generator.device, generator=generator)
     random_values: list[float] = random_values_n.cpu().tolist()
 
     if random_values[0] < policy.flip_p:
         resized_rgb_chw = torch.flip(resized_rgb_chw, dims=(-1,))
-        resized_inverse_depth_hw = torch.flip(resized_inverse_depth_hw, dims=(-1,))
+        resized_target_hw = torch.flip(resized_target_hw, dims=(-1,))
+        if prompt_depth_m_hw is not None and prompt_valid_hw is not None:
+            prompt_depth_m_hw = torch.flip(prompt_depth_m_hw, dims=(-1,))
+            prompt_valid_hw = torch.flip(prompt_valid_hw, dims=(-1,))
 
     if random_values[1] < policy.channel_shuffle_p:
         channel_order: Int64[Tensor, "3"] = torch.randperm(3, device=generator.device, generator=generator).to(device=rgb_chw.device)
@@ -290,8 +442,19 @@ def build_training_sample_cuda(
         )
         resized_rgb_chw = torch.round(gray_hw).clamp_(0.0, 255.0).to(dtype=torch.uint8).expand_as(resized_rgb_chw)
 
-    quantized_i32_hw: Shaped[Tensor, "out_h out_w"] = torch.round(resized_inverse_depth_hw * INV_DEPTH_SCALE).clamp_(0.0, 65535.0).to(dtype=torch.int32)
-    mask_1hw: Bool[Tensor, "1 out_h out_w"] = (quantized_i32_hw > 0).unsqueeze(0).contiguous()
-    depth_1hw: UInt16[Tensor, "1 out_h out_w"] = quantized_i32_hw.to(dtype=torch.uint16).unsqueeze(0).contiguous()
     image_chw: UInt8[Tensor, "3 out_h out_w"] = resized_rgb_chw.contiguous()
-    return {"image": image_chw, "depth": depth_1hw, "mask": mask_1hw}
+    if target_mode == "ssi":
+        quantized_i32_hw: Shaped[Tensor, "out_h out_w"] = torch.round(resized_target_hw * INV_DEPTH_SCALE).clamp_(0.0, 65535.0).to(dtype=torch.int32)
+        mask_1hw: Bool[Tensor, "1 out_h out_w"] = (quantized_i32_hw > 0).unsqueeze(0).contiguous()
+        depth_1hw: UInt16[Tensor, "1 out_h out_w"] = quantized_i32_hw.to(dtype=torch.uint16).unsqueeze(0).contiguous()
+        sample: dict[str, Tensor] = {"image": image_chw, "depth": depth_1hw, "mask": mask_1hw}
+    else:
+        target_depth_1hw: Float32[Tensor, "1 out_h out_w"] = resized_target_hw.unsqueeze(0).contiguous()
+        target_valid_1hw: Bool[Tensor, "1 out_h out_w"] = (
+            (target_depth_1hw >= MIN_DEPTH_MM / 1000.0) & (target_depth_1hw <= MAX_DEPTH_MM / 1000.0)
+        )
+        sample = {"image": image_chw, "target_depth": target_depth_1hw, "target_valid": target_valid_1hw}
+    if prompt_depth_m_hw is not None and prompt_valid_hw is not None:
+        sample["prompt_depth"] = prompt_depth_m_hw.unsqueeze(0).contiguous()
+        sample["prompt_valid"] = prompt_valid_hw.unsqueeze(0).contiguous()
+    return sample

--- a/packages/zipdepth/zipdepth/loss/__init__.py
+++ b/packages/zipdepth/zipdepth/loss/__init__.py
@@ -1,1 +1,4 @@
 from zipdepth.loss.depth_loss import ZipDepthLoss
+from zipdepth.loss.metric_depth_loss import MetricDepthLoss
+
+__all__: list[str] = ["MetricDepthLoss", "ZipDepthLoss"]

--- a/packages/zipdepth/zipdepth/loss/metric_depth_loss.py
+++ b/packages/zipdepth/zipdepth/loss/metric_depth_loss.py
@@ -1,0 +1,48 @@
+"""Metric PromptDA distillation loss."""
+
+import torch
+from jaxtyping import Bool, Float
+from torch import Tensor, nn
+
+from zipdepth.loss.depth_loss import ZipDepthLoss
+
+
+class MetricDepthLoss(nn.Module):
+    """Masked metre L1 plus the existing multi-scale gradient loss."""
+
+    def __init__(self, gradient_weight: float = 0.5, grad_scales: int = 4) -> None:
+        super().__init__()
+        if gradient_weight < 0.0:
+            raise ValueError("gradient_weight must be non-negative")
+        if grad_scales <= 0:
+            raise ValueError("grad_scales must be positive")
+        self.gradient_weight: float = gradient_weight
+        self._gradient: ZipDepthLoss = ZipDepthLoss(alpha_ssi=0.0, alpha_grad=1.0, grad_scales=grad_scales)
+
+    def forward(
+        self,
+        pred: Float[Tensor, "b 1 h w"],
+        target: Float[Tensor, "b 1 h w"],
+        mask: Bool[Tensor, "b 1 h w"] | Float[Tensor, "b 1 h w"] | None = None,
+    ) -> tuple[Tensor, dict[str, float]]:
+        """Compute the fixed Stage-1 metric objective.
+
+        Args:
+            pred: Predicted float depth in metres with shape
+                ``(batch, 1, height, width)``.
+            target: Dense teacher float depth in metres with the same shape.
+            mask: Optional explicit teacher-valid mask with the same shape.
+
+        Returns:
+            Scalar loss and detached ``l1``/``grad`` components.
+        """
+        valid_b1hw: Tensor = torch.isfinite(target) & (target >= 0.1) & (target <= 4.0)
+        if mask is not None:
+            valid_b1hw = valid_b1hw & (mask > 0)
+        mask_b1hw: Tensor = valid_b1hw.to(dtype=pred.dtype)
+        safe_prediction_b1hw: Tensor = torch.where(valid_b1hw, pred, torch.zeros_like(pred))
+        safe_target_b1hw: Tensor = torch.where(valid_b1hw, target, torch.zeros_like(target))
+        l1_loss: Tensor = self._gradient._ssi_loss(safe_prediction_b1hw, safe_target_b1hw, mask_b1hw)
+        gradient_loss: Tensor = self._gradient._gradient_loss(safe_prediction_b1hw, safe_target_b1hw, mask_b1hw)
+        total_loss: Tensor = l1_loss + self.gradient_weight * gradient_loss
+        return total_loss, {"l1": float(l1_loss.detach().item()), "grad": float(gradient_loss.detach().item())}

--- a/packages/zipdepth/zipdepth/training/trainer.py
+++ b/packages/zipdepth/zipdepth/training/trainer.py
@@ -59,6 +59,7 @@ class ZipDepthTrainer:
                 alpha_ssi: float = 1.0,
                 alpha_grad: float = 2.0,
                 target_mode: Literal['ssi', 'metric'] = 'ssi',
+                metric_gradient_weight: float = 0.5,
                 ):
         """
         Args:
@@ -84,6 +85,9 @@ class ZipDepthTrainer:
             alpha_ssi: Weight for SSI loss component
             alpha_grad: Weight for gradient loss component
             target_mode: Relative SSI or prompted metric training lane
+            metric_gradient_weight: Weight on the multi-scale gradient term in the metric
+                lane. Upstream ZipDepth's SSI lane uses 2.0; 0.5 leaves the term at ~9%
+                of the objective, which under-penalizes depth-discontinuity errors.
         """
         self.student = student.to(device)
         self.train_loader = train_loader
@@ -115,7 +119,7 @@ class ZipDepthTrainer:
 
         # Loss function initialization
         self.criterion = (
-            MetricDepthLoss(gradient_weight=0.5, grad_scales=4)
+            MetricDepthLoss(gradient_weight=metric_gradient_weight, grad_scales=4)
             if target_mode == 'metric'
             else ZipDepthLoss(alpha_ssi=alpha_ssi, alpha_grad=alpha_grad)
         ).to(device)

--- a/packages/zipdepth/zipdepth/training/trainer.py
+++ b/packages/zipdepth/zipdepth/training/trainer.py
@@ -4,6 +4,7 @@ import glob
 import os
 import time
 from contextlib import nullcontext, suppress
+from typing import Literal
 
 import torch
 from torch.profiler import ProfilerActivity, profile, schedule, tensorboard_trace_handler
@@ -17,7 +18,7 @@ except ImportError:
 
 from monopriors.third_party.zipdepth.model_utils import strip_state_dict_prefixes
 
-from zipdepth.loss import ZipDepthLoss
+from zipdepth.loss import MetricDepthLoss, ZipDepthLoss
 from zipdepth.training.visualization import depth_to_spectral
 
 
@@ -57,6 +58,7 @@ class ZipDepthTrainer:
                 amp_dtype='bfloat16',
                 alpha_ssi: float = 1.0,
                 alpha_grad: float = 2.0,
+                target_mode: Literal['ssi', 'metric'] = 'ssi',
                 ):
         """
         Args:
@@ -81,6 +83,7 @@ class ZipDepthTrainer:
                        or 'float16' (requires GradScaler, narrower range)
             alpha_ssi: Weight for SSI loss component
             alpha_grad: Weight for gradient loss component
+            target_mode: Relative SSI or prompted metric training lane
         """
         self.student = student.to(device)
         self.train_loader = train_loader
@@ -106,9 +109,16 @@ class ZipDepthTrainer:
         self._snapshot_start = None
         self._restart_interval = 1000
         self._loader_config = None
+        if target_mode not in ('ssi', 'metric'):
+            raise ValueError(f"unknown target mode {target_mode!r}")
+        self.target_mode = target_mode
 
         # Loss function initialization
-        self.criterion = ZipDepthLoss(alpha_ssi=alpha_ssi, alpha_grad=alpha_grad).to(device)
+        self.criterion = (
+            MetricDepthLoss(gradient_weight=0.5, grad_scales=4)
+            if target_mode == 'metric'
+            else ZipDepthLoss(alpha_ssi=alpha_ssi, alpha_grad=alpha_grad)
+        ).to(device)
 
         # GradScaler only needed for FP16 — BF16 has FP32-range exponents so no overflow
         self.scaler = (
@@ -297,18 +307,26 @@ class ZipDepthTrainer:
                 images = batch['image'].to(self.device, non_blocking=True)
                 images = images.float() / 255.0
 
-                teacher_depth = batch['depth'].to(self.device, non_blocking=True)
-                teacher_depth = teacher_depth.float().div_(256.0)
+                prompt_depth = None
+                if self.target_mode == 'metric':
+                    teacher_depth = batch['target_depth'].to(self.device, non_blocking=True).float()
+                    mask = batch['target_valid'].to(self.device, non_blocking=True)
+                    raw_prompt_depth = batch['prompt_depth'].to(self.device, non_blocking=True).float()
+                    prompt_valid = batch['prompt_valid'].to(self.device, non_blocking=True)
+                    prompt_depth = torch.where(prompt_valid, raw_prompt_depth, torch.zeros_like(raw_prompt_depth))
+                else:
+                    teacher_depth = batch['depth'].to(self.device, non_blocking=True)
+                    teacher_depth = teacher_depth.float().div_(256.0)
 
-                # Local addition: sparse catalog targets carry an explicit validity mask.
-                mask = batch.get('mask')
-                if mask is not None:
-                    mask = mask.to(self.device, non_blocking=True).float()
+                    # Local addition: sparse catalog targets carry an explicit validity mask.
+                    mask = batch.get('mask')
+                    if mask is not None:
+                        mask = mask.to(self.device, non_blocking=True).float()
 
                 del batch
 
                 with torch.amp.autocast('cuda', dtype=self.amp_dtype, enabled=self.use_amp):
-                    student_depth = self.student(images)
+                    student_depth = self.student(images, prompt_depth) if prompt_depth is not None else self.student(images)
                     loss, loss_dict = self.criterion(
                         pred=student_depth,
                         target=teacher_depth,
@@ -345,6 +363,7 @@ class ZipDepthTrainer:
                     break
 
                 avg_loss = total_loss / processed_batches
+                primary_name = 'l1' if self.target_mode == 'metric' else 'ssi'
 
                 if not disable_tqdm:
                     pbar.update(1)
@@ -353,7 +372,7 @@ class ZipDepthTrainer:
                         'B': f"{batch_idx+1}/{num_batches}",
                         'loss': f"{loss_value:.3f}",
                         'avg_loss': f"{avg_loss:.3f}",
-                        'ssi': f"{loss_dict['ssi']:.3f}",
+                        primary_name: f"{loss_dict[primary_name]:.3f}",
                     })
 
                 # Logging
@@ -361,7 +380,7 @@ class ZipDepthTrainer:
                     if self.global_step % 750 == 0:
                         self.writer.add_scalar('train/loss', loss.item(), self.global_step)
                         self.writer.add_scalar('train/lr', self.optimizer.param_groups[0]['lr'], self.global_step)
-                        self.writer.add_scalar('train/loss_ssi', loss_dict['ssi'], self.global_step)
+                        self.writer.add_scalar(f'train/loss_{primary_name}', loss_dict[primary_name], self.global_step)
                         self.writer.add_scalar('train/loss_grad', loss_dict['grad'], self.global_step)
 
                     if self.global_step % 750 == 0:
@@ -388,7 +407,7 @@ class ZipDepthTrainer:
                     print(f'\n  -> Checkpoint saved at step {self.global_step}')
                     self.cleanup_step_checkpoints()
 
-                del student_depth, teacher_depth, mask, loss
+                del student_depth, teacher_depth, mask, prompt_depth, loss
 
                 # Advance profiler schedule (no-op after schedule completes or when profiling disabled)
                 if prof is not None:

--- a/packages/zipdepth/zipdepth/training/trainer.py
+++ b/packages/zipdepth/zipdepth/training/trainer.py
@@ -311,9 +311,13 @@ class ZipDepthTrainer:
                 if self.target_mode == 'metric':
                     teacher_depth = batch['target_depth'].to(self.device, non_blocking=True).float()
                     mask = batch['target_valid'].to(self.device, non_blocking=True)
-                    raw_prompt_depth = batch['prompt_depth'].to(self.device, non_blocking=True).float()
-                    prompt_valid = batch['prompt_valid'].to(self.device, non_blocking=True)
-                    prompt_depth = torch.where(prompt_valid, raw_prompt_depth, torch.zeros_like(raw_prompt_depth))
+                    # Feed the RAW prompt, exactly what the teacher saw when it produced
+                    # these labels (promptda_stream.py:254). Zeroing low-confidence pixels
+                    # made the student solve a different problem from the teacher, and the
+                    # degenerate cases it guarded against are already handled inside the
+                    # model, which computes its own finite/0.1-4 m validity for the
+                    # normalization range and clamps the span.
+                    prompt_depth = batch['prompt_depth'].to(self.device, non_blocking=True).float()
                 else:
                     teacher_depth = batch['depth'].to(self.device, non_blocking=True)
                     teacher_depth = teacher_depth.float().div_(256.0)

--- a/pixi.lock
+++ b/pixi.lock
@@ -6,18 +6,7 @@ platforms:
   - __linux=4.18
   - __glibc=2.28
   - __archspec=0=x86_64
-- name: linux-aarch64
-  virtual-packages:
-  - __unix=0=0
-  - __linux=4.18
-  - __glibc=2.28
-  - __archspec=0=aarch64
-- name: osx-arm64
-  virtual-packages:
-  - __unix=0=0
-  - __osx=13.0
-  - __archspec=0=m1
-- name: p1
+- name: linux-64-cuda13
   subdir: linux-64
   virtual-packages:
   - __cuda=13.0
@@ -25,7 +14,13 @@ platforms:
   - __unix=0=0
   - __linux=4.18
   - __archspec=0=x86_64
-- name: p2
+- name: linux-aarch64
+  virtual-packages:
+  - __unix=0=0
+  - __linux=4.18
+  - __glibc=2.28
+  - __archspec=0=aarch64
+- name: linux-aarch64-cuda13
   subdir: linux-aarch64
   virtual-packages:
   - __cuda=13.0
@@ -33,6 +28,11 @@ platforms:
   - __unix=0=0
   - __linux=4.18
   - __archspec=0=aarch64
+- name: osx-arm64
+  virtual-packages:
+  - __unix=0=0
+  - __osx=13.0
+  - __archspec=0=m1
 environments:
   arkitscenes-download:
     channels:
@@ -3551,7 +3551,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/ai-demos/linux-64/lietorch-1.0-hecd5ce2_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
@@ -4047,7 +4047,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/websocket-client-1.9.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dpretrieval[d5cd5e62] @ packages/dpretrieval
+      - conda_source: dpretrieval[34f6a2c9] @ packages/dpretrieval
       - pypi: ./packages/dpvo
       - pypi: ./packages/simplecv
       - pypi: https://files.pythonhosted.org/packages/01/55/bb3e701f4af504e5e39e837135dc80022ec4c84858b2886ad577fe696a77/cuda_core-1.0.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
@@ -4169,7 +4169,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/ai-demos/linux-64/lietorch-1.0-hecd5ce2_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
@@ -4670,7 +4670,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/websocket-client-1.9.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dpretrieval[d5cd5e62] @ packages/dpretrieval
+      - conda_source: dpretrieval[34f6a2c9] @ packages/dpretrieval
       - pypi: ./packages/dpvo
       - pypi: ./packages/simplecv
       - pypi: https://files.pythonhosted.org/packages/01/55/bb3e701f4af504e5e39e837135dc80022ec4c84858b2886ad577fe696a77/cuda_core-1.0.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
@@ -4794,7 +4794,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.14.1-py312h5d8c7f2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
@@ -5429,7 +5429,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fc/b4/d088047afe39827556df21118cac9ffd20cc3f968c99a7681494d1eb333c/cuda_pathfinder-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
       - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-11.2.1.2.tar.gz
-      p2:
+      linux-aarch64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aiohttp-3.14.1-py312he7e3343_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/alsa-lib-1.2.16.1-he30d5cf_0.conda
@@ -6016,7 +6016,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.14.1-py312h5d8c7f2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
@@ -6661,7 +6661,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fc/b4/d088047afe39827556df21118cac9ffd20cc3f968c99a7681494d1eb333c/cuda_pathfinder-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
       - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-11.2.1.2.tar.gz
-      p2:
+      linux-aarch64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aiohttp-3.14.1-py312he7e3343_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/alsa-lib-1.2.16.1-he30d5cf_0.conda
@@ -7258,7 +7258,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
@@ -7784,7 +7784,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
@@ -12723,7 +12723,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
@@ -13288,7 +13288,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
@@ -13865,7 +13865,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026062206-release.conda
       - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026062206-release.conda
       - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026062206-release.conda
@@ -14385,8 +14385,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/werkzeug-3.1.8-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/wslink-2.5.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: asmk[10e5161b] @ packages/asmk
-      - conda_source: mast3r[50afa763] @ packages/mast3r
+      - conda_source: asmk[ac964423] @ packages/asmk
+      - conda_source: mast3r[8996e175] @ packages/mast3r
       - pypi: ./packages/mast3r-slam
       - pypi: ./packages/simplecv
       - pypi: https://files.pythonhosted.org/packages/01/55/bb3e701f4af504e5e39e837135dc80022ec4c84858b2886ad577fe696a77/cuda_core-1.0.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
@@ -14478,7 +14478,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b3.dev2026062206-release.conda
       - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b3.dev2026062206-release.conda
       - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.5.0.dev2026062206-release.conda
@@ -15006,8 +15006,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/werkzeug-3.1.8-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/wslink-2.5.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: asmk[10e5161b] @ packages/asmk
-      - conda_source: mast3r[50afa763] @ packages/mast3r
+      - conda_source: asmk[ac964423] @ packages/asmk
+      - conda_source: mast3r[8996e175] @ packages/mast3r
       - pypi: ./packages/mast3r-slam
       - pypi: ./packages/simplecv
       - pypi: https://files.pythonhosted.org/packages/01/55/bb3e701f4af504e5e39e837135dc80022ec4c84858b2886ad577fe696a77/cuda_core-1.0.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
@@ -15099,7 +15099,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.14.1-py312h5d8c7f2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
@@ -15725,7 +15725,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.14.1-py312h5d8c7f2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
@@ -16361,7 +16361,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.14.1-py312h5d8c7f2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
@@ -17031,7 +17031,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.14.1-py312h5d8c7f2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
@@ -17596,7 +17596,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.14.1-py312h5d8c7f2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
@@ -18445,7 +18445,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.14.1-py312h5d8c7f2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
@@ -19125,7 +19125,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
@@ -19562,7 +19562,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
       - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-11.2.1.2.tar.gz
-      p2:
+      linux-aarch64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/alsa-lib-1.2.16.1-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aom-3.14.1-pl5321h8fffa31_1.conda
@@ -19997,7 +19997,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
@@ -20444,7 +20444,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
       - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-11.2.1.2.tar.gz
-      p2:
+      linux-aarch64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/alsa-lib-1.2.16.1-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aom-3.14.1-pl5321h8fffa31_1.conda
@@ -20889,7 +20889,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
@@ -21457,7 +21457,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
@@ -22034,7 +22034,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
@@ -22580,7 +22580,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
@@ -23136,7 +23136,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.14.1-py312h5d8c7f2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
@@ -23735,7 +23735,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.14.1-py312h5d8c7f2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
@@ -24344,7 +24344,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.14.3-py312h5d8c7f2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
@@ -24861,7 +24861,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.14.3-py312h5d8c7f2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
@@ -25388,7 +25388,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/ai-demos/linux-64/brush-0.3.0-hcc556be_0.conda
       - conda: https://prefix.dev/ai-demos/linux-64/libfaiss-1.10.0-cuda130h2b3f426_0_cuda.conda
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -25988,7 +25988,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/ai-demos/linux-64/brush-0.3.0-hcc556be_0.conda
       - conda: https://prefix.dev/ai-demos/linux-64/libfaiss-1.10.0-cuda130h2b3f426_0_cuda.conda
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -30218,7 +30218,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
@@ -30757,7 +30757,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
@@ -31306,7 +31306,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.14.1-py312h5d8c7f2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
@@ -31919,7 +31919,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.14.1-py312h5d8c7f2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
@@ -32542,7 +32542,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
@@ -33101,7 +33101,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
@@ -33670,7 +33670,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
@@ -34210,7 +34210,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
@@ -34760,7 +34760,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.14.1-py312h5d8c7f2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
@@ -35415,7 +35415,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.14.1-py312h5d8c7f2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
@@ -35965,7 +35965,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.14.1-py312h5d8c7f2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
@@ -36525,7 +36525,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aiohttp-3.14.1-py312h5d8c7f2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
@@ -39016,7 +39016,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
@@ -39542,7 +39542,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fc/b4/d088047afe39827556df21118cac9ffd20cc3f968c99a7681494d1eb333c/cuda_pathfinder-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
       - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-11.2.1.2.tar.gz
-      p2:
+      linux-aarch64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/alsa-lib-1.2.16.1-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aom-3.14.1-pl5321h8fffa31_1.conda
@@ -40075,7 +40075,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
@@ -40610,7 +40610,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fc/b4/d088047afe39827556df21118cac9ffd20cc3f968c99a7681494d1eb333c/cuda_pathfinder-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
       - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-11.2.1.2.tar.gz
-      p2:
+      linux-aarch64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/alsa-lib-1.2.16.1-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aom-3.14.1-pl5321h8fffa31_1.conda
@@ -41152,7 +41152,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/ai-demos/linux-64/gsplat-1.5.3-py312_torch212_cuda130_h9a733f9_1.conda
       - conda: https://prefix.dev/ai-demos/linux-64/splat-transform-1.9.2-hcc556be_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -41772,7 +41772,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/ai-demos/linux-64/gsplat-1.5.3-py312_torch212_cuda130_h9a733f9_1.conda
       - conda: https://prefix.dev/ai-demos/linux-64/splat-transform-1.9.2-hcc556be_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -42402,7 +42402,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
@@ -42958,7 +42958,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fc/b4/d088047afe39827556df21118cac9ffd20cc3f968c99a7681494d1eb333c/cuda_pathfinder-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
       - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-11.2.1.2.tar.gz
-      p2:
+      linux-aarch64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/alsa-lib-1.2.16.1-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aom-3.14.1-pl5321h8fffa31_1.conda
@@ -43502,7 +43502,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
@@ -44068,7 +44068,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fc/b4/d088047afe39827556df21118cac9ffd20cc3f968c99a7681494d1eb333c/cuda_pathfinder-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
       - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-11.2.1.2.tar.gz
-      p2:
+      linux-aarch64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/alsa-lib-1.2.16.1-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aom-3.14.1-pl5321h8fffa31_1.conda
@@ -44622,7 +44622,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-h7cc23a3_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h57e6904_2.conda
@@ -45109,6 +45109,7 @@ environments:
       - pypi: ./packages/monoprior
       - pypi: ./packages/sam3
       - pypi: ./packages/simplecv
+      - pypi: ./packages/trtkit
       - pypi: ./packages/zipdepth
       - pypi: https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/e8/5c880ffd8d4bb9df4cdf75ab8b44fc8f7011b6cb629b3e6242f3d5944b4f/stringzilla-5.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -45201,7 +45202,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
       - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-11.2.1.2.tar.gz
-      p2:
+      linux-aarch64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/alsa-lib-1.2.16.1-h5bc82ec_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aom-3.14.1-pl5321hf5316b6_2.conda
@@ -45680,6 +45681,7 @@ environments:
       - pypi: ./packages/monoprior
       - pypi: ./packages/sam3
       - pypi: ./packages/simplecv
+      - pypi: ./packages/trtkit
       - pypi: ./packages/zipdepth
       - pypi: https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/07/42/a687e7091928806e514f89fa2666f25ec9bfe0a902fc4402b25e51ce408b/nh3-0.3.7-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
@@ -45778,7 +45780,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-h7cc23a3_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h57e6904_2.conda
@@ -46193,6 +46195,7 @@ environments:
       - pypi: ./packages/monoprior
       - pypi: ./packages/sam3
       - pypi: ./packages/simplecv
+      - pypi: ./packages/trtkit
       - pypi: ./packages/zipdepth
       - pypi: https://files.pythonhosted.org/packages/03/e8/5c880ffd8d4bb9df4cdf75ab8b44fc8f7011b6cb629b3e6242f3d5944b4f/stringzilla-5.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0a/e2/91f145e1f32428e9e1f21f46a7022ffe63d11f549ee55c3b9265ff5207fc/albucore-0.0.24-py3-none-any.whl
@@ -46272,7 +46275,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-h7cc23a3_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h57e6904_2.conda
@@ -46696,6 +46699,7 @@ environments:
       - pypi: ./packages/monoprior
       - pypi: ./packages/sam3
       - pypi: ./packages/simplecv
+      - pypi: ./packages/trtkit
       - pypi: ./packages/zipdepth
       - pypi: https://files.pythonhosted.org/packages/03/e8/5c880ffd8d4bb9df4cdf75ab8b44fc8f7011b6cb629b3e6242f3d5944b4f/stringzilla-5.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0a/e2/91f145e1f32428e9e1f21f46a7022ffe63d11f549ee55c3b9265ff5207fc/albucore-0.0.24-py3-none-any.whl
@@ -46776,7 +46780,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-h7cc23a3_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h57e6904_2.conda
@@ -47271,6 +47275,7 @@ environments:
       - pypi: ./packages/monoprior
       - pypi: ./packages/sam3
       - pypi: ./packages/simplecv
+      - pypi: ./packages/trtkit
       - pypi: ./packages/zipdepth
       - pypi: https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/e8/5c880ffd8d4bb9df4cdf75ab8b44fc8f7011b6cb629b3e6242f3d5944b4f/stringzilla-5.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -47364,7 +47369,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
       - pypi: https://pypi.nvidia.com/tensorrt-cu13/tensorrt_cu13-11.2.1.2.tar.gz
-      p2:
+      linux-aarch64-cuda13:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/alsa-lib-1.2.16.1-h5bc82ec_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aom-3.14.1-pl5321hf5316b6_2.conda
@@ -47851,6 +47856,7 @@ environments:
       - pypi: ./packages/monoprior
       - pypi: ./packages/sam3
       - pypi: ./packages/simplecv
+      - pypi: ./packages/trtkit
       - pypi: ./packages/zipdepth
       - pypi: https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/07/42/a687e7091928806e514f89fa2666f25ec9bfe0a902fc4402b25e51ce408b/nh3-0.3.7-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
@@ -49785,6 +49791,35 @@ packages:
   run_exports: {}
   size: 7017
   timestamp: 1786642183250
+- conda: https://prefix.dev/conda-forge/linux-64/cairo-1.18.4-h3c89d7e_2.conda
+  sha256: 8395bb43e188b76be0842b8ecd440e79a8d202d320bfee009e31b6623390b40d
+  md5: e83331a940393006789fedddc3b492f3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - fontconfig >=2.18.3,<3.0a0
+  - fonts-conda-ecosystem
+  - icu >=78.3,<79.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=15
+  - libglib >=2.88.3,<3.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libstdcxx >=15
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - pixman >=0.46.4,<1.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: LGPL-2.1-only or MPL-1.1
+  run_exports:
+    weak:
+    - cairo >=1.18.4,<2.0a0
+  size: 989707
+  timestamp: 1787926031792
 - conda: https://prefix.dev/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
   sha256: 06525fa0c4e4f56e771a3b986d0fdf0f0fc5a3270830ee47e127a5105bde1b9a
   md5: bb6c4808bfa69d6f7f6b07e5846ced37
@@ -50070,27 +50105,27 @@ packages:
   run_exports: {}
   size: 23168153
   timestamp: 1781778936323
-- conda: https://prefix.dev/conda-forge/linux-64/cmake-4.4.2-hc85cc9f_0.conda
-  sha256: 5c8027d6f51e4aea86dfa74a09481f6e275742a620c5a88b132ec01405e9bd6e
-  md5: c7d7ad5d723ffc37a7892d9dd9dd115d
+- conda: https://prefix.dev/conda-forge/linux-64/cmake-4.4.3-hff7ac6b_0.conda
+  sha256: a6d21b5166cd7a44fa975e541f1abf851579a8ac3458e72e77125761da06c842
+  md5: e9d08c8f9a02853bfc6f8c3a4b0b19a4
   depends:
+  - libgcc >=15
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=15
+  - ncurses >=6.6,<7.0a0
   - bzip2 >=1.0.8,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
   - libexpat >=2.8.1,<3.0a0
-  - libgcc >=14
   - liblzma >=5.8.3,<6.0a0
-  - libstdcxx >=14
+  - libcurl >=8.21.0,<9.0a0
+  - rhash >=1.4.6,<2.0a0
   - libuv >=1.52.1,<2.0a0
   - libzlib >=1.3.2,<2.0a0
-  - ncurses >=6.6,<7.0a0
-  - rhash >=1.4.6,<2.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 23711960
-  timestamp: 1785533746305
+  size: 26077721
+  timestamp: 1787711119591
 - conda: https://prefix.dev/conda-forge/linux-64/colmap-4.0.4-cpu_h19de2b4_2.conda
   sha256: b75280ba613967e8fde689c0452a823cbd55ab58218f48121bd7cb4ca9dd27dd
   md5: 7c0effdf7e11a72eb110293b99900d41
@@ -50721,20 +50756,20 @@ packages:
     - cyrus-sasl >=2.1.28,<3.0a0
   size: 210103
   timestamp: 1771943128249
-- conda: https://prefix.dev/conda-forge/linux-64/cython-3.2.9-py311h0daaf2c_0.conda
-  sha256: cef18857c8dae61fc4661d9438c8ff774950beaed4c034e66e12ad0729d2f5bb
-  md5: eb17831e81f7bf85bedbd4a641a71c3c
+- conda: https://prefix.dev/conda-forge/linux-64/cython-3.3.0-py311h781f220_0.conda
+  sha256: 97e7dc4b4791ab2b56990458e51e35059251175a2c0dd0fc550ee1221296830d
+  md5: d9bcdd8160cc7e352642140611b74e0f
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
+  - libgcc >=15
+  - libstdcxx >=15
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   license: Apache-2.0
   license_family: APACHE
   run_exports: {}
-  size: 3752945
-  timestamp: 1785016083216
+  size: 3978625
+  timestamp: 1787435601647
 - conda: https://prefix.dev/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
   sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
   md5: 418c6ca5929a611cbd69204907a83995
@@ -51368,72 +51403,6 @@ packages:
     - ffmpeg >=8.1.2,<9.0a0
   size: 13037808
   timestamp: 1786301079741
-- conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-9.0.0-gpl_h95e667c_900.conda
-  sha256: 6cd7e0f7ae87f773b004888d5d1ca569e9c0e260e69faf014cb19f1b983ca706
-  md5: d2270310efc9b4616069cd393743d42e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.16.1,<1.3.0a0
-  - aom >=3.14.1,<3.15.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.18.2,<3.0a0
-  - fonts-conda-ecosystem
-  - gmp >=6.3.0,<7.0a0
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.5,<0.17.6.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libfreetype >=2.14.3
-  - libfreetype6 >=2.14.3
-  - libgcc >=14
-  - libharfbuzz >=14.3.0
-  - libiconv >=1.18,<2.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libopenvino >=2026.3.0,<2026.3.1.0a0
-  - libopenvino-auto-batch-plugin >=2026.3.0,<2026.3.1.0a0
-  - libopenvino-auto-plugin >=2026.3.0,<2026.3.1.0a0
-  - libopenvino-hetero-plugin >=2026.3.0,<2026.3.1.0a0
-  - libopenvino-intel-cpu-plugin >=2026.3.0,<2026.3.1.0a0
-  - libopenvino-intel-gpu-plugin >=2026.3.0,<2026.3.1.0a0
-  - libopenvino-intel-npu-plugin >=2026.3.0,<2026.3.1.0a0
-  - libopenvino-ir-frontend >=2026.3.0,<2026.3.1.0a0
-  - libopenvino-onnx-frontend >=2026.3.0,<2026.3.1.0a0
-  - libopenvino-paddle-frontend >=2026.3.0,<2026.3.1.0a0
-  - libopenvino-pytorch-frontend >=2026.3.0,<2026.3.1.0a0
-  - libopenvino-tensorflow-frontend >=2026.3.0,<2026.3.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2026.3.0,<2026.3.1.0a0
-  - libopus >=1.6.1,<2.0a0
-  - libplacebo >=7.360.1,<7.361.0a0
-  - librsvg >=2.62.3,<3.0a0
-  - libstdcxx >=14
-  - libva >=2.24.1,<3.0a0
-  - libvorbis >=1.3.7,<1.4.0a0
-  - libvpl >=2.16.0,<2.17.0a0
-  - libvpx >=1.15.2,<1.16.0a0
-  - libvulkan-loader >=1.4.357.0,<2.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libzlib >=1.3.2,<2.0a0
-  - openh264 >=2.6.0,<2.6.1.0a0
-  - openssl >=3.5.7,<4.0a0
-  - pulseaudio-client >=17.0,<17.1.0a0
-  - sdl2 >=2.32.56,<3.0a0
-  - svt-av1 >=4.2.0,<4.2.1.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  - xorg-libx11 >=1.8.13,<2.0a0
-  constrains:
-  - __cuda  >=12.8
-  license: GPL-2.0-or-later
-  license_family: GPL
-  run_exports:
-    weak:
-    - ffmpeg >=9.0.0,<10.0a0
-  size: 13550988
-  timestamp: 1786321280624
 - conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-9.0.1-gpl_hc45e1dd_900.conda
   sha256: 3848776a096b92665b6419ea5bd7867a3bd5e512bf8a328ef1264e4609dcae4d
   md5: 21be8a374cbd1a1c75c75a9179b604e8
@@ -51951,23 +51920,23 @@ packages:
   run_exports: {}
   size: 82843060
   timestamp: 1787618483258
-- conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-16.1.0-h5fcb69b_1.conda
-  sha256: 00c87015522248adb5565a1b8f977cfe927831dd7ef0cb0a5d13f896844af719
-  md5: 419982d8913246db404319048e062d3e
+- conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-16.2.0-h176d5d0_4.conda
+  sha256: d09c1e8ae19bc03a6336516fb2b55f09d1b86bbe16242d911dbf4d23f709b5d5
+  md5: 15426bff4573d78ab030e6d439fc820b
   depends:
   - binutils_impl_linux-64 >=2.46.1
-  - libgcc >=16.1.0
-  - libgcc-devel_linux-64 16.1.0 h59071f9_101
-  - libgomp >=16.1.0
-  - libsanitizer 16.1.0 hf2715c6_1
-  - libstdcxx >=16.1.0
-  - libstdcxx-devel_linux-64 16.1.0 h41cdd0d_101
+  - libgcc >=16.2.0
+  - libgcc-devel_linux-64 16.2.0 he3ce08f_104
+  - libgomp >=16.2.0
+  - libsanitizer 16.2.0 h3048135_4
+  - libstdcxx >=16.2.0
+  - libstdcxx-devel_linux-64 16.2.0 h86e191b_104
   - sysroot_linux-64
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   run_exports: {}
-  size: 85161422
-  timestamp: 1785375529345
+  size: 86474258
+  timestamp: 1787618763737
 - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-14.3.0-h50e9bb6_27.conda
   sha256: d7f427d6db94a5eed2a43b186f8dc17cc1fbeb03517442390a36f1cde02548b0
   md5: 90369fa27fae2f7bf7eaaccc34c793e2
@@ -52028,11 +51997,11 @@ packages:
     - libgcc >=15
   size: 29771
   timestamp: 1787166287979
-- conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-16.1.0-h5fd2508_0.conda
-  sha256: 22d2b2c0386fda70971c87afd4926cb20ba1a247421f5be617c43512570fa4f7
-  md5: 15b9577e4be98443deb42e88e9c44656
+- conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-16.2.0-h0ab548f_1.conda
+  sha256: 584032e84caafa6aca232cb2624d428e85b6c9c32d9b0043f9569533bbba0150
+  md5: bd343ebae16dcb6e0535409d1ea2904e
   depends:
-  - gcc_impl_linux-64 16.1.0.*
+  - gcc_impl_linux-64 16.2.0.*
   - binutils_linux-64
   - sysroot_linux-64
   license: BSD-3-Clause
@@ -52040,8 +52009,8 @@ packages:
   run_exports:
     strong:
     - libgcc >=16
-  size: 29720
-  timestamp: 1785386616206
+  size: 29773
+  timestamp: 1787671867996
 - conda: https://prefix.dev/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda
   sha256: c5594497f0646e9079705b3199dbb2d5b13c48173cf110000fa1c8818e2b3e0c
   md5: 7892f39a39ed39591a89a28eba03e987
@@ -52836,19 +52805,19 @@ packages:
   run_exports: {}
   size: 16252239
   timestamp: 1787618666649
-- conda: https://prefix.dev/conda-forge/linux-64/gxx_impl_linux-64-16.1.0-he33a5f8_1.conda
-  sha256: 4b7e7a082fab18a58409b05c2611b8edb4aeb06ee07be380a73da5de911da2ba
-  md5: aaeab97072d79e7945182dc7d4e1a035
+- conda: https://prefix.dev/conda-forge/linux-64/gxx_impl_linux-64-16.2.0-h0d273dc_4.conda
+  sha256: 839b4701fa8eb6b315b28ac8a245310b08aec62893a64727d7cabf260467281a
+  md5: d7f18a0ab325cc612bfd7842bf53756e
   depends:
-  - gcc_impl_linux-64 16.1.0 h5fcb69b_1
-  - libstdcxx-devel_linux-64 16.1.0 h41cdd0d_101
+  - gcc_impl_linux-64 16.2.0 h176d5d0_4
+  - libstdcxx-devel_linux-64 16.2.0 h86e191b_104
   - sysroot_linux-64
   - tzdata
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   run_exports: {}
-  size: 16633585
-  timestamp: 1785375706410
+  size: 17668584
+  timestamp: 1787618949985
 - conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-14.3.0-hd240bd5_27.conda
   sha256: cf5a44d14732b79e3c2bc6ebe1dba4f6b9077939f3093c75e36ad340737b5c15
   md5: 41fae38a424bbc78438cfec6a4fde187
@@ -52917,12 +52886,12 @@ packages:
     - libgcc >=15
   size: 28165
   timestamp: 1787166287979
-- conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-16.1.0-h5525346_0.conda
-  sha256: c8c0b721dadcc8d48d2a5a9ee56add4b46ce5427adbf6ff685e0f75fabd52cbd
-  md5: 4521cfa739a42179511b351566374c6e
+- conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-16.2.0-h38dc33c_1.conda
+  sha256: 2822b09c60c018b06478195c8ae44a8e7cb3adc6a97817133d87de60d93f64be
+  md5: d9bbb40b0d585ed45f741da4e774aa74
   depends:
-  - gxx_impl_linux-64 16.1.0.*
-  - gcc_linux-64 ==16.1.0 h5fd2508_0
+  - gxx_impl_linux-64 16.2.0.*
+  - gcc_linux-64 ==16.2.0 h0ab548f_1
   - binutils_linux-64
   - sysroot_linux-64
   license: BSD-3-Clause
@@ -52931,8 +52900,8 @@ packages:
     strong:
     - libstdcxx >=16
     - libgcc >=16
-  size: 28116
-  timestamp: 1785386616206
+  size: 28158
+  timestamp: 1787671867996
 - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha4f8f14_102.conda
   sha256: de9ec9b1b01b90f2da2d896a5835a2fd8049859aff0c6331ca4594327ec79a8b
   md5: b270340809d19ae40ff9913f277b803a
@@ -54542,6 +54511,25 @@ packages:
     - libavif16 >=1.4.2,<2.0a0
   size: 149787
   timestamp: 1780665914755
+- conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-10_h4a7cf45_openblas.conda
+  build_number: 10
+  sha256: 3b0600d79b16cc868421adbba03364ba59d2a3c088c79eef678f4a0b43fc7c07
+  md5: e2ca3eadd889d39b4e4b6b1ecc671816
+  depends:
+  - libopenblas >=0.3.34,<0.3.35.0a0
+  - libopenblas >=0.3.34,<1.0a0
+  constrains:
+  - blas 2.310   openblas
+  - libcblas   3.11.0   10*_openblas
+  - liblapack  3.11.0   10*_openblas
+  - liblapacke 3.11.0   10*_openblas
+  - mkl <2027
+  license: BSD-3-Clause
+  run_exports:
+    weak:
+    - libblas >=3.11.0,<4.0a0
+  size: 17975
+  timestamp: 1788076997926
 - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
   build_number: 8
   sha256: b2da6bfd72a1c9cb143ccf64bf5b28790cb4eb58bd1cb978f6537b2322f7d48b
@@ -54585,26 +54573,6 @@ packages:
     - libblas >=3.11.0,<4.0a0
   size: 19257
   timestamp: 1779859078137
-- conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-9_h4a7cf45_openblas.conda
-  build_number: 9
-  sha256: 39c7b3c5427b435c9c059ede9da61d46d42574e5b846ad37fdc3af4a5eab1e48
-  md5: f5c4b041925dea221dc4bad2e50569d9
-  depends:
-  - libopenblas >=0.3.34,<0.3.35.0a0
-  - libopenblas >=0.3.34,<1.0a0
-  constrains:
-  - blas 2.309   openblas
-  - libcblas   3.11.0   9*_openblas
-  - liblapack  3.11.0   9*_openblas
-  - liblapacke 3.11.0   9*_openblas
-  - mkl <2027
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports:
-    weak:
-    - libblas >=3.11.0,<4.0a0
-  size: 18033
-  timestamp: 1786059035239
 - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-9_h5875eb1_mkl.conda
   build_number: 9
   sha256: a8c8b832fb56469221612e1f33c1c01868146c85721966b663a35d4248121e7e
@@ -54791,6 +54759,22 @@ packages:
     - libcap >=2.78,<2.79.0a0
   size: 124335
   timestamp: 1775488792584
+- conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-10_h0358290_openblas.conda
+  build_number: 10
+  sha256: 90fd992748d501f6efe2b8310aa81f5ee4a63629450dd88e851ba4ab757f3c3a
+  md5: a275bd95aa4e22c24120bf6ece6eb056
+  depends:
+  - libblas 3.11.0 10_h4a7cf45_openblas
+  constrains:
+  - blas 2.310   openblas
+  - liblapack  3.11.0   10*_openblas
+  - liblapacke 3.11.0   10*_openblas
+  license: BSD-3-Clause
+  run_exports:
+    weak:
+    - libcblas >=3.11.0,<4.0a0
+  size: 17959
+  timestamp: 1788077003985
 - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
   build_number: 8
   sha256: 1a2bc77bb26520255904a3d9b1f40e6bf0bf9d8d3405c7709dd162282820915a
@@ -54829,23 +54813,6 @@ packages:
     - libcblas >=3.11.0,<4.0a0
   size: 18902
   timestamp: 1779859085492
-- conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-9_h0358290_openblas.conda
-  build_number: 9
-  sha256: 4c532a70ea9aeff2fa1aabaa4828ebc00c2ed12b22aa8ba19da5302b882fc82b
-  md5: 092c5649f3727af436ab0f67f48c3811
-  depends:
-  - libblas 3.11.0 9_h4a7cf45_openblas
-  constrains:
-  - blas 2.309   openblas
-  - liblapack  3.11.0   9*_openblas
-  - liblapacke 3.11.0   9*_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports:
-    weak:
-    - libcblas >=3.11.0,<4.0a0
-  size: 17998
-  timestamp: 1786059041397
 - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-9_hfef963f_mkl.conda
   build_number: 9
   sha256: 8ce1b4cdc6e0feb53c5f8e3cf69b1b2c034f5e2726a4027b2fa6feeb0e7fb93e
@@ -56224,6 +56191,24 @@ packages:
     - libglib >=2.88.3,<3.0a0
   size: 4755172
   timestamp: 1786457663614
+- conda: https://prefix.dev/conda-forge/linux-64/libglib-2.88.3-he503a2a_2.conda
+  sha256: af6c14f387f810c5df491b328ae955329596d3bc73b1e2e091ab5adb46a10759
+  md5: 533d342dedadf134c67760ce6fc5b748
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - pcre2 >=10.47,<10.48.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libffi >=3.7.0,<3.8.0a0
+  constrains:
+  - glib >2.66
+  license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - libglib >=2.88.3,<3.0a0
+  size: 4758097
+  timestamp: 1787884091247
 - conda: https://prefix.dev/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
   sha256: a0105eb88f76073bbb30169312e797ed5449ebb4e964a756104d6e54633d17ef
   md5: 8422fcc9e5e172c91e99aef703b3ce65
@@ -56965,6 +56950,22 @@ packages:
     - libklu >=2.3.5,<3.0a0
   size: 131775
   timestamp: 1741963824816
+- conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-10_h47877c9_openblas.conda
+  build_number: 10
+  sha256: 166da1ef513efd2f9ea9e132246766306e5d1a18b4e83b8b8425b5adffb6345e
+  md5: 7b918d4958f359c889c662aa361cf992
+  depends:
+  - libblas 3.11.0 10_h4a7cf45_openblas
+  constrains:
+  - blas 2.310   openblas
+  - libcblas   3.11.0   10*_openblas
+  - liblapacke 3.11.0   10*_openblas
+  license: BSD-3-Clause
+  run_exports:
+    weak:
+    - liblapack >=3.11.0,<3.12.0a0
+  size: 17978
+  timestamp: 1788077010883
 - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
   build_number: 8
   sha256: 168e327d737059553e15cc6ec36d76b9bbb3931c2a7721555fd68b4c9348b247
@@ -57003,23 +57004,6 @@ packages:
     - liblapack >=3.11.0,<3.12.0a0
   size: 18921
   timestamp: 1779859092867
-- conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-9_h47877c9_openblas.conda
-  build_number: 9
-  sha256: ea989e2dabd21d296a5a4ec515e695645aefcdf778ffdb5eeea515421d243ab5
-  md5: e51473c2b7e1f9cb61daafccfd912abf
-  depends:
-  - libblas 3.11.0 9_h4a7cf45_openblas
-  constrains:
-  - blas 2.309   openblas
-  - libcblas   3.11.0   9*_openblas
-  - liblapacke 3.11.0   9*_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports:
-    weak:
-    - liblapack >=3.11.0,<3.12.0a0
-  size: 18021
-  timestamp: 1786059046733
 - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-9_h5e43f62_mkl.conda
   build_number: 9
   sha256: 3060d9393e7013a192eb55354def1a522348baa57c3ce4dc9cb904bf392a9ac1
@@ -57040,6 +57024,22 @@ packages:
     - liblapack >=3.11.0,<3.12.0a0
   size: 18128
   timestamp: 1786059007914
+- conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-10_h6ae95b6_openblas.conda
+  build_number: 10
+  sha256: 96532b53b1743c9abfe25c2c2ea3d267737a0c5af9595e98a1c1cdb697812ef4
+  md5: 52caccfdceb79e427db4137ac4e13d68
+  depends:
+  - libblas 3.11.0 10_h4a7cf45_openblas
+  - libcblas 3.11.0 10_h0358290_openblas
+  - liblapack 3.11.0 10_h47877c9_openblas
+  constrains:
+  - blas 2.310   openblas
+  license: BSD-3-Clause
+  run_exports:
+    weak:
+    - liblapacke >=3.11.0,<3.12.0a0
+  size: 17998
+  timestamp: 1788077016927
 - conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-8_h6ae95b6_openblas.conda
   build_number: 8
   sha256: 0b982865888a73fe7c2e7d8e8ee3738ac378b83012a7da1a12264a473cb2382b
@@ -57078,23 +57078,6 @@ packages:
     - liblapacke >=3.11.0,<3.12.0a0
   size: 18932
   timestamp: 1779859100242
-- conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-9_h6ae95b6_openblas.conda
-  build_number: 9
-  sha256: 7534e06a82865d3cfa050937c77887e8e85e7edeb4623972f6fe837cc7d13334
-  md5: d76700bd66c92d6159bfcfd3c8f83bb8
-  depends:
-  - libblas 3.11.0 9_h4a7cf45_openblas
-  - libcblas 3.11.0 9_h0358290_openblas
-  - liblapack 3.11.0 9_h47877c9_openblas
-  constrains:
-  - blas 2.309   openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports:
-    weak:
-    - liblapacke >=3.11.0,<3.12.0a0
-  size: 18034
-  timestamp: 1786059054936
 - conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-9_hdba1596_mkl.conda
   build_number: 9
   sha256: 68f7318c0859627e58708d8eb6e297a945f9c04bff29672ea9e6351791be4c88
@@ -57519,23 +57502,22 @@ packages:
     - libopenblas >=0.3.33,<1.0a0
   size: 5931919
   timestamp: 1776993658641
-- conda: https://prefix.dev/conda-forge/linux-64/libopenblas-0.3.34-pthreads_h94d23a6_0.conda
-  sha256: 23392fc4f4e5ba230fcd1ef825878ba5ca7ee4f6259fac0cbb13299134b7bf7a
-  md5: c282d68f272927612462b5d626838ef1
+- conda: https://prefix.dev/conda-forge/linux-64/libopenblas-0.3.34-pthreads_hcf972fe_1.conda
+  sha256: b2846ca0b00cc08d248589d289ba891856d4b42da4a3c823be6b2d660bd80a83
+  md5: 25994250f54292352a82eb05ab4499ba
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - libgcc >=15
   - libgfortran
-  - libgfortran5 >=14.3.0
+  - libgfortran5 >=15.3.0
   constrains:
   - openblas >=0.3.34,<0.3.35.0a0
   license: BSD-3-Clause
-  license_family: BSD
   run_exports:
     weak:
     - libopenblas >=0.3.34,<1.0a0
-  size: 5952629
-  timestamp: 1784287497473
+  size: 5994112
+  timestamp: 1788056652715
 - conda: https://prefix.dev/conda-forge/linux-64/libopencolorio-2.5.2-ha05381d_5.conda
   sha256: 563ee78e03fc3fa0586f6f9d5c677b9c5dcb4e792bd9c3e7a9c4fc7c4c6c88b2
   md5: a1a5f38042871b9f486f98cfdbf2edf9
@@ -59762,20 +59744,20 @@ packages:
     - libsanitizer 15.3.0
   size: 7579092
   timestamp: 1787618435127
-- conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-16.1.0-hf2715c6_1.conda
-  sha256: 85662ecadd3961bc96cbcc38dbc024a768cc35932c8440677ed028ea6322c36c
-  md5: abd77210925872ee084672cf5be1d491
+- conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-16.2.0-h3048135_4.conda
+  sha256: d08ce38542e0b7782572dbed7eac9d648aad8fd951a82346d93a5d5a78e50232
+  md5: fbc8b8b630d4dfa30a7a0b673367cf37
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=16.1.0
-  - libstdcxx >=16.1.0
+  - libgcc >=16.2.0
+  - libstdcxx >=16.2.0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   run_exports:
     weak:
-    - libsanitizer 16.1.0
-  size: 7780843
-  timestamp: 1785375481116
+    - libsanitizer 16.2.0
+  size: 8194231
+  timestamp: 1787618720100
 - conda: https://prefix.dev/conda-forge/linux-64/libsndfile-1.2.2-hbc6d301_3.conda
   sha256: 3503121a77d76e33f668916b69d4b20cb6a21f62aa4351d1506271ae9d184c61
   md5: a2bc10137c845d9c45067f3c53aad6e5
@@ -60892,6 +60874,22 @@ packages:
     - libxcb >=1.17.0,<2.0a0
   size: 397355
   timestamp: 1787077466600
+- conda: https://prefix.dev/conda-forge/linux-64/libxcb-1.17.0-hb83e432_2.conda
+  sha256: 7b49e6fd2a584b7f072943e6adf4149677af5121246975278804782d37752837
+  md5: 61f0ffba9161cbb3a77722869b21e4bb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - pthread-stubs
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdmcp >=1.1.5,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libxcb >=1.17.0,<2.0a0
+  size: 395120
+  timestamp: 1787885788278
 - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
   sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
   md5: 5aa797f8787fe7a17d1b0821485b5adc
@@ -61913,6 +61911,7 @@ packages:
   - libstdcxx >=14
   - libgcc >=14
   license: Apache-2.0
+  license_family: APACHE
   purls: []
   run_exports: {}
   size: 186767
@@ -63179,6 +63178,7 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   license: GPL-3.0-or-later
+  license_family: GPL
   run_exports: {}
   size: 110235
   timestamp: 1786290759191
@@ -64310,6 +64310,37 @@ packages:
     - python
   size: 30907259
   timestamp: 1781149782225
+- conda: https://prefix.dev/conda-forge/linux-64/python-3.11.16-h8ab3286_0_cpython.conda
+  sha256: 16bf00ae05ca86a6dd4ecb19afc238a8c07e09efba9147e2c8b5b9ebd1e12e39
+  md5: 69c543702fe40032d1af308597174f9c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.7.0,<3.8.0a0
+  - libgcc >=14
+  - liblzma >=5.8.3,<6.0a0
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libuuid >=2.42.2,<3.0a0
+  - libxcrypt >=4.4.38
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.7,<4.0a0
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  run_exports:
+    weak:
+    - python_abi 3.11.* *_cp311
+    noarch:
+    - python
+  size: 30923685
+  timestamp: 1787353217431
 - conda: https://prefix.dev/conda-forge/linux-64/python-3.12.0-hab00c5b_0_cpython.conda
   sha256: 5398ebae6a1ccbfd3f76361eac75f3ac071527a8072627c4bf9008c689034f48
   md5: 7f97faab5bebcc2580f4f299285323da
@@ -65508,6 +65539,19 @@ packages:
   run_exports: {}
   size: 414574
   timestamp: 1784433185142
+- conda: https://prefix.dev/conda-forge/linux-64/rhash-1.4.6-hb03c661_2.conda
+  sha256: 186a5b225077ad5f4656966da947d43307101950751ef4a239b455588756b4e1
+  md5: 007602d697e07c11ff9864964eba5ee3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - rhash >=1.4.6,<2.0a0
+  size: 194994
+  timestamp: 1786731436520
 - conda: https://prefix.dev/conda-forge/linux-64/rhash-1.4.6-hb9d3cd8_1.conda
   sha256: d5c73079c1dd2c2a313c3bfd81c73dbd066b7eb08d213778c8bff520091ae894
   md5: c1c9b02933fdb2cfb791d936c20e887e
@@ -84111,16 +84155,16 @@ packages:
   run_exports: {}
   size: 3093906
   timestamp: 1787618317103
-- conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-16.1.0-h59071f9_101.conda
-  sha256: b314251d957b16c71ec241119ac09b9530c5c4ce140026ec98d297f55d6c5e08
-  md5: 19b0151ecb1d122f706ebd2f82f9a017
+- conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-16.2.0-he3ce08f_104.conda
+  sha256: 5365adce4b7564ba3773d037d84070d68ec1269d4b35f3ab92536ee1087a99a5
+  md5: f2cf63d33e7be7f7722479fb30d9e332
   depends:
   - __unix
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   run_exports: {}
-  size: 3096495
-  timestamp: 1785375361053
+  size: 3095149
+  timestamp: 1787618545895
 - conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-aarch64-14.3.0-h25ba3ff_119.conda
   sha256: e06d098cd33eac577b9c994a47243de5439ca8fd9ff6e790723fbfdc3d61a76c
   md5: 970ca6cb337de6a7bccfaaa344e9863b
@@ -84241,16 +84285,16 @@ packages:
   run_exports: {}
   size: 20671212
   timestamp: 1787618340216
-- conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-16.1.0-h41cdd0d_101.conda
-  sha256: c1521172f2fdf5510d79b621ea835064209fe3131518e0d8b2b43362a75e7b4c
-  md5: 8593636203272a748b63d56cbd674753
+- conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-16.2.0-h86e191b_104.conda
+  sha256: 435877f29650022730300859dec5c0dee162d10536e1b6fd01cf93ca33a71fde
+  md5: 83cdebeadbdacc2692cb4797d188c77a
   depends:
   - __unix
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   run_exports: {}
-  size: 22519609
-  timestamp: 1785375386152
+  size: 22447939
+  timestamp: 1787618628584
 - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-aarch64-14.3.0-h57c8d61_119.conda
   sha256: 918ae042d508617da3c06fb55332f1280340eb705a69a0b1d14fa6fddb790145
   md5: 8c7bc9930a1b7c38557311fbea9a433f
@@ -86932,17 +86976,17 @@ packages:
   run_exports: {}
   size: 258232
   timestamp: 1775160081069
-- conda: https://prefix.dev/conda-forge/noarch/wheel-0.47.0-pyhd8ed1ab_0.conda
-  sha256: 9e156ffaefb8463437144326ada4b85d1de17961b9997ac5f1cbbaf747bd8bed
-  md5: d0e3b2f0030cf4fca58bde71d246e94c
+- conda: https://prefix.dev/conda-forge/noarch/wheel-0.48.0-pyhd8ed1ab_0.conda
+  sha256: ba64b29b6d418024cb565081a1799262cb2780d2534ff4c14f76aa858c4286cd
+  md5: 9a2124517bfd5d792e0f7b86eefdfeb8
   depends:
   - packaging >=24.0
   - python >=3.10
   license: MIT
   license_family: MIT
   run_exports: {}
-  size: 33491
-  timestamp: 1776878563806
+  size: 34528
+  timestamp: 1786613220176
 - conda: https://prefix.dev/conda-forge/noarch/wslink-2.5.7-pyhd8ed1ab_0.conda
   sha256: 894762dc1a6520888de7cbe8d6f59999a94005aad11951fddcfdbef85d726a2d
   md5: 410dee7cbee308f33b01645f16f11efc
@@ -91972,7 +92016,7 @@ packages:
     - zstd >=1.5.7,<1.6.0a0
   size: 433413
   timestamp: 1764777166076
-- conda_source: asmk[10e5161b] @ packages/asmk
+- conda_source: asmk[ac964423] @ packages/asmk
   variants:
     target_platform: linux-64
   depends:
@@ -91983,51 +92027,51 @@ packages:
   - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   - conda: https://prefix.dev/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
   - conda: https://prefix.dev/conda-forge/linux-64/binutils_linux-64-2.46.1-default_h4852527_102.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-16.1.0-h5fcb69b_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-16.1.0-h5fd2508_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-16.2.0-h176d5d0_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-16.2.0-h0ab548f_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-16.1.0-hf2715c6_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-16.2.0-h3048135_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
   - conda: https://prefix.dev/conda-forge/noarch/kernel-headers_linux-64-5.14.0-he073ed8_3.conda
-  - conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-16.1.0-h59071f9_101.conda
-  - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-16.1.0-h41cdd0d_101.conda
+  - conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-16.2.0-he3ce08f_104.conda
+  - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-16.2.0-h86e191b_104.conda
   - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-64-2.34-h087de78_3.conda
   - conda: https://prefix.dev/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
   host_packages:
   - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/cython-3.2.9-py311h0daaf2c_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-h54a6638_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/cython-3.3.0-py311h781f220_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
   - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
   - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
   - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/python-3.11.15-h7508c33_1_cpython.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/python-3.11.16-h8ab3286_0_cpython.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
   - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/pip-26.2.1-pyh8b19718_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.11-8_cp311.conda
   - conda: https://prefix.dev/conda-forge/noarch/setuptools-84.0.0-pyh332efcf_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/wheel-0.47.0-pyhd8ed1ab_0.conda
-- conda_source: dpretrieval[d5cd5e62] @ packages/dpretrieval
+  - conda: https://prefix.dev/conda-forge/noarch/wheel-0.48.0-pyhd8ed1ab_0.conda
+- conda_source: dpretrieval[34f6a2c9] @ packages/dpretrieval
   variants:
     target_platform: linux-64
   depends:
@@ -92042,51 +92086,51 @@ packages:
   - conda: https://prefix.dev/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
   - conda: https://prefix.dev/conda-forge/linux-64/binutils_linux-64-2.46.1-default_h4852527_102.conda
   - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.8-h280c20c_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/cmake-4.4.2-hc85cc9f_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-16.1.0-h5fcb69b_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-16.1.0-h5fd2508_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/cmake-4.4.3-hff7ac6b_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-16.2.0-h176d5d0_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-16.2.0-h0ab548f_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/git-2.55.0-pl5321h5685339_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/gxx_impl_linux-64-16.1.0-he33a5f8_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-16.1.0-h5525346_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-h54a6638_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/gxx_impl_linux-64-16.2.0-h0d273dc_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-16.2.0-h38dc33c_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
   - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.21.0-heca4667_4.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.21.0-ha042cf0_5.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-16.1.0-h69a702a_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-16.2.0-h69a702a_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
   - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libpsl-0.23.0-hf670292_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-16.1.0-hf2715c6_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libpsl-0.23.1-hd9e3e90_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-16.2.0-h3048135_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-h6154650_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
   - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/ninja-1.13.2-h171cf75_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/ninja-1.13.2-h171cf75_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.47-h8b3dc9c_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/rhash-1.4.6-hb9d3cd8_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/rhash-1.4.6-hb03c661_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
   - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/kernel-headers_linux-64-5.14.0-he073ed8_3.conda
-  - conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-16.1.0-h59071f9_101.conda
-  - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-16.1.0-h41cdd0d_101.conda
+  - conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-16.2.0-he3ce08f_104.conda
+  - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-16.2.0-h86e191b_104.conda
   - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-64-2.34-h087de78_3.conda
   - conda: https://prefix.dev/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
   host_packages:
   - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h039972f_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-h7cc23a3_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/aom-3.14.1-pl5321h57e6904_2.conda
   - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.4-h4610da3_2.conda
   - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.15-h6bbde05_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.14.3-hb03c661_0.conda
@@ -92097,83 +92141,83 @@ packages:
   - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.7-h01ee8f8_3.conda
   - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-h01ee8f8_5.conda
   - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.8-h280c20c_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/cairo-1.18.4-h3c89d7e_2.conda
   - conda: https://prefix.dev/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-9.0.0-gpl_h95e667c_900.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/fontconfig-2.18.3-h27c8c51_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/freetype-2.14.3-ha770c72_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/ffmpeg-9.0.1-gpl_hc45e1dd_900.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/freetype-2.14.3-ha770c72_2.conda
   - conda: https://prefix.dev/conda-forge/linux-64/fribidi-1.0.16-hb03c661_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/gdk-pixbuf-2.44.7-h2b0a6b4_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/glslang-16.5.0-h718be3e_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/gdk-pixbuf-2.44.8-h68053f1_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/glslang-16.5.0-h980caa0_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/gmp-6.3.0-hfd2156b_3.conda
   - conda: https://prefix.dev/conda-forge/linux-64/graphite2-1.3.15-h54a6638_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-14.3.0-ha770c72_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-14.4.0-ha770c72_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.2.0-nompi_hc529623_100.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-h54a6638_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
   - conda: https://prefix.dev/conda-forge/linux-64/imath-3.2.2-hde8ca8f_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/intel-gmmlib-22.10.0-hb700be7_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/intel-media-driver-26.1.6-hecca717_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+  - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/lame-4.0-h770b6ad_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
   - conda: https://prefix.dev/conda-forge/linux-64/lerc-4.2.0-hdb68285_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/level-zero-1.29.0-hb700be7_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20260526.0-cxx17_h7b12aa8_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20260526.0-cxx17_h0dc7533_2.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libass-0.17.5-h434b012_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libavif16-1.4.2-h0ed3d04_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-9_h4a7cf45_openblas.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-10_h4a7cf45_openblas.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_3.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libcap-2.78-h084b8d7_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-9_h0358290_openblas.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-10_h0358290_openblas.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.21.0-heca4667_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.21.0-ha042cf0_5.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libdovi-3.4.0-ha23c83e_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libdrm-2.4.127-hb03c661_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libdrm-2.4.129-h7cc23a3_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_5.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_5.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-16.1.0-h69a702a_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libgfortran-16.1.0-h69a702a_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-16.1.0-h79bb938_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.88.3-h0d30a3d_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libharfbuzz-14.3.0-h17a8019_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libharfbuzz-devel-14.3.0-h17a8019_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libfreetype6-2.14.3-h5e6c136_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-16.2.0-h69a702a_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-16.2.0-h6b99dfc_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_5.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_5.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.88.3-he503a2a_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_5.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_5.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_5.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libharfbuzz-14.4.0-h23af247_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libharfbuzz-devel-14.4.0-h23af247_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libhwloc-2.13.0-default_he001693_1000.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libhwy-1.4.0-h3a9caae_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libhwy-1.4.0-h57c4cff_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libjxl-0.12.0-h174a0a3_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-9_h47877c9_openblas.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-9_h6ae95b6_openblas.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libjxl-0.12.0-heb2dce7_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-10_h47877c9_openblas.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-10_h6ae95b6_openblas.conda
   - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libopenblas-0.3.34-pthreads_h94d23a6_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libopenblas-0.3.34-pthreads_hcf972fe_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libopencv-4.13.0-qt6_hbf336e1_616.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-2026.3.0-hb2f3c86_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-auto-batch-plugin-2026.3.0-h9f30d58_0.conda
@@ -92188,68 +92232,68 @@ packages:
   - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-pytorch-frontend-2026.3.0-h0542e35_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-frontend-2026.3.0-h565fa1b_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2026.3.0-h0542e35_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libopus-1.6.1-hebe6cf0_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libpciaccess-0.19-hb03c661_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libplacebo-7.360.1-hc50b9dd_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libpq-18.4-hd5a49e9_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libprotobuf-7.35.1-h2840a7c_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libpsl-0.23.0-hf670292_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libpng-1.6.58-h922cc85_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libpq-18.6-h9d76c99_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libprotobuf-7.35.1-h622638d_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libpsl-0.23.1-hd9e3e90_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/librsvg-2.62.3-h4c96295_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libsystemd0-261.1-h6f4a2f1_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libudev1-261.1-h6f4a2f1_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libsndfile-1.2.2-hbc6d301_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-h6154650_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-16.2.0-hdf11a46_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libsystemd0-261.2-h6f4a2f1_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libtiff-4.7.2-hcc2c06a_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libudev1-261.2-h6f4a2f1_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/liburing-2.14-hb700be7_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libva-2.24.1-he1eb515_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libva-2.24.1-hb83e432_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libvpl-2.16.0-h54a6638_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libvpx-1.15.2-hecca717_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libvulkan-loader-1.4.357.0-h5279c79_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libvpx-1.15.2-hd2095e1_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libvulkan-loader-1.4.357.0-h0e34353_2.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libxcb-1.17.0-hb83e432_2.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.13.2-hca5e8e5_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.13.2-h51789e4_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/mpg123-1.32.9-h8142553_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/mpg123-1.33.7-h877a99e_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/ocl-icd-2.3.4-hb03c661_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/opencl-headers-2025.06.13-hecca717_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/openexr-3.4.14-h6de6307_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/openh264-2.6.0-h65dd3cf_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/openexr-3.4.15-ha9edf89_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/openh264-2.6.0-h8c49934_2.conda
   - conda: https://prefix.dev/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/openjph-0.31.0-h8d634f6_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/pango-1.58.2-hda50119_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.47-h8b3dc9c_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/pixman-0.46.4-h54a6638_3.conda
   - conda: https://prefix.dev/conda-forge/linux-64/pthread-stubs-0.4-hb03c661_1003.conda
   - conda: https://prefix.dev/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/python-3.11.15-h7508c33_1_cpython.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/qt6-main-6.11.1-pl5321h16c4a6b_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/python-3.11.16-h8ab3286_0_cpython.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/qt6-main-6.11.2-pl5321h9df5c37_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/rav1e-0.8.1-h1fbca29_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.6-h7e3ee7f_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/sdl3-3.4.14-hdeec2a5_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/shaderc-2026.3-h1b60276_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/shaderc-2026.3-hcebf71c_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/spirv-tools-2026.2-hb700be7_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-4.2.0-hecca717_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/spirv-tools-2026.3-h7148c6a_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-4.2.0-hd2095e1_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.26.0-hd6090a7_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.26.0-hc1c935e_2.conda
   - conda: https://prefix.dev/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
   - conda: https://prefix.dev/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
   - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
@@ -92259,24 +92303,24 @@ packages:
   - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-h280c20c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libsm-1.2.6-h0d788c3_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_2.conda
   - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxi-1.8.3-hb03c661_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxext-1.3.7-h7cc23a3_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxfixes-6.0.2-h7cc23a3_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxi-1.8.3-h7cc23a3_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrandr-1.5.5-h7cc23a3_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxrender-0.9.12-hb03c661_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxtst-1.2.5-h7cc23a3_4.conda
   - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/xorg-xorgproto-2025.1-h280c20c_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
   - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   - conda: https://prefix.dev/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
@@ -92288,7 +92332,7 @@ packages:
   - conda: https://prefix.dev/conda-forge/noarch/pybind11-global-3.1.0-pyh648e204_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/wayland-protocols-1.49-hd8ed1ab_0.conda
-- conda_source: mast3r[50afa763] @ packages/mast3r
+- conda_source: mast3r[8996e175] @ packages/mast3r
   variants:
     target_platform: noarch
   depends:
@@ -92297,60 +92341,60 @@ packages:
   build_packages:
   - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.8-h280c20c_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
   - conda: https://prefix.dev/conda-forge/linux-64/git-2.55.0-pl5321h5685339_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-h54a6638_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.21.0-heca4667_4.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.21.0-ha042cf0_5.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-16.1.0-h69a702a_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libpsl-0.23.0-hf670292_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-16.2.0-h69a702a_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libpsl-0.23.1-hd9e3e90_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-h6154650_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
   - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/patch-2.8-h280c20c_1003.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.47-h8b3dc9c_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
   - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
   host_packages:
   - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-h54a6638_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
   - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
   - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
   - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/python-3.11.15-h7508c33_1_cpython.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/python-3.11.16-h8ab3286_0_cpython.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
   - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/pip-26.2.1-pyh8b19718_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/setuptools-84.0.0-pyh332efcf_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/wheel-0.47.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/wheel-0.48.0-pyhd8ed1ab_0.conda
 - pypi: ./packages/arkitscenes-download
   name: arkitscenes-download
   requires_dist:
@@ -92515,7 +92559,7 @@ packages:
 - pypi: ./packages/simplecv
   name: simplecv
   requires_dist:
-  - jaxtyping>=0.2.36,<0.3.0
+  - jaxtyping>=0.2.36
   - numpy>=2.0
   - einops>=0.8.0
   - icecream>=2.1.3

--- a/pixi.toml
+++ b/pixi.toml
@@ -708,7 +708,7 @@ description = "Smoke: 2 catalog segments -> short fine-tune -> resume -> torchru
 [feature.zipdepth-catalog.tasks.zipdepth-eval-catalog]
 cmd = "python tools/eval_catalog.py"
 cwd = "packages/zipdepth"
-description = "Scale-shift-aligned AbsRel/delta1 vs PromptDA pseudo-labels on held-out catalog segments (released vs trained)"
+description = "Unaligned metric AbsRel/delta1/MAE vs held-out PromptDA labels, with separately named aligned diagnostics"
 
 # ═══════════════════════════════════════════════════════════════════════════
 # wilor-nano

--- a/pixi.toml
+++ b/pixi.toml
@@ -571,6 +571,12 @@ depends-on = ["_prompt-da-download-polycam-example"]
 cwd = "packages/prompt-da"
 description = "Run batched TensorRT PromptDA on the example Polycam dataset"
 
+[feature.prompt-da-demo.tasks.prompt-da-polycam-compare]
+cmd = "python tools/polycam_compare.py --polycam-zip-path data/6G-room-example.zip"
+depends-on = ["_prompt-da-download-polycam-example"]
+cwd = "packages/prompt-da"
+description = "Compare PromptDA-large against a trained ZipDepth-PromptDA checkpoint on the example Polycam capture"
+
 [feature.prompt-da-demo.tasks.prompt-da-app]
 cmd = "python tools/gradio_app.py"
 depends-on = ["_prompt-da-download-polycam-example"]

--- a/pixi.toml
+++ b/pixi.toml
@@ -648,6 +648,7 @@ libjpeg-turbo = ">=3.0.0,<4"
 [feature.zipdepth.pypi-dependencies]
 zipdepth = { path = "packages/zipdepth", editable = true }
 monopriors = { path = "packages/monoprior", editable = true }
+trtkit = { path = "packages/trtkit", editable = true }
 # monopriors' metadata requires sam3; resolve it to the workspace package like the other monopriors consumers
 sam3 = { path = "packages/sam3", editable = true }
 # albucore -> simsimd has no conda-forge linux-aarch64 build
@@ -668,6 +669,11 @@ description = "ZipDepth single-image inference visualized in Rerun (2D + 3D); --
 cmd = "python tools/train_smoke.py"
 cwd = "packages/zipdepth"
 description = "Smoke: self-distilled example data -> train -> resume -> torchrun -> checkpoints load through monopriors ZipDepthPredictor"
+
+[feature.zipdepth.tasks.zipdepth-export-prompted-trt]
+cmd = "python tools/export_prompted_trt.py"
+cwd = "packages/zipdepth"
+description = "Export, build, parity-check, and benchmark static-batch fp16 ZipDepth-PromptDA ONNX/TensorRT"
 
 # Catalog training lane: chosen-frame PromptDA pseudo-labels from the local Rerun catalog.
 # linux-64 only: NVDEC decode via torchcodec, mirroring prompt-da-stream.

--- a/pixi.toml
+++ b/pixi.toml
@@ -577,6 +577,12 @@ depends-on = ["_prompt-da-download-polycam-example"]
 cwd = "packages/prompt-da"
 description = "Compare PromptDA-large against a trained ZipDepth-PromptDA checkpoint on the example Polycam capture"
 
+[feature.prompt-da-demo.tasks.prompt-da-polycam-trio]
+cmd = "python tools/polycam_trio.py --polycam-zip-path data/6G-room-example.zip"
+depends-on = ["_prompt-da-download-polycam-example"]
+cwd = "packages/prompt-da"
+description = "Three-way Polycam comparison: raw ARKit LiDAR vs PromptDA-large vs ZipDepth-PromptDA, with a fused mesh each"
+
 [feature.prompt-da-demo.tasks.prompt-da-app]
 cmd = "python tools/gradio_app.py"
 depends-on = ["_prompt-da-download-polycam-example"]


### PR DESCRIPTION
## ZipDepth-PromptDA — prompted metric depth distilled from PromptDA

Builds a 6.14 M-parameter student that takes `(hi-res RGB, 192x256 metric LiDAR prompt) -> metric depth`,
trained purely on PromptDA-large pseudo-labels. It is to PromptDA what ZipDepth is to Depth Anything v2.

Design follows PromptDA's mechanism at ZipDepth's budget: per-image prompt normalisation, multi-scale
injection into all four decoder fusion stages through zero-initialised adapters, and a sigmoid +
denormalise head so metric scale comes from the prompt rather than from RGB.

### Results — held-out metric eval, 20 seed-0 segments, 1,452 frames, no alignment

| | AbsRel | delta1 | MAE |
|---|---:|---:|---:|
| Untrained affine reference | 0.1347 | 0.8094 | 0.222 m |
| **ZipDepth-PromptDA (70k steps)** | **0.0215** | **0.9857** | **0.0338 m** |
| improvement | **6.3x** | +0.176 | **6.6x** |

The aligned diagnostic (0.0208) sits essentially on top of the unaligned metric number (0.0215), which is
the point: the model is genuinely metric, not a relative-depth model rescued by alignment.

Per-segment AbsRel spans 0.015-0.033 across all 20 segments; no outliers, no failures.
Training ran 70,000/70,000 clean, loss 0.081 -> 0.0548.

### Resolution check

Same checkpoint evaluated at two resolutions:

| eval resolution | AbsRel | delta1 | MAE |
|---|---:|---:|---:|
| 768x1024 (training res) | 0.0215 | 0.9857 | 3.38 cm |
| 384x512 (2x LiDAR) | 0.0265 | 0.9838 | 4.00 cm |

768 wins by 23% AbsRel. Note the 384 row carries a train/eval mismatch penalty and is somewhat
pessimistic. Architecturally 768 is the right operating point because `decoder.fuse1` lands at exactly
192x256, the prompt's native size; at 384 the finest decoder stage falls *below* the prompt.

### Visual validation

`prompt-da-polycam-compare` runs teacher and student over the same Polycam capture.
Mean |teacher - student| over 105 frames: **33.3 mm**, consistent with the 33.8 mm holdout MAE on data
from a different capture device. Error is confined to depth discontinuities; surface interiors match.

Evidence and notes: `/tmp/rerun-viewer-validation/zdpda-polycam/`.

### Harness bug found during validation

The first comparison run reported 128.8 mm. Cause: it fed the confidence-masked prompt to *both* models.
PromptDA normalises by the prompt's own min/max with no mask and no epsilon, so zeroed holes drag its
minimum to 0 and corrupt the teacher. The teacher's near-zero pixel fraction tracked the mask fraction
almost 1:1 (6.7% -> 0.4%, 51.5% -> 36.4%). Fixed: teacher gets the raw prompt, student gets the masked one.

### Known gap

The training run was **loader-bound, not GPU-bound** — GPU averaged 58-70% with ~49% of wall time waiting
on data, dominated by `segment_query` bursts of 50-82 ms at segment transitions. It did not affect
correctness, but a future run should raise `num_producers` and the prefetch buffer first.
