### PR TITLE
exo-calib: refinement, report, blueprint, and the pipeline driver (stack 6/6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Set `PIXI_ENV` in a gitignored `.envrc.local` to override a directory's default.
 | [dpretrieval](packages/dpretrieval/) | Pixi-build recipe for a DBoW2/pybind11 image-retrieval extension used by DPVO. |
 | [dpvo](packages/dpvo/) | Deep Patch Visual Odometry with Rerun and Gradio integrations. |
 | [egoexo-forge](packages/egoexo-forge/) | Rerun and Gradio tools for egocentric and exocentric human datasets. |
+| [exo-calib](packages/exo-calib/) | Exo-camera calibration from human keypoints over a Rerun catalog: G3T + MoGe-2 init, tracked RTMW-x keypoints, kornia-rs bundle adjustment, evaluation against dataset ground truth. |
 | [gsplat-rust-renderer](packages/gsplat-rust-renderer/) | GPU Gaussian-splat viewer implemented as a custom Rerun visualizer. See its [README](packages/gsplat-rust-renderer/README.md). |
 | [live-rerun](packages/live-rerun/) | Zero-transcode live H.264/H.265 sensor streaming into Rerun. |
 | [mamma](packages/mamma/) | Streaming multiview body capture from decode through SMPL-X fitting and Rerun logging. |

--- a/packages/exo-calib/exo_calib/apis/blueprint.py
+++ b/packages/exo-calib/exo_calib/apis/blueprint.py
@@ -1,0 +1,87 @@
+"""Write and register the exocalib viewer layout as the catalog dataset's default blueprint.
+
+Catalog datasets carry no layout of their own: the converters' base rrds embed a
+blueprint the catalog does not serve, and only the dataforge converters register a
+dataset default (a 2D grid for wildcap, whose bases have no calibration to place in
+3D). This stage registers the exoego layout — a 3D scene, the ego cameras tabbed
+beside it, the exo cameras as a strip below — plus the two visibility rules only a
+blueprint can express: Stage B's queryable ``…_raw`` record stays out of the 2D
+views, and an ego camera without calibration (no pose in any layer) stays out of
+the 3D scene. Everything else about how exocalib data looks — the init / refined
+frustum colours, class colours, radii — is logged with the data.
+
+Catalog partitions use the dataset id as their application id, and the id changes
+whenever the dataset is recreated, so rerun this tool after a dataset recreate.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import rerun.blueprint as rrb
+import tyro
+
+from exo_calib.catalog_io import RigLayout, StageConfig, StageContext, stage_context
+from exo_calib.kp2d_layer import kp2d_raw_entity
+from exo_calib.layer_io import pinhole_entity
+
+BLUEPRINT_FILENAME: str = "exocalib.rbl"
+"""Written under ``output_dir``; a ``-N`` suffix is added if it exists (the server caches file descriptors, so registered files are never overwritten)."""
+
+
+@dataclass
+class BlueprintConfig:
+    """Config for the blueprint writer; ``register`` sets the .rbl as the dataset's default blueprint."""
+
+    stage: tyro.conf.OmitArgPrefixes[StageConfig] = field(default_factory=StageConfig)
+    """Shared stage flags (catalog, dataset, segment, rigs, output, register); the CLI shows them unprefixed."""
+    loop_playback: bool = False
+    """Loop the whole timeline instead of parking on the last frame; for short standalone exports of a segment."""
+
+
+def main(config: BlueprintConfig) -> None:
+    """Recreate the exoego viewer layout, bound to the dataset's current id.
+
+    Mirrors ``simplecv.apis.view_exoego.create_container`` (the base rrd's own
+    blueprint, which the catalog does not serve). Not imported from simplecv
+    because that module pulls in dataset configs with deps outside this env.
+    """
+    context: StageContext = stage_context(config.stage)
+    layout: RigLayout = context.layout
+    exo_tabs: list[rrb.Tabs] = [
+        rrb.Tabs(rrb.Spatial2DView(origin=pinhole_entity(name), name=name, overrides={kp2d_raw_entity(name): rrb.EntityBehavior(visible=False)}))
+        for name in layout.exo_camera_names
+    ]
+    ego_tabs: list[rrb.Tabs] = [rrb.Tabs(rrb.Spatial2DView(origin=pinhole_entity(name), name=name)) for name in layout.ego_camera_names]
+    main_view: rrb.Horizontal = rrb.Horizontal(
+        contents=[
+            rrb.Spatial3DView(
+                origin="/",
+                name="3D View",
+                contents="/**",
+                spatial_information=rrb.SpatialInformation.from_fields(show_axes=True),
+                # An ego camera without dataset calibration has no pose in any layer, so keep it out of the 3D scene.
+                overrides={
+                    pinhole_entity(name): rrb.EntityBehavior(visible=False)
+                    for name in layout.ego_camera_names
+                    if name not in layout.calibrated_camera_names
+                },
+            ),
+            rrb.Vertical(contents=ego_tabs) if ego_tabs else rrb.Tabs(),
+        ],
+        column_shares=[4, 1],
+    )
+    container: rrb.Vertical = rrb.Vertical(main_view, rrb.Horizontal(contents=exo_tabs), row_shares=[4, 1])
+    # An explicit time panel opts out of ``collapse_panels``, so restate the collapsed state.
+    panels: list[rrb.TimePanel] = [rrb.TimePanel(loop_mode="All", state=rrb.PanelState.Collapsed)] if config.loop_playback else []
+    blueprint: rrb.Blueprint = rrb.Blueprint(container, *panels, collapse_panels=True)
+    config.stage.output_dir.mkdir(parents=True, exist_ok=True)
+    rbl_path: Path = config.stage.output_dir / BLUEPRINT_FILENAME
+    counter: int = 1
+    while rbl_path.exists():
+        rbl_path = config.stage.output_dir / f"{Path(BLUEPRINT_FILENAME).stem}-{counter}.rbl"
+        counter += 1
+    blueprint.save(str(context.dataset.id), str(rbl_path))
+    print(f"wrote {rbl_path} for application id {context.dataset.id}")
+    if config.stage.register:
+        context.dataset.register_blueprint(rbl_path.resolve().as_uri(), set_default=True)
+        print(f"registered as default blueprint: {context.dataset.default_blueprint()}")

--- a/packages/exo-calib/exo_calib/apis/pipeline.py
+++ b/packages/exo-calib/exo_calib/apis/pipeline.py
@@ -1,0 +1,41 @@
+"""The exo-calib pipeline: Stage A once, two passes of Stage B + refinement, then the report.
+
+The second Stage B pass tracks person boxes through the refined rig instead of
+the Stage A estimate, which tightens the 2D observations the second refinement
+consumes. Both passes replace the same ``exocalib_kp2d`` / ``exocalib_refined``
+layers, so the catalog ends up holding the final pass only. The individual
+stage tools remain available for diagnosis.
+"""
+
+from dataclasses import dataclass, field
+
+import tyro
+
+from exo_calib.apis import calibrate_init, keypoints2d, refine, report
+from exo_calib.catalog_io import StageConfig
+from exo_calib.layer_io import CALIBRATION_VARIANTS
+
+
+@dataclass
+class PipelineConfig:
+    """Config for the full calibration pipeline: the shared stage fields plus each stage's own knob."""
+
+    stage: tyro.conf.OmitArgPrefixes[StageConfig] = field(default_factory=StageConfig)
+    """Shared stage flags (catalog, dataset, segment, rigs, output, register); the CLI shows them unprefixed."""
+    frame_index: int = 0
+    """Sample index of the synchronized frame Stage A calibrates from."""
+    batch_size: int = 32
+    """Largest inference batch the Stage B TensorRT engines are built for."""
+
+
+def main(config: PipelineConfig) -> None:
+    """Run every stage in order, registering each layer into the catalog."""
+    print("=== Stage A: initial calibration ===")
+    calibrate_init.main(calibrate_init.InitCalibrationConfig(stage=config.stage, frame_index=config.frame_index))
+    for camera_variant in CALIBRATION_VARIANTS:
+        print(f"\n=== Stage B: 2D keypoints, boxes tracked through the {camera_variant} rig ===")
+        keypoints2d.main(keypoints2d.Keypoints2dConfig(stage=config.stage, batch_size=config.batch_size), camera_variant=camera_variant)
+        print("\n=== Stage C+D: refinement ===")
+        refine.main(config.stage)
+    print("\n=== Stage E: report ===")
+    report.main(config.stage)

--- a/packages/exo-calib/exo_calib/apis/refine.py
+++ b/packages/exo-calib/exo_calib/apis/refine.py
@@ -1,0 +1,219 @@
+"""Stage C+D: Kineo-style correspondences, robust triangulation, and staged BA.
+
+Consumes Stage A (``exocalib_init`` layer) and Stage B (``exocalib_kp2d``
+layer) straight from the catalog: applies the AssemblyHands-X confidence
+post-processing (temporal median filter, crop-margin downweight,
+threshold-rescale), builds spatio-temporal correspondences with Kineo's pair
+rule, triangulates robustly against the initial cameras, and refines the
+extrinsics with kornia-rs bundle adjustment (re-triangulating between rounds),
+then one log-focal scale per camera, a rotation-update guard, and a MoGe-2
+metric rescale. Logs init/refined 3D keypoint tracks with Kineo's pairwise
+reprojection consensus confidence, plus the refined frusta.
+"""
+
+from typing import Literal
+
+import numpy as np
+from jaxtyping import Bool, Float64
+from numpy import ndarray
+
+from exo_calib.ba import BaResult, PosePrior, mean_reprojection_error_px, refine_extrinsics, revert_large_pose_updates
+from exo_calib.cameras import RigCameras, camera_centers
+from exo_calib.catalog_io import StageConfig, StageContext, stage_context
+from exo_calib.confidence import drop_face_confidences, kineo_point_confidence_for_obs
+from exo_calib.correspondences import ObservationSet, build_observations, under_supported_view_indices
+from exo_calib.eval import rig_geometry
+from exo_calib.focal import FocalRefinementResult, refine_focals
+from exo_calib.keypoints import AHX_CONF_TAU, AHX_MARGIN_PX, AHX_MEDIAN_WINDOW, CameraKeypoints, GatedKeypoints, stack_postprocessed
+from exo_calib.kp2d_layer import load_stage_b
+from exo_calib.layer_io import (
+    CALIBRATION_VARIANTS,
+    EXOCALIB_ROOT,
+    REFINED_LAYER,
+    VARIANT_COLOR,
+    CalibrationVariant,
+    ClassSpec,
+    RefinementDiagnostics,
+    exocalib_entity,
+    kp3d_entity,
+    log_cameras_layer,
+    log_coco133_class_context,
+    log_point_tracks,
+    log_refinement_diagnostics,
+    new_layer_recording,
+    read_rig_cameras,
+    register_layer,
+    write_base_calibration,
+)
+from exo_calib.metric_scale import estimate_metric_rescale
+from exo_calib.triangulation import RobustTriangulationResult, triangulate_points, triangulate_robust
+
+MIN_PAIR_CONFIDENCE: float = 0.90
+"""Kineo pair rule: geometric-mean confidence a view pair must exceed (Kineo's default is 0.75)."""
+MIN_VIEWS: int = 2
+"""Minimum observing cameras per correspondence point."""
+REPROJECTION_THRESHOLD_PX: float = 100.0
+"""Per-observation gate for robust triangulation; wide, so Cauchy BA sees every useful observation."""
+BA_ROUNDS: int = 2
+"""Bundle-adjust / re-triangulate rounds."""
+BA_MAX_ITERATIONS: int = 50
+"""LM iterations per bundle-adjust call."""
+ROBUST_KERNEL: Literal["cauchy"] = "cauchy"
+"""Robust kernel for the BA residuals."""
+ROBUST_SCALE_PX: float = 1.0
+"""Robust-kernel scale in pixels."""
+POSE_PRIOR_SIGMA_RATIO: float = 0.06
+"""Soft prior anchoring camera centers to the Stage A estimate, as a fraction of the rig's median
+pairwise camera distance; pins the similarity gauge without freezing rigs of any size."""
+MINIMUM_VIEW_SUPPORT_RATIO: float = 0.10
+"""Fix views whose robust-observation count is below this fraction of the median count."""
+MAXIMUM_ROTATION_UPDATE_DEG: float = 10.0
+"""Revert a camera pose when BA rotates it farther from Stage A than this data-independent safety bound."""
+FOCAL_ITERATIONS: int = 300
+"""Adam iterations for focal-only refinement."""
+FOCAL_LEARNING_RATE: float = 0.03
+"""Adam learning rate for per-camera log-focal scales."""
+FOCAL_ROBUST_SCALE_PX: float = 1.0
+"""Cauchy pixel scale for focal-only reprojection residuals."""
+LAMBDA_DECAY: float = 1.0
+"""Kineo exponential decay for the logged 3D point confidence."""
+
+
+def main(config: StageConfig) -> None:
+    """Run correspondence building, robust triangulation, staged BA, and layer logging."""
+    context: StageContext = stage_context(config)
+    dataset, segment_id = context.dataset, context.segment_id
+    names: tuple[str, ...] = context.layout.exo_camera_names
+    if len(names) < 2:
+        raise ValueError(f"extrinsic refinement needs at least two exo cameras; found {list(names)}")
+    init: RigCameras = read_rig_cameras(dataset, segment_id, names, source="init")
+    per_camera: dict[str, CameraKeypoints] = load_stage_b(dataset, segment_id, names)
+
+    gated: GatedKeypoints = stack_postprocessed(per_camera, names, AHX_MEDIAN_WINDOW, AHX_MARGIN_PX, AHX_CONF_TAU)
+    kp_xy: Float64[ndarray, "v t 133 2"] = gated.xy
+    conf: Float64[ndarray, "v t 133"] = drop_face_confidences(gated.conf)
+    print(f"{kp_xy.shape[1]} frames x {len(names)} views; mean post conf {conf[conf > 0].mean():.3f}")
+
+    candidates: ObservationSet = build_observations(kp_xy, conf, min_pair_conf=MIN_PAIR_CONFIDENCE, min_views=MIN_VIEWS)
+    print(f"observations: {len(candidates.obs_view_idx)} over {len(candidates.point_frame_idx)} points")
+    robust: RobustTriangulationResult = triangulate_robust(candidates, init.intrinsics, init.cam_T_world, reproj_threshold_px=REPROJECTION_THRESHOLD_PX)
+    points_init: Float64[ndarray, "n 3"] = robust.points_xyz
+    obs: ObservationSet = robust.obs
+    print(f"robust triangulation kept {obs.obs_point_idx.size}/{candidates.obs_point_idx.size} observations")
+    init_reprojection_px: float = mean_reprojection_error_px(obs, points_init, init.intrinsics, init.cam_T_world)
+    print(f"init mean reprojection error: {init_reprojection_px:.2f} px")
+
+    fixed_pose_indices: tuple[int, ...] = under_supported_view_indices(obs.obs_view_idx, len(names), MINIMUM_VIEW_SUPPORT_RATIO)
+    if fixed_pose_indices:
+        print(f"fixed under-supported camera poses: {list(fixed_pose_indices)}")
+
+    # Soft anchors on the Stage A centres, shared by every BA call; sigma follows the rig's size.
+    pairwise_distance: Float64[ndarray, "v v"] = rig_geometry(init.cam_T_world).pairwise_distance_m
+    sigma_m: float = POSE_PRIOR_SIGMA_RATIO * float(np.median(pairwise_distance[np.triu_indices(len(names), k=1)]))
+    prior: PosePrior = PosePrior(centers=camera_centers(init.cam_T_world), sigma_m=sigma_m)
+    print(f"centre prior sigma {sigma_m:.3f} m")
+    ba: BaResult = refine_extrinsics(
+        init.cam_T_world,
+        init.intrinsics,
+        obs,
+        points_init,
+        rounds=BA_ROUNDS,
+        robust=ROBUST_KERNEL,
+        robust_scale_px=ROBUST_SCALE_PX,
+        max_iterations=BA_MAX_ITERATIONS,
+        pose_prior=prior,
+        fixed_pose_indices=fixed_pose_indices,
+    )
+    reprojection_px_per_round: list[float] = list(ba.mean_reproj_px_per_round)
+    print(f"BA reprojection error per round (px): {[round(e, 3) for e in reprojection_px_per_round]}, converged={ba.converged}")
+
+    # One log-focal scale per camera with poses and points fixed, then one more BA round.
+    focal: FocalRefinementResult = refine_focals(
+        init.intrinsics,
+        ba.cam_T_world,
+        ba.points_xyz,
+        obs,
+        iterations=FOCAL_ITERATIONS,
+        learning_rate=FOCAL_LEARNING_RATE,
+        robust_scale_px=FOCAL_ROBUST_SCALE_PX,
+        device="cuda",
+    )
+    refined_intrinsics: Float64[ndarray, "v 3 3"] = focal.intrinsics
+    print(f"focal-only Cauchy loss {focal.initial_loss:.4f}->{focal.final_loss:.4f}; scales {np.round(focal.focal_scale, 5).tolist()}")
+    focal_ba: BaResult = refine_extrinsics(
+        ba.cam_T_world,
+        refined_intrinsics,
+        obs,
+        ba.points_xyz,
+        rounds=1,
+        robust=ROBUST_KERNEL,
+        robust_scale_px=ROBUST_SCALE_PX,
+        max_iterations=BA_MAX_ITERATIONS,
+        pose_prior=prior,
+        fixed_pose_indices=fixed_pose_indices,
+    )
+    cam_T_world: Float64[ndarray, "v 4 4"] = focal_ba.cam_T_world.copy()
+    points_xyz: Float64[ndarray, "n 3"] = focal_ba.points_xyz.copy()
+    reprojection_px_per_round.extend(focal_ba.mean_reproj_px_per_round)
+    print(f"post-focal BA reprojection error (px): {reprojection_px_per_round[-1]:.3f}, converged={focal_ba.converged}")
+
+    guarded_cam_T_world, reverted = revert_large_pose_updates(cam_T_world, init.cam_T_world, maximum_rotation_deg=MAXIMUM_ROTATION_UPDATE_DEG)
+    if reverted:
+        cam_T_world = guarded_cam_T_world
+        points_xyz = triangulate_points(obs, refined_intrinsics, cam_T_world)
+        reprojection_px_per_round.append(mean_reprojection_error_px(obs, points_xyz, refined_intrinsics, cam_T_world))
+        print(f"rotation-update guard reverted camera poses {list(reverted)}; reprojection {reprojection_px_per_round[-1]:.3f} px")
+
+    first_cam: CameraKeypoints = per_camera[names[0]]
+    estimated_scale: float | None = estimate_metric_rescale(dataset, segment_id, cam_T_world, refined_intrinsics, obs, points_xyz, first_cam.sample_indices, names)
+    scale_fix: float = 1.0 if estimated_scale is None else estimated_scale
+    cam_T_world[:, :3, 3] *= scale_fix
+    points_xyz *= scale_fix
+
+    recording, rrd_path = new_layer_recording(segment_id, context.segment_dir / f"{REFINED_LAYER}.rrd")
+    log_refinement_diagnostics(
+        recording,
+        RefinementDiagnostics(
+            init_reprojection_px=init_reprojection_px,
+            ba_reprojection_px=reprojection_px_per_round,
+            observation_count_per_view=np.bincount(obs.obs_view_idx, minlength=len(names)).tolist(),
+            metric_rescale_fix=scale_fix,
+            focal_scale=focal.focal_scale.tolist(),
+        ),
+    )
+    # No skeleton edges: a frame's 3D track holds only the joints that triangulated, so most
+    # COCO-133 links would dangle and the viewer warns about every unresolved one.
+    log_coco133_class_context(
+        recording,
+        EXOCALIB_ROOT,
+        tuple(ClassSpec(class_id, f"kp3d {variant}", VARIANT_COLOR[variant]) for class_id, variant in enumerate(CALIBRATION_VARIANTS, start=1)),
+        connections=False,
+    )
+    video_wh: tuple[int, int] = (int(first_cam.video_wh[0]), int(first_cam.video_wh[1]))
+    refined: RigCameras = RigCameras(names=init.names, intrinsics=refined_intrinsics, cam_T_world=cam_T_world)
+    log_cameras_layer(refined, video_wh, exocalib_entity("refined"), recording, color=VARIANT_COLOR["refined"])
+    uncalibrated_idx: list[int] = [i for i, name in enumerate(init.names) if name not in context.layout.calibrated_camera_names]
+    if uncalibrated_idx:
+        write_base_calibration(
+            recording,
+            RigCameras(
+                names=tuple(init.names[i] for i in uncalibrated_idx),
+                intrinsics=refined_intrinsics[uncalibrated_idx],
+                cam_T_world=cam_T_world[uncalibrated_idx],
+            ),
+            video_wh,
+        )
+        print(f"base calibration written for {len(uncalibrated_idx)} camera(s) without ground truth")
+    # Kineo pairwise reprojection consensus confidences for both camera sets.
+    variant_rigs: dict[CalibrationVariant, tuple[RigCameras, Float64[ndarray, "n 3"]]] = {"init": (init, points_init), "refined": (refined, points_xyz)}
+    for class_id, variant in enumerate(CALIBRATION_VARIANTS, start=1):
+        rig, variant_points = variant_rigs[variant]
+        conf_points: Float64[ndarray, " n"] = kineo_point_confidence_for_obs(variant_points, obs, rig.intrinsics, rig.cam_T_world, kp_xy, conf, LAMBDA_DECAY)
+        valid: Bool[ndarray, " n"] = np.isfinite(variant_points).all(axis=1)
+        print(f"{variant}: {int(valid.sum())} points, mean 3D confidence {conf_points[valid].mean():.3f}")
+        log_point_tracks(recording, kp3d_entity(variant), obs, variant_points, conf_points, first_cam.times_ns, class_id)
+    recording.flush(timeout_sec=30.0)
+    print(f"wrote {rrd_path}")
+    if config.register:
+        register_layer(dataset, rrd_path, REFINED_LAYER)
+        print(f"registered layer {REFINED_LAYER}")

--- a/packages/exo-calib/exo_calib/apis/report.py
+++ b/packages/exo-calib/exo_calib/apis/report.py
@@ -1,0 +1,207 @@
+"""Stage E: score init and refined cameras against the dataset ground truth.
+
+GT enters here and nowhere else. Both variants are aligned to the GT rig with
+SE(3) (primary — tests the metric claim) and Sim(3) (secondary — isolates the
+scale error), then per-camera rotation/translation errors and focal errors are
+reported and written to ``eval.json``. Datasets without ground truth still get
+the refinement diagnostics and the self-contained rig geometry.
+"""
+
+import json
+from dataclasses import asdict, dataclass
+
+import numpy as np
+import rerun as rr
+from jaxtyping import Float64
+from numpy import ndarray
+from simplecv.ops.umeyama import SimilarityTransform
+
+from exo_calib.cameras import RigCameras, camera_centers
+from exo_calib.catalog_io import StageConfig, StageContext, stage_context
+from exo_calib.eval import RIG_MODES, CameraErrors, RigGeometry, RigMode, align_rigs, evaluate_rig, rig_geometry
+from exo_calib.layer_io import (
+    ALIGN_LAYER,
+    CALIBRATION_VARIANTS,
+    VARIANT_COLOR,
+    CalibrationVariant,
+    RefinementDiagnostics,
+    exocalib_entity,
+    kp3d_entity,
+    new_layer_recording,
+    read_refinement_diagnostics,
+    read_rig_cameras,
+    register_layer,
+)
+
+
+@dataclass(slots=True, frozen=True)
+class ErrorStats:
+    """Per-camera errors and their summary, rounded for ``eval.json``."""
+
+    per_camera: list[float]
+    mean: float
+    median: float
+    max: float
+
+
+def error_stats(values: Float64[ndarray, " v"], digits: int) -> ErrorStats:
+    """Summarize one per-camera error vector."""
+    return ErrorStats(
+        per_camera=[round(float(x), digits) for x in values],
+        mean=round(float(np.mean(values)), digits),
+        median=round(float(np.median(values)), digits),
+        max=round(float(np.max(values)), digits),
+    )
+
+
+@dataclass(slots=True, frozen=True)
+class AlignedErrors:
+    """Pose errors after aligning the rig onto GT under one alignment model."""
+
+    rotation_deg: ErrorStats
+    translation_cm: ErrorStats
+    scale: float
+    """Scale the alignment applied (1.0 under SE(3))."""
+
+
+@dataclass(slots=True, frozen=True)
+class FocalErrors:
+    """Focal-length error of the estimated intrinsics against GT, in percent."""
+
+    per_camera: list[float]
+    mean_abs: float
+    max_abs: float
+
+
+@dataclass(slots=True, frozen=True)
+class VariantMetrics:
+    """Everything ``eval.json`` records about one camera set."""
+
+    se3: AlignedErrors
+    sim3: AlignedErrors
+    focal_error_pct: FocalErrors
+
+
+def variant_metrics(pred: RigCameras, gt: RigCameras) -> VariantMetrics:
+    """Score one camera set against GT under SE(3) and Sim(3) alignment."""
+    aligned: dict[RigMode, AlignedErrors] = {}
+    for mode in RIG_MODES:
+        errors: CameraErrors = evaluate_rig(pred.cam_T_world, gt.cam_T_world, mode=mode)
+        aligned[mode] = AlignedErrors(
+            rotation_deg=error_stats(errors.rotation_error_deg, 4),
+            translation_cm=error_stats(errors.translation_error_cm, 4),
+            scale=round(float(errors.alignment_scale), 6),
+        )
+    focal_pct: Float64[ndarray, " v"] = (pred.intrinsics[:, 0, 0] - gt.intrinsics[:, 0, 0]) / gt.intrinsics[:, 0, 0] * 100.0
+    return VariantMetrics(
+        se3=aligned["se3"],
+        sim3=aligned["sim3"],
+        focal_error_pct=FocalErrors(
+            per_camera=[round(float(x), 3) for x in focal_pct],
+            mean_abs=round(float(np.abs(focal_pct).mean()), 3),
+            max_abs=round(float(np.abs(focal_pct).max()), 3),
+        ),
+    )
+
+
+@dataclass(slots=True, frozen=True)
+class RigGeometryReport:
+    """``RigGeometry`` as JSON lists (metres), rounded to 6 digits."""
+
+    camera_centers_m: list[list[float]]
+    pairwise_distance_m: list[list[float]]
+    height_above_floor_m: list[float]
+
+
+@dataclass(slots=True, frozen=True)
+class EvalReport:
+    """The ``eval.json`` schema: identity, per-variant GT metrics when GT exists, and the GT-free diagnostics."""
+
+    segment_id: str
+    dataset_name: str
+    camera_names: list[str]
+    init: VariantMetrics | None
+    refined: VariantMetrics | None
+    refinement_diagnostics: RefinementDiagnostics
+    refined_rig_geometry: RigGeometryReport
+
+
+def main(config: StageConfig) -> None:
+    """Score both variants, write ``eval.json``, and register the viewer alignment layer."""
+    context: StageContext = stage_context(config)
+    dataset, segment_id = context.dataset, context.segment_id
+    names: tuple[str, ...] = context.layout.exo_camera_names
+    missing_gt: tuple[str, ...] = tuple(name for name in names if name not in context.layout.calibrated_camera_names)
+    gt: RigCameras | None = None
+    if missing_gt:
+        print(f"ground truth: unavailable for {len(missing_gt)}/{len(names)} cameras — evaluation and alignment skipped")
+    else:
+        gt = read_rig_cameras(dataset, segment_id, names, source="ground_truth")
+    variants: dict[CalibrationVariant, RigCameras] = {variant: read_rig_cameras(dataset, segment_id, names, source=variant) for variant in CALIBRATION_VARIANTS}
+
+    metrics: dict[CalibrationVariant, VariantMetrics] = {}
+    if gt is not None:
+        for variant, pred in variants.items():
+            metrics[variant] = variant_metrics(pred, gt)
+            for mode in RIG_MODES:
+                m: AlignedErrors = getattr(metrics[variant], mode)
+                print(
+                    f"{variant:8s} {mode:4s}: trans cm mean {m.translation_cm.mean:6.2f} med {m.translation_cm.median:6.2f} "
+                    f"max {m.translation_cm.max:6.2f} | rot deg mean {m.rotation_deg.mean:5.2f} med {m.rotation_deg.median:5.2f} "
+                    f"max {m.rotation_deg.max:5.2f} | scale {m.scale:.4f}"
+                )
+    diagnostics: RefinementDiagnostics = read_refinement_diagnostics(dataset, segment_id)
+    print(f"refinement diagnostics: {json.dumps(asdict(diagnostics), separators=(',', ':'))}")
+    geometry: RigGeometry = rig_geometry(variants["refined"].cam_T_world)
+    print(f"refined pairwise camera distances (m): {geometry.pairwise_distance_m.round(3).tolist()}")
+    print(f"refined camera heights above fitted floor (m): {geometry.height_above_floor_m.round(3).tolist()}")
+    report: EvalReport = EvalReport(
+        segment_id=segment_id,
+        dataset_name=config.dataset_name,
+        camera_names=list(names),
+        init=metrics.get("init"),
+        refined=metrics.get("refined"),
+        refinement_diagnostics=diagnostics,
+        refined_rig_geometry=RigGeometryReport(
+            camera_centers_m=geometry.camera_centers_m.round(6).tolist(),
+            pairwise_distance_m=geometry.pairwise_distance_m.round(6).tolist(),
+            height_above_floor_m=geometry.height_above_floor_m.round(6).tolist(),
+        ),
+    )
+    context.segment_dir.mkdir(parents=True, exist_ok=True)
+    eval_path = context.segment_dir / "eval.json"
+    eval_path.write_text(json.dumps({key: value for key, value in asdict(report).items() if value is not None}, indent=2))
+    print(f"wrote {eval_path}")
+
+    # Viewer alignment: give each variant its own SE(3) pred-world -> GT-world
+    # transform (on its frusta and kp3d subtrees) so everything overlays GT, and
+    # draw labeled error lines from each aligned camera center to its GT center.
+    recording, rrd_path = new_layer_recording(segment_id, context.segment_dir / f"{ALIGN_LAYER}.rrd")
+    if gt is None:
+        recording.log("/world/exocalib_report", rr.AnyValues(ground_truth_available=False), static=True)
+    else:
+        gt_centers: Float64[ndarray, "v 3"] = camera_centers(gt.cam_T_world)
+        for variant, pred in variants.items():
+            gt_T_pred: SimilarityTransform = align_rigs(pred.cam_T_world, gt.cam_T_world, with_scale=False)
+            transform: rr.Transform3D = rr.Transform3D(translation=gt_T_pred.dst_t_src, mat3x3=gt_T_pred.dst_R_src)
+            recording.log(exocalib_entity(variant), transform, static=True)
+            recording.log(kp3d_entity(variant), transform, static=True)
+            aligned_centers: Float64[ndarray, "v 3"] = gt_T_pred.apply(camera_centers(pred.cam_T_world))
+            errors_cm: Float64[ndarray, " v"] = np.linalg.norm(aligned_centers - gt_centers, axis=1) * 100.0
+            recording.log(
+                f"/world/exocalib_error/{variant}",
+                rr.LineStrips3D(
+                    strips=[np.stack([aligned_centers[i], gt_centers[i]]) for i in range(len(gt.names))],
+                    labels=[f"{name}: {errors_cm[i]:.1f} cm" for i, name in enumerate(gt.names)],
+                    colors=VARIANT_COLOR[variant],
+                    radii=0.004,
+                    show_labels=True,
+                ),
+                static=True,
+            )
+            print(f"{variant}: alignment + error lines logged (mean {errors_cm.mean():.1f} cm)")
+    recording.flush(timeout_sec=30.0)
+    print(f"wrote {rrd_path}")
+    if config.register:
+        register_layer(dataset, rrd_path, ALIGN_LAYER)
+        print(f"registered layer {ALIGN_LAYER}")

--- a/packages/exo-calib/exo_calib/metric_scale.py
+++ b/packages/exo-calib/exo_calib/metric_scale.py
@@ -1,0 +1,133 @@
+"""Global metric rescale of a refined rig from MoGe-2 metric depth at the surviving 2D observations."""
+
+import numpy as np
+import torch
+from jaxtyping import Bool, Float64, Int64, UInt8
+from monopriors.models.metric_depth.moge_v2 import MoGeV2MetricPredictor
+from numpy import ndarray
+from rerun.catalog import DatasetEntry
+from torch import Tensor
+
+from exo_calib.correspondences import ObservationSet
+from exo_calib.video_io import ExoVideoStreams, open_exo_streams
+
+METRIC_RESCALE_FRAMES: int = 6
+"""Frames per view sampled for the MoGe-2 metric rescale after BA."""
+MIN_RESCALE_GROUPS: int = 8
+"""Fewest (view, frame) depth-ratio groups before the rescale is trusted; below it the rig keeps its scale."""
+MIN_RESCALE_SAMPLES_PER_GROUP: int = 3
+"""Fewest valid depth ratios a (view, frame) group needs to contribute its median."""
+MIN_DEPTH_M: float = 0.1
+"""Depths at or below this (metric or triangulated) are not trusted as ratio samples."""
+
+
+def grouped_medians(group: Int64[ndarray, " n"], values: Float64[ndarray, " n"], min_count: int) -> tuple[Float64[ndarray, " g"], int]:
+    """Median of ``values`` within each group, for the groups that hold at least ``min_count`` samples.
+
+    One sort by (group, value) replaces a mask-and-median pass per group; the
+    medians equal :func:`numpy.median` over each group's values exactly.
+
+    Args:
+        group: Group id per sample.
+        values: Sample per row of ``group``.
+        min_count: Smallest group that contributes a median.
+
+    Returns:
+        The medians in ascending group-id order and the number of samples they pooled.
+    """
+    order: Int64[ndarray, " n"] = np.lexsort((values, group))
+    sorted_group: Int64[ndarray, " n"] = group[order]
+    sorted_values: Float64[ndarray, " n"] = values[order]
+    _, start, count = np.unique(sorted_group, return_index=True, return_counts=True)
+    keep: Bool[ndarray, " u"] = count >= min_count
+    start, count = start[keep], count[keep]
+    upper: Int64[ndarray, " g"] = start + count // 2
+    lower: Int64[ndarray, " g"] = np.where(count % 2 == 0, upper - 1, upper)
+    return 0.5 * (sorted_values[lower] + sorted_values[upper]), int(count.sum())
+
+
+def estimate_metric_rescale(
+    dataset: DatasetEntry,
+    segment_id: str,
+    cam_T_world: Float64[ndarray, "v 4 4"],
+    intrinsics: Float64[ndarray, "v 3 3"],
+    obs: ObservationSet,
+    points_xyz: Float64[ndarray, "n 3"],
+    sample_indices: Int64[ndarray, "t"],
+    names: tuple[str, ...],
+) -> float | None:
+    """Estimate a global scale correction from MoGe-2 metric depth at the keypoints.
+
+    For ``METRIC_RESCALE_FRAMES`` frames spread over the capture, each view's
+    MoGe-2 metric depth is sampled at the surviving 2D observations and divided
+    by the depth of the triangulated point in that camera; the median ratio over
+    all (view, frame) groups is the correction (1.0 = the rig is already metric).
+    Pooling thousands of depth ratios beats Stage A's few single-frame medians.
+
+    Args:
+        dataset: Catalog dataset entry (frames are decoded from it).
+        segment_id: Segment being refined.
+        cam_T_world: Refined world-to-camera transforms.
+        intrinsics: Camera intrinsics at video resolution.
+        obs: Surviving observations (pixel coordinates index the video frames).
+        points_xyz: Triangulated points in the rig's (pre-rescale) frame.
+        sample_indices: Stage B decoder sample index per correspondence frame.
+        names: Exo camera entity names in view order.
+
+    Returns:
+        Median metric/current depth ratio over all valid groups, or ``None`` when fewer than
+        ``MIN_RESCALE_GROUPS`` groups had enough valid samples.
+    """
+    # Evenly-spaced frames among those dense enough to form valid (view, frame)
+    # groups. On dense captures every frame qualifies; on long captures the points
+    # spread thin and a blind linspace would leave every group under the floor.
+    n_views: int = cam_T_world.shape[0]
+    observation_frames: Int64[ndarray, " n_obs"] = obs.point_frame_idx[obs.obs_point_idx]
+    frames_used: Int64[ndarray, " f"] = np.unique(obs.point_frame_idx)
+    obs_per_frame: Int64[ndarray, " f"] = np.bincount(np.searchsorted(frames_used, observation_frames), minlength=frames_used.size).astype(np.int64)
+    eligible_frames: Int64[ndarray, " e"] = frames_used[obs_per_frame >= MIN_RESCALE_SAMPLES_PER_GROUP * n_views]
+    if eligible_frames.size == 0:
+        eligible_frames = frames_used
+    chosen_frames: Int64[ndarray, " c"] = eligible_frames[
+        np.linspace(0, eligible_frames.size - 1, min(METRIC_RESCALE_FRAMES, eligible_frames.size)).astype(np.int64)
+    ]
+
+    # Every observation on a chosen frame joins the (view, frame) group ``view * c + position``;
+    # its triangulated depth in that camera comes from one batched transform.
+    position: Int64[ndarray, " n_obs"] = np.minimum(np.searchsorted(chosen_frames, observation_frames), chosen_frames.size - 1)
+    rows: Int64[ndarray, " r"] = np.flatnonzero(chosen_frames[position] == observation_frames)
+    view: Int64[ndarray, " r"] = obs.obs_view_idx[rows]
+    group: Int64[ndarray, " r"] = view * chosen_frames.size + position[rows]
+    points: Float64[ndarray, "r 3"] = points_xyz[obs.obs_point_idx[rows]]
+    finite: Bool[ndarray, " r"] = np.isfinite(points).all(axis=1)
+    camera_rows: Float64[ndarray, "r 4 4"] = cam_T_world[view]
+    current_z: Float64[ndarray, " r"] = np.einsum("rj,rj->r", camera_rows[:, 2, :3], points) + camera_rows[:, 2, 3]
+
+    # MoGe runs once per (view, frame) group that has a finite point to compare against, one
+    # batched NVDEC read per view; all surviving joints feed the estimator, since body-only
+    # sampling has too few correspondences and MoGe's body depth runs a few percent short.
+    streams: ExoVideoStreams = open_exo_streams(dataset, segment_id, names)
+    moge: MoGeV2MetricPredictor = MoGeV2MetricPredictor(device="cuda")
+    metric_z: Float64[ndarray, " r"] = np.full(rows.size, np.nan)
+    for view_idx in np.unique(view[finite]):
+        view_groups: Int64[ndarray, " k"] = np.unique(group[finite & (view == view_idx)])
+        decode_idx: list[int] = [int(sample_indices[chosen_frames[int(g) - int(view_idx) * chosen_frames.size]]) for g in view_groups]
+        frames: UInt8[Tensor, "k 3 h w"] = streams.decoders[int(view_idx)].get_frames_at(decode_idx).data
+        for group_id, frame in zip(view_groups, frames, strict=True):
+            frame_rgb: UInt8[ndarray, "h w 3"] = frame.permute(1, 2, 0).contiguous().cpu().numpy()
+            depth: Float64[ndarray, "h w"] = moge(frame_rgb, K_33=intrinsics[int(view_idx)].astype(np.float32)).depth_meters.astype(np.float64)
+            in_group: Bool[ndarray, " r"] = group == group_id
+            px: Int64[ndarray, " m"] = np.clip(np.round(obs.obs_xy[rows[in_group], 0]).astype(np.int64), 0, depth.shape[1] - 1)
+            py: Int64[ndarray, " m"] = np.clip(np.round(obs.obs_xy[rows[in_group], 1]).astype(np.int64), 0, depth.shape[0] - 1)
+            metric_z[in_group] = depth[py, px]
+    del moge
+    torch.cuda.empty_cache()
+
+    valid: Bool[ndarray, " r"] = finite & np.isfinite(metric_z) & (metric_z > MIN_DEPTH_M) & (current_z > MIN_DEPTH_M)
+    group_medians, n_samples = grouped_medians(group[valid], metric_z[valid] / current_z[valid], MIN_RESCALE_SAMPLES_PER_GROUP)
+    if group_medians.size < MIN_RESCALE_GROUPS:
+        print(f"metric rescale skipped: only {group_medians.size} (view, frame) groups")
+        return None
+    scale: float = float(np.median(group_medians))
+    print(f"metric rescale: {n_samples} samples in {group_medians.size} groups, median-of-medians = {scale:.4f}")
+    return scale

--- a/packages/exo-calib/tests/test_metric_scale.py
+++ b/packages/exo-calib/tests/test_metric_scale.py
@@ -1,0 +1,56 @@
+import numpy as np
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from jaxtyping import Float64, Int64
+from numpy import ndarray
+
+from exo_calib.metric_scale import grouped_medians
+
+
+def _reference(group: Int64[ndarray, " n"], values: Float64[ndarray, " n"], min_count: int) -> tuple[Float64[ndarray, " g"], int]:
+    """The mask-and-median loop the vectorized helper replaced."""
+    medians: list[float] = []
+    n_samples: int = 0
+    for group_id in np.unique(group):
+        members: Float64[ndarray, " m"] = values[group == group_id]
+        if members.size >= min_count:
+            medians.append(float(np.median(members)))
+            n_samples += members.size
+    return np.asarray(medians, dtype=np.float64), n_samples
+
+
+@settings(max_examples=300, deadline=None)
+@given(
+    seed=st.integers(0, 2**31 - 1),
+    n_samples=st.integers(0, 400),
+    n_groups=st.integers(1, 40),
+    min_count=st.integers(1, 6),
+)
+def test_grouped_medians_matches_per_group_numpy_median(seed: int, n_samples: int, n_groups: int, min_count: int) -> None:
+    rng = np.random.default_rng(seed)
+    group: Int64[ndarray, " n"] = rng.integers(0, n_groups, n_samples).astype(np.int64)
+    # Repeated values exercise the even-count midpoint and ties in the sort.
+    values: Float64[ndarray, " n"] = rng.choice(rng.uniform(0.5, 1.5, 12), n_samples)
+
+    medians, pooled = grouped_medians(group, values, min_count)
+    expected_medians, expected_pooled = _reference(group, values, min_count)
+
+    np.testing.assert_array_equal(medians, expected_medians)
+    assert pooled == expected_pooled
+
+
+def test_grouped_medians_drops_small_groups_and_reports_pooled_count() -> None:
+    group: Int64[ndarray, " n"] = np.array([0, 0, 0, 1, 1, 2, 2, 2, 2], dtype=np.int64)
+    values: Float64[ndarray, " n"] = np.array([3.0, 1.0, 2.0, 9.0, 9.0, 4.0, 1.0, 3.0, 2.0])
+
+    medians, pooled = grouped_medians(group, values, min_count=3)
+
+    np.testing.assert_array_equal(medians, np.array([2.0, 2.5]))
+    assert pooled == 7
+
+
+def test_grouped_medians_on_no_samples_is_empty() -> None:
+    medians, pooled = grouped_medians(np.zeros(0, dtype=np.int64), np.zeros(0), min_count=3)
+
+    assert medians.shape == (0,)
+    assert pooled == 0

--- a/packages/exo-calib/tests/test_tool_shims.py
+++ b/packages/exo-calib/tests/test_tool_shims.py
@@ -1,0 +1,17 @@
+"""Every ``tools/apps`` shim must import: they are thin wiring over ``exo_calib.apis`` and nothing else exercises them."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SHIMS: list[Path] = sorted((Path(__file__).resolve().parents[1] / "tools" / "apps").glob("*.py"))
+
+
+@pytest.mark.parametrize("shim", SHIMS, ids=[p.stem for p in SHIMS])
+def test_tool_shim_imports(shim: Path) -> None:
+    spec = importlib.util.spec_from_file_location(f"exo_calib_shim_{shim.stem}", shim)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # ``__name__`` is not ``__main__``, so nothing runs
+    assert callable(module.main)

--- a/packages/exo-calib/tools/apps/blueprint.py
+++ b/packages/exo-calib/tools/apps/blueprint.py
@@ -1,0 +1,6 @@
+import tyro
+
+from exo_calib.apis.blueprint import BlueprintConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(BlueprintConfig, description="Write the exocalib .rbl blueprint for a catalog dataset."))

--- a/packages/exo-calib/tools/apps/pipeline.py
+++ b/packages/exo-calib/tools/apps/pipeline.py
@@ -1,0 +1,6 @@
+import tyro
+
+from exo_calib.apis.pipeline import PipelineConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(PipelineConfig))

--- a/packages/exo-calib/tools/apps/refine.py
+++ b/packages/exo-calib/tools/apps/refine.py
@@ -1,0 +1,7 @@
+import tyro
+
+from exo_calib.apis.refine import main
+from exo_calib.catalog_io import StageConfig
+
+if __name__ == "__main__":
+    main(tyro.cli(StageConfig, description="Stage C+D: correspondences, robust triangulation, and kornia-rs staged bundle adjustment."))

--- a/packages/exo-calib/tools/apps/report.py
+++ b/packages/exo-calib/tools/apps/report.py
@@ -1,0 +1,7 @@
+import tyro
+
+from exo_calib.apis.report import main
+from exo_calib.catalog_io import StageConfig
+
+if __name__ == "__main__":
+    main(tyro.cli(StageConfig, description="Stage E: score init and refined exo cameras against dataset ground truth."))

--- a/pixi.toml
+++ b/pixi.toml
@@ -1432,6 +1432,18 @@ vggt = { git = "https://github.com/pablovela5620/vggt.git", rev = "5ed6ec88a951f
 PACKAGE_DIR = "packages/exo-calib"
 PYREFLY_TARGET = "exo_calib"
 
+[feature.exo-calib.tasks.exocalib-pipeline]
+cmd = "python tools/apps/pipeline.py"
+cwd = "packages/exo-calib"
+env = { RERUN_INSECURE_SKIP_HOST_CHECK = "1" }
+description = "Full calibration of one catalog segment: Stage A, two passes of Stage B + C+D, Stage E"
+
+[feature.exo-calib.tasks.exocalib-blueprint]
+cmd = "python tools/apps/blueprint.py"
+cwd = "packages/exo-calib"
+env = { RERUN_INSECURE_SKIP_HOST_CHECK = "1" }
+description = "Write the exoego-layout .rbl bound to the dataset's current id and register it as the default blueprint"
+
 [feature.exo-calib.tasks.exocalib-init]
 cmd = "python tools/apps/calibrate_init.py"
 cwd = "packages/exo-calib"
@@ -1443,6 +1455,18 @@ cmd = "python tools/apps/keypoints2d.py"
 cwd = "packages/exo-calib"
 env = { RERUN_INSECURE_SKIP_HOST_CHECK = "1" }
 description = "Stage B: reprojection-tracked boxes (YOLOX re-anchoring) + RTMW-x (TensorRT) COCO-133 keypoints over the whole capture, registered as exocalib_kp2d"
+
+[feature.exo-calib.tasks.exocalib-refine]
+cmd = "python tools/apps/refine.py"
+cwd = "packages/exo-calib"
+env = { RERUN_INSECURE_SKIP_HOST_CHECK = "1" }
+description = "Stage C+D: correspondences, robust triangulation, kornia-rs BA, focal stage, MoGe-2 metric rescale, registered as exocalib_refined"
+
+[feature.exo-calib.tasks.exocalib-report]
+cmd = "python tools/apps/report.py"
+cwd = "packages/exo-calib"
+env = { RERUN_INSECURE_SKIP_HOST_CHECK = "1" }
+description = "Stage E: SE3/Sim3 eval vs GT (eval.json) plus the exocalib_align layer"
 
 # ═══════════════════════════════════════════════════════════════════════════
 # vistadream


### PR DESCRIPTION
**exo-calib stack:** [1/6 workspace](https://github.com/rerun-io/examples-monorepo/pull/178) · [2/6 simplecv](https://github.com/rerun-io/examples-monorepo/pull/179) · [3/6 mv-api](https://github.com/rerun-io/examples-monorepo/pull/180) · [4/6 geometry core](https://github.com/rerun-io/examples-monorepo/pull/181) · [5/6 catalog + Stage A/B](https://github.com/rerun-io/examples-monorepo/pull/182) · [6/6 refine + pipeline](https://github.com/rerun-io/examples-monorepo/pull/183). Merge in order, #185 first.

## What
- `refine` (Stage C+D): AHX post-processing → Kineo correspondences → robust triangulation against the init rig → Schur BA with centre priors → focal stage + one BA round → rotation-update guard → MoGe-2 metric rescale → `exocalib_refined`. Cameras without dataset calibration get the refined one on their base node.
- `report` (Stage E): SE(3) / Sim(3) errors against ground truth into `eval.json` (typed `EvalReport`), plus the `exocalib_align` viewer layer.
- `blueprint`: the exoego viewer layout, registered as the dataset default.
- `pipeline`: one task (`exocalib-pipeline`): Stage A, then Stage B + refine through the init rig and again through the refined rig, then the report.

## Results (rerun 0.37 catalog, DGX Spark, 2026-09-03)

| dataset | Sim3 cm | rot ° | SE3 cm | init SE3 cm / ° |
|---|---|---|---|---|
| assembly101 (8 cams) | 1.51 | 1.14 | 1.9 | 6.9 / 5.4 |
| hocap | 1.77 | 1.66 | 1.9 | 3.1 / 2.2 |
| epfl-smart-kitchen | 9.5–12.6 | 4.1–5.0 | 16–19 | 24.2 / 3.4 |
| wildcap-mamma hugging (vs MAMMA meta) | 3.27 | 0.47 | — | — |

Sim3 and rotation are stable run to run; SE3 carries the MoGe rescale noise. EPFL is guard-dominated (the rotation guard reverts four of five cameras) and swings between runs on the same code.

## Verified
ruff, pyrefly, vulture, 36 tests (beartype on); the full pipeline on the four segments above. Viewer screenshots under `/tmp/rerun-viewer-validation/exocalib-037/` on the Spark.
