### PR TITLE
zipdepth: hard-frame mining, fixed hard-20 scorer, Polycam three-way comparison (stack 7/7)

### DIFF
--- a/packages/monoprior/monopriors/apis/benchmark_moge_v2_trt.py
+++ b/packages/monoprior/monopriors/apis/benchmark_moge_v2_trt.py
@@ -247,8 +247,8 @@ def main(config: Config) -> None:
         if backend == "moge-infer":
             loaded: tuple[MoGeModel, int] = load_pinned_moge_v2(config.encoder, config.resolution_level)
             model: MoGeModel = loaded[0]
-            primary_image_b3hw: Float32[Tensor, "b 3 h w"] = rearrange(primary_rgb_bhw3, "b h w c -> b c h w").float() / 255.0  # pyrefly: ignore  # bad-argument-type — einops stub false positive
-            widescreen_image_b3hw: Float32[Tensor, "1 3 h w"] = rearrange(widescreen_rgb_bhw3, "b h w c -> b c h w").float() / 255.0  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+            primary_image_b3hw: Float32[Tensor, "b 3 h w"] = rearrange(primary_rgb_bhw3, "b h w c -> b c h w").float() / 255.0
+            widescreen_image_b3hw: Float32[Tensor, "1 3 h w"] = rearrange(widescreen_rgb_bhw3, "b h w c -> b c h w").float() / 255.0
             for batch_size in config.batch_sizes:
                 rows.append(_benchmark_moge_infer(model, primary_image_b3hw[:batch_size], config.resolution_level, config.warmup_iters, config.timed_iters))
             rows.append(_benchmark_moge_infer(model, widescreen_image_b3hw, config.resolution_level, config.warmup_iters, config.timed_iters))

--- a/packages/monoprior/monopriors/models/moge_v2/export.py
+++ b/packages/monoprior/monopriors/models/moge_v2/export.py
@@ -165,7 +165,7 @@ def preprocess_rgb(
     if image_hw[0] < 1 or image_hw[1] < 1:
         raise ValueError(f"MoGe v2 network dimensions must be positive, got {image_hw}.")
 
-    image_b3hw: Float32[Tensor, "b 3 h w"] = rearrange(rgb_bhw3, "b h w c -> b c h w").to(dtype=torch.float32) / 255.0  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    image_b3hw: Float32[Tensor, "b 3 h w"] = rearrange(rgb_bhw3, "b h w c -> b c h w").to(dtype=torch.float32) / 255.0
     if tuple(image_b3hw.shape[-2:]) != image_hw:
         image_b3hw = F.interpolate(image_b3hw, size=image_hw, mode="bilinear", antialias=True)
     return image_b3hw

--- a/packages/monoprior/monopriors/models/moge_v2/predictor.py
+++ b/packages/monoprior/monopriors/models/moge_v2/predictor.py
@@ -98,12 +98,12 @@ def _resize_and_normalize_normals(
     Returns:
         Owning float32 unit normals shaped ``b h w 3``.
     """
-    normals_b3nhw: Float32[Tensor, "b 3 nh nw"] = rearrange(normals_bnhw3.float(), "b h w c -> b c h w")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    normals_b3nhw: Float32[Tensor, "b 3 nh nw"] = rearrange(normals_bnhw3.float(), "b h w c -> b c h w")
     if tuple(normals_b3nhw.shape[-2:]) != output_hw:
         normals_b3hw: Float32[Tensor, "b 3 h w"] = F.interpolate(normals_b3nhw, size=output_hw, mode="bilinear", align_corners=False)
     else:
         normals_b3hw = normals_b3nhw
-    normals_bhw3: Float32[Tensor, "b h w 3"] = rearrange(normals_b3hw, "b c h w -> b h w c")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    normals_bhw3: Float32[Tensor, "b h w 3"] = rearrange(normals_b3hw, "b c h w -> b h w c")
     return F.normalize(normals_bhw3, dim=-1)
 
 
@@ -121,12 +121,12 @@ def postprocess_moge_v2_normal(
         Owning float32 unit normals and validity probabilities at caller resolution.
     """
     normals_bhw3: Float32[Tensor, "b h w 3"] = _resize_and_normalize_normals(graph_output.normals_bhw3, output_hw)
-    mask_b1nhw: Float32[Tensor, "b 1 nh nw"] = rearrange(graph_output.mask_bhw.float(), "b h w -> b 1 h w")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    mask_b1nhw: Float32[Tensor, "b 1 nh nw"] = rearrange(graph_output.mask_bhw.float(), "b h w -> b 1 h w")
     if tuple(mask_b1nhw.shape[-2:]) != output_hw:
         mask_b1hw: Float32[Tensor, "b 1 h w"] = F.interpolate(mask_b1nhw, size=output_hw, mode="bilinear", align_corners=False)
     else:
         mask_b1hw = mask_b1nhw.clone()
-    mask_bhw: Float32[Tensor, "b h w"] = rearrange(mask_b1hw, "b 1 h w -> b h w")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    mask_bhw: Float32[Tensor, "b h w"] = rearrange(mask_b1hw, "b 1 h w -> b h w")
     return MoGeV2NormalOutput(normals_bhw3=normals_bhw3, mask_bhw=mask_bhw)
 
 
@@ -165,8 +165,8 @@ def postprocess_moge_v2_geometry(
     positive_z_bnhw: Bool[Tensor, "b nh nw"] = points_bnhw3[..., 2] > 0.0
     mask_bnhw = torch.where(positive_z_bnhw, mask_bnhw, 0.0)
 
-    points_b3nhw: Float32[Tensor, "b 3 nh nw"] = rearrange(points_bnhw3, "b h w c -> b c h w")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
-    mask_b1nhw: Float32[Tensor, "b 1 nh nw"] = rearrange(mask_bnhw, "b h w -> b 1 h w")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    points_b3nhw: Float32[Tensor, "b 3 nh nw"] = rearrange(points_bnhw3, "b h w c -> b c h w")
+    mask_b1nhw: Float32[Tensor, "b 1 nh nw"] = rearrange(mask_bnhw, "b h w -> b 1 h w")
     if (network_height, network_width) != output_hw:
         points_b3hw: Float32[Tensor, "b 3 h w"] = F.interpolate(points_b3nhw, size=output_hw, mode="bilinear", align_corners=False)
         mask_b1hw: Float32[Tensor, "b 1 h w"] = F.interpolate(mask_b1nhw, size=output_hw, mode="bilinear", align_corners=False)
@@ -174,9 +174,9 @@ def postprocess_moge_v2_geometry(
         points_b3hw = points_b3nhw
         mask_b1hw = mask_b1nhw
 
-    points_bhw3: Float32[Tensor, "b h w 3"] = rearrange(points_b3hw, "b c h w -> b h w c").contiguous()  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    points_bhw3: Float32[Tensor, "b h w 3"] = rearrange(points_b3hw, "b c h w -> b h w c").contiguous()
     depth_bhw: Float32[Tensor, "b h w"] = points_bhw3[..., 2]
-    resized_mask_bhw: Float32[Tensor, "b h w"] = rearrange(mask_b1hw, "b 1 h w -> b h w")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    resized_mask_bhw: Float32[Tensor, "b h w"] = rearrange(mask_b1hw, "b 1 h w -> b h w")
     mask_bhw: Float32[Tensor, "b h w"] = torch.where(depth_bhw > 0.0, resized_mask_bhw, 0.0)
     return MoGeV2GeometryOutput(
         depth_bhw=depth_bhw,

--- a/packages/monoprior/tests/test_moge_v2_adapters.py
+++ b/packages/monoprior/tests/test_moge_v2_adapters.py
@@ -90,7 +90,7 @@ def test_all_single_image_adapters_match_vendored_infer_on_room() -> None:
     if bgr_hw3 is None:
         pytest.skip(f"{image_path} missing; run the monoprior download task")
     rgb_hw3: UInt8[np.ndarray, "h w 3"] = cv2.cvtColor(bgr_hw3, cv2.COLOR_BGR2RGB)
-    image_3hw: Float32[Tensor, "3 h w"] = rearrange(torch.from_numpy(rgb_hw3).to(device="cuda"), "h w c -> c h w").float() / 255.0  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    image_3hw: Float32[Tensor, "3 h w"] = rearrange(torch.from_numpy(rgb_hw3).to(device="cuda"), "h w c -> c h w").float() / 255.0
     checkpoint: tuple[str, str] = MOGE_V2_CHECKPOINTS["vitl"]
     reference_model: MoGeModel = MoGeModel.from_pretrained(checkpoint[0], revision=checkpoint[1]).to("cuda").eval()
     reference: InferenceOutput = reference_model.infer(image_3hw, force_projection=False, apply_mask=True)

--- a/packages/monoprior/tests/test_moge_v2_predictor.py
+++ b/packages/monoprior/tests/test_moge_v2_predictor.py
@@ -311,7 +311,7 @@ def test_trt_geometry_matches_vendored_infer_convention(encoder: Encoder, caller
     resized_bgr_hw3: UInt8[np.ndarray, "h w 3"] = cv2.resize(bgr_hw3, (caller_hw[1], caller_hw[0]), interpolation=cv2.INTER_AREA)
     rgb_hw3: UInt8[np.ndarray, "h w 3"] = cv2.cvtColor(resized_bgr_hw3, cv2.COLOR_BGR2RGB)
     rgb_bhw3: UInt8[Tensor, "1 h w 3"] = torch.from_numpy(rgb_hw3).cuda()[None]
-    image_3hw: Float32[Tensor, "3 h w"] = rearrange(rgb_bhw3[0], "h w c -> c h w").float() / 255.0  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    image_3hw: Float32[Tensor, "3 h w"] = rearrange(rgb_bhw3[0], "h w c -> c h w").float() / 255.0
 
     trt_predictor: MoGeV2TrtPredictor = MoGeV2TrtPredictor(encoder=encoder, heads="geometry", batch_size=8)
     loaded: tuple[MoGeModel, int] = load_pinned_moge_v2(encoder, 9)

--- a/packages/prompt-da/src/rerun_prompt_da/apis/catalog_promptda.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/catalog_promptda.py
@@ -146,7 +146,7 @@ def process_segment(dataset: DatasetEntry, segment_id: str, config: Config, pred
         })["depth"]
         # Undo the collate's landscape rotation so the prediction sits in the same frame
         # as the relayed video and the stored intrinsics.
-        depth_bhw: Float32[Tensor, "b net_h net_w"] = rearrange(depth_b1hw, "b 1 h w -> b h w")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+        depth_bhw: Float32[Tensor, "b net_h net_w"] = rearrange(depth_b1hw, "b 1 h w -> b h w")
         depth_mm_bhw: UInt16[Tensor, "b pred_h pred_w"] = torch.rot90(
             (depth_bhw * 1000.0).to(torch.uint16), -batch.quarter_turns, dims=(1, 2)
         )

--- a/packages/prompt-da/src/rerun_prompt_da/apis/polycam_trio.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/polycam_trio.py
@@ -1,0 +1,398 @@
+"""Three-way Polycam comparison: raw ARKit LiDAR, PromptDA-large, and ZipDepth-PromptDA.
+
+Runs both depth models over the same frames and fuses
+each depth source into its own TSDF volume, so the three reconstructions can be
+compared as geometry rather than only as depth images. Accumulated depth error
+shows up in a mesh in ways a per-frame depth view hides.
+
+The raw ARKit stream is the device's own upsampled depth -- the baseline any
+phone gives you for free, and the thing both models have to beat.
+"""
+
+import time
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+
+import cv2
+import numpy as np
+import rerun as rr
+import rerun.blueprint as rrb
+import torch
+from jaxtyping import Float32, UInt8, UInt16
+from monopriors.models.depth_completion import PromptDAConfig, ZipDepthPromptConfig
+from monopriors.models.depth_completion.base_completion_depth import BaseCompletionPredictor
+from monopriors.models.depth_completion.prompt_da import DEFAULT_PROMPTDA_CACHE_DIR
+from numpy import ndarray
+from simplecv.camera_parameters import rescale_intri
+from simplecv.data.polycam import (
+    DepthConfidenceLevel,
+    PolycamData,
+    PolycamDataset,
+    load_polycam_data,
+    prepare_polycam_batches,
+    stack_polycam_batch,
+)
+from simplecv.ops.depth import quantize_depth_m_to_mm
+from simplecv.ops.tsdf_depth_fuser import Open3DFuser, log_fused_mesh
+from simplecv.rerun_log_utils import RerunTyroConfig, log_pinhole
+from torch import Tensor
+from trtkit import TensorRtBackendConfig, TorchBackendConfig
+
+from rerun_prompt_da.apis.prompt_da_polycam import filter_depth
+
+
+@dataclass
+class PolycamTrioConfig:
+    """Runtime configuration for the three-way Polycam comparison."""
+
+    polycam_zip_path: Path
+    """Polycam capture zip (or extracted directory) to process."""
+    teacher: PromptDAConfig = field(
+        default_factory=lambda: PromptDAConfig(
+            backend=TensorRtBackendConfig(max_batch_size=8, opt_batch_size=8, cache_dir=DEFAULT_PROMPTDA_CACHE_DIR / "trt")
+        )
+    )
+    """Teacher completion model and backend."""
+    student: ZipDepthPromptConfig = field(
+        default_factory=lambda: ZipDepthPromptConfig(checkpoint=Path(), backend=TorchBackendConfig())
+    )
+    """Student completion model and backend."""
+    zipdepth_checkpoint: Path | None = None
+    """Compatibility alias for ``student=zipdepth-promptda --checkpoint``."""
+    rr_config: RerunTyroConfig = field(default_factory=RerunTyroConfig)
+    """Rerun viewer/save/connect behavior."""
+    batch_size: int = 8
+    """Frames per model batch."""
+    max_depth_range_meter: float = 4.0
+    """Depth beyond this is dropped before TSDF fusion."""
+    depth_fusion_resolution: float = 0.04
+    """TSDF voxel size in metres."""
+    max_frames: int | None = None
+    """Optional cap on processed frames."""
+    log_incremental_mesh: bool = False
+    """Log all three fused meshes after every batch instead of only at the end.
+
+    Shows the reconstructions growing as the capture is walked, which makes it obvious
+    where each source starts accumulating drift. Costs one mesh upload per source per
+    batch, so the recording is substantially larger."""
+
+
+ERROR_RANGE_MM: tuple[float, float] = (0.0, 250.0)
+"""Shared colour range for both error panes, so they read against each other."""
+SPIN_SPEED: float = 0.25
+"""Orbital spin applied to every mesh view, so all three rotate together and the
+reconstructions can be compared from the same angle without manual navigation."""
+
+
+def create_trio_blueprint(parent_log_path: Path) -> rrb.Blueprint:
+    """Lay out the fused meshes, plus a tab comparing each source against the teacher."""
+    pinhole_path: Path = parent_log_path / "cam" / "pinhole"
+    lowres_path: Path = parent_log_path / "cam" / "pinhole_lowres"
+    return rrb.Blueprint(
+        rrb.Tabs(
+            _mesh_tab(parent_log_path, pinhole_path, lowres_path),
+            _comparison_tab(pinhole_path, lowres_path),
+        ),
+        collapse_panels=True,
+    )
+
+
+def _comparison_tab(pinhole_path: Path, lowres_path: Path) -> rrb.Vertical:
+    """Two rows against a common reference: the teacher.
+
+    Row 2 is the size of the problem -- everything PromptDA changes about the raw ARKit
+    depth. Row 1 is the student's residual -- the part of that correction it did not
+    reproduce. Both error panes share one scale, so they read directly against each other.
+    """
+    return rrb.Vertical(
+        rrb.Horizontal(
+            rrb.Spatial2DView(origin=str(lowres_path / "arkit_depth"), name="raw ARKit LiDAR (192x256, native)"),
+            rrb.Spatial2DView(origin=str(pinhole_path / "zipdepth_depth"), name="ZipDepth-PromptDA (6.95M)"),
+            rrb.Spatial2DView(origin=str(pinhole_path / "err_student"), name="|ZipDepth - PromptDA|  (student residual)"),
+        ),
+        rrb.Horizontal(
+            rrb.Spatial2DView(origin=str(lowres_path / "arkit_depth"), name="raw ARKit LiDAR (192x256, native)"),
+            rrb.Spatial2DView(origin=str(pinhole_path / "promptda_depth"), name="PromptDA-large (DAv2, 340M)"),
+            rrb.Spatial2DView(origin=str(lowres_path / "err_arkit"), name="|ARKit - PromptDA|  (what the teacher fixes)"),
+        ),
+        name="side by side",
+    )
+
+
+def _mesh_tab(parent_log_path: Path, pinhole_path: Path, lowres_path: Path) -> rrb.Horizontal:
+    """The fused reconstructions beside the raw depth streams."""
+    return rrb.Horizontal(
+            rrb.Vertical(
+                rrb.Spatial3DView(
+                    origin=str(parent_log_path / "arkit"),
+                    contents=["$origin/**", str(parent_log_path / "cam") + "/**"],
+                    name="mesh: raw ARKit LiDAR (192x256)",
+                    eye_controls=rrb.EyeControls3D(kind=rrb.Eye3DKind.Orbital, spin_speed=SPIN_SPEED),
+                ),
+                rrb.Spatial3DView(
+                    origin=str(parent_log_path / "promptda"),
+                    contents=["$origin/**", str(parent_log_path / "cam") + "/**"],
+                    name="mesh: PromptDA-large (DAv2, 340M)",
+                    eye_controls=rrb.EyeControls3D(kind=rrb.Eye3DKind.Orbital, spin_speed=SPIN_SPEED),
+                ),
+                rrb.Spatial3DView(
+                    origin=str(parent_log_path / "zipdepth"),
+                    contents=["$origin/**", str(parent_log_path / "cam") + "/**"],
+                    name="mesh: ZipDepth-PromptDA (6.95M)",
+                    eye_controls=rrb.EyeControls3D(kind=rrb.Eye3DKind.Orbital, spin_speed=SPIN_SPEED),
+                ),
+            ),
+            rrb.Vertical(
+                rrb.Spatial2DView(origin=str(pinhole_path / "image"), name="RGB"),
+                rrb.Spatial2DView(origin=str(lowres_path / "confidence"), name="ARKit confidence (192x256)"),
+                rrb.Spatial2DView(origin=str(lowres_path / "arkit_depth"), name="raw ARKit LiDAR (192x256, native)"),
+                rrb.Spatial2DView(origin=str(pinhole_path / "promptda_depth"), name="PromptDA-large"),
+                rrb.Spatial2DView(origin=str(pinhole_path / "zipdepth_depth"), name="ZipDepth-PromptDA"),
+            ),
+        column_shares=[3, 2],
+        name="meshes",
+    )
+
+
+def _log_source_mesh(parent_log_path: Path, source: str, fuser: Open3DFuser) -> None:
+    """Log one source's fused TSDF mesh under its own entity, at the current time."""
+    mesh = fuser.get_mesh()
+    mesh.compute_vertex_normals()
+    log_fused_mesh(str(parent_log_path / source / "mesh"), mesh, static=False)
+
+
+def _fuse_source(
+    fuser: Open3DFuser,
+    depth_mm: UInt16[ndarray, "h w"],
+    confidence_hw: UInt8[ndarray, "h w"],
+    k_matrix: Float32[ndarray, "3 3"],
+    rgb_hwc: UInt8[ndarray, "h w 3"],
+    polycam_data: PolycamData,
+    max_depth_range_meter: float,
+) -> None:
+    """Filter and fuse one depth source for a Polycam frame.
+
+    Args:
+        fuser: TSDF volume receiving the frame.
+        depth_mm: UInt16 depth image in millimetres with shape ``(H, W)``.
+        confidence_hw: UInt8 confidence image with shape ``(H, W)``.
+        k_matrix: Float32 camera intrinsics with shape ``(3, 3)``.
+        rgb_hwc: UInt8 RGB image with shape ``(H, W, 3)``.
+        polycam_data: Frame carrying the camera pose.
+        max_depth_range_meter: Maximum retained fusion depth in metres.
+    """
+    fuser.fuse_frames(
+        depth_hw=filter_depth(
+            depth_mm=depth_mm,
+            confidence=confidence_hw,
+            confidence_threshold=DepthConfidenceLevel.MEDIUM,
+            max_depth_meter=max_depth_range_meter,
+        ),
+        K_33=k_matrix,
+        cam_T_world_44=polycam_data.pinhole_params.extrinsics.cam_T_world,
+        rgb_hw3=rgb_hwc,
+    )
+
+
+def polycam_trio(config: PolycamTrioConfig) -> None:
+    """Fuse and log raw ARKit, PromptDA, and ZipDepth-PromptDA depth for one capture."""
+    parent_log_path: Path = Path("world")
+    pinhole_path: Path = parent_log_path / "cam" / "pinhole"
+    lowres_path: Path = parent_log_path / "cam" / "pinhole_lowres"
+    rr.log("/", rr.ViewCoordinates.RUB, static=True)
+    rr.send_blueprint(create_trio_blueprint(parent_log_path))
+    rr.log(
+        str(lowres_path / "confidence"),
+        rr.AnnotationContext(
+            [
+                rr.AnnotationInfo(id=0, label="low", color=(220, 40, 40)),
+                rr.AnnotationInfo(id=1, label="medium", color=(235, 200, 40)),
+                rr.AnnotationInfo(id=2, label="high", color=(60, 200, 90)),
+            ]
+        ),
+        static=True,
+    )
+
+    dataset: PolycamDataset = load_polycam_data(polycam_zip_or_directory_path=config.polycam_zip_path)
+    arkit_fuser: Open3DFuser = Open3DFuser(
+        fusion_resolution=config.depth_fusion_resolution, max_fusion_depth=config.max_depth_range_meter
+    )
+    teacher_fuser: Open3DFuser = Open3DFuser(
+        fusion_resolution=config.depth_fusion_resolution, max_fusion_depth=config.max_depth_range_meter
+    )
+    student_fuser: Open3DFuser = Open3DFuser(
+        fusion_resolution=config.depth_fusion_resolution, max_fusion_depth=config.max_depth_range_meter
+    )
+
+    batch_plan = prepare_polycam_batches(
+        dataset,
+        batch_size=config.batch_size,
+        max_frames=config.max_frames,
+        capture_path=config.polycam_zip_path,
+        description="Trio",
+    )
+    first_batch: tuple[PolycamData, ...] = batch_plan.first_batch
+
+    # The raw LiDAR is a fixed 192x256 per PolycamData; one static scale transform maps
+    # its 2D frame onto the full-res image (the posekit SAM2-mask pattern, track_ui.py).
+    native_hw: tuple[int, int] = first_batch[0].original_depth_hw.shape
+    native_scale: float = first_batch[0].rgb_hw3.shape[1] / native_hw[1]
+    rr.log(str(lowres_path), rr.Transform3D(scale=native_scale), static=True)
+
+    student_config: ZipDepthPromptConfig = config.student
+    if config.zipdepth_checkpoint is not None:
+        student_config = replace(student_config, checkpoint=config.zipdepth_checkpoint)
+    teacher: BaseCompletionPredictor = config.teacher.setup()
+    student: BaseCompletionPredictor = student_config.setup()
+    teacher_label: str = type(config.teacher).__name__
+    student_label: str = type(student_config).__name__
+
+    n_frames: int = 0
+    teacher_seconds: float = 0.0
+    student_seconds: float = 0.0
+    wall_start: float = time.perf_counter()
+
+    batch: tuple[PolycamData, ...]
+    for batch in batch_plan:
+        batch_start: int = n_frames
+        n_frames += len(batch)
+
+        tensor_batch: tuple[UInt8[Tensor, "b h w 3"], Float32[Tensor, "b 192 256"]] = stack_polycam_batch(batch)
+        rgb_bhwc: UInt8[Tensor, "b h w 3"] = tensor_batch[0]
+        prompt_bhw: Float32[Tensor, "b 192 256"] = tensor_batch[1]
+
+        torch.cuda.synchronize()
+        started: float = time.perf_counter()
+        teacher_bhw: Float32[Tensor, "b h w"] = teacher(rgb_bhwc, prompt_bhw)
+        torch.cuda.synchronize()
+        teacher_seconds += time.perf_counter() - started
+
+        started = time.perf_counter()
+        student_bhw: Float32[Tensor, "b h w"] = student(rgb_bhwc, prompt_bhw)
+        torch.cuda.synchronize()
+        student_seconds += time.perf_counter() - started
+
+        teacher_mm_bhw: UInt16[ndarray, "b h w"] = quantize_depth_m_to_mm(teacher_bhw).cpu().numpy()
+        student_mm_bhw: UInt16[ndarray, "b h w"] = quantize_depth_m_to_mm(student_bhw).cpu().numpy()
+
+        frame_offset: int
+        polycam_data: PolycamData
+        for frame_offset, polycam_data in enumerate(batch):
+            rr.set_time("frame_idx", sequence=batch_start + frame_offset)
+            k_matrix: Float32[ndarray, "3 3"] | None = polycam_data.pinhole_params.intrinsics.k_matrix
+            if k_matrix is None:
+                raise ValueError("Polycam pinhole intrinsics must include a 3x3 k_matrix for TSDF fusion.")
+
+            log_pinhole(camera=polycam_data.pinhole_params, cam_log_path=parent_log_path / "cam")
+            rr.log(str(pinhole_path / "image"), rr.Image(polycam_data.rgb_hw3).compress(jpeg_quality=75))
+
+            # The raw LiDAR is 192x256. Log and fuse it at that size -- upsampling it first
+            # would flatter the sensor and hide the 16x resolution gap the models close.
+            # A static Transform3D scales its 2D frame onto the full-res image, the same
+            # pattern posekit uses for SAM2 masks (track_ui.py:160).
+            rr.log(
+                str(lowres_path / "arkit_depth"),
+                rr.DepthImage(polycam_data.original_depth_hw, meter=1000.0, colormap="Viridis"),
+            )
+            # Polycam stores confidence as 0/54/255; compact to class ids 0/1/2 so the
+            # annotation context colors apply (red = low, yellow = medium, green = high).
+            confidence_class_hw: UInt8[ndarray, "nh nw"] = (
+                (polycam_data.original_confidence_hw >= DepthConfidenceLevel.MEDIUM).astype(np.uint8)
+                + (polycam_data.original_confidence_hw >= DepthConfidenceLevel.HIGH).astype(np.uint8)
+            )
+            rr.log(str(lowres_path / "confidence"), rr.SegmentationImage(confidence_class_hw))
+
+            # Errors share one reference -- the teacher -- so the two panes read against
+            # each other: row 2 is the correction PromptDA makes to the raw sensor, row 1
+            # is the part of that correction the student did not reproduce. Row 2 is
+            # measured at the sensor's own resolution by pooling the teacher down to it.
+            teacher_full_hw: Float32[ndarray, "h w"] = teacher_mm_bhw[frame_offset].astype(np.float32)
+            student_error_hw: UInt16[ndarray, "h w"] = (
+                np.abs(student_mm_bhw[frame_offset].astype(np.float32) - teacher_full_hw).clip(0.0, 65535.0).astype(np.uint16)
+            )
+            rr.log(
+                str(pinhole_path / "err_student"),
+                rr.DepthImage(student_error_hw, meter=1000.0, colormap="Inferno", depth_range=ERROR_RANGE_MM),
+            )
+            teacher_native_hw: Float32[ndarray, "nh nw"] = cv2.resize(
+                teacher_full_hw, (native_hw[1], native_hw[0]), interpolation=cv2.INTER_AREA
+            )
+            arkit_error_hw: UInt16[ndarray, "nh nw"] = (
+                np.abs(polycam_data.original_depth_hw.astype(np.float32) - teacher_native_hw).clip(0.0, 65535.0).astype(np.uint16)
+            )
+            rr.log(
+                str(lowres_path / "err_arkit"),
+                rr.DepthImage(arkit_error_hw, meter=1000.0, colormap="Inferno", depth_range=ERROR_RANGE_MM),
+            )
+
+            # Each source fuses on its own grid: the models at full resolution, the raw
+            # sensor at 192x256 with matching RGB and rescaled intrinsics, so the ARKit
+            # mesh shows what the LiDAR alone actually reconstructs.
+            native_rgb_hwc: UInt8[ndarray, "nh nw 3"] = cv2.resize(
+                polycam_data.rgb_hw3, (native_hw[1], native_hw[0]), interpolation=cv2.INTER_AREA
+            )
+            native_k_matrix: Float32[ndarray, "3 3"] | None = rescale_intri(
+                camera_intrinsics=polycam_data.pinhole_params.intrinsics,
+                target_height=native_hw[0],
+                target_width=native_hw[1],
+            ).k_matrix
+            if native_k_matrix is None:
+                raise ValueError("rescaled Polycam intrinsics must include a 3x3 k_matrix for native-resolution fusion.")
+            rr.log(
+                str(pinhole_path / "promptda_depth"),
+                rr.DepthImage(teacher_mm_bhw[frame_offset], meter=1000.0, colormap="Viridis"),
+            )
+            rr.log(
+                str(pinhole_path / "zipdepth_depth"),
+                rr.DepthImage(student_mm_bhw[frame_offset], meter=1000.0, colormap="Viridis"),
+            )
+            _fuse_source(
+                arkit_fuser,
+                polycam_data.original_depth_hw,
+                polycam_data.original_confidence_hw,
+                native_k_matrix,
+                native_rgb_hwc,
+                polycam_data,
+                config.max_depth_range_meter,
+            )
+            _fuse_source(
+                teacher_fuser,
+                teacher_mm_bhw[frame_offset],
+                polycam_data.confidence_hw,
+                k_matrix,
+                polycam_data.rgb_hw3,
+                polycam_data,
+                config.max_depth_range_meter,
+            )
+            _fuse_source(
+                student_fuser,
+                student_mm_bhw[frame_offset],
+                polycam_data.confidence_hw,
+                k_matrix,
+                polycam_data.rgb_hw3,
+                polycam_data,
+                config.max_depth_range_meter,
+            )
+
+        if config.log_incremental_mesh:
+            _log_source_mesh(parent_log_path, "arkit", arkit_fuser)
+            _log_source_mesh(parent_log_path, "promptda", teacher_fuser)
+            _log_source_mesh(parent_log_path, "zipdepth", student_fuser)
+
+    if not config.log_incremental_mesh:
+        # The incremental path already logged the final state after the last batch.
+        _log_source_mesh(parent_log_path, "arkit", arkit_fuser)
+        _log_source_mesh(parent_log_path, "promptda", teacher_fuser)
+        _log_source_mesh(parent_log_path, "zipdepth", student_fuser)
+
+    wall_seconds: float = time.perf_counter() - wall_start
+    print(f"frames                {n_frames}")
+    print(f"{teacher_label:<22}{1000.0 * teacher_seconds / n_frames:.2f} ms/frame")
+    print(f"{student_label:<22}{1000.0 * student_seconds / n_frames:.2f} ms/frame")
+    print(f"speedup               {teacher_seconds / student_seconds:.1f}x")
+    print(f"wall                  {wall_seconds:.1f} s  (three TSDF volumes)")
+
+
+def main(config: PolycamTrioConfig) -> None:
+    """Entry point for the three-way Polycam comparison."""
+    polycam_trio(config)

--- a/packages/prompt-da/tests/test_polycam_trio.py
+++ b/packages/prompt-da/tests/test_polycam_trio.py
@@ -1,0 +1,15 @@
+"""Tests for the three-way Polycam comparison API."""
+
+from typing import get_type_hints
+
+from monopriors.models.depth_completion import PromptDAConfig, ZipDepthPromptConfig
+
+from rerun_prompt_da.apis.polycam_trio import PolycamTrioConfig
+
+
+def test_trio_config_fixes_teacher_and_student_model_families() -> None:
+    """Expose backend choices without allowing the teacher and student roles to swap."""
+    hints: dict[str, object] = get_type_hints(PolycamTrioConfig)
+
+    assert hints["teacher"] is PromptDAConfig
+    assert hints["student"] is ZipDepthPromptConfig

--- a/packages/prompt-da/tools/polycam_trio.py
+++ b/packages/prompt-da/tools/polycam_trio.py
@@ -1,0 +1,8 @@
+"""Thin CLI shim for the three-way ARKit / PromptDA / ZipDepth-PromptDA Polycam comparison."""
+
+import tyro
+
+from rerun_prompt_da.apis.polycam_trio import PolycamTrioConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(PolycamTrioConfig))

--- a/packages/zipdepth/tests/test_eval_hard_frames.py
+++ b/packages/zipdepth/tests/test_eval_hard_frames.py
@@ -1,0 +1,214 @@
+"""Fixed hard-frame scorer tests."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from jaxtyping import Float32
+from monopriors.models.depth_completion.zipdepth_prompt import ZipDepthPrompt
+from numpy import ndarray
+from serde.json import from_json
+from torch import Tensor, nn
+
+from zipdepth.apis.eval_hard_frames import (
+    Config,
+    DepthMetrics,
+    H2Diagnostic,
+    HardFrameData,
+    HardFramesEvaluationReport,
+    ModelPredictions,
+    evaluate_hard_frames,
+    score_depth_metrics,
+    score_h2_diagnostic,
+)
+from zipdepth.apis.hard_frame_data import (
+    FrameMetrics,
+    HardFrameArchive,
+    HardFramesReport,
+    KeptFrameRecord,
+    RankedFrameRecord,
+    RunMetadata,
+    write_hard_frame_archive,
+    write_hard_frames_report,
+)
+
+
+def _write_eval_set(
+    eval_dir: Path,
+    frame_indices: tuple[int, ...],
+    teacher_hw: Float32[ndarray, "h w"],
+    prompt_hw: Float32[ndarray, "192 256"],
+    stored_student_hw: Float32[ndarray, "h w"],
+) -> None:
+    """Write a small typed hard-frame set for scorer integration tests."""
+    frames_dir: Path = eval_dir / "frames"
+    frames_dir.mkdir(parents=True)
+    kept_records: list[KeptFrameRecord] = []
+    ranked_records: list[RankedFrameRecord] = []
+    for rank, frame_index in enumerate(frame_indices, start=1):
+        metrics = FrameMetrics(
+            frame_index=frame_index,
+            student_overall_dev_m=0.1,
+            student_edge_dev_m=0.1,
+            student_flat_dev_m=0.1,
+            baseline_overall_dev_m=0.2,
+            baseline_edge_dev_m=0.2,
+            baseline_flat_dev_m=0.2,
+        )
+        frame_relative_path: Path = Path("frames") / f"frame_{frame_index:05d}.npz"
+        write_hard_frame_archive(
+            eval_dir / frame_relative_path,
+            HardFrameArchive(
+                frame_index=frame_index,
+                rgb_hwc=np.full((*teacher_hw.shape, 3), frame_index, dtype=np.uint8),
+                prompt_hw=prompt_hw,
+                teacher_hw=teacher_hw,
+                student_hw=stored_student_hw,
+            ),
+        )
+        kept_records.append(
+            KeptFrameRecord(
+                rank=rank,
+                frame_path=frame_relative_path.as_posix(),
+                preview_path=f"previews/frame_{frame_index:05d}.png",
+                metrics=metrics,
+            )
+        )
+        ranked_records.append(RankedFrameRecord(rank=rank, metrics=metrics))
+    write_hard_frames_report(
+        eval_dir / "metrics.json",
+        HardFramesReport(
+            run=RunMetadata(
+                capture_path="capture.zip",
+                checkpoint_path="student.pth",
+                edge_quantile=0.9,
+                capture_hw=teacher_hw.shape,
+                teacher_config_class="PromptDAConfig",
+                student_config_class="ZipDepthPromptConfig",
+                student_reference_version="v4",
+                student_output_role="reference_only",
+                eval_label_field="teacher",
+                batch_size=8,
+                max_frames=None,
+                max_keep=len(frame_indices),
+                processed_frames=len(frame_indices),
+            ),
+            kept_frames=kept_records,
+            full_ranking=ranked_records,
+        ),
+    )
+
+
+def test_edge_weighted_metrics_match_a_worked_two_step_frame() -> None:
+    """Score errors at teacher steps of magnitude one and three exactly."""
+    teacher_hw: Float32[ndarray, "10 10"] = np.ones((10, 10), dtype=np.float32)
+    teacher_hw[:, 5:] += 1.0
+    teacher_hw[:, 8:] += 3.0
+    prediction_hw: Float32[ndarray, "10 10"] = teacher_hw.copy()
+    prediction_hw[:, 5] += 2.0
+    prediction_hw[:, 8] += 4.0
+
+    metrics: DepthMetrics = score_depth_metrics(prediction_hw, teacher_hw)
+
+    assert metrics.edge_mae_m == pytest.approx(4.0)
+    assert metrics.flat_mae_m == pytest.approx(20.0 / 90.0)
+    assert metrics.overall_mae_m == pytest.approx(0.6)
+    assert metrics.ewmae_m == pytest.approx((1.0 * 2.0 + 3.0 * 4.0) / (1.0 + 3.0))
+
+
+def test_h2_diagnostic_uses_two_by_two_teacher_mean_and_gradient_retention() -> None:
+    """Give an exact H/2 student zero error and full teacher-gradient retention."""
+    teacher_half_hw: Float32[ndarray, "10 10"] = np.ones((10, 10), dtype=np.float32)
+    teacher_half_hw[:, 5:] = 2.0
+    teacher_hw: Float32[ndarray, "20 20"] = np.repeat(np.repeat(teacher_half_hw, 2, axis=0), 2, axis=1)
+
+    diagnostic: H2Diagnostic = score_h2_diagnostic(teacher_half_hw, teacher_hw)
+
+    assert diagnostic.edge_mae_m == pytest.approx(0.0)
+    assert diagnostic.flat_mae_m == pytest.approx(0.0)
+    assert diagnostic.half_gradient_retention == pytest.approx(1.0)
+
+
+def test_fixed_scorer_writes_json_and_only_requested_plant_preview(tmp_path: Path) -> None:
+    """Consume saved frames without mining and route fake model outputs to artifacts."""
+    eval_dir: Path = tmp_path / "hard20"
+    teacher_hw: Float32[ndarray, "20 20"] = np.ones((20, 20), dtype=np.float32)
+    teacher_hw[:, 8:] += 1.0
+    teacher_hw[:, 16:] += 3.0
+    stored_student_hw: Float32[ndarray, "20 20"] = teacher_hw + 0.1
+    prompt_hw: Float32[ndarray, "192 256"] = np.full((192, 256), 1.5, dtype=np.float32)
+    prompt_hw[:, :32] = 0.0
+    _write_eval_set(eval_dir, (6,), teacher_hw, prompt_hw, stored_student_hw)
+    checkpoint: Path = tmp_path / "candidate.pth"
+    checkpoint.touch()
+    output: Path = tmp_path / "candidate-hard20.json"
+
+    def fake_model_runner(frames: list[HardFrameData], _: Config) -> ModelPredictions:
+        return ModelPredictions(
+            student_depths=[frames[0].stored_student_hw],
+            student_half_depths=[teacher_hw.reshape(10, 2, 10, 2).mean(axis=(1, 3)).astype(np.float32)],
+        )
+
+    result: Path = evaluate_hard_frames(
+        Config(eval_dir=eval_dir, checkpoint=checkpoint, output=output),
+        model_runner=fake_model_runner,
+    )
+
+    assert result == output
+    report: HardFramesEvaluationReport = from_json(HardFramesEvaluationReport, output.read_text())
+    assert report.per_frame[0].frame_index == 6
+    assert report.macro_average.student.edge_mae_m == pytest.approx(0.1)
+    assert report.macro_average.baseline.edge_mae_m > 0.0
+    assert (tmp_path / "candidate-hard20_frame_00006.png").is_file()
+    assert not (tmp_path / "candidate-hard20_frame_00007.png").exists()
+
+
+def test_fixed_scorer_batches_distinct_frames_and_captures_only_h2_logits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Run eight distinct frames, pad only the tail, and decode captured H/2 logits."""
+    eval_dir: Path = tmp_path / "hard20"
+    teacher_hw: Float32[ndarray, "20 20"] = np.ones((20, 20), dtype=np.float32)
+    teacher_hw[:, 8:] += 1.0
+    teacher_hw[:, 16:] += 3.0
+    prompt_hw: Float32[ndarray, "192 256"] = np.full((192, 256), 1.5, dtype=np.float32)
+    _write_eval_set(eval_dir, tuple(range(8, 17)), teacher_hw, prompt_hw, teacher_hw)
+    checkpoint: Path = tmp_path / "signed-head.pth"
+    checkpoint.touch()
+
+    model: ZipDepthPrompt = ZipDepthPrompt()
+    head_half: nn.Conv2d = model.backbone.decoder.head_half
+    nn.init.zeros_(head_half.weight)
+    assert head_half.bias is not None
+    nn.init.zeros_(head_half.bias)
+    observed_first_pixels: list[Float32[Tensor, "b"]] = []
+
+    def forward_with_range(
+        image: Float32[Tensor, "b 3 h w"],
+        prompt_depth: Float32[Tensor, "b 1 192 256"],
+    ) -> tuple[Float32[Tensor, "b 1 h w"], Float32[Tensor, "b 1 1 1"], Float32[Tensor, "b 1 1 1"]]:
+        """Run head_half but bypass the vendored convex helper."""
+        batch_size: int = image.shape[0]
+        observed_first_pixels.append(image[:, 0, 0, 0].detach().cpu())
+        features_bchw: Float32[Tensor, "b 32 10 10"] = torch.zeros((batch_size, 32, 10, 10), device=image.device)
+        head_half(features_bchw)
+        full_depth_bchw: Float32[Tensor, "b 1 20 20"] = torch.full((batch_size, 1, 20, 20), 1.5, device=image.device)
+        min_depth_b: Float32[Tensor, "b 1 1 1"] = torch.ones((batch_size, 1, 1, 1), device=prompt_depth.device)
+        max_depth_b: Float32[Tensor, "b 1 1 1"] = torch.full((batch_size, 1, 1, 1), 2.0, device=prompt_depth.device)
+        return full_depth_bchw, min_depth_b, max_depth_b
+
+    monkeypatch.setattr(model, "fuse_for_inference", lambda: model)
+    monkeypatch.setattr(model, "forward_with_range", forward_with_range)
+    monkeypatch.setattr("zipdepth.apis.eval_hard_frames.load_zipdepth_prompt", lambda *_args, **_kwargs: model)
+
+    output: Path = evaluate_hard_frames(
+        Config(eval_dir=eval_dir, checkpoint=checkpoint, device="cpu"),
+    )
+
+    assert output.is_file()
+    report: HardFramesEvaluationReport = from_json(HardFramesEvaluationReport, output.read_text())
+    assert report.macro_average.h2.overall_mae_m == pytest.approx(1.1)
+    assert len(observed_first_pixels) == 2
+    torch.testing.assert_close(observed_first_pixels[0], torch.arange(8, 16, dtype=torch.float32) / 255.0)
+    torch.testing.assert_close(observed_first_pixels[1], torch.full((8,), 16.0 / 255.0))

--- a/packages/zipdepth/tests/test_polycam_hard_frames.py
+++ b/packages/zipdepth/tests/test_polycam_hard_frames.py
@@ -1,0 +1,108 @@
+"""Tests for shared Polycam hard-frame artifacts."""
+
+import json
+from pathlib import Path
+
+import cv2
+import numpy as np
+import torch
+from jaxtyping import Bool, Float32, UInt8
+from numpy import ndarray
+from torch import Tensor
+
+from zipdepth.apis.hard_frame_data import (
+    FrameMetrics,
+    HardFrameArchive,
+    HardFramesReport,
+    KeptFrameRecord,
+    RankedFrameRecord,
+    RunMetadata,
+    prompt_upsample_depth,
+    read_hard_frame_archive,
+    read_hard_frames_report,
+    write_hard_frame_archive,
+    write_hard_frame_preview,
+    write_hard_frames_report,
+)
+
+
+def test_prompt_upsample_depth_fills_holes_without_zero_bleed() -> None:
+    """Use valid support where available and the frame median elsewhere."""
+    prompt_bhw: Float32[Tensor, "2 4 4"] = torch.zeros((2, 4, 4), dtype=torch.float32)
+    valid_bhw: Bool[Tensor, "2 4 4"] = torch.zeros((2, 4, 4), dtype=torch.bool)
+    prompt_bhw[0, 1:3, 1:3] = 2.0
+    valid_bhw[0, 1:3, 1:3] = True
+
+    upsampled_bhw: Float32[Tensor, "2 8 8"] = prompt_upsample_depth(prompt_bhw, valid_bhw, height=8, width=8)
+
+    assert tuple(upsampled_bhw.shape) == (2, 8, 8)
+    assert torch.equal(upsampled_bhw[0], torch.full((8, 8), 2.0))
+    assert torch.equal(upsampled_bhw[1], torch.ones((8, 8)))
+
+
+def test_hard_frame_manifest_and_archive_round_trip_without_ratios(tmp_path: Path) -> None:
+    """Share one typed manifest and validated NPZ format between miner and scorer."""
+    metrics = FrameMetrics(
+        frame_index=6,
+        student_overall_dev_m=0.1,
+        student_edge_dev_m=0.2,
+        student_flat_dev_m=0.05,
+        baseline_overall_dev_m=0.15,
+        baseline_edge_dev_m=0.3,
+        baseline_flat_dev_m=0.075,
+    )
+    report = HardFramesReport(
+        run=RunMetadata(
+            capture_path="capture.zip",
+            checkpoint_path="student.pth",
+            edge_quantile=0.9,
+            capture_hw=(20, 20),
+            teacher_config_class="PromptDAConfig",
+            student_config_class="ZipDepthPromptConfig",
+            student_reference_version="v4",
+            student_output_role="reference_only",
+            eval_label_field="teacher",
+            batch_size=8,
+            max_frames=None,
+            max_keep=20,
+            processed_frames=1,
+        ),
+        kept_frames=[
+            KeptFrameRecord(
+                rank=1,
+                frame_path="frames/frame_00006.npz",
+                preview_path="previews/frame_00006.png",
+                metrics=metrics,
+            )
+        ],
+        full_ranking=[RankedFrameRecord(rank=1, metrics=metrics)],
+    )
+    report_path: Path = tmp_path / "metrics.json"
+    write_hard_frames_report(report_path, report)
+
+    document: dict[str, object] = json.loads(report_path.read_text())
+    assert "baseline_to_student_edge_ratio" not in document["kept_frames"][0]  # type: ignore[index]
+    assert read_hard_frames_report(report_path) == report
+
+    archive = HardFrameArchive(
+        frame_index=6,
+        rgb_hwc=np.full((20, 20, 3), 127, dtype=np.uint8),
+        prompt_hw=np.full((192, 256), 1.5, dtype=np.float32),
+        teacher_hw=np.ones((20, 20), dtype=np.float32),
+        student_hw=np.full((20, 20), 1.1, dtype=np.float32),
+    )
+    archive_path: Path = tmp_path / "frame.npz"
+    write_hard_frame_archive(archive_path, archive)
+    loaded: HardFrameArchive = read_hard_frame_archive(archive_path)
+
+    assert loaded.frame_index == archive.frame_index
+    np.testing.assert_array_equal(loaded.rgb_hwc, archive.rgb_hwc)
+    np.testing.assert_array_equal(loaded.prompt_hw, archive.prompt_hw)
+    np.testing.assert_array_equal(loaded.teacher_hw, archive.teacher_hw)
+    np.testing.assert_array_equal(loaded.student_hw, archive.student_hw)
+
+    preview_path: Path = tmp_path / "preview.png"
+    write_hard_frame_preview(preview_path, loaded.rgb_hwc, loaded.teacher_hw, loaded.student_hw)
+    preview_bgr_hwc: UInt8[ndarray, "h four_w 3"] | None = cv2.imread(str(preview_path))
+    assert preview_bgr_hwc is not None
+    assert preview_bgr_hwc.shape == (20, 80, 3)

--- a/packages/zipdepth/tools/eval_hard_frames.py
+++ b/packages/zipdepth/tools/eval_hard_frames.py
@@ -1,0 +1,8 @@
+"""CLI shim for fixed hard-frame evaluation."""
+
+import tyro
+
+from zipdepth.apis.eval_hard_frames import Config, main
+
+if __name__ == "__main__":
+    main(tyro.cli(Config))

--- a/packages/zipdepth/tools/polycam_hard_frames.py
+++ b/packages/zipdepth/tools/polycam_hard_frames.py
@@ -1,0 +1,8 @@
+"""Thin CLI shim for Polycam hard-frame mining."""
+
+import tyro
+
+from zipdepth.apis.polycam_hard_frames import PolycamHardFramesConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(PolycamHardFramesConfig))

--- a/packages/zipdepth/zipdepth/apis/eval_hard_frames.py
+++ b/packages/zipdepth/zipdepth/apis/eval_hard_frames.py
@@ -1,0 +1,447 @@
+"""Score fixed saved hard frames without rerunning the teacher or mining frames."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from itertools import batched
+from pathlib import Path
+from typing import Literal, TypeAlias
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from jaxtyping import Bool, Float, Float32, UInt8
+from monopriors.models.depth_completion.base_completion_depth import preprocess_completion_batch
+from monopriors.models.depth_completion.zipdepth_prompt import ZipDepthPrompt, load_zipdepth_prompt
+from numpy import ndarray
+from serde import serde
+from serde.json import to_json
+from torch import Tensor, nn
+from torch.utils.hooks import RemovableHandle
+
+from zipdepth.apis.hard_frame_data import (
+    HardFrameArchive,
+    KeptFrameRecord,
+    prompt_upsample_depth,
+    read_hard_frame_archive,
+    read_hard_frames_report,
+    write_hard_frame_preview,
+)
+from zipdepth.evaluation.edge_metrics import EDGE_QUANTILE, DepthMetrics, EdgeStratifiedResult, edge_stratified_mae
+
+DEFAULT_EVAL_DIR: Path = Path("data/eval/polycam-hard20")
+"""Saved hard-20 set produced once by the miner."""
+DEFAULT_CHECKPOINT: Path = Path("data/checkpoints/zdpda-v4/final_model.pth")
+"""Production v4 checkpoint whose outputs are stored in the hard-20 archives."""
+MODEL_BATCH_SIZE: int = 8
+"""Static production batch used to reproduce the stored v4 arrays."""
+DepthMap: TypeAlias = Float32[ndarray, "h w"]
+ImageRGB: TypeAlias = UInt8[ndarray, "h w 3"]
+DeviceChoice: TypeAlias = Literal["auto", "cuda", "cpu"]
+
+
+@dataclass(frozen=True, slots=True)
+class Config:
+    """Fixed hard-frame scoring configuration."""
+
+    eval_dir: Path = DEFAULT_EVAL_DIR
+    """Directory containing ``metrics.json`` and the frozen frame archives."""
+    checkpoint: Path = DEFAULT_CHECKPOINT
+    """Student checkpoint to score; the teacher is never loaded."""
+    output: Path | None = None
+    """JSON output path; None writes beside the checkpoint."""
+    device: DeviceChoice = "cuda"
+    """Inference device; production parity uses CUDA fp16 autocast."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class H2Diagnostic:
+    """Student H/2 depth quality relative to the 2x2-mean teacher."""
+
+    edge_mae_m: float
+    """H/2 mean absolute error on teacher H/2 edges."""
+    flat_mae_m: float
+    """H/2 mean absolute error outside teacher H/2 edges."""
+    overall_mae_m: float
+    """H/2 mean absolute error over all valid teacher H/2 pixels."""
+    half_gradient_retention: float
+    """Teacher H/2 edge fraction where the student keeps at least half its gradient."""
+
+
+@dataclass(frozen=True, slots=True)
+class HardFrameData:
+    """One immutable saved hard-frame input and reference record."""
+
+    rank: int
+    """Fixed rank recorded by the miner."""
+    frame_index: int
+    """Source capture frame index."""
+    rgb_hwc: ImageRGB
+    """Capture-resolution uint8 RGB image."""
+    prompt_hw: DepthMap
+    """Raw 192x256 metric prompt; zero denotes invalid."""
+    teacher_hw: DepthMap
+    """Frozen capture-resolution teacher depth in metres."""
+    stored_student_hw: DepthMap
+    """Frozen v4 output used only for the v4 preprocessing parity check."""
+    miner_student_edge_mae_m: float | None
+    """Original miner edge deviation, when present in ``metrics.json``."""
+
+
+@dataclass(frozen=True, slots=True)
+class ModelPredictions:
+    """Full-resolution and captured H/2 outputs in input-frame order."""
+
+    student_depths: list[DepthMap]
+    """Current student predictions at capture resolution."""
+    student_half_depths: list[DepthMap]
+    """Current student metric depths decoded directly from H/2 logits."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class FrameResult:
+    """All fixed-scorer measurements for one saved frame."""
+
+    rank: int
+    """Fixed miner rank."""
+    frame_index: int
+    """Source capture frame index."""
+    student: DepthMetrics
+    """Current student versus frozen teacher."""
+    baseline: DepthMetrics
+    """Hole-aware bilinear prompt baseline versus frozen teacher."""
+    h2: H2Diagnostic
+    """Current student's own H/2 diagnostic."""
+    parity_max_abs_m: float | None
+    """Current versus stored v4 maximum difference, only for the reference checkpoint."""
+    miner_student_edge_mae_m: float | None
+    """Student edge MAE saved by the original miner."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class EvaluationReportConfig:
+    """Resolved fixed hard-frame evaluation configuration."""
+
+    eval_dir: Path
+    """Directory containing the frozen evaluation frames."""
+    checkpoint: Path
+    """Student checkpoint that was scored."""
+    output: Path
+    """Written JSON report path."""
+    device: DeviceChoice
+    """Requested inference device policy."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class MacroAverage:
+    """Macro-average scorer metrics across the fixed frames."""
+
+    student: DepthMetrics
+    """Current student metrics relative to the frozen teacher."""
+    baseline: DepthMetrics
+    """Hole-aware prompt-upsample metrics relative to the frozen teacher."""
+    h2: H2Diagnostic
+    """Current student H/2 diagnostic."""
+    parity_max_abs_m: float | None
+    """Maximum current-versus-reference difference, when checked."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class HardFramesEvaluationReport:
+    """Typed fixed hard-frame scorer document."""
+
+    config: EvaluationReportConfig
+    """Resolved evaluation configuration."""
+    per_frame: list[FrameResult]
+    """Metrics for each fixed frame in miner rank order."""
+    macro_average: MacroAverage
+    """Macro-average metrics over every fixed frame."""
+
+
+ModelRunner: TypeAlias = Callable[[list[HardFrameData], Config], ModelPredictions]
+
+
+def _resolve_device(device: DeviceChoice) -> str:
+    """Resolve a requested Torch device and reject an unavailable explicit CUDA device."""
+    if device == "auto":
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("CUDA was requested but is not visible")
+    return device
+
+
+def score_depth_metrics(prediction_hw: DepthMap, teacher_hw: DepthMap) -> DepthMetrics:
+    """Score one full-resolution depth prediction with the fixed hard-frame rule.
+
+    Args:
+        prediction_hw: Float32 predicted metric depth with shape ``(H, W)``.
+        teacher_hw: Float32 frozen teacher metric depth with shape ``(H, W)``.
+
+    Returns:
+        Edge, flat, overall, and teacher-gradient-weighted absolute errors.
+    """
+    if prediction_hw.shape != teacher_hw.shape:
+        raise ValueError("prediction and teacher must have equal 2D shapes")
+    teacher_valid_hw: Bool[ndarray, "h w"] = np.isfinite(teacher_hw) & (teacher_hw > 0.0)
+    result: EdgeStratifiedResult | None = edge_stratified_mae(
+        prediction_hw,
+        teacher_hw,
+        teacher_valid_hw,
+        edge_quantile=EDGE_QUANTILE,
+    )
+    if result is None:
+        raise ValueError("teacher must produce nonempty valid edge and flat strata")
+    return result.prediction
+
+
+def score_h2_diagnostic(student_half_hw: DepthMap, teacher_hw: DepthMap) -> H2Diagnostic:
+    """Compare decoded student H/2 depth with the teacher's exact 2x2 mean."""
+    teacher: Float32[Tensor, "h w"] = torch.from_numpy(np.ascontiguousarray(teacher_hw)).to(dtype=torch.float32)
+    if teacher.ndim != 2 or teacher.shape[0] % 2 != 0 or teacher.shape[1] % 2 != 0:
+        raise ValueError("teacher height and width must both be even for the H/2 diagnostic")
+    teacher_half: Float32[Tensor, "half_h half_w"] = F.avg_pool2d(teacher[None, None], kernel_size=2, stride=2)[0, 0]
+    teacher_half_hw: DepthMap = teacher_half.numpy().astype(np.float32, copy=False)
+    if student_half_hw.shape != teacher_half_hw.shape:
+        raise ValueError(f"student H/2 shape {student_half_hw.shape} does not match teacher H/2 shape {teacher_half_hw.shape}")
+    teacher_valid_hw: Bool[ndarray, "h w"] = np.isfinite(teacher_half_hw) & (teacher_half_hw > 0.0)
+    result: EdgeStratifiedResult | None = edge_stratified_mae(
+        student_half_hw,
+        teacher_half_hw,
+        teacher_valid_hw,
+        edge_quantile=EDGE_QUANTILE,
+    )
+    if result is None:
+        raise ValueError("H/2 teacher must produce nonempty valid edge and flat strata")
+    student: Float32[Tensor, "half_h half_w"] = torch.from_numpy(np.ascontiguousarray(student_half_hw)).to(dtype=torch.float32)
+    student_gradient: Float32[Tensor, "half_h half_w"] = torch.zeros_like(student)
+    student_gradient[:, 1:] += (student[:, 1:] - student[:, :-1]).abs()
+    student_gradient[1:, :] += (student[1:, :] - student[:-1, :]).abs()
+    retained: Bool[Tensor, "half_h half_w"] = result.edge_hw & (student_gradient >= 0.5 * result.gradient_hw)
+    return H2Diagnostic(
+        edge_mae_m=result.prediction.edge_mae_m,
+        flat_mae_m=result.prediction.flat_mae_m,
+        overall_mae_m=result.prediction.overall_mae_m,
+        half_gradient_retention=float(retained.sum().div(result.edge_hw.sum()).item()),
+    )
+
+
+def _load_frames(eval_dir: Path) -> list[HardFrameData]:
+    """Load the immutable frame order from the miner report and validate every archive."""
+    metrics_path: Path = eval_dir / "metrics.json"
+    report = read_hard_frames_report(metrics_path)
+    frames: list[HardFrameData] = []
+    item: KeptFrameRecord
+    for item in report.kept_frames:
+        archive: HardFrameArchive = read_hard_frame_archive(eval_dir / item.frame_path)
+        frames.append(
+            HardFrameData(
+                rank=item.rank,
+                frame_index=archive.frame_index,
+                rgb_hwc=archive.rgb_hwc,
+                prompt_hw=archive.prompt_hw,
+                teacher_hw=archive.teacher_hw,
+                stored_student_hw=archive.student_hw,
+                miner_student_edge_mae_m=item.metrics.student_edge_dev_m,
+            )
+        )
+    if not frames:
+        raise ValueError("metrics.json kept_frames is empty")
+    return frames
+
+
+def _run_model(frames: list[HardFrameData], config: Config) -> ModelPredictions:
+    """Run the student in static batches and capture metric depth at H/2."""
+    if not config.checkpoint.is_file():
+        raise FileNotFoundError(f"student checkpoint is missing: {config.checkpoint}")
+    device: str = _resolve_device(config.device)
+    model: ZipDepthPrompt = load_zipdepth_prompt(config.checkpoint).to(device=device, dtype=torch.float32).fuse_for_inference()
+    captured_logits: Float[Tensor, "b 1 half_h half_w"] | None = None
+
+    def capture_head_half(
+        _module: nn.Module,
+        _inputs: tuple[Float[Tensor, "b 32 half_h half_w"], ...],
+        output: Float[Tensor, "b 1 half_h half_w"],
+    ) -> None:
+        nonlocal captured_logits
+        captured_logits = output.detach()
+
+    hook_handle: RemovableHandle = model.backbone.decoder.head_half.register_forward_hook(capture_head_half)
+    student_depths: list[DepthMap] = []
+    student_half_depths: list[DepthMap] = []
+    try:
+        frame_batch: tuple[HardFrameData, ...]
+        for frame_batch in batched(frames, MODEL_BATCH_SIZE):
+            real_batch_size: int = len(frame_batch)
+            padded_batch: tuple[HardFrameData, ...] = frame_batch + (frame_batch[-1],) * (MODEL_BATCH_SIZE - real_batch_size)
+            rgb_bhwc: UInt8[Tensor, "b h w 3"] = torch.from_numpy(np.stack([frame.rgb_hwc for frame in padded_batch])).to(device=device)
+            prompt_bhw: Float32[Tensor, "b 192 256"] = torch.from_numpy(np.stack([frame.prompt_hw for frame in padded_batch])).to(
+                device=device, dtype=torch.float32
+            )
+            image_hw: tuple[int, int] = frame_batch[0].rgb_hwc.shape[:2]
+            image_bchw: Float32[Tensor, "b 3 h w"]
+            prompt_bchw: Float32[Tensor, "b 1 192 256"]
+            image_bchw, prompt_bchw = preprocess_completion_batch(rgb_bhwc, prompt_bhw, image_hw)
+            captured_logits = None
+            with torch.inference_mode():
+                output: tuple[Float32[Tensor, "b 1 h w"], Float32[Tensor, "b 1 1 1"], Float32[Tensor, "b 1 1 1"]]
+                if device == "cuda":
+                    with torch.autocast(device_type="cuda", dtype=torch.float16):
+                        output = model.forward_with_range(image_bchw, prompt_bchw)
+                else:
+                    output = model.forward_with_range(image_bchw, prompt_bchw)
+            if captured_logits is None:
+                raise RuntimeError("H/2 logits were not captured from decoder.head_half")
+            student_bchw: Float32[Tensor, "b 1 h w"] = output[0]
+            min_depth_b: Float32[Tensor, "b 1 1 1"] = output[1]
+            max_depth_b: Float32[Tensor, "b 1 1 1"] = output[2]
+            span_b: Float32[Tensor, "b 1 1 1"] = (max_depth_b - min_depth_b).clamp_min(1.0e-6)
+            student_half_bchw: Float32[Tensor, "b 1 half_h half_w"] = torch.sigmoid(captured_logits) * span_b + min_depth_b
+            for batch_index in range(real_batch_size):
+                student_depths.append(student_bchw[batch_index, 0].float().cpu().numpy().astype(np.float32, copy=False))
+                student_half_depths.append(student_half_bchw[batch_index, 0].float().cpu().numpy().astype(np.float32, copy=False))
+    finally:
+        hook_handle.remove()
+    return ModelPredictions(student_depths=student_depths, student_half_depths=student_half_depths)
+
+
+def _mean_depth_metrics(results: list[FrameResult], field_name: Literal["student", "baseline"]) -> DepthMetrics:
+    """Macro-average one full-resolution metric group over fixed frames."""
+    values: list[DepthMetrics] = [getattr(result, field_name) for result in results]
+    return DepthMetrics(
+        edge_mae_m=float(np.mean([value.edge_mae_m for value in values])),
+        flat_mae_m=float(np.mean([value.flat_mae_m for value in values])),
+        overall_mae_m=float(np.mean([value.overall_mae_m for value in values])),
+        ewmae_m=float(np.mean([value.ewmae_m for value in values])),
+    )
+
+
+def _mean_h2(results: list[FrameResult]) -> H2Diagnostic:
+    """Macro-average the H/2 diagnostics over fixed frames."""
+    return H2Diagnostic(
+        edge_mae_m=float(np.mean([result.h2.edge_mae_m for result in results])),
+        flat_mae_m=float(np.mean([result.h2.flat_mae_m for result in results])),
+        overall_mae_m=float(np.mean([result.h2.overall_mae_m for result in results])),
+        half_gradient_retention=float(np.mean([result.h2.half_gradient_retention for result in results])),
+    )
+
+
+def _print_table(results: list[FrameResult]) -> None:
+    """Print one compact millimetre table plus the macro-average row."""
+    print("frame  student E/F/O mm       baseline E/F/O mm      EW/B-EW mm   H2 E/F mm    H2 retain  parity mm")
+    for result in results:
+        parity_mm: str = "-" if result.parity_max_abs_m is None else f"{1000.0 * result.parity_max_abs_m:.4f}"
+        print(
+            f"{result.frame_index:5d}  "
+            f"{1000.0 * result.student.edge_mae_m:6.1f}/{1000.0 * result.student.flat_mae_m:6.1f}/{1000.0 * result.student.overall_mae_m:6.1f}  "
+            f"{1000.0 * result.baseline.edge_mae_m:6.1f}/{1000.0 * result.baseline.flat_mae_m:6.1f}/{1000.0 * result.baseline.overall_mae_m:6.1f}  "
+            f"{1000.0 * result.student.ewmae_m:6.1f}/{1000.0 * result.baseline.ewmae_m:6.1f}  "
+            f"{1000.0 * result.h2.edge_mae_m:6.1f}/{1000.0 * result.h2.flat_mae_m:6.1f}  "
+            f"{100.0 * result.h2.half_gradient_retention:8.2f}%  {parity_mm:>9}"
+        )
+    student: DepthMetrics = _mean_depth_metrics(results, "student")
+    baseline: DepthMetrics = _mean_depth_metrics(results, "baseline")
+    h2: H2Diagnostic = _mean_h2(results)
+    parity_values: list[float] = [result.parity_max_abs_m for result in results if result.parity_max_abs_m is not None]
+    parity_mm: str = "-" if not parity_values else f"{1000.0 * max(parity_values):.4f}"
+    print(
+        f"macro  {1000.0 * student.edge_mae_m:6.1f}/{1000.0 * student.flat_mae_m:6.1f}/{1000.0 * student.overall_mae_m:6.1f}  "
+        f"{1000.0 * baseline.edge_mae_m:6.1f}/{1000.0 * baseline.flat_mae_m:6.1f}/{1000.0 * baseline.overall_mae_m:6.1f}  "
+        f"{1000.0 * student.ewmae_m:6.1f}/{1000.0 * baseline.ewmae_m:6.1f}  "
+        f"{1000.0 * h2.edge_mae_m:6.1f}/{1000.0 * h2.flat_mae_m:6.1f}  "
+        f"{100.0 * h2.half_gradient_retention:8.2f}%  {parity_mm:>9}"
+    )
+
+
+def evaluate_hard_frames(config: Config, *, model_runner: ModelRunner = _run_model) -> Path:
+    """Score the fixed saved frames, write JSON and plant previews, and print a table."""
+    frames: list[HardFrameData] = _load_frames(config.eval_dir)
+    predictions: ModelPredictions = model_runner(frames, config)
+    if len(predictions.student_depths) != len(frames) or len(predictions.student_half_depths) != len(frames):
+        raise ValueError("model runner must return one full-resolution and H/2 prediction per frame")
+    reference_checkpoint: bool = config.checkpoint.resolve() == DEFAULT_CHECKPOINT.resolve()
+    results: list[FrameResult] = []
+    output: Path = config.output or config.checkpoint.parent / f"hard20_{config.checkpoint.stem}.json"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    frame: HardFrameData
+    student_hw: DepthMap
+    student_half_hw: DepthMap
+    for frame, student_hw, student_half_hw in zip(
+        frames, predictions.student_depths, predictions.student_half_depths, strict=True
+    ):
+        prompt_hw: Float32[Tensor, "1 192 256"] = torch.from_numpy(np.ascontiguousarray(frame.prompt_hw))[None]
+        prompt_valid_hw: Bool[Tensor, "1 192 256"] = torch.isfinite(prompt_hw) & (prompt_hw > 0.0)
+        baseline_hw: DepthMap = prompt_upsample_depth(
+            prompt_hw,
+            prompt_valid_hw,
+            height=frame.teacher_hw.shape[0],
+            width=frame.teacher_hw.shape[1],
+        )[0].numpy().astype(np.float32, copy=False)
+        parity_max_abs_m: float | None = None
+        if reference_checkpoint:
+            parity_max_abs_m = float(np.max(np.abs(student_hw - frame.stored_student_hw)))
+            if parity_max_abs_m > 1.0e-5:
+                raise AssertionError(
+                    f"frame {frame.frame_index} v4 preprocessing parity failed: maximum difference is {1000.0 * parity_max_abs_m:.4f} mm"
+                )
+        teacher_valid_hw: Bool[ndarray, "h w"] = np.isfinite(frame.teacher_hw) & (frame.teacher_hw > 0.0)
+        stratified: EdgeStratifiedResult | None = edge_stratified_mae(
+            student_hw,
+            frame.teacher_hw,
+            teacher_valid_hw,
+            baseline_hw,
+            edge_quantile=EDGE_QUANTILE,
+        )
+        if stratified is None or stratified.baseline is None:
+            raise ValueError(f"frame {frame.frame_index} must produce valid student and baseline edge metrics")
+        result: FrameResult = FrameResult(
+            rank=frame.rank,
+            frame_index=frame.frame_index,
+            student=stratified.prediction,
+            baseline=stratified.baseline,
+            h2=score_h2_diagnostic(student_half_hw, frame.teacher_hw),
+            parity_max_abs_m=parity_max_abs_m,
+            miner_student_edge_mae_m=frame.miner_student_edge_mae_m,
+        )
+        results.append(result)
+        if frame.frame_index in (6, 7):
+            write_hard_frame_preview(
+                output.with_name(f"{output.stem}_frame_{frame.frame_index:05d}.png"),
+                frame.rgb_hwc,
+                frame.teacher_hw,
+                student_hw,
+            )
+
+    macro_student: DepthMetrics = _mean_depth_metrics(results, "student")
+    macro_baseline: DepthMetrics = _mean_depth_metrics(results, "baseline")
+    macro_h2: H2Diagnostic = _mean_h2(results)
+    parity_values: list[float] = [result.parity_max_abs_m for result in results if result.parity_max_abs_m is not None]
+    document: HardFramesEvaluationReport = HardFramesEvaluationReport(
+        config=EvaluationReportConfig(
+            eval_dir=config.eval_dir,
+            checkpoint=config.checkpoint,
+            output=output,
+            device=config.device,
+        ),
+        per_frame=results,
+        macro_average=MacroAverage(
+            student=macro_student,
+            baseline=macro_baseline,
+            h2=macro_h2,
+            parity_max_abs_m=max(parity_values) if parity_values else None,
+        ),
+    )
+    output.write_text(to_json(document) + "\n", encoding="utf-8")
+    _print_table(results)
+    print(f"wrote {output}")
+    return output
+
+
+def main(config: Config) -> Path:
+    """Run the fixed hard-frame scorer."""
+    return evaluate_hard_frames(config)

--- a/packages/zipdepth/zipdepth/apis/hard_frame_data.py
+++ b/packages/zipdepth/zipdepth/apis/hard_frame_data.py
@@ -1,0 +1,243 @@
+"""Hard-frame manifests, archives, previews, and the batched hole-aware prompt upsampler."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypeAlias
+
+import cv2
+import numpy as np
+import torch
+import torch.nn.functional as F
+from jaxtyping import Bool, Float32, UInt8
+from numpy import ndarray
+from serde import field as serde_field
+from serde import serde
+from serde.json import from_json, to_json
+from torch import Tensor
+
+ERROR_MAX_MM: float = 250.0
+"""Upper bound of every hard-frame preview error heatmap."""
+
+DepthMap: TypeAlias = Float32[ndarray, "h w"]
+ImageRGB: TypeAlias = UInt8[ndarray, "h w 3"]
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class FrameMetrics:
+    """Teacher-relative errors retained for one mined capture frame."""
+
+    frame_index: int
+    """Zero-based frame index in capture iteration order."""
+    student_overall_dev_m: float
+    """Student-teacher mean absolute deviation over valid pixels, in metres."""
+    student_edge_dev_m: float
+    """Student-teacher mean absolute deviation on teacher edges, in metres."""
+    student_flat_dev_m: float
+    """Student-teacher mean absolute deviation off teacher edges, in metres."""
+    baseline_overall_dev_m: float
+    """Baseline-teacher mean absolute deviation over valid pixels, in metres."""
+    baseline_edge_dev_m: float
+    """Baseline-teacher mean absolute deviation on teacher edges, in metres."""
+    baseline_flat_dev_m: float
+    """Baseline-teacher mean absolute deviation off teacher edges, in metres."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class RankedFrameRecord:
+    """One full-ranking entry."""
+
+    rank: int
+    """One-based rank by descending student edge deviation."""
+    metrics: FrameMetrics = serde_field(flatten=True)
+    """Teacher-relative metrics flattened into this record."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class KeptFrameRecord:
+    """One written hard frame and its artifact paths."""
+
+    rank: int
+    """One-based rank by descending student edge deviation."""
+    frame_path: str
+    """Frame NPZ path relative to the output directory."""
+    preview_path: str
+    """Preview PNG path relative to the output directory."""
+    metrics: FrameMetrics = serde_field(flatten=True)
+    """Teacher-relative metrics flattened into this record."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class RunMetadata:
+    """Provenance of one hard-frame mining run."""
+
+    capture_path: str
+    """Polycam capture the frames came from."""
+    checkpoint_path: str | None
+    """Student checkpoint, when the student is ZipDepth-PromptDA."""
+    edge_quantile: float
+    """Per-frame teacher-gradient quantile defining edges."""
+    capture_hw: tuple[int, int]
+    """Capture resolution as height and width."""
+    teacher_config_class: str
+    """Completion config class that produced the labels."""
+    student_config_class: str
+    """Completion config class whose deviations ranked frames."""
+    student_reference_version: str
+    """Human label for the stored student checkpoint generation."""
+    student_output_role: str
+    """How downstream evaluation should use stored student depth."""
+    eval_label_field: str
+    """NPZ field holding the evaluation label."""
+    batch_size: int
+    """Frames per model batch."""
+    max_frames: int | None
+    """Frame cap applied to the capture, if any."""
+    max_keep: int
+    """Maximum number of highest-error frames written."""
+    processed_frames: int
+    """Frames processed by the miner."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
+class HardFramesReport:
+    """Typed hard-frame ``metrics.json`` document."""
+
+    run: RunMetadata
+    """Provenance of this mining run."""
+    kept_frames: list[KeptFrameRecord]
+    """Written frames in rank order."""
+    full_ranking: list[RankedFrameRecord]
+    """Every processed frame in rank order."""
+
+
+@dataclass(frozen=True, slots=True)
+class HardFrameArchive:
+    """Arrays stored for one selected hard frame."""
+
+    frame_index: int
+    """Zero-based source capture frame index."""
+    rgb_hwc: ImageRGB
+    """Capture-resolution uint8 RGB image."""
+    prompt_hw: DepthMap
+    """Raw 192x256 metric prompt; zero denotes invalid."""
+    teacher_hw: DepthMap
+    """Frozen capture-resolution teacher depth in metres."""
+    student_hw: DepthMap
+    """Frozen capture-resolution reference-student depth in metres."""
+
+
+def prompt_upsample_depth(
+    prompt_depth_bhw: Float32[Tensor, "b ph pw"],
+    prompt_valid_bhw: Bool[Tensor, "b ph pw"],
+    *,
+    height: int,
+    width: int,
+) -> Float32[Tensor, "b h w"]:
+    """Bilinearly upsample batched LiDAR prompts without bleeding holes.
+
+    Args:
+        prompt_depth_bhw: Float32 metric prompts with shape ``(B, PH, PW)``.
+        prompt_valid_bhw: Boolean prompt validity with shape ``(B, PH, PW)``.
+        height: Output height.
+        width: Output width.
+
+    Returns:
+        Dense Float32 metric depth with shape ``(B, height, width)``.
+    """
+    if prompt_depth_bhw.ndim != 3 or prompt_valid_bhw.shape != prompt_depth_bhw.shape:
+        raise ValueError("prompt depth and validity must share one BxHxW shape.")
+    valid_weight_bhw: Float32[Tensor, "b ph pw"] = prompt_valid_bhw.to(dtype=torch.float32)
+    weighted_bhw: Float32[Tensor, "b ph pw"] = prompt_depth_bhw * valid_weight_bhw
+    weighted_up_bhw: Float32[Tensor, "b h w"] = F.interpolate(
+        weighted_bhw[:, None], size=(height, width), mode="bilinear", align_corners=False
+    )[:, 0]
+    weight_up_bhw: Float32[Tensor, "b h w"] = F.interpolate(
+        valid_weight_bhw[:, None], size=(height, width), mode="bilinear", align_corners=False
+    )[:, 0]
+    fallback_values: list[Float32[Tensor, ""]] = [
+        torch.quantile(depth_hw[valid_hw], 0.5) if bool(valid_hw.any()) else torch.tensor(1.0, device=depth_hw.device, dtype=depth_hw.dtype)
+        for depth_hw, valid_hw in zip(prompt_depth_bhw, prompt_valid_bhw, strict=True)
+    ]
+    fallback_b: Float32[Tensor, "b 1 1"] = torch.stack(fallback_values)[:, None, None]
+    supported_bhw: Bool[Tensor, "b h w"] = weight_up_bhw > 1.0e-3
+    return torch.where(supported_bhw, weighted_up_bhw / weight_up_bhw.clamp_min(1.0e-3), fallback_b)
+
+
+def read_hard_frames_report(path: Path) -> HardFramesReport:
+    """Deserialize one typed hard-frame manifest."""
+    if not path.is_file():
+        raise FileNotFoundError(f"hard-frame metrics file is missing: {path}")
+    return from_json(HardFramesReport, path.read_text(encoding="utf-8"))
+
+
+def write_hard_frames_report(path: Path, report: HardFramesReport) -> None:
+    """Serialize one typed hard-frame manifest."""
+    path.write_text(to_json(report) + "\n", encoding="utf-8")
+
+
+def read_hard_frame_archive(path: Path) -> HardFrameArchive:
+    """Load and validate one hard-frame NPZ archive."""
+    if not path.is_file():
+        raise FileNotFoundError(f"hard-frame archive is missing: {path}")
+    with np.load(path) as archive:
+        required_keys: set[str] = {"rgb", "prompt", "teacher", "student", "frame_index"}
+        if not required_keys.issubset(archive.files):
+            raise ValueError(f"{path} is missing keys {sorted(required_keys - set(archive.files))}")
+        frame = HardFrameArchive(
+            frame_index=int(archive["frame_index"].item()),
+            rgb_hwc=np.ascontiguousarray(archive["rgb"].astype(np.uint8, copy=False)),
+            prompt_hw=np.ascontiguousarray(archive["prompt"].astype(np.float32, copy=False)),
+            teacher_hw=np.ascontiguousarray(archive["teacher"].astype(np.float32, copy=False)),
+            student_hw=np.ascontiguousarray(archive["student"].astype(np.float32, copy=False)),
+        )
+    if frame.rgb_hwc.ndim != 3 or frame.rgb_hwc.shape[-1] != 3:
+        raise ValueError(f"{path}: rgb must have shape HxWx3")
+    if frame.prompt_hw.shape != (192, 256):
+        raise ValueError(f"{path}: prompt must have shape 192x256")
+    if frame.teacher_hw.shape != frame.rgb_hwc.shape[:2] or frame.student_hw.shape != frame.teacher_hw.shape:
+        raise ValueError(f"{path}: teacher and stored student must match RGB spatial shape")
+    return frame
+
+
+def write_hard_frame_archive(path: Path, frame: HardFrameArchive) -> None:
+    """Write one hard-frame NPZ archive."""
+    np.savez_compressed(
+        path,
+        rgb=frame.rgb_hwc,
+        prompt=frame.prompt_hw,
+        teacher=frame.teacher_hw,
+        student=frame.student_hw,
+        frame_index=frame.frame_index,
+    )
+
+
+def write_hard_frame_preview(
+    path: Path,
+    rgb_hwc: ImageRGB,
+    teacher_hw: DepthMap,
+    student_hw: DepthMap,
+) -> None:
+    """Write RGB, Turbo depths, and fixed 0--250 mm Turbo error as one strip."""
+    min_depth_m: float = float(min(teacher_hw.min(), student_hw.min()))
+    max_depth_m: float = float(max(teacher_hw.max(), student_hw.max()))
+    depth_span_m: float = max(max_depth_m - min_depth_m, float(np.finfo(np.float32).eps))
+    teacher_scaled_hw: UInt8[ndarray, "h w"] = np.clip((teacher_hw - min_depth_m) * (255.0 / depth_span_m), 0.0, 255.0).astype(np.uint8)
+    student_scaled_hw: UInt8[ndarray, "h w"] = np.clip((student_hw - min_depth_m) * (255.0 / depth_span_m), 0.0, 255.0).astype(np.uint8)
+    error_mm_hw: DepthMap = np.abs(student_hw - teacher_hw) * 1000.0
+    error_scaled_hw: UInt8[ndarray, "h w"] = np.clip(error_mm_hw * (255.0 / ERROR_MAX_MM), 0.0, 255.0).astype(np.uint8)
+    preview_bgr_hwc: UInt8[ndarray, "h four_w 3"] = np.concatenate(
+        (
+            cv2.cvtColor(rgb_hwc, cv2.COLOR_RGB2BGR),
+            cv2.applyColorMap(teacher_scaled_hw, cv2.COLORMAP_TURBO),
+            cv2.applyColorMap(student_scaled_hw, cv2.COLORMAP_TURBO),
+            cv2.applyColorMap(error_scaled_hw, cv2.COLORMAP_TURBO),
+        ),
+        axis=1,
+    )
+    if not cv2.imwrite(str(path), preview_bgr_hwc):
+        raise OSError(f"failed to write preview: {path}")

--- a/packages/zipdepth/zipdepth/apis/polycam_hard_frames.py
+++ b/packages/zipdepth/zipdepth/apis/polycam_hard_frames.py
@@ -1,0 +1,242 @@
+"""Mine Polycam frames where ZipDepth-PromptDA deviates most at depth edges."""
+
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+
+import torch
+from jaxtyping import Bool, Float32, UInt8
+from monopriors.models.depth_completion import AnnotatedCompletionConfig, PromptDAConfig, ZipDepthPromptConfig
+from monopriors.models.depth_completion.base_completion_depth import BaseCompletionPredictor
+from monopriors.models.depth_completion.prompt_da import DEFAULT_PROMPTDA_CACHE_DIR
+from numpy import ndarray
+from simplecv.data.polycam import (
+    PolycamBatchPlan,
+    PolycamData,
+    PolycamDataset,
+    load_polycam_data,
+    prepare_polycam_batches,
+    stack_polycam_batch,
+)
+from torch import Tensor
+from trtkit import TensorRtBackendConfig, TorchBackendConfig
+
+from zipdepth.apis.hard_frame_data import (
+    FrameMetrics,
+    HardFrameArchive,
+    HardFramesReport,
+    KeptFrameRecord,
+    RankedFrameRecord,
+    RunMetadata,
+    prompt_upsample_depth,
+    write_hard_frame_archive,
+    write_hard_frame_preview,
+    write_hard_frames_report,
+)
+from zipdepth.evaluation.edge_metrics import EdgeStratifiedResult, edge_stratified_mae
+
+
+@dataclass
+class PolycamHardFramesConfig:
+    """Runtime configuration for Polycam hard-frame mining."""
+
+    polycam_zip_path: Path
+    """Polycam capture zip (or extracted directory) to process."""
+    teacher: AnnotatedCompletionConfig = field(
+        default_factory=lambda: PromptDAConfig(
+            backend=TensorRtBackendConfig(max_batch_size=8, opt_batch_size=8, cache_dir=DEFAULT_PROMPTDA_CACHE_DIR / "trt")
+        )
+    )
+    """Teacher completion model and backend."""
+    student: AnnotatedCompletionConfig = field(
+        default_factory=lambda: ZipDepthPromptConfig(checkpoint=Path(), backend=TorchBackendConfig())
+    )
+    """Student completion model and backend."""
+    zipdepth_checkpoint: Path | None = None
+    """Compatibility alias for ``student=zipdepth-promptda --checkpoint``."""
+    out_dir: Path = Path("data/polycam-hard-frames")
+    """Directory receiving the standalone hard-frame eval set."""
+    max_keep: int = 20
+    """Maximum number of highest-error frames to write."""
+    batch_size: int = 8
+    """Frames per model batch."""
+    edge_quantile: float = 0.90
+    """Per-frame teacher-gradient quantile defining the edge region."""
+    max_frames: int | None = None
+    """Optional cap on processed frames."""
+
+
+@dataclass(frozen=True, slots=True)
+class HardFrame:
+    """Host arrays retained for one current top-N frame."""
+
+    metrics: FrameMetrics
+    """Teacher-relative scalar metrics used for ranking."""
+    archive: HardFrameArchive
+    """Arrays written for this retained frame."""
+
+
+def polycam_hard_frames(config: PolycamHardFramesConfig) -> None:
+    """Rank one Polycam capture and write its highest edge-deviation frames."""
+    if config.max_keep <= 0:
+        raise ValueError("max_keep must be positive.")
+    if not 0.0 <= config.edge_quantile <= 1.0:
+        raise ValueError("edge_quantile must be in [0, 1].")
+
+    dataset: PolycamDataset = load_polycam_data(polycam_zip_or_directory_path=config.polycam_zip_path)
+    batch_plan: PolycamBatchPlan = prepare_polycam_batches(
+        dataset,
+        batch_size=config.batch_size,
+        max_frames=config.max_frames,
+        capture_path=config.polycam_zip_path,
+        description="Hard frames",
+    )
+    capture_hw: tuple[int, int] = batch_plan.first_batch[0].rgb_hw3.shape[:2]
+
+    student_config: AnnotatedCompletionConfig = config.student
+    if config.zipdepth_checkpoint is not None:
+        if not isinstance(student_config, ZipDepthPromptConfig):
+            raise ValueError("--zipdepth-checkpoint requires the ZipDepth-PromptDA student config.")
+        student_config = replace(student_config, checkpoint=config.zipdepth_checkpoint)
+    teacher: BaseCompletionPredictor = config.teacher.setup()
+    student: BaseCompletionPredictor = student_config.setup()
+
+    all_metrics: list[FrameMetrics] = []
+    kept_frames: list[HardFrame] = []
+    n_frames: int = 0
+    batch: tuple[PolycamData, ...]
+    for batch in batch_plan:
+        batch_start: int = n_frames
+        n_frames += len(batch)
+        tensor_batch: tuple[UInt8[Tensor, "b h w 3"], Float32[Tensor, "b 192 256"]] = stack_polycam_batch(batch)
+        rgb_bhwc: UInt8[Tensor, "b h w 3"] = tensor_batch[0]
+        prompt_bhw: Float32[Tensor, "b 192 256"] = tensor_batch[1]
+        teacher_bhw: Float32[Tensor, "b h w"] = teacher(rgb_bhwc, prompt_bhw)
+        student_bhw: Float32[Tensor, "b h w"] = student(rgb_bhwc, prompt_bhw)
+        prompt_valid_bhw: Bool[Tensor, "b 192 256"] = torch.isfinite(prompt_bhw) & (prompt_bhw > 0.0)
+        baseline_bhw: Float32[Tensor, "b h w"] = prompt_upsample_depth(
+            prompt_bhw,
+            prompt_valid_bhw,
+            height=capture_hw[0],
+            width=capture_hw[1],
+        )
+
+        frame_offset: int
+        polycam_data: PolycamData
+        for frame_offset, polycam_data in enumerate(batch):
+            frame_index: int = batch_start + frame_offset
+            teacher_hw: Float32[Tensor, "h w"] = teacher_bhw[frame_offset]
+            teacher_valid_hw: Bool[Tensor, "h w"] = torch.isfinite(teacher_hw) & (teacher_hw > 0.0)
+            stratified: EdgeStratifiedResult | None = edge_stratified_mae(
+                student_bhw[frame_offset],
+                teacher_hw,
+                teacher_valid_hw,
+                baseline_bhw[frame_offset],
+                edge_quantile=config.edge_quantile,
+            )
+            if stratified is None or stratified.baseline is None:
+                raise ValueError(f"frame {frame_index} must produce valid student and baseline edge metrics")
+            metrics = FrameMetrics(
+                frame_index=frame_index,
+                student_overall_dev_m=stratified.prediction.overall_mae_m,
+                student_edge_dev_m=stratified.prediction.edge_mae_m,
+                student_flat_dev_m=stratified.prediction.flat_mae_m,
+                baseline_overall_dev_m=stratified.baseline.overall_mae_m,
+                baseline_edge_dev_m=stratified.baseline.edge_mae_m,
+                baseline_flat_dev_m=stratified.baseline.flat_mae_m,
+            )
+            all_metrics.append(metrics)
+
+            candidate_is_kept: bool = len(kept_frames) < config.max_keep
+            if not candidate_is_kept:
+                worst_metrics: FrameMetrics = kept_frames[-1].metrics
+                candidate_is_kept = (metrics.student_edge_dev_m, -metrics.frame_index) > (
+                    worst_metrics.student_edge_dev_m,
+                    -worst_metrics.frame_index,
+                )
+            if candidate_is_kept:
+                prompt_hw: Float32[ndarray, "192 256"] = prompt_bhw[frame_offset].detach().cpu().numpy().copy()
+                teacher_array_hw: Float32[ndarray, "h w"] = teacher_hw.detach().cpu().numpy().copy()
+                student_hw: Float32[ndarray, "h w"] = student_bhw[frame_offset].detach().cpu().numpy().copy()
+                kept_frames.append(
+                    HardFrame(
+                        metrics=metrics,
+                        archive=HardFrameArchive(
+                            frame_index=frame_index,
+                            rgb_hwc=polycam_data.rgb_hw3.copy(),
+                            prompt_hw=prompt_hw,
+                            teacher_hw=teacher_array_hw,
+                            student_hw=student_hw,
+                        ),
+                    )
+                )
+                kept_frames.sort(key=lambda frame: (-frame.metrics.student_edge_dev_m, frame.metrics.frame_index))
+                if len(kept_frames) > config.max_keep:
+                    kept_frames.pop()
+
+    ranked_metrics: list[FrameMetrics] = sorted(
+        all_metrics,
+        key=lambda metrics: (-metrics.student_edge_dev_m, metrics.frame_index),
+    )
+    frames_dir: Path = config.out_dir / "frames"
+    previews_dir: Path = config.out_dir / "previews"
+    frames_dir.mkdir(parents=True, exist_ok=True)
+    previews_dir.mkdir(parents=True, exist_ok=True)
+
+    kept_records: list[KeptFrameRecord] = []
+    frame: HardFrame
+    for rank, frame in enumerate(kept_frames, start=1):
+        frame_name: str = f"frame_{frame.metrics.frame_index:05d}"
+        frame_relative_path: Path = Path("frames") / f"{frame_name}.npz"
+        preview_relative_path: Path = Path("previews") / f"{frame_name}.png"
+        write_hard_frame_archive(config.out_dir / frame_relative_path, frame.archive)
+        write_hard_frame_preview(
+            config.out_dir / preview_relative_path,
+            frame.archive.rgb_hwc,
+            frame.archive.teacher_hw,
+            frame.archive.student_hw,
+        )
+        kept_records.append(
+            KeptFrameRecord(
+                rank=rank,
+                frame_path=frame_relative_path.as_posix(),
+                preview_path=preview_relative_path.as_posix(),
+                metrics=frame.metrics,
+            )
+        )
+
+    checkpoint_path: Path | None = student_config.checkpoint if isinstance(student_config, ZipDepthPromptConfig) else None
+    report = HardFramesReport(
+        run=RunMetadata(
+            capture_path=str(config.polycam_zip_path),
+            checkpoint_path=str(checkpoint_path) if checkpoint_path is not None else None,
+            edge_quantile=config.edge_quantile,
+            capture_hw=capture_hw,
+            teacher_config_class=type(config.teacher).__name__,
+            student_config_class=type(student_config).__name__,
+            student_reference_version="v4",
+            student_output_role="reference_only",
+            eval_label_field="teacher",
+            batch_size=config.batch_size,
+            max_frames=config.max_frames,
+            max_keep=config.max_keep,
+            processed_frames=n_frames,
+        ),
+        kept_frames=kept_records,
+        full_ranking=[RankedFrameRecord(rank=rank, metrics=metrics) for rank, metrics in enumerate(ranked_metrics, start=1)],
+    )
+    metrics_path: Path = config.out_dir / "metrics.json"
+    write_hard_frames_report(metrics_path, report)
+
+    print(f"{'frame':>7}  {'edge dev mm':>11}  {'overall dev mm':>14}  {'baseline/student edge':>21}")
+    for frame in kept_frames:
+        print(
+            f"{frame.metrics.frame_index:7d}  "
+            f"{1000.0 * frame.metrics.student_edge_dev_m:11.2f}  "
+            f"{1000.0 * frame.metrics.student_overall_dev_m:14.2f}  "
+            f"{frame.metrics.baseline_edge_dev_m / max(frame.metrics.student_edge_dev_m, 1.0e-9):21.3f}"
+        )
+
+
+def main(config: PolycamHardFramesConfig) -> None:
+    """Entry point for Polycam hard-frame mining."""
+    polycam_hard_frames(config)

--- a/pixi.toml
+++ b/pixi.toml
@@ -571,6 +571,12 @@ depends-on = ["_prompt-da-download-polycam-example"]
 cwd = "packages/prompt-da"
 description = "Run batched TensorRT PromptDA on the example Polycam dataset"
 
+[feature.prompt-da-demo.tasks.prompt-da-polycam-trio]
+cmd = "python tools/polycam_trio.py --polycam-zip-path data/6G-room-example.zip"
+depends-on = ["_prompt-da-download-polycam-example"]
+cwd = "packages/prompt-da"
+description = "Three-way Polycam comparison; pass --zipdepth-checkpoint PATH, then select the teacher and student backends (defaults: tensorrt then torch)"
+
 [feature.prompt-da-demo.tasks.prompt-da-app]
 cmd = "python tools/gradio_app.py"
 depends-on = ["_prompt-da-download-polycam-example"]
@@ -714,6 +720,22 @@ cmd = "python tools/eval_catalog.py"
 cwd = "packages/zipdepth"
 description = "Unaligned metric AbsRel/delta1/MAE vs held-out PromptDA labels, with separately named aligned diagnostics"
 
+[feature.zipdepth-catalog.tasks.zipdepth-eval-hard20]
+cmd = "python tools/eval_hard_frames.py"
+cwd = "packages/zipdepth"
+description = "Score the frozen Polycam hard-20 set without rerunning the teacher or selecting frames"
+
+[feature.zipdepth-catalog.tasks._zipdepth-download-polycam-example]
+cmd = "hf download pablovela5620/polycam-example-data 6G-room-example.zip --repo-type dataset --local-dir data/"
+cwd = "packages/zipdepth"
+outputs = ["packages/zipdepth/data/6G-room-example.zip"]
+description = "Download the example Polycam zip from HuggingFace"
+
+[feature.zipdepth-catalog.tasks.zipdepth-polycam-hard-frames]
+cmd = "python tools/polycam_hard_frames.py --polycam-zip-path data/6G-room-example.zip --max-keep 20"
+depends-on = ["_zipdepth-download-polycam-example"]
+cwd = "packages/zipdepth"
+description = "Mine Polycam frames with the largest edge-region ZipDepth-PromptDA teacher deviation"
 
 # ═══════════════════════════════════════════════════════════════════════════
 # wilor-nano


### PR DESCRIPTION
Stack **7/9** — the ZipDepth-PromptDA work re-cut into one focused stack (replaces #132 #133 #134 #129 #164 #165 #166 #167 #172 #173 #174 #175 #177; #131 is already merged). Review bottom-up.

| # | PR | what | lines (no lock) |
|---|---|---|---:|
| 1 | #186 | workspace rerun-sdk 0.37.0 (pins + API ports) — lock | +533/−317 |
| 2 | #187 | simplecv depth/mesh helpers; PromptDA teacher batch tool on the GPU + malloc_trim; catalog-server rules | +196/−74 |
| 3 | #188 | monoprior config-first depth-completion zoo (PromptDA torch/onnx/trt) — refactor only | +752/−565 |
| 4 | #189 | **ZipDepth-PromptDA model** + static-batch TensorRT export — lock (+trtkit) | +1132/−11 |
| 5 | #190 | zipdepth-catalog lane: streaming dataset, CUDA builders, holdout eval — lock (+2 envs) | +3176/−25 |
| 6 | #191 | catalog fine-tune trainer + live smoke gate + IO instrumentation | +1576/−27 |
| 7 | #192 | hard-frame mining, fixed hard-20 scorer, Polycam three-way comparison | +1727/−14 |
| 8 | #203 | training-speed knobs + named presets for the wall-clock hill-climb | +670/−76 |
| 9 | #204 | idiomatic Rerun 0.37 dataloader as executable reference (`--dataloader rerun`), catalog-query audit | +1027/−54 |

Whole stack vs main: 108 files, +8486/−995. The old chain was 13 open PRs (+10.4k lines) plus 11 unpushed commits; the head-variant experiments and the default-off loss knobs were dropped (negative results, see the [project report](https://pablos-4800gt.ilish-ruler.ts.net:8768/zipdepth/zipdepth-promptda-final-report.html)), and every slice went through a four-lens simplify pass before cutting. Review-pass changes (2026-09-03) are folded into the same PRs: zero `Any` on added lines, jaxtyping dtype+shape on every added array annotation, no dtype/shape in new identifiers, shared metre→mm quantiser, `upsample_depth_to_image`, condensed AGENTS section, stale einops suppressions dropped in touched files.

## zipdepth: hard-frame mining, fixed hard-20 scorer, Polycam three-way comparison
**What** The tools that judge the student where it matters, in the package that owns the student:
- `zipdepth-polycam-hard-frames` mines the Polycam capture for the frames whose student depth deviates most from PromptDA inside the teacher's edge stratum and writes them as a fixed evaluation set (NPZ archives + previews + a typed pyserde manifest). The zero-parameter baseline is the hole-aware prompt upsample. The top-20 of the 6G-room capture is stable; frames 6 and 7 are the plant shots.
- `zipdepth-eval-hard20` scores any checkpoint on that set: student, baseline and the H/2 diagnostic on one reusable teacher stencil per frame, eight distinct frames per static batch, previews on request. Production v4: macro edge MAE 125.8 mm, plant frames 6/7 = 199.5 / 192.0 mm, H/2 diagnostic 134.6 mm (re-run on this branch, identical to the reference).
- `prompt-da-polycam-trio` streams ARKit / PromptDA / ZipDepth-PromptDA side by side with fused meshes (teacher and student typed as fixed model families; backends and the `--zipdepth-checkpoint` alias kept).
One manifest schema, one archive reader/writer and one preview renderer (`hard_frame_data.py`); the edge metric itself is `zipdepth.evaluation.edge_metrics`. `polycam_compare` is gone (trio covers it).
**Follow-up noted** `eval_catalog` keeps its per-frame NumPy prompt upsampler while the miner/scorer use the batched torch one; unify on the torch version.
**Gates** zipdepth-catalog-dev 81 passed + lint/typecheck/deadcode; prompt-da-dev 9 passed + deadcode; simplecv-dev 155; monoprior-dev 80. Tree is byte-identical to the gated final tree.
