### PR TITLE
simplecv: catalog rig-layout parser, typed umeyama result, codec-aware segment decoder (exo-calib stack 2/6)

### DIFF
--- a/packages/simplecv/docs/exoego_schema.md
+++ b/packages/simplecv/docs/exoego_schema.md
@@ -139,6 +139,11 @@ When ingesting a recording:
 4. GT tensors resolve under `/world/gt/...` when `config.load_labels` is true.
 5. Timeline is `video_time` everywhere.
 
+The read side of these rules is `simplecv/catalog_rig_layout.py`: `parse_rig_layout`
+turns a catalog schema back into typed cameras (video stream, moving rig, rig `kind`,
+calibration presence, camera-node markers). Consumers add only their selection policy
+on top of it instead of parsing entity paths themselves.
+
 ## 7. Dataset author checklist
 
 Datasets need **no** per-dataset rig code — `build_rig_layout` derives everything

--- a/packages/simplecv/simplecv/apis/metric_exoego_calib.py
+++ b/packages/simplecv/simplecv/apis/metric_exoego_calib.py
@@ -33,6 +33,7 @@ from simplecv.data.skeleton.coco_133 import (
     RIGHT_HAND_IDX,
 )
 from simplecv.ops.triangulate import batch_triangulate
+from simplecv.ops.umeyama import umeyama_alignment
 from simplecv.rerun_custom_types import PinholeWithDistortion, Points2DWithConfidence, Points3DWithConfidence, confidence_scores_to_rgb
 from simplecv.rerun_log_utils import RerunTyroConfig, log_pinhole, log_video
 from simplecv.rig import rebuild_camera_with_extrinsics
@@ -237,7 +238,7 @@ def single_frame_mv_hands(
 
     uvc_coco_list: list[Float32[ndarray, "133 3"]] = []
     uvc_cam_names: list[str] = []
-    for ego_cam_name, rgb_hw3 in tqdm(
+    for ego_cam_name, frame_rgb in tqdm(
         list(zip(ego_sequence.ego_cam_dict.keys(), rgb_list, strict=True)),
         desc="Hand detect/keypoints (calib frame)",
         leave=False,
@@ -245,15 +246,15 @@ def single_frame_mv_hands(
         # don't run on the quest cameras
         if "quest" in ego_cam_name.lower() or "rgb" in ego_cam_name.lower():
             continue
-        det_results: DetectionResult = hand_detector(rgb_hw3, hand_conf=0.3)
+        det_results: DetectionResult = hand_detector(frame_rgb, hand_conf=0.3)
         cam_log_path: Path = parent_log_path / "ego" / ego_cam_name
         pinhole_log_path: Path = cam_log_path / "pinhole"
-        rr.log(f"{pinhole_log_path}/image", rr.Image(rgb_hw3).compress(jpeg_quality=90))
+        rr.log(f"{pinhole_log_path}/image", rr.Image(frame_rgb).compress(jpeg_quality=90))
         uvc_coco: Float32[ndarray, "133 3"] = np.full((133, 3), np.nan, dtype=np.float32)
         # log detected hands and keypoints
         if det_results.left_xyxy is not None:
             wilor_preds: FinalWilorPred | KeypointResults = hand_keypoint_model(
-                rgb_hw3=rgb_hw3, xyxy=det_results.left_xyxy, handedness="left"
+                rgb_hw3=frame_rgb, xyxy=det_results.left_xyxy, handedness="left"
             )
             assert isinstance(wilor_preds, KeypointResults)
             if debug:
@@ -272,7 +273,7 @@ def single_frame_mv_hands(
 
         if det_results.right_xyxy is not None:
             wilor_preds: FinalWilorPred | KeypointResults = hand_keypoint_model(
-                rgb_hw3=rgb_hw3, xyxy=det_results.right_xyxy, handedness="right"
+                rgb_hw3=frame_rgb, xyxy=det_results.right_xyxy, handedness="right"
             )
             assert isinstance(wilor_preds, KeypointResults)
             if debug:
@@ -377,12 +378,8 @@ def single_frame_mv_hands(
     # dst_points are GT joints expressed in the Quest/world frame coming from the labels.
     dst_points: Float[ndarray, "n_valid 3"] = gt_xyzc[valid_mask, :3].astype(np.float64, copy=False)
 
-    # Similarity that maps Oak→new-Oak-world (destination ← source).
-    new_oak_world_T_oak_world: Float32[ndarray, "4 4"] = umeyama_transform(
-        src_points=src_points,
-        dst_points=dst_points,
-        allow_scaling=False,
-    )
+    # Rigid transform that maps Oak-world into new-Oak-world, as a homogeneous matrix.
+    new_oak_world_T_oak_world: Float32[ndarray, "4 4"] = umeyama_alignment(src_points, dst_points, allow_scaling=False).as_matrix().astype(np.float32)
     src_points_h: Float[ndarray, "n_valid 4"] = np.concatenate(
         (src_points, np.ones((num_valid, 1), dtype=np.float64)),
         axis=1,
@@ -690,83 +687,6 @@ def log_reprojected_gt_uv(
                 ).partition(keypoint_lengths),
             ],
         )
-
-
-def umeyama_transform(
-    *,
-    src_points: Float[ndarray, "n 3"],
-    dst_points: Float[ndarray, "n 3"],
-    allow_scaling: bool = False,
-    eps: float = 1e-9,
-) -> Float32[ndarray, "4 4"]:
-    """Compute the similarity transform aligning ``src_points`` to ``dst_points``.
-
-    The returned transform follows the right-to-left convention::
-
-        dst_points ≈ (dst_T_src[:3, :3] @ src_points.T).T + dst_T_src[:3, 3]
-
-    Args:
-        src_points: Source XYZ coordinates (e.g., triangulated Oak keypoints).
-        dst_points: Target XYZ coordinates (e.g., quest ground-truth keypoints).
-        allow_scaling: If True, estimate an isotropic scale factor; otherwise fix scale=1.
-        eps: Small value guarding against degenerate variance.
-
-    Returns:
-        dst_R_src: Rotation matrix mapping source → destination.
-        dst_t_src: Translation vector (destination frame) mapping source → destination.
-        scale: Isotropic scale factor.
-        dst_T_src: 4x4 homogeneous transform representing the similarity.
-
-    Raises:
-        ValueError: If fewer than 3 correspondences are provided or the source variance is degenerate.
-    """
-    if src_points.shape != dst_points.shape:
-        msg = f"Source and destination shapes must match; got {src_points.shape} vs {dst_points.shape}"
-        raise ValueError(msg)
-
-    n_points: int = int(src_points.shape[0])
-    if n_points < 3:
-        msg = f"Umeyama transform requires at least 3 correspondences; received {n_points}"
-        raise ValueError(msg)
-
-    src_f64: Float[ndarray, "n 3"] = src_points.astype(np.float64, copy=False)
-    dst_f64: Float[ndarray, "n 3"] = dst_points.astype(np.float64, copy=False)
-
-    src_mean: Float[ndarray, "3"] = np.mean(src_f64, axis=0)
-    dst_mean: Float[ndarray, "3"] = np.mean(dst_f64, axis=0)
-
-    src_centered: Float[ndarray, "n 3"] = src_f64 - src_mean
-    dst_centered: Float[ndarray, "n 3"] = dst_f64 - dst_mean
-
-    covariance: Float[ndarray, "3 3"] = (dst_centered.T @ src_centered) / float(n_points)
-
-    u: Float[ndarray, "3 3"]
-    singular_vals: Float[ndarray, "3"]
-    vt: Float[ndarray, "3 3"]
-    u, singular_vals, vt = np.linalg.svd(covariance)
-
-    reflection: Float[ndarray, "3"] = np.ones(3, dtype=np.float64)
-    if np.linalg.det(u) * np.linalg.det(vt) < 0:
-        reflection = np.array([1.0, 1.0, -1.0], dtype=np.float64)
-
-    dst_R_src: Float[ndarray, "3 3"] = u @ np.diag(reflection) @ vt
-
-    src_var: float = float(np.mean(np.sum(src_centered**2, axis=1)))
-    if src_var <= eps:
-        msg = f"Source variance too small for stable Umeyama estimation (variance={src_var})"
-        raise ValueError(msg)
-
-    scale: float = 1.0
-    if allow_scaling:
-        scale = float(np.sum(singular_vals * reflection) / src_var)
-
-    dst_t_src: Float[ndarray, "3"] = dst_mean - scale * (dst_R_src @ src_mean)
-
-    dst_T_src: Float[ndarray, "4 4"] = np.eye(4, dtype=np.float64)
-    dst_T_src[:3, :3] = scale * dst_R_src
-    dst_T_src[:3, 3] = dst_t_src
-
-    return dst_T_src.astype(np.float32)
 
 
 @dataclass

--- a/packages/simplecv/simplecv/catalog_calibration.py
+++ b/packages/simplecv/simplecv/catalog_calibration.py
@@ -1,0 +1,58 @@
+"""Read a camera's static calibration back out of a Rerun catalog layer.
+
+The inverse of ``simplecv.rerun_log_utils.log_pinhole``: the camera node carries a
+static ``Transform3D`` (``cam_R_world`` / ``cam_t_world``, logged ``from_parent``)
+and its ``pinhole`` child a static ``Pinhole`` (``image_from_camera`` plus the
+``resolution``). Rerun stores both 3x3 matrices column-major, so they are
+transposed here — the one place that convention lives on the read side.
+"""
+
+from collections.abc import Sequence
+
+import numpy as np
+import pyarrow as pa
+from jaxtyping import Float64
+from numpy import ndarray
+from rerun.catalog import DatasetEntry
+
+from simplecv.camera_parameters import Extrinsics, Intrinsics, PinholeParameters
+from simplecv.rrd_query_utils import first_valid_value
+
+
+def read_camera_calibration(dataset: DatasetEntry, segment_id: str, camera_entities: Sequence[str]) -> dict[str, PinholeParameters]:
+    """Read the static pinhole calibration of the given camera nodes.
+
+    Args:
+        dataset: Catalog dataset entry.
+        segment_id: Segment to read.
+        camera_entities: Camera node entity paths, e.g. ``/world/rig_00/cam_00``; each carries the
+            ``Transform3D`` and has a ``pinhole`` child carrying the ``Pinhole``.
+
+    Returns:
+        Float64 pinhole parameters (RDF, ``cam_T_world``) keyed by camera entity path.
+
+    Raises:
+        ValueError: If a camera lacks one of the four calibration components in this segment.
+    """
+    view = dataset.filter_segments(segment_id).filter_contents([f"{entity}/**" for entity in camera_entities])
+    table: pa.Table = view.reader(index=None).to_arrow_table()
+
+    def static_value(column_name: str) -> Float64[ndarray, " n"]:
+        if column_name not in table.column_names:
+            raise ValueError(f"column {column_name} has no data in segment {segment_id}")
+        return np.asarray(first_valid_value(table.column(column_name), component_name=column_name), dtype=np.float64).reshape(-1)
+
+    calibration: dict[str, PinholeParameters] = {}
+    for entity in camera_entities:
+        cam_R_world: Float64[ndarray, "3 3"] = static_value(f"{entity}:Transform3D:mat3x3").reshape(3, 3).T
+        cam_t_world: Float64[ndarray, "3"] = static_value(f"{entity}:Transform3D:translation").reshape(3)
+        image_from_camera: Float64[ndarray, "3 3"] = static_value(f"{entity}/pinhole:Pinhole:image_from_camera").reshape(3, 3).T
+        resolution_wh: Float64[ndarray, "2"] = static_value(f"{entity}/pinhole:Pinhole:resolution").reshape(2)
+        calibration[entity] = PinholeParameters(
+            name=entity.removeprefix("/world/").replace("/", "_"),
+            intrinsics=Intrinsics(
+                camera_conventions="RDF", k_matrix=image_from_camera, width=int(resolution_wh[0]), height=int(resolution_wh[1])
+            ),
+            extrinsics=Extrinsics(cam_R_world=cam_R_world, cam_t_world=cam_t_world),
+        )
+    return calibration

--- a/packages/simplecv/simplecv/catalog_rig_layout.py
+++ b/packages/simplecv/simplecv/catalog_rig_layout.py
@@ -1,0 +1,241 @@
+"""Read-side model of the ``exoego:v2`` rig layout as it appears in a Rerun catalog schema.
+
+The writer (``simplecv.rerun_rig_logger`` through ``BaseExoEgoSequence.build_rig_layout``)
+puts every camera under ``/world/rig_NN/cam_MM``: the video stream on
+``.../pinhole/video``, the intrinsics on ``.../pinhole``, the camera's static
+``Transform3D`` on the camera node, and a temporal ``Transform3D`` on the rig node
+of a moving (worn) rig. See ``docs/exoego_schema.md``. This module is the one place
+that turns a catalog schema — entity paths, component identifiers, static flags —
+back into typed cameras; consumers (exo-calib, mv-api) keep only their own
+selection policy on top of :class:`CatalogRigLayout`.
+"""
+
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Literal, Protocol, TypeAlias, get_args, runtime_checkable
+
+import numpy as np
+import pyarrow as pa
+from rerun.catalog import DatasetEntry
+
+from simplecv.rrd_query_utils import first_valid_value
+
+RigKind: TypeAlias = Literal["exo", "ego", "quest"]
+"""The ``kind`` metadata the writer logs on a rig node (``docs/exoego_schema.md``): a static exocentric rig,
+a worn egocentric device, or a Quest headset."""
+RIG_KINDS: tuple[RigKind, ...] = get_args(RigKind)
+RIG_KIND_BY_NAME: dict[str, RigKind] = {kind: kind for kind in RIG_KINDS}
+"""Narrows a stored ``kind`` string back to :data:`RigKind` (``None`` for anything else)."""
+
+_CAMERA_VIDEO_PATH: re.Pattern[str] = re.compile(r"^/world/(rig_\d+)/(cam_\d+)/pinhole/video$")
+_CAMERA_PINHOLE_PATH: re.Pattern[str] = re.compile(r"^/world/(rig_\d+)/(cam_\d+)/pinhole$")
+_CAMERA_NODE_PATH: re.Pattern[str] = re.compile(r"^/world/(rig_\d+)/(cam_\d+)$")
+_RIG_NODE_PATH: re.Pattern[str] = re.compile(r"^/world/(rig_\d+)$")
+
+
+@runtime_checkable
+class ComponentColumnLike(Protocol):
+    """The three attributes this module reads from a schema column.
+
+    ``rerun_bindings.ComponentColumnDescriptor`` (what ``Schema.component_columns()``
+    yields) satisfies it; tests use plain stand-ins.
+    """
+
+    @property
+    def entity_path(self) -> str: ...
+
+    @property
+    def component(self) -> str: ...
+
+    @property
+    def is_static(self) -> bool: ...
+
+
+@runtime_checkable
+class SchemaLike(Protocol):
+    """A catalog schema: ``rerun.catalog.Schema`` or anything else that lists its component columns."""
+
+    def component_columns(self) -> Iterable[ComponentColumnLike]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogComponent:
+    """One component column of a catalog schema, with rerun's ``Archetype:field`` identifier parsed."""
+
+    entity_path: str
+    """Entity path with a leading slash, e.g. ``/world/rig_00/cam_00``."""
+    archetype: str | None
+    """Archetype of the component, e.g. ``Transform3D``; ``None`` for a bare ``AnyValues`` field."""
+    field: str
+    """Field within the archetype (``translation``), or the bare field name."""
+    is_static: bool
+    """Whether the column is static (logged without a timeline)."""
+
+    @classmethod
+    def parse(cls, entity_path: str, component: str, is_static: bool) -> "CatalogComponent":
+        """Build from rerun's column identifier, ``Archetype:field`` or a bare field name.
+
+        A namespaced archetype (``rerun.archetypes.Transform3D:mat3x3``, as older bindings
+        spelled it) is reduced to its bare name.
+        """
+        archetype, separator, field = component.partition(":")
+        return cls(
+            entity_path=f"/{entity_path.lstrip('/')}",
+            archetype=archetype.rsplit(".", 1)[-1] if separator else None,
+            field=field if separator else archetype,
+            is_static=is_static,
+        )
+
+    @property
+    def component(self) -> str:
+        """Rerun's column identifier, as stored in the catalog."""
+        return f"{self.archetype}:{self.field}" if self.archetype is not None else self.field
+
+
+def catalog_components(schema: SchemaLike) -> list[CatalogComponent]:
+    """Parse a catalog schema's component columns."""
+    return [
+        CatalogComponent.parse(str(column.entity_path), str(column.component), bool(column.is_static))
+        for column in schema.component_columns()
+    ]
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogCamera:
+    """One rig camera that has a video stream in the catalog."""
+
+    rig: str
+    """Rig entity id, e.g. ``rig_00``."""
+    camera: str
+    """Camera entity id within the rig, e.g. ``cam_00``."""
+    rig_kind: RigKind | None
+    """The rig node's static ``kind`` metadata when the writer logged one."""
+    rig_is_moving: bool
+    """Whether the rig node carries a temporal ``Transform3D`` (a worn device)."""
+    has_calibration: bool
+    """Whether the camera node has a static ``Transform3D`` and its pinhole node a ``Pinhole``."""
+    camera_node_components: frozenset[str]
+    """Static component identifiers on the camera node (calibration plus any writer markers)."""
+
+    @property
+    def name(self) -> str:
+        """Camera name under ``/world``, e.g. ``rig_00/cam_00``."""
+        return f"{self.rig}/{self.camera}"
+
+    @property
+    def transform_entity(self) -> str:
+        """Entity path of the camera node, which carries ``Transform3D``."""
+        return f"/world/{self.rig}/{self.camera}"
+
+    @property
+    def pinhole_entity(self) -> str:
+        """Entity path of the camera's pinhole node."""
+        return f"/world/{self.rig}/{self.camera}/pinhole"
+
+    @property
+    def video_entity(self) -> str:
+        """Entity path of the camera's ``VideoStream``."""
+        return f"/world/{self.rig}/{self.camera}/pinhole/video"
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogRigLayout:
+    """Every rig camera with a video stream, in rig / camera index order."""
+
+    cameras: tuple[CatalogCamera, ...]
+    """Cameras sorted by numeric rig index, then camera index."""
+
+    @property
+    def rigs(self) -> tuple[str, ...]:
+        """Rig entity ids with at least one video camera, in rig index order."""
+        return tuple(dict.fromkeys(camera.rig for camera in self.cameras))
+
+
+def _camera_sort_key(camera: CatalogCamera) -> tuple[int, int]:
+    return int(camera.rig.removeprefix("rig_")), int(camera.camera.removeprefix("cam_"))
+
+
+def parse_rig_layout(components: Iterable[CatalogComponent], rig_kinds: Mapping[str, RigKind] | None = None) -> CatalogRigLayout:
+    """Discover the rig cameras described by a catalog schema.
+
+    Args:
+        components: The schema's component columns (see :func:`catalog_components`).
+        rig_kinds: Static ``kind`` metadata per rig id, read separately from the data
+            (the schema only names the column).
+
+    Returns:
+        The rig layout. Only cameras whose video entity carries ``VideoStream:sample``
+        are reported; a codec column alone is not a video.
+    """
+    kinds: Mapping[str, RigKind] = rig_kinds if rig_kinds is not None else {}
+    video_cameras: set[tuple[str, str]] = set()
+    moving_rigs: set[str] = set()
+    static_transform_cameras: set[tuple[str, str]] = set()
+    pinhole_cameras: set[tuple[str, str]] = set()
+    camera_node_components: dict[tuple[str, str], set[str]] = {}
+    for item in components:
+        video_match: re.Match[str] | None = _CAMERA_VIDEO_PATH.fullmatch(item.entity_path)
+        if video_match is not None and item.archetype == "VideoStream" and item.field == "sample":
+            video_cameras.add((video_match.group(1), video_match.group(2)))
+            continue
+        rig_match: re.Match[str] | None = _RIG_NODE_PATH.fullmatch(item.entity_path)
+        if rig_match is not None and item.archetype == "Transform3D" and not item.is_static:
+            moving_rigs.add(rig_match.group(1))
+            continue
+        camera_match: re.Match[str] | None = _CAMERA_NODE_PATH.fullmatch(item.entity_path)
+        if camera_match is not None and item.is_static:
+            key: tuple[str, str] = (camera_match.group(1), camera_match.group(2))
+            camera_node_components.setdefault(key, set()).add(item.component)
+            if item.archetype == "Transform3D":
+                static_transform_cameras.add(key)
+            continue
+        pinhole_match: re.Match[str] | None = _CAMERA_PINHOLE_PATH.fullmatch(item.entity_path)
+        if pinhole_match is not None and item.archetype == "Pinhole":
+            pinhole_cameras.add((pinhole_match.group(1), pinhole_match.group(2)))
+    cameras: list[CatalogCamera] = [
+        CatalogCamera(
+            rig=rig,
+            camera=camera,
+            rig_kind=kinds.get(rig),
+            rig_is_moving=rig in moving_rigs,
+            has_calibration=(rig, camera) in static_transform_cameras and (rig, camera) in pinhole_cameras,
+            camera_node_components=frozenset(camera_node_components.get((rig, camera), set())),
+        )
+        for rig, camera in video_cameras
+    ]
+    return CatalogRigLayout(cameras=tuple(sorted(cameras, key=_camera_sort_key)))
+
+
+def read_rig_kinds(dataset: DatasetEntry, segment_id: str, rigs: Iterable[str]) -> dict[str, RigKind]:
+    """Read the static ``kind`` metadata of the given rig nodes (the schema only names the column).
+
+    Args:
+        dataset: Catalog dataset entry.
+        segment_id: Segment to read.
+        rigs: Rig entity ids such as ``rig_00`` (see :attr:`CatalogRigLayout.rigs`).
+
+    Returns:
+        Kind per rig id, for the rigs whose node carries one.
+
+    Raises:
+        ValueError: If a rig carries a kind outside :data:`RIG_KINDS`.
+    """
+    rig_paths: list[str] = sorted(f"/world/{rig}" for rig in rigs)
+    if not rig_paths:
+        return {}
+    table: pa.Table = dataset.filter_segments(segment_id).filter_contents(rig_paths).reader(index=None).to_arrow_table()
+    kinds: dict[str, RigKind] = {}
+    for rig_path in rig_paths:
+        column_name: str = f"{rig_path}:kind"
+        if column_name not in table.column_names:
+            continue
+        column: pa.ChunkedArray = table.column(column_name).drop_null()
+        if len(column) == 0:
+            continue
+        kind_name: str = str(np.asarray(first_valid_value(column, component_name=column_name), dtype=str).reshape(-1)[0])
+        kind: RigKind | None = RIG_KIND_BY_NAME.get(kind_name)
+        if kind is None:
+            raise ValueError(f"{column_name} = {kind_name!r}; expected one of {RIG_KINDS}")
+        kinds[rig_path.removeprefix("/world/")] = kind
+    return kinds

--- a/packages/simplecv/simplecv/catalog_video_codec.py
+++ b/packages/simplecv/simplecv/catalog_video_codec.py
@@ -1,0 +1,27 @@
+"""The catalog's ``VideoStream:codec`` component, mapped to the codec names the decoders take.
+
+Rerun stores the codec as a big-endian FourCC integer (``rr.VideoCodec``). Both
+video paths in the workspace — simplecv's segment-wide NVDEC decoder and rerun's
+``VideoFrameDecoder`` — accept the same three names.
+"""
+
+from typing import Literal, TypeAlias
+
+import rerun as rr
+
+CatalogCodecName: TypeAlias = Literal["av1", "h264", "hevc"]
+"""Codec names shared by PyAV muxing and ``VideoFrameDecoder`` (which aliases ``hevc`` to its H.265 decoder)."""
+
+_CODEC_NAME: dict[rr.VideoCodec, CatalogCodecName] = {rr.VideoCodec.AV1: "av1", rr.VideoCodec.H264: "h264", rr.VideoCodec.H265: "hevc"}
+
+
+def catalog_codec_name(fourcc: int) -> CatalogCodecName:
+    """Map a ``VideoStream:codec`` FourCC integer to a decoder codec name.
+
+    Raises:
+        ValueError: If the FourCC is not a Rerun video codec, or one the workspace decoders cannot handle (VP8, VP9).
+    """
+    codec: rr.VideoCodec = rr.VideoCodec(int(fourcc))
+    if codec not in _CODEC_NAME:
+        raise ValueError(f"unsupported catalog video codec {codec.name} ({int(fourcc):#x})")
+    return _CODEC_NAME[codec]

--- a/packages/simplecv/simplecv/ops/umeyama.py
+++ b/packages/simplecv/simplecv/ops/umeyama.py
@@ -1,0 +1,87 @@
+"""Umeyama similarity alignment between two row-aligned point sets."""
+
+from dataclasses import dataclass
+
+import numpy as np
+from jaxtyping import Float, Float64
+from numpy import ndarray
+
+MIN_CORRESPONDENCES: int = 3
+"""Fewest row-aligned point pairs that determine a 3D similarity; two points leave the rotation about their axis free."""
+
+
+@dataclass(slots=True, frozen=True)
+class SimilarityTransform:
+    """Similarity mapping source coordinates into destination coordinates.
+
+    ``dst ≈ scale * (dst_R_src @ src.T).T + dst_t_src``.
+    """
+
+    dst_R_src: Float64[ndarray, "3 3"]
+    """Rotation taking source-frame vectors into the destination frame."""
+    dst_t_src: Float64[ndarray, "3"]
+    """Translation of the source origin, expressed in the destination frame."""
+    scale: float
+    """Isotropic scale; ``1.0`` for a rigid alignment."""
+
+    def apply(self, src_points: Float[ndarray, "n 3"]) -> Float64[ndarray, "n 3"]:
+        """Map source-frame points into the destination frame."""
+        return self.scale * np.einsum("ij,nj->ni", self.dst_R_src, src_points.astype(np.float64, copy=False)) + self.dst_t_src
+
+    def as_matrix(self) -> Float64[ndarray, "4 4"]:
+        """The similarity as a homogeneous ``dst_T_src`` matrix (scale folded into the rotation block)."""
+        dst_T_src: Float64[ndarray, "4 4"] = np.eye(4, dtype=np.float64)
+        dst_T_src[:3, :3] = self.scale * self.dst_R_src
+        dst_T_src[:3, 3] = self.dst_t_src
+        return dst_T_src
+
+
+def umeyama_alignment(
+    src_points: Float[ndarray, "n 3"],
+    dst_points: Float[ndarray, "n 3"],
+    *,
+    allow_scaling: bool = False,
+    eps: float = 1e-9,
+) -> SimilarityTransform:
+    """Least-squares similarity aligning ``src_points`` onto ``dst_points`` (Umeyama 1991).
+
+    The estimate runs in float64 whatever the input dtype: the SVD and the scale
+    ratio lose precision in float32, and callers pass float32 detections.
+
+    Args:
+        src_points: Source XYZ coordinates.
+        dst_points: Target XYZ coordinates, row-aligned with ``src_points``.
+        allow_scaling: Estimate an isotropic scale; otherwise the scale is fixed at 1.
+        eps: Smallest source variance accepted before the problem counts as degenerate.
+
+    Returns:
+        The similarity such that ``dst_points ≈ scale * (dst_R_src @ src_points.T).T + dst_t_src``.
+
+    Raises:
+        ValueError: If the shapes differ, fewer than three pairs are given, or the source variance is at most ``eps``.
+    """
+    if src_points.shape != dst_points.shape:
+        raise ValueError(f"Source and destination shapes must match; got {src_points.shape} vs {dst_points.shape}")
+    if src_points.shape[0] < MIN_CORRESPONDENCES:
+        raise ValueError(f"Umeyama alignment needs at least {MIN_CORRESPONDENCES} correspondences; got {src_points.shape[0]}")
+    src: Float64[ndarray, "n 3"] = src_points.astype(np.float64, copy=False)
+    dst: Float64[ndarray, "n 3"] = dst_points.astype(np.float64, copy=False)
+    src_mean: Float64[ndarray, "3"] = np.mean(src, axis=0)
+    dst_mean: Float64[ndarray, "3"] = np.mean(dst, axis=0)
+    src_centered: Float64[ndarray, "n 3"] = src - src_mean
+    dst_centered: Float64[ndarray, "n 3"] = dst - dst_mean
+    covariance: Float64[ndarray, "3 3"] = (dst_centered.T @ src_centered) / float(src.shape[0])
+    svd: tuple[Float64[ndarray, "3 3"], Float64[ndarray, "3"], Float64[ndarray, "3 3"]] = np.linalg.svd(covariance)
+    u: Float64[ndarray, "3 3"] = svd[0]
+    singular_values: Float64[ndarray, "3"] = svd[1]
+    vt: Float64[ndarray, "3 3"] = svd[2]
+    reflection: Float64[ndarray, "3"] = np.ones(3, dtype=np.float64)
+    if np.linalg.det(u) * np.linalg.det(vt) < 0.0:
+        reflection[2] = -1.0
+    dst_R_src: Float64[ndarray, "3 3"] = u @ np.diag(reflection) @ vt
+    src_variance: float = float(np.mean(np.sum(src_centered**2, axis=1)))
+    if src_variance <= eps:
+        raise ValueError(f"Source variance too small for stable Umeyama estimation (variance={src_variance})")
+    scale: float = float(np.sum(singular_values * reflection) / src_variance) if allow_scaling else 1.0
+    dst_t_src: Float64[ndarray, "3"] = dst_mean - scale * (dst_R_src @ src_mean)
+    return SimilarityTransform(dst_R_src=dst_R_src, dst_t_src=dst_t_src, scale=scale)

--- a/packages/simplecv/simplecv/rerun_dataloader.py
+++ b/packages/simplecv/simplecv/rerun_dataloader.py
@@ -26,6 +26,7 @@ from typing import TypeAlias
 
 import av
 import numpy as np
+import pyarrow as pa
 import torch
 from jaxtyping import Shaped, UInt8
 from numpy import ndarray
@@ -33,6 +34,8 @@ from rerun.catalog import DatasetEntry, DatasetView
 from rerun.experimental.dataloader import ColumnDecoder, DecodeRequest, FieldBatch
 from torch import Tensor
 from torchcodec.decoders import VideoDecoder
+
+from simplecv.catalog_video_codec import CatalogCodecName, catalog_codec_name
 
 TimedeltaNs: TypeAlias = Shaped[ndarray, " n_samples"]
 """Sample timestamps in timeline order, dtype ``timedelta64[ns]`` (jaxtyping has no timedelta dtype)."""
@@ -45,7 +48,7 @@ RECOMMENDED_FETCH_BLOCK_SIZE: int = 1024
 def open_segment_decoder(
     dataset: DatasetEntry, segment_id: str, entity: str, timeline: str, device: torch.device, fps: int
 ) -> tuple[TimedeltaNs, list[bytes], list[bool], VideoDecoder]:
-    """Fetch one segment's video packets (one query), wrap them, and open a GPU decoder.
+    """Fetch one segment's video packets (one query), wrap them in the stream's codec, and open a GPU decoder.
 
     Args:
         dataset: Rerun catalog dataset entry holding the segment.
@@ -68,7 +71,7 @@ def open_segment_decoder(
     # ever breaks instead of silently corrupting packet order.
     table = (
         view.reader(index=timeline)
-        .select(timeline, f"/{entity}:VideoStream:sample", f"/{entity}:VideoStream:is_keyframe")
+        .select(timeline, f"/{entity}:VideoStream:sample", f"/{entity}:VideoStream:is_keyframe", f"/{entity}:VideoStream:codec")
         .to_arrow_table()
     )
     times: TimedeltaNs = table[0].combine_chunks().to_numpy(zero_copy_only=False)
@@ -79,11 +82,19 @@ def open_segment_decoder(
     offsets: list[int] = blobs.offsets.to_pylist()
     samples: list[bytes] = [bytes(data[start:end]) for start, end in zip(offsets[:-1], offsets[1:], strict=True)]
     keyframes: list[bool] = [bool(flag) for flag in table[2].combine_chunks().flatten().to_pylist()]
-    decoder: VideoDecoder = VideoDecoder(wrap_mp4(samples, keyframes, fps), device=device, seek_mode="exact", num_ffmpeg_threads=0)
+    codec_column: pa.Array = table[3].combine_chunks().flatten()
+    if len(codec_column) == 0:
+        raise ValueError(f"video codec is missing for {entity} in segment {segment_id}")
+    decoder: VideoDecoder = VideoDecoder(
+        wrap_mp4(samples, keyframes, fps, codec=catalog_codec_name(int(codec_column[0].as_py()))),
+        device=device,
+        seek_mode="exact",
+        num_ffmpeg_threads=0,
+    )
     return times, samples, keyframes, decoder
 
 
-def wrap_mp4(samples: list[bytes], keyframes: list[bool], fps: int, codec: str = "av1") -> bytes:
+def wrap_mp4(samples: list[bytes], keyframes: list[bool], fps: int, codec: CatalogCodecName) -> bytes:
     """Mux pre-encoded samples into an in-memory MP4 with positional pts (no re-encode).
 
     ``add_mux_stream`` muxes without instantiating an encoder. The nominal 16x16

--- a/packages/simplecv/simplecv/rrd_query_utils.py
+++ b/packages/simplecv/simplecv/rrd_query_utils.py
@@ -4,13 +4,15 @@ import hashlib
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import rerun as rr
 from numpy import ndarray
+
+T = TypeVar("T")  # simplecv still supports Python 3.10, so no PEP 695 type parameters here.
 
 
 def _normalize_content_expr(expr: str) -> str:
@@ -54,6 +56,18 @@ def first_valid_value(
         return None
     column_name = component_name or "(unknown component)"
     raise ValueError(f"Expected at least one non-null value in column '{column_name}'")
+
+
+def first_valid_value_as(column: pa.ChunkedArray | pa.Array, kind: type[T], *, component_name: str | None = None) -> T:
+    """:func:`first_valid_value` narrowed to ``kind``, so callers get a precise type instead of ``Any``.
+
+    Raises:
+        TypeError: If the first non-null value is not an instance of ``kind``.
+    """
+    value = first_valid_value(column, component_name=component_name)
+    if not isinstance(value, kind):
+        raise TypeError(f"column '{component_name or '(unknown component)'}' holds {type(value).__name__}, expected {kind.__name__}")
+    return value
 
 
 def series_to_int64_ns(series: pd.Series) -> ndarray:

--- a/packages/simplecv/tests/test_catalog_rig_layout.py
+++ b/packages/simplecv/tests/test_catalog_rig_layout.py
@@ -1,0 +1,120 @@
+from simplecv.catalog_rig_layout import CatalogComponent, CatalogRigLayout, catalog_components, parse_rig_layout
+
+
+def _components(rows: list[tuple[str, str, bool]]) -> list[CatalogComponent]:
+    return [CatalogComponent.parse(*row) for row in rows]
+
+
+def test_parse_rig_layout_orders_cameras_and_flags_moving_rigs() -> None:
+    rows: list[tuple[str, str, bool]] = []
+    for rig_idx in (2, 0, 1):
+        camera_path: str = f"/world/rig_{rig_idx:02d}/cam_00"
+        rows.extend(
+            (
+                (camera_path, "Transform3D:translation", True),
+                (f"{camera_path}/pinhole", "Pinhole:image_from_camera", True),
+                (f"{camera_path}/pinhole/video", "VideoStream:sample", False),
+            )
+        )
+    rows.extend(
+        (
+            ("/world/rig_03", "Transform3D:translation", False),
+            ("/world/rig_03/cam_01/pinhole/video", "VideoStream:sample", False),
+            ("/world/rig_03/cam_00/pinhole/video", "VideoStream:sample", False),
+            ("/world/rig_04/cam_00/pinhole", "Pinhole:image_from_camera", True),  # no video: not a camera
+            ("/world/rig_05/cam_00/pinhole/video", "VideoStream:codec", True),  # codec column alone: not a video
+        )
+    )
+
+    layout: CatalogRigLayout = parse_rig_layout(_components(rows))
+
+    assert [camera.name for camera in layout.cameras] == [
+        "rig_00/cam_00",
+        "rig_01/cam_00",
+        "rig_02/cam_00",
+        "rig_03/cam_00",
+        "rig_03/cam_01",
+    ]
+    assert [camera.rig_is_moving for camera in layout.cameras] == [False, False, False, True, True]
+    assert [camera.has_calibration for camera in layout.cameras] == [True, True, True, False, False]
+    assert layout.cameras[0].video_entity == "/world/rig_00/cam_00/pinhole/video"
+    assert layout.cameras[0].pinhole_entity == "/world/rig_00/cam_00/pinhole"
+    assert layout.cameras[0].transform_entity == "/world/rig_00/cam_00"
+    assert layout.rigs == ("rig_00", "rig_01", "rig_02", "rig_03")
+
+
+def test_parse_rig_layout_attaches_rig_kinds_and_camera_node_markers() -> None:
+    rows: list[tuple[str, str, bool]] = [
+        ("/world/rig_00", "kind", True),
+        ("/world/rig_00/cam_00", "Transform3D:translation", True),
+        ("/world/rig_00/cam_00", "exocalib_written", True),
+        ("/world/rig_00/cam_00/pinhole", "Pinhole:image_from_camera", True),
+        ("/world/rig_00/cam_00/pinhole/video", "VideoStream:sample", False),
+        ("/world/rig_01", "kind", True),
+        ("/world/rig_01/cam_00/pinhole/video", "VideoStream:sample", False),
+    ]
+
+    layout: CatalogRigLayout = parse_rig_layout(_components(rows), rig_kinds={"rig_00": "exo", "rig_01": "ego"})
+
+    exo, ego = layout.cameras
+    assert (exo.rig_kind, ego.rig_kind) == ("exo", "ego")
+    assert exo.has_calibration and not ego.has_calibration
+    assert exo.camera_node_components == frozenset({"Transform3D:translation", "exocalib_written"})
+    assert ego.camera_node_components == frozenset()
+
+
+def test_parse_rig_layout_requires_both_transform_and_pinhole_for_calibration() -> None:
+    rows: list[tuple[str, str, bool]] = [
+        ("/world/rig_00/cam_00", "Transform3D:translation", True),
+        ("/world/rig_00/cam_00/pinhole/video", "VideoStream:sample", False),
+        ("/world/rig_01/cam_00/pinhole", "Pinhole:image_from_camera", True),
+        ("/world/rig_01/cam_00/pinhole/video", "VideoStream:sample", False),
+        ("/world/rig_02/cam_00", "Transform3D:translation", False),  # temporal transform is not calibration
+        ("/world/rig_02/cam_00/pinhole", "Pinhole:image_from_camera", True),
+        ("/world/rig_02/cam_00/pinhole/video", "VideoStream:sample", False),
+    ]
+
+    layout: CatalogRigLayout = parse_rig_layout(_components(rows))
+
+    assert [camera.has_calibration for camera in layout.cameras] == [False, False, False]
+
+
+class _Column:
+    def __init__(self, entity_path: str, component: str, is_static: bool = True) -> None:
+        self.entity_path: str = entity_path
+        self.component: str = component
+        self.is_static: bool = is_static
+
+
+class _Schema:
+    def __init__(self, columns: list[_Column]) -> None:
+        self._columns: list[_Column] = columns
+
+    def component_columns(self) -> list[_Column]:
+        return self._columns
+
+
+def test_catalog_components_parses_rerun_column_identifiers() -> None:
+    schema: _Schema = _Schema(
+        [
+            _Column("world/rig_00/cam_00", "Transform3D:translation"),
+            _Column("/world/rig_00/cam_00", "exocalib_written"),
+            _Column("/world/rig_00/cam_00/pinhole/video", "VideoStream:sample", is_static=False),
+        ]
+    )
+
+    components: list[CatalogComponent] = catalog_components(schema)
+
+    assert components == [
+        CatalogComponent("/world/rig_00/cam_00", "Transform3D", "translation", True),
+        CatalogComponent("/world/rig_00/cam_00", None, "exocalib_written", True),
+        CatalogComponent("/world/rig_00/cam_00/pinhole/video", "VideoStream", "sample", False),
+    ]
+    assert components[0].component == "Transform3D:translation"
+    assert components[1].component == "exocalib_written"
+
+
+def test_catalog_components_reduces_namespaced_archetypes() -> None:
+    component: CatalogComponent = CatalogComponent.parse("/world/exo/C10095", "rerun.archetypes.Transform3D:mat3x3", True)
+
+    assert (component.archetype, component.field, component.component) == ("Transform3D", "mat3x3", "Transform3D:mat3x3")

--- a/packages/simplecv/tests/test_catalog_video_codec.py
+++ b/packages/simplecv/tests/test_catalog_video_codec.py
@@ -1,0 +1,16 @@
+import pytest
+
+from simplecv.catalog_video_codec import catalog_codec_name
+
+
+def test_catalog_codec_name_maps_catalog_codecs() -> None:
+    assert catalog_codec_name(int.from_bytes(b"av01", "big")) == "av1"
+    assert catalog_codec_name(int.from_bytes(b"avc1", "big")) == "h264"
+    assert catalog_codec_name(int.from_bytes(b"hev1", "big")) == "hevc"
+
+
+def test_catalog_codec_name_rejects_unknown_and_undecodable_codecs() -> None:
+    with pytest.raises(ValueError):  # not a Rerun VideoCodec at all
+        catalog_codec_name(int.from_bytes(b"mp4v", "big"))
+    with pytest.raises(ValueError, match="unsupported catalog video codec VP9"):
+        catalog_codec_name(int.from_bytes(b"vp09", "big"))

--- a/packages/simplecv/tests/test_umeyama.py
+++ b/packages/simplecv/tests/test_umeyama.py
@@ -1,0 +1,69 @@
+import numpy as np
+import pytest
+from jaxtyping import Float32, Float64
+from numpy import ndarray
+
+from simplecv.ops.umeyama import SimilarityTransform, umeyama_alignment
+
+
+def _rotation_about_z(angle_rad: float) -> Float64[ndarray, "3 3"]:
+    c, s = float(np.cos(angle_rad)), float(np.sin(angle_rad))
+    return np.array([[c, -s, 0.0], [s, c, 0.0], [0.0, 0.0, 1.0]], dtype=np.float64)
+
+
+def test_umeyama_alignment_recovers_known_similarity() -> None:
+    rng = np.random.default_rng(0)
+    src: Float64[ndarray, "n 3"] = rng.normal(size=(12, 3))
+    rotation: Float64[ndarray, "3 3"] = _rotation_about_z(0.7)
+    translation: Float64[ndarray, "3"] = np.array([0.3, -1.2, 2.5])
+    dst: Float64[ndarray, "n 3"] = 1.8 * (rotation @ src.T).T + translation
+
+    similarity: SimilarityTransform = umeyama_alignment(src, dst, allow_scaling=True)
+
+    assert np.allclose(similarity.dst_R_src, rotation, atol=1e-9)
+    assert np.allclose(similarity.dst_t_src, translation, atol=1e-9)
+    assert similarity.scale == pytest.approx(1.8, abs=1e-9)
+    assert np.allclose(similarity.scale * (similarity.dst_R_src @ src.T).T + similarity.dst_t_src, dst, atol=1e-9)
+
+
+def test_umeyama_alignment_without_scaling_keeps_unit_scale() -> None:
+    src: Float64[ndarray, "n 3"] = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+    dst: Float64[ndarray, "n 3"] = 2.0 * src + 1.0
+
+    similarity: SimilarityTransform = umeyama_alignment(src, dst, allow_scaling=False)
+
+    assert similarity.scale == 1.0
+
+
+def test_umeyama_alignment_estimates_in_float64_from_float32_inputs() -> None:
+    src: Float32[ndarray, "n 3"] = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], dtype=np.float32)
+
+    similarity: SimilarityTransform = umeyama_alignment(src, src + np.float32(0.5))
+
+    assert similarity.dst_R_src.dtype == np.float64 and similarity.dst_t_src.dtype == np.float64
+    assert np.allclose(similarity.dst_t_src, np.full(3, 0.5), atol=1e-12)
+
+
+def test_umeyama_alignment_rejects_degenerate_source() -> None:
+    src: Float64[ndarray, "n 3"] = np.zeros((4, 3))
+    with pytest.raises(ValueError, match="variance"):
+        umeyama_alignment(src, src + 1.0)
+
+
+def test_umeyama_alignment_rejects_fewer_than_three_correspondences() -> None:
+    src: Float64[ndarray, "n 3"] = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])  # two distinct points pass the variance check
+    with pytest.raises(ValueError, match="at least 3 correspondences"):
+        umeyama_alignment(src, src + 1.0)
+
+
+def test_similarity_transform_apply_and_matrix_agree_with_the_formula() -> None:
+    rng = np.random.default_rng(1)
+    src: Float64[ndarray, "n 3"] = rng.normal(size=(6, 3))
+    dst: Float64[ndarray, "n 3"] = 0.5 * (_rotation_about_z(-0.4) @ src.T).T + np.array([1.0, 2.0, 3.0])
+
+    similarity: SimilarityTransform = umeyama_alignment(src, dst, allow_scaling=True)
+    src_h: Float64[ndarray, "n 4"] = np.column_stack((src, np.ones(6)))
+
+    assert np.allclose(similarity.apply(src), dst, atol=1e-9)
+    assert np.allclose((similarity.as_matrix() @ src_h.T).T[:, :3], dst, atol=1e-9)
+    assert similarity.as_matrix().dtype == np.float64


### PR DESCRIPTION
**exo-calib stack:** [1/6 workspace](https://github.com/rerun-io/examples-monorepo/pull/178) · [2/6 simplecv](https://github.com/rerun-io/examples-monorepo/pull/179) · [3/6 mv-api](https://github.com/rerun-io/examples-monorepo/pull/180) · [4/6 geometry core](https://github.com/rerun-io/examples-monorepo/pull/181) · [5/6 catalog + Stage A/B](https://github.com/rerun-io/examples-monorepo/pull/182) · [6/6 refine + pipeline](https://github.com/rerun-io/examples-monorepo/pull/183). Merge in order, #185 first.

## What
- `simplecv/catalog_rig_layout.py`: the read-side parser of the exoego:v2 rig layout from a catalog schema (`CatalogRigLayout`, `parse_rig_layout`, `read_rig_kinds`; `RigKind` is exo / ego / quest). Consumers keep only their selection policy.
- `simplecv/catalog_calibration.py`: `read_camera_calibration` (pinhole + transform, column-major transpose), shared by exo-calib and mv-api.
- `simplecv/catalog_video_codec.py`: `catalog_codec_name` maps the `VideoStream:codec` FourCC; `open_segment_decoder` muxes AV1 / H.264 / H.265 from it.
- `umeyama_alignment` returns a `SimilarityTransform` with `apply()` / `as_matrix()` and a ≥3-correspondence guard; the metric exoego calibration drops its private copy.

## Verified
ruff, pyrefly; simplecv tests 171 passed / 29 skipped on the dl-server and the Spark.
