### PR TITLE
simplecv depth/mesh helpers; PromptDA teacher batch tool GPU cast + malloc_trim (stack 2/7)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,28 @@ layer. `arkitscenes-download-serve` uses `ulimit -n 524288`; restart the server
 to inherit it. This is a capacity workaround—the upstream fix is open-on-demand
 files or an LRU descriptor pool.
 
+### The shared catalog server (:51235) is in-memory — never kill Rerun by name
+
+`rerun server` keeps every registration in memory: any exit, even SIGTERM, loses
+the whole corpus and re-registering takes ~90 s warm / ~16 min cold. It has died to
+two things, both from agent sessions on this host:
+
+- **Name-based kills** (`pkill -x rerun`, `pkill rerun`, `killall rerun`,
+  `pkill -f rerun`) hit every process called `rerun`. Kill your own viewer by pid or
+  with a pattern that includes your port, e.g. `pkill -f "rerun --headless --port 9877"`,
+  and check `ss -ltnp | grep 51235` before touching anything named `rerun`. (The
+  server currently runs through a `rerun-catalog` symlink so its process name is not
+  `rerun`; that hides the symptom, it does not excuse a name-based kill.)
+- **paseo restarts.** `paseo.service` uses `KillMode=control-group`, so a restart —
+  including the one systemd triggers when the kernel OOM-kills any process in that
+  cgroup — SIGTERMs every agent session and everything they spawned.
+  `setsid`/`nohup`/`disown` do not leave the cgroup. Start long-lived servers and
+  batches with `tmux new-session` (lives in the SSH session scope; verify with
+  `cat /proc/<pid>/cgroup`) or `systemd-run --user`.
+
+Real fixes, not yet done: a persistent catalog store, and running the server under
+a supervisor instead of a shell.
+
 ## Testing Rerun builds
 
 **Rust follows the primary Python Rerun lane.** The `common` / `rerun-prerelease`

--- a/packages/monoprior/monopriors/apis/polycam_inference.py
+++ b/packages/monoprior/monopriors/apis/polycam_inference.py
@@ -7,7 +7,7 @@ import rerun as rr
 from jaxtyping import Float, Float32, UInt8, UInt16
 from simplecv.camera_parameters import PinholeParameters
 from simplecv.data.polycam import PolycamData, PolycamDataset, load_polycam_data
-from simplecv.ops.tsdf_depth_fuser import Open3DFuser
+from simplecv.ops.tsdf_depth_fuser import Open3DFuser, log_fused_mesh
 from simplecv.rerun_log_utils import RerunTyroConfig
 from tqdm import tqdm
 
@@ -138,22 +138,16 @@ def polycam_inference(config: PolycamConfig) -> None:
     pred_mesh = pred_fuser.get_mesh()
     pred_mesh.compute_vertex_normals()
 
-    rr.log(
+    log_fused_mesh(
         f"{parent_path}/gt_mesh",
-        rr.Mesh3D(
-            vertex_positions=gt_mesh.vertices,
-            triangle_indices=gt_mesh.triangles,
-            vertex_normals=gt_mesh.vertex_normals,
-            vertex_colors=gt_mesh.vertex_colors,
-        ),
+        gt_mesh,
+        static=False,
+        face_rendering=rr.components.MeshFaceRendering.DoubleSided,
     )
 
-    rr.log(
+    log_fused_mesh(
         f"{parent_path}/pred_mesh",
-        rr.Mesh3D(
-            vertex_positions=pred_mesh.vertices,
-            triangle_indices=pred_mesh.triangles,
-            vertex_normals=pred_mesh.vertex_normals,
-            vertex_colors=pred_mesh.vertex_colors,
-        ),
+        pred_mesh,
+        static=False,
+        face_rendering=rr.components.MeshFaceRendering.DoubleSided,
     )

--- a/packages/prompt-da/src/rerun_prompt_da/apis/arkitscenes_shared.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/arkitscenes_shared.py
@@ -5,8 +5,6 @@ from typing import Any
 
 import cv2
 import numpy as np
-import open3d as o3d
-import rerun as rr
 from arkitscenes_download.ingest.depth import ArkitDepthConfidence
 from beartype.roar import BeartypeException
 from einops import rearrange
@@ -14,6 +12,7 @@ from jaxtyping import Float, Float32, UInt8, UInt16
 from numpy import ndarray
 from rerun.catalog import CatalogClient
 from scipy.spatial.transform import Rotation
+from simplecv.ops.depth import quantize_depth_m_to_mm
 from torch import Tensor
 
 from rerun_prompt_da.trt_predictor import PromptDATrtPredictor, postprocess_depth, preprocess_batch
@@ -137,28 +136,13 @@ def run_promptda_batch(
     image_b3hw, prompt_b1hw = preprocess_batch(rgb_bhw3, prompt_bhw, predictor.image_hw)
     depth_model_b1hw: Float32[Tensor, "b 1 nh nw"] = predictor.runtime({"image": image_b3hw, "prompt_depth": prompt_b1hw})["depth"]
     depth_bhw: Float32[Tensor, "b oh ow"] = postprocess_depth(depth_model_b1hw, output_hw)
-    depth_mm_bhw: UInt16[ndarray, "b oh ow"] = (depth_bhw.cpu().numpy() * 1000.0).astype(np.uint16)
+    # Scale and cast on the GPU: halves the device-to-host copy and drops two full-size host passes.
+    depth_mm_bhw: UInt16[ndarray, "b oh ow"] = quantize_depth_m_to_mm(depth_bhw).cpu().numpy()
     depth_model_mm_bhw: UInt16[ndarray, "b nh nw"] = (
-        rearrange(depth_model_b1hw, "b 1 h w -> b h w").cpu().numpy() * 1000.0  # pyrefly: ignore  # bad-argument-type — einops stub false positive
-    ).astype(np.uint16)
-    return depth_mm_bhw, depth_model_mm_bhw
-
-
-def log_fused_mesh(recording: rr.RecordingStream, entity_path: str, mesh: o3d.geometry.TriangleMesh) -> None:
-    """Log a fused TSDF mesh statically.
-
-    Same see-through treatment as the ARKit mesh: cull back-facing walls so the
-    3D view looks into the room from outside.
-    """
-    rr.log(
-        entity_path,
-        rr.Mesh3D(
-            vertex_positions=np.asarray(mesh.vertices),
-            triangle_indices=np.asarray(mesh.triangles),
-            vertex_normals=np.asarray(mesh.vertex_normals),
-            vertex_colors=np.asarray(mesh.vertex_colors),
-            face_rendering=rr.components.MeshFaceRendering.Front,
-        ),
-        static=True,
-        recording=recording,
+        quantize_depth_m_to_mm(
+            rearrange(depth_model_b1hw, "b 1 h w -> b h w")
+        )
+        .cpu()
+        .numpy()
     )
+    return depth_mm_bhw, depth_model_mm_bhw

--- a/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_arkitscenes.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_arkitscenes.py
@@ -5,30 +5,34 @@ local Rerun catalog, completes depth frame-by-frame, fuses a final TSDF mesh,
 and writes a replaceable ``promptda`` layer back to the dataset.
 """
 
+import ctypes
+import gc
 from collections.abc import Iterable, Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 
-import cv2
 import numpy as np
 import open3d as o3d
 import pyarrow as pa
 import rerun as rr
 import torch
+import torch.nn.functional as F
 from arkitscenes_download.ingest.blueprint import DEPTH_RANGE_MM, make_blueprint
 from arkitscenes_download.ingest.catalog import DEFAULT_CATALOG_URL
 from arkitscenes_download.ingest.cells import landscape_quarter_turns, portrait_from_segment_row
 from arkitscenes_download.ingest.depth import encode_depth_png
 from arkitscenes_download.ingest.paths import DEPTH_PROMPTDA, PROMPTDA_MESH, TIMELINE
 from arkitscenes_download.ingest.recording import atomic_recording
+from einops import rearrange
 from jaxtyping import Float, UInt8, UInt16
 from numpy import ndarray
 from rerun.catalog import CatalogClient, DatasetEntry, OnDuplicateSegmentLayer, RegistrationHandle
 from rerun.experimental.dataloader import RerunIterableDataset
 from simplecv.camera_parameters import Intrinsics, rescale_intri
-from simplecv.ops.tsdf_depth_fuser import Open3DFuser
+from simplecv.ops.tsdf_depth_fuser import Open3DFuser, log_fused_mesh
 from simplecv.rerun_log_utils import mesh_bounding_geometry
+from torch import Tensor
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
@@ -37,7 +41,6 @@ from rerun_prompt_da.apis.arkitscenes_shared import (
     NATIVE_FPS,
     connect_catalog,
     filter_depth_for_fusion,
-    log_fused_mesh,
     run_promptda_batch,
     segments_to_process,
     stride_for,
@@ -47,6 +50,11 @@ from rerun_prompt_da.promptda_stream import PromptDABatch, PromptDACollate, prom
 from rerun_prompt_da.trt_predictor import PromptDATrtPredictor
 
 PROMPTDA_LAYER = "promptda"
+
+_MALLOC_TRIM = ctypes.CDLL(None).malloc_trim
+"""glibc ``malloc_trim``; Linux-only, like the rest of this pipeline (NVDEC, TensorRT)."""
+_MALLOC_TRIM.argtypes = [ctypes.c_size_t]
+_MALLOC_TRIM.restype = ctypes.c_int
 
 
 @dataclass
@@ -106,8 +114,8 @@ class CompletedPromptDABatch:
     """Full-resolution predicted depth in millimetres, in inference orientation."""
     depth_model_mm_bhw: UInt16[ndarray, "b nh nw"]
     """Network-resolution predicted depth in millimetres, in inference orientation."""
-    rgb_stored_bhw3: UInt8[ndarray, "b stored_h stored_w 3"]
-    """RGB frames restored to catalog orientation."""
+    rgb_stored_bhw3: UInt8[ndarray, "b fh fw 3"]
+    """RGB frames at the fusion (network) resolution, restored to catalog orientation."""
     confidence_bhw: UInt8[ndarray, "b stored_prompt_h stored_prompt_w"]
     """ARKit confidence in catalog orientation."""
     K_native_b33: Float[ndarray, "b 3 3"]
@@ -160,16 +168,14 @@ def fuse_and_log_batch(
         predicted_depth_hw: UInt16[ndarray, "h w"] = np.ascontiguousarray(np.rot90(batch.depth_mm_bhw[row], -batch.quarter_turns))
         fusion_depth_hw: UInt16[ndarray, "fh fw"] = np.ascontiguousarray(np.rot90(batch.depth_model_mm_bhw[row], -batch.quarter_turns))
         confidence_hw: UInt8[ndarray, "h2 w2"] = batch.confidence_bhw[row]
-        rgb_hw3: UInt8[ndarray, "h w 3"] = batch.rgb_stored_bhw3[row]
         log_promptda_frame(recording, timestamp_ns, predicted_depth_hw)
         filtered_depth_hw: UInt16[ndarray, "h w"] = filter_depth_for_fusion(
             fusion_depth_hw,
             confidence_hw,
             max_depth_meter,
         )
-        rgb_fusion_hw3: UInt8[ndarray, "fh fw 3"] = np.asarray(
-            cv2.resize(rgb_hw3, (fusion_depth_hw.shape[1], fusion_depth_hw.shape[0]), interpolation=cv2.INTER_AREA), dtype=np.uint8
-        )
+        # Already at the fusion resolution and catalog orientation — downscaled on the GPU.
+        rgb_fusion_hw3: UInt8[ndarray, "fh fw 3"] = batch.rgb_stored_bhw3[row]
         stored_k_33: Float[ndarray, "3 3"] = batch.K_native_b33[row]
         stored_intrinsics: Intrinsics = Intrinsics.from_k_matrix(
             camera_conventions="RDF",
@@ -257,9 +263,22 @@ def run_segment(
                 batch.prompt_bhw,
                 (batch.rgb_bhw3.shape[1], batch.rgb_bhw3.shape[2]),
             )
-            rgb_stored_bhw3: UInt8[ndarray, "b stored_h stored_w 3"] = np.asarray(
-                torch.rot90(batch.rgb_bhw3, -batch.quarter_turns, dims=(1, 2)).cpu().numpy(),
-                dtype=np.uint8,
+            # Fusion only needs colour at the network resolution, so downscale on the
+            # GPU and keep the full-resolution frame off the bus entirely.
+            fusion_hw: tuple[int, int] = (inference_result[1].shape[1], inference_result[1].shape[2])
+            rgb_fusion_bchw: Float[Tensor, "b 3 fh fw"] = F.interpolate(
+                rearrange(batch.rgb_bhw3, "b h w c -> b c h w").float(),
+                size=fusion_hw,
+                mode="bilinear",
+                antialias=True,
+            )
+            rgb_stored_bhw3: UInt8[ndarray, "b fh fw 3"] = np.ascontiguousarray(
+                rearrange(torch.rot90(rgb_fusion_bchw, -batch.quarter_turns, dims=(2, 3)), "b c h w -> b h w c")
+                .round()
+                .clamp(0.0, 255.0)
+                .to(torch.uint8)
+                .cpu()
+                .numpy()
             )
             if pending_batch is not None:
                 inferred_frames += pending_batch.result()
@@ -282,7 +301,7 @@ def run_segment(
         mesh: o3d.geometry.TriangleMesh = fuser.get_mesh()
         mesh.compute_vertex_normals()
         vertices: Float[ndarray, "n 3"] = np.asarray(mesh.vertices)
-        log_fused_mesh(recording, PROMPTDA_MESH, mesh)
+        log_fused_mesh(PROMPTDA_MESH, mesh, recording=recording)
         # Embed the PromptDA layout in this layer, framed on the fused mesh (the
         # same per-sequence treatment the base layer gives the ARKit mesh). Sent at
         # the end of the stream so it wins blueprint activation when the segment's
@@ -292,6 +311,11 @@ def run_segment(
                 make_blueprint(portrait=portrait, framing=mesh_bounding_geometry(vertices), include_promptda=True),
                 recording=recording,
             )
+    # Open3D's TSDF churn leaves ~0.6 GB of freed native pages per segment resident in
+    # glibc arenas (measured: OOM at 142 GB after 234 segments). The fuser, executor and
+    # recording are out of scope here, so return those pages to the OS at the boundary.
+    gc.collect()
+    _MALLOC_TRIM(0)
     skipped_decodes: int = 0 if expected_frames is None else expected_frames - inferred_frames
     return SegmentResult(rrd_path=rrd_path, inferred_frames=inferred_frames, skipped_decodes=skipped_decodes)
 

--- a/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_arkitscenes_raw.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/prompt_da_arkitscenes_raw.py
@@ -40,7 +40,7 @@ from jaxtyping import Float, Float32, Float64, UInt8, UInt16
 from numpy import ndarray
 from rerun.catalog import CatalogClient, DatasetEntry, OnDuplicateSegmentLayer, RegistrationHandle
 from simplecv.camera_parameters import Intrinsics, rescale_intri
-from simplecv.ops.tsdf_depth_fuser import Open3DFuser
+from simplecv.ops.tsdf_depth_fuser import Open3DFuser, log_fused_mesh
 from torch import Tensor
 from torchcodec.decoders import VideoDecoder
 from tqdm import tqdm
@@ -50,7 +50,6 @@ from rerun_prompt_da.apis.arkitscenes_shared import (
     NATIVE_FPS,
     connect_catalog,
     filter_depth_for_fusion,
-    log_fused_mesh,
     run_promptda_batch,
     segments_to_process,
     stride_for,
@@ -365,7 +364,7 @@ def process_segment_raw(
     mesh.compute_vertex_normals()
     fusion_s += time.perf_counter() - fusion_started
     log_started = time.perf_counter()
-    log_fused_mesh(recording, PROMPTDA_RAW_MESH, mesh)
+    log_fused_mesh(PROMPTDA_RAW_MESH, mesh, recording=recording)
     recording.flush()
     log_s += time.perf_counter() - log_started
 

--- a/packages/prompt-da/tests/test_prompt_da_arkitscenes.py
+++ b/packages/prompt-da/tests/test_prompt_da_arkitscenes.py
@@ -11,7 +11,7 @@ import torch
 from numpy.testing import assert_allclose, assert_array_equal
 from rerun.catalog import DatasetEntry
 from rerun.experimental import RrdReader
-from simplecv.ops.tsdf_depth_fuser import Open3DFuser
+from simplecv.ops.tsdf_depth_fuser import Open3DFuser, log_fused_mesh
 
 pytest.importorskip("pyarrow", reason="ARKitScenes catalog deps live in the PromptDA catalog lanes")
 pytest.importorskip("arkitscenes_download", reason="ARKitScenes catalog deps live in the PromptDA catalog lanes")
@@ -25,7 +25,6 @@ from simplecv.rerun_dataloader import SegmentNvdecDecoder  # noqa: E402
 
 from rerun_prompt_da.apis.arkitscenes_shared import (  # noqa: E402
     filter_depth_for_fusion,
-    log_fused_mesh,
     segments_to_process,
     stride_for,
     world_t_cam_from_pose,
@@ -50,7 +49,7 @@ def test_promptda_layer_rrd_keeps_depth_and_mesh_contract(tmp_path: Path) -> Non
             o3d.utility.Vector3iVector(np.array([[0, 1, 2]], dtype=np.int32)),
         )
         mesh.compute_vertex_normals()
-        log_fused_mesh(recording, PROMPTDA_MESH, mesh)
+        log_fused_mesh(PROMPTDA_MESH, mesh, recording=recording)
 
     reader: RrdReader = RrdReader(rrd_path)
     chunks = list(reader.stream(store=reader.recordings()[0]).to_chunks())
@@ -82,6 +81,7 @@ def test_promptda_dataset_uses_nvdec_and_fetches_fusion_confidence(monkeypatch: 
     fields = captured["dataset_kwargs"]["fields"]  # type: ignore[index]
     assert fields["video"].decode is decoder  # type: ignore[index]
     assert fields["conf"].path == f"/{CONFIDENCE}:SegmentationImage:buffer"  # type: ignore[index]
+    assert captured["dataset_kwargs"]["fetch_block_size"] == 1024  # type: ignore[index]
 
 
 def test_promptda_collate_keeps_stored_confidence_and_honors_ingest_rotation() -> None:

--- a/packages/simplecv/simplecv/apis/view_polycam_data.py
+++ b/packages/simplecv/simplecv/apis/view_polycam_data.py
@@ -16,7 +16,7 @@ from simplecv.data.polycam import (
     PolycamDataset,
     load_polycam_data,
 )
-from simplecv.ops.tsdf_depth_fuser import Open3DFuser
+from simplecv.ops.tsdf_depth_fuser import Open3DFuser, log_fused_mesh
 from simplecv.rerun_log_utils import RerunTyroConfig, log_pinhole
 
 
@@ -124,26 +124,20 @@ def view_polycam_data(config: PolyViewConfig) -> None:
             gt_mesh: o3d.geometry.TriangleMesh = depth_fuser.get_mesh()
             gt_mesh.compute_vertex_normals()
 
-            rr.log(
+            log_fused_mesh(
                 f"{parent_path}/gt_mesh",
-                rr.Mesh3D(
-                    vertex_positions=gt_mesh.vertices,
-                    triangle_indices=gt_mesh.triangles,
-                    vertex_normals=gt_mesh.vertex_normals,
-                    vertex_colors=gt_mesh.vertex_colors,
-                ),
+                gt_mesh,
+                static=False,
+                face_rendering=rr.components.MeshFaceRendering.DoubleSided,
             )
 
     # export mesh
     gt_mesh: o3d.geometry.TriangleMesh = depth_fuser.get_mesh()
     gt_mesh.compute_vertex_normals()
 
-    rr.log(
+    log_fused_mesh(
         f"{parent_path}/gt_mesh",
-        rr.Mesh3D(
-            vertex_positions=gt_mesh.vertices,
-            triangle_indices=gt_mesh.triangles,
-            vertex_normals=gt_mesh.vertex_normals,
-            vertex_colors=gt_mesh.vertex_colors,
-        ),
+        gt_mesh,
+        static=False,
+        face_rendering=rr.components.MeshFaceRendering.DoubleSided,
     )

--- a/packages/simplecv/simplecv/ops/depth.py
+++ b/packages/simplecv/simplecv/ops/depth.py
@@ -1,0 +1,24 @@
+"""Shared metric-depth conversion helpers."""
+
+import torch
+from jaxtyping import Float, UInt16
+from torch import Tensor
+
+
+def quantize_depth_m_to_mm(depth_m: Float[Tensor, "*shape"]) -> UInt16[Tensor, "*shape"]:
+    """Quantize torch metre depth to uint16 millimetres on-device.
+
+    Args:
+        depth_m: Floating-point metric depth tensor with arbitrary shape.
+            Non-finite values become zero.
+
+    Returns:
+        Same-shape uint16 millimetres, rounded to nearest and clipped to
+        ``[0, 65535]``.
+    """
+    safe_depth_m: Float[Tensor, "*shape"] = torch.where(torch.isfinite(depth_m), depth_m, torch.zeros_like(depth_m))
+    depth_mm: UInt16[Tensor, "*shape"] = torch.round(safe_depth_m * 1000.0).clamp(0.0, 65535.0).to(dtype=torch.uint16)
+    return depth_mm
+
+
+__all__ = ("quantize_depth_m_to_mm",)

--- a/packages/simplecv/simplecv/ops/tsdf_depth_fuser.py
+++ b/packages/simplecv/simplecv/ops/tsdf_depth_fuser.py
@@ -14,10 +14,44 @@ from pathlib import Path
 
 import numpy as np
 import open3d as o3d
+import rerun as rr
 from jaxtyping import Float, Float32, UInt8, UInt16
 from numpy import ndarray
 
 from simplecv.camera_parameters import PinholeParameters
+
+
+def log_fused_mesh(
+    entity_path: str,
+    mesh: o3d.geometry.TriangleMesh,
+    *,
+    recording: rr.RecordingStream | None = None,
+    static: bool = True,
+    face_rendering: rr.components.MeshFaceRendering = rr.components.MeshFaceRendering.Front,
+) -> None:
+    """Log a fused Open3D triangle mesh to Rerun.
+
+    Args:
+        entity_path: Rerun entity path for the mesh.
+        mesh: Open3D triangle mesh to log.
+        recording: Explicit recording stream, or ``None`` for the global stream.
+        static: Whether to log timeless data instead of the current time.
+        face_rendering: Which wound faces the viewer renders. Front-face-only
+            is the room-reconstruction default; pass ``DoubleSided`` to retain
+            Rerun's general mesh default.
+    """
+    rr.log(
+        entity_path,
+        rr.Mesh3D(
+            vertex_positions=np.asarray(mesh.vertices),
+            triangle_indices=np.asarray(mesh.triangles),
+            vertex_normals=np.asarray(mesh.vertex_normals),
+            vertex_colors=np.asarray(mesh.vertex_colors),
+            face_rendering=face_rendering,
+        ),
+        static=static,
+        recording=recording,
+    )
 
 
 @dataclass

--- a/packages/simplecv/tests/test_depth_ops.py
+++ b/packages/simplecv/tests/test_depth_ops.py
@@ -1,0 +1,16 @@
+"""Tests for shared metric-depth conversion helpers."""
+
+import torch
+from jaxtyping import Float32, UInt16
+from torch import Tensor
+
+from simplecv.ops.depth import quantize_depth_m_to_mm
+
+
+def test_torch_depth_quantization_rounds_clips_and_zeros_nonfinite() -> None:
+    """Torch metre depth matches the numpy quantization policy on-device."""
+    depth_m: Float32[Tensor, "6"] = torch.tensor([torch.nan, torch.inf, -1.0, 1.2344, 1.2346, 70.0], dtype=torch.float32)
+
+    depth_mm: UInt16[Tensor, "6"] = quantize_depth_m_to_mm(depth_m)
+
+    assert torch.equal(depth_mm, torch.tensor([0, 0, 0, 1234, 1235, 65535], dtype=torch.uint16))

--- a/packages/simplecv/tests/test_mesh_logging.py
+++ b/packages/simplecv/tests/test_mesh_logging.py
@@ -1,0 +1,31 @@
+"""Tests for shared fused-mesh Rerun logging."""
+
+import numpy as np
+import open3d as o3d
+import pytest
+import rerun as rr
+
+from simplecv.ops.tsdf_depth_fuser import log_fused_mesh
+
+
+def test_log_fused_mesh_uses_entity_first_and_keyword_recording(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the common entity/data arguments positional and logging controls keyword-only."""
+    mesh: o3d.geometry.TriangleMesh = o3d.geometry.TriangleMesh()
+    mesh.vertices = o3d.utility.Vector3dVector(np.zeros((3, 3), dtype=np.float64))
+    mesh.triangles = o3d.utility.Vector3iVector(np.array([[0, 1, 2]], dtype=np.int32))
+    mesh.vertex_normals = o3d.utility.Vector3dVector(np.zeros((3, 3), dtype=np.float64))
+    mesh.vertex_colors = o3d.utility.Vector3dVector(np.ones((3, 3), dtype=np.float64))
+    recording: rr.RecordingStream = rr.RecordingStream(application_id="test-mesh-logging", recording_id="mesh")
+    captured: dict[str, object] = {}
+
+    def fake_log(entity_path: str, archetype: rr.Mesh3D, *, static: bool, recording: rr.RecordingStream | None) -> None:
+        captured.update(entity_path=entity_path, archetype=archetype, static=static, recording=recording)
+
+    monkeypatch.setattr(rr, "log", fake_log)
+
+    log_fused_mesh("world/mesh", mesh, recording=recording, static=False)
+
+    assert captured["entity_path"] == "world/mesh"
+    assert isinstance(captured["archetype"], rr.Mesh3D)
+    assert captured["static"] is False
+    assert captured["recording"] is recording


### PR DESCRIPTION
Stack **2/9** — the ZipDepth-PromptDA work re-cut into one focused stack (replaces #132 #133 #134 #129 #164 #165 #166 #167 #172 #173 #174 #175 #177; #131 is already merged). Review bottom-up.

| # | PR | what | lines (no lock) |
|---|---|---|---:|
| 1 | #186 | workspace rerun-sdk 0.37.0 (pins + API ports) — lock | +533/−317 |
| 2 | #187 | simplecv depth/mesh helpers; PromptDA teacher batch tool on the GPU + malloc_trim; catalog-server rules | +196/−74 |
| 3 | #188 | monoprior config-first depth-completion zoo (PromptDA torch/onnx/trt) — refactor only | +752/−565 |
| 4 | #189 | **ZipDepth-PromptDA model** + static-batch TensorRT export — lock (+trtkit) | +1132/−11 |
| 5 | #190 | zipdepth-catalog lane: streaming dataset, CUDA builders, holdout eval — lock (+2 envs) | +3176/−25 |
| 6 | #191 | catalog fine-tune trainer + live smoke gate + IO instrumentation | +1576/−27 |
| 7 | #192 | hard-frame mining, fixed hard-20 scorer, Polycam three-way comparison | +1727/−14 |
| 8 | #203 | training-speed knobs + named presets for the wall-clock hill-climb | +670/−76 |
| 9 | #204 | idiomatic Rerun 0.37 dataloader as executable reference (`--dataloader rerun`), catalog-query audit | +1027/−54 |

Whole stack vs main: 108 files, +8486/−995. The old chain was 13 open PRs (+10.4k lines) plus 11 unpushed commits; the head-variant experiments and the default-off loss knobs were dropped (negative results, see the [project report](https://pablos-4800gt.ilish-ruler.ts.net:8768/zipdepth/zipdepth-promptda-final-report.html)), and every slice went through a four-lens simplify pass before cutting. Review-pass changes (2026-09-03) are folded into the same PRs: zero `Any` on added lines, jaxtyping dtype+shape on every added array annotation, no dtype/shape in new identifiers, shared metre→mm quantiser, `upsample_depth_to_image`, condensed AGENTS section, stale einops suppressions dropped in touched files.

## simplecv depth/mesh helpers; PromptDA teacher batch tool on the GPU, malloc_trim per segment
**What** `simplecv.ops.depth.quantize_depth_m_to_mm` (torch, on-device) and `simplecv.ops.tsdf_depth_fuser.log_fused_mesh` (typed `mesh: o3d.geometry.TriangleMesh`, beside the fuser that produces the meshes; entity-first; keyword `recording`/`static`/`face_rendering`) replace inlined copies in view_polycam_data, monoprior polycam_inference and the prompt-da ARKitScenes tools.
The chosen-frame PromptDA batch tool (`prompt-da-arkitscenes`) casts depth to uint16 and downsizes the fusion RGB on the GPU before the D2H copy (22.4 → 6.3 MB/frame, 17.3 → 21.6 frames/s on the 5090; stored bytes and layer contract unchanged; A/B mesh vertex count identical) and returns Open3D's TSDF arena pages to the OS at each segment boundary (`gc.collect()` + `malloc_trim(0)`), which fixed the ~0.6 GB/segment host growth that OOM-killed the corpus batch at 142 GB RSS (RSS now 4–8 GB across 570 segments).
AGENTS.md gains the catalog-server rules from that incident: never kill Rerun by name, paseo's cgroup `KillMode`, tmux / systemd-run for long jobs.
**Gates** simplecv-dev 152 passed; prompt-da-dev 8 passed + deadcode; monoprior-dev lint/typecheck.
