### PR TITLE
workspace: pin sibling packages with [tool.uv.sources]; guard the lock against PyPI namesakes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ packages/<name>/
 
 ## Adding a new package
 
-1. Create `packages/<name>/` with `pyproject.toml`, the source module, `tools/`, and `tests/` (structure above).
+1. Create `packages/<name>/` with `pyproject.toml`, the source module, `tools/`, and `tests/` (structure above). If it imports another workspace package, list that name in `[project].dependencies` **and** pin it in `[tool.uv.sources]` (`name = { path = "../<dir>", editable = true }`); `packages/simplecv/tests/test_workspace_sources.py` checks both and fails if the lock ever resolves a workspace name from PyPI.
 2. Add `[feature.<name>]` in the root `pixi.toml`: conda deps, pypi deps (editable install), `activation.env` with `PACKAGE_DIR = "packages/<name>"`, and tasks with `cwd = "packages/<name>"`. Declare `platforms` explicitly (see **Platforms & lockfile**).
 3. Add `<name>` and `<name>-dev` entries in `[environments]`, both with `solve-group = "<name>"` and `no-default-feature = true`; `<name>-dev` adds the `dev` feature.
 4. Copy a package `.envrc` (defaults `PIXI_ENV` to `<name>-dev`) and add `packages/<name>/data/` to `.gitignore`.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ environments or demo tasks; their role is described in the second column.
   lockfile.
 - List the tasks available in an environment with
   `pixi task list -e <name>` or `pixi task list -e <name>-dev`.
+- In-repo packages depend on each other by name in `[project].dependencies`
+  and pin that name to the sibling's path with `[tool.uv.sources]` in their
+  own `pyproject.toml`; the root manifest installs the same paths editable.
+  The pin keeps a PyPI namesake (there is one for `monopriors`) out of the
+  solve. pixi-build source packages, which `asmk`, `dpretrieval`, and
+  `mast3r` already are, are the eventual replacement once that preview
+  stabilizes.
 
 For agent and contributor documentation — architecture, platform rules, adding
 a new package, Rerun version policy, and known issues — see

--- a/packages/monoprior/pyproject.toml
+++ b/packages/monoprior/pyproject.toml
@@ -121,3 +121,9 @@ ignore_names = [
 [tool.pytest.ini_options]
 markers = ["slow: loads a checkpoint or builds a TensorRT engine (deselected by default; run with -m slow)"]
 addopts = "-m 'not slow'"
+
+# Workspace siblings named above resolve to their in-repo path (never to a PyPI
+# namesake); the root manifest installs the same paths editable.
+[tool.uv.sources]
+sam3 = { path = "../sam3", editable = true }
+

--- a/packages/mv-api/pyproject.toml
+++ b/packages/mv-api/pyproject.toml
@@ -13,6 +13,12 @@ name = "mv-api"
 requires-python = ">= 3.12"
 version = "0.1.0"
 
+# Workspace siblings named above resolve to their in-repo path (never to a PyPI
+# namesake); the root manifest installs the same paths editable.
+[tool.uv.sources]
+monopriors = { path = "../monoprior", editable = true }
+wilor-nano = { path = "../wilor-nano", editable = true }
+
 [build-system]
 build-backend = "hatchling.build"
 requires = ["hatchling"]

--- a/packages/posekit/pyproject.toml
+++ b/packages/posekit/pyproject.toml
@@ -11,6 +11,11 @@ name = "posekit"
 requires-python = ">= 3.12"
 version = "0.1.0"
 
+# Workspace siblings named above resolve to their in-repo path (never to a PyPI
+# namesake); the root manifest installs the same paths editable.
+[tool.uv.sources]
+simplecv = { path = "../simplecv", editable = true }
+
 [build-system]
 build-backend = "hatchling.build"
 requires = ["hatchling"]

--- a/packages/prompt-da/pyproject.toml
+++ b/packages/prompt-da/pyproject.toml
@@ -10,6 +10,11 @@ name = "rerun-prompt-da"
 requires-python = ">= 3.12"
 version = "0.1.0"
 
+# Workspace siblings named above resolve to their in-repo path (never to a PyPI
+# namesake); the root manifest installs the same paths editable.
+[tool.uv.sources]
+monopriors = { path = "../monoprior", editable = true }
+
 [build-system]
 build-backend = "hatchling.build"
 requires = ["hatchling"]

--- a/packages/sam3d-body/pyproject.toml
+++ b/packages/sam3d-body/pyproject.toml
@@ -23,6 +23,12 @@ requires-python = ">= 3.12"
 version = "0.1.0"
 
 
+# Workspace siblings named above resolve to their in-repo path (never to a PyPI
+# namesake); the root manifest installs the same paths editable.
+[tool.uv.sources]
+monopriors = { path = "../monoprior", editable = true }
+sam3 = { path = "../sam3", editable = true }
+
 [build-system]
 build-backend = "hatchling.build"
 requires = ["hatchling"]

--- a/packages/sapiens-coco133-pose/pyproject.toml
+++ b/packages/sapiens-coco133-pose/pyproject.toml
@@ -5,13 +5,17 @@ dependencies = [
     #         pyserde, av, opencv, transformers, simplecv
     # cuda: pytorch-gpu, torchvision
     "sapiens2-pose",
-    "mv-api",
     "tyro>=0.9.1",
 ]
 description = "RTMLib YOLOX human detection plus Sapiens2 COCO-133 pose estimation with iterable and batched TensorRT video paths"
 name = "sapiens-coco133-pose"
 requires-python = ">= 3.12"
 version = "0.1.0"
+
+# Workspace siblings named above resolve to their in-repo path (never to a PyPI
+# namesake); the root manifest installs the same paths editable.
+[tool.uv.sources]
+sapiens2-pose = { path = "../sapiens2-pose", editable = true }
 
 [build-system]
 build-backend = "hatchling.build"

--- a/packages/simplecv/tests/test_workspace_sources.py
+++ b/packages/simplecv/tests/test_workspace_sources.py
@@ -1,0 +1,66 @@
+"""Workspace guards: a sibling package named in a member's pyproject must resolve to the in-repo path, never to a PyPI namesake.
+
+Pixi resolves each editable member's ``[project].dependencies`` through uv. A bare
+sibling name is an ordinary registry requirement unless the member pins it with
+``[tool.uv.sources]``, and PyPI does host unrelated packages called ``monopriors``,
+``simplecv`` and ``sam3``. The first test checks the pins; the second checks the
+lock, which is the only place a fallback would show up.
+"""
+
+import re
+from pathlib import Path
+
+import tomllib
+
+REPO_ROOT: Path = Path(__file__).resolve().parents[3]
+PACKAGES_DIR: Path = REPO_ROOT / "packages"
+
+
+def _normalize(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _workspace_packages() -> dict[str, Path]:
+    """Normalized distribution name -> package directory, for every packages/*/pyproject.toml."""
+    packages: dict[str, Path] = {}
+    for pyproject in PACKAGES_DIR.glob("*/pyproject.toml"):
+        name: str | None = tomllib.loads(pyproject.read_text()).get("project", {}).get("name")
+        if name:
+            packages[_normalize(name)] = pyproject.parent
+    return packages
+
+
+def _requirement_name(requirement: str) -> str:
+    return _normalize(re.split(r"[<>=!~\[; @]", requirement, maxsplit=1)[0].strip())
+
+
+def test_member_pyprojects_pin_workspace_siblings_with_uv_sources() -> None:
+    packages: dict[str, Path] = _workspace_packages()
+    problems: list[str] = []
+    for name, package_dir in sorted(packages.items()):
+        manifest: dict = tomllib.loads((package_dir / "pyproject.toml").read_text())
+        sources: dict[str, dict] = {_normalize(k): v for k, v in manifest.get("tool", {}).get("uv", {}).get("sources", {}).items()}
+        for requirement in manifest.get("project", {}).get("dependencies", []):
+            sibling: str = _requirement_name(requirement)
+            if sibling not in packages or sibling == name:
+                continue
+            source: dict | None = sources.get(sibling)
+            if source is None or "path" not in source:
+                problems.append(f"{package_dir.name}: `{sibling}` needs `[tool.uv.sources] {sibling} = {{ path = ..., editable = true }}`")
+                continue
+            if (package_dir / source["path"]).resolve() != packages[sibling].resolve():
+                problems.append(f"{package_dir.name}: `{sibling}` source path {source['path']!r} does not point at packages/{packages[sibling].name}")
+    assert not problems, "\n".join(problems)
+
+
+def test_lock_never_resolves_a_workspace_package_from_an_index() -> None:
+    packages: dict[str, Path] = _workspace_packages()
+    lock_text: str = (REPO_ROOT / "pixi.lock").read_text()
+    package_section: str = lock_text.split("\npackages:\n", maxsplit=1)[1]
+    from_index: list[str] = []
+    for entry in re.finditer(r"^- pypi: (\S+)\n((?:  .*\n)+)", package_section, re.M):
+        locator: str = entry.group(1)
+        name_match: re.Match[str] | None = re.search(r"^  name: (\S+)$", entry.group(2), re.M)
+        if name_match and _normalize(name_match.group(1)) in packages and locator.startswith(("http://", "https://")):
+            from_index.append(f"{name_match.group(1)} <- {locator}")
+    assert not from_index, "workspace packages resolved from an index (pin them with [tool.uv.sources]):\n" + "\n".join(from_index)

--- a/packages/vistadream/pyproject.toml
+++ b/packages/vistadream/pyproject.toml
@@ -13,6 +13,11 @@ dependencies = [
     "monopriors>=0.3.2",
 ]
 
+# Workspace siblings named above resolve to their in-repo path (never to a PyPI
+# namesake); the root manifest installs the same paths editable.
+[tool.uv.sources]
+monopriors = { path = "../monoprior", editable = true }
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/packages/zipdepth/pyproject.toml
+++ b/packages/zipdepth/pyproject.toml
@@ -10,6 +10,11 @@ name = "zipdepth"
 requires-python = ">= 3.12"
 version = "0.1.0"
 
+# Workspace siblings named above resolve to their in-repo path (never to a PyPI
+# namesake); the root manifest installs the same paths editable.
+[tool.uv.sources]
+monopriors = { path = "../monoprior", editable = true }
+
 [build-system]
 build-backend = "hatchling.build"
 requires = ["hatchling"]

--- a/pixi.lock
+++ b/pixi.lock
@@ -32988,7 +32988,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/websocket-client-1.9.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - pypi: ./packages/mv-api
       - pypi: ./packages/sapiens-coco133-pose
       - pypi: ./packages/sapiens2-pose
       - pypi: ./packages/simplecv
@@ -33055,7 +33054,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b7/97/30a3a3775ead580134088dfc116a410e2ae490c044ec357109eeb11503ec/monopriors-0.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/1f/73c53fcbfb0b5a78f91176df41945ca466e71e9d9d836e5c522abda39ee7/pydantic-2.11.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/76/de1bfac17d183c49c6d0887903d3064ced51cf1d9ba7a8d611c1a8808c4f/timm-1.0.28-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c4/13/680c54afe3e65767bed7ec1a15571e1a2f1257128733851ade24abcefbcc/kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -33555,7 +33553,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/websocket-client-1.9.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - pypi: ./packages/mv-api
       - pypi: ./packages/sapiens-coco133-pose
       - pypi: ./packages/sapiens2-pose
       - pypi: ./packages/simplecv
@@ -33624,7 +33621,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b7/97/30a3a3775ead580134088dfc116a410e2ae490c044ec357109eeb11503ec/monopriors-0.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/1f/73c53fcbfb0b5a78f91176df41945ca466e71e9d9d836e5c522abda39ee7/pydantic-2.11.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/76/de1bfac17d183c49c6d0887903d3064ced51cf1d9ba7a8d611c1a8808c4f/timm-1.0.28-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c4/13/680c54afe3e65767bed7ec1a15571e1a2f1257128733851ade24abcefbcc/kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -92464,14 +92460,14 @@ packages:
   - pytorch-lightning>=2.5.1,<3
   - diffusers[torch]>=0.32.2
   - timm>=1.0.15,<2
-  - sam3>=0.1.0
+  - sam3 @ ./packages/sam3
   requires_python: '>=3.11.0'
 - pypi: ./packages/mv-api
   name: mv-api
   requires_dist:
-  - monopriors
+  - monopriors @ ./packages/monoprior
   - tyro>=0.9.1
-  - wilor-nano
+  - wilor-nano @ ./packages/wilor-nano
   requires_python: '>=3.12'
 - pypi: ./packages/mvs
   name: mvs
@@ -92481,13 +92477,13 @@ packages:
 - pypi: ./packages/posekit
   name: posekit
   requires_dist:
-  - simplecv
+  - simplecv @ ./packages/simplecv
   - tyro>=0.9.1
   requires_python: '>=3.12'
 - pypi: ./packages/prompt-da
   name: rerun-prompt-da
   requires_dist:
-  - monopriors>=0.3.2
+  - monopriors @ ./packages/monoprior
   requires_python: '>=3.12'
 - pypi: ./packages/pysfm
   name: pysfm
@@ -92558,14 +92554,13 @@ packages:
   - omegaconf>=2.3.0,<3
   - termcolor>=3.2.0,<4
   - spaces>=0.43.0
-  - monopriors>=0.3.2
-  - sam3>=0.1.0
+  - monopriors @ ./packages/monoprior
+  - sam3 @ ./packages/sam3
   requires_python: '>=3.12'
 - pypi: ./packages/sapiens-coco133-pose
   name: sapiens-coco133-pose
   requires_dist:
-  - sapiens2-pose
-  - mv-api
+  - sapiens2-pose @ ./packages/sapiens2-pose
   - tyro>=0.9.1
   requires_python: '>=3.12'
 - pypi: ./packages/sapiens2-pose
@@ -92613,7 +92608,7 @@ packages:
   name: vistadream
   requires_dist:
   - einops>=0.8.1,<0.9
-  - monopriors>=0.3.2
+  - monopriors @ ./packages/monoprior
   requires_python: '>=3.11'
 - pypi: ./packages/wilor-nano
   name: wilor-nano
@@ -92627,7 +92622,7 @@ packages:
 - pypi: ./packages/zipdepth
   name: zipdepth
   requires_dist:
-  - monopriors>=0.3.3
+  - monopriors @ ./packages/monoprior
   requires_python: '>=3.12'
 - pypi: direct+https://github.com/nvidia-isaac/cuVSLAM/releases/download/v15.0.0/cuvslam-15.0.0%2Bcu13-cp312-abi3-manylinux_2_39_aarch64.whl
   name: cuvslam
@@ -97497,11 +97492,6 @@ packages:
   version: 2.27.0.0
   sha256: 33cf852883baeaa274069eceefe2b2de4e2d1da1c8b16939aea676a5ac37781c
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/b7/97/30a3a3775ead580134088dfc116a410e2ae490c044ec357109eeb11503ec/monopriors-0.1.0-py3-none-any.whl
-  name: monopriors
-  version: 0.1.0
-  sha256: 5198d2d6a7e2f78caad9a4755bf383bb973996579a493709def1179dcad125bc
-  requires_python: '>=3.10.0'
 - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
   name: six
   version: 1.17.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -1138,7 +1138,6 @@ tyro = ">=0.9.1,<0.10"
 sapiens-coco133-pose = { path = "packages/sapiens-coco133-pose", editable = true }
 trtkit = { path = "packages/trtkit", editable = true }
 sapiens2-pose = { path = "packages/sapiens2-pose", editable = true }
-mv-api = { path = "packages/mv-api", editable = true }
 wilor_nano = { path = "packages/wilor-nano", editable = true }
 rtmlib = { git = "https://github.com/pablovela5620/rtmlib.git", rev = "98bca2193c39b349034b280803b54c9ee58f7c68" }
 onnx = "*"


### PR DESCRIPTION
## What
- Every package whose `[project].dependencies` names a sibling now pins it to the in-repo path with `[tool.uv.sources]`. Without the pin pixi resolves the bare name through uv as a registry requirement, and PyPI hosts unrelated `monopriors`, `simplecv` and `sam3` packages.
- `sapiens-coco133-pose` drops `mv-api` (nothing imports it); its envs had pulled the unrelated PyPI `monopriors` 0.1.0.
- `simplecv/tests/test_workspace_sources.py` fails if a sibling is unpinned or the lock ever resolves a workspace name from an index.
- README and AGENTS.md record the convention. `pixi.lock` regenerated; only the two sapiens envs differ from main.

## Verified
`pixi lock --check`, idempotent `pixi lock`, and the `tests` task of every changed package on the dl-server (linux-64), the Spark (aarch64) and the 3060 desktop.

Base of the exo-calib stack (#178–#183). Merge this first.
