### PR TITLE
zipdepth: training-speed knobs and named presets for the wall-clock hill-climb (stack 8/9)

### DIFF
--- a/packages/zipdepth/pyproject.toml
+++ b/packages/zipdepth/pyproject.toml
@@ -37,4 +37,4 @@ paths = ["zipdepth/apis", "zipdepth/catalog", "zipdepth/__init__.py", "tests", "
 exclude = ["*/.pixi/*", "*/__pycache__/*"]
 sort_by_size = true
 min_confidence = 60
-ignore_names = ["allow_tf32", "baseline_flat_dev_m", "baseline_overall_dev_m", "benchmark", "capture_path", "eval_label_field", "forward", "forward_with_range", "frames_per_second", "full_ranking", "get_lr", "gpu", "id", "median_ms_per_batch", "median_ms_per_frame", "p95_ms_per_batch", "processed_frames", "rank_count", "resolved_max_lr", "rr_config", "student_config_class", "student_flat_dev_m", "student_output_role", "student_reference_version", "teacher_config_class", "train_epoch"]
+ignore_names = ["allow_tf32", "baseline_flat_dev_m", "baseline_overall_dev_m", "benchmark", "capture_path", "eval_label_field", "forward", "forward_with_range", "frames_per_second", "full_ranking", "get_lr", "gpu", "id", "median_ms_per_batch", "median_ms_per_frame", "p95_ms_per_batch", "processed_frames", "rank_count", "resolved_max_lr", "rr_config", "student_config_class", "student_flat_dev_m", "student_output_role", "student_reference_version", "teacher_config_class", "train_epoch", "training_stage"]

--- a/packages/zipdepth/pyproject.toml
+++ b/packages/zipdepth/pyproject.toml
@@ -37,4 +37,4 @@ paths = ["zipdepth/apis", "zipdepth/catalog", "zipdepth/__init__.py", "tests", "
 exclude = ["*/.pixi/*", "*/__pycache__/*"]
 sort_by_size = true
 min_confidence = 60
-ignore_names = ["allow_tf32", "baseline_flat_dev_m", "baseline_overall_dev_m", "benchmark", "capture_path", "eval_label_field", "forward", "forward_with_range", "frames_per_second", "full_ranking", "gpu", "id", "median_ms_per_batch", "median_ms_per_frame", "p95_ms_per_batch", "processed_frames", "rank_count", "resolved_max_lr", "rr_config", "student_config_class", "student_flat_dev_m", "student_output_role", "student_reference_version", "teacher_config_class", "train_epoch"]
+ignore_names = ["allow_tf32", "baseline_flat_dev_m", "baseline_overall_dev_m", "benchmark", "capture_path", "eval_label_field", "forward", "forward_with_range", "frames_per_second", "full_ranking", "get_lr", "gpu", "id", "median_ms_per_batch", "median_ms_per_frame", "p95_ms_per_batch", "processed_frames", "rank_count", "resolved_max_lr", "rr_config", "student_config_class", "student_flat_dev_m", "student_output_role", "student_reference_version", "teacher_config_class", "train_epoch"]

--- a/packages/zipdepth/tests/test_catalog_train.py
+++ b/packages/zipdepth/tests/test_catalog_train.py
@@ -337,8 +337,16 @@ def test_checkpoint_carries_the_progressive_resolution_stage(tmp_path: Path) -> 
     assert saved["training_stage"] == 1
 
 
-def test_v4_and_reserved_fast_presets_match_todays_recipe() -> None:
-    """Keep v4 bit-compatible and leave fast unchanged until the hill-climb picks a winner."""
+def test_fast_preset_only_raises_the_peak_learning_rate() -> None:
+    """The hill-climb winner: fast = v4 with max_lr config/10 instead of config/100; an explicit --max-lr still wins."""
+    assert resolve_max_lr(config_lr=1e-3, override=None, from_scratch=False, preset="v4") == pytest.approx(1e-5)
+    assert resolve_max_lr(config_lr=1e-3, override=None, from_scratch=False, preset="fast") == pytest.approx(1e-4)
+    assert resolve_max_lr(config_lr=1e-3, override=3e-5, from_scratch=False, preset="fast") == pytest.approx(3e-5)
+    assert resolve_max_lr(config_lr=1e-3, override=None, from_scratch=True, preset="fast") == pytest.approx(1e-3)
+
+
+def test_v4_and_fast_presets_share_every_runtime_control() -> None:
+    """Keep v4 bit-compatible; fast shares the whole recipe except the peak learning rate."""
     upstream: UpstreamTrainConfig = _load_json_config(Path("configs/default.json"))
 
     v4: TrainingRecipe = resolve_training_recipe(TrainCatalogConfig(preset="v4"), upstream.scheduler, upstream.amp)

--- a/packages/zipdepth/tests/test_catalog_train.py
+++ b/packages/zipdepth/tests/test_catalog_train.py
@@ -13,6 +13,8 @@ from zipdepth.apis.train_catalog import (
     ConstantCooldownLR,
     ResolutionStage,
     TrainCatalogConfig,
+    TrainingRecipe,
+    UpstreamTrainConfig,
     _adamw_optimizer,
     _build_scheduler,
     _load_json_config,
@@ -20,6 +22,7 @@ from zipdepth.apis.train_catalog import (
     parse_stage_schedule,
     resolve_amp_dtype,
     resolve_max_lr,
+    resolve_training_recipe,
 )
 from zipdepth.catalog.segments import split_holdout_segments
 from zipdepth.loss import MetricDepthLoss, ZipDepthLoss
@@ -316,6 +319,58 @@ def test_checkpoint_carries_the_progressive_resolution_stage(tmp_path: Path) -> 
 
     assert isinstance(saved, dict)
     assert saved["training_stage"] == 1
+
+
+def test_v4_and_reserved_fast_presets_match_todays_recipe() -> None:
+    """Keep v4 bit-compatible and leave fast unchanged until the hill-climb picks a winner."""
+    upstream: UpstreamTrainConfig = _load_json_config(Path("configs/default.json"))
+
+    v4: TrainingRecipe = resolve_training_recipe(TrainCatalogConfig(preset="v4"), upstream.scheduler, upstream.amp)
+    fast: TrainingRecipe = resolve_training_recipe(TrainCatalogConfig(preset="fast"), upstream.scheduler, upstream.amp)
+
+    assert v4 == TrainingRecipe(
+        compile_mode="reduce-overhead",
+        channels_last=False,
+        fused_adamw=False,
+        amp_dtype="bfloat16",
+        schedule="onecycle",
+        warmup_pct=0.05,
+        final_div_factor=1000.0,
+        cooldown_pct=0.1,
+        stage_schedule=None,
+    )
+    assert fast == v4
+
+
+def test_explicit_training_knobs_override_the_named_preset() -> None:
+    """Let a hill-climb arm replace any individual value without defining a new preset."""
+    upstream: UpstreamTrainConfig = _load_json_config(Path("configs/default.json"))
+    config: TrainCatalogConfig = TrainCatalogConfig(
+        preset="fast",
+        compile_mode="off",
+        channels_last=True,
+        fused_adamw=True,
+        amp_dtype="float16",
+        schedule="constant-cooldown",
+        warmup_pct=0.2,
+        final_div_factor=20.0,
+        cooldown_pct=0.3,
+        stage_schedule="384x512:0.3,768x1024:0.7",
+    )
+
+    recipe: TrainingRecipe = resolve_training_recipe(config, upstream.scheduler, upstream.amp)
+
+    assert recipe == TrainingRecipe(
+        compile_mode="off",
+        channels_last=True,
+        fused_adamw=True,
+        amp_dtype="float16",
+        schedule="constant-cooldown",
+        warmup_pct=0.2,
+        final_div_factor=20.0,
+        cooldown_pct=0.3,
+        stage_schedule="384x512:0.3,768x1024:0.7",
+    )
 
 
 @pytest.mark.parametrize(("skip_batches", "expected_skip"), [(0, 0), (None, 3)])

--- a/packages/zipdepth/tests/test_catalog_train.py
+++ b/packages/zipdepth/tests/test_catalog_train.py
@@ -265,15 +265,15 @@ def test_constant_cooldown_is_flat_then_linear() -> None:
         final_div_factor=10.0,
         cooldown_pct=0.3,
     )
-    lrs: list[float] = [optimizer.param_groups[0]["lr"]]
+    used_lrs: list[float] = []
     for _ in range(10):
+        used_lrs.append(optimizer.param_groups[0]["lr"])
         optimizer.step()
         scheduler.step()
-        lrs.append(optimizer.param_groups[0]["lr"])
 
     assert isinstance(scheduler, ConstantCooldownLR)
-    assert lrs[:8] == [1.0] * 8
-    assert lrs[8:] == pytest.approx([0.7, 0.4, 0.1])
+    assert used_lrs[:7] == [1.0] * 7
+    assert used_lrs[7:] == pytest.approx([0.7, 0.4, 0.1])
 
 
 def test_stage_schedule_defaults_to_one_unchanged_resolution() -> None:

--- a/packages/zipdepth/tests/test_catalog_train.py
+++ b/packages/zipdepth/tests/test_catalog_train.py
@@ -10,8 +10,10 @@ from tqdm import tqdm
 
 from zipdepth.apis.train_catalog import (
     CompileMode,
+    ConstantCooldownLR,
     TrainCatalogConfig,
     _adamw_optimizer,
+    _build_scheduler,
     _load_json_config,
     _model_to_device,
     resolve_amp_dtype,
@@ -165,6 +167,108 @@ def test_catalog_training_uses_one_explicit_optimizer_step_schedule() -> None:
     assert config.total_steps == 70_000
     assert not hasattr(config, "epochs")
     assert not hasattr(config, "max_steps")
+
+
+def test_scheduler_defaults_match_existing_onecycle_state() -> None:
+    """Construct the same OneCycle scheduler and optimizer state as today's recipe."""
+    config: TrainCatalogConfig = TrainCatalogConfig()
+    expected_model: nn.Linear = nn.Linear(1, 1)
+    actual_model: nn.Linear = nn.Linear(1, 1)
+    expected_optimizer: optim.AdamW = optim.AdamW(expected_model.parameters(), lr=1e-5, weight_decay=0.05)
+    actual_optimizer: optim.AdamW = optim.AdamW(actual_model.parameters(), lr=1e-5, weight_decay=0.05)
+    expected: optim.lr_scheduler.OneCycleLR = optim.lr_scheduler.OneCycleLR(
+        expected_optimizer,
+        max_lr=1e-5,
+        total_steps=100,
+        pct_start=0.05,
+        anneal_strategy="cos",
+        div_factor=25.0,
+        final_div_factor=1000.0,
+    )
+    actual: optim.lr_scheduler.LRScheduler = _build_scheduler(
+        actual_optimizer,
+        schedule=config.schedule,
+        max_lr=1e-5,
+        total_steps=100,
+        warmup_pct=0.05,
+        div_factor=25.0,
+        final_div_factor=1000.0,
+        cooldown_pct=config.cooldown_pct,
+    )
+
+    assert config.schedule == "onecycle"
+    assert config.warmup_pct is None
+    assert config.final_div_factor is None
+    assert config.cooldown_pct == 0.1
+    assert isinstance(actual, optim.lr_scheduler.OneCycleLR)
+    assert actual.state_dict() == expected.state_dict()
+    assert actual_optimizer.state_dict() == expected_optimizer.state_dict()
+
+
+def test_onecycle_overrides_change_the_lr_trajectory() -> None:
+    """Pass warmup percentage and final division through to OneCycleLR."""
+    default_model: nn.Linear = nn.Linear(1, 1)
+    tuned_model: nn.Linear = nn.Linear(1, 1)
+    default_optimizer: optim.SGD = optim.SGD(default_model.parameters(), lr=1e-3)
+    tuned_optimizer: optim.SGD = optim.SGD(tuned_model.parameters(), lr=1e-3)
+    default_scheduler: optim.lr_scheduler.LRScheduler = _build_scheduler(
+        default_optimizer,
+        schedule="onecycle",
+        max_lr=1e-3,
+        total_steps=100,
+        warmup_pct=0.05,
+        div_factor=25.0,
+        final_div_factor=1000.0,
+        cooldown_pct=0.1,
+    )
+    tuned_scheduler: optim.lr_scheduler.LRScheduler = _build_scheduler(
+        tuned_optimizer,
+        schedule="onecycle",
+        max_lr=1e-3,
+        total_steps=100,
+        warmup_pct=0.25,
+        div_factor=25.0,
+        final_div_factor=10.0,
+        cooldown_pct=0.1,
+    )
+    default_lrs: list[float] = [default_optimizer.param_groups[0]["lr"]]
+    tuned_lrs: list[float] = [tuned_optimizer.param_groups[0]["lr"]]
+    for _ in range(100):
+        default_optimizer.step()
+        tuned_optimizer.step()
+        default_scheduler.step()
+        tuned_scheduler.step()
+        default_lrs.append(default_optimizer.param_groups[0]["lr"])
+        tuned_lrs.append(tuned_optimizer.param_groups[0]["lr"])
+
+    assert tuned_lrs != default_lrs
+    assert tuned_lrs[20] > default_lrs[20]
+    assert tuned_lrs[-1] > default_lrs[-1]
+
+
+def test_constant_cooldown_is_flat_then_linear() -> None:
+    """Hold max LR before cooling linearly over the requested final fraction."""
+    model: nn.Linear = nn.Linear(1, 1)
+    optimizer: optim.SGD = optim.SGD(model.parameters(), lr=1.0)
+    scheduler: optim.lr_scheduler.LRScheduler = _build_scheduler(
+        optimizer,
+        schedule="constant-cooldown",
+        max_lr=1.0,
+        total_steps=10,
+        warmup_pct=0.05,
+        div_factor=25.0,
+        final_div_factor=10.0,
+        cooldown_pct=0.3,
+    )
+    lrs: list[float] = [optimizer.param_groups[0]["lr"]]
+    for _ in range(10):
+        optimizer.step()
+        scheduler.step()
+        lrs.append(optimizer.param_groups[0]["lr"])
+
+    assert isinstance(scheduler, ConstantCooldownLR)
+    assert lrs[:8] == [1.0] * 8
+    assert lrs[8:] == pytest.approx([0.7, 0.4, 0.1])
 
 
 @pytest.mark.parametrize(("skip_batches", "expected_skip"), [(0, 0), (None, 3)])

--- a/packages/zipdepth/tests/test_catalog_train.py
+++ b/packages/zipdepth/tests/test_catalog_train.py
@@ -11,11 +11,13 @@ from tqdm import tqdm
 from zipdepth.apis.train_catalog import (
     CompileMode,
     ConstantCooldownLR,
+    ResolutionStage,
     TrainCatalogConfig,
     _adamw_optimizer,
     _build_scheduler,
     _load_json_config,
     _model_to_device,
+    parse_stage_schedule,
     resolve_amp_dtype,
     resolve_max_lr,
 )
@@ -269,6 +271,51 @@ def test_constant_cooldown_is_flat_then_linear() -> None:
     assert isinstance(scheduler, ConstantCooldownLR)
     assert lrs[:8] == [1.0] * 8
     assert lrs[8:] == pytest.approx([0.7, 0.4, 0.1])
+
+
+def test_stage_schedule_defaults_to_one_unchanged_resolution() -> None:
+    """Keep the configured height and width for every step by default."""
+    config: TrainCatalogConfig = TrainCatalogConfig()
+
+    stages: list[ResolutionStage] = parse_stage_schedule(config.stage_schedule, config.total_steps, config.height, config.width)
+
+    assert config.stage_schedule is None
+    assert stages == [ResolutionStage(height=768, width=1024, start_step=0, end_step=70_000)]
+
+
+def test_stage_schedule_assigns_each_fraction_to_a_resolution() -> None:
+    """Convert progressive fractions into exact, contiguous optimizer-step ranges."""
+    stages: list[ResolutionStage] = parse_stage_schedule("384x512:0.3,768x1024:0.7", total_steps=10, height=1, width=1)
+
+    assert stages == [
+        ResolutionStage(height=384, width=512, start_step=0, end_step=3),
+        ResolutionStage(height=768, width=1024, start_step=3, end_step=10),
+    ]
+
+
+@pytest.mark.parametrize(
+    "stage_schedule",
+    ["", "384x512", "384x512:0.0,768x1024:1.0", "384x512:0.4,768x1024:0.5"],
+)
+def test_stage_schedule_rejects_invalid_or_incomplete_fractions(stage_schedule: str) -> None:
+    """Reject malformed stages, empty stages, and fractions that do not cover the run."""
+    with pytest.raises(ValueError):
+        parse_stage_schedule(stage_schedule, total_steps=10, height=768, width=1024)
+
+
+def test_checkpoint_carries_the_progressive_resolution_stage(tmp_path: Path) -> None:
+    """Persist the active stage so a checkpoint records where training stopped."""
+    model: nn.Linear = nn.Linear(1, 1)
+    optimizer: optim.SGD = optim.SGD(model.parameters(), lr=0.1)
+    trainer: ZipDepthTrainer = ZipDepthTrainer(model, [], optimizer, None, "cpu", use_amp=False)
+    trainer.training_stage = 1
+    checkpoint: Path = tmp_path / "stage.pth"
+
+    trainer.save_checkpoint(checkpoint, epoch=0, loss=0.5)
+    saved: object = torch.load(checkpoint, map_location="cpu", weights_only=True)
+
+    assert isinstance(saved, dict)
+    assert saved["training_stage"] == 1
 
 
 @pytest.mark.parametrize(("skip_batches", "expected_skip"), [(0, 0), (None, 3)])

--- a/packages/zipdepth/tests/test_catalog_train.py
+++ b/packages/zipdepth/tests/test_catalog_train.py
@@ -82,6 +82,10 @@ def test_runtime_accelerator_defaults_match_existing_training_objects() -> None:
     assert _model_to_device(actual_model, torch.device("cpu"), channels_last=False) is actual_model
     assert actual_model.weight.stride() == expected_model.weight.stride()
     assert actual_model.state_dict().keys() == expected_model.state_dict().keys()
+    name: str
+    tensor: torch.Tensor
+    for name, tensor in actual_model.state_dict().items():
+        assert torch.equal(tensor, expected_model.state_dict()[name])
     assert actual_optimizer.defaults == expected_optimizer.defaults
     assert actual_optimizer.state_dict() == expected_optimizer.state_dict()
     assert resolve_amp_dtype(config.amp_dtype, "bfloat16") == "bfloat16"
@@ -92,10 +96,22 @@ def test_runtime_accelerator_flags_change_constructed_objects() -> None:
     model: nn.Conv2d = nn.Conv2d(3, 4, kernel_size=3)
     prepared: nn.Module = _model_to_device(model, torch.device("cpu"), channels_last=True)
     optimizer: optim.AdamW = _adamw_optimizer(prepared, lr=1e-5, weight_decay=0.05, fused=True)
+    trainer: ZipDepthTrainer = ZipDepthTrainer(
+        prepared,
+        [],
+        optimizer,
+        None,
+        "cpu",
+        use_amp=False,
+        amp_dtype=resolve_amp_dtype("float16", "bfloat16"),
+        compile_mode="off",
+        channels_last=True,
+    )
 
     assert model.weight.is_contiguous(memory_format=torch.channels_last)
     assert optimizer.defaults["fused"] is True
-    assert resolve_amp_dtype("float16", "bfloat16") == "float16"
+    assert trainer.amp_dtype is torch.float16
+    assert trainer.channels_last is True
 
 
 @pytest.mark.parametrize("compile_mode", ["default", "reduce-overhead", "max-autotune"])

--- a/packages/zipdepth/tests/test_catalog_train.py
+++ b/packages/zipdepth/tests/test_catalog_train.py
@@ -8,7 +8,15 @@ from torch import nn, optim
 from torch.utils.data import DataLoader, TensorDataset
 from tqdm import tqdm
 
-from zipdepth.apis.train_catalog import TrainCatalogConfig, _load_json_config, resolve_max_lr
+from zipdepth.apis.train_catalog import (
+    CompileMode,
+    TrainCatalogConfig,
+    _adamw_optimizer,
+    _load_json_config,
+    _model_to_device,
+    resolve_amp_dtype,
+    resolve_max_lr,
+)
 from zipdepth.catalog.segments import split_holdout_segments
 from zipdepth.loss import MetricDepthLoss, ZipDepthLoss
 from zipdepth.training.trainer import ZipDepthTrainer
@@ -49,6 +57,76 @@ def test_catalog_training_defaults_to_parallel_segment_producers() -> None:
     assert config.prefetch_samples == 256
     assert not hasattr(config, "prefetch")
     assert not hasattr(config, "gpu_augment")
+
+
+def test_runtime_accelerator_defaults_match_existing_training_objects() -> None:
+    """Keep the v4 model layout, AdamW arguments, compile mode, and JSON AMP default."""
+    config: TrainCatalogConfig = TrainCatalogConfig()
+    expected_model: nn.Conv2d = nn.Conv2d(3, 4, kernel_size=3)
+    actual_model: nn.Conv2d = nn.Conv2d(3, 4, kernel_size=3)
+    actual_model.load_state_dict(expected_model.state_dict())
+    expected_optimizer: optim.AdamW = optim.AdamW(expected_model.parameters(), lr=1e-5, weight_decay=0.05)
+    actual_optimizer: optim.AdamW = _adamw_optimizer(actual_model, lr=1e-5, weight_decay=0.05, fused=False)
+
+    assert config.compile_mode == "reduce-overhead"
+    assert config.channels_last is False
+    assert config.fused_adamw is False
+    assert config.amp_dtype is None
+    assert _model_to_device(actual_model, torch.device("cpu"), channels_last=False) is actual_model
+    assert actual_model.weight.stride() == expected_model.weight.stride()
+    assert actual_model.state_dict().keys() == expected_model.state_dict().keys()
+    assert actual_optimizer.defaults == expected_optimizer.defaults
+    assert actual_optimizer.state_dict() == expected_optimizer.state_dict()
+    assert resolve_amp_dtype(config.amp_dtype, "bfloat16") == "bfloat16"
+
+
+def test_runtime_accelerator_flags_change_constructed_objects() -> None:
+    """Apply channels-last layout, fused AdamW, and an explicit AMP dtype."""
+    model: nn.Conv2d = nn.Conv2d(3, 4, kernel_size=3)
+    prepared: nn.Module = _model_to_device(model, torch.device("cpu"), channels_last=True)
+    optimizer: optim.AdamW = _adamw_optimizer(prepared, lr=1e-5, weight_decay=0.05, fused=True)
+
+    assert model.weight.is_contiguous(memory_format=torch.channels_last)
+    assert optimizer.defaults["fused"] is True
+    assert resolve_amp_dtype("float16", "bfloat16") == "float16"
+
+
+@pytest.mark.parametrize("compile_mode", ["default", "reduce-overhead", "max-autotune"])
+def test_compile_mode_selects_torch_compile(monkeypatch: pytest.MonkeyPatch, compile_mode: CompileMode) -> None:
+    """Compile with the selected production mode."""
+    model: nn.Linear = nn.Linear(1, 1)
+    optimizer: optim.SGD = optim.SGD(model.parameters(), lr=0.1)
+    observed_modes: list[str] = []
+
+    def fake_compile(module: nn.Module, *, mode: str) -> nn.Module:
+        observed_modes.append(mode)
+        return module
+
+    monkeypatch.delenv("PIXI_DEV_MODE", raising=False)
+    monkeypatch.setattr(torch, "compile", fake_compile)
+
+    ZipDepthTrainer(model, [], optimizer, None, "cpu", use_amp=False, compile_mode=compile_mode)
+
+    assert observed_modes == [compile_mode]
+
+
+def test_compile_can_be_disabled_by_flag_or_dev_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep compilation off when requested and whenever beartype instrumentation is active."""
+    model: nn.Linear = nn.Linear(1, 1)
+    optimizer: optim.SGD = optim.SGD(model.parameters(), lr=0.1)
+    observed_modes: list[str] = []
+
+    def fake_compile(module: nn.Module, *, mode: str) -> nn.Module:
+        observed_modes.append(mode)
+        return module
+
+    monkeypatch.delenv("PIXI_DEV_MODE", raising=False)
+    monkeypatch.setattr(torch, "compile", fake_compile)
+    ZipDepthTrainer(model, [], optimizer, None, "cpu", use_amp=False, compile_mode="off")
+    monkeypatch.setenv("PIXI_DEV_MODE", "1")
+    ZipDepthTrainer(model, [], optimizer, None, "cpu", use_amp=False, compile_mode="max-autotune")
+
+    assert observed_modes == []
 
 
 def test_catalog_training_defaults_to_metric_with_an_explicit_ssi_lane() -> None:

--- a/packages/zipdepth/zipdepth/apis/train_catalog.py
+++ b/packages/zipdepth/zipdepth/apis/train_catalog.py
@@ -30,6 +30,7 @@ from zipdepth.training.distributed import barrier, cleanup_distributed, fix_stat
 from zipdepth.training.trainer import ZipDepthTrainer
 
 AmpDtype: TypeAlias = Literal["bfloat16", "float16"]
+CompileMode: TypeAlias = Literal["off", "default", "reduce-overhead", "max-autotune"]
 
 
 @serde
@@ -192,6 +193,15 @@ class TrainCatalogConfig:
     """OneCycle peak LR; None uses config LR / 100 for fine-tuning and config LR from scratch.
     Measured on the fixed probe set: at config/10 (1e-4, batch 4) fine-tuning diverges once
     warmup ends; at config/100 (1e-5) it improves the probe loss ~29% in 120 steps."""
+    compile_mode: CompileMode = "reduce-overhead"
+    """``torch.compile`` mode for the student; ``off`` disables it. Beartype dev mode
+    disables compilation regardless of this setting."""
+    channels_last: bool = False
+    """Store the model and four-dimensional training tensors in channels-last format."""
+    fused_adamw: bool = False
+    """Use the fused CUDA AdamW implementation."""
+    amp_dtype: AmpDtype | None = None
+    """AMP dtype override; None keeps the upstream JSON setting."""
 
 
 @serde
@@ -217,6 +227,27 @@ def resolve_max_lr(config_lr: float, override: float | None, from_scratch: bool)
     if max_lr <= 0.0:
         raise ValueError("max_lr must be positive")
     return max_lr
+
+
+def resolve_amp_dtype(override: AmpDtype | None, configured: AmpDtype) -> AmpDtype:
+    """Resolve the CLI AMP dtype override against the upstream JSON setting."""
+    return configured if override is None else override
+
+
+def _model_to_device(model: nn.Module, device: torch.device, channels_last: bool) -> nn.Module:
+    """Move a model before DDP construction and optionally select channels-last storage."""
+    if channels_last:
+        # PyTorch supports this documented overload; pyrefly's torch stubs omit it.
+        # pyrefly: ignore [no-matching-overload]
+        return model.to(device=device, memory_format=torch.channels_last)
+    return model.to(device=device)
+
+
+def _adamw_optimizer(model: nn.Module, lr: float, weight_decay: float, fused: bool) -> optim.AdamW:
+    """Build AdamW without changing the established defaults when fusion is disabled."""
+    if fused:
+        return optim.AdamW(model.parameters(), lr=lr, weight_decay=weight_decay, fused=True)
+    return optim.AdamW(model.parameters(), lr=lr, weight_decay=weight_decay)
 
 
 def _select_train_and_holdout(config: TrainCatalogConfig, catalog: PromptDACatalog) -> tuple[list[str], list[str]]:
@@ -396,6 +427,7 @@ def main(
         training_config: UpstreamTrainingConfig = upstream_config.training
         config_lr: float = optimizer_config.lr
         actual_max_lr: float = resolve_max_lr(config_lr, config.max_lr, config.from_scratch)
+        actual_amp_dtype: AmpDtype = resolve_amp_dtype(config.amp_dtype, amp_config.dtype)
 
         if is_main:
             config.save_dir.mkdir(parents=True, exist_ok=True)
@@ -478,15 +510,16 @@ def main(
         if pin_batchnorm_eval:
             pinned: int = sum(isinstance(module, nn.modules.batchnorm._BatchNorm) for module in model.modules())
             print_main(f"Pinned {pinned} BatchNorm modules to eval (released running stats)", rank)
-        model = model.to(device)
+        model = _model_to_device(model, device, config.channels_last)
         wrapped_model: nn.Module | DDP = (
             DDP(model, device_ids=[local_rank], output_device=local_rank, find_unused_parameters=False) if is_distributed else model
         )
 
-        optimizer: optim.AdamW = optim.AdamW(
-            model.parameters(),
+        optimizer: optim.AdamW = _adamw_optimizer(
+            model,
             lr=actual_max_lr,
             weight_decay=optimizer_config.weight_decay,
+            fused=config.fused_adamw,
         )
         scheduler: optim.lr_scheduler.OneCycleLR = _one_cycle_scheduler(optimizer, actual_max_lr, total_steps, scheduler_config)
         trainer: ZipDepthTrainer = ZipDepthTrainer(
@@ -500,7 +533,9 @@ def main(
             is_distributed=is_distributed,
             rank=rank,
             world_size=world_size,
-            amp_dtype=amp_config.dtype,
+            amp_dtype=actual_amp_dtype,
+            compile_mode=config.compile_mode,
+            channels_last=config.channels_last,
             alpha_ssi=loss_config.alpha_ssi,
             alpha_grad=loss_config.alpha_grad,
             target_mode=config.target_mode,

--- a/packages/zipdepth/zipdepth/apis/train_catalog.py
+++ b/packages/zipdepth/zipdepth/apis/train_catalog.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import shutil
 from dataclasses import dataclass, field
-from math import ceil
+from math import ceil, isclose, isfinite
 from pathlib import Path
 from typing import Literal, TypeAlias
 
@@ -212,6 +212,23 @@ class TrainCatalogConfig:
     """Ratio between the initial and final learning rates; None keeps the upstream JSON setting."""
     cooldown_pct: float = 0.1
     """Fraction of total steps used by the linear tail of ``constant-cooldown``."""
+    stage_schedule: str | None = None
+    """Optional ``HEIGHTxWIDTH:FRACTION,...`` progressive-resolution schedule. Fractions
+    must sum to one; the catalog loader is rebuilt at each stage boundary."""
+
+
+@dataclass(frozen=True, slots=True)
+class ResolutionStage:
+    """One progressive-resolution optimizer-step interval."""
+
+    height: int
+    """Training image height during the stage."""
+    width: int
+    """Training image width during the stage."""
+    start_step: int
+    """Inclusive global optimizer step at which the stage starts."""
+    end_step: int
+    """Exclusive global optimizer step at which the stage ends."""
 
 
 @serde
@@ -242,6 +259,54 @@ def resolve_max_lr(config_lr: float, override: float | None, from_scratch: bool)
 def resolve_amp_dtype(override: AmpDtype | None, configured: AmpDtype) -> AmpDtype:
     """Resolve the CLI AMP dtype override against the upstream JSON setting."""
     return configured if override is None else override
+
+
+def parse_stage_schedule(specification: str | None, total_steps: int, height: int, width: int) -> list[ResolutionStage]:
+    """Parse progressive resolutions into contiguous global-step intervals."""
+    if total_steps <= 0 or height <= 0 or width <= 0:
+        raise ValueError("total_steps, height, and width must be positive")
+    if specification is None:
+        return [ResolutionStage(height=height, width=width, start_step=0, end_step=total_steps)]
+    if not specification.strip():
+        raise ValueError("stage_schedule must not be empty")
+
+    entries: list[tuple[int, int, float]] = []
+    entry: str
+    for entry in specification.split(","):
+        resolution: str
+        fraction_text: str
+        resolution, fraction_separator, fraction_text = entry.strip().partition(":")
+        height_text: str
+        width_text: str
+        height_text, resolution_separator, width_text = resolution.partition("x")
+        if not fraction_separator or not resolution_separator:
+            raise ValueError(f"invalid stage {entry!r}; expected HEIGHTxWIDTH:FRACTION")
+        try:
+            stage_height: int = int(height_text)
+            stage_width: int = int(width_text)
+            fraction: float = float(fraction_text)
+        except ValueError as error:
+            raise ValueError(f"invalid stage {entry!r}; expected HEIGHTxWIDTH:FRACTION") from error
+        if stage_height <= 0 or stage_width <= 0 or not isfinite(fraction) or fraction <= 0.0:
+            raise ValueError(f"stage dimensions and fraction must be positive: {entry!r}")
+        entries.append((stage_height, stage_width, fraction))
+
+    fraction_sum: float = sum(fraction for _, _, fraction in entries)
+    if not isclose(fraction_sum, 1.0, rel_tol=0.0, abs_tol=1e-9):
+        raise ValueError(f"stage fractions must sum to 1.0, got {fraction_sum}")
+
+    stages: list[ResolutionStage] = []
+    cumulative_fraction: float = 0.0
+    start_step: int = 0
+    index: int
+    for index, (stage_height, stage_width, fraction) in enumerate(entries):
+        cumulative_fraction += fraction
+        end_step: int = total_steps if index == len(entries) - 1 else round(total_steps * cumulative_fraction)
+        if end_step <= start_step:
+            raise ValueError("each stage must receive at least one optimizer step")
+        stages.append(ResolutionStage(stage_height, stage_width, start_step, end_step))
+        start_step = end_step
+    return stages
 
 
 def _model_to_device(model: nn.Module, device: torch.device, channels_last: bool) -> nn.Module:
@@ -427,6 +492,10 @@ def _restore_resume_state(
     if not isinstance(raw_global_step, int):
         raise ValueError("resume checkpoint global_step must be an integer")
     trainer.global_step = raw_global_step
+    raw_training_stage: object = checkpoint.get("training_stage", 0)
+    if not isinstance(raw_training_stage, int) or raw_training_stage < 0:
+        raise ValueError("resume checkpoint training_stage must be a non-negative integer")
+    trainer.training_stage = raw_training_stage
     raw_scheduler_state: object = checkpoint.get("scheduler_state_dict")
     scheduler_state: dict[str, object] | None = raw_scheduler_state if isinstance(raw_scheduler_state, dict) else None
     raw_old_total_steps: object | None = scheduler_state.get("total_steps") if scheduler_state is not None else None
@@ -475,6 +544,7 @@ def main(
             raise ValueError("save_every_steps must be non-negative")
         if config.target_mode not in ("ssi", "metric"):
             raise ValueError(f"unknown target mode {config.target_mode!r}")
+        stages: list[ResolutionStage] = parse_stage_schedule(config.stage_schedule, config.total_steps, config.height, config.width)
         torch.backends.cudnn.benchmark = True
         torch.backends.cuda.matmul.allow_tf32 = True
         torch.backends.cudnn.allow_tf32 = True
@@ -525,42 +595,46 @@ def main(
             writer = SummaryWriter(log_dir=str(config.save_dir / "runs"))
             owns_writer = True
 
-        dataset: CatalogPromptDepthDataset = CatalogPromptDepthDataset(
-            catalog.dataset_entry,
-            train_segment_ids,
-            catalog.row_by_id,
-            device=device,
-            builder_factory=lambda: CudaSampleBuilder(
-                (config.height, config.width),
-                AugmentPolicy(),
-                config.min_depth_span,
-                device,
-                target_mode=config.target_mode,
-            ),
-            shuffle_buffer_size=config.shuffle_buffer_size,
-            seed=config.seed,
-            rank=rank,
-            world_size=world_size,
-            num_producers=config.num_producers,
-            prefetch_samples=config.prefetch_samples,
-            # Training ignores confidence: the student takes the raw prompt and the model
-            # range-gates internally. Skipping the column drops a column and ~48 KB/frame
-            # off every segment query.
-            load_confidence=False
-        )
-        data_loader: DataLoader[dict[str, Tensor]] = DataLoader(
-            dataset,
-            batch_size=config.batch_size,
-            num_workers=0,
-            pin_memory=False,
-            drop_last=True,
-        )
-        train_loader: InstrumentedLoader = InstrumentedLoader(
-            dataset,
-            data_loader,
-            steps_per_epoch=steps_per_epoch,
-            writer=writer if is_main else None,
-        )
+        def build_train_loader(stage: ResolutionStage, stage_steps: int) -> InstrumentedLoader:
+            """Build the catalog stream for one resolution stage."""
+            dataset: CatalogPromptDepthDataset = CatalogPromptDepthDataset(
+                catalog.dataset_entry,
+                train_segment_ids,
+                catalog.row_by_id,
+                device=device,
+                builder_factory=lambda: CudaSampleBuilder(
+                    (stage.height, stage.width),
+                    AugmentPolicy(),
+                    config.min_depth_span,
+                    device,
+                    target_mode=config.target_mode,
+                ),
+                shuffle_buffer_size=config.shuffle_buffer_size,
+                seed=config.seed,
+                rank=rank,
+                world_size=world_size,
+                num_producers=config.num_producers,
+                prefetch_samples=config.prefetch_samples,
+                # Training ignores confidence: the student takes the raw prompt and the model
+                # range-gates internally. Skipping the column drops a column and ~48 KB/frame
+                # off every segment query.
+                load_confidence=False,
+            )
+            data_loader: DataLoader[dict[str, Tensor]] = DataLoader(
+                dataset,
+                batch_size=config.batch_size,
+                num_workers=0,
+                pin_memory=False,
+                drop_last=True,
+            )
+            return InstrumentedLoader(
+                dataset,
+                data_loader,
+                steps_per_epoch=stage_steps,
+                writer=writer if is_main else None,
+            )
+
+        train_loader: InstrumentedLoader = build_train_loader(stages[0], stages[0].end_step)
 
         initialization: Path | None = config.init_checkpoint
         if initialization is None and not config.from_scratch and config.resume is None:
@@ -651,15 +725,29 @@ def main(
             f"Catalog train: {len(train_segment_ids)} segments, {total_steps} optimizer steps, max_lr={actual_max_lr:.2e}, device={device}",
             rank,
         )
-        trainer.train(
-            num_epochs=1,
-            save_dir=str(config.save_dir),
-            start_epoch=0,
-            save_every_steps=config.save_every_steps,
-            max_step_checkpoints=training_config.max_step_checkpoints,
-            max_steps=total_steps,
-            skip_batches=0,
-        )
+        stage_index: int
+        stage: ResolutionStage
+        for stage_index, stage in enumerate(stages):
+            if trainer.global_step >= stage.end_step:
+                continue
+            if stage_index > 0:
+                train_loader = build_train_loader(stage, stage.end_step - trainer.global_step)
+                trainer.train_loader = train_loader
+            train_loader.set_global_step(trainer.global_step)
+            trainer.training_stage = stage_index
+            print_main(
+                f"Resolution stage {stage_index + 1}/{len(stages)}: {stage.height}x{stage.width}, steps {trainer.global_step}:{stage.end_step}",
+                rank,
+            )
+            trainer.train(
+                num_epochs=1,
+                save_dir=str(config.save_dir),
+                start_epoch=0,
+                save_every_steps=config.save_every_steps,
+                max_step_checkpoints=training_config.max_step_checkpoints,
+                max_steps=stage.end_step,
+                skip_batches=0,
+            )
         barrier()
         latest: Path = config.save_dir / "latest.pth"
         if is_main:

--- a/packages/zipdepth/zipdepth/apis/train_catalog.py
+++ b/packages/zipdepth/zipdepth/apis/train_catalog.py
@@ -278,9 +278,12 @@ class ResolvedTrainCatalogConfig:
     """Fully resolved runtime recipe used by training."""
 
 
-def resolve_max_lr(config_lr: float, override: float | None, from_scratch: bool) -> float:
+def resolve_max_lr(config_lr: float, override: float | None, from_scratch: bool, preset: TrainPreset = "v4") -> float:
     """Resolve the OneCycle peak learning rate from initialization policy."""
-    max_lr: float = override if override is not None else config_lr if from_scratch else config_lr / 100.0
+    # v4 fine-tunes the released weights at config/100 (1e-5). The hill-climb of 2026-09-03 found config/10 (1e-4) reaches
+    # the same quick-holdout quality in 2.5-3x fewer steps and keeps improving where v4 stalls; nothing else moved.
+    divisor: float = 10.0 if preset == "fast" else 100.0
+    max_lr: float = override if override is not None else config_lr if from_scratch else config_lr / divisor
     if max_lr <= 0.0:
         raise ValueError("max_lr must be positive")
     return max_lr
@@ -299,8 +302,8 @@ def resolve_training_recipe(
     """Resolve v4/fast plus explicit hill-climb overrides into runtime values."""
     if config.preset not in ("v4", "fast"):
         raise ValueError(f"unknown training preset {config.preset!r}")
-    # The fast recipe is deliberately the v4 recipe until measured hill-climb results
-    # select different defaults. Explicit flags remain usable for every trial arm.
+    # `fast` differs from v4 only in the peak learning rate (see resolve_max_lr); every other
+    # runtime control is identical, and explicit flags override both presets.
     return TrainingRecipe(
         compile_mode=config.compile_mode,
         channels_last=config.channels_last,
@@ -622,7 +625,7 @@ def main(
         model_config: UpstreamModelConfig = upstream_config.model
         training_config: UpstreamTrainingConfig = upstream_config.training
         config_lr: float = optimizer_config.lr
-        actual_max_lr: float = resolve_max_lr(config_lr, config.max_lr, config.from_scratch)
+        actual_max_lr: float = resolve_max_lr(config_lr, config.max_lr, config.from_scratch, config.preset)
         recipe: TrainingRecipe = resolve_training_recipe(config, scheduler_config, amp_config)
         stages: list[ResolutionStage] = parse_stage_schedule(recipe.stage_schedule, config.total_steps, config.height, config.width)
 

--- a/packages/zipdepth/zipdepth/apis/train_catalog.py
+++ b/packages/zipdepth/zipdepth/apis/train_catalog.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import shutil
 from dataclasses import dataclass, field
+from math import ceil
 from pathlib import Path
 from typing import Literal, TypeAlias
 
@@ -31,6 +32,7 @@ from zipdepth.training.trainer import ZipDepthTrainer
 
 AmpDtype: TypeAlias = Literal["bfloat16", "float16"]
 CompileMode: TypeAlias = Literal["off", "default", "reduce-overhead", "max-autotune"]
+ScheduleName: TypeAlias = Literal["onecycle", "constant-cooldown"]
 
 
 @serde
@@ -202,6 +204,14 @@ class TrainCatalogConfig:
     """Use the fused CUDA AdamW implementation."""
     amp_dtype: AmpDtype | None = None
     """AMP dtype override; None keeps the upstream JSON setting."""
+    schedule: ScheduleName = "onecycle"
+    """Learning-rate schedule."""
+    warmup_pct: float | None = None
+    """OneCycle warmup fraction; None keeps the upstream JSON setting."""
+    final_div_factor: float | None = None
+    """Ratio between the initial and final learning rates; None keeps the upstream JSON setting."""
+    cooldown_pct: float = 0.1
+    """Fraction of total steps used by the linear tail of ``constant-cooldown``."""
 
 
 @serde
@@ -290,22 +300,78 @@ def load_trainable_checkpoint(model: ZipDepth, checkpoint: Path) -> None:
     model.load_state_dict(load_zipdepth_state_dict(checkpoint), strict=True)
 
 
-def _one_cycle_scheduler(
+class ConstantCooldownLR(optim.lr_scheduler.LRScheduler):
+    """Hold the peak learning rate, then linearly cool to its final ratio."""
+
+    def __init__(
+        self,
+        optimizer: optim.Optimizer,
+        max_lr: float,
+        total_steps: int,
+        cooldown_pct: float,
+        final_div_factor: float,
+        last_epoch: int = -1,
+    ) -> None:
+        """Configure a step-counted constant schedule with a linear cooldown."""
+        if total_steps <= 0:
+            raise ValueError("total_steps must be positive")
+        if not 0.0 < cooldown_pct <= 1.0:
+            raise ValueError("cooldown_pct must be in (0, 1]")
+        if final_div_factor <= 0.0:
+            raise ValueError("final_div_factor must be positive")
+        self.total_steps: int = total_steps
+        self.cooldown_steps: int = max(1, ceil(total_steps * cooldown_pct))
+        self.constant_steps: int = total_steps - self.cooldown_steps
+        self.final_factor: float = 1.0 / final_div_factor
+        group: dict[str, object]
+        for group in optimizer.param_groups:
+            group["lr"] = max_lr
+            group["initial_lr"] = max_lr
+        super().__init__(optimizer, last_epoch=last_epoch)
+
+    def get_lr(self) -> list[float | Tensor]:
+        """Return the learning rate for the scheduler's current step."""
+        step: int = min(self.last_epoch, self.total_steps)
+        if step <= self.constant_steps:
+            factor: float = 1.0
+        else:
+            progress: float = (step - self.constant_steps) / self.cooldown_steps
+            factor = 1.0 + (self.final_factor - 1.0) * progress
+        return [base_lr * factor for base_lr in self.base_lrs]
+
+
+def _build_scheduler(
     optimizer: optim.Optimizer,
+    *,
+    schedule: ScheduleName,
     max_lr: float,
     total_steps: int,
-    scheduler_config: UpstreamSchedulerConfig,
+    warmup_pct: float,
+    div_factor: float,
+    final_div_factor: float,
+    cooldown_pct: float,
     last_epoch: int = -1,
-) -> optim.lr_scheduler.OneCycleLR:
-    """Build the upstream OneCycle schedule with resolved total steps."""
-    return optim.lr_scheduler.OneCycleLR(
+) -> optim.lr_scheduler.LRScheduler:
+    """Build the selected step-counted learning-rate schedule."""
+    if schedule == "onecycle":
+        if not 0.0 < warmup_pct <= 1.0:
+            raise ValueError("warmup_pct must be in (0, 1]")
+        return optim.lr_scheduler.OneCycleLR(
+            optimizer,
+            max_lr=max_lr,
+            total_steps=total_steps,
+            pct_start=warmup_pct,
+            anneal_strategy="cos",
+            div_factor=div_factor,
+            final_div_factor=final_div_factor,
+            last_epoch=last_epoch,
+        )
+    return ConstantCooldownLR(
         optimizer,
         max_lr=max_lr,
         total_steps=total_steps,
-        pct_start=scheduler_config.pct_start,
-        anneal_strategy="cos",
-        div_factor=scheduler_config.div_factor,
-        final_div_factor=scheduler_config.final_div_factor,
+        cooldown_pct=cooldown_pct,
+        final_div_factor=final_div_factor,
         last_epoch=last_epoch,
     )
 
@@ -327,6 +393,10 @@ def _restore_resume_state(
     total_steps: int,
     actual_max_lr: float,
     scheduler_config: UpstreamSchedulerConfig,
+    schedule: ScheduleName,
+    warmup_pct: float,
+    final_div_factor: float,
+    cooldown_pct: float,
 ) -> None:
     """Restore model, optimizer, schedule, and trainer step."""
     print_main(f"Resuming from: {resume}", trainer.rank)
@@ -366,15 +436,19 @@ def _restore_resume_state(
     if scheduler_state is not None and old_total_steps == total_steps:
         trainer.scheduler.load_state_dict(scheduler_state)
     else:
-        rebased_scheduler: optim.lr_scheduler.OneCycleLR = _one_cycle_scheduler(
+        rebased_scheduler: optim.lr_scheduler.LRScheduler = _build_scheduler(
             trainer.optimizer,
-            actual_max_lr,
-            total_steps,
-            scheduler_config,
+            schedule=schedule,
+            max_lr=actual_max_lr,
+            total_steps=total_steps,
+            warmup_pct=warmup_pct,
+            div_factor=scheduler_config.div_factor,
+            final_div_factor=final_div_factor,
+            cooldown_pct=cooldown_pct,
             last_epoch=trainer.global_step - 1,
         )
         trainer.scheduler = rebased_scheduler
-        print_main(f"Rebased OneCycle schedule from {old_total_steps} to {total_steps} total steps", trainer.rank)
+        print_main(f"Rebased {schedule} schedule from {old_total_steps} to {total_steps} total steps", trainer.rank)
 
 
 def main(
@@ -428,6 +502,8 @@ def main(
         config_lr: float = optimizer_config.lr
         actual_max_lr: float = resolve_max_lr(config_lr, config.max_lr, config.from_scratch)
         actual_amp_dtype: AmpDtype = resolve_amp_dtype(config.amp_dtype, amp_config.dtype)
+        warmup_pct: float = scheduler_config.pct_start if config.warmup_pct is None else config.warmup_pct
+        final_div_factor: float = scheduler_config.final_div_factor if config.final_div_factor is None else config.final_div_factor
 
         if is_main:
             config.save_dir.mkdir(parents=True, exist_ok=True)
@@ -521,7 +597,16 @@ def main(
             weight_decay=optimizer_config.weight_decay,
             fused=config.fused_adamw,
         )
-        scheduler: optim.lr_scheduler.OneCycleLR = _one_cycle_scheduler(optimizer, actual_max_lr, total_steps, scheduler_config)
+        scheduler: optim.lr_scheduler.LRScheduler = _build_scheduler(
+            optimizer,
+            schedule=config.schedule,
+            max_lr=actual_max_lr,
+            total_steps=total_steps,
+            warmup_pct=warmup_pct,
+            div_factor=scheduler_config.div_factor,
+            final_div_factor=final_div_factor,
+            cooldown_pct=config.cooldown_pct,
+        )
         trainer: ZipDepthTrainer = ZipDepthTrainer(
             student=wrapped_model,
             train_loader=train_loader,
@@ -555,6 +640,10 @@ def main(
                 total_steps=total_steps,
                 actual_max_lr=actual_max_lr,
                 scheduler_config=scheduler_config,
+                schedule=config.schedule,
+                warmup_pct=warmup_pct,
+                final_div_factor=final_div_factor,
+                cooldown_pct=config.cooldown_pct,
             )
             train_loader.set_global_step(trainer.global_step)
 

--- a/packages/zipdepth/zipdepth/apis/train_catalog.py
+++ b/packages/zipdepth/zipdepth/apis/train_catalog.py
@@ -450,10 +450,10 @@ class ConstantCooldownLR(optim.lr_scheduler.LRScheduler):
     def get_lr(self) -> list[float | Tensor]:
         """Return the learning rate for the scheduler's current step."""
         step: int = min(self.last_epoch, self.total_steps)
-        if step <= self.constant_steps:
+        if step < self.constant_steps:
             factor: float = 1.0
         else:
-            progress: float = (step - self.constant_steps) / self.cooldown_steps
+            progress: float = min((step - self.constant_steps + 1) / self.cooldown_steps, 1.0)
             factor = 1.0 + (self.final_factor - 1.0) * progress
         return [base_lr * factor for base_lr in self.base_lrs]
 

--- a/packages/zipdepth/zipdepth/apis/train_catalog.py
+++ b/packages/zipdepth/zipdepth/apis/train_catalog.py
@@ -33,6 +33,7 @@ from zipdepth.training.trainer import ZipDepthTrainer
 AmpDtype: TypeAlias = Literal["bfloat16", "float16"]
 CompileMode: TypeAlias = Literal["off", "default", "reduce-overhead", "max-autotune"]
 ScheduleName: TypeAlias = Literal["onecycle", "constant-cooldown"]
+TrainPreset: TypeAlias = Literal["v4", "fast"]
 
 
 @serde
@@ -195,6 +196,8 @@ class TrainCatalogConfig:
     """OneCycle peak LR; None uses config LR / 100 for fine-tuning and config LR from scratch.
     Measured on the fixed probe set: at config/10 (1e-4, batch 4) fine-tuning diverges once
     warmup ends; at config/100 (1e-5) it improves the probe loss ~29% in 120 steps."""
+    preset: TrainPreset = "v4"
+    """Named training recipe. ``fast`` intentionally matches ``v4`` until the hill-climb winner lands."""
     compile_mode: CompileMode = "reduce-overhead"
     """``torch.compile`` mode for the student; ``off`` disables it. Beartype dev mode
     disables compilation regardless of this setting."""
@@ -233,6 +236,31 @@ class ResolutionStage:
 
 @serde
 @dataclass(frozen=True, slots=True)
+class TrainingRecipe:
+    """Resolved runtime controls selected by a preset and explicit overrides."""
+
+    compile_mode: CompileMode
+    """torch.compile mode, or ``off``."""
+    channels_last: bool
+    """Whether model and batch tensors use channels-last storage."""
+    fused_adamw: bool
+    """Whether AdamW uses its fused implementation."""
+    amp_dtype: AmpDtype
+    """Automatic mixed-precision dtype."""
+    schedule: ScheduleName
+    """Learning-rate schedule name."""
+    warmup_pct: float
+    """OneCycle warmup fraction."""
+    final_div_factor: float
+    """Ratio between the initial and final learning rates."""
+    cooldown_pct: float
+    """Constant-cooldown tail fraction."""
+    stage_schedule: str | None
+    """Optional progressive-resolution schedule."""
+
+
+@serde
+@dataclass(frozen=True, slots=True)
 class ResolvedTrainCatalogConfig:
     """Catalog training configuration plus values resolved at runtime."""
 
@@ -246,6 +274,8 @@ class ResolvedTrainCatalogConfig:
     """Total optimizer steps in the run."""
     resolved_max_lr: float
     """Peak learning rate after applying the initialization policy."""
+    recipe: TrainingRecipe
+    """Fully resolved runtime recipe used by training."""
 
 
 def resolve_max_lr(config_lr: float, override: float | None, from_scratch: bool) -> float:
@@ -259,6 +289,29 @@ def resolve_max_lr(config_lr: float, override: float | None, from_scratch: bool)
 def resolve_amp_dtype(override: AmpDtype | None, configured: AmpDtype) -> AmpDtype:
     """Resolve the CLI AMP dtype override against the upstream JSON setting."""
     return configured if override is None else override
+
+
+def resolve_training_recipe(
+    config: TrainCatalogConfig,
+    scheduler_config: UpstreamSchedulerConfig,
+    amp_config: UpstreamAmpConfig,
+) -> TrainingRecipe:
+    """Resolve v4/fast plus explicit hill-climb overrides into runtime values."""
+    if config.preset not in ("v4", "fast"):
+        raise ValueError(f"unknown training preset {config.preset!r}")
+    # The fast recipe is deliberately the v4 recipe until measured hill-climb results
+    # select different defaults. Explicit flags remain usable for every trial arm.
+    return TrainingRecipe(
+        compile_mode=config.compile_mode,
+        channels_last=config.channels_last,
+        fused_adamw=config.fused_adamw,
+        amp_dtype=resolve_amp_dtype(config.amp_dtype, amp_config.dtype),
+        schedule=config.schedule,
+        warmup_pct=scheduler_config.pct_start if config.warmup_pct is None else config.warmup_pct,
+        final_div_factor=scheduler_config.final_div_factor if config.final_div_factor is None else config.final_div_factor,
+        cooldown_pct=config.cooldown_pct,
+        stage_schedule=config.stage_schedule,
+    )
 
 
 def parse_stage_schedule(specification: str | None, total_steps: int, height: int, width: int) -> list[ResolutionStage]:
@@ -544,7 +597,6 @@ def main(
             raise ValueError("save_every_steps must be non-negative")
         if config.target_mode not in ("ssi", "metric"):
             raise ValueError(f"unknown target mode {config.target_mode!r}")
-        stages: list[ResolutionStage] = parse_stage_schedule(config.stage_schedule, config.total_steps, config.height, config.width)
         torch.backends.cudnn.benchmark = True
         torch.backends.cuda.matmul.allow_tf32 = True
         torch.backends.cudnn.allow_tf32 = True
@@ -571,9 +623,8 @@ def main(
         training_config: UpstreamTrainingConfig = upstream_config.training
         config_lr: float = optimizer_config.lr
         actual_max_lr: float = resolve_max_lr(config_lr, config.max_lr, config.from_scratch)
-        actual_amp_dtype: AmpDtype = resolve_amp_dtype(config.amp_dtype, amp_config.dtype)
-        warmup_pct: float = scheduler_config.pct_start if config.warmup_pct is None else config.warmup_pct
-        final_div_factor: float = scheduler_config.final_div_factor if config.final_div_factor is None else config.final_div_factor
+        recipe: TrainingRecipe = resolve_training_recipe(config, scheduler_config, amp_config)
+        stages: list[ResolutionStage] = parse_stage_schedule(recipe.stage_schedule, config.total_steps, config.height, config.width)
 
         if is_main:
             config.save_dir.mkdir(parents=True, exist_ok=True)
@@ -587,6 +638,7 @@ def main(
                 steps_per_epoch=steps_per_epoch,
                 total_steps=total_steps,
                 resolved_max_lr=actual_max_lr,
+                recipe=recipe,
             )
             (config.save_dir / "resolved_config.json").write_text(to_json(resolved) + "\n", encoding="utf-8")
         barrier()
@@ -660,7 +712,7 @@ def main(
         if pin_batchnorm_eval:
             pinned: int = sum(isinstance(module, nn.modules.batchnorm._BatchNorm) for module in model.modules())
             print_main(f"Pinned {pinned} BatchNorm modules to eval (released running stats)", rank)
-        model = _model_to_device(model, device, config.channels_last)
+        model = _model_to_device(model, device, recipe.channels_last)
         wrapped_model: nn.Module | DDP = (
             DDP(model, device_ids=[local_rank], output_device=local_rank, find_unused_parameters=False) if is_distributed else model
         )
@@ -669,17 +721,17 @@ def main(
             model,
             lr=actual_max_lr,
             weight_decay=optimizer_config.weight_decay,
-            fused=config.fused_adamw,
+            fused=recipe.fused_adamw,
         )
         scheduler: optim.lr_scheduler.LRScheduler = _build_scheduler(
             optimizer,
-            schedule=config.schedule,
+            schedule=recipe.schedule,
             max_lr=actual_max_lr,
             total_steps=total_steps,
-            warmup_pct=warmup_pct,
+            warmup_pct=recipe.warmup_pct,
             div_factor=scheduler_config.div_factor,
-            final_div_factor=final_div_factor,
-            cooldown_pct=config.cooldown_pct,
+            final_div_factor=recipe.final_div_factor,
+            cooldown_pct=recipe.cooldown_pct,
         )
         trainer: ZipDepthTrainer = ZipDepthTrainer(
             student=wrapped_model,
@@ -692,9 +744,9 @@ def main(
             is_distributed=is_distributed,
             rank=rank,
             world_size=world_size,
-            amp_dtype=actual_amp_dtype,
-            compile_mode=config.compile_mode,
-            channels_last=config.channels_last,
+            amp_dtype=recipe.amp_dtype,
+            compile_mode=recipe.compile_mode,
+            channels_last=recipe.channels_last,
             alpha_ssi=loss_config.alpha_ssi,
             alpha_grad=loss_config.alpha_grad,
             target_mode=config.target_mode,
@@ -714,10 +766,10 @@ def main(
                 total_steps=total_steps,
                 actual_max_lr=actual_max_lr,
                 scheduler_config=scheduler_config,
-                schedule=config.schedule,
-                warmup_pct=warmup_pct,
-                final_div_factor=final_div_factor,
-                cooldown_pct=config.cooldown_pct,
+                schedule=recipe.schedule,
+                warmup_pct=recipe.warmup_pct,
+                final_div_factor=recipe.final_div_factor,
+                cooldown_pct=recipe.cooldown_pct,
             )
             train_loader.set_global_step(trainer.global_step)
 

--- a/packages/zipdepth/zipdepth/apis/train_catalog_smoke.py
+++ b/packages/zipdepth/zipdepth/apis/train_catalog_smoke.py
@@ -15,7 +15,7 @@ from numpy import ndarray
 from torch import Tensor
 from torch.utils.data import DataLoader
 
-from zipdepth.apis.train_catalog import TrainCatalogConfig, load_trainable_checkpoint
+from zipdepth.apis.train_catalog import AmpDtype, CompileMode, TrainCatalogConfig, load_trainable_checkpoint
 from zipdepth.apis.train_catalog import main as train_catalog
 from zipdepth.apis.train_smoke import check_checkpoint, example_rgb, publish_latest, run_required
 from zipdepth.catalog.segments import DEFAULT_CATALOG_URL, DEFAULT_DATASET_NAME, PromptDACatalog, load_promptda_catalog, split_holdout_segments
@@ -44,6 +44,14 @@ class TrainCatalogSmokeConfig:
     """Updates in the one-process torchrun leg."""
     probe_batches: int = 12
     """Fixed probe batches (of the training batch size) scored before and after training."""
+    compile_mode: CompileMode = "reduce-overhead"
+    """torch.compile mode exercised by each training leg."""
+    channels_last: bool = False
+    """Exercise channels-last model and batch storage."""
+    fused_adamw: bool = False
+    """Exercise fused CUDA AdamW."""
+    amp_dtype: AmpDtype | None = None
+    """AMP dtype override passed to each training leg."""
 
 
 def collect_probe_batches(config: TrainCatalogConfig, num_batches: int) -> list[dict[str, Tensor]]:
@@ -149,6 +157,10 @@ def main(config: TrainCatalogSmokeConfig) -> None:
         train_config=config.train_config,
         save_dir=single_dir,
         save_every_steps=5,
+        compile_mode=config.compile_mode,
+        channels_last=config.channels_last,
+        fused_adamw=config.fused_adamw,
+        amp_dtype=config.amp_dtype,
     )
     probe: list[dict[str, Tensor]] = collect_probe_batches(base, config.probe_batches)
     released_loss: float = mean_probe_loss(None, probe)
@@ -223,7 +235,15 @@ def main(config: TrainCatalogSmokeConfig) -> None:
         str(ddp.save_every_steps),
         "--init-checkpoint",
         str(resumed_checkpoint),
+        "--compile-mode",
+        ddp.compile_mode,
     ]
+    if ddp.channels_last:
+        command.append("--channels-last")
+    if ddp.fused_adamw:
+        command.append("--fused-adamw")
+    if ddp.amp_dtype is not None:
+        command.extend(["--amp-dtype", ddp.amp_dtype])
     run_required(command)
 
     image_path: Path = Path(__file__).resolve().parents[2] / "assets" / "examples" / "im0.jpg"

--- a/packages/zipdepth/zipdepth/training/trainer.py
+++ b/packages/zipdepth/zipdepth/training/trainer.py
@@ -107,6 +107,7 @@ class ZipDepthTrainer:
         self.log_wandb = log_wandb and WANDB_AVAILABLE
         self.writer = writer
         self.global_step = 0
+        self.training_stage = 0
         self.is_distributed = is_distributed
         self.rank = rank
         self.world_size = world_size
@@ -457,6 +458,7 @@ class ZipDepthTrainer:
         checkpoint = {
             'epoch': epoch,
             'global_step': self.global_step,
+            'training_stage': self.training_stage,
             'model_state_dict': model_state,
             'optimizer_state_dict': self.optimizer.state_dict(),
             'loss': loss,

--- a/packages/zipdepth/zipdepth/training/trainer.py
+++ b/packages/zipdepth/zipdepth/training/trainer.py
@@ -4,7 +4,7 @@ import glob
 import os
 import time
 from contextlib import nullcontext, suppress
-from typing import Literal
+from typing import Literal, TypeAlias
 
 import torch
 from torch import nn
@@ -21,6 +21,8 @@ from monopriors.third_party.zipdepth.model_utils import strip_state_dict_prefixe
 
 from zipdepth.loss import MetricDepthLoss, ZipDepthLoss
 from zipdepth.training.visualization import depth_to_spectral
+
+CompileMode: TypeAlias = Literal['off', 'default', 'reduce-overhead', 'max-autotune']
 
 
 def trim_memory():
@@ -62,6 +64,8 @@ class ZipDepthTrainer:
                 target_mode: Literal['ssi', 'metric'] = 'ssi',
                 metric_gradient_weight: float = 0.5,
                 pin_batchnorm_eval: bool = False,
+                compile_mode: CompileMode = 'reduce-overhead',
+                channels_last: bool = False,
                 ):
         """
         Args:
@@ -91,6 +95,8 @@ class ZipDepthTrainer:
                 lane. Upstream ZipDepth's SSI lane uses 2.0; 0.5 leaves the term at ~9%
                 of the objective, which under-penalizes depth-discontinuity errors.
             pin_batchnorm_eval: Return BatchNorm modules to eval after entering train mode
+            compile_mode: torch.compile mode, or 'off'; dev-mode beartype disables it
+            channels_last: Move four-dimensional batches with channels-last strides
         """
         self.student = student.to(device)
         self.train_loader = train_loader
@@ -120,6 +126,7 @@ class ZipDepthTrainer:
             raise ValueError(f"unknown target mode {target_mode!r}")
         self.target_mode = target_mode
         self.pin_batchnorm_eval = pin_batchnorm_eval
+        self.channels_last = channels_last
 
         # Loss function initialization
         self.criterion: nn.Module = (
@@ -138,8 +145,8 @@ class ZipDepthTrainer:
         # Compile student for faster iteration (PyTorch >= 2.0)
         # Under the beartype dev env, Dynamo tracing through beartype's jaxtyping wrapper
         # raises a desynchronization error; production environments still compile.
-        if os.environ.get("PIXI_DEV_MODE") != "1":
-            self.student = torch.compile(self.student, mode="reduce-overhead")
+        if compile_mode != 'off' and os.environ.get("PIXI_DEV_MODE") != "1":
+            self.student = torch.compile(self.student, mode=compile_mode)
 
     def train(self, num_epochs: int, save_dir: str = './checkpoints', start_epoch: int = 0,
             save_every_steps: int = 0, max_step_checkpoints: int = 5, max_steps: int = 0,
@@ -316,28 +323,29 @@ class ZipDepthTrainer:
                     pbar.update(1)
                     continue
 
-                images = batch['image'].to(self.device, non_blocking=True)
+                memory_format: torch.memory_format = torch.channels_last if self.channels_last else torch.preserve_format
+                images = batch['image'].to(self.device, non_blocking=True, memory_format=memory_format)
                 images = images.float() / 255.0
 
                 prompt_depth = None
                 if self.target_mode == 'metric':
-                    teacher_depth = batch['target_depth'].to(self.device, non_blocking=True).float()
-                    mask = batch['target_valid'].to(self.device, non_blocking=True)
+                    teacher_depth = batch['target_depth'].to(self.device, non_blocking=True, memory_format=memory_format).float()
+                    mask = batch['target_valid'].to(self.device, non_blocking=True, memory_format=memory_format)
                     # Feed the RAW prompt, exactly what the teacher saw when it produced
                     # these labels (promptda_stream.py:254). Zeroing low-confidence pixels
                     # made the student solve a different problem from the teacher, and the
                     # degenerate cases it guarded against are already handled inside the
                     # model, which computes its own finite/0.1-4 m validity for the
                     # normalization range and clamps the span.
-                    prompt_depth = batch['prompt_depth'].to(self.device, non_blocking=True).float()
+                    prompt_depth = batch['prompt_depth'].to(self.device, non_blocking=True, memory_format=memory_format).float()
                 else:
-                    teacher_depth = batch['depth'].to(self.device, non_blocking=True)
+                    teacher_depth = batch['depth'].to(self.device, non_blocking=True, memory_format=memory_format)
                     teacher_depth = teacher_depth.float().div_(256.0)
 
                     # Local addition: sparse catalog targets carry an explicit validity mask.
                     mask = batch.get('mask')
                     if mask is not None:
-                        mask = mask.to(self.device, non_blocking=True).float()
+                        mask = mask.to(self.device, non_blocking=True, memory_format=memory_format).float()
 
                 del batch
 


### PR DESCRIPTION
Stack **8/9**, on top of #192. Groundwork for the training-speed hill-climb (goal: fastest wall-clock on one RTX 5090 from the released ZipDepth weights to a v4-equivalent checkpoint, data streamed from the catalog on the NAS). No architecture, loss, eval or dataset change; every default is today's behaviour, proven by bit-equal object tests.

**New `zipdepth-train-catalog` flags**
- Runtime: `--compile-mode {off,default,reduce-overhead,max-autotune}` (default keeps today's reduce-overhead compile; disabled under beartype dev mode), `--channels-last`, `--fused-adamw`, `--amp-dtype {bfloat16,float16}`.
- Schedule: `--warmup-pct`, `--final-div-factor`, `--schedule {onecycle,constant-cooldown}` + `--cooldown-pct` (constant LR, then linear cooldown over the last fraction of `total_steps`; the final optimizer steps really use the cooldown).
- Progressive resolution: `--stage-schedule "384x512:0.3,768x1024:0.7"` (fractions of `total_steps`; the loader rebuilds at each boundary; the stage is saved in and restored from checkpoints).
- `--preset {v4,fast}`: named recipes; `v4` = today's recipe, `fast` currently aliases `v4` and receives the hill-climb's winning values.

**Verification** 103 tests pass (defaults bit-equal to today's model/optimizer/scheduler objects; each flag changes the constructed object; 7-then-linear cooldown case; stage ranges `0:3` and `3:10`); lint/typecheck/deadcode clean. Live catalog smoke with `--compile-mode default --channels-last --fused-adamw` passed on the 5090 (fixed-probe loss 0.7997 → 0.7040, resume and torchrun legs green).

**Hill-climb protocol** (agreed): finish line = full 20-segment holdout AbsRel ≤ 0.0140 and edge MAE ≤ 73 mm plus hard-20 macro edge ≤ 128.5 mm; clock = wall-clock from process start to the first passing checkpoint; quick 6-segment proxy (v4 scores 0.01273 / 79.4 mm there → proxy 0.01311 / 81.8 mm); 10 h budget: 90 min baseline, ≤ 60 min arms proposed by Codex from the results table (allow-listed options only), 2 h final confirmation. Results and the `fast` preset land here.