### PR TITLE
ZipDepth-PromptDA: prompted metric depth distilled from PromptDA + static-batch TRT export (stack 4/7)

### DIFF
--- a/packages/monoprior/docs/architecture.md
+++ b/packages/monoprior/docs/architecture.md
@@ -61,9 +61,10 @@ Refines sparse or noisy depth using an RGB guide. Defined in `monopriors/models/
 | Predictor class | Model | Source |
 |---|---|---|
 | `PromptDAPredictor` | PromptDA | [PromptDA](https://github.com/AnyQuantAI/PromptDA) |
+| `ZipDepthPromptPredictor` | ZipDepth-PromptDA | [ZipDepth](https://github.com/fabiotosi92/ZipDepth) |
 
 Base class: `BaseCompletionPredictor`
-Output: `CompletionDepthPrediction(depth_mm, confidence)`
+Output: `Float32[Tensor, "b h w"]` metric depth in metres. `CompletionDepthPrediction` is a compatibility-only legacy container, not the current predictor return type.
 
 ### Composite models
 

--- a/packages/monoprior/monopriors/models/depth_completion/__init__.py
+++ b/packages/monoprior/monopriors/models/depth_completion/__init__.py
@@ -1,6 +1,33 @@
-"""Depth-completion model registry."""
+"""Depth-completion model registry: tyro subcommands over model configs."""
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import tyro
 
 from monopriors.models.depth_completion.base_completion_depth import BaseCompletionPredictor
 from monopriors.models.depth_completion.prompt_da import PromptDAConfig, PromptDAPredictor
+from monopriors.models.depth_completion.zipdepth_prompt import ZipDepthPromptConfig, ZipDepthPromptPredictor
 
-__all__ = ("BaseCompletionPredictor", "PromptDAConfig", "PromptDAPredictor")
+if TYPE_CHECKING:
+    CompletionConfig = PromptDAConfig | ZipDepthPromptConfig
+else:
+    CompletionConfig = tyro.extras.subcommand_type_from_defaults(
+        {
+            "prompt-da": PromptDAConfig(),
+            "zipdepth-promptda": ZipDepthPromptConfig(checkpoint=Path()),
+        },
+        prefix_names=False,
+    )
+
+AnnotatedCompletionConfig = tyro.conf.OmitSubcommandPrefixes[CompletionConfig]
+
+__all__ = (
+    "AnnotatedCompletionConfig",
+    "BaseCompletionPredictor",
+    "CompletionConfig",
+    "PromptDAConfig",
+    "PromptDAPredictor",
+    "ZipDepthPromptConfig",
+    "ZipDepthPromptPredictor",
+)

--- a/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt.py
+++ b/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt.py
@@ -1,0 +1,283 @@
+"""Prompt-conditioned metric ZipDepth model.
+
+The wrapper keeps the vendored ZipDepth-base tensors unchanged, injects a
+normalized metric prompt into all four decoder stages, and returns depth in the
+same units as the prompt (metres for the public API).
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Self
+
+import torch
+import torch.nn.functional as F
+from jaxtyping import Bool, Float, Float32, UInt8
+from torch import Tensor, nn
+from trtkit import (
+    BackendConfig,
+    OnnxBackendConfig,
+    TensorRtBackendConfig,
+    TensorRuntime,
+    TensorSpec,
+    TorchBackendConfig,
+    TorchRuntime,
+    create_runtime_from_onnx,
+)
+
+from monopriors.models.depth_completion.base_completion_depth import (
+    DEPTH_OUTPUT_NAME,
+    IMAGE_INPUT_NAME,
+    MAX_METRIC_DEPTH_M,
+    MIN_METRIC_DEPTH_M,
+    PROMPT_DEPTH_HW,
+    PROMPT_INPUT_NAME,
+    BaseCompletionPredictor,
+)
+from monopriors.models.zipdepth_checkpoint import load_zipdepth_state_dict
+from monopriors.third_party.zipdepth.architecture import EncoderOutput, FeaturePyramid, ZipDepth, create_model
+from monopriors.third_party.zipdepth.model_utils import StateDict
+
+MIN_PROMPT_SPAN_M: float = 1.0e-6
+
+
+def _make_prompt_branch(channels: int) -> nn.Sequential:
+    """Build one PromptDA-style depthwise-separable prompt branch.
+
+    Args:
+        channels: Decoder-stage channel count.
+
+    Returns:
+        A branch mapping float normalized prompt depth with shape
+        ``(batch, 1, height, width)`` to float features with shape
+        ``(batch, channels, height, width)``. The last pointwise convolution is
+        exactly zero-initialized, so the branch initially contributes zero.
+    """
+    input_conv: nn.Conv2d = nn.Conv2d(1, channels, kernel_size=3, padding=1)
+    depthwise_conv: nn.Conv2d = nn.Conv2d(channels, channels, kernel_size=3, padding=1, groups=channels)
+    final_conv: nn.Conv2d = nn.Conv2d(channels, channels, kernel_size=1)
+    branch: nn.Sequential = nn.Sequential(
+        input_conv,
+        nn.ReLU(inplace=True),
+        depthwise_conv,
+        nn.ReLU(inplace=True),
+        final_conv,
+    )
+    nn.init.zeros_(final_conv.weight)
+    if final_conv.bias is not None:
+        nn.init.zeros_(final_conv.bias)
+    return branch
+
+
+def _inject_prompt(
+    feature_bchw: Float[Tensor, "b c h w"],
+    normalized_prompt_bchw: Float32[Tensor, "b 1 192 256"],
+    branch: nn.Module,
+) -> Float[Tensor, "b c h w"]:
+    """Resize and inject one normalized prompt into a decoder feature."""
+    feature_hw: tuple[int, int] = (int(feature_bchw.shape[-2]), int(feature_bchw.shape[-1]))
+    prompt_bchw: Float32[Tensor, "b 1 prompt_h prompt_w"] = normalized_prompt_bchw
+    if tuple(int(dim) for dim in prompt_bchw.shape[-2:]) != feature_hw:
+        prompt_bchw = F.interpolate(prompt_bchw, size=feature_hw, mode="bilinear", align_corners=False)
+    return feature_bchw + branch(prompt_bchw.to(dtype=feature_bchw.dtype))
+
+
+class ZipDepthPrompt(nn.Module):
+    """ZipDepth-base with PromptDA-style multi-scale metric conditioning."""
+
+    def __init__(self, backbone: ZipDepth | None = None) -> None:
+        super().__init__()
+        self.backbone: ZipDepth = create_model(variant="base") if backbone is None else backbone
+        if self.backbone.variant != "base":
+            raise ValueError(f"ZipDepthPrompt requires the base variant, got {self.backbone.variant!r}")
+        if not self.backbone.decoder.convex_up.use_unfold:
+            raise ValueError("ZipDepthPrompt currently requires ZipDepth's unfold-based convex head")
+        self.prompt_branches: nn.ModuleList = nn.ModuleList(
+            [_make_prompt_branch(channels) for channels in (288, 192, 144, 96)]
+        )
+
+    def forward(
+        self,
+        image: UInt8[Tensor, "b 3 h w"] | Float[Tensor, "b 3 h w"],
+        prompt_depth: Float32[Tensor, "b 1 192 256"],
+    ) -> Float[Tensor, "b 1 h w"]:
+        """Predict metric depth from RGB and a low-resolution metric prompt.
+
+        Confidence-invalid prompt pixels must be zeroed by the caller. This
+        method also rejects non-finite values and depths outside 0.1--4.0 m
+        when computing the per-image prompt range.
+
+        Args:
+            image: UInt8 RGB or float RGB tensor with shape
+                ``(batch, 3, height, width)``. UInt8 values are scaled to
+                ``[0, 1]``; float values are already expected in that range.
+            prompt_depth: Float32 metric prompt in metres with shape
+                ``(batch, 1, 192, 256)``. Invalid pixels are zero.
+
+        Returns:
+            Float metric depth in metres with shape
+                ``(batch, 1, height, width)``.
+        """
+        metric_depth_bchw: Float[Tensor, "b 1 h w"]
+        metric_depth_bchw, _, _ = self.forward_with_range(image, prompt_depth)
+        return metric_depth_bchw
+
+    def forward_with_range(
+        self,
+        image: UInt8[Tensor, "b 3 h w"] | Float[Tensor, "b 3 h w"],
+        prompt_depth: Float32[Tensor, "b 1 192 256"],
+    ) -> tuple[
+        Float[Tensor, "b 1 h w"],
+        Float32[Tensor, "b 1 1 1"],
+        Float32[Tensor, "b 1 1 1"],
+    ]:
+        """Predict metric depth and expose the prompt range for TRT export.
+
+        The two scalar outputs force TensorRT to materialize the input-derived
+        reductions. Normal callers use :meth:`forward` and receive depth only.
+        """
+        if image.dtype == torch.uint8:
+            image_bchw: Float[Tensor, "b 3 h w"] = image.to(dtype=self.backbone.mean.dtype) / 255.0
+        else:
+            image_bchw = image.to(dtype=self.backbone.mean.dtype)
+
+        valid_bchw: Bool[Tensor, "b 1 192 256"] = (
+            torch.isfinite(prompt_depth)
+            & (prompt_depth >= MIN_METRIC_DEPTH_M)
+            & (prompt_depth <= MAX_METRIC_DEPTH_M)
+        )
+        valid_any_b: Bool[Tensor, "b 1 1 1"] = valid_bchw.any(dim=(1, 2, 3), keepdim=True)
+        masked_min_b: Float32[Tensor, "b 1 1 1"] = torch.where(
+            valid_bchw, prompt_depth, torch.inf
+        ).amin(dim=(1, 2, 3), keepdim=True)
+        masked_max_b: Float32[Tensor, "b 1 1 1"] = torch.where(
+            valid_bchw, prompt_depth, -torch.inf
+        ).amax(dim=(1, 2, 3), keepdim=True)
+        min_depth_b: Float32[Tensor, "b 1 1 1"] = torch.where(
+            valid_any_b, masked_min_b, MIN_METRIC_DEPTH_M
+        )
+        max_depth_b: Float32[Tensor, "b 1 1 1"] = torch.where(
+            valid_any_b, masked_max_b, MAX_METRIC_DEPTH_M
+        )
+        span_b: Float32[Tensor, "b 1 1 1"] = (max_depth_b - min_depth_b).clamp_min(MIN_PROMPT_SPAN_M)
+        normalized_prompt_bchw: Float32[Tensor, "b 1 192 256"] = torch.where(
+            valid_bchw,
+            (prompt_depth - min_depth_b) / span_b,
+            0.0,
+        )
+
+        normalized_image_bchw: Float[Tensor, "b 3 h w"] = (image_bchw - self.backbone.mean).div_(self.backbone.std)
+        encoder_output: EncoderOutput = self.backbone.encoder(normalized_image_bchw)
+        stem_half_bchw: Float[Tensor, "b c_half h_half w_half"] = encoder_output[0]
+        encoder_features: FeaturePyramid = encoder_output[1]
+        c1_bchw: Float[Tensor, "b c1 h_quarter w_quarter"] = encoder_features[0]
+        c2_bchw: Float[Tensor, "b c2 h_eighth w_eighth"] = encoder_features[1]
+        c3_bchw: Float[Tensor, "b c3 h_sixteenth w_sixteenth"] = encoder_features[2]
+        c4_bchw: Float[Tensor, "b c4 h_thirtysecond w_thirtysecond"] = encoder_features[3]
+
+        decoder = self.backbone.decoder
+        f4_bchw: Float[Tensor, "b 288 h_thirtysecond w_thirtysecond"] = decoder.proj4(c4_bchw)
+        f4_bchw = _inject_prompt(f4_bchw, normalized_prompt_bchw, self.prompt_branches[0])
+
+        f3_bchw: Float[Tensor, "b 192 h_sixteenth w_sixteenth"] = decoder.fuse3(c3_bchw, f4_bchw)
+        f3_bchw = _inject_prompt(f3_bchw, normalized_prompt_bchw, self.prompt_branches[1])
+
+        f2_bchw: Float[Tensor, "b 144 h_eighth w_eighth"] = decoder.fuse2(c2_bchw, f3_bchw)
+        f2_bchw = _inject_prompt(f2_bchw, normalized_prompt_bchw, self.prompt_branches[2])
+
+        f1_bchw: Float[Tensor, "b 96 h_quarter w_quarter"] = decoder.fuse1(c1_bchw, f2_bchw)
+        f1_bchw = _inject_prompt(f1_bchw, normalized_prompt_bchw, self.prompt_branches[3])
+
+        f_half_bchw: Float[Tensor, "b 32 h_half w_half"] = decoder.fuse_half(stem_half_bchw, f1_bchw)
+        depth_logits_half_bchw: Float[Tensor, "b 1 h_half w_half"] = decoder.head_half(f_half_bchw)
+        depth_logits_bchw: Float[Tensor, "b 1 h w"] = decoder.convex_up._forward_unfold(f_half_bchw, depth_logits_half_bchw)
+        normalized_depth_bchw: Float[Tensor, "b 1 h w"] = torch.sigmoid(depth_logits_bchw)
+        metric_depth_bchw: Float[Tensor, "b 1 h w"] = normalized_depth_bchw * span_b + min_depth_b
+        return metric_depth_bchw, min_depth_b, max_depth_b
+
+    def fuse_for_inference(self) -> Self:
+        """Fuse the released ZipDepth backbone in place and enter eval mode."""
+        self.backbone.fuse_for_inference()
+        self.eval()
+        return self
+
+
+def load_zipdepth_prompt(checkpoint: Path) -> ZipDepthPrompt:
+    """Load a complete released ZipDepth-base checkpoint into the wrapper.
+
+    Args:
+        checkpoint: Bare ZipDepth state dict or trainer checkpoint containing
+            ``model_state_dict``. DDP and ``torch.compile`` prefixes are
+            accepted.
+
+    Returns:
+        A trainable prompted model. Every released tensor is loaded strictly;
+        prompt-branch tensors retain their zero-output initialization.
+    """
+    state_dict: StateDict = load_zipdepth_state_dict(checkpoint)
+    if any(key.startswith("backbone.") for key in state_dict):
+        prompted_model: ZipDepthPrompt = ZipDepthPrompt()
+        prompted_model.load_state_dict(state_dict, strict=True)
+        return prompted_model
+    backbone: ZipDepth = create_model(variant="base")
+    backbone.load_state_dict(state_dict, strict=True)
+    return ZipDepthPrompt(backbone)
+
+
+@dataclass(frozen=True, slots=True)
+class ZipDepthPromptConfig:
+    """ZipDepth-PromptDA model and runtime configuration."""
+
+    checkpoint: Path = Path()
+    """Prompted model checkpoint; an empty path is only a CLI placeholder."""
+    backend: BackendConfig = field(default_factory=TorchBackendConfig)
+    """Backend running the network: torch, ONNX Runtime CUDA, or TensorRT."""
+    image_height: int = 768
+    """Static network image height; must be divisible by 32."""
+    image_width: int = 1024
+    """Static network image width; must be divisible by 32."""
+
+    def setup(self) -> "ZipDepthPromptPredictor":
+        """Build the selected runtime and return a ready predictor."""
+        if not self.checkpoint.is_file():
+            raise FileNotFoundError(f"ZipDepth-PromptDA checkpoint is not a file: {self.checkpoint}")
+        image_hw: tuple[int, int] = (self.image_height, self.image_width)
+        image_spec = TensorSpec(IMAGE_INPUT_NAME, (3, *image_hw), torch.float32)
+        prompt_spec = TensorSpec(PROMPT_INPUT_NAME, (1, *PROMPT_DEPTH_HW), torch.float32)
+        depth_spec = TensorSpec(DEPTH_OUTPUT_NAME, (1, *image_hw), torch.float32)
+        if isinstance(self.backend, TorchBackendConfig):
+            model: nn.Module = load_zipdepth_prompt(self.checkpoint).cuda().fuse_for_inference()
+            runtime: TensorRuntime = TorchRuntime(
+                model,
+                input_specs=(image_spec, prompt_spec),
+                output_specs=(depth_spec,),
+                max_batch_size=self.backend.max_batch_size,
+                autocast_dtype=self.backend.autocast_dtype,
+            )
+        else:
+            from monopriors.models.depth_completion.zipdepth_prompt_export import export_zipdepth_prompt_onnx
+
+            export_batch_size: int
+            if isinstance(self.backend, TensorRtBackendConfig):
+                export_batch_size = self.backend.opt_batch_size
+            else:
+                onnx_backend: OnnxBackendConfig = self.backend
+                export_batch_size = onnx_backend.max_batch_size
+            onnx_path: Path = export_zipdepth_prompt_onnx(
+                checkpoint=self.checkpoint,
+                image_hw=image_hw,
+                batch_size=export_batch_size,
+            )
+            runtime = create_runtime_from_onnx(onnx_path, self.backend)
+        return ZipDepthPromptPredictor(runtime=runtime)
+
+
+class ZipDepthPromptPredictor(BaseCompletionPredictor):
+    """ZipDepth-PromptDA through the shared batched GPU tensor contract."""
+
+
+__all__ = (
+    "ZipDepthPrompt",
+    "ZipDepthPromptConfig",
+    "ZipDepthPromptPredictor",
+    "load_zipdepth_prompt",
+)

--- a/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt_export.py
+++ b/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt_export.py
@@ -1,0 +1,185 @@
+"""Static-batch ONNX export for ZipDepth-PromptDA."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+import torch
+from jaxtyping import Float32
+from torch import Tensor, nn
+
+from monopriors.models.depth_completion.base_completion_depth import DEPTH_OUTPUT_NAME, IMAGE_INPUT_NAME, PROMPT_DEPTH_HW, PROMPT_INPUT_NAME
+from monopriors.models.depth_completion.zipdepth_prompt import load_zipdepth_prompt
+from monopriors.models.relative_depth.zipdepth import download_zipdepth_checkpoint
+
+ONNX_EXPORT_VERSION: int = 1
+DEFAULT_CACHE_DIR: Path = Path(os.environ.get("ZIPDEPTH_PROMPT_TRT_CACHE", "~/.cache/zipdepth-promptda")).expanduser()
+"""Portable ZipDepth-PromptDA ONNX cache root."""
+
+
+@runtime_checkable
+class PromptedDepthModel(Protocol):
+    """Prompt-conditioned model operations required by ONNX export."""
+
+    def __call__(
+        self,
+        image: Float32[Tensor, "b 3 h w"],
+        prompt_depth: Float32[Tensor, "b 1 192 256"],
+    ) -> Float32[Tensor, "b 1 h w"]:
+        """Predict metric depth from RGB and a prompt."""
+        ...
+
+    def forward_with_range(
+        self,
+        image: Float32[Tensor, "b 3 h w"],
+        prompt_depth: Float32[Tensor, "b 1 192 256"],
+    ) -> tuple[Float32[Tensor, "b 1 h w"], Float32[Tensor, "b 1 1 1"], Float32[Tensor, "b 1 1 1"]]:
+        """Return metric depth and the input-derived minimum and maximum."""
+        ...
+
+    def fuse_for_inference(self) -> "PromptedDepthModel":
+        """Fuse inference-time layers and enter evaluation mode."""
+        ...
+
+    def to(self, device: torch.device, dtype: torch.dtype) -> "PromptedDepthModel":
+        """Move model parameters to the requested device and dtype."""
+        ...
+
+
+ModelLoader = Callable[[Path], PromptedDepthModel]
+ExportFn = Callable[..., None]
+
+
+class _ExportOutputs(nn.Module):
+    """Expose prompt min/max reductions as TensorRT fusion barriers."""
+
+    def __init__(self, model: PromptedDepthModel) -> None:
+        super().__init__()
+        self.model: PromptedDepthModel = model
+
+    def forward(
+        self,
+        image: Float32[Tensor, "b 3 h w"],
+        prompt_depth: Float32[Tensor, "b 1 192 256"],
+    ) -> tuple[Float32[Tensor, "b 1 h w"], Float32[Tensor, "b 1 1 1"], Float32[Tensor, "b 1 1 1"]]:
+        """Return depth and the two prompt-range fusion barriers."""
+        return self.model.forward_with_range(image, prompt_depth)
+
+
+def _checkpoint_tag(checkpoint: Path) -> str:
+    """Return a stable short identity for released and local weights."""
+    parts: tuple[str, ...] = checkpoint.parts
+    if "snapshots" in parts:
+        return parts[parts.index("snapshots") + 1][:8]
+    digest = hashlib.sha256()
+    with checkpoint.open("rb") as file:
+        while block := file.read(1024 * 1024):
+            digest.update(block)
+    return digest.hexdigest()[:8]
+
+
+def prepare_zipdepth_prompt_for_export(
+    model: PromptedDepthModel,
+    image_hw: tuple[int, int],
+    device: torch.device,
+) -> PromptedDepthModel:
+    """Fuse and convert a prompted model for a static fp16 graph.
+
+    Args:
+        model: ZipDepth-PromptDA module exposing ``fuse_for_inference``.
+        image_hw: Static export image height and width.
+        device: Export device.
+
+    Returns:
+        Fused fp16 evaluation module on ``device``.
+    """
+    height, width = image_hw
+    if height <= 0 or width <= 0 or height % 32 != 0 or width % 32 != 0:
+        raise ValueError(f"ZipDepth image dimensions must be positive multiples of 32, got {image_hw}")
+    fused_model: PromptedDepthModel = model.fuse_for_inference()
+    return fused_model.to(device, torch.float16)
+
+
+def export_zipdepth_prompt_onnx(
+    *,
+    checkpoint: Path | None = None,
+    image_hw: tuple[int, int] = (768, 1024),
+    batch_size: int = 8,
+    cache_dir: Path = DEFAULT_CACHE_DIR,
+    model_loader: ModelLoader = load_zipdepth_prompt,
+    export_fn: ExportFn | None = None,
+    device: str = "cuda",
+) -> Path:
+    """Export a fixed-batch, two-input ONNX graph with fp32 I/O.
+
+    Args:
+        checkpoint: Prompted checkpoint; ``None`` downloads released base weights.
+        image_hw: Static image height and width.
+        batch_size: Batch baked into the graph.
+        cache_dir: Portable ONNX cache root.
+        model_loader: Model loader boundary used by export tests.
+        export_fn: ONNX writer boundary; defaults to :func:`trtkit.export_onnx`.
+        device: Torch export device.
+
+    Returns:
+        Existing or newly exported ONNX graph path.
+    """
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+    height, width = image_hw
+    resolved_checkpoint: Path = checkpoint or download_zipdepth_checkpoint()
+    tag: str = _checkpoint_tag(resolved_checkpoint)
+    onnx_dir: Path = cache_dir / "onnx"
+    onnx_path: Path = onnx_dir / f"zipdepth-prompt_{height}x{width}_b{batch_size}_fp16_v{ONNX_EXPORT_VERSION}_{tag}.onnx"
+    if onnx_path.is_file():
+        return onnx_path
+
+    resolved_device = torch.device(device)
+    if resolved_device.type == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for the fp16 ZipDepth ONNX export")
+    model: PromptedDepthModel = prepare_zipdepth_prompt_for_export(model_loader(resolved_checkpoint), image_hw, resolved_device)
+    wrapper: nn.Module = _ExportOutputs(model).eval()
+    dummy_image_bchw: Float32[Tensor, "b 3 h w"] = torch.rand(
+        (batch_size, 3, height, width), dtype=torch.float32, device=resolved_device
+    )
+    prompt_pixels: int = PROMPT_DEPTH_HW[0] * PROMPT_DEPTH_HW[1]
+    dummy_prompt_bchw: Float32[Tensor, "1 1 192 256"] = torch.linspace(
+        0.2, 3.8, prompt_pixels, dtype=torch.float32, device=resolved_device
+    ).reshape(1, 1, *PROMPT_DEPTH_HW)
+    dummy_prompt_bchw = dummy_prompt_bchw.expand(batch_size, -1, -1, -1).contiguous()
+    dummy_prompt_bchw[:, :, 24:160:3, 32:224:4] = 0.0
+
+    if export_fn is None:
+        from trtkit import export_onnx
+
+        export_fn = export_onnx
+    export_fn(
+        wrapper,
+        (dummy_image_bchw, dummy_prompt_bchw),
+        onnx_path,
+        input_names=[IMAGE_INPUT_NAME, PROMPT_INPUT_NAME],
+        output_names=[DEPTH_OUTPUT_NAME, "min_depth", "max_depth"],
+        compute_dtype=None,
+        dynamic_batch_max=None,
+    )
+    del wrapper, model
+    if resolved_device.type == "cuda":
+        torch.cuda.empty_cache()
+    return onnx_path
+
+
+__all__ = (
+    "DEFAULT_CACHE_DIR",
+    "DEPTH_OUTPUT_NAME",
+    "IMAGE_INPUT_NAME",
+    "ONNX_EXPORT_VERSION",
+    "PROMPT_INPUT_NAME",
+    "PromptedDepthModel",
+    "_ExportOutputs",
+    "export_zipdepth_prompt_onnx",
+    "prepare_zipdepth_prompt_for_export",
+)

--- a/packages/monoprior/monopriors/models/relative_depth/zipdepth.py
+++ b/packages/monoprior/monopriors/models/relative_depth/zipdepth.py
@@ -10,8 +10,8 @@ from huggingface_hub import hf_hub_download
 from jaxtyping import Float, Float32, UInt8
 
 from monopriors.depth_utils import disparity_to_depth, estimate_intrinsics
+from monopriors.models.zipdepth_checkpoint import load_zipdepth_state_dict
 from monopriors.third_party.zipdepth.architecture import ZipDepth, create_model
-from monopriors.third_party.zipdepth.model_utils import strip_state_dict_prefixes
 
 from .base_relative_depth import BaseRelativePredictor, RelativeDepthPrediction
 
@@ -33,10 +33,8 @@ def load_zipdepth(checkpoint: Path, npu: bool = False) -> ZipDepth:
     DDP / torch.compile key prefixes are stripped. Loading is strict: the checkpoint must be a
     complete ZipDepth-base.
     """
-    ckpt = torch.load(checkpoint, map_location="cpu", weights_only=True)
-    state_dict = strip_state_dict_prefixes(ckpt.get("model_state_dict", ckpt))
     model = create_model(variant="base", upsample_unfold=not npu)
-    model.load_state_dict(state_dict, strict=True)
+    model.load_state_dict(load_zipdepth_state_dict(checkpoint), strict=True)
     return model.fuse_for_inference()  # RepVGG re-parameterisation; the fused graph is what the paper benchmarks
 
 

--- a/packages/monoprior/monopriors/models/zipdepth_checkpoint.py
+++ b/packages/monoprior/monopriors/models/zipdepth_checkpoint.py
@@ -1,0 +1,35 @@
+"""Shared ZipDepth checkpoint decoding."""
+
+from pathlib import Path
+
+import torch
+from torch import Tensor
+
+from monopriors.third_party.zipdepth.model_utils import StateDict, strip_state_dict_prefixes
+
+
+def narrow_zipdepth_state_dict(raw_state: object, checkpoint: Path) -> dict[str, Tensor]:
+    """Validate and type a serialized ZipDepth model state mapping."""
+    if not isinstance(raw_state, dict):
+        raise ValueError(f"checkpoint model state must contain a mapping: {checkpoint}")
+    state_dict: dict[str, Tensor] = {}
+    for key, value in raw_state.items():
+        if not isinstance(key, str):
+            raise ValueError(f"checkpoint model state has non-string key {key!r}: {checkpoint}")
+        if not isinstance(value, Tensor):
+            raise ValueError(f"checkpoint model state key {key!r} must contain a Tensor: {checkpoint}")
+        state_dict[key] = value
+    return state_dict
+
+
+def load_zipdepth_state_dict(checkpoint: Path) -> StateDict:
+    """Load, unwrap, and clean a bare or trainer ZipDepth state dictionary."""
+    loaded: dict[str, object] = torch.load(checkpoint, map_location="cpu", weights_only=True)
+    if not isinstance(loaded, dict):
+        raise ValueError(f"checkpoint must contain a mapping: {checkpoint}")
+    raw_state: object = loaded.get("model_state_dict", loaded)
+    state_dict: dict[str, Tensor] = narrow_zipdepth_state_dict(raw_state, checkpoint)
+    return strip_state_dict_prefixes(state_dict)
+
+
+__all__ = ("load_zipdepth_state_dict", "narrow_zipdepth_state_dict")

--- a/packages/monoprior/tests/test_depth_completion_models.py
+++ b/packages/monoprior/tests/test_depth_completion_models.py
@@ -8,7 +8,7 @@ from jaxtyping import Float32, UInt8
 from torch import Tensor
 from trtkit import RuntimeSpec, TensorSpec
 
-from monopriors.models.depth_completion import PromptDAPredictor
+from monopriors.models.depth_completion import PromptDAPredictor, ZipDepthPromptPredictor
 from monopriors.models.depth_completion.base_completion_depth import upsample_depth_to_image
 
 
@@ -57,9 +57,9 @@ def test_upsample_depth_to_image_preserves_sampling_and_ownership_policy() -> No
     assert owned_bhw.untyped_storage().data_ptr() != depth_bchw.untyped_storage().data_ptr()
 
 
-@pytest.mark.parametrize("predictor_factory", [PromptDAPredictor])
+@pytest.mark.parametrize("predictor_factory", [PromptDAPredictor, ZipDepthPromptPredictor])
 def test_completion_predictor_owns_layout_scale_and_output_resize(
-    predictor_factory: Callable[..., PromptDAPredictor],
+    predictor_factory: Callable[..., PromptDAPredictor | ZipDepthPromptPredictor],
 ) -> None:
     """Every model-zoo predictor exposes the same backend-neutral family contract."""
     runtime = _RecordingRuntime()

--- a/packages/monoprior/tests/test_zipdepth_predictor.py
+++ b/packages/monoprior/tests/test_zipdepth_predictor.py
@@ -12,6 +12,7 @@ import torch
 
 from monopriors.models.relative_depth import RELATIVE_PREDICTORS, ZipDepthPredictor, get_relative_predictor
 from monopriors.models.relative_depth import zipdepth as zipdepth_module
+from monopriors.models.zipdepth_checkpoint import load_zipdepth_state_dict
 from monopriors.third_party.zipdepth.architecture import create_model
 
 
@@ -37,6 +38,15 @@ def predictor(trainer_checkpoint: Path) -> ZipDepthPredictor:
 def test_local_checkpoint_bypasses_download(monkeypatch: pytest.MonkeyPatch, trainer_checkpoint: Path) -> None:
     monkeypatch.setattr(zipdepth_module, "download_zipdepth_checkpoint", lambda npu=False: pytest.fail("should not download"))
     ZipDepthPredictor(device="cpu", checkpoint=trainer_checkpoint, input_size=64)
+
+
+def test_checkpoint_rejects_non_tensor_state_value(tmp_path: Path) -> None:
+    """Name the malformed state key instead of passing it into model loading."""
+    checkpoint: Path = tmp_path / "malformed.pth"
+    torch.save({"model_state_dict": {"encoder.weight": "not-a-tensor"}}, checkpoint)
+
+    with pytest.raises(ValueError, match="encoder.weight"):
+        load_zipdepth_state_dict(checkpoint)
 
 
 def test_call_contract(predictor: ZipDepthPredictor) -> None:

--- a/packages/trtkit/README.md
+++ b/packages/trtkit/README.md
@@ -90,6 +90,31 @@ strongly-typed network that takes dtypes from the graph — the escape hatch for
 fp16-overflow-prone ViTs). `allow_tf32=False` disables TF32 for strict-fp32
 models and is part of the cache key (`-notf32`).
 
+## Known TensorRT limitations
+
+**Dynamic batch + Myelin `CHECK(is_const())`.** A graph whose reshape depends on
+the batch symbol can fail to build with `dynamic_batch_max` set:
+
+```
+Could not find any implementation for node {ForeignNode[ONNXTRT_ShapeShuffle_…]}
+MyelinCheckException: value.h:872: CHECK(is_const()) failed
+```
+
+Seen with ZipDepth-base, whose `F.unfold` upsampling head dynamo lowers to a
+gather indexed off `Shape(...)`; head rewrites (`view(-1, …)`, static slices, the
+NPU head) only move the failure earlier, and it reproduces identically on
+TensorRT 10.16.1, 11.0.0, 11.1.0 and 11.2.1 on sm_120 (2026-08-30). It is a
+Myelin limitation on a non-constant leading dim, not a graph bug, and it is not
+in NVIDIA's release notes or tracker. Every other trtkit consumer here (PromptDA,
+MoGe, MammaNet, RTMW, Sapiens) builds fine with a dynamic batch profile.
+
+Workaround: export with `dynamic_batch_max=None` (static batch) and build one
+engine per batch size (`TrtBuildConfig(max_batch_size=b, opt_batch_size=b)`).
+Zero model change; upstream ZipDepth's own `export.py` hardcodes batch 1 for the
+same reason. Related: fp16 via `model.half()`, not autocast — an autocast export
+can leave a float conv kernel beside a half input, which a strongly-typed build
+rejects at parse time.
+
 ## Dev
 
 ```bash

--- a/packages/zipdepth/pyproject.toml
+++ b/packages/zipdepth/pyproject.toml
@@ -37,4 +37,4 @@ paths = ["zipdepth/apis", "zipdepth/__init__.py", "tests", "tools"]
 exclude = ["*/.pixi/*", "*/__pycache__/*"]
 sort_by_size = true
 min_confidence = 60
-ignore_names = ["rr_config"]
+ignore_names = ["fuse_for_inference", "allow_tf32", "baseline_flat_dev_m", "baseline_overall_dev_m", "benchmark", "capture_path", "eval_label_field", "forward", "forward_with_range", "frames_per_second", "full_ranking", "gpu", "id", "median_ms_per_batch", "median_ms_per_frame", "p95_ms_per_batch", "processed_frames", "rank_count", "resolved_max_lr", "rr_config", "student_config_class", "student_flat_dev_m", "student_output_role", "student_reference_version", "teacher_config_class", "train_epoch"]

--- a/packages/zipdepth/tests/test_prompted_model.py
+++ b/packages/zipdepth/tests/test_prompted_model.py
@@ -1,0 +1,71 @@
+"""Behavior tests for the prompted metric ZipDepth wrapper."""
+
+from pathlib import Path
+
+import torch
+from jaxtyping import Float32, UInt8
+from monopriors.models.depth_completion.zipdepth_prompt import ZipDepthPrompt, load_zipdepth_prompt
+from monopriors.third_party.zipdepth.architecture import ZipDepth, create_model
+from torch import Tensor
+
+
+def _prompt_with_fixed_range(*, flip: bool = False) -> Float32[Tensor, "1 1 192 256"]:
+    prompt_bchw: Float32[Tensor, "1 1 192 256"] = torch.linspace(0.2, 3.8, 192 * 256, dtype=torch.float32).reshape(1, 1, 192, 256)
+    if flip:
+        prompt_bchw = torch.flip(prompt_bchw, dims=(-1,))
+    prompt_bchw[:, :, 40:80, 60:120] = 0.0
+    return prompt_bchw
+
+
+def test_zero_initialized_prompt_injection_has_no_spatial_contribution() -> None:
+    model: ZipDepthPrompt = ZipDepthPrompt().eval()
+    image_bchw: Float32[Tensor, "1 3 64 96"] = torch.rand(1, 3, 64, 96)
+
+    with torch.inference_mode():
+        first_depth_bchw: Float32[Tensor, "1 1 64 96"] = model(image_bchw, _prompt_with_fixed_range())
+        second_depth_bchw: Float32[Tensor, "1 1 64 96"] = model(image_bchw, _prompt_with_fixed_range(flip=True))
+
+    assert torch.equal(first_depth_bchw, second_depth_bchw)
+
+
+def test_prompted_model_accepts_raw_and_normalized_rgb() -> None:
+    model: ZipDepthPrompt = ZipDepthPrompt().eval()
+    raw_image_bchw: UInt8[Tensor, "1 3 64 96"] = torch.randint(0, 256, (1, 3, 64, 96), dtype=torch.uint8)
+    normalized_image_bchw: Float32[Tensor, "1 3 64 96"] = raw_image_bchw.to(dtype=torch.float32) / 255.0
+    prompt_bchw: Float32[Tensor, "1 1 192 256"] = _prompt_with_fixed_range()
+
+    with torch.inference_mode():
+        raw_input_depth_bchw: Float32[Tensor, "1 1 64 96"] = model(raw_image_bchw, prompt_bchw)
+        normalized_input_depth_bchw: Float32[Tensor, "1 1 64 96"] = model(normalized_image_bchw, prompt_bchw)
+
+    assert raw_input_depth_bchw.shape == (1, 1, 64, 96)
+    torch.testing.assert_close(raw_input_depth_bchw, normalized_input_depth_bchw, rtol=0.0, atol=0.0)
+    assert float(raw_input_depth_bchw.min()) >= 0.2
+    assert float(raw_input_depth_bchw.max()) <= 3.8
+
+
+def test_degenerate_prompts_produce_finite_metric_depth() -> None:
+    model: ZipDepthPrompt = ZipDepthPrompt().eval()
+    image_bchw: Float32[Tensor, "2 3 64 96"] = torch.rand(2, 3, 64, 96)
+    prompt_bchw: Float32[Tensor, "2 1 192 256"] = torch.zeros(2, 1, 192, 256)
+    prompt_bchw[0] = 1.25
+
+    with torch.inference_mode():
+        depth_bchw: Float32[Tensor, "2 1 64 96"] = model(image_bchw, prompt_bchw)
+
+    assert depth_bchw.shape == (2, 1, 64, 96)
+    assert torch.isfinite(depth_bchw).all()
+
+
+def test_released_zipdepth_state_loads_strictly_into_backbone(tmp_path: Path) -> None:
+    released: ZipDepth = create_model(variant="base")
+    checkpoint: Path = tmp_path / "zipdepth_base.pth"
+    torch.save(released.state_dict(), checkpoint)
+
+    prompted: ZipDepthPrompt = load_zipdepth_prompt(checkpoint)
+
+    prompted_backbone_state: dict[str, Tensor] = prompted.backbone.state_dict()
+    released_state: dict[str, Tensor] = released.state_dict()
+    assert prompted_backbone_state.keys() == released_state.keys()
+    for key, released_tensor in released_state.items():
+        assert torch.equal(prompted_backbone_state[key], released_tensor), key

--- a/packages/zipdepth/tests/test_prompted_trt.py
+++ b/packages/zipdepth/tests/test_prompted_trt.py
@@ -1,0 +1,158 @@
+"""Static-batch ONNX/TensorRT export tests for ZipDepth-PromptDA."""
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypeAlias
+
+import pytest
+import torch
+from jaxtyping import Float32
+from monopriors.models.depth_completion.zipdepth_prompt_export import (
+    IMAGE_INPUT_NAME,
+    PROMPT_INPUT_NAME,
+    PromptedDepthModel,
+    export_zipdepth_prompt_onnx,
+)
+from monopriors.models.relative_depth.zipdepth import download_zipdepth_checkpoint
+from torch import Tensor, nn
+
+from zipdepth.apis import prompted_trt
+
+ExportInputs: TypeAlias = tuple[Float32[Tensor, "b 3 h w"], Float32[Tensor, "b 1 192 256"]]
+
+
+@dataclass(frozen=True, slots=True)
+class _ExportCall:
+    """Typed ONNX export call captured by the test boundary."""
+
+    model: nn.Module
+    """Export wrapper module."""
+    inputs: ExportInputs
+    """Example tensors supplied to the exporter."""
+    out_path: Path
+    """Target ONNX path."""
+    input_names: list[str]
+    """Ordered ONNX input names."""
+    output_names: list[str]
+    """Ordered ONNX output names."""
+    dynamic_batch_max: int | None
+    """Dynamic batch limit, or None for a static graph."""
+
+
+class _FakePromptModel(nn.Module):
+    """Small model double exposing the prompted export contract."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(()))
+        self.fused = False
+
+    def fuse_for_inference(self) -> "_FakePromptModel":
+        self.fused = True
+        return self
+
+    def forward_with_range(
+        self,
+        image: Float32[Tensor, "b 3 h w"],
+        prompt_depth: Float32[Tensor, "b 1 192 256"],
+    ) -> tuple[Float32[Tensor, "b 1 h w"], Float32[Tensor, "b 1 1 1"], Float32[Tensor, "b 1 1 1"]]:
+        depth: Float32[Tensor, "b 1 h w"] = image[:, :1] * self.weight
+        return depth, prompt_depth.amin(dim=(1, 2, 3), keepdim=True), prompt_depth.amax(dim=(1, 2, 3), keepdim=True)
+
+
+def test_fake_model_satisfies_prompted_export_protocol() -> None:
+    """Keep exporter tests structural rather than coupled to ZipDepthPrompt."""
+    assert isinstance(_FakePromptModel(), PromptedDepthModel)
+
+
+def test_export_uses_two_inputs_with_export_dtype_and_static_batch_eight(tmp_path: Path) -> None:
+    checkpoint: Path = tmp_path / "zipdepth_base.pth"
+    checkpoint.write_bytes(b"released")
+    fake_model = _FakePromptModel()
+    calls: list[_ExportCall] = []
+
+    def fake_export(model: nn.Module, example_inputs: ExportInputs, out_path: Path, **kwargs: object) -> None:
+        input_names: object = kwargs.get("input_names")
+        output_names: object = kwargs.get("output_names")
+        dynamic_batch_max: object = kwargs.get("dynamic_batch_max")
+        if not isinstance(input_names, list) or not all(isinstance(name, str) for name in input_names):
+            raise AssertionError("export input_names must be a list of strings")
+        if not isinstance(output_names, list) or not all(isinstance(name, str) for name in output_names):
+            raise AssertionError("export output_names must be a list of strings")
+        if dynamic_batch_max is not None and not isinstance(dynamic_batch_max, int):
+            raise AssertionError("dynamic_batch_max must be an integer or None")
+        calls.append(
+            _ExportCall(
+                model=model,
+                inputs=example_inputs,
+                out_path=out_path,
+                input_names=[name for name in input_names if isinstance(name, str)],
+                output_names=[name for name in output_names if isinstance(name, str)],
+                dynamic_batch_max=dynamic_batch_max,
+            )
+        )
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_bytes(b"onnx")
+
+    onnx_path: Path = export_zipdepth_prompt_onnx(
+        checkpoint=checkpoint,
+        image_hw=(768, 1024),
+        batch_size=8,
+        cache_dir=tmp_path / "cache",
+        model_loader=lambda _checkpoint: fake_model,
+        export_fn=fake_export,
+        device="cpu",
+    )
+
+    call: _ExportCall = calls[0]
+    assert onnx_path == call.out_path
+    assert "768x1024_b8_fp16" in onnx_path.name
+    assert call.input_names == [IMAGE_INPUT_NAME, PROMPT_INPUT_NAME]
+    assert call.output_names == ["depth", "min_depth", "max_depth"]
+    assert call.dynamic_batch_max is None
+    assert [tuple(tensor.shape) for tensor in call.inputs] == [(8, 3, 768, 1024), (8, 1, 192, 256)]
+    assert all(tensor.dtype == torch.float32 for tensor in call.inputs)
+    assert fake_model.fused
+    assert fake_model.weight.dtype == torch.float16
+
+
+trt_parity = pytest.mark.skipif(
+    os.environ.get("ZIPDEPTH_TRT_PARITY") != "1" or not torch.cuda.is_available(),
+    reason="set ZIPDEPTH_TRT_PARITY=1 on a CUDA/TensorRT host",
+)
+
+
+@trt_parity
+def test_holey_and_narrow_prompt_torch_onnx_trt_parity() -> None:
+    """Compare the real fp16 graph across Torch, ONNX Runtime, and TensorRT."""
+    from trtkit import TensorRtRuntime, TrtBuildConfig, ensure_engine, onnx_static_batch_size
+
+    batch_size: int = 8
+    cache_dir: Path = Path(os.environ.get("ZIPDEPTH_PROMPT_TRT_CACHE", "/tmp/zd-pda-research/trt"))
+    checkpoint: Path = download_zipdepth_checkpoint()
+    onnx_path: Path = export_zipdepth_prompt_onnx(checkpoint=checkpoint, batch_size=batch_size, cache_dir=cache_dir)
+    assert onnx_static_batch_size(onnx_path) == batch_size
+    engine_path: Path = ensure_engine(
+        onnx_path,
+        TrtBuildConfig(max_batch_size=batch_size, opt_batch_size=batch_size),
+        cache_dir=cache_dir / "engines",
+    )
+    assert engine_path.is_file()
+
+    inputs: prompted_trt.ParityInputs = prompted_trt._parity_inputs(batch_size, (768, 1024), torch.device("cuda"))
+    parity: prompted_trt.TrtParityReport = prompted_trt.verify_three_backend_parity(
+        checkpoint,
+        onnx_path,
+        (768, 1024),
+        inputs,
+        TensorRtRuntime(engine_path),
+    )
+    summaries: tuple[prompted_trt.ParityError, ...] = (
+        parity.holey.onnx_vs_torch,
+        parity.holey.trt_vs_torch,
+        parity.narrow.onnx_vs_torch,
+        parity.narrow.trt_vs_torch,
+    )
+    assert max(summary.median_abs_m for summary in summaries) < 0.003
+    assert max(summary.max_abs_m for summary in summaries) < 0.02

--- a/packages/zipdepth/tools/export_prompted_trt.py
+++ b/packages/zipdepth/tools/export_prompted_trt.py
@@ -1,0 +1,8 @@
+"""Tyro shim for static-batch ZipDepth-PromptDA TensorRT export."""
+
+import tyro
+
+from zipdepth.apis.prompted_trt import TrtExportConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(TrtExportConfig))

--- a/packages/zipdepth/zipdepth/apis/prompted_trt.py
+++ b/packages/zipdepth/zipdepth/apis/prompted_trt.py
@@ -1,0 +1,314 @@
+"""Static-batch fp16 ONNX/TensorRT export for ZipDepth-PromptDA."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypeAlias
+
+import numpy as np
+import torch
+from jaxtyping import Float32
+from monopriors.models.depth_completion.base_completion_depth import PROMPT_DEPTH_HW
+from monopriors.models.depth_completion.zipdepth_prompt import load_zipdepth_prompt
+from monopriors.models.depth_completion.zipdepth_prompt_export import (
+    DEFAULT_CACHE_DIR,
+    DEPTH_OUTPUT_NAME,
+    IMAGE_INPUT_NAME,
+    PROMPT_INPUT_NAME,
+    PromptedDepthModel,
+    export_zipdepth_prompt_onnx,
+    prepare_zipdepth_prompt_for_export,
+)
+from monopriors.models.relative_depth.zipdepth import download_zipdepth_checkpoint
+from serde import serde
+from serde.json import to_json
+from torch import Tensor
+from trtkit import TensorRuntime
+
+ParityInputs: TypeAlias = dict[
+    str,
+    Float32[Tensor, "b 3 h w"] | Float32[Tensor, "b 1 192 256"],
+]
+
+
+@dataclass(frozen=True, slots=True)
+class TrtExportConfig:
+    """Export, parity-check, and benchmark configuration."""
+
+    checkpoint: Path | None = None
+    """Prompted trainer checkpoint; None uses released ZipDepth-base with a zero branch."""
+    cache_dir: Path = DEFAULT_CACHE_DIR
+    """Portable ONNX, machine-local engine, and result cache root."""
+    height: int = 768
+    """Static image height."""
+    width: int = 1024
+    """Static image width."""
+    batch_size: int = 8
+    """Batch baked into both ONNX and TensorRT artifacts."""
+    warmup: int = 10
+    """Unmeasured TensorRT calls before timing."""
+    iterations: int = 50
+    """Measured TensorRT calls."""
+    result_path: Path = Path("/tmp/zd-pda-research/trt-parity-latency.json")
+    """JSON report containing artifact paths, parity errors, and CUDA-event latency."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class TrtReportConfig:
+    """Resolved TensorRT report configuration."""
+
+    checkpoint: Path
+    """Checkpoint used for the export and parity run."""
+    cache_dir: Path
+    """Portable ONNX and engine cache root."""
+    height: int
+    """Static image height."""
+    width: int
+    """Static image width."""
+    batch_size: int
+    """Static export and engine batch size."""
+    warmup: int
+    """Unmeasured TensorRT calls before timing."""
+    iterations: int
+    """Measured TensorRT calls."""
+    result_path: Path
+    """Written report path."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class ParityError:
+    """Absolute metric-depth error for one backend comparison."""
+
+    median_abs_m: float
+    """Median absolute error in metres."""
+    max_abs_m: float
+    """Maximum absolute error in metres."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class BackendParity:
+    """ONNX and TensorRT errors relative to Torch for one prompt case."""
+
+    onnx_vs_torch: ParityError
+    """ONNX Runtime error relative to Torch."""
+    trt_vs_torch: ParityError
+    """TensorRT error relative to Torch."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class TrtParityReport:
+    """Backend parity for the wide/holey and narrow prompt cases."""
+
+    holey: BackendParity
+    """Parity for prompts with invalid holes and a wide metric range."""
+    narrow: BackendParity
+    """Parity for prompts with a narrow metric range."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class TrtLatency:
+    """CUDA-event TensorRT latency measurements."""
+
+    batch_size: int
+    """Frames processed per engine call."""
+    warmup: int
+    """Unmeasured engine calls."""
+    iterations: int
+    """Measured engine calls."""
+    median_ms_per_batch: float
+    """Median milliseconds per engine call."""
+    p95_ms_per_batch: float
+    """95th-percentile milliseconds per engine call."""
+    median_ms_per_frame: float
+    """Median amortized milliseconds per frame."""
+    frames_per_second: float
+    """Median aggregate throughput."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class TrtReport:
+    """TensorRT artifacts, parity results, and latency report."""
+
+    config: TrtReportConfig
+    """Resolved run configuration."""
+    onnx_path: Path
+    """Exported ONNX graph path."""
+    engine_path: Path
+    """Built TensorRT engine path."""
+    static_batch: int
+    """Batch dimension found in the ONNX graph."""
+    parity: TrtParityReport
+    """Torch, ONNX Runtime, and TensorRT parity results."""
+    latency: TrtLatency
+    """TensorRT CUDA-event latency results."""
+    gpu: str
+    """CUDA device name used for the run."""
+
+
+def _parity_inputs(batch_size: int, image_hw: tuple[int, int], device: torch.device) -> ParityInputs:
+    """Create deterministic image plus alternating holey/narrow prompts."""
+    generator: torch.Generator = torch.Generator(device=device).manual_seed(7)
+    image: Float32[Tensor, "b 3 h w"] = torch.rand((batch_size, 3, *image_hw), generator=generator, dtype=torch.float32, device=device)
+    prompt_pixels: int = PROMPT_DEPTH_HW[0] * PROMPT_DEPTH_HW[1]
+    wide: Float32[Tensor, "1 1 192 256"] = torch.linspace(
+        0.2, 3.8, prompt_pixels, dtype=torch.float32, device=device
+    ).reshape(1, 1, *PROMPT_DEPTH_HW)
+    wide[:, :, 24:160:3, 32:224:4] = 0.0
+    narrow: Float32[Tensor, "1 1 192 256"] = torch.linspace(
+        1.500, 1.503, prompt_pixels, dtype=torch.float32, device=device
+    ).reshape(1, 1, *PROMPT_DEPTH_HW)
+    prompt_rows: list[Float32[Tensor, "1 1 192 256"]] = [wide if index % 2 == 0 else narrow for index in range(batch_size)]
+    return {IMAGE_INPUT_NAME: image, PROMPT_INPUT_NAME: torch.cat(prompt_rows, dim=0).contiguous()}
+
+
+def _error_summary(
+    actual: Float32[Tensor, "b 1 h w"],
+    expected: Float32[Tensor, "b 1 h w"],
+    rows: slice,
+) -> ParityError:
+    """Summarize absolute metric-depth parity error for selected rows."""
+    error: Float32[Tensor, "selected 1 h w"] = (actual[rows] - expected[rows]).abs()
+    return ParityError(median_abs_m=float(error.median()), max_abs_m=float(error.max()))
+
+
+def verify_three_backend_parity(
+    checkpoint: Path,
+    onnx_path: Path,
+    image_hw: tuple[int, int],
+    inputs: ParityInputs,
+    trt_runtime: TensorRuntime,
+) -> TrtParityReport:
+    """Measure Torch-vs-ONNX-vs-TRT error for holey and narrow prompts."""
+    from trtkit import OnnxCudaRuntime
+
+    device = torch.device("cuda")
+    model: PromptedDepthModel = prepare_zipdepth_prompt_for_export(load_zipdepth_prompt(checkpoint), image_hw, device)
+    with torch.inference_mode():
+        expected: Float32[Tensor, "b 1 h w"] = model(inputs[IMAGE_INPUT_NAME], inputs[PROMPT_INPUT_NAME]).clone()
+    onnx_depth: Float32[Tensor, "b 1 h w"] = OnnxCudaRuntime(onnx_path)(inputs)[DEPTH_OUTPUT_NAME].clone()
+    trt_depth: Float32[Tensor, "b 1 h w"] = trt_runtime(inputs)[DEPTH_OUTPUT_NAME].clone()
+    result: TrtParityReport = TrtParityReport(
+        holey=BackendParity(
+            onnx_vs_torch=_error_summary(onnx_depth, expected, slice(0, None, 2)),
+            trt_vs_torch=_error_summary(trt_depth, expected, slice(0, None, 2)),
+        ),
+        narrow=BackendParity(
+            onnx_vs_torch=_error_summary(onnx_depth, expected, slice(1, None, 2)),
+            trt_vs_torch=_error_summary(trt_depth, expected, slice(1, None, 2)),
+        ),
+    )
+    del model
+    torch.cuda.empty_cache()
+    return result
+
+
+def benchmark_tensorrt(
+    runtime: TensorRuntime,
+    inputs: ParityInputs,
+    warmup: int,
+    iterations: int,
+) -> TrtLatency:
+    """Measure engine-call latency with CUDA events, including input copies."""
+    if warmup < 0 or iterations <= 0:
+        raise ValueError("warmup must be nonnegative and iterations must be positive")
+    batch_size: int = int(inputs[IMAGE_INPUT_NAME].shape[0])
+    for _ in range(warmup):
+        runtime(inputs)
+    torch.cuda.synchronize()
+    elapsed_ms: list[float] = []
+    for _ in range(iterations):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        runtime(inputs)
+        end.record()
+        end.synchronize()
+        elapsed_ms.append(float(start.elapsed_time(end)))
+    median_ms: float = float(np.median(elapsed_ms))
+    return TrtLatency(
+        batch_size=batch_size,
+        warmup=warmup,
+        iterations=iterations,
+        median_ms_per_batch=median_ms,
+        p95_ms_per_batch=float(np.percentile(elapsed_ms, 95)),
+        median_ms_per_frame=median_ms / batch_size,
+        frames_per_second=1000.0 * batch_size / median_ms,
+    )
+
+
+def main(config: TrtExportConfig) -> Path:
+    """Export, build, verify parity, benchmark, and write a JSON report."""
+    if not torch.cuda.is_available():
+        raise RuntimeError("ZipDepth TensorRT export requires CUDA")
+    checkpoint: Path = config.checkpoint or download_zipdepth_checkpoint()
+    image_hw: tuple[int, int] = (config.height, config.width)
+    onnx_path: Path = export_zipdepth_prompt_onnx(
+        checkpoint=checkpoint,
+        image_hw=image_hw,
+        batch_size=config.batch_size,
+        cache_dir=config.cache_dir,
+    )
+    from trtkit import TensorRtRuntime, TrtBuildConfig, ensure_engine, onnx_static_batch_size
+
+    static_batch: int | None = onnx_static_batch_size(onnx_path)
+    if static_batch is None or static_batch != config.batch_size:
+        raise RuntimeError(f"ONNX batch must be static {config.batch_size}, got {static_batch}")
+    engine_path: Path = ensure_engine(
+        onnx_path,
+        TrtBuildConfig(max_batch_size=config.batch_size, opt_batch_size=config.batch_size),
+        cache_dir=config.cache_dir / "engines",
+    )
+    inputs: ParityInputs = _parity_inputs(config.batch_size, image_hw, torch.device("cuda"))
+    trt_runtime: TensorRuntime = TensorRtRuntime(engine_path)
+    parity: TrtParityReport = verify_three_backend_parity(
+        checkpoint,
+        onnx_path,
+        image_hw,
+        inputs,
+        trt_runtime,
+    )
+    parity_cases: tuple[tuple[str, BackendParity], ...] = (("holey", parity.holey), ("narrow", parity.narrow))
+    for case_name, backends in parity_cases:
+        backend_errors: tuple[tuple[str, ParityError], ...] = (
+            ("onnx_vs_torch", backends.onnx_vs_torch),
+            ("trt_vs_torch", backends.trt_vs_torch),
+        )
+        for backend_name, errors in backend_errors:
+            if errors.median_abs_m >= 0.003 or errors.max_abs_m >= 0.02:
+                raise RuntimeError(f"parity failed for {backend_name}:{case_name}: {errors}")
+    latency: TrtLatency = benchmark_tensorrt(
+        trt_runtime,
+        inputs,
+        config.warmup,
+        config.iterations,
+    )
+    report: TrtReport = TrtReport(
+        config=TrtReportConfig(
+            checkpoint=checkpoint,
+            cache_dir=config.cache_dir,
+            height=config.height,
+            width=config.width,
+            batch_size=config.batch_size,
+            warmup=config.warmup,
+            iterations=config.iterations,
+            result_path=config.result_path,
+        ),
+        onnx_path=onnx_path,
+        engine_path=engine_path,
+        static_batch=static_batch,
+        parity=parity,
+        latency=latency,
+        gpu=torch.cuda.get_device_name(),
+    )
+    report_json: str = to_json(report)
+    config.result_path.parent.mkdir(parents=True, exist_ok=True)
+    config.result_path.write_text(report_json + "\n", encoding="utf-8")
+    print(report_json)
+    return config.result_path

--- a/pixi.lock
+++ b/pixi.lock
@@ -45097,6 +45097,7 @@ environments:
       - pypi: ./packages/monoprior
       - pypi: ./packages/sam3
       - pypi: ./packages/simplecv
+      - pypi: ./packages/trtkit
       - pypi: ./packages/zipdepth
       - pypi: https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/e8/5c880ffd8d4bb9df4cdf75ab8b44fc8f7011b6cb629b3e6242f3d5944b4f/stringzilla-5.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -45668,6 +45669,7 @@ environments:
       - pypi: ./packages/monoprior
       - pypi: ./packages/sam3
       - pypi: ./packages/simplecv
+      - pypi: ./packages/trtkit
       - pypi: ./packages/zipdepth
       - pypi: https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/07/42/a687e7091928806e514f89fa2666f25ec9bfe0a902fc4402b25e51ce408b/nh3-0.3.7-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
@@ -46261,6 +46263,7 @@ environments:
       - pypi: ./packages/monoprior
       - pypi: ./packages/sam3
       - pypi: ./packages/simplecv
+      - pypi: ./packages/trtkit
       - pypi: ./packages/zipdepth
       - pypi: https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/e8/5c880ffd8d4bb9df4cdf75ab8b44fc8f7011b6cb629b3e6242f3d5944b4f/stringzilla-5.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -46841,6 +46844,7 @@ environments:
       - pypi: ./packages/monoprior
       - pypi: ./packages/sam3
       - pypi: ./packages/simplecv
+      - pypi: ./packages/trtkit
       - pypi: ./packages/zipdepth
       - pypi: https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/07/42/a687e7091928806e514f89fa2666f25ec9bfe0a902fc4402b25e51ce408b/nh3-0.3.7-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl

--- a/pixi.toml
+++ b/pixi.toml
@@ -646,6 +646,7 @@ libjpeg-turbo = ">=3.0.0,<4"
 [feature.zipdepth.pypi-dependencies]
 zipdepth = { path = "packages/zipdepth", editable = true }
 monopriors = { path = "packages/monoprior", editable = true }
+trtkit = { path = "packages/trtkit", editable = true }
 # monopriors' metadata requires sam3; resolve it to the workspace package like the other monopriors consumers
 sam3 = { path = "packages/sam3", editable = true }
 # albucore -> simsimd has no conda-forge linux-aarch64 build
@@ -667,6 +668,11 @@ cmd = "python tools/train_smoke.py"
 cwd = "packages/zipdepth"
 description = "Smoke: self-distilled example data -> train -> resume -> torchrun -> checkpoints load through monopriors ZipDepthPredictor"
 
+[feature.zipdepth.tasks.zipdepth-export-prompted-trt]
+cmd = "python tools/export_prompted_trt.py"
+cwd = "packages/zipdepth"
+description = "Export, build, parity-check, and benchmark static-batch fp16 ZipDepth-PromptDA ONNX/TensorRT"
+# linux-64 only: NVDEC decode via torchcodec, mirroring prompt-da-stream.
 
 # ═══════════════════════════════════════════════════════════════════════════
 # wilor-nano


### PR DESCRIPTION
Stack **4/9** — the ZipDepth-PromptDA work re-cut into one focused stack (replaces #132 #133 #134 #129 #164 #165 #166 #167 #172 #173 #174 #175 #177; #131 is already merged). Review bottom-up.

| # | PR | what | lines (no lock) |
|---|---|---|---:|
| 1 | #186 | workspace rerun-sdk 0.37.0 (pins + API ports) — lock | +533/−317 |
| 2 | #187 | simplecv depth/mesh helpers; PromptDA teacher batch tool on the GPU + malloc_trim; catalog-server rules | +196/−74 |
| 3 | #188 | monoprior config-first depth-completion zoo (PromptDA torch/onnx/trt) — refactor only | +752/−565 |
| 4 | #189 | **ZipDepth-PromptDA model** + static-batch TensorRT export — lock (+trtkit) | +1132/−11 |
| 5 | #190 | zipdepth-catalog lane: streaming dataset, CUDA builders, holdout eval — lock (+2 envs) | +3176/−25 |
| 6 | #191 | catalog fine-tune trainer + live smoke gate + IO instrumentation | +1576/−27 |
| 7 | #192 | hard-frame mining, fixed hard-20 scorer, Polycam three-way comparison | +1727/−14 |
| 8 | #203 | training-speed knobs + named presets for the wall-clock hill-climb | +670/−76 |
| 9 | #204 | idiomatic Rerun 0.37 dataloader as executable reference (`--dataloader rerun`), catalog-query audit | +1027/−54 |

Whole stack vs main: 108 files, +8486/−995. The old chain was 13 open PRs (+10.4k lines) plus 11 unpushed commits; the head-variant experiments and the default-off loss knobs were dropped (negative results, see the [project report](https://pablos-4800gt.ilish-ruler.ts.net:8768/zipdepth/zipdepth-promptda-final-report.html)), and every slice went through a four-lens simplify pass before cutting. Review-pass changes (2026-09-03) are folded into the same PRs: zero `Any` on added lines, jaxtyping dtype+shape on every added array annotation, no dtype/shape in new identifiers, shared metre→mm quantiser, `upsample_depth_to_image`, condensed AGENTS section, stale einops suppressions dropped in touched files.

## ZipDepth-PromptDA: prompted metric depth distilled from PromptDA, with static-batch TensorRT export
**What** `ZipDepthPrompt` wraps the vendored ZipDepth-base network (untouched) with what PromptDA does, at ZipDepth's budget: per-image prompt normalisation, four zero-initialised prompt adapters (Conv3×3 → ReLU → depthwise 3×3 → ReLU → 1×1, one `_inject_prompt` helper at decoder stages f4..f1), and a sigmoid head denormalised by the prompt's depth range so metric scale comes from the LiDAR prompt, not RGB. 6.95 M parameters. It joins the registry as `zipdepth-promptda` (torch | onnx | tensorrt); `load_zipdepth_prompt` fills the wrapper from the released ZipDepth weights or a fine-tuned checkpoint through the shared `zipdepth_checkpoint` decoder.
`zipdepth-export-prompted-trt` exports a static-batch fp16 ONNX/TensorRT engine, checks torch/onnx/trt parity on holey and narrow prompts (worst max error 1.8 mm holey, 0.0015 mm narrow; medians 0), and benchmarks it: **0.73 ms/frame** at 768×1024, batch 8, RTX 5090 (PromptDA-L TensorRT: 18.5 ms). The trtkit README records why the batch is static: TensorRT 10.16–11.2 fails with `CHECK(is_const())` on any reshape that depends on a dynamic batch symbol (ZipDepth's convex-upsampling `unfold`).
**Lock** the zipdepth feature gains the editable trtkit dependency (zipdepth / zipdepth-dev envs: +1 package). **Behaviour** the production v4 checkpoint's outputs are bit-exact through the wrapper refactor (`torch.equal` on a seeded 768×1024 batch).
**Review focus** `zipdepth_prompt.py` forward and `load_zipdepth_prompt`; `zipdepth_prompt_export.py` outputs.
**Gates** monoprior-dev 80 passed + deadcode; zipdepth-dev 8 passed + deadcode (the real TRT parity test also passed when enabled).
