### PR TITLE
zipdepth: skip the dataloader equivalence test outside the catalog lane

### DIFF
--- a/packages/zipdepth/tests/test_catalog_dataloader_dataset.py
+++ b/packages/zipdepth/tests/test_catalog_dataloader_dataset.py
@@ -9,6 +9,9 @@ import pytest
 import torch
 from jaxtyping import Int64, Shaped
 from numpy import ndarray
+
+pytest.importorskip("rerun.catalog", reason="Rerun catalog dependencies live in the zipdepth catalog lane")
+pytest.importorskip("arkitscenes_download", reason="ARKitScenes catalog dependencies live in the zipdepth catalog lane")
 from rerun.catalog import DatasetEntry
 from rerun.experimental.dataloader import NoShuffle
 


### PR DESCRIPTION
Follow-up to #204. The new `tests/test_catalog_dataloader_dataset.py` imports `rerun.catalog` and (via `zipdepth.catalog.builders`) `arkitscenes_download`, which only exist in the `zipdepth-catalog` lane, so `pixi run -e zipdepth-dev tests` on main failed at collection with `ModuleNotFoundError: arkitscenes_download`.

Guard the module with the same `pytest.importorskip` pair that `test_catalog_dataset.py` and `test_catalog_png.py` already use.

| env | before | after |
|---|---|---|
| `zipdepth-dev` tests | 1 collection error | 89 passed, 4 skipped |
| `zipdepth-catalog-dev` tests | 107 passed, 2 skipped | 107 passed, 2 skipped |

Found by the post-merge verification of main (35514f2e); every other gate in the touched packages is green there.
