### PR TITLE
zipdepth: catalog fine-tune trainer, live smoke gate, IO instrumentation (stack 6/7)

### DIFF
--- a/packages/zipdepth/tests/test_catalog_instrument.py
+++ b/packages/zipdepth/tests/test_catalog_instrument.py
@@ -1,0 +1,174 @@
+"""Behavioral tests for catalog loader instrumentation."""
+
+from collections.abc import Iterator
+from dataclasses import replace
+from pathlib import Path
+from time import sleep
+
+import pytest
+import torch
+from torch.utils.data import DataLoader, IterableDataset
+from torch.utils.tensorboard import SummaryWriter
+
+from zipdepth.catalog.instrument import InstrumentedDataset, InstrumentedLoader
+from zipdepth.catalog.stats import CatalogDatasetStats
+
+
+class _FakeDataset(IterableDataset[dict[str, torch.Tensor]]):
+    """Small iterable with the catalog dataset's public control surface."""
+
+    def __init__(self) -> None:
+        self._stats: CatalogDatasetStats = CatalogDatasetStats()
+        self.stats_reads: int = 0
+        self.epochs: list[int] = []
+
+    @property
+    def stats(self) -> CatalogDatasetStats:
+        """Return the cumulative stats and count snapshot reads."""
+        self.stats_reads += 1
+        return replace(self._stats)
+
+    def set_epoch(self, epoch: int) -> None:
+        """Record the forwarded epoch."""
+        self.epochs.append(epoch)
+
+    def __iter__(self) -> Iterator[dict[str, torch.Tensor]]:
+        """Yield two one-frame batches."""
+        for value in range(2):
+            yield {"image": torch.tensor([value])}
+
+
+def test_fake_dataset_satisfies_instrumentation_protocol() -> None:
+    """Keep loader instrumentation structural and usable with lightweight datasets."""
+    assert isinstance(_FakeDataset(), InstrumentedDataset)
+
+
+def test_fixed_schedule_cycles_over_reshuffled_dataset_passes() -> None:
+    """Expose the exact run length and reseed every finite dataset pass."""
+    dataset: _FakeDataset = _FakeDataset()
+    loader: DataLoader[dict[str, torch.Tensor]] = DataLoader(dataset, batch_size=1, num_workers=0)
+    instrumented: InstrumentedLoader = InstrumentedLoader(dataset, loader, steps_per_epoch=5, writer=None)
+
+    values: list[int] = [int(batch["image"].item()) for batch in instrumented]
+
+    assert len(instrumented) == 5
+    assert values == [0, 1, 0, 1, 0]
+    assert dataset.epochs == [0, 1, 2]
+    assert instrumented.sampler is None  # compatibility attribute for the vendored trainer probe; there is no set_epoch to call
+
+
+class _RecordingWriter(SummaryWriter):
+    """SummaryWriter that keeps scalar calls visible to tests."""
+
+    def __init__(self, log_dir: Path) -> None:
+        super().__init__(log_dir=str(log_dir))
+        self.scalars: dict[str, list[tuple[float, int]]] = {}
+
+    def add_scalar(
+        self,
+        tag: str,
+        scalar_value: float,
+        global_step: int | None = None,
+        walltime: float | None = None,
+        new_style: bool = False,
+        double_precision: bool = False,
+    ) -> None:
+        """Record one scalar without writing it to an event file."""
+        del walltime, new_style, double_precision
+        self.scalars.setdefault(tag, []).append((float(scalar_value), int(global_step or 0)))
+
+
+class _DelayedDataset(_FakeDataset):
+    """Yield delayed values while updating catalog-like counters."""
+
+    def __init__(self, values: list[int], delay_s: float = 0.0) -> None:
+        super().__init__()
+        self._values: list[int] = values
+        self._delay_s: float = delay_s
+
+    def __iter__(self) -> Iterator[dict[str, torch.Tensor]]:
+        """Yield in order, updating catalog-like cumulative stage counters."""
+        value: int
+        for value in self._values:
+            sleep(self._delay_s)
+            self._stats.blob_decode += 0.002
+            self._stats.samples_built += 1
+            yield {"image": torch.tensor([[value]])}
+
+
+def test_data_wait_and_compute_are_attributed_separately(tmp_path: Path) -> None:
+    """Measure blocking ``next`` time apart from work done by the consumer."""
+    dataset: _DelayedDataset = _DelayedDataset([0, 1], delay_s=0.015)
+    loader: DataLoader[dict[str, torch.Tensor]] = DataLoader(dataset, batch_size=None, num_workers=0)
+    writer: _RecordingWriter = _RecordingWriter(tmp_path)
+    instrumented: InstrumentedLoader = InstrumentedLoader(
+        dataset,
+        loader,
+        steps_per_epoch=2,
+        writer=writer,
+        log_every=2,
+    )
+
+    iterator: Iterator[dict[str, torch.Tensor]] = iter(instrumented)
+    next(iterator)
+    sleep(0.025)
+    next(iterator)
+
+    data_wait_ms: float = writer.scalars["io/data_wait_ms"][-1][0]
+    compute_ms: float = writer.scalars["io/compute_ms"][-1][0]
+    blob_decode_ms: float = writer.scalars["io/blob_decode_ms"][-1][0]
+    assert data_wait_ms == pytest.approx(15.0, abs=10.0)
+    assert compute_ms == pytest.approx(25.0, abs=10.0)
+    assert blob_decode_ms == pytest.approx(2.0, abs=0.2)
+    assert writer.scalars["io/frames_per_s"][-1][0] > 0.0
+    assert dataset.stats_reads == 2  # constructor baseline plus one report snapshot
+
+
+def test_compute_time_is_not_counted_twice_at_a_pass_boundary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Account consumer work once when the next finite dataset pass starts."""
+    times: Iterator[float] = iter([0.0, 0.0, 0.0, 10.0, 11.0, 11.0, 12.0, 12.0, 12.0, 13.0])
+    monkeypatch.setattr("zipdepth.catalog.instrument.perf_counter", lambda: next(times))
+    dataset: _DelayedDataset = _DelayedDataset([0])
+    loader: DataLoader[dict[str, torch.Tensor]] = DataLoader(dataset, batch_size=None, num_workers=0)
+    writer: _RecordingWriter = _RecordingWriter(tmp_path)
+    instrumented: InstrumentedLoader = InstrumentedLoader(dataset, loader, steps_per_epoch=2, writer=writer, log_every=2)
+
+    list(instrumented)
+
+    assert writer.scalars["io/compute_ms"] == [(1000.0, 2)]
+
+
+def test_gpu_utilization_failure_warns_once_and_disables_probe(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Do not retry a GPU utilization backend that raised an exception."""
+    probe_calls: int = 0
+
+    def fail_probe() -> int:
+        nonlocal probe_calls
+        probe_calls += 1
+        raise RuntimeError("NVML unavailable")
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "utilization", fail_probe)
+    dataset: _DelayedDataset = _DelayedDataset([0, 1])
+    loader: DataLoader[dict[str, torch.Tensor]] = DataLoader(dataset, batch_size=None, num_workers=0)
+    writer: _RecordingWriter = _RecordingWriter(tmp_path)
+    instrumented: InstrumentedLoader = InstrumentedLoader(dataset, loader, steps_per_epoch=2, writer=writer, log_every=1)
+
+    with pytest.warns(RuntimeWarning, match="NVML unavailable"):
+        list(instrumented)
+
+    assert probe_calls == 1
+
+
+def test_logging_global_step_starts_after_restored_training_step(tmp_path: Path) -> None:
+    """Keep resumed TensorBoard steps monotonic when the trainer recreates the iterator."""
+    dataset: _DelayedDataset = _DelayedDataset([0])
+    loader: DataLoader[dict[str, torch.Tensor]] = DataLoader(dataset, batch_size=None, num_workers=0)
+    writer: _RecordingWriter = _RecordingWriter(tmp_path)
+    instrumented: InstrumentedLoader = InstrumentedLoader(dataset, loader, steps_per_epoch=1, writer=writer, log_every=1)
+    instrumented.set_global_step(40)
+
+    list(instrumented)
+    list(instrumented)
+
+    assert [step for _, step in writer.scalars["io/data_wait_ms"]] == [41, 42]

--- a/packages/zipdepth/tests/test_catalog_train.py
+++ b/packages/zipdepth/tests/test_catalog_train.py
@@ -1,0 +1,179 @@
+"""Pure policy tests for catalog fine-tuning."""
+
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn, optim
+from torch.utils.data import DataLoader, TensorDataset
+from tqdm import tqdm
+
+from zipdepth.apis.train_catalog import TrainCatalogConfig, _load_json_config, resolve_max_lr
+from zipdepth.catalog.segments import split_holdout_segments
+from zipdepth.loss import MetricDepthLoss, ZipDepthLoss
+from zipdepth.training.trainer import ZipDepthTrainer
+
+
+def test_upstream_train_config_loads_shipped_values_and_fallbacks(tmp_path: Path) -> None:
+    """Ignore unused upstream keys while preserving every catalog-training fallback."""
+    shipped = _load_json_config(Path("configs/default.json"))
+
+    assert shipped.optimizer.lr == 1e-3
+    assert shipped.optimizer.weight_decay == 0.05
+    assert shipped.scheduler.pct_start == 0.05
+    assert shipped.loss.alpha_grad == 2.0
+    assert shipped.amp.dtype == "bfloat16"
+    assert shipped.model.upsample_unfold is True
+    assert shipped.training.max_step_checkpoints == 5
+
+    minimal_path: Path = tmp_path / "minimal.json"
+    minimal_path.write_text("{}")
+    minimal = _load_json_config(minimal_path)
+
+    assert minimal.optimizer.lr == 1e-3
+    assert minimal.optimizer.weight_decay == 0.01
+    assert minimal.scheduler.div_factor == 25.0
+    assert minimal.scheduler.final_div_factor == 1000.0
+    assert minimal.loss.alpha_ssi == 1.0
+    assert minimal.amp.enabled is True
+    assert minimal.model.upsample_unfold is True
+    assert minimal.training.max_step_checkpoints == 5
+
+
+def test_catalog_training_defaults_to_parallel_segment_producers() -> None:
+    """Keep enough catalog producers and bounded sample prefetch for GPU training."""
+    config: TrainCatalogConfig = TrainCatalogConfig()
+
+    assert config.shuffle_buffer_size == 256
+    assert config.num_producers == 6
+    assert config.prefetch_samples == 256
+    assert not hasattr(config, "prefetch")
+    assert not hasattr(config, "gpu_augment")
+
+
+def test_catalog_training_defaults_to_metric_with_an_explicit_ssi_lane() -> None:
+    """Make prompted metric distillation the default without removing relative training."""
+    assert TrainCatalogConfig().target_mode == "metric"
+    assert TrainCatalogConfig(target_mode="ssi").target_mode == "ssi"
+
+
+def test_catalog_training_exposes_only_the_fixed_metric_loss_weight() -> None:
+    """Keep the fixed metric objective free of default-off tuning knobs."""
+    config: TrainCatalogConfig = TrainCatalogConfig()
+
+    assert config.metric_gradient_weight == 0.5
+    assert not hasattr(config, "metric_grad_scale_weights")
+    assert not hasattr(config, "metric_grad_max_depth_m")
+    assert not hasattr(config, "metric_grad_pool_mask_threshold")
+    assert not hasattr(config, "metric_edge_weight_alpha")
+
+
+def test_trainer_selects_the_objective_without_mixing_ssi_into_metric() -> None:
+    """Use the fixed metric criterion only for the prompted lane."""
+    model: nn.Linear = nn.Linear(1, 1)
+    optimizer: optim.SGD = optim.SGD(model.parameters(), lr=0.1)
+
+    ssi_trainer: ZipDepthTrainer = ZipDepthTrainer(model, [], optimizer, None, "cpu", use_amp=False, target_mode="ssi")
+    metric_trainer: ZipDepthTrainer = ZipDepthTrainer(model, [], optimizer, None, "cpu", use_amp=False, target_mode="metric")
+
+    assert isinstance(ssi_trainer.criterion, ZipDepthLoss)
+    assert isinstance(metric_trainer.criterion, MetricDepthLoss)
+
+
+def test_catalog_training_uses_one_explicit_optimizer_step_schedule() -> None:
+    """Size the run directly without a fabricated epoch or frame-count model."""
+    config: TrainCatalogConfig = TrainCatalogConfig()
+
+    assert config.total_steps == 70_000
+    assert not hasattr(config, "epochs")
+    assert not hasattr(config, "max_steps")
+
+
+@pytest.mark.parametrize(("skip_batches", "expected_skip"), [(0, 0), (None, 3)])
+def test_trainer_accepts_an_explicit_resume_skip_override(skip_batches: int | None, expected_skip: int) -> None:
+    """Bypass decoded-batch replay for unordered streams without changing the upstream default."""
+    model: nn.Linear = nn.Linear(1, 1)
+    optimizer: optim.SGD = optim.SGD(model.parameters(), lr=0.1)
+    trainer: ZipDepthTrainer = ZipDepthTrainer(
+        student=model,
+        train_loader=[{"image": model.weight.detach()}] * 10,
+        optimizer=optimizer,
+        scheduler=None,
+        device="cpu",
+        use_amp=False,
+        is_distributed=True,
+        rank=1,
+    )
+    trainer.global_step = 3
+    observed_skips: list[int] = []
+
+    def fake_train_epoch(epoch: int, num_epochs: int, pbar: object, skip_batches: int = 0, max_steps: int = 0) -> float:
+        del epoch, num_epochs, pbar, max_steps
+        observed_skips.append(skip_batches)
+        trainer.global_step = 4
+        return 0.0
+
+    trainer.train_epoch = fake_train_epoch  # type: ignore[method-assign]
+
+    trainer.train(num_epochs=1, max_steps=4, skip_batches=skip_batches)
+
+    assert observed_skips == [expected_skip]
+
+
+def test_holdout_split_is_deterministic_disjoint_and_complete() -> None:
+    """Reserve one stable holdout without losing or duplicating segments."""
+    segment_ids: list[str] = [f"segment-{index}" for index in range(12)]
+
+    first: tuple[list[str], list[str]] = split_holdout_segments(segment_ids, holdout_count=4, seed=17)
+    second: tuple[list[str], list[str]] = split_holdout_segments(list(reversed(segment_ids)), holdout_count=4, seed=17)
+
+    train_ids: list[str] = first[0]
+    holdout_ids: list[str] = first[1]
+    assert first == second
+    assert set(train_ids).isdisjoint(holdout_ids)
+    assert set(train_ids) | set(holdout_ids) == set(segment_ids)
+    assert len(train_ids) + len(holdout_ids) == len(segment_ids)
+
+
+@pytest.mark.parametrize(
+    ("override", "from_scratch", "expected"),
+    [
+        (None, False, 1e-5),
+        (None, True, 1e-3),
+        (2e-5, False, 2e-5),
+        (2e-5, True, 2e-5),
+    ],
+)
+def test_max_lr_defaults_follow_initialization_policy(override: float | None, from_scratch: bool, expected: float) -> None:
+    """Use one hundredth of upstream LR for fine-tuning and full LR from scratch."""
+    actual: float = resolve_max_lr(config_lr=1e-3, override=override, from_scratch=from_scratch)
+
+    assert actual == pytest.approx(expected)
+
+
+def test_trainer_pins_wrapped_batchnorm_after_entering_train_mode() -> None:
+    """Freeze BatchNorm through a wrapper without replacing the model's train method."""
+    inner: nn.Sequential = nn.Sequential(nn.Linear(3, 3), nn.BatchNorm1d(3), nn.Sequential(nn.BatchNorm1d(3)))
+    wrapped: nn.Sequential = nn.Sequential(inner)
+    optimizer: optim.SGD = optim.SGD(wrapped.parameters(), lr=0.1)
+    trainer: ZipDepthTrainer = ZipDepthTrainer(
+        student=wrapped,
+        train_loader=DataLoader(TensorDataset(torch.empty(0)), batch_size=1),
+        optimizer=optimizer,
+        scheduler=None,
+        device="cpu",
+        use_amp=False,
+        pin_batchnorm_eval=True,
+    )
+    original_train = wrapped.train
+    batchnorms: list[nn.modules.batchnorm._BatchNorm] = [
+        module for module in wrapped.modules() if isinstance(module, nn.modules.batchnorm._BatchNorm)
+    ]
+
+    with tqdm(disable=True) as progress:
+        trainer.train_epoch(epoch=0, num_epochs=1, pbar=progress)
+
+    assert wrapped.train == original_train
+    assert wrapped.training is True
+    assert inner[0].training is True
+    assert all(not module.training for module in batchnorms)

--- a/packages/zipdepth/tests/test_metric_depth_loss.py
+++ b/packages/zipdepth/tests/test_metric_depth_loss.py
@@ -1,0 +1,67 @@
+"""Metric distillation-loss behavior tests, including legacy bit-parity at defaults."""
+
+import pytest
+import torch
+from jaxtyping import Bool, Float32
+from torch import Tensor
+
+from zipdepth.loss.depth_loss import ZipDepthLoss
+from zipdepth.loss.metric_depth_loss import MetricDepthLoss
+
+
+def test_metric_depth_loss_is_masked_l1_plus_half_gradient() -> None:
+    """Use metre-space errors directly, without SSI normalization."""
+    prediction_bchw: Float32[Tensor, "1 1 2 2"] = torch.tensor([[[[1.0, 2.0], [1.0, 2.0]]]])
+    target_bchw: Float32[Tensor, "1 1 2 2"] = torch.ones(1, 1, 2, 2)
+    valid_bchw: Bool[Tensor, "1 1 2 2"] = torch.ones(1, 1, 2, 2, dtype=torch.bool)
+    criterion: MetricDepthLoss = MetricDepthLoss(grad_scales=1)
+
+    loss: Float32[Tensor, ""]
+    parts: dict[str, Float32[Tensor, ""]]
+    loss, parts = criterion(prediction_bchw, target_bchw, valid_bchw)
+
+    assert float(loss) == pytest.approx(0.75)
+    assert {key: float(value) for key, value in parts.items()} == {"l1": pytest.approx(0.5), "grad": pytest.approx(0.5)}
+
+
+def test_metric_depth_loss_applies_teacher_range_and_explicit_mask() -> None:
+    """Supervise only explicit finite teacher pixels in the 0.1--4 m lane."""
+    prediction_bchw: Float32[Tensor, "1 1 1 5"] = torch.tensor([[[[2.0, 2.0, 2.0, 2.0, 2.0]]]])
+    target_bchw: Float32[Tensor, "1 1 1 5"] = torch.tensor([[[[0.0, 1.0, 3.0, 5.0, float("nan")]]]])
+    valid_bchw: Bool[Tensor, "1 1 1 5"] = torch.tensor([[[[True, True, False, True, True]]]])
+    criterion: MetricDepthLoss = MetricDepthLoss(grad_scales=1)
+
+    loss: Float32[Tensor, ""] = criterion(prediction_bchw, target_bchw, valid_bchw)[0]
+
+    assert float(loss) == pytest.approx(1.0)
+
+
+def _fixture() -> tuple[Float32[Tensor, "2 1 64 80"], Float32[Tensor, "2 1 64 80"], Bool[Tensor, "2 1 64 80"]]:
+    generator: torch.Generator = torch.Generator().manual_seed(0)
+    target: Float32[Tensor, "2 1 64 80"] = torch.rand((2, 1, 64, 80), generator=generator) * 6.0  # includes > 4 m values
+    target[:, :, :4, :4] = 0.0  # invalid teacher pixels
+    pred: Float32[Tensor, "2 1 64 80"] = target + 0.05 * torch.randn((2, 1, 64, 80), generator=generator)
+    mask: Bool[Tensor, "2 1 64 80"] = torch.ones_like(target, dtype=torch.bool)
+    return pred, target, mask
+
+
+def test_defaults_match_legacy_objective() -> None:
+    fixture: tuple[Float32[Tensor, "2 1 64 80"], Float32[Tensor, "2 1 64 80"], Bool[Tensor, "2 1 64 80"]] = _fixture()
+    pred: Float32[Tensor, "2 1 64 80"] = fixture[0]
+    target: Float32[Tensor, "2 1 64 80"] = fixture[1]
+    mask: Bool[Tensor, "2 1 64 80"] = fixture[2]
+    total: Float32[Tensor, ""]
+    parts: dict[str, Float32[Tensor, ""]]
+    total, parts = MetricDepthLoss(gradient_weight=0.5)(pred=pred, target=target, mask=mask)
+
+    legacy: ZipDepthLoss = ZipDepthLoss(alpha_ssi=0.0, alpha_grad=1.0, grad_scales=4)
+    valid: Bool[Tensor, "2 1 64 80"] = torch.isfinite(target) & (target >= 0.1) & (target <= 4.0) & mask
+    safe_pred: Float32[Tensor, "2 1 64 80"] = torch.where(valid, pred, torch.zeros_like(pred))
+    safe_target: Float32[Tensor, "2 1 64 80"] = torch.where(valid, target, torch.zeros_like(target))
+    weights: Float32[Tensor, "2 1 64 80"] = valid.to(pred.dtype)
+    expected_l1: Float32[Tensor, ""] = legacy._ssi_loss(safe_pred, safe_target, weights)
+    expected_grad: Float32[Tensor, ""] | float = legacy._gradient_loss(safe_pred, safe_target, weights)
+    assert isinstance(expected_grad, Tensor)
+    assert torch.equal(parts["l1"], expected_l1)
+    assert torch.equal(parts["grad"], expected_grad)
+    assert torch.equal(total, expected_l1 + 0.5 * expected_grad)

--- a/packages/zipdepth/tools/train_catalog.py
+++ b/packages/zipdepth/tools/train_catalog.py
@@ -1,0 +1,8 @@
+"""Tyro shim for catalog ZipDepth fine-tuning."""
+
+import tyro
+
+from zipdepth.apis.train_catalog import TrainCatalogConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(TrainCatalogConfig))

--- a/packages/zipdepth/tools/train_catalog_smoke.py
+++ b/packages/zipdepth/tools/train_catalog_smoke.py
@@ -1,0 +1,8 @@
+"""Tyro shim for the live catalog training smoke gate."""
+
+import tyro
+
+from zipdepth.apis.train_catalog_smoke import TrainCatalogSmokeConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(TrainCatalogSmokeConfig))

--- a/packages/zipdepth/zipdepth/apis/train_catalog.py
+++ b/packages/zipdepth/zipdepth/apis/train_catalog.py
@@ -1,0 +1,548 @@
+"""Fine-tune trainable ZipDepth-base weights on catalog PromptDA targets."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal, TypeAlias
+
+import torch
+import torch.distributed as dist
+from monopriors.models.depth_completion.zipdepth_prompt import ZipDepthPrompt, load_zipdepth_prompt
+from monopriors.models.relative_depth.zipdepth import download_zipdepth_checkpoint
+from monopriors.models.zipdepth_checkpoint import load_zipdepth_state_dict, narrow_zipdepth_state_dict
+from monopriors.third_party.zipdepth.architecture import ZipDepth, create_model
+from monopriors.third_party.zipdepth.model_utils import strip_state_dict_prefixes
+from serde import field as serde_field
+from serde import serde
+from serde.json import from_json, to_json
+from torch import Tensor, nn, optim
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.data import DataLoader
+from torch.utils.tensorboard import SummaryWriter
+
+from zipdepth.catalog.instrument import InstrumentedLoader
+from zipdepth.catalog.segments import DEFAULT_CATALOG_URL, DEFAULT_DATASET_NAME, PromptDACatalog, load_promptda_catalog, split_holdout_segments
+from zipdepth.catalog.targets import AugmentPolicy, TargetMode
+from zipdepth.training.distributed import barrier, cleanup_distributed, fix_state_dict_prefix, print_main, setup_distributed
+from zipdepth.training.trainer import ZipDepthTrainer
+
+AmpDtype: TypeAlias = Literal["bfloat16", "float16"]
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class UpstreamOptimizerConfig:
+    """Upstream optimizer settings used by catalog training."""
+
+    lr: float = 1e-3
+    """Base learning rate before the fine-tuning policy is applied."""
+    weight_decay: float = 0.01
+    """AdamW weight decay."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class UpstreamSchedulerConfig:
+    """Upstream OneCycle scheduler settings used by catalog training."""
+
+    pct_start: float = 0.05
+    """Fraction of optimizer steps spent increasing the learning rate."""
+    div_factor: float = 25.0
+    """Ratio between the peak and initial learning rates."""
+    final_div_factor: float = 1000.0
+    """Ratio between the initial and final learning rates."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class UpstreamLossConfig:
+    """Upstream relative-depth loss settings used by catalog training."""
+
+    alpha_ssi: float = 1.0
+    """Weight of the scale-and-shift-invariant loss term."""
+    alpha_grad: float = 2.0
+    """Weight of the upstream gradient loss term."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class UpstreamAmpConfig:
+    """Upstream automatic mixed-precision settings."""
+
+    enabled: bool = True
+    """Whether automatic mixed precision is enabled."""
+    dtype: AmpDtype = "bfloat16"
+    """Floating-point format used by automatic mixed precision."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class UpstreamModelConfig:
+    """Upstream model construction settings used by catalog training."""
+
+    upsample_unfold: bool = True
+    """Whether ZipDepth uses its unfold-based upsampling path."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class UpstreamTrainingConfig:
+    """Upstream checkpoint-retention settings used by catalog training."""
+
+    max_step_checkpoints: int = 5
+    """Maximum number of periodic step checkpoints retained."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class UpstreamTrainConfig:
+    """Typed subset of the upstream training JSON consumed by this command."""
+
+    optimizer: UpstreamOptimizerConfig = field(default_factory=UpstreamOptimizerConfig)
+    """Optimizer settings."""
+    scheduler: UpstreamSchedulerConfig = field(default_factory=UpstreamSchedulerConfig)
+    """OneCycle scheduler settings."""
+    loss: UpstreamLossConfig = field(default_factory=UpstreamLossConfig)
+    """Relative-depth loss settings."""
+    amp: UpstreamAmpConfig = field(default_factory=UpstreamAmpConfig)
+    """Automatic mixed-precision settings."""
+    model: UpstreamModelConfig = field(default_factory=UpstreamModelConfig)
+    """Model construction settings."""
+    training: UpstreamTrainingConfig = field(default_factory=UpstreamTrainingConfig)
+    """Checkpoint-retention settings."""
+
+
+@serde
+@dataclass(slots=True)
+class TrainCatalogConfig:
+    """Catalog fine-tuning configuration."""
+
+    catalog_url: str = DEFAULT_CATALOG_URL
+    """URL of the local Rerun catalog server."""
+    dataset_name: str = DEFAULT_DATASET_NAME
+    """Catalog dataset containing ARKitScenes and PromptDA layers."""
+    num_segments: int | None = None
+    """Number of training-split segments to use; None uses all of them."""
+    segment_ids: list[str] | None = None
+    """Explicit training segment identifiers; overrides ``num_segments``."""
+    holdout_count: int = 20
+    """Number of PromptDA segments reserved from training for evaluation."""
+    holdout_seed: int = 0
+    """Seed for the deterministic holdout split."""
+    height: int = 768
+    """Training image height after augmentation."""
+    width: int = 1024
+    """Training image width after augmentation."""
+    batch_size: int = 8
+    """Samples per rank and optimizer step."""
+    target_mode: TargetMode = "metric"
+    """Prompted metric distillation by default; ``ssi`` retains the legacy RGB-only lane."""
+    total_steps: int = 70_000
+    """Optimizer steps in the run; the OneCycle schedule spans exactly this many. 70k is about one pass over the 875-segment train split at batch 8 (70.5k steps measured 2026-08-28)."""
+    shuffle_buffer_size: int = 256
+    """Maximum decoded samples held for bounded random shuffling. CUDA samples
+    use about 4.7 MB each at 1024x768, so this and the default producer queue
+    retain about 2.4 GB of device memory together."""
+    seed: int = 0
+    """Base seed for dataset segment order and shuffle-buffer eviction."""
+    num_producers: int = 6
+    """Whole-segment catalog producer threads, each with its own video decoder."""
+    prefetch_samples: int = 256
+    """Maximum completed samples buffered across catalog producers."""
+    min_depth_span: float = 1.25
+    """Minimum valid-depth p95/p5 ratio; zero disables flat-frame filtering."""
+    from_scratch: bool = False
+    """Start with random weights instead of the released ZipDepth-base weights."""
+    metric_gradient_weight: float = 0.5
+    """Weight on the multi-scale gradient term in the metric loss (L1 + w * grad).
+    At 0.5 the term supplies only ~9% of the objective; upstream ZipDepth weights its
+    equivalent term at 2.0. Raising it targets depth-discontinuity error, where the model
+    beats a bilinear prompt upsample by the smallest margin."""
+    freeze_bn: bool = True
+    """Pin BatchNorm to eval mode while fine-tuning: forwards use the released running
+    stats instead of batch statistics, and the stats never drift toward the new data.
+    Without this, train-mode forwards rewrite the running stats within ~100 small
+    batches and eval-mode loss degrades even at zero learning rate. Ignored from scratch."""
+    init_checkpoint: Path | None = None
+    """Local trainable ``.pth`` initialization; overrides the released checkpoint."""
+    train_config: Path = Path("configs/default.json")
+    """Upstream JSON providing loss, optimizer, scheduler, AMP, and model settings."""
+    save_dir: Path = Path("data/checkpoints/catalog")
+    """Directory for split manifests, TensorBoard events, and checkpoints."""
+    save_every_steps: int = 500
+    """Write a step checkpoint after this many updates; zero disables step checkpoints."""
+    resume: Path | None = None
+    """Training checkpoint whose model, optimizer, scheduler, and global step are restored."""
+    profile: bool = False
+    """Record one torch.profiler trace (CPU+CUDA ops, shapes, memory, stacks) and print the
+    trainer's bottleneck summary. Uses the trainer's existing profiler machinery."""
+    profile_dir: Path = Path("data/profiler")
+    """Output directory for the profiler trace, summary, and TensorBoard events."""
+    profile_wait: int = 100
+    """Steps to skip before the profiler warms up; must clear the torch.compile warmup so the
+    recorded window reflects steady-state kernels, not compilation."""
+    profile_warmup: int = 5
+    """Profiler schedule — steps the profiler warms up on without recording."""
+    profile_active: int = 10
+    """Profiler schedule — steps actually recorded in the trace."""
+    max_lr: float | None = None
+    """OneCycle peak LR; None uses config LR / 100 for fine-tuning and config LR from scratch.
+    Measured on the fixed probe set: at config/10 (1e-4, batch 4) fine-tuning diverges once
+    warmup ends; at config/100 (1e-5) it improves the probe loss ~29% in 120 steps."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class ResolvedTrainCatalogConfig:
+    """Catalog training configuration plus values resolved at runtime."""
+
+    config: TrainCatalogConfig = serde_field(flatten=True)
+    """User-provided catalog training configuration, flattened in the document."""
+    rank_count: int
+    """Number of distributed ranks participating in training."""
+    steps_per_epoch: int
+    """Optimizer steps assigned to the single catalog epoch."""
+    total_steps: int
+    """Total optimizer steps in the run."""
+    resolved_max_lr: float
+    """Peak learning rate after applying the initialization policy."""
+
+
+def resolve_max_lr(config_lr: float, override: float | None, from_scratch: bool) -> float:
+    """Resolve the OneCycle peak learning rate from initialization policy."""
+    max_lr: float = override if override is not None else config_lr if from_scratch else config_lr / 100.0
+    if max_lr <= 0.0:
+        raise ValueError("max_lr must be positive")
+    return max_lr
+
+
+def _select_train_and_holdout(config: TrainCatalogConfig, catalog: PromptDACatalog) -> tuple[list[str], list[str]]:
+    """Apply explicit selection or the deterministic holdout-first train split."""
+    if config.holdout_count < 0:
+        raise ValueError("holdout_count must be non-negative")
+    if config.segment_ids is not None:
+        selected_ids: list[str] = list(config.segment_ids)
+        if len(set(selected_ids)) != len(selected_ids):
+            raise ValueError("explicit segment_ids must be unique")
+        catalog.require_segments(selected_ids)
+        holdout_candidates: list[str] = [segment_id for segment_id in catalog.segment_ids if segment_id not in set(selected_ids)]
+        candidate_split: tuple[list[str], list[str]] = split_holdout_segments(
+            holdout_candidates,
+            config.holdout_count,
+            config.holdout_seed,
+        )
+        holdout_ids: list[str] = candidate_split[1]
+        train_ids: list[str] = selected_ids
+    else:
+        train_ids, holdout_ids = split_holdout_segments(catalog.segment_ids, config.holdout_count, config.holdout_seed)
+        if config.num_segments is not None:
+            if config.num_segments <= 0:
+                raise ValueError("num_segments must be positive when set")
+            train_ids = train_ids[: config.num_segments]
+    if not train_ids:
+        raise RuntimeError("catalog split selected no training segments")
+    return train_ids, holdout_ids
+
+
+def _load_json_config(path: Path) -> UpstreamTrainConfig:
+    """Read the required upstream training JSON."""
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    return from_json(UpstreamTrainConfig, path.read_text(encoding="utf-8"))
+
+
+def load_trainable_checkpoint(model: ZipDepth, checkpoint: Path) -> None:
+    """Strictly load cleaned DDP/compile weights without inference fusion."""
+    model.load_state_dict(load_zipdepth_state_dict(checkpoint), strict=True)
+
+
+def _one_cycle_scheduler(
+    optimizer: optim.Optimizer,
+    max_lr: float,
+    total_steps: int,
+    scheduler_config: UpstreamSchedulerConfig,
+    last_epoch: int = -1,
+) -> optim.lr_scheduler.OneCycleLR:
+    """Build the upstream OneCycle schedule with resolved total steps."""
+    return optim.lr_scheduler.OneCycleLR(
+        optimizer,
+        max_lr=max_lr,
+        total_steps=total_steps,
+        pct_start=scheduler_config.pct_start,
+        anneal_strategy="cos",
+        div_factor=scheduler_config.div_factor,
+        final_div_factor=scheduler_config.final_div_factor,
+        last_epoch=last_epoch,
+    )
+
+
+def _atomic_latest(final_checkpoint: Path) -> Path:
+    """Publish a recoverable latest checkpoint with an atomic final rename."""
+    latest: Path = final_checkpoint.parent / "latest.pth"
+    temporary: Path = final_checkpoint.parent / ".latest.pth.tmp"
+    shutil.copy2(final_checkpoint, temporary)
+    temporary.replace(latest)
+    return latest
+
+
+def _restore_resume_state(
+    resume: Path,
+    wrapped_model: nn.Module,
+    trainer: ZipDepthTrainer,
+    *,
+    total_steps: int,
+    actual_max_lr: float,
+    scheduler_config: UpstreamSchedulerConfig,
+) -> None:
+    """Restore model, optimizer, schedule, and trainer step."""
+    print_main(f"Resuming from: {resume}", trainer.rank)
+    checkpoint: dict[str, object] | None
+    if trainer.is_distributed:
+        loaded_checkpoint: dict[str, object] | None = torch.load(resume, map_location="cpu", weights_only=True) if trainer.is_main else None
+        checkpoint = loaded_checkpoint if isinstance(loaded_checkpoint, dict) else None
+        barrier()
+        objects: list[dict[str, object] | None] = [checkpoint]
+        dist.broadcast_object_list(objects, src=0)
+        checkpoint = objects[0]
+        barrier()
+    else:
+        loaded_checkpoint = torch.load(resume, map_location=trainer.device, weights_only=True)
+        checkpoint = loaded_checkpoint if isinstance(loaded_checkpoint, dict) else None
+    if checkpoint is None:
+        raise ValueError(f"resume checkpoint must contain a mapping: {resume}")
+    raw_resume_state: object = checkpoint.get("model_state_dict", checkpoint)
+    tensor_state: dict[str, Tensor] = narrow_zipdepth_state_dict(raw_resume_state, resume)
+    resume_state: dict[str, Tensor] = fix_state_dict_prefix(strip_state_dict_prefixes(tensor_state), trainer.is_distributed)
+    wrapped_model.load_state_dict(resume_state, strict=True)
+    raw_optimizer_state: object = checkpoint.get("optimizer_state_dict")
+    if not isinstance(raw_optimizer_state, dict):
+        raise ValueError("resume checkpoint has no optimizer state")
+    optimizer_state: dict[str, object] = raw_optimizer_state
+    trainer.optimizer.load_state_dict(optimizer_state)
+    raw_global_step: object = checkpoint.get("global_step", 0)
+    if not isinstance(raw_global_step, int):
+        raise ValueError("resume checkpoint global_step must be an integer")
+    trainer.global_step = raw_global_step
+    raw_scheduler_state: object = checkpoint.get("scheduler_state_dict")
+    scheduler_state: dict[str, object] | None = raw_scheduler_state if isinstance(raw_scheduler_state, dict) else None
+    raw_old_total_steps: object | None = scheduler_state.get("total_steps") if scheduler_state is not None else None
+    if raw_old_total_steps is not None and not isinstance(raw_old_total_steps, int):
+        raise ValueError("resume checkpoint scheduler total_steps must be an integer")
+    old_total_steps: int | None = raw_old_total_steps
+    if scheduler_state is not None and old_total_steps == total_steps:
+        trainer.scheduler.load_state_dict(scheduler_state)
+    else:
+        rebased_scheduler: optim.lr_scheduler.OneCycleLR = _one_cycle_scheduler(
+            trainer.optimizer,
+            actual_max_lr,
+            total_steps,
+            scheduler_config,
+            last_epoch=trainer.global_step - 1,
+        )
+        trainer.scheduler = rebased_scheduler
+        print_main(f"Rebased OneCycle schedule from {old_total_steps} to {total_steps} total steps", trainer.rank)
+
+
+def main(
+    config: TrainCatalogConfig,
+    *,
+    writer: SummaryWriter | None = None,
+) -> Path:
+    """Run catalog fine-tuning and return the atomically published latest checkpoint."""
+    distributed_result: tuple[int, int, int, bool] = setup_distributed()
+    rank: int = distributed_result[0]
+    world_size: int = distributed_result[1]
+    local_rank: int = distributed_result[2]
+    is_distributed: bool = distributed_result[3]
+    is_main: bool = rank == 0
+    owns_writer: bool = False
+    try:
+        if config.height <= 0 or config.width <= 0 or config.batch_size <= 0 or config.total_steps <= 0:
+            raise ValueError("height, width, batch_size, and total_steps must be positive")
+        if config.shuffle_buffer_size <= 0:
+            raise ValueError("shuffle_buffer_size must be positive")
+        if config.num_producers <= 0 or config.prefetch_samples <= 0:
+            raise ValueError("num_producers and prefetch_samples must be positive")
+        if config.save_every_steps < 0:
+            raise ValueError("save_every_steps must be non-negative")
+        if config.target_mode not in ("ssi", "metric"):
+            raise ValueError(f"unknown target mode {config.target_mode!r}")
+        torch.backends.cudnn.benchmark = True
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True
+        device: torch.device = torch.device(f"cuda:{local_rank}") if is_distributed else torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+        catalog: PromptDACatalog = load_promptda_catalog(config.catalog_url, config.dataset_name)
+        selected: tuple[list[str], list[str]] = _select_train_and_holdout(config, catalog)
+        train_segment_ids: list[str] = selected[0]
+        holdout_segment_ids: list[str] = selected[1]
+
+        # Catalog-only imports stay local so zipdepth-dev can run the pure policy tests.
+        from zipdepth.catalog.builders import CudaSampleBuilder
+        from zipdepth.catalog.dataset import CatalogPromptDepthDataset
+
+        steps_per_epoch: int = config.total_steps
+        total_steps: int = config.total_steps
+
+        upstream_config: UpstreamTrainConfig = _load_json_config(config.train_config)
+        optimizer_config: UpstreamOptimizerConfig = upstream_config.optimizer
+        scheduler_config: UpstreamSchedulerConfig = upstream_config.scheduler
+        loss_config: UpstreamLossConfig = upstream_config.loss
+        amp_config: UpstreamAmpConfig = upstream_config.amp
+        model_config: UpstreamModelConfig = upstream_config.model
+        training_config: UpstreamTrainingConfig = upstream_config.training
+        config_lr: float = optimizer_config.lr
+        actual_max_lr: float = resolve_max_lr(config_lr, config.max_lr, config.from_scratch)
+
+        if is_main:
+            config.save_dir.mkdir(parents=True, exist_ok=True)
+            with (config.save_dir / "train_segments.json").open("w") as file:
+                json.dump(train_segment_ids, file, indent=2)
+            with (config.save_dir / "holdout_segments.json").open("w") as file:
+                json.dump(holdout_segment_ids, file, indent=2)
+            resolved: ResolvedTrainCatalogConfig = ResolvedTrainCatalogConfig(
+                config=config,
+                rank_count=world_size,
+                steps_per_epoch=steps_per_epoch,
+                total_steps=total_steps,
+                resolved_max_lr=actual_max_lr,
+            )
+            (config.save_dir / "resolved_config.json").write_text(to_json(resolved) + "\n", encoding="utf-8")
+        barrier()
+
+        if writer is None and is_main:
+            writer = SummaryWriter(log_dir=str(config.save_dir / "runs"))
+            owns_writer = True
+
+        dataset: CatalogPromptDepthDataset = CatalogPromptDepthDataset(
+            catalog.dataset_entry,
+            train_segment_ids,
+            catalog.row_by_id,
+            device=device,
+            builder_factory=lambda: CudaSampleBuilder(
+                (config.height, config.width),
+                AugmentPolicy(),
+                config.min_depth_span,
+                device,
+                target_mode=config.target_mode,
+            ),
+            shuffle_buffer_size=config.shuffle_buffer_size,
+            seed=config.seed,
+            rank=rank,
+            world_size=world_size,
+            num_producers=config.num_producers,
+            prefetch_samples=config.prefetch_samples,
+            # Training ignores confidence: the student takes the raw prompt and the model
+            # range-gates internally. Skipping the column drops a column and ~48 KB/frame
+            # off every segment query.
+            load_confidence=False
+        )
+        data_loader: DataLoader[dict[str, Tensor]] = DataLoader(
+            dataset,
+            batch_size=config.batch_size,
+            num_workers=0,
+            pin_memory=False,
+            drop_last=True,
+        )
+        train_loader: InstrumentedLoader = InstrumentedLoader(
+            dataset,
+            data_loader,
+            steps_per_epoch=steps_per_epoch,
+            writer=writer if is_main else None,
+        )
+
+        initialization: Path | None = config.init_checkpoint
+        if initialization is None and not config.from_scratch and config.resume is None:
+            initialization = download_zipdepth_checkpoint()
+        if config.target_mode == "metric":
+            if initialization is not None:
+                print_main(f"Loading prompted trainable initialization: {initialization}", rank)
+                model: nn.Module = load_zipdepth_prompt(initialization)
+            else:
+                model = ZipDepthPrompt(
+                    create_model(variant="base", upsample_unfold=model_config.upsample_unfold)
+                )
+                print_main("Training ZipDepth-PromptDA from scratch", rank)
+        else:
+            relative_model: ZipDepth = create_model(variant="base", upsample_unfold=model_config.upsample_unfold)
+            if initialization is not None:
+                print_main(f"Loading trainable initialization: {initialization}", rank)
+                load_trainable_checkpoint(relative_model, initialization)
+            else:
+                print_main("Training ZipDepth-base from scratch", rank)
+            model = relative_model
+        pin_batchnorm_eval: bool = config.freeze_bn and not config.from_scratch
+        if pin_batchnorm_eval:
+            pinned: int = sum(isinstance(module, nn.modules.batchnorm._BatchNorm) for module in model.modules())
+            print_main(f"Pinned {pinned} BatchNorm modules to eval (released running stats)", rank)
+        model = model.to(device)
+        wrapped_model: nn.Module | DDP = (
+            DDP(model, device_ids=[local_rank], output_device=local_rank, find_unused_parameters=False) if is_distributed else model
+        )
+
+        optimizer: optim.AdamW = optim.AdamW(
+            model.parameters(),
+            lr=actual_max_lr,
+            weight_decay=optimizer_config.weight_decay,
+        )
+        scheduler: optim.lr_scheduler.OneCycleLR = _one_cycle_scheduler(optimizer, actual_max_lr, total_steps, scheduler_config)
+        trainer: ZipDepthTrainer = ZipDepthTrainer(
+            student=wrapped_model,
+            train_loader=train_loader,
+            optimizer=optimizer,
+            scheduler=scheduler,
+            device=device,
+            use_amp=amp_config.enabled,
+            writer=writer if is_main else None,
+            is_distributed=is_distributed,
+            rank=rank,
+            world_size=world_size,
+            amp_dtype=amp_config.dtype,
+            alpha_ssi=loss_config.alpha_ssi,
+            alpha_grad=loss_config.alpha_grad,
+            target_mode=config.target_mode,
+            metric_gradient_weight=config.metric_gradient_weight,
+            pin_batchnorm_eval=pin_batchnorm_eval,
+            use_profiler=config.profile,
+            profile_dir=str(config.profile_dir),
+            profile_wait=config.profile_wait,
+            profile_warmup=config.profile_warmup,
+            profile_active=config.profile_active,
+        )
+        if config.resume is not None:
+            _restore_resume_state(
+                config.resume,
+                wrapped_model,
+                trainer,
+                total_steps=total_steps,
+                actual_max_lr=actual_max_lr,
+                scheduler_config=scheduler_config,
+            )
+            train_loader.set_global_step(trainer.global_step)
+
+        print_main(
+            f"Catalog train: {len(train_segment_ids)} segments, {total_steps} optimizer steps, max_lr={actual_max_lr:.2e}, device={device}",
+            rank,
+        )
+        trainer.train(
+            num_epochs=1,
+            save_dir=str(config.save_dir),
+            start_epoch=0,
+            save_every_steps=config.save_every_steps,
+            max_step_checkpoints=training_config.max_step_checkpoints,
+            max_steps=total_steps,
+            skip_batches=0,
+        )
+        barrier()
+        latest: Path = config.save_dir / "latest.pth"
+        if is_main:
+            latest = _atomic_latest(config.save_dir / "final_model.pth")
+        barrier()
+        return latest
+    finally:
+        if owns_writer and writer is not None:
+            writer.close()
+        cleanup_distributed()

--- a/packages/zipdepth/zipdepth/apis/train_catalog_smoke.py
+++ b/packages/zipdepth/zipdepth/apis/train_catalog_smoke.py
@@ -1,0 +1,235 @@
+"""Live end-to-end smoke gate for catalog train, resume, DDP, and inference."""
+
+from __future__ import annotations
+
+import tempfile
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+import numpy as np
+import torch
+from jaxtyping import Float32, UInt8
+from monopriors.models.relative_depth.zipdepth import download_zipdepth_checkpoint
+from monopriors.third_party.zipdepth.architecture import ZipDepth, create_model
+from numpy import ndarray
+from torch import Tensor
+from torch.utils.data import DataLoader
+
+from zipdepth.apis.train_catalog import TrainCatalogConfig, load_trainable_checkpoint
+from zipdepth.apis.train_catalog import main as train_catalog
+from zipdepth.apis.train_smoke import check_checkpoint, example_rgb, publish_latest, run_required
+from zipdepth.catalog.segments import DEFAULT_CATALOG_URL, DEFAULT_DATASET_NAME, PromptDACatalog, load_promptda_catalog, split_holdout_segments
+from zipdepth.catalog.targets import build_eval_transform
+from zipdepth.data.transforms import AlbumentationsWrapper
+from zipdepth.loss import ZipDepthLoss
+
+
+@dataclass(slots=True)
+class TrainCatalogSmokeConfig:
+    """Small live catalog smoke configuration."""
+
+    catalog_url: str = DEFAULT_CATALOG_URL
+    """URL of the live local Rerun catalog server."""
+    dataset_name: str = DEFAULT_DATASET_NAME
+    """Catalog dataset containing ARKitScenes and PromptDA layers."""
+    work_dir: Path = Path("data/smoke/catalog-runs")
+    """Parent directory whose ``latest`` child is published after every gate passes."""
+    train_config: Path = Path("configs/default.json")
+    """Upstream training JSON used by every smoke leg."""
+    total_steps: int = 120
+    """Initial fine-tuning updates; 120 is the shortest horizon that moved the fixed probe reliably (36 was order-sensitive)."""
+    resume_steps: int = 4
+    """Additional updates after resuming the atomic latest checkpoint."""
+    ddp_steps: int = 4
+    """Updates in the one-process torchrun leg."""
+    probe_batches: int = 12
+    """Fixed probe batches (of the training batch size) scored before and after training."""
+
+
+def collect_probe_batches(config: TrainCatalogConfig, num_batches: int) -> list[dict[str, Tensor]]:
+    """Materialize a fixed, deterministic probe set from the smoke's two training segments.
+
+    Uses the deterministic eval transform (no flip or color jitter), a stride that
+    spreads the probe across each segment's easy and hard sections, and a
+    unit shuffle buffer so ordering stays reproducible. The probe measures
+    before/after training loss on IDENTICAL data — a windowed mean over the live
+    stream confounds learning with scene difficulty (later scene sections score
+    ~2.5x worse under the frozen released model).
+    """
+    # Catalog-only imports stay local so zipdepth-dev can import this module.
+    from zipdepth.catalog.builders import CpuSampleBuilder
+    from zipdepth.catalog.dataset import CatalogPromptDepthDataset
+
+    catalog: PromptDACatalog = load_promptda_catalog(config.catalog_url, config.dataset_name)
+    if config.segment_ids is not None:
+        segment_ids: list[str] = list(config.segment_ids)
+        catalog.require_segments(segment_ids)
+    else:
+        segment_ids = split_holdout_segments(catalog.segment_ids, config.holdout_count, config.holdout_seed)[0]
+        if config.num_segments is not None:
+            segment_ids = segment_ids[: config.num_segments]
+    if not segment_ids:
+        raise RuntimeError("probe selection contains no training segments")
+    transform: AlbumentationsWrapper = build_eval_transform(config.height, config.width)
+    dataset: CatalogPromptDepthDataset = CatalogPromptDepthDataset(
+        catalog.dataset_entry,
+        segment_ids,
+        catalog.row_by_id,
+        device=torch.device("cuda"),
+        builder_factory=lambda: CpuSampleBuilder(transform, min_depth_span=config.min_depth_span, target_mode=config.target_mode),
+        shuffle_buffer_size=1,
+        frame_stride=8,
+        num_producers=config.num_producers,
+        prefetch_samples=config.prefetch_samples,
+        load_confidence=False,
+    )
+    loader: DataLoader[dict[str, Tensor]] = DataLoader(dataset, batch_size=config.batch_size, num_workers=0, drop_last=True)
+    batches: list[dict[str, Tensor]] = []
+    batch: dict[str, Tensor]
+    for batch in loader:
+        batches.append(batch)
+        if len(batches) >= num_batches:
+            break
+    if len(batches) < num_batches:
+        raise RuntimeError(f"probe collection produced {len(batches)} batches, expected {num_batches}")
+    return batches
+
+
+def mean_probe_loss(checkpoint: Path | None, batches: list[dict[str, Tensor]]) -> float:
+    """Score one trainable checkpoint (None = released weights) on the fixed probe set.
+
+    Mirrors the trainer's batch arithmetic (image/255, depth/256, float mask) but
+    runs eval-mode fp32 so released and trained weights are compared identically.
+    """
+    device: torch.device = torch.device("cuda")
+    model: ZipDepth = create_model(variant="base")
+    load_trainable_checkpoint(model, checkpoint if checkpoint is not None else download_zipdepth_checkpoint())
+    model = model.to(device).eval()
+    criterion: ZipDepthLoss = ZipDepthLoss()
+    losses: list[float] = []
+    with torch.no_grad():
+        batch: dict[str, Tensor]
+        for batch in batches:
+            image: Float32[Tensor, "b 3 h w"] = batch["image"].to(device).float() / 255.0
+            depth: Float32[Tensor, "b 1 h w"] = batch["depth"].to(device).float() / 256.0
+            mask: Float32[Tensor, "b 1 h w"] = batch["mask"].to(device).float()
+            pred: Float32[Tensor, "b 1 h w"] = model(image)
+            loss: Float32[Tensor, ""] = criterion(pred=pred, target=depth, mask=mask)[0]
+            losses.append(float(loss.item()))
+    del model
+    torch.cuda.empty_cache()
+    return float(np.mean(losses))
+
+
+def main(config: TrainCatalogSmokeConfig) -> None:
+    """Run the live catalog smoke and atomically publish its output directory."""
+    if config.total_steps <= 0:
+        raise ValueError("total_steps must be positive")
+    if config.resume_steps <= 0 or config.ddp_steps <= 0:
+        raise ValueError("resume_steps and ddp_steps must be positive")
+    if config.probe_batches <= 0:
+        raise ValueError("probe_batches must be positive")
+    config.work_dir.mkdir(parents=True, exist_ok=True)
+    run_dir: Path = Path(tempfile.mkdtemp(prefix="run-", dir=config.work_dir))
+    single_dir: Path = run_dir / "single"
+    ddp_dir: Path = run_dir / "ddp"
+    base: TrainCatalogConfig = TrainCatalogConfig(
+        catalog_url=config.catalog_url,
+        dataset_name=config.dataset_name,
+        num_segments=2,
+        holdout_count=0,
+        height=768,
+        width=1024,
+        batch_size=4,
+        target_mode="ssi",
+        total_steps=config.total_steps,
+        shuffle_buffer_size=32,
+        num_producers=1,
+        prefetch_samples=8,
+        train_config=config.train_config,
+        save_dir=single_dir,
+        save_every_steps=5,
+    )
+    probe: list[dict[str, Tensor]] = collect_probe_batches(base, config.probe_batches)
+    released_loss: float = mean_probe_loss(None, probe)
+
+    latest_checkpoint: Path = train_catalog(base)
+    saved: object = torch.load(latest_checkpoint, map_location="cpu", weights_only=True)
+    saved_step: object = saved.get("global_step") if isinstance(saved, dict) else None
+    if saved_step != config.total_steps:
+        raise RuntimeError(f"checkpoint global_step is {saved_step!r}, expected {config.total_steps}")
+
+    trained_loss: float = mean_probe_loss(latest_checkpoint, probe)
+    if not trained_loss < released_loss:
+        raise RuntimeError(f"fixed-probe loss did not fall: released={released_loss:.6f}, trained={trained_loss:.6f}")
+    print(f"loss gate passed on the fixed probe set: released={released_loss:.6f}, trained={trained_loss:.6f}")
+
+    expected_resume_step: int = config.total_steps + config.resume_steps
+    resume_config: TrainCatalogConfig = replace(
+        base,
+        resume=latest_checkpoint,
+        total_steps=expected_resume_step,
+    )
+    resumed_checkpoint: Path = train_catalog(resume_config)
+    resumed: object = torch.load(resumed_checkpoint, map_location="cpu", weights_only=True)
+    resumed_step: object = resumed.get("global_step") if isinstance(resumed, dict) else None
+    if resumed_step != expected_resume_step:
+        raise RuntimeError(f"resumed checkpoint global_step is {resumed_step!r}, expected {expected_resume_step}")
+
+    tool_path: Path = Path(__file__).resolve().parents[2] / "tools" / "train_catalog.py"
+    ddp: TrainCatalogConfig = replace(
+        base,
+        total_steps=config.ddp_steps,
+        save_dir=ddp_dir,
+        save_every_steps=2,
+        init_checkpoint=resumed_checkpoint,
+    )
+    command: list[str] = [
+        "torchrun",
+        "--nproc_per_node=1",
+        str(tool_path),
+        "--catalog-url",
+        ddp.catalog_url,
+        "--dataset-name",
+        ddp.dataset_name,
+        "--num-segments",
+        str(ddp.num_segments),
+        "--holdout-count",
+        str(ddp.holdout_count),
+        "--height",
+        str(ddp.height),
+        "--width",
+        str(ddp.width),
+        "--batch-size",
+        str(ddp.batch_size),
+        # Pin the lane explicitly: the CLI default became "metric", and without this
+        # flag the DDP leg silently trained the prompted model while check_checkpoint
+        # verifies the bare one (broken since the default changed).
+        "--target-mode",
+        ddp.target_mode,
+        "--total-steps",
+        str(ddp.total_steps),
+        "--shuffle-buffer-size",
+        str(ddp.shuffle_buffer_size),
+        "--num-producers",
+        str(ddp.num_producers),
+        "--prefetch-samples",
+        str(ddp.prefetch_samples),
+        "--train-config",
+        str(ddp.train_config),
+        "--save-dir",
+        str(ddp.save_dir),
+        "--save-every-steps",
+        str(ddp.save_every_steps),
+        "--init-checkpoint",
+        str(resumed_checkpoint),
+    ]
+    run_required(command)
+
+    image_path: Path = Path(__file__).resolve().parents[2] / "assets" / "examples" / "im0.jpg"
+    rgb_hwc: UInt8[ndarray, "h w 3"] = example_rgb(image_path)
+    check_checkpoint(single_dir / "final_model.pth", rgb_hwc)
+    check_checkpoint(ddp_dir / "final_model.pth", rgb_hwc)
+
+    latest_dir: Path = publish_latest(config.work_dir, run_dir)
+    print(f"catalog smoke passed; outputs in {latest_dir}")

--- a/packages/zipdepth/zipdepth/apis/train_smoke.py
+++ b/packages/zipdepth/zipdepth/apis/train_smoke.py
@@ -14,9 +14,11 @@ from pathlib import Path
 import cv2
 import numpy as np
 import torch
+from jaxtyping import UInt8
 from monopriors.models.relative_depth.zipdepth import ZipDepthPredictor
 from monopriors.third_party.zipdepth.architecture import create_model
 from monopriors.third_party.zipdepth.model_utils import strip_state_dict_prefixes
+from numpy import ndarray
 
 from zipdepth.apis.smoke_data import SmokeDataConfig, build_smoke_data, smoke_data_ready
 
@@ -33,12 +35,29 @@ class TrainSmokeConfig:
     save_every_steps: int = 5
 
 
-def _run(argv: list[str]) -> None:
+def run_required(argv: list[str]) -> None:
+    """Run one required subprocess and fail on a non-zero exit."""
     print("$", " ".join(argv), flush=True)
     subprocess.run(argv, check=True)
 
 
-def check_checkpoint(path: Path, rgb: np.ndarray) -> None:
+def example_rgb(path: Path) -> UInt8[ndarray, "h w 3"]:
+    """Read one required example image and convert it from BGR to RGB."""
+    bgr_hwc: UInt8[ndarray, "h w 3"] | None = cv2.imread(str(path))
+    if bgr_hwc is None:
+        raise FileNotFoundError(path)
+    return cv2.cvtColor(bgr_hwc, cv2.COLOR_BGR2RGB)
+
+
+def publish_latest(work_dir: Path, run_dir: Path) -> Path:
+    """Replace the published smoke output only after every gate has passed."""
+    latest_dir: Path = work_dir / "latest"
+    shutil.rmtree(latest_dir, ignore_errors=True)
+    run_dir.rename(latest_dir)
+    return latest_dir
+
+
+def check_checkpoint(path: Path, rgb: UInt8[ndarray, "h w 3"]) -> None:
     """A training checkpoint must load strictly into the vendored model and run through ZipDepthPredictor."""
     ckpt = torch.load(path, map_location="cpu", weights_only=True)
     missing_sections = {"model_state_dict", "optimizer_state_dict", "scheduler_state_dict"} - set(ckpt)
@@ -66,18 +85,13 @@ def train_smoke(config: TrainSmokeConfig) -> None:
         "--batch-size", str(config.batch_size), "--num-workers", str(config.num_workers),
         "--save-every-steps", str(config.save_every_steps),
     ]  # fmt: skip
-    _run([sys.executable, *common, "--epochs", "2", "--save-dir", str(single)])
-    _run([sys.executable, *common, "--epochs", "2", "--save-dir", str(single), "--resume", str(single / "epoch_0.pth")])
-    _run(["torchrun", "--nproc_per_node=1", *common, "--epochs", "1", "--save-dir", str(ddp)])
+    run_required([sys.executable, *common, "--epochs", "2", "--save-dir", str(single)])
+    run_required([sys.executable, *common, "--epochs", "2", "--save-dir", str(single), "--resume", str(single / "epoch_0.pth")])
+    run_required(["torchrun", "--nproc_per_node=1", *common, "--epochs", "1", "--save-dir", str(ddp)])
 
-    bgr = cv2.imread(str(config.data.image))
-    if bgr is None:
-        raise FileNotFoundError(config.data.image)
-    rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+    rgb: UInt8[ndarray, "h w 3"] = example_rgb(config.data.image)
     check_checkpoint(single / "final_model.pth", rgb)
     check_checkpoint(ddp / "final_model.pth", rgb)
 
-    latest = config.work_dir / "latest"
-    shutil.rmtree(latest, ignore_errors=True)
-    run_dir.rename(latest)
+    latest: Path = publish_latest(config.work_dir, run_dir)
     print(f"smoke passed; checkpoints in {latest}")

--- a/packages/zipdepth/zipdepth/catalog/instrument.py
+++ b/packages/zipdepth/zipdepth/catalog/instrument.py
@@ -1,0 +1,204 @@
+"""Measure catalog data stalls separately from trainer compute time."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from itertools import count
+from time import perf_counter
+from typing import Protocol, runtime_checkable
+from warnings import warn
+
+import torch
+from beartype.roar import BeartypeException
+from jaxtyping import Num
+from torch import Tensor
+from torch.utils.data import DataLoader
+from torch.utils.tensorboard import SummaryWriter
+
+from zipdepth.catalog.stats import STAGE_FIELDS, CatalogDatasetStats
+
+
+@runtime_checkable
+class InstrumentedDataset(Protocol):
+    """Catalog dataset operations used by loader instrumentation."""
+
+    @property
+    def stats(self) -> CatalogDatasetStats:
+        """Return cumulative catalog processing counters."""
+        ...
+
+    def set_epoch(self, epoch: int) -> None:
+        """Select the seed for one finite dataset pass."""
+        ...
+
+    def __iter__(self) -> Iterator[dict[str, Tensor]]:
+        """Yield one finite pass of training batches."""
+        ...
+
+
+@dataclass(slots=True)
+class _Interval:
+    """Mutable wait, compute, and frame totals for one logging interval."""
+
+    data_wait_s: float = 0.0
+    """Seconds blocked on the next batch."""
+    data_wait_count: int = 0
+    """Number of measured batch waits."""
+    compute_s: float = 0.0
+    """Seconds spent by the consumer between yielded batches."""
+    compute_count: int = 0
+    """Number of measured consumer intervals."""
+    frames: int = 0
+    """Frames yielded during the interval."""
+
+    def reset(self) -> None:
+        """Clear every interval counter in place."""
+        self.data_wait_s = 0.0
+        self.data_wait_count = 0
+        self.compute_s = 0.0
+        self.compute_count = 0
+        self.frames = 0
+
+
+class InstrumentedLoader:
+    """Wrap a catalog DataLoader with fixed pacing and IO timing."""
+
+    def __init__(
+        self,
+        dataset: InstrumentedDataset,
+        loader: DataLoader[dict[str, Tensor]],
+        steps_per_epoch: int,
+        writer: SummaryWriter | None,
+        log_every: int = 50,
+    ) -> None:
+        """Configure fixed-length iteration and periodic instrumentation.
+
+        Args:
+            dataset: Catalog dataset whose epoch and stage counters are exposed.
+            loader: In-process DataLoader; it must use ``num_workers=0``.
+            steps_per_epoch: Batches yielded to the trainer in one epoch.
+            writer: Optional TensorBoard scalar sink.
+            log_every: Number of yielded batches between reports.
+
+        Raises:
+            ValueError: If a count is not positive.
+        """
+        if steps_per_epoch <= 0:
+            raise ValueError("steps_per_epoch must be positive")
+        if log_every <= 0:
+            raise ValueError("log_every must be positive")
+        self._dataset: InstrumentedDataset = dataset
+        self._loader: DataLoader[dict[str, Tensor]] = loader
+        self._steps_per_epoch: int = steps_per_epoch
+        self.sampler: None = None
+        """The vendored trainer probes ``loader.sampler.set_epoch``; pass seeding lives in ``__iter__``, so there is none."""
+        self._writer: SummaryWriter | None = writer
+        self._log_every: int = log_every
+        self._global_step: int = 0
+        self._stats_snapshot: CatalogDatasetStats = dataset.stats
+        self._gpu_utilization_enabled: bool = True
+
+    def __len__(self) -> int:
+        """Return the fixed optimizer steps assigned to each epoch."""
+        return self._steps_per_epoch
+
+    def set_global_step(self, global_step: int) -> None:
+        """Start subsequent reports after a restored trainer step."""
+        if global_step < 0:
+            raise ValueError("global_step must be non-negative")
+        self._global_step = global_step
+
+    def _log_interval(self, interval: _Interval) -> None:
+        """Report one interval to the console and optional TensorBoard writer."""
+        data_wait_ms: float = interval.data_wait_s * 1000.0 / max(interval.data_wait_count, 1)
+        compute_ms: float = interval.compute_s * 1000.0 / max(interval.compute_count, 1)
+        frames_per_s: float = interval.frames / max(interval.data_wait_s + interval.compute_s, 1e-12)
+        current_stats: CatalogDatasetStats = self._dataset.stats
+        built_delta: int = current_stats.samples_built - self._stats_snapshot.samples_built
+        stage_ms: dict[str, float] = {
+            stage: (getattr(current_stats, stage) - getattr(self._stats_snapshot, stage)) * 1000.0 / max(built_delta, 1.0)
+            for stage in STAGE_FIELDS
+        }
+        self._stats_snapshot = current_stats
+
+        gpu_util_pct: float | None = None
+        try:
+            if self._gpu_utilization_enabled and torch.cuda.is_available():
+                gpu_util_pct = float(torch.cuda.utilization())
+        except BeartypeException:
+            raise
+        except Exception as error:
+            warn(f"GPU utilization probe disabled after exception: {error!r}", RuntimeWarning, stacklevel=2)
+            self._gpu_utilization_enabled = False
+
+        gpu_text: str = "n/a" if gpu_util_pct is None else f"{gpu_util_pct:.0f}%"
+        stage_text: str = " ".join(f"{name}={stage_ms[name]:.1f}ms" for name in STAGE_FIELDS)
+        print(
+            f"[catalog io step {self._global_step}] wait={data_wait_ms:.1f}ms compute={compute_ms:.1f}ms "
+            f"throughput={frames_per_s:.2f} frames/s gpu={gpu_text} "
+            f"{stage_text} skipped={current_stats.skipped_frames}"
+        )
+        if self._writer is None:
+            return
+        scalar_values: dict[str, float] = {
+            "io/data_wait_ms": data_wait_ms,
+            "io/compute_ms": compute_ms,
+            "io/frames_per_s": frames_per_s,
+            "io/skipped_frames": float(current_stats.skipped_frames),
+        }
+        name: str
+        for name in STAGE_FIELDS:
+            scalar_values[f"io/{name}_ms"] = stage_ms[name]
+        if gpu_util_pct is not None:
+            scalar_values["io/gpu_util_pct"] = gpu_util_pct
+        tag: str
+        value: float
+        for tag, value in scalar_values.items():
+            self._writer.add_scalar(tag, value, self._global_step)
+
+    def __iter__(self) -> Iterator[dict[str, Tensor]]:
+        """Yield the fixed run length across reshuffled finite dataset passes.
+
+        A pass exhausts the filtered stream once. It is not an epoch: the
+        schedule has only an explicit optimizer-step count. Each new pass gets
+        a distinct dataset seed through :meth:`set_epoch`.
+        """
+        interval: _Interval = _Interval()
+        yield_started: float | None = None
+        yielded_batches: int = 0
+        pass_index: int
+        for pass_index in count():
+            self._dataset.set_epoch(pass_index)
+            batches: Iterator[dict[str, Tensor]] = iter(self._loader)
+            pass_batches: int = 0
+            while yielded_batches < self._steps_per_epoch:
+                resumed: float = perf_counter()
+                if yield_started is not None:
+                    interval.compute_s += resumed - yield_started
+                    interval.compute_count += 1
+                    yield_started = None
+
+                wait_started: float = perf_counter()
+                try:
+                    batch: dict[str, Tensor] = next(batches)
+                except StopIteration:
+                    break
+                interval.data_wait_s += perf_counter() - wait_started
+                interval.data_wait_count += 1
+                pass_batches += 1
+                yielded_batches += 1
+                image: Num[Tensor, "*shape"] = batch["image"]
+                interval.frames += int(image.shape[0]) if image.ndim > 0 else 1
+                self._global_step += 1
+
+                if self._global_step % self._log_every == 0:
+                    self._log_interval(interval)
+                    interval.reset()
+
+                yield_started = perf_counter()
+                yield batch
+            if yielded_batches >= self._steps_per_epoch:
+                return
+            if pass_batches == 0:
+                raise RuntimeError("catalog dataset pass yielded no batches")

--- a/packages/zipdepth/zipdepth/loss/__init__.py
+++ b/packages/zipdepth/zipdepth/loss/__init__.py
@@ -1,1 +1,4 @@
 from zipdepth.loss.depth_loss import ZipDepthLoss
+from zipdepth.loss.metric_depth_loss import MetricDepthLoss
+
+__all__: list[str] = ["MetricDepthLoss", "ZipDepthLoss"]

--- a/packages/zipdepth/zipdepth/loss/metric_depth_loss.py
+++ b/packages/zipdepth/zipdepth/loss/metric_depth_loss.py
@@ -1,0 +1,49 @@
+"""Metric PromptDA distillation loss."""
+
+import torch
+from jaxtyping import Bool, Float
+from monopriors.models.depth_completion.base_completion_depth import MAX_METRIC_DEPTH_M, MIN_METRIC_DEPTH_M
+from torch import Tensor, nn
+
+from zipdepth.loss.depth_loss import ZipDepthLoss
+
+
+class MetricDepthLoss(nn.Module):
+    """Masked metre L1 plus the existing multi-scale gradient loss."""
+
+    def __init__(self, gradient_weight: float = 0.5, grad_scales: int = 4) -> None:
+        super().__init__()
+        if gradient_weight < 0.0:
+            raise ValueError("gradient_weight must be non-negative")
+        if grad_scales <= 0:
+            raise ValueError("grad_scales must be positive")
+        self.gradient_weight: float = gradient_weight
+        self._gradient: ZipDepthLoss = ZipDepthLoss(alpha_ssi=0.0, alpha_grad=1.0, grad_scales=grad_scales)
+
+    def forward(
+        self,
+        pred: Float[Tensor, "b 1 h w"],
+        target: Float[Tensor, "b 1 h w"],
+        mask: Bool[Tensor, "b 1 h w"] | Float[Tensor, "b 1 h w"] | None = None,
+    ) -> tuple[Float[Tensor, ""], dict[str, Float[Tensor, ""]]]:
+        """Compute the fixed Stage-1 metric objective.
+
+        Args:
+            pred: Predicted float depth in metres with shape
+                ``(batch, 1, height, width)``.
+            target: Dense teacher float depth in metres with the same shape.
+            mask: Optional explicit teacher-valid mask with the same shape.
+
+        Returns:
+            Scalar loss and detached 0-dim ``l1``/``grad`` components.
+        """
+        valid_bchw: Bool[Tensor, "b 1 h w"] = torch.isfinite(target) & (target >= MIN_METRIC_DEPTH_M) & (target <= MAX_METRIC_DEPTH_M)
+        if mask is not None:
+            valid_bchw = valid_bchw & (mask > 0)
+        mask_bchw: Float[Tensor, "b 1 h w"] = valid_bchw.to(dtype=pred.dtype)
+        safe_prediction_bchw: Float[Tensor, "b 1 h w"] = torch.where(valid_bchw, pred, torch.zeros_like(pred))
+        safe_target_bchw: Float[Tensor, "b 1 h w"] = torch.where(valid_bchw, target, torch.zeros_like(target))
+        l1_loss: Float[Tensor, ""] = self._gradient._ssi_loss(safe_prediction_bchw, safe_target_bchw, mask_bchw)
+        gradient_loss: Float[Tensor, ""] = self._gradient._gradient_loss(safe_prediction_bchw, safe_target_bchw, mask_bchw)
+        total_loss: Float[Tensor, ""] = l1_loss + self.gradient_weight * gradient_loss
+        return total_loss, {"l1": l1_loss.detach(), "grad": gradient_loss.detach()}

--- a/packages/zipdepth/zipdepth/training/trainer.py
+++ b/packages/zipdepth/zipdepth/training/trainer.py
@@ -4,8 +4,10 @@ import glob
 import os
 import time
 from contextlib import nullcontext, suppress
+from typing import Literal
 
 import torch
+from torch import nn
 from torch.profiler import ProfilerActivity, profile, schedule, tensorboard_trace_handler
 from tqdm import tqdm
 
@@ -17,7 +19,7 @@ except ImportError:
 
 from monopriors.third_party.zipdepth.model_utils import strip_state_dict_prefixes
 
-from zipdepth.loss import ZipDepthLoss
+from zipdepth.loss import MetricDepthLoss, ZipDepthLoss
 from zipdepth.training.visualization import depth_to_spectral
 
 
@@ -57,6 +59,9 @@ class ZipDepthTrainer:
                 amp_dtype='bfloat16',
                 alpha_ssi: float = 1.0,
                 alpha_grad: float = 2.0,
+                target_mode: Literal['ssi', 'metric'] = 'ssi',
+                metric_gradient_weight: float = 0.5,
+                pin_batchnorm_eval: bool = False,
                 ):
         """
         Args:
@@ -81,6 +86,11 @@ class ZipDepthTrainer:
                        or 'float16' (requires GradScaler, narrower range)
             alpha_ssi: Weight for SSI loss component
             alpha_grad: Weight for gradient loss component
+            target_mode: Relative SSI or prompted metric training lane
+            metric_gradient_weight: Weight on the multi-scale gradient term in the metric
+                lane. Upstream ZipDepth's SSI lane uses 2.0; 0.5 leaves the term at ~9%
+                of the objective, which under-penalizes depth-discontinuity errors.
+            pin_batchnorm_eval: Return BatchNorm modules to eval after entering train mode
         """
         self.student = student.to(device)
         self.train_loader = train_loader
@@ -106,9 +116,17 @@ class ZipDepthTrainer:
         self._snapshot_start = None
         self._restart_interval = 1000
         self._loader_config = None
+        if target_mode not in ('ssi', 'metric'):
+            raise ValueError(f"unknown target mode {target_mode!r}")
+        self.target_mode = target_mode
+        self.pin_batchnorm_eval = pin_batchnorm_eval
 
         # Loss function initialization
-        self.criterion = ZipDepthLoss(alpha_ssi=alpha_ssi, alpha_grad=alpha_grad).to(device)
+        self.criterion: nn.Module = (
+            MetricDepthLoss(gradient_weight=metric_gradient_weight)
+            if target_mode == 'metric'
+            else ZipDepthLoss(alpha_ssi=alpha_ssi, alpha_grad=alpha_grad)
+        ).to(device)
 
         # GradScaler only needed for FP16 — BF16 has FP32-range exponents so no overflow
         self.scaler = (
@@ -124,7 +142,8 @@ class ZipDepthTrainer:
             self.student = torch.compile(self.student, mode="reduce-overhead")
 
     def train(self, num_epochs: int, save_dir: str = './checkpoints', start_epoch: int = 0,
-            save_every_steps: int = 0, max_step_checkpoints: int = 5, max_steps: int = 0):
+            save_every_steps: int = 0, max_step_checkpoints: int = 5, max_steps: int = 0,
+            skip_batches: int | None = None):
         if self.is_main:
             os.makedirs(save_dir, exist_ok=True)
 
@@ -136,7 +155,7 @@ class ZipDepthTrainer:
 
         # When resuming mid-epoch, skip the batches already processed so the
         # scheduler is stepped exactly the right number of times.
-        initial_skip = self.global_step % steps_per_epoch if self.global_step > 0 else 0
+        initial_skip = skip_batches if skip_batches is not None else self.global_step % steps_per_epoch
         if initial_skip > 0 and self.is_main:
             print(f"\nResume: skipping first {initial_skip}/{steps_per_epoch} batches "
                   f"of epoch {start_epoch} (global_step={self.global_step})")
@@ -280,6 +299,10 @@ class ZipDepthTrainer:
             self.train_loader.sampler.set_epoch(epoch)
 
         self.student.train()
+        if self.pin_batchnorm_eval:
+            for module in self.student.modules():
+                if isinstance(module, nn.modules.batchnorm._BatchNorm):
+                    module.eval()
         total_loss = 0.0
         num_batches = len(self.train_loader)
         processed_batches = 0
@@ -296,19 +319,35 @@ class ZipDepthTrainer:
                 images = batch['image'].to(self.device, non_blocking=True)
                 images = images.float() / 255.0
 
-                teacher_depth = batch['depth'].to(self.device, non_blocking=True)
-                teacher_depth = teacher_depth.float().div_(256.0)
+                prompt_depth = None
+                if self.target_mode == 'metric':
+                    teacher_depth = batch['target_depth'].to(self.device, non_blocking=True).float()
+                    mask = batch['target_valid'].to(self.device, non_blocking=True)
+                    # Feed the RAW prompt, exactly what the teacher saw when it produced
+                    # these labels (promptda_stream.py:254). Zeroing low-confidence pixels
+                    # made the student solve a different problem from the teacher, and the
+                    # degenerate cases it guarded against are already handled inside the
+                    # model, which computes its own finite/0.1-4 m validity for the
+                    # normalization range and clamps the span.
+                    prompt_depth = batch['prompt_depth'].to(self.device, non_blocking=True).float()
+                else:
+                    teacher_depth = batch['depth'].to(self.device, non_blocking=True)
+                    teacher_depth = teacher_depth.float().div_(256.0)
+
+                    # Local addition: sparse catalog targets carry an explicit validity mask.
+                    mask = batch.get('mask')
+                    if mask is not None:
+                        mask = mask.to(self.device, non_blocking=True).float()
 
                 del batch
 
                 with torch.amp.autocast('cuda', dtype=self.amp_dtype, enabled=self.use_amp):
-                    student_depth = self.student(images)
+                    student_depth = self.student(images, prompt_depth) if prompt_depth is not None else self.student(images)
                     loss, loss_dict = self.criterion(
                         pred=student_depth,
                         target=teacher_depth,
+                        mask=mask,
                     )
-
-                loss_value = loss.item()
 
                 if self.scaler is not None:
                     # FP16: use GradScaler to prevent overflow
@@ -328,6 +367,12 @@ class ZipDepthTrainer:
 
                 self.optimizer.zero_grad(set_to_none=True)
 
+                # Sync the host only after the whole step is enqueued: an .item() before
+                # backward() drains the CUDA queue on the critical path and costs the
+                # overlap that hides the next batch's data wait.
+                loss_value = loss.item()
+                loss_dict = {key: float(value) for key, value in loss_dict.items()}
+
                 self.global_step += 1
                 total_loss += loss_value
                 processed_batches += 1
@@ -338,6 +383,7 @@ class ZipDepthTrainer:
                     break
 
                 avg_loss = total_loss / processed_batches
+                primary_name = 'l1' if self.target_mode == 'metric' else 'ssi'
 
                 if not disable_tqdm:
                     pbar.update(1)
@@ -346,15 +392,15 @@ class ZipDepthTrainer:
                         'B': f"{batch_idx+1}/{num_batches}",
                         'loss': f"{loss_value:.3f}",
                         'avg_loss': f"{avg_loss:.3f}",
-                        'ssi': f"{loss_dict['ssi']:.3f}",
+                        primary_name: f"{loss_dict[primary_name]:.3f}",
                     })
 
                 # Logging
                 if self.is_main and self.writer is not None:
                     if self.global_step % 750 == 0:
-                        self.writer.add_scalar('train/loss', loss.item(), self.global_step)
+                        self.writer.add_scalar('train/loss', loss_value, self.global_step)
                         self.writer.add_scalar('train/lr', self.optimizer.param_groups[0]['lr'], self.global_step)
-                        self.writer.add_scalar('train/loss_ssi', loss_dict['ssi'], self.global_step)
+                        self.writer.add_scalar(f'train/loss_{primary_name}', loss_dict[primary_name], self.global_step)
                         self.writer.add_scalar('train/loss_grad', loss_dict['grad'], self.global_step)
 
                     if self.global_step % 750 == 0:
@@ -381,7 +427,7 @@ class ZipDepthTrainer:
                     print(f'\n  -> Checkpoint saved at step {self.global_step}')
                     self.cleanup_step_checkpoints()
 
-                del student_depth, teacher_depth, loss
+                del student_depth, teacher_depth, mask, prompt_depth, loss
 
                 # Advance profiler schedule (no-op after schedule completes or when profiling disabled)
                 if prof is not None:

--- a/packages/zipdepth/zipdepth/upstream_cli/__init__.py
+++ b/packages/zipdepth/zipdepth/upstream_cli/__init__.py
@@ -2,6 +2,10 @@
 
 Bodies are unmodified apart from model imports (``monopriors.third_party.zipdepth``), ``eval.py``
 running inference through ``monopriors`` ``ZipDepthPredictor``, and ``train.py``'s ``__main__`` block
-wrapped as ``cli()``. Upstream ``infer.py`` was dropped — ``ZipDepthPredictor`` / ``apis/infer_rerun``
+wrapped as ``cli()``. The shared trainer has local catalog-lane support for sparse and prompted
+metric targets, fixed-step checkpointing and resume skipping, and optional BatchNorm pinning. It
+also disables compilation under beartype dev instrumentation. Its defaults preserve upstream SSI
+training behavior.
+Upstream ``infer.py`` was dropped — ``ZipDepthPredictor`` / ``apis/infer_rerun``
 cover it. Converting them to tyro ``apis/`` is phase-2 debt.
 """

--- a/pixi.toml
+++ b/pixi.toml
@@ -699,6 +699,16 @@ cmd = "python tools/catalog_throughput.py"
 cwd = "packages/zipdepth"
 description = "Measure catalog->batch throughput (frames/s, per-stage ms) over warm promptda segments"
 
+[feature.zipdepth-catalog.tasks.zipdepth-train-catalog]
+cmd = "python tools/train_catalog.py"
+cwd = "packages/zipdepth"
+description = "Fine-tune ZipDepth on chosen-frame PromptDA pseudo-labels streamed from the local Rerun catalog"
+
+[feature.zipdepth-catalog.tasks.zipdepth-catalog-train-smoke]
+cmd = "python tools/train_catalog_smoke.py"
+cwd = "packages/zipdepth"
+description = "Smoke: 2 catalog segments -> short fine-tune -> resume -> torchrun -> checkpoint loads through ZipDepthPredictor"
+
 [feature.zipdepth-catalog.tasks.zipdepth-eval-catalog]
 cmd = "python tools/eval_catalog.py"
 cwd = "packages/zipdepth"


### PR DESCRIPTION
Stack **6/9** — the ZipDepth-PromptDA work re-cut into one focused stack (replaces #132 #133 #134 #129 #164 #165 #166 #167 #172 #173 #174 #175 #177; #131 is already merged). Review bottom-up.

| # | PR | what | lines (no lock) |
|---|---|---|---:|
| 1 | #186 | workspace rerun-sdk 0.37.0 (pins + API ports) — lock | +533/−317 |
| 2 | #187 | simplecv depth/mesh helpers; PromptDA teacher batch tool on the GPU + malloc_trim; catalog-server rules | +196/−74 |
| 3 | #188 | monoprior config-first depth-completion zoo (PromptDA torch/onnx/trt) — refactor only | +752/−565 |
| 4 | #189 | **ZipDepth-PromptDA model** + static-batch TensorRT export — lock (+trtkit) | +1132/−11 |
| 5 | #190 | zipdepth-catalog lane: streaming dataset, CUDA builders, holdout eval — lock (+2 envs) | +3176/−25 |
| 6 | #191 | catalog fine-tune trainer + live smoke gate + IO instrumentation | +1576/−27 |
| 7 | #192 | hard-frame mining, fixed hard-20 scorer, Polycam three-way comparison | +1727/−14 |
| 8 | #203 | training-speed knobs + named presets for the wall-clock hill-climb | +670/−76 |
| 9 | #204 | idiomatic Rerun 0.37 dataloader as executable reference (`--dataloader rerun`), catalog-query audit | +1027/−54 |

Whole stack vs main: 108 files, +8486/−995. The old chain was 13 open PRs (+10.4k lines) plus 11 unpushed commits; the head-variant experiments and the default-off loss knobs were dropped (negative results, see the [project report](https://pablos-4800gt.ilish-ruler.ts.net:8768/zipdepth/zipdepth-promptda-final-report.html)), and every slice went through a four-lens simplify pass before cutting. Review-pass changes (2026-09-03) are folded into the same PRs: zero `Any` on added lines, jaxtyping dtype+shape on every added array annotation, no dtype/shape in new identifiers, shared metre→mm quantiser, `upsample_depth_to_image`, condensed AGENTS section, stale einops suppressions dropped in touched files.

## zipdepth: fine-tune on catalog pseudo-labels, with a live smoke gate and IO instrumentation
**What** `zipdepth-train-catalog` fine-tunes the released ZipDepth weights (wrapped as ZipDepth-PromptDA) on the streamed PromptDA labels. The recipe that made it learn instead of degrade: BatchNorm pinned to eval as an explicit trainer option (running-stat drift hurts the released model at any lr, even 0), peak lr = config/100, resize-only augmentation, the flat-frame filter, and `MetricDepthLoss` = range-gated L1 + ZipDepth's own multi-scale gradient loss on the fixed `[0.1, 4.0]` m window (the loss reuses the vendored reductions; the trainer builds it from `metric_gradient_weight`).
`InstrumentedLoader` separates data-wait from compute per window and logs `io/*` scalars (data_wait_ms, compute_ms, frames_per_s, gpu_util_pct, per-stage ms); step numbering continues across resumes. Two documented hunks remain in the shared trainer (`upstream_cli/__init__.py`): the sparse target mask forwarded to the criterion and an optional `skip_batches` override for resuming an unordered stream.
`zipdepth-catalog-train-smoke`: 2 catalog segments → short fine-tune → resume (schedule rebased 120 → 124) → torchrun leg → checkpoint loads through the predictor; asserts the saved `global_step` and a fixed-probe loss drop.
**Review focus** `train_catalog.main()`, `_restore_resume_state`, `InstrumentedLoader.__iter__` (this is the step schedule), the two trainer hunks against the docstring.
**Gates** zipdepth-catalog-dev 75 passed + lint/typecheck/deadcode; zipdepth-dev 60 passed; live smoke passed on this branch (probe loss 0.7997 → 0.6925, resume to step 124, torchrun leg green).
