### PR TITLE
chore: drop the stale einops pyrefly suppressions

### DIFF
--- a/packages/gauss-surf/src/gauss_surf/apis/frame_selection.py
+++ b/packages/gauss-surf/src/gauss_surf/apis/frame_selection.py
@@ -99,7 +99,7 @@ def _score_camera(
     with torch.inference_mode():
         for frame_index in range(len(timestamps_n)):
             frame_chw: UInt8[Tensor, "3 h w"] = decoder.get_frame_at(frame_index).data
-            frame_hwc: UInt8[Tensor, "h w 3"] = rearrange(frame_chw, "c h w -> h w c")  # pyrefly: ignore  # bad-argument-type — einops stub
+            frame_hwc: UInt8[Tensor, "h w 3"] = rearrange(frame_chw, "c h w -> h w c")
             pending_frames_hwc.append(frame_hwc)
             if len(pending_frames_hwc) < batch_size:
                 continue

--- a/packages/gauss-surf/src/gauss_surf/apis/moge_normals.py
+++ b/packages/gauss-surf/src/gauss_surf/apis/moge_normals.py
@@ -144,11 +144,11 @@ def _infer_and_write_normals(
             frames_hwc: list[UInt8[Tensor, "h w 3"]] = []
             for _timestamp in batch_timestamps_n:
                 frame_chw: UInt8[Tensor, "3 h w"] = next(decoded_frames)
-                frame_hwc: UInt8[Tensor, "h w 3"] = rearrange(frame_chw, "c h w -> h w c")  # pyrefly: ignore  # bad-argument-type — einops stub
+                frame_hwc: UInt8[Tensor, "h w 3"] = rearrange(frame_chw, "c h w -> h w c")
                 frames_hwc.append(frame_hwc)
 
             frames_bhw3: UInt8[Tensor, "batch h w 3"] = torch.stack(frames_hwc)
-            frames_b3hw: Float32[Tensor, "batch 3 h w"] = rearrange(frames_bhw3, "b h w c -> b c h w").to(torch.float32)  # pyrefly: ignore  # bad-argument-type — einops stub
+            frames_b3hw: Float32[Tensor, "batch 3 h w"] = rearrange(frames_bhw3, "b h w c -> b c h w").to(torch.float32)
             resized_b3hw: Float32[Tensor, "batch 3 net_h=756 net_w=1008"] = functional.interpolate(
                 frames_b3hw,
                 size=DEFAULT_IMAGE_HW,
@@ -158,7 +158,7 @@ def _infer_and_write_normals(
             resized_bhw3: UInt8[Tensor, "batch net_h=756 net_w=1008 3"] = rearrange(
                 resized_b3hw.round().clamp(0.0, 255.0).to(torch.uint8),
                 "b c h w -> b h w c",
-            )  # pyrefly: ignore  # bad-argument-type — einops stub
+            )
             prediction: MoGeV2NormalOutput = predictor.predict_normals(resized_bhw3)
             # MoGe emits toward-camera RDF normals; the layer stores the negated
             # away-from-camera convention — the gaussurf training target and the

--- a/packages/gauss-surf/src/gauss_surf/apis/ultrawide_signals.py
+++ b/packages/gauss-surf/src/gauss_surf/apis/ultrawide_signals.py
@@ -324,7 +324,7 @@ def _process_and_write(
         depth_png_blobs: list[bytes] = []
         for batch_offset, _timestamp in enumerate(batch_timestamps_n):
             frame_chw: UInt8[Tensor, "3 h w"] = next(decoded_frames)
-            frame_hwc: UInt8[Tensor, "h w 3"] = rearrange(frame_chw, "c h w -> h w c")  # pyrefly: ignore  # bad-argument-type — einops stub
+            frame_hwc: UInt8[Tensor, "h w 3"] = rearrange(frame_chw, "c h w -> h w c")
             rgb_hw3: UInt8[ndarray, "h w 3"] = frame_hwc.cpu().numpy().astype(np.uint8, copy=False)
             if rgb_hw3.shape != (ULTRAWIDE_IMAGE_HW[0], ULTRAWIDE_IMAGE_HW[1], 3):
                 raise RuntimeError(f"decoded ultrawide frame has shape {rgb_hw3.shape}, expected (480, 640, 3)")

--- a/packages/gauss-surf/src/gauss_surf/train_gsplat/cache.py
+++ b/packages/gauss-surf/src/gauss_surf/train_gsplat/cache.py
@@ -316,7 +316,7 @@ def load_gpu_cache(
     wide_rgb_nhw3: torch.Tensor = torch.empty((len(wide_rows), *wide_hw, 3), dtype=torch.uint8, device=device)
     decoded_wide = reader.decode_frames(VIDEO_WIDE, wide_timestamps, fps=WIDE_FPS, device=device)
     for index, (row, frame_chw) in enumerate(zip(wide_rows, decoded_wide, strict=True)):
-        decoded_rgb_hw3: torch.Tensor = rearrange(frame_chw, "c h w -> h w c")  # pyrefly: ignore  # einops stubs
+        decoded_rgb_hw3: torch.Tensor = rearrange(frame_chw, "c h w -> h w c")
         depth_hw: np.ndarray = _decode_png_uint16(blob_bytes(row[PROMPTDA_DEPTH_BLOB_COLUMN], PROMPTDA_DEPTH_BLOB_COLUMN))
         normal_hw3: np.ndarray = first_wide_normal_hw3 if index == 0 else decode_rgb_image(blob_bytes(row[WIDE_NORMAL_COLUMN], WIDE_NORMAL_COLUMN))
         if tuple(decoded_rgb_hw3.shape) != (*wide_hw, 3) or depth_hw.shape != wide_hw or normal_hw3.shape != wide_normal_hw3:

--- a/packages/monoprior/monopriors/apis/benchmark_moge_v2_trt.py
+++ b/packages/monoprior/monopriors/apis/benchmark_moge_v2_trt.py
@@ -247,8 +247,8 @@ def main(config: Config) -> None:
         if backend == "moge-infer":
             loaded: tuple[MoGeModel, int] = load_pinned_moge_v2(config.encoder, config.resolution_level)
             model: MoGeModel = loaded[0]
-            primary_image_b3hw: Float32[Tensor, "b 3 h w"] = rearrange(primary_rgb_bhw3, "b h w c -> b c h w").float() / 255.0  # pyrefly: ignore  # bad-argument-type — einops stub false positive
-            widescreen_image_b3hw: Float32[Tensor, "1 3 h w"] = rearrange(widescreen_rgb_bhw3, "b h w c -> b c h w").float() / 255.0  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+            primary_image_b3hw: Float32[Tensor, "b 3 h w"] = rearrange(primary_rgb_bhw3, "b h w c -> b c h w").float() / 255.0
+            widescreen_image_b3hw: Float32[Tensor, "1 3 h w"] = rearrange(widescreen_rgb_bhw3, "b h w c -> b c h w").float() / 255.0
             for batch_size in config.batch_sizes:
                 rows.append(_benchmark_moge_infer(model, primary_image_b3hw[:batch_size], config.resolution_level, config.warmup_iters, config.timed_iters))
             rows.append(_benchmark_moge_infer(model, widescreen_image_b3hw, config.resolution_level, config.warmup_iters, config.timed_iters))

--- a/packages/monoprior/monopriors/models/moge_v2/export.py
+++ b/packages/monoprior/monopriors/models/moge_v2/export.py
@@ -165,7 +165,7 @@ def preprocess_rgb(
     if image_hw[0] < 1 or image_hw[1] < 1:
         raise ValueError(f"MoGe v2 network dimensions must be positive, got {image_hw}.")
 
-    image_b3hw: Float32[Tensor, "b 3 h w"] = rearrange(rgb_bhw3, "b h w c -> b c h w").to(dtype=torch.float32) / 255.0  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    image_b3hw: Float32[Tensor, "b 3 h w"] = rearrange(rgb_bhw3, "b h w c -> b c h w").to(dtype=torch.float32) / 255.0
     if tuple(image_b3hw.shape[-2:]) != image_hw:
         image_b3hw = F.interpolate(image_b3hw, size=image_hw, mode="bilinear", antialias=True)
     return image_b3hw

--- a/packages/monoprior/monopriors/models/moge_v2/predictor.py
+++ b/packages/monoprior/monopriors/models/moge_v2/predictor.py
@@ -98,12 +98,12 @@ def _resize_and_normalize_normals(
     Returns:
         Owning float32 unit normals shaped ``b h w 3``.
     """
-    normals_b3nhw: Float32[Tensor, "b 3 nh nw"] = rearrange(normals_bnhw3.float(), "b h w c -> b c h w")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    normals_b3nhw: Float32[Tensor, "b 3 nh nw"] = rearrange(normals_bnhw3.float(), "b h w c -> b c h w")
     if tuple(normals_b3nhw.shape[-2:]) != output_hw:
         normals_b3hw: Float32[Tensor, "b 3 h w"] = F.interpolate(normals_b3nhw, size=output_hw, mode="bilinear", align_corners=False)
     else:
         normals_b3hw = normals_b3nhw
-    normals_bhw3: Float32[Tensor, "b h w 3"] = rearrange(normals_b3hw, "b c h w -> b h w c")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    normals_bhw3: Float32[Tensor, "b h w 3"] = rearrange(normals_b3hw, "b c h w -> b h w c")
     return F.normalize(normals_bhw3, dim=-1)
 
 
@@ -121,12 +121,12 @@ def postprocess_moge_v2_normal(
         Owning float32 unit normals and validity probabilities at caller resolution.
     """
     normals_bhw3: Float32[Tensor, "b h w 3"] = _resize_and_normalize_normals(graph_output.normals_bhw3, output_hw)
-    mask_b1nhw: Float32[Tensor, "b 1 nh nw"] = rearrange(graph_output.mask_bhw.float(), "b h w -> b 1 h w")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    mask_b1nhw: Float32[Tensor, "b 1 nh nw"] = rearrange(graph_output.mask_bhw.float(), "b h w -> b 1 h w")
     if tuple(mask_b1nhw.shape[-2:]) != output_hw:
         mask_b1hw: Float32[Tensor, "b 1 h w"] = F.interpolate(mask_b1nhw, size=output_hw, mode="bilinear", align_corners=False)
     else:
         mask_b1hw = mask_b1nhw.clone()
-    mask_bhw: Float32[Tensor, "b h w"] = rearrange(mask_b1hw, "b 1 h w -> b h w")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    mask_bhw: Float32[Tensor, "b h w"] = rearrange(mask_b1hw, "b 1 h w -> b h w")
     return MoGeV2NormalOutput(normals_bhw3=normals_bhw3, mask_bhw=mask_bhw)
 
 
@@ -165,8 +165,8 @@ def postprocess_moge_v2_geometry(
     positive_z_bnhw: Bool[Tensor, "b nh nw"] = points_bnhw3[..., 2] > 0.0
     mask_bnhw = torch.where(positive_z_bnhw, mask_bnhw, 0.0)
 
-    points_b3nhw: Float32[Tensor, "b 3 nh nw"] = rearrange(points_bnhw3, "b h w c -> b c h w")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
-    mask_b1nhw: Float32[Tensor, "b 1 nh nw"] = rearrange(mask_bnhw, "b h w -> b 1 h w")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    points_b3nhw: Float32[Tensor, "b 3 nh nw"] = rearrange(points_bnhw3, "b h w c -> b c h w")
+    mask_b1nhw: Float32[Tensor, "b 1 nh nw"] = rearrange(mask_bnhw, "b h w -> b 1 h w")
     if (network_height, network_width) != output_hw:
         points_b3hw: Float32[Tensor, "b 3 h w"] = F.interpolate(points_b3nhw, size=output_hw, mode="bilinear", align_corners=False)
         mask_b1hw: Float32[Tensor, "b 1 h w"] = F.interpolate(mask_b1nhw, size=output_hw, mode="bilinear", align_corners=False)
@@ -174,9 +174,9 @@ def postprocess_moge_v2_geometry(
         points_b3hw = points_b3nhw
         mask_b1hw = mask_b1nhw
 
-    points_bhw3: Float32[Tensor, "b h w 3"] = rearrange(points_b3hw, "b c h w -> b h w c").contiguous()  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    points_bhw3: Float32[Tensor, "b h w 3"] = rearrange(points_b3hw, "b c h w -> b h w c").contiguous()
     depth_bhw: Float32[Tensor, "b h w"] = points_bhw3[..., 2]
-    resized_mask_bhw: Float32[Tensor, "b h w"] = rearrange(mask_b1hw, "b 1 h w -> b h w")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    resized_mask_bhw: Float32[Tensor, "b h w"] = rearrange(mask_b1hw, "b 1 h w -> b h w")
     mask_bhw: Float32[Tensor, "b h w"] = torch.where(depth_bhw > 0.0, resized_mask_bhw, 0.0)
     return MoGeV2GeometryOutput(
         depth_bhw=depth_bhw,

--- a/packages/monoprior/tests/test_moge_v2_adapters.py
+++ b/packages/monoprior/tests/test_moge_v2_adapters.py
@@ -90,7 +90,7 @@ def test_all_single_image_adapters_match_vendored_infer_on_room() -> None:
     if bgr_hw3 is None:
         pytest.skip(f"{image_path} missing; run the monoprior download task")
     rgb_hw3: UInt8[np.ndarray, "h w 3"] = cv2.cvtColor(bgr_hw3, cv2.COLOR_BGR2RGB)
-    image_3hw: Float32[Tensor, "3 h w"] = rearrange(torch.from_numpy(rgb_hw3).to(device="cuda"), "h w c -> c h w").float() / 255.0  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    image_3hw: Float32[Tensor, "3 h w"] = rearrange(torch.from_numpy(rgb_hw3).to(device="cuda"), "h w c -> c h w").float() / 255.0
     checkpoint: tuple[str, str] = MOGE_V2_CHECKPOINTS["vitl"]
     reference_model: MoGeModel = MoGeModel.from_pretrained(checkpoint[0], revision=checkpoint[1]).to("cuda").eval()
     reference: InferenceOutput = reference_model.infer(image_3hw, force_projection=False, apply_mask=True)

--- a/packages/monoprior/tests/test_moge_v2_predictor.py
+++ b/packages/monoprior/tests/test_moge_v2_predictor.py
@@ -311,7 +311,7 @@ def test_trt_geometry_matches_vendored_infer_convention(encoder: Encoder, caller
     resized_bgr_hw3: UInt8[np.ndarray, "h w 3"] = cv2.resize(bgr_hw3, (caller_hw[1], caller_hw[0]), interpolation=cv2.INTER_AREA)
     rgb_hw3: UInt8[np.ndarray, "h w 3"] = cv2.cvtColor(resized_bgr_hw3, cv2.COLOR_BGR2RGB)
     rgb_bhw3: UInt8[Tensor, "1 h w 3"] = torch.from_numpy(rgb_hw3).cuda()[None]
-    image_3hw: Float32[Tensor, "3 h w"] = rearrange(rgb_bhw3[0], "h w c -> c h w").float() / 255.0  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    image_3hw: Float32[Tensor, "3 h w"] = rearrange(rgb_bhw3[0], "h w c -> c h w").float() / 255.0
 
     trt_predictor: MoGeV2TrtPredictor = MoGeV2TrtPredictor(encoder=encoder, heads="geometry", batch_size=8)
     loaded: tuple[MoGeModel, int] = load_pinned_moge_v2(encoder, 9)

--- a/packages/prompt-da/src/rerun_prompt_da/apis/arkitscenes_shared.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/arkitscenes_shared.py
@@ -139,7 +139,7 @@ def run_promptda_batch(
     depth_bhw: Float32[Tensor, "b oh ow"] = postprocess_depth(depth_model_b1hw, output_hw)
     depth_mm_bhw: UInt16[ndarray, "b oh ow"] = (depth_bhw.cpu().numpy() * 1000.0).astype(np.uint16)
     depth_model_mm_bhw: UInt16[ndarray, "b nh nw"] = (
-        rearrange(depth_model_b1hw, "b 1 h w -> b h w").cpu().numpy() * 1000.0  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+        rearrange(depth_model_b1hw, "b 1 h w -> b h w").cpu().numpy() * 1000.0
     ).astype(np.uint16)
     return depth_mm_bhw, depth_model_mm_bhw
 

--- a/packages/prompt-da/src/rerun_prompt_da/apis/catalog_promptda.py
+++ b/packages/prompt-da/src/rerun_prompt_da/apis/catalog_promptda.py
@@ -146,7 +146,7 @@ def process_segment(dataset: DatasetEntry, segment_id: str, config: Config, pred
         })["depth"]
         # Undo the collate's landscape rotation so the prediction sits in the same frame
         # as the relayed video and the stored intrinsics.
-        depth_bhw: Float32[Tensor, "b net_h net_w"] = rearrange(depth_b1hw, "b 1 h w -> b h w")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+        depth_bhw: Float32[Tensor, "b net_h net_w"] = rearrange(depth_b1hw, "b 1 h w -> b h w")
         depth_mm_bhw: UInt16[Tensor, "b pred_h pred_w"] = torch.rot90(
             (depth_bhw * 1000.0).to(torch.uint16), -batch.quarter_turns, dims=(1, 2)
         )

--- a/packages/prompt-da/src/rerun_prompt_da/promptda_stream.py
+++ b/packages/prompt-da/src/rerun_prompt_da/promptda_stream.py
@@ -189,7 +189,7 @@ class PromptDACollate:
             frame_indices.append(self._grid_index)
             timestamps_ns.append(self._index_start_ns + self._grid_index * self._ns_per_sample)
             frames_3hw.append(frame_chw)
-            prompts_hw.append(rearrange(depth_1hw, "1 h w -> h w"))  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+            prompts_hw.append(rearrange(depth_1hw, "1 h w -> h w"))
             confidence_hw: UInt8[Tensor, "stored_prompt_h stored_prompt_w"] = confidence_n.reshape(depth_1hw.shape[1:])
             confidences_hw.append(confidence_hw)
             # Rerun stores Pinhole image_from_camera flattened column-major.
@@ -250,7 +250,7 @@ def assemble_promptda_batch(
         frame_indices=frame_indices,
         timestamps_ns=timestamps_ns,
         quarter_turns=turns,
-        rgb_bhw3=rearrange(rgb_b3hw, "b c h w -> b h w c"),  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+        rgb_bhw3=rearrange(rgb_b3hw, "b c h w -> b h w c"),
         prompt_bhw=prompt_bhw.float() / 1000.0,
         prompt_mm_bhw=prompt_stored_bhw.cpu().numpy().astype(np.uint16),
         confidence_bhw=confidence_stored_bhw.cpu().numpy().astype(np.uint8),

--- a/packages/prompt-da/src/rerun_prompt_da/trt_predictor.py
+++ b/packages/prompt-da/src/rerun_prompt_da/trt_predictor.py
@@ -42,11 +42,11 @@ def preprocess_batch(
         float32 CUDA tensors: RGB ``[B,3,nh,nw]`` in [0,1] resized to
         ``image_hw``, and prompt depth ``[B,1,192,256]`` in meters.
     """
-    rgb_b3hw: Float32[Tensor, "b 3 h w"] = rearrange(rgb_bhw3.to("cuda", non_blocking=True), "b h w c -> b c h w").float() / 255.0  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    rgb_b3hw: Float32[Tensor, "b 3 h w"] = rearrange(rgb_bhw3.to("cuda", non_blocking=True), "b h w c -> b c h w").float() / 255.0
     if tuple(rgb_b3hw.shape[-2:]) != image_hw:
         # antialias=True approximates the cv2 INTER_AREA downscale the torch demo uses.
         rgb_b3hw = F.interpolate(rgb_b3hw, size=image_hw, mode="bilinear", antialias=True)
-    prompt_b1hw: Float32[Tensor, "b 1 192 256"] = rearrange(prompt_depth_bhw.to("cuda", non_blocking=True), "b h w -> b 1 h w")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    prompt_b1hw: Float32[Tensor, "b 1 192 256"] = rearrange(prompt_depth_bhw.to("cuda", non_blocking=True), "b h w -> b 1 h w")
     return rgb_b3hw, prompt_b1hw
 
 
@@ -69,7 +69,7 @@ def postprocess_depth(
         depth_b1hw = F.interpolate(depth_b1hw, size=out_hw, mode="bilinear", align_corners=False)
     else:
         depth_b1hw = depth_b1hw.clone()
-    return rearrange(depth_b1hw, "b 1 h w -> b h w")  # pyrefly: ignore  # bad-argument-type — einops stub false positive
+    return rearrange(depth_b1hw, "b 1 h w -> b h w")
 
 
 class PromptDATrtPredictor:


### PR DESCRIPTION
Every `# pyrefly: ignore  # bad-argument-type — einops stub false positive` on a `rearrange` call is stale: with the einops the dev environments resolve (0.8.2), pyrefly 1.1.1 (locked) and 1.2.0 report **zero errors** on these lines with the suppressions removed (26 sites in 13 files on main). Comment-only change.

**Gates on this branch.** monoprior-dev lint/typecheck/tests green (77 passed; the pre-existing hypothesis failure in `tests/test_g3t_model.py::test_confidence_filter_matches_linear_percentile_mask` deselected, see below); prompt-da-dev and prompt-da-stream-dev green; gauss-surf-dev lint green. gauss-surf-dev typecheck and tests are red **on main itself** in this worktree (main:  INFO 2 errors (1 suppressed, 3 warnings not shown); 8 failed, 97 passed, 2 skipped in 5.66s) — unrelated to this change: the typecheck errors are the `extra_signals` kwargs of the pinned gsplat fork (fixed by the pyrefly baseline in #186), the test failures are the same eight on main.

**Why the suppressions existed.** The error shape reproduces only against einops 0.9.0.dev0, whose new typing (einops PR #430) bounds the `Tensor` TypeVar to a Protocol that leaves `__getitem__` untyped; pyrefly then rejects plain `torch.Tensor` (jaxtyping is not involved, its annotations erase to `Tensor`). The lock carries that dev release in exactly one env, `mv-api-catalog-register-mac`, the only feature with `einops = ">=0.8.0"` instead of `<0.9` — follow-up: tighten that pin. No einops or pyrefly issue tracks this; a local stub was evaluated and rejected as maintenance for a prerelease we do not use.

The ZipDepth-PromptDA stack (#186 → #192) drops the same comments in the files it touches, so the overlap merges cleanly either way. Notes with the version matrix: `/tmp/zdp-recut/einops/REPORT.md` on pablo-dl-server.

Unrelated bug found on the way: `test_confidence_filter_matches_linear_percentile_mask` fails on main once hypothesis finds a counterexample (NumPy's linear percentile vs the order-statistic mask in `multiview_model.py`); it deserves its own fix.