### PR TITLE
exo-calib: geometry core — correspondences, triangulation, BA, focal, confidence, eval (re-land of #181)

### DIFF
--- a/packages/exo-calib/exo_calib/ba.py
+++ b/packages/exo-calib/exo_calib/ba.py
@@ -1,0 +1,229 @@
+"""Bundle adjustment for multi-camera calibration."""
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+from jaxtyping import Bool, Float64, Int64
+from kornia_rs.k3d import bundle_adjust  # pyrefly: ignore[missing-import]  # Compiled extension exposes k3d only at runtime.
+from numpy import ndarray
+
+from exo_calib.correspondences import ObservationSet
+from exo_calib.triangulation import reprojection_errors_px, triangulate_points, valid_observation_mask
+
+
+@dataclass(slots=True, frozen=True)
+class PosePrior:
+    """Soft anchors on the camera centres.
+
+    Reprojection-only BA leaves a 7-DOF similarity gauge (fixing one pose still
+    leaves global scale free); weak centre priors pin every gauge direction
+    without fighting real signal, and keep the refinement a *refinement* of the
+    Stage A metric rig.
+    """
+
+    centers: Float64[ndarray, "v 3"]
+    """Float64 world-frame centres the cameras are anchored to, shape ``(v, 3)``."""
+    sigma_m: float
+    """Prior standard deviation in metres, shared by every camera."""
+
+
+@dataclass(slots=True)
+class BaResult:
+    """Refined calibration and per-round diagnostics."""
+
+    cam_T_world: Float64[ndarray, "v 4 4"]
+    """Refined Float64 world-to-camera transforms with shape ``(v, 4, 4)``."""
+    points_xyz: Float64[ndarray, "n_points 3"]
+    """Re-triangulated Float64 world points with shape ``(n_points, 3)``."""
+    mean_reproj_px_per_round: list[float]
+    """Confidence-weighted pixel error after each refinement round."""
+    converged: bool
+    """Whether bundle adjustment converged in every round."""
+
+
+def mean_reprojection_error_px(
+    obs: ObservationSet,
+    points_xyz: Float64[ndarray, "n_points 3"],
+    intrinsics: Float64[ndarray, "v 3 3"],
+    cam_T_world: Float64[ndarray, "v 4 4"],
+) -> float:
+    """Compute confidence-weighted mean reprojection error in pixels.
+
+    Args:
+        obs: Sparse pixel observations for the points.
+        points_xyz: Float64 world points with shape ``(n_points, 3)``.
+        intrinsics: Float64 camera intrinsics with shape ``(v, 3, 3)``.
+        cam_T_world: Float64 world-to-camera transforms with shape ``(v, 4, 4)``.
+
+    Returns:
+        Confidence-weighted mean pixel error, or NaN when no observation is valid.
+    """
+    reprojection_error: Float64[ndarray, "n_obs"] = reprojection_errors_px(obs, points_xyz, intrinsics, cam_T_world)
+    finite_mask: Bool[ndarray, "n_obs"] = np.isfinite(reprojection_error)
+    if not finite_mask.any():
+        return float("nan")
+    weights: Float64[ndarray, "r"] = obs.obs_conf[finite_mask]
+    return float(np.sum(weights * reprojection_error[finite_mask]) / np.sum(weights))
+
+
+def refine_extrinsics(
+    cam_T_world: Float64[ndarray, "v 4 4"],
+    intrinsics: Float64[ndarray, "v 3 3"],
+    obs: ObservationSet,
+    points_xyz: Float64[ndarray, "n_points 3"],
+    *,
+    rounds: int,
+    robust: Literal["huber", "cauchy"],
+    robust_scale_px: float,
+    max_iterations: int,
+    fixed_pose_indices: tuple[int, ...] = (0,),
+    pose_prior: PosePrior | None = None,
+) -> BaResult:
+    """Refine camera extrinsics with normalized-intrinsics bundle adjustment.
+
+    Args:
+        cam_T_world: Float64 initial world-to-camera transforms with shape ``(v, 4, 4)``.
+        intrinsics: Float64 per-camera intrinsics with shape ``(v, 3, 3)``.
+        obs: Sparse pixel observations for the points.
+        points_xyz: Float64 initial world points with shape ``(n_points, 3)``.
+        rounds: Number of bundle-adjustment and re-triangulation rounds.
+        robust: Robust loss used by ``kornia_rs``.
+        robust_scale_px: Robust loss scale in pixels before focal normalization.
+        fixed_pose_indices: Camera poses held fixed to remove gauge freedom.
+        max_iterations: Maximum solver iterations in each round.
+        pose_prior: Soft camera-centre anchors; ``None`` runs reprojection-only BA.
+
+    Returns:
+        Refined poses, re-triangulated points, diagnostics, and convergence state.
+    """
+    n_views: int = cam_T_world.shape[0]
+    n_points: int = points_xyz.shape[0]
+    current_cam_T_world: Float64[ndarray, "v 4 4"] = cam_T_world.copy()
+    current_points_xyz: Float64[ndarray, "n_points 3"] = points_xyz.copy()
+    mean_reproj_px_per_round: list[float] = []
+    all_converged: bool = True
+    inverse_intrinsics: Float64[ndarray, "v 3 3"] = np.linalg.inv(intrinsics)
+    focal: Float64[ndarray, "v"] = (intrinsics[:, 0, 0] + intrinsics[:, 1, 1]) / 2.0
+    mean_focal: float = float(np.mean(focal))
+    normalized_robust_scale: float = robust_scale_px / mean_focal
+    fixed_pose_index_list: list[int] = list(fixed_pose_indices)
+    prior_centers: Float64[ndarray, "v 3"] | None = None
+    prior_sigmas: Float64[ndarray, "v"] | None = None
+    if pose_prior is not None:
+        prior_centers = pose_prior.centers
+        prior_sigmas = np.full(n_views, pose_prior.sigma_m, dtype=np.float64)
+
+    _round_idx: int
+    for _round_idx in range(rounds):
+        round_start_cam_T_world: Float64[ndarray, "v 4 4"] = current_cam_T_world.copy()
+        round_start_points_xyz: Float64[ndarray, "n_points 3"] = current_points_xyz.copy()
+        valid_reference_mask: Bool[ndarray, "n_obs"] = valid_observation_mask(obs, n_views, n_points=n_points)
+        valid_reference_idx: Int64[ndarray, "q"] = np.flatnonzero(valid_reference_mask).astype(np.int64)
+        if valid_reference_idx.size == 0:
+            all_converged = False
+            break
+        referenced_point_idx: Int64[ndarray, "q"] = obs.obs_point_idx[valid_reference_idx]
+        finite_point_mask: Bool[ndarray, "q"] = np.isfinite(current_points_xyz[referenced_point_idx]).all(axis=1)
+        valid_obs_idx: Int64[ndarray, "m_valid"] = valid_reference_idx[finite_point_mask]
+        if valid_obs_idx.size == 0:
+            all_converged = False
+            break
+
+        old_point_idx: Int64[ndarray, "m_valid"] = obs.obs_point_idx[valid_obs_idx]
+        dense_old_point_idx: Int64[ndarray, "n_valid"] = np.unique(old_point_idx).astype(np.int64)
+        old_to_dense: Int64[ndarray, "n_points"] = np.full(n_points, -1, dtype=np.int64)
+        old_to_dense[dense_old_point_idx] = np.arange(dense_old_point_idx.size, dtype=np.int64)
+        dense_point_idx: Int64[ndarray, "m_valid"] = old_to_dense[old_point_idx]
+        view_idx: Int64[ndarray, "m_valid"] = obs.obs_view_idx[valid_obs_idx]
+        pixel_homo: Float64[ndarray, "m_valid 3"] = np.column_stack(
+            (obs.obs_xy[valid_obs_idx], np.ones(valid_obs_idx.size, dtype=np.float64))
+        )
+        normalized_homo: Float64[ndarray, "m_valid 3"] = np.einsum("mij,mj->mi", inverse_intrinsics[view_idx], pixel_homo)
+        normalized_xy: Float64[ndarray, "m_valid 2"] = normalized_homo[:, :2]
+        ba_observations: Float64[ndarray, "m_valid 4"] = np.column_stack(
+            (view_idx.astype(np.float64), dense_point_idx.astype(np.float64), normalized_xy)
+        )
+        rotations: Float64[ndarray, "v 3 3"] = current_cam_T_world[:, :3, :3].copy()
+        translations: Float64[ndarray, "v 3"] = current_cam_T_world[:, :3, 3].copy()
+        dense_points_xyz: Float64[ndarray, "n_valid 3"] = current_points_xyz[dense_old_point_idx].copy()
+        identity_intrinsics: Float64[ndarray, "3 3"] = np.eye(3, dtype=np.float64)
+        ba_output: tuple[
+            Float64[ndarray, "v 3 3"], Float64[ndarray, "v 3"], Float64[ndarray, "n_valid 3"], int, bool
+        ] = bundle_adjust(
+            rotations,
+            translations,
+            dense_points_xyz,
+            ba_observations,
+            identity_intrinsics,
+            fixed_pose_indices=fixed_pose_index_list,
+            fix_all_points=False,
+            max_iterations=max_iterations,
+            robust=robust,
+            robust_scale=normalized_robust_scale,
+            # "schur" eliminates the 3N point parameters into a camera-only
+            # reduced system; dense "lm" builds O((6V+3N)^2) normal equations
+            # and stalls for minutes at a few thousand points. It is also the
+            # only solver honoring pose priors.
+            solver="schur",
+            pose_prior_centers=None if prior_centers is None else prior_centers.astype(np.float32),
+            pose_prior_sigmas=None if prior_sigmas is None else prior_sigmas.astype(np.float32),
+        )
+        optimized_rotations: Float64[ndarray, "v 3 3"] = ba_output[0]
+        optimized_translations: Float64[ndarray, "v 3"] = ba_output[1]
+        optimized_dense_points_xyz: Float64[ndarray, "n_valid 3"] = ba_output[2]
+        round_converged: bool = ba_output[4]
+        current_cam_T_world[:, :3, :3] = optimized_rotations
+        current_cam_T_world[:, :3, 3] = optimized_translations
+        current_points_xyz[dense_old_point_idx] = optimized_dense_points_xyz
+        round_mean_reproj_px: float = mean_reprojection_error_px(obs, current_points_xyz, intrinsics, current_cam_T_world)
+        if mean_reproj_px_per_round and round_mean_reproj_px > mean_reproj_px_per_round[-1]:
+            current_cam_T_world = round_start_cam_T_world
+            current_points_xyz = round_start_points_xyz
+            mean_reproj_px_per_round.append(mean_reproj_px_per_round[-1])
+            all_converged = all_converged and round_converged
+            continue
+        mean_reproj_px_per_round.append(round_mean_reproj_px)
+        current_points_xyz = triangulate_points(obs, intrinsics, current_cam_T_world)
+        all_converged = all_converged and round_converged
+
+    return BaResult(
+        cam_T_world=current_cam_T_world,
+        points_xyz=current_points_xyz,
+        mean_reproj_px_per_round=mean_reproj_px_per_round,
+        converged=all_converged,
+    )
+
+
+def revert_large_pose_updates(
+    refined_cam_T_world: Float64[ndarray, "v 4 4"],
+    initial_cam_T_world: Float64[ndarray, "v 4 4"],
+    *,
+    maximum_rotation_deg: float,
+) -> tuple[Float64[ndarray, "v 4 4"], tuple[int, ...]]:
+    """Restore initial poses whose BA rotation update exceeds a data-independent bound.
+
+    Args:
+        refined_cam_T_world: Float64 refined world-to-camera transforms, shape ``(v, 4, 4)``.
+        initial_cam_T_world: Float64 initial world-to-camera transforms, shape ``(v, 4, 4)``.
+        maximum_rotation_deg: Largest accepted rotation change per camera.
+
+    Returns:
+        The guarded transforms and the indices of the reverted cameras.
+    """
+    if maximum_rotation_deg < 0.0:
+        raise ValueError("maximum_rotation_deg must be nonnegative")
+    relative_rotation: Float64[ndarray, "v 3 3"] = np.einsum(
+        "vij,vkj->vik", refined_cam_T_world[:, :3, :3], initial_cam_T_world[:, :3, :3]
+    )
+    cosine: Float64[ndarray, "v"] = np.clip(
+        (np.trace(relative_rotation, axis1=1, axis2=2) - 1.0) / 2.0,
+        -1.0,
+        1.0,
+    )
+    update_deg: Float64[ndarray, "v"] = np.rad2deg(np.arccos(cosine))
+    reverted: tuple[int, ...] = tuple(int(view_idx) for view_idx in np.flatnonzero(update_deg > maximum_rotation_deg))
+    guarded_cam_T_world: Float64[ndarray, "v 4 4"] = refined_cam_T_world.copy()
+    if reverted:
+        guarded_cam_T_world[np.asarray(reverted, dtype=np.int64)] = initial_cam_T_world[np.asarray(reverted, dtype=np.int64)]
+    return guarded_cam_T_world, reverted

--- a/packages/exo-calib/exo_calib/boxes.py
+++ b/packages/exo-calib/exo_calib/boxes.py
@@ -1,0 +1,156 @@
+"""Person boxes: reprojection-driven tracking boxes and the pose model's crop rectangles."""
+
+import numpy as np
+import torch
+from jaxtyping import Bool, Float32, Float64
+from numpy import ndarray
+from posekit.ops.crops import CropSpec, bbox_xyxy_to_center_scale
+
+
+def boxes_from_projected_keypoints(
+    points_xyz: Float64[ndarray, "j 3"],
+    conf: Float64[ndarray, "j"],
+    camera_intrinsics: Float64[ndarray, "3 3"],
+    camera_T_world: Float64[ndarray, "4 4"],
+    image_wh: tuple[int, int],
+    *,
+    pad: float,
+    min_joints: int,
+    min_confidence: float,
+) -> Float64[ndarray, "4"]:
+    """Project a 3D skeleton into one view and return a padded XYXY box.
+
+    Args:
+        points_xyz: Float64 world keypoints with shape ``(j, 3)``.
+        conf: Float64 keypoint confidences with shape ``(j,)``.
+        camera_intrinsics: Float64 camera intrinsics with shape ``(3, 3)``.
+        camera_T_world: Float64 world-to-camera transform with shape ``(4, 4)``.
+        image_wh: Image width and height in pixels.
+        pad: Multiplicative width and height padding about the box center.
+        min_joints: Minimum confident, projectable joints inside the image.
+        min_confidence: Inclusive confidence threshold for projected joints.
+
+    Returns:
+        Float64 XYXY box with shape ``(4,)``, clipped to the image, or NaNs
+        when too few joints can define a usable box.
+    """
+    if pad <= 0.0:
+        raise ValueError("pad must be positive")
+    if min_joints < 1:
+        raise ValueError("min_joints must be positive")
+    image_w: int = image_wh[0]
+    image_h: int = image_wh[1]
+    if image_w < 1 or image_h < 1:
+        raise ValueError("image dimensions must be positive")
+
+    points_homo: Float64[ndarray, "j 4"] = np.column_stack(
+        (points_xyz, np.ones(points_xyz.shape[0], dtype=np.float64))
+    )
+    points_cam: Float64[ndarray, "j 3"] = np.einsum("ij,nj->ni", camera_T_world[:3], points_homo)
+    projected_homo: Float64[ndarray, "j 3"] = np.einsum("ij,nj->ni", camera_intrinsics, points_cam)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        projected_xy: Float64[ndarray, "j 2"] = projected_homo[:, :2] / projected_homo[:, 2:3]
+    usable: Bool[ndarray, "j"] = (
+        np.isfinite(points_xyz).all(axis=1)
+        & np.isfinite(conf)
+        & (conf >= min_confidence)
+        & (points_cam[:, 2] > 0.0)
+        & np.isfinite(projected_xy).all(axis=1)
+        & (projected_xy[:, 0] >= 0.0)
+        & (projected_xy[:, 0] < float(image_w))
+        & (projected_xy[:, 1] >= 0.0)
+        & (projected_xy[:, 1] < float(image_h))
+    )
+    if int(usable.sum()) < min_joints:
+        return np.full(4, np.nan, dtype=np.float64)
+
+    usable_xy: Float64[ndarray, "m 2"] = projected_xy[usable]
+    minimum_xy: Float64[ndarray, "2"] = usable_xy.min(axis=0)
+    maximum_xy: Float64[ndarray, "2"] = usable_xy.max(axis=0)
+    center_xy: Float64[ndarray, "2"] = (minimum_xy + maximum_xy) / 2.0
+    padded_size_wh: Float64[ndarray, "2"] = (maximum_xy - minimum_xy) * pad
+    box_xyxy: Float64[ndarray, "4"] = np.concatenate(
+        (center_xy - padded_size_wh / 2.0, center_xy + padded_size_wh / 2.0)
+    )
+    box_xyxy[[0, 2]] = np.clip(box_xyxy[[0, 2]], 0.0, float(image_w))
+    box_xyxy[[1, 3]] = np.clip(box_xyxy[[1, 3]], 0.0, float(image_h))
+    if box_xyxy[2] <= box_xyxy[0] or box_xyxy[3] <= box_xyxy[1]:
+        return np.full(4, np.nan, dtype=np.float64)
+    return box_xyxy
+
+
+def boxes_needing_detection(
+    boxes_xyxy: Float64[ndarray, "v 4"], image_wh: tuple[int, int]
+) -> Bool[ndarray, "v"]:
+    """Mark missing or image-boundary projected boxes for detector re-anchoring.
+
+    Args:
+        boxes_xyxy: Float64 projected XYXY boxes with shape ``(v, 4)``.
+        image_wh: Image width and height in pixels.
+
+    Returns:
+        Boolean mask with shape ``(v,)``. A clipped box touching any image
+        boundary is marked because its unpadded projection left the image.
+    """
+    image_w: int = image_wh[0]
+    image_h: int = image_wh[1]
+    finite_mask: Bool[ndarray, "v"] = np.isfinite(boxes_xyxy).all(axis=1)
+    touches_boundary: Bool[ndarray, "v"] = (
+        (boxes_xyxy[:, 0] <= 0.0)
+        | (boxes_xyxy[:, 1] <= 0.0)
+        | (boxes_xyxy[:, 2] >= float(image_w))
+        | (boxes_xyxy[:, 3] >= float(image_h))
+    )
+    return ~finite_mask | touches_boundary
+
+
+def extrapolate_keypoints(
+    latest_points_xyz: Float64[ndarray, "j 3"],
+    previous_points_xyz: Float64[ndarray, "j 3"],
+    *,
+    step_ratio: float = 1.0,
+) -> Float64[ndarray, "j 3"]:
+    """Extrapolate a skeleton with constant velocity from its last two states.
+
+    Args:
+        latest_points_xyz: Float64 latest world keypoints with shape ``(j, 3)``.
+        previous_points_xyz: Float64 preceding world keypoints with shape ``(j, 3)``.
+        step_ratio: Prediction interval divided by the two-state interval.
+
+    Returns:
+        Float64 predicted world keypoints with shape ``(j, 3)``. Joints with
+        only a latest state are carried forward; joints absent from the latest
+        state remain NaN.
+    """
+    if step_ratio < 0.0:
+        raise ValueError("step_ratio must be nonnegative")
+    predicted_points_xyz: Float64[ndarray, "j 3"] = latest_points_xyz.copy()
+    velocity_available: Bool[ndarray, "j"] = np.isfinite(latest_points_xyz).all(axis=1) & np.isfinite(previous_points_xyz).all(axis=1)
+    predicted_points_xyz[velocity_available] = latest_points_xyz[velocity_available] + step_ratio * (
+        latest_points_xyz[velocity_available] - previous_points_xyz[velocity_available]
+    )
+    return predicted_points_xyz
+
+
+def crop_rectangles(bbox_xyxy: Float32[ndarray, "t 4"], crop_spec: CropSpec) -> tuple[Float32[ndarray, "t 2"], Float32[ndarray, "t 2"]]:
+    """Crop rectangles exactly as posekit prepares them (center/scale convention); NaN rows where there is no box.
+
+    Args:
+        bbox_xyxy: Per-frame person boxes; NaN where no detection.
+        crop_spec: The pose model's crop input size and padding.
+
+    Returns:
+        Image-space crop origins and sizes, index-aligned with ``bbox_xyxy``.
+    """
+    valid_box: Bool[ndarray, "t"] = np.isfinite(bbox_xyxy).all(axis=1)
+    crop_origin_xy: Float32[ndarray, "t 2"] = np.full((bbox_xyxy.shape[0], 2), np.nan, dtype=np.float32)
+    crop_size_wh: Float32[ndarray, "t 2"] = np.full((bbox_xyxy.shape[0], 2), np.nan, dtype=np.float32)
+    if valid_box.any():
+        crop_w, crop_h = crop_spec.input_size
+        centers, scales = bbox_xyxy_to_center_scale(
+            torch.as_tensor(bbox_xyxy[valid_box]), aspect_wh=float(crop_w) / float(crop_h), padding=crop_spec.padding
+        )
+        crop_scale_wh: Float32[ndarray, "m 2"] = scales.cpu().numpy()
+        crop_origin_xy[valid_box] = centers.cpu().numpy() - crop_scale_wh / 2.0
+        crop_size_wh[valid_box] = crop_scale_wh
+    return crop_origin_xy, crop_size_wh

--- a/packages/exo-calib/exo_calib/cameras.py
+++ b/packages/exo-calib/exo_calib/cameras.py
@@ -1,0 +1,24 @@
+"""Camera rig container and camera-frame geometry shared by every stage."""
+
+from dataclasses import dataclass
+
+import numpy as np
+from jaxtyping import Float64
+from numpy import ndarray
+
+
+@dataclass(slots=True)
+class RigCameras:
+    """A camera rig read back from a catalog layer (GT base layer or an exocalib layer)."""
+
+    names: tuple[str, ...]
+    """Camera entity names, e.g. ``rig_00/cam_00``."""
+    intrinsics: Float64[ndarray, "v 3 3"]
+    """Pinhole intrinsics at the native video resolution."""
+    cam_T_world: Float64[ndarray, "v 4 4"]
+    """World-to-camera transforms (RDF, metric, +Z-up world)."""
+
+
+def camera_centers(cam_T_world: Float64[ndarray, "v 4 4"]) -> Float64[ndarray, "v 3"]:
+    """World-frame camera centres ``-Rᵀt`` of world-to-camera transforms."""
+    return -np.einsum("vji,vj->vi", cam_T_world[:, :3, :3], cam_T_world[:, :3, 3])

--- a/packages/exo-calib/exo_calib/confidence.py
+++ b/packages/exo-calib/exo_calib/confidence.py
@@ -1,0 +1,161 @@
+"""Confidence processing for multi-view keypoints."""
+
+import warnings
+
+import numpy as np
+from jaxtyping import Bool, Float64
+from numpy import ndarray
+
+from exo_calib.correspondences import ObservationSet
+
+
+def modulate_crop_edge_confidence(
+    kp_xy: Float64[ndarray, "n 2"], conf: Float64[ndarray, "n"], crop_wh: tuple[int, int], margin_px: float
+) -> Float64[ndarray, "n"]:
+    """Reduce confidence near or outside crop edges.
+
+    Args:
+        kp_xy: Float64 pixel coordinates with shape ``(n, 2)``.
+        conf: Float64 detector confidences with shape ``(n,)``.
+        crop_wh: Crop width and height in pixels.
+        margin_px: Width of the confidence falloff in pixels.
+
+    Returns:
+        Float64 modulated confidences with shape ``(n,)``.
+    """
+    crop_w: int = crop_wh[0]
+    crop_h: int = crop_wh[1]
+    x: Float64[ndarray, "n"] = kp_xy[:, 0]
+    y: Float64[ndarray, "n"] = kp_xy[:, 1]
+    edge_scale: Float64[ndarray, "n"] = np.minimum.reduce(
+        (x / margin_px, (float(crop_w) - x) / margin_px, y / margin_px, (float(crop_h) - y) / margin_px, np.ones_like(x))
+    )
+    edge_scale = np.where(np.isfinite(kp_xy).all(axis=1), np.maximum(edge_scale, 0.0), 0.0)
+    modulated_conf: Float64[ndarray, "n"] = np.where(edge_scale > 0.0, conf * edge_scale, 0.0)
+    return modulated_conf
+
+
+def threshold_rescale_confidence(conf: Float64[ndarray, "n"], *, tau: float) -> Float64[ndarray, "n"]:
+    """Threshold and linearly rescale detector confidences.
+
+    Args:
+        conf: Float64 detector confidences with shape ``(n,)``.
+        tau: Inclusive confidence cutoff mapped to zero.
+
+    Returns:
+        Float64 rescaled confidences with shape ``(n,)``.
+    """
+    rescaled_conf: Float64[ndarray, "n"] = np.where(conf >= tau, (conf - tau) / (1.0 - tau), 0.0)
+    return rescaled_conf
+
+
+def median_filter_keypoints(kp_xy: Float64[ndarray, "t n 2"], *, window: int) -> Float64[ndarray, "t n 2"]:
+    """Apply a centered temporal median to keypoint coordinates.
+
+    Args:
+        kp_xy: Float64 keypoint coordinates with shape ``(t, n, 2)``.
+        window: Odd temporal window size.
+
+    Returns:
+        Float64 filtered keypoint coordinates with shape ``(t, n, 2)``.
+    """
+    half_window: int = window // 2
+    filtered_xy: Float64[ndarray, "t n 2"] = np.empty_like(kp_xy)
+    frame_idx: int
+    for frame_idx in range(kp_xy.shape[0]):
+        start_idx: int = max(0, frame_idx - half_window)
+        stop_idx: int = min(kp_xy.shape[0], frame_idx + half_window + 1)
+        window_xy: Float64[ndarray, "window_t n 2"] = kp_xy[start_idx:stop_idx]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            filtered_xy[frame_idx] = np.nanmedian(window_xy, axis=0)
+    return filtered_xy
+
+
+def kineo_point_confidence(
+    points_xyz: Float64[ndarray, "n 3"],
+    kp_xy: Float64[ndarray, "v n 2"],
+    conf: Float64[ndarray, "v n"],
+    intrinsics: Float64[ndarray, "v 3 3"],
+    cam_T_world: Float64[ndarray, "v 4 4"],
+    *,
+    lambda_decay: float,
+) -> Float64[ndarray, "n"]:
+    """Compute Kineo confidence from multi-view reprojection consistency.
+
+    Args:
+        points_xyz: Float64 world points with shape ``(n, 3)``.
+        kp_xy: Float64 observed pixels with shape ``(v, n, 2)``.
+        conf: Float64 detector confidences with shape ``(v, n)``.
+        intrinsics: Float64 camera intrinsics with shape ``(v, 3, 3)``.
+        cam_T_world: Float64 world-to-camera transforms with shape ``(v, 4, 4)``.
+        lambda_decay: Exponential reprojection-error decay.
+
+    Returns:
+        Float64 point confidences with shape ``(n,)``.
+    """
+    n_points: int = points_xyz.shape[0]
+    n_views: int = kp_xy.shape[0]
+    if n_views < 2:
+        return np.zeros(n_points, dtype=np.float64)
+
+    points_homo: Float64[ndarray, "n 4"] = np.concatenate((points_xyz, np.ones((n_points, 1), dtype=np.float64)), axis=1)
+    points_cam: Float64[ndarray, "v n 3"] = np.einsum("vij,nj->vni", cam_T_world[:, :3, :], points_homo)
+    projected_homo: Float64[ndarray, "v n 3"] = np.einsum("vij,vnj->vni", intrinsics, points_cam)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        projected_xy: Float64[ndarray, "v n 2"] = projected_homo[:, :, :2] / projected_homo[:, :, 2:3]
+
+    focal: Float64[ndarray, "v"] = (intrinsics[:, 0, 0] + intrinsics[:, 1, 1]) / 2.0
+    reproj_error: Float64[ndarray, "v n"] = np.linalg.norm(projected_xy - kp_xy, axis=2)
+    normalized_error: Float64[ndarray, "v n"] = reproj_error / (focal[:, None] + 1e-8)
+    valid_view: Bool[ndarray, "v n"] = (
+        (points_cam[:, :, 2] > 0.0)
+        & np.isfinite(projected_xy).all(axis=2)
+        & np.isfinite(kp_xy).all(axis=2)
+        & np.isfinite(conf)
+        & (conf > 0.0)
+    )
+    view_score: Float64[ndarray, "v n"] = np.where(valid_view, np.exp(-lambda_decay * normalized_error), 0.0)
+    valid_conf: Float64[ndarray, "v n"] = np.where(valid_view, conf, 0.0)
+    pair_sum: Float64[ndarray, "n"] = np.zeros(n_points, dtype=np.float64)
+    first_view_idx: int
+    second_view_idx: int
+    for first_view_idx in range(n_views - 1):
+        for second_view_idx in range(first_view_idx + 1, n_views):
+            pair_score: Float64[ndarray, "n"] = np.sqrt(view_score[first_view_idx] * view_score[second_view_idx])
+            pair_weight: Float64[ndarray, "n"] = np.sqrt(valid_conf[first_view_idx] * valid_conf[second_view_idx])
+            pair_sum += pair_score * pair_weight
+
+    n_pairs: int = n_views * (n_views - 1) // 2
+    point_conf: Float64[ndarray, "n"] = pair_sum / float(n_pairs)
+    point_conf[np.sum(valid_view, axis=0) < 2] = 0.0
+    return point_conf
+
+
+def drop_face_confidences(conf: Float64[ndarray, "v t 133"]) -> Float64[ndarray, "v t 133"]:
+    """Zero the 68 COCO WholeBody face landmarks (23–90); body, feet, and hands stay."""
+    selected: Float64[ndarray, "v t 133"] = conf.copy()
+    selected[..., 23:91] = 0.0
+    return selected
+
+
+def kineo_point_confidence_for_obs(
+    points_xyz: Float64[ndarray, "n 3"],
+    obs: ObservationSet,
+    intrinsics: Float64[ndarray, "v 3 3"],
+    cam_T_world: Float64[ndarray, "v 4 4"],
+    kp_xy: Float64[ndarray, "v t 133 2"],
+    conf: Float64[ndarray, "v t 133"],
+    lambda_decay: float,
+) -> Float64[ndarray, " n"]:
+    """Score every triangulated point with the Kineo pairwise consensus confidence.
+
+    Gathers the dense per-view keypoint / confidence arrays at each point's
+    (frame, joint) and delegates to :func:`kineo_point_confidence`.
+    """
+    num_views: int = intrinsics.shape[0]
+    kp_per_view: Float64[ndarray, "v n 2"] = np.stack(
+        [kp_xy[v, obs.point_frame_idx, obs.point_joint_idx] for v in range(num_views)]
+    )
+    conf_per_view: Float64[ndarray, "v n"] = np.stack([conf[v, obs.point_frame_idx, obs.point_joint_idx] for v in range(num_views)])
+    return kineo_point_confidence(points_xyz, kp_per_view, conf_per_view, intrinsics, cam_T_world, lambda_decay=lambda_decay)

--- a/packages/exo-calib/exo_calib/correspondences.py
+++ b/packages/exo-calib/exo_calib/correspondences.py
@@ -1,0 +1,101 @@
+"""Selection and storage of multi-view keypoint observations."""
+
+from dataclasses import dataclass
+
+import numpy as np
+from jaxtyping import Bool, Float64, Int64
+from numpy import ndarray
+
+
+@dataclass(slots=True, frozen=True)
+class ObservationSet:
+    """Sparse observations associated with frame-joint 3D points."""
+
+    point_frame_idx: Int64[ndarray, "n_points"]
+    """Frame index of each 3D point."""
+    point_joint_idx: Int64[ndarray, "n_points"]
+    """Joint index of each 3D point."""
+    obs_point_idx: Int64[ndarray, "n_obs"]
+    """3D point row referenced by each observation."""
+    obs_view_idx: Int64[ndarray, "n_obs"]
+    """Camera index of each observation."""
+    obs_xy: Float64[ndarray, "n_obs 2"]
+    """Observed pixel coordinates."""
+    obs_conf: Float64[ndarray, "n_obs"]
+    """Modulated detector confidence of each observation."""
+
+
+def build_observations(
+    kp_xy: Float64[ndarray, "v t j 2"],
+    conf: Float64[ndarray, "v t j"],
+    *,
+    min_pair_conf: float,
+    min_views: int,
+) -> ObservationSet:
+    """Build sparse observations over every frame using Kineo's cross-view confidence rule.
+
+    Args:
+        kp_xy: Float64 keypoint pixels with shape ``(v, t, j, 2)``.
+        conf: Float64 detector confidences with shape ``(v, t, j)``.
+        min_pair_conf: Strict lower bound for a pair's geometric-mean confidence.
+        min_views: Minimum number of surviving views per point.
+
+    Returns:
+        Sparse point and observation arrays.
+    """
+    n_views: int = kp_xy.shape[0]
+    candidate_mask: Bool[ndarray, "v t j"] = (conf > 0.0) & np.isfinite(kp_xy).all(axis=-1)
+    candidate_conf: Float64[ndarray, "v t j"] = np.where(candidate_mask, conf, 0.0)
+    # Kineo pair rule over all view pairs at once: a view survives a cell when it
+    # forms at least one pair whose geometric-mean confidence clears the bound.
+    pair_survives: Bool[ndarray, "w v t j"] = (
+        (np.sqrt(candidate_conf[None, :] * candidate_conf[:, None]) > min_pair_conf)
+        & candidate_mask[None, :]
+        & candidate_mask[:, None]
+    )
+    view_diag_idx: Int64[ndarray, "v"] = np.arange(n_views, dtype=np.int64)
+    pair_survives[view_diag_idx, view_diag_idx] = False
+    surviving: Bool[ndarray, "v t j"] = pair_survives.any(axis=0)
+    point_mask: Bool[ndarray, "t j"] = surviving.sum(axis=0) >= min_views
+
+    point_frame_raw, point_joint_raw = np.nonzero(point_mask)  # frame-major order
+    point_frame_idx: Int64[ndarray, "n_points"] = point_frame_raw.astype(np.int64)
+    point_row: Int64[ndarray, "t j"] = np.full(point_mask.shape, -1, dtype=np.int64)
+    point_row[point_frame_raw, point_joint_raw] = np.arange(point_frame_idx.size, dtype=np.int64)
+
+    obs_view_raw, obs_frame_raw, obs_joint_raw = np.nonzero(surviving & point_mask[None])
+    obs_point_raw: Int64[ndarray, "n_obs"] = point_row[obs_frame_raw, obs_joint_raw]
+    obs_order: Int64[ndarray, "n_obs"] = np.lexsort((obs_view_raw, obs_point_raw)).astype(np.int64)
+    return ObservationSet(
+        point_frame_idx=point_frame_idx,
+        point_joint_idx=point_joint_raw.astype(np.int64),
+        obs_point_idx=obs_point_raw[obs_order],
+        obs_view_idx=obs_view_raw[obs_order].astype(np.int64),
+        obs_xy=kp_xy[obs_view_raw, obs_frame_raw, obs_joint_raw][obs_order],
+        obs_conf=conf[obs_view_raw, obs_frame_raw, obs_joint_raw][obs_order],
+    )
+
+
+def under_supported_view_indices(
+    obs_view_idx: Int64[ndarray, "m"],
+    n_views: int,
+    minimum_ratio: float,
+) -> tuple[int, ...]:
+    """Find camera views with anomalously little robust correspondence support.
+
+    Args:
+        obs_view_idx: Camera index of every surviving observation.
+        n_views: Number of cameras.
+        minimum_ratio: Fraction of the median per-view support below which a view
+            counts as under-supported.
+
+    Returns:
+        Indices of the under-supported views.
+    """
+    if minimum_ratio < 0.0:
+        raise ValueError("minimum_ratio must be nonnegative")
+    support: Int64[ndarray, "v"] = np.bincount(obs_view_idx, minlength=n_views).astype(np.int64)
+    positive_support: Int64[ndarray, " p"] = support[support > 0]
+    reference_support: float = float(np.median(positive_support)) if positive_support.size else 0.0
+    minimum_support: int = max(1, int(np.ceil(reference_support * minimum_ratio)))
+    return tuple(int(view_idx) for view_idx in np.flatnonzero(support < minimum_support))

--- a/packages/exo-calib/exo_calib/eval.py
+++ b/packages/exo-calib/exo_calib/eval.py
@@ -1,0 +1,119 @@
+"""Similarity alignment and error metrics for camera rigs."""
+
+from dataclasses import dataclass
+from typing import Literal, TypeAlias, get_args
+
+import numpy as np
+from jaxtyping import Float64
+from numpy import ndarray
+from simplecv.ops.umeyama import SimilarityTransform, umeyama_alignment
+
+from exo_calib.cameras import camera_centers
+
+RigMode: TypeAlias = Literal["se3", "sim3"]
+RIG_MODES: tuple[RigMode, ...] = get_args(RigMode)
+
+
+@dataclass(slots=True)
+class CameraErrors:
+    """Per-camera pose errors; aggregate with plain numpy at the call site."""
+
+    rotation_error_deg: Float64[ndarray, "v"]
+    """Per-camera geodesic rotation errors in degrees."""
+    translation_error_cm: Float64[ndarray, "v"]
+    """Per-camera center errors in centimeters."""
+    alignment_scale: float
+    """Scale of the alignment applied before measuring errors."""
+
+
+def align_rigs(
+    pred_cam_T_world: Float64[ndarray, "v 4 4"],
+    gt_cam_T_world: Float64[ndarray, "v 4 4"],
+    *,
+    with_scale: bool = False,
+) -> SimilarityTransform:
+    """Align predicted camera centers to ground truth with Umeyama's method.
+
+    Args:
+        pred_cam_T_world: Float64 predicted world-to-camera transforms with shape ``(v, 4, 4)``.
+        gt_cam_T_world: Float64 ground-truth world-to-camera transforms with shape ``(v, 4, 4)``.
+        with_scale: Estimate a similarity scale when true.
+
+    Returns:
+        Transform mapping predicted world coordinates into the ground-truth world frame.
+    """
+    return umeyama_alignment(camera_centers(pred_cam_T_world), camera_centers(gt_cam_T_world), allow_scaling=with_scale)
+
+
+def camera_errors(
+    pred_cam_T_world: Float64[ndarray, "v 4 4"],
+    gt_cam_T_world: Float64[ndarray, "v 4 4"],
+    *,
+    gt_T_pred: SimilarityTransform,
+) -> CameraErrors:
+    """Measure aligned camera orientation and center errors.
+
+    Args:
+        pred_cam_T_world: Float64 predicted world-to-camera transforms with shape ``(v, 4, 4)``.
+        gt_cam_T_world: Float64 ground-truth world-to-camera transforms with shape ``(v, 4, 4)``.
+        gt_T_pred: Similarity mapping predicted world coordinates into the ground-truth world.
+
+    Returns:
+        Per-camera errors, summaries, and the applied scale.
+    """
+    pred_rotation: Float64[ndarray, "v 3 3"] = pred_cam_T_world[:, :3, :3]
+    gt_rotation: Float64[ndarray, "v 3 3"] = gt_cam_T_world[:, :3, :3]
+    aligned_pred_rotation: Float64[ndarray, "v 3 3"] = np.einsum("vij,jk->vik", pred_rotation, gt_T_pred.dst_R_src.T)
+    relative_rotation: Float64[ndarray, "v 3 3"] = np.einsum(
+        "vij,vkj->vik", gt_rotation, aligned_pred_rotation
+    )
+    rotation_cosine: Float64[ndarray, "v"] = np.clip((np.trace(relative_rotation, axis1=1, axis2=2) - 1.0) / 2.0, -1.0, 1.0)
+    rotation_cosine[np.isclose(rotation_cosine, 1.0, atol=1e-12)] = 1.0
+    rotation_error_deg: Float64[ndarray, "v"] = np.rad2deg(np.arccos(rotation_cosine))
+
+    pred_centers: Float64[ndarray, "v 3"] = camera_centers(pred_cam_T_world)
+    gt_centers: Float64[ndarray, "v 3"] = camera_centers(gt_cam_T_world)
+    aligned_pred_centers: Float64[ndarray, "v 3"] = gt_T_pred.apply(pred_centers)
+    translation_error_cm: Float64[ndarray, "v"] = np.linalg.norm(gt_centers - aligned_pred_centers, axis=1) * 100.0
+    translation_error_cm[np.isclose(translation_error_cm, 0.0, atol=1e-10)] = 0.0
+    return CameraErrors(
+        rotation_error_deg=rotation_error_deg,
+        translation_error_cm=translation_error_cm,
+        alignment_scale=gt_T_pred.scale,
+    )
+
+
+def evaluate_rig(
+    pred_cam_T_world: Float64[ndarray, "v 4 4"], gt_cam_T_world: Float64[ndarray, "v 4 4"], mode: RigMode = "se3"
+) -> CameraErrors:
+    """Align and evaluate a predicted camera rig.
+
+    Args:
+        pred_cam_T_world: Float64 predicted world-to-camera transforms with shape ``(v, 4, 4)``.
+        gt_cam_T_world: Float64 ground-truth world-to-camera transforms with shape ``(v, 4, 4)``.
+        mode: Rigid ``"se3"`` or similarity ``"sim3"`` alignment.
+
+    Returns:
+        Per-camera aligned pose errors and summaries.
+    """
+    gt_T_pred: SimilarityTransform = align_rigs(pred_cam_T_world, gt_cam_T_world, with_scale=mode == "sim3")
+    return camera_errors(pred_cam_T_world, gt_cam_T_world, gt_T_pred=gt_T_pred)
+
+
+@dataclass(slots=True, frozen=True)
+class RigGeometry:
+    """Self-contained rig geometry in the Stage A floor frame (``z = 0`` is the fitted floor); meaningful without ground truth."""
+
+    camera_centers_m: Float64[ndarray, "v 3"]
+    """World-frame camera centres in metres."""
+    pairwise_distance_m: Float64[ndarray, "v v"]
+    """Distance between every pair of camera centres in metres."""
+    height_above_floor_m: Float64[ndarray, "v"]
+    """Camera height above the fitted floor in metres."""
+
+
+def rig_geometry(cam_T_world: Float64[ndarray, "v 4 4"]) -> RigGeometry:
+    """Measure the rig in its own floor frame."""
+    centers: Float64[ndarray, "v 3"] = camera_centers(cam_T_world)
+    pairwise_distance: Float64[ndarray, "v v"] = np.linalg.norm(centers[:, None, :] - centers[None, :, :], axis=2)
+    return RigGeometry(camera_centers_m=centers, pairwise_distance_m=pairwise_distance, height_above_floor_m=centers[:, 2])

--- a/packages/exo-calib/exo_calib/focal.py
+++ b/packages/exo-calib/exo_calib/focal.py
@@ -1,0 +1,124 @@
+"""Per-camera focal refinement with fixed poses and 3D points."""
+
+from dataclasses import dataclass
+from typing import Literal, TypeAlias
+
+import numpy as np
+import torch
+from jaxtyping import Bool, Float64, Int64
+from numpy import ndarray
+from torch import Tensor
+
+from exo_calib.correspondences import ObservationSet
+from exo_calib.triangulation import valid_observation_mask
+
+TorchDevice: TypeAlias = Literal["cuda", "cpu"]
+
+
+@dataclass(slots=True)
+class FocalRefinementResult:
+    """Refined intrinsics and optimization diagnostics."""
+
+    intrinsics: Float64[ndarray, "v 3 3"]
+    """Float64 refined camera intrinsics with shape ``(v, 3, 3)``."""
+    focal_scale: Float64[ndarray, "v"]
+    """Per-camera multiplicative scale applied to both focal axes."""
+    initial_loss: float
+    """Confidence-weighted Cauchy loss before optimization."""
+    final_loss: float
+    """Confidence-weighted Cauchy loss after optimization."""
+
+
+def refine_focals(
+    intrinsics: Float64[ndarray, "v 3 3"],
+    cam_T_world: Float64[ndarray, "v 4 4"],
+    points_xyz: Float64[ndarray, "n 3"],
+    obs: ObservationSet,
+    *,
+    iterations: int,
+    learning_rate: float,
+    robust_scale_px: float,
+    device: TorchDevice = "cuda",
+) -> FocalRefinementResult:
+    """Refine one log-focal scale per camera with fixed poses and points.
+
+    Args:
+        intrinsics: Float64 initial intrinsics with shape ``(v, 3, 3)``.
+        cam_T_world: Float64 fixed world-to-camera transforms with shape ``(v, 4, 4)``.
+        points_xyz: Float64 fixed world points with shape ``(n, 3)``.
+        obs: Sparse pixel observations of ``points_xyz``.
+        iterations: Adam update count.
+        learning_rate: Adam learning rate for log-focal scales.
+        robust_scale_px: Cauchy residual scale in pixels.
+        device: Torch device the solve runs on.
+
+    Returns:
+        Refined intrinsics, focal scales, and loss diagnostics.
+    """
+    if iterations < 1:
+        raise ValueError("iterations must be positive")
+    if learning_rate <= 0.0:
+        raise ValueError("learning_rate must be positive")
+    if robust_scale_px <= 0.0:
+        raise ValueError("robust_scale_px must be positive")
+    n_views: int = intrinsics.shape[0]
+    valid_mask: Bool[ndarray, "n_obs"] = valid_observation_mask(obs, n_views, n_points=points_xyz.shape[0])
+    valid_idx: Int64[ndarray, "q"] = np.flatnonzero(valid_mask).astype(np.int64)
+    if valid_idx.size == 0:
+        raise ValueError("no valid observations for focal refinement")
+    observation_point_idx: Int64[ndarray, "q"] = obs.obs_point_idx[valid_idx]
+    finite_point_mask: Bool[ndarray, "q"] = np.isfinite(points_xyz[observation_point_idx]).all(axis=1)
+    valid_idx = valid_idx[finite_point_mask]
+    observation_point_idx = obs.obs_point_idx[valid_idx]
+    observation_view_idx: Int64[ndarray, "q"] = obs.obs_view_idx[valid_idx]
+    points_homo: Float64[ndarray, "q 4"] = np.column_stack(
+        (points_xyz[observation_point_idx], np.ones(observation_point_idx.size, dtype=np.float64))
+    )
+    points_cam: Float64[ndarray, "q 3"] = np.einsum(
+        "qij,qj->qi", cam_T_world[observation_view_idx, :3], points_homo
+    )
+    positive_depth: Bool[ndarray, "q"] = points_cam[:, 2] > 0.0
+    valid_idx = valid_idx[positive_depth]
+    observation_view_idx = observation_view_idx[positive_depth]
+    points_cam = points_cam[positive_depth]
+    if valid_idx.size == 0:
+        raise ValueError("no positive-depth observations for focal refinement")
+
+    dtype: torch.dtype = torch.float64
+    view_idx: Int64[Tensor, "q"] = torch.as_tensor(observation_view_idx, dtype=torch.long, device=device)
+    normalized_xy: Float64[Tensor, "q 2"] = torch.as_tensor(points_cam[:, :2] / points_cam[:, 2:3], dtype=dtype, device=device)
+    observed_xy: Float64[Tensor, "q 2"] = torch.as_tensor(obs.obs_xy[valid_idx], dtype=dtype, device=device)
+    weights: Float64[Tensor, "q"] = torch.as_tensor(obs.obs_conf[valid_idx], dtype=dtype, device=device)
+    focal_lengths: Float64[Tensor, "v 2"] = torch.as_tensor(np.column_stack((intrinsics[:, 0, 0], intrinsics[:, 1, 1])), dtype=dtype, device=device)
+    principal_points: Float64[Tensor, "v 2"] = torch.as_tensor(np.column_stack((intrinsics[:, 0, 2], intrinsics[:, 1, 2])), dtype=dtype, device=device)
+    skew: Float64[Tensor, "v"] = torch.as_tensor(intrinsics[:, 0, 1], dtype=dtype, device=device)
+    log_focal_delta: torch.nn.Parameter = torch.nn.Parameter(torch.zeros(n_views, dtype=dtype, device=device))
+
+    def loss_value() -> Float64[Tensor, ""]:
+        observation_focal_scale: Float64[Tensor, "q"] = torch.exp(log_focal_delta[view_idx])
+        projected_xy: Float64[Tensor, "q 2"] = normalized_xy * focal_lengths[view_idx] * observation_focal_scale[:, None]
+        projected_xy[:, 0] += skew[view_idx] * normalized_xy[:, 1]
+        projected_xy += principal_points[view_idx]
+        residual_sq: Float64[Tensor, "q"] = torch.sum((projected_xy - observed_xy) ** 2, dim=1)
+        return torch.sum(weights * torch.log1p(residual_sq / robust_scale_px**2)) / torch.sum(weights)
+
+    initial_loss: float = float(loss_value().detach().cpu())
+    optimizer: torch.optim.Adam = torch.optim.Adam([log_focal_delta], lr=learning_rate)
+    for _iteration in range(iterations):
+        optimizer.zero_grad()
+        loss: Float64[Tensor, ""] = loss_value()
+        loss.backward()
+        optimizer.step()
+        with torch.no_grad():
+            log_focal_delta.clamp_(min=-0.25, max=0.25)
+    final_loss: float = float(loss_value().detach().cpu())
+    focal_scale: Float64[ndarray, "v"] = torch.exp(log_focal_delta.detach()).cpu().numpy()
+    refined_intrinsics: Float64[ndarray, "v 3 3"] = intrinsics.copy()
+    refined_intrinsics[:, 0, 0] *= focal_scale
+    refined_intrinsics[:, 1, 1] *= focal_scale
+    return FocalRefinementResult(
+        intrinsics=refined_intrinsics,
+        focal_scale=focal_scale,
+        initial_loss=initial_loss,
+        final_loss=final_loss,
+    )

--- a/packages/exo-calib/exo_calib/keypoints.py
+++ b/packages/exo-calib/exo_calib/keypoints.py
@@ -1,0 +1,115 @@
+"""Per-camera Stage B keypoint records and the AssemblyHands-X confidence post-processing."""
+
+from dataclasses import dataclass
+from typing import Literal, NamedTuple, TypeAlias, get_args
+
+import numpy as np
+from jaxtyping import Float32, Float64, Int64
+from numpy import ndarray
+
+from exo_calib.confidence import median_filter_keypoints, modulate_crop_edge_confidence, threshold_rescale_confidence
+
+# AssemblyHands-X gate: temporal median window (frames), crop-edge margin (crop
+# pixels), and the confidence threshold before rescaling to [0, 1]. Stage B's
+# overlay and the refinement use the same values, so the two cannot drift.
+AHX_MEDIAN_WINDOW: int = 5
+AHX_MARGIN_PX: float = 32.0
+AHX_CONF_TAU: float = 0.15
+
+BoxSource: TypeAlias = Literal["yolox", "tracked", "none"]
+"""Per-frame person-box provenance: detected, projected from the tracked skeleton, or absent."""
+BOX_SOURCE_BY_NAME: dict[str, BoxSource] = {source: source for source in get_args(BoxSource)}
+"""Narrows a stored provenance string back to :data:`BoxSource` (``None`` for anything else)."""
+
+STAGE_B_FRAME_BUDGET: int = 1000
+"""Frames Stage B processes per view, spread evenly over the capture; shorter captures use every frame."""
+
+
+class GatedKeypoints(NamedTuple):
+    """Keypoints after the AssemblyHands-X post-processing: median-filtered pixels and the gated confidences."""
+
+    xy: Float64[ndarray, "*batch 133 2"]
+    conf: Float64[ndarray, "*batch 133"]
+
+
+@dataclass(slots=True)
+class CameraKeypoints:
+    """Raw Stage B output for one camera."""
+
+    sample_indices: Int64[ndarray, "t"]
+    """Decoder sample indices of the processed frames."""
+    times_ns: Int64[ndarray, "t"]
+    """Timeline timestamps (nanoseconds) of the processed frames."""
+    kp_xy: Float32[ndarray, "t 133 2"]
+    """Image-space keypoints; NaN where no detection."""
+    conf: Float32[ndarray, "t 133"]
+    """Raw pose-network keypoint confidences; 0 where no detection."""
+    bbox_xyxy: Float32[ndarray, "t 4"]
+    """Person box per frame; NaN where no detection."""
+    box_source: tuple[BoxSource, ...]
+    """Per-frame box provenance, index-aligned with ``bbox_xyxy``."""
+    crop_origin_xy: Float32[ndarray, "t 2"]
+    """Image-space origin of the model crop rectangle."""
+    crop_size_wh: Float32[ndarray, "t 2"]
+    """Image-space size of the model crop rectangle."""
+    crop_input_wh: Int64[ndarray, "2"]
+    """Pose model crop input size (width, height) the crop rectangles map into;
+    the AssemblyHands-X margin rule operates in this pixel frame."""
+    video_wh: Int64[ndarray, "2"]
+    """Native video frame size (width, height)."""
+
+
+def sampled_frame_indices(num_samples: int, budget: int) -> Int64[ndarray, "t"]:
+    """Spread at most ``budget`` frames evenly over a capture of ``num_samples`` frames.
+
+    Returns:
+        Int64 sample indices with shape ``(t,)``, every frame when the capture fits the budget.
+    """
+    if budget < 1:
+        raise ValueError("budget must be positive")
+    if num_samples < 1:
+        raise ValueError("the capture has no frames")
+    return np.linspace(0, num_samples - 1, min(budget, num_samples)).round().astype(np.int64)
+
+
+def postprocess_confidences(cam: CameraKeypoints, median_window: int, margin_px: float, conf_tau: float) -> GatedKeypoints:
+    """Apply the AssemblyHands-X 2D post-processing to one camera's keypoints.
+
+    Args:
+        cam: Raw Stage B output for one camera.
+        median_window: Temporal median-filter window in frames.
+        margin_px: Crop-edge confidence falloff width in crop pixels.
+        conf_tau: Inclusive confidence cutoff before linear rescaling.
+
+    Returns:
+        Median-filtered keypoints and the crop-margin-modulated, threshold-rescaled
+        confidences, both on the full frame grid (shape ``(t, 133, …)``).
+    """
+    crop_wh: tuple[int, int] = (int(cam.crop_input_wh[0]), int(cam.crop_input_wh[1]))
+    filtered_xy: Float64[ndarray, "t 133 2"] = median_filter_keypoints(cam.kp_xy.astype(np.float64), window=median_window)
+    num_frames: int = filtered_xy.shape[0]
+    post_conf: Float64[ndarray, "t 133"] = np.zeros((num_frames, 133), dtype=np.float64)
+    for t in range(num_frames):
+        if not np.isfinite(cam.crop_origin_xy[t]).all():
+            continue
+        size_wh: Float64[ndarray, "2"] = cam.crop_size_wh[t].astype(np.float64)
+        kp_crop_xy: Float64[ndarray, "133 2"] = (filtered_xy[t] - cam.crop_origin_xy[t].astype(np.float64)) / size_wh * np.asarray(crop_wh, dtype=np.float64)
+        modulated: Float64[ndarray, "133"] = modulate_crop_edge_confidence(kp_crop_xy, cam.conf[t].astype(np.float64), crop_wh, margin_px)
+        post_conf[t] = threshold_rescale_confidence(modulated, tau=conf_tau)
+    return GatedKeypoints(xy=filtered_xy, conf=post_conf)
+
+
+def stack_postprocessed(
+    per_camera: dict[str, CameraKeypoints], names: tuple[str, ...], median_window: int, margin_px: float, conf_tau: float
+) -> GatedKeypoints:
+    """Post-process every camera and stack onto the common frame grid (shape ``(v, t, 133, …)``).
+
+    Raises:
+        ValueError: If the cameras were not processed on the same frame grid.
+    """
+    sample_indices: Int64[ndarray, "t"] = per_camera[names[0]].sample_indices
+    for name in names[1:]:
+        if not np.array_equal(per_camera[name].sample_indices, sample_indices):
+            raise ValueError(f"camera {name} was processed on a different frame grid than {names[0]}")
+    gated: list[GatedKeypoints] = [postprocess_confidences(per_camera[name], median_window, margin_px, conf_tau) for name in names]
+    return GatedKeypoints(xy=np.stack([g.xy for g in gated]), conf=np.stack([g.conf for g in gated]))

--- a/packages/exo-calib/exo_calib/triangulation.py
+++ b/packages/exo-calib/exo_calib/triangulation.py
@@ -1,0 +1,315 @@
+"""Confidence-weighted multi-view triangulation (fully vectorized).
+
+``triangulate_points`` solves every point's weighted DLT at once: each valid
+observation contributes two confidence-scaled rows, the rows scatter into
+per-point 4x4 Gram matrices (``A^T A``) via bincount, and one batched ``eigh``
+extracts the null-space vector per point. ``triangulate_robust`` prunes
+observations whose reprojection residual exceeds a threshold, resolving
+ambiguous cases with leave-one-out consensus — all trials of a round are
+triangulated in a single batched call, grouped by view count.
+"""
+
+from typing import NamedTuple
+
+import numpy as np
+from jaxtyping import Bool, Float64, Int64
+from numpy import ndarray
+
+from exo_calib.correspondences import ObservationSet
+
+ROBUST_TRIANGULATION_ROUNDS: int = 2
+"""Triangulate-then-prune passes; the second pass re-fits without the observations the first one rejected."""
+
+
+class RobustTriangulationResult(NamedTuple):
+    """Triangulated points and the observations that survived the reprojection gate."""
+
+    points_xyz: Float64[ndarray, "n_points 3"]
+    obs: ObservationSet
+
+
+def reprojection_errors_px(
+    obs: ObservationSet,
+    points_xyz: Float64[ndarray, "n_points 3"],
+    intrinsics: Float64[ndarray, "v 3 3"],
+    cam_T_world: Float64[ndarray, "v 4 4"],
+) -> Float64[ndarray, "n_obs"]:
+    """Compute pixel residuals, with infinity for invalid observations.
+
+    Args:
+        obs: Sparse pixel observations for the points.
+        points_xyz: Float64 world points with shape ``(n_points, 3)``.
+        intrinsics: Float64 camera intrinsics with shape ``(v, 3, 3)``.
+        cam_T_world: Float64 world-to-camera transforms with shape ``(v, 4, 4)``.
+
+    Returns:
+        Float64 reprojection errors with shape ``(n_obs,)``.
+    """
+    n_views: int = intrinsics.shape[0]
+    n_obs: int = obs.obs_point_idx.size
+    reproj_error: Float64[ndarray, "n_obs"] = np.full(n_obs, np.inf, dtype=np.float64)
+    valid_reference_mask: Bool[ndarray, "n_obs"] = valid_observation_mask(obs, n_views, n_points=points_xyz.shape[0])
+    valid_reference_idx: Int64[ndarray, "q"] = np.flatnonzero(valid_reference_mask).astype(np.int64)
+    if valid_reference_idx.size == 0:
+        return reproj_error
+
+    observation_point_idx: Int64[ndarray, "q"] = obs.obs_point_idx[valid_reference_idx]
+    observation_view_idx: Int64[ndarray, "q"] = obs.obs_view_idx[valid_reference_idx]
+    point_homo: Float64[ndarray, "q 4"] = np.column_stack(
+        (points_xyz[observation_point_idx], np.ones(valid_reference_idx.size, dtype=np.float64))
+    )
+    points_cam: Float64[ndarray, "q 3"] = np.einsum("qij,qj->qi", cam_T_world[observation_view_idx, :3, :], point_homo)
+    projected_homo: Float64[ndarray, "q 3"] = np.einsum("qij,qj->qi", intrinsics[observation_view_idx], points_cam)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        projected_xy: Float64[ndarray, "q 2"] = projected_homo[:, :2] / projected_homo[:, 2:3]
+    projectable: Bool[ndarray, "q"] = (points_cam[:, 2] > 0.0) & np.isfinite(projected_xy).all(axis=1)
+    valid_error_idx: Int64[ndarray, "r"] = valid_reference_idx[projectable]
+    reproj_error[valid_error_idx] = np.linalg.norm(projected_xy[projectable] - obs.obs_xy[valid_error_idx], axis=1)
+    return reproj_error
+
+
+def valid_observation_mask(obs: ObservationSet, n_views: int, n_points: int | None = None) -> Bool[ndarray, "n_obs"]:
+    """Return the mask of usable observations; ``n_points`` adds point-index bounds checks."""
+    mask: Bool[ndarray, "n_obs"] = (
+        np.isfinite(obs.obs_xy).all(axis=1)
+        & np.isfinite(obs.obs_conf)
+        & (obs.obs_conf > 0.0)
+        & (obs.obs_view_idx >= 0)
+        & (obs.obs_view_idx < n_views)
+    )
+    if n_points is not None:
+        mask &= (obs.obs_point_idx >= 0) & (obs.obs_point_idx < n_points)
+    return mask
+
+
+def triangulate_points(
+    obs: ObservationSet, intrinsics: Float64[ndarray, "v 3 3"], cam_T_world: Float64[ndarray, "v 4 4"]
+) -> Float64[ndarray, "n_points 3"]:
+    """Triangulate all points at once with confidence-weighted DLT.
+
+    Each observation contributes rows ``w * (u * P[2] - P[0])`` and
+    ``w * (v * P[2] - P[1])``; the per-point normal matrix ``A^T A`` is
+    accumulated with bincount scatters (zero rows contribute nothing), and the
+    null-space vector is the eigenvector of the smallest eigenvalue from one
+    batched ``eigh`` over all solvable points.
+
+    Args:
+        obs: Sparse pixel observations for the points.
+        intrinsics: Float64 camera intrinsics with shape ``(v, 3, 3)``.
+        cam_T_world: Float64 world-to-camera transforms with shape ``(v, 4, 4)``.
+
+    Returns:
+        Float64 world points with shape ``(n_points, 3)``. Invalid points are NaN.
+    """
+    n_points: int = obs.point_frame_idx.size
+    n_views: int = intrinsics.shape[0]
+    points_xyz: Float64[ndarray, "n_points 3"] = np.full((n_points, 3), np.nan, dtype=np.float64)
+    valid_mask: Bool[ndarray, "n_obs"] = valid_observation_mask(obs, n_views)
+    if not valid_mask.any():
+        return points_xyz
+
+    observation_point_idx: Int64[ndarray, "q"] = obs.obs_point_idx[valid_mask]
+    observation_view_idx: Int64[ndarray, "q"] = obs.obs_view_idx[valid_mask]
+    xy: Float64[ndarray, "q 2"] = obs.obs_xy[valid_mask]
+    observation_conf: Float64[ndarray, "q"] = obs.obs_conf[valid_mask]
+
+    projection: Float64[ndarray, "v 3 4"] = np.einsum("vij,vjk->vik", intrinsics, cam_T_world[:, :3, :])
+    observation_projection: Float64[ndarray, "q 3 4"] = projection[observation_view_idx]
+    row_u: Float64[ndarray, "q 4"] = observation_conf[:, None] * (xy[:, 0:1] * observation_projection[:, 2] - observation_projection[:, 0])
+    row_v: Float64[ndarray, "q 4"] = observation_conf[:, None] * (xy[:, 1:2] * observation_projection[:, 2] - observation_projection[:, 1])
+    rows: Float64[ndarray, "r 4"] = np.concatenate((row_u, row_v))
+    row_point_idx: Int64[ndarray, "r"] = np.concatenate((observation_point_idx, observation_point_idx))
+
+    gram: Float64[ndarray, "n_points 4 4"] = np.zeros((n_points, 4, 4), dtype=np.float64)
+    for i in range(4):
+        for j in range(i, 4):
+            entry: Float64[ndarray, "n_points"] = np.bincount(
+                row_point_idx, weights=rows[:, i] * rows[:, j], minlength=n_points
+            )
+            gram[:, i, j] = entry
+            gram[:, j, i] = entry
+
+    obs_count: Int64[ndarray, "n_points"] = np.bincount(observation_point_idx, minlength=n_points).astype(np.int64)
+    solvable: Bool[ndarray, "n_points"] = (obs_count >= 2) & np.isfinite(gram).all(axis=(1, 2))
+    if not solvable.any():
+        return points_xyz
+
+    eig_result: tuple[Float64[ndarray, "s 4"], Float64[ndarray, "s 4 4"]] = np.linalg.eigh(gram[solvable])
+    homogeneous: Float64[ndarray, "s 4"] = eig_result[1][:, :, 0]
+    with np.errstate(divide="ignore", invalid="ignore"):
+        dehomogenized: Float64[ndarray, "s 3"] = homogeneous[:, :3] / homogeneous[:, 3:4]
+    usable: Bool[ndarray, "s"] = (np.abs(homogeneous[:, 3]) > np.finfo(np.float64).eps) & np.isfinite(dehomogenized).all(axis=1)
+    solvable_idx: Int64[ndarray, "s"] = np.flatnonzero(solvable).astype(np.int64)
+    points_xyz[solvable_idx[usable]] = dehomogenized[usable]
+    return points_xyz
+
+
+def _leave_one_out_drops(
+    obs: ObservationSet,
+    keep_obs_mask: Bool[ndarray, "n_obs"],
+    offending_point: Bool[ndarray, "n_points"],
+    intrinsics: Float64[ndarray, "v 3 3"],
+    cam_T_world: Float64[ndarray, "v 4 4"],
+) -> Int64[ndarray, " n_drop"]:
+    """For each offending point (>= 3 kept obs), pick the single observation whose
+    removal minimizes the point's max reprojection error.
+
+    All leave-one-out trials of all points with the same view count are batched
+    into one synthetic ``ObservationSet`` and triangulated in a single call.
+
+    Returns:
+        Observation indices to drop, one per offending point.
+    """
+    kept_idx: Int64[ndarray, "k"] = np.flatnonzero(keep_obs_mask & offending_point[obs.obs_point_idx]).astype(np.int64)
+    order: Int64[ndarray, "k"] = np.argsort(obs.obs_point_idx[kept_idx], kind="stable").astype(np.int64)
+    kept_idx = kept_idx[order]
+    kept_point: Int64[ndarray, "k"] = obs.obs_point_idx[kept_idx]
+    group_starts: Int64[ndarray, "g"] = np.flatnonzero(np.r_[True, kept_point[1:] != kept_point[:-1]]).astype(np.int64)
+    group_sizes: Int64[ndarray, "g"] = np.diff(np.r_[group_starts, kept_point.size]).astype(np.int64)
+
+    drop_indices: list[Int64[ndarray, " d"]] = []
+    for group_size in np.unique(group_sizes):
+        size: int = int(group_size)
+        starts: Int64[ndarray, "h"] = group_starts[group_sizes == group_size]
+        obs_idx: Int64[ndarray, "h q"] = kept_idx[starts[:, None] + np.arange(size)[None, :]]
+        # (h, q, q-1): trial s of group keeps every position except s.
+        off_diag: Int64[ndarray, "q q1"] = np.stack([np.delete(np.arange(size), s) for s in range(size)]).astype(np.int64)
+        trial_obs_idx: Int64[ndarray, "f"] = obs_idx[:, off_diag].reshape(-1)
+        n_trials: int = starts.size * size
+        trial_id: Int64[ndarray, "f"] = np.repeat(np.arange(n_trials, dtype=np.int64), size - 1)
+        trial_set: ObservationSet = ObservationSet(
+            point_frame_idx=np.zeros(n_trials, dtype=np.int64),
+            point_joint_idx=np.zeros(n_trials, dtype=np.int64),
+            obs_point_idx=trial_id,
+            obs_view_idx=obs.obs_view_idx[trial_obs_idx],
+            obs_xy=obs.obs_xy[trial_obs_idx],
+            obs_conf=obs.obs_conf[trial_obs_idx],
+        )
+        trial_points: Float64[ndarray, "t 3"] = triangulate_points(trial_set, intrinsics, cam_T_world)
+        trial_errors: Float64[ndarray, "f"] = reprojection_errors_px(trial_set, trial_points, intrinsics, cam_T_world)
+        max_error: Float64[ndarray, "h q"] = trial_errors.reshape(starts.size, size, size - 1).max(axis=2)
+        best_position: Int64[ndarray, "h"] = np.argmin(max_error, axis=1).astype(np.int64)
+        drop_indices.append(obs_idx[np.arange(starts.size), best_position])
+    return np.concatenate(drop_indices) if drop_indices else np.empty(0, dtype=np.int64)
+
+
+def triangulate_robust(
+    obs: ObservationSet,
+    intrinsics: Float64[ndarray, "v 3 3"],
+    cam_T_world: Float64[ndarray, "v 4 4"],
+    *,
+    reproj_threshold_px: float,
+) -> RobustTriangulationResult:
+    """Triangulate while iteratively pruning large reprojection residuals.
+
+    Args:
+        obs: Sparse pixel observations for the points.
+        intrinsics: Float64 camera intrinsics with shape ``(v, 3, 3)``.
+        cam_T_world: Float64 world-to-camera transforms with shape ``(v, 4, 4)``.
+        reproj_threshold_px: Maximum retained reprojection error in pixels.
+        ROBUST_TRIANGULATION_ROUNDS: Maximum pruning rounds.
+
+    Returns:
+        Float64 refined world points with shape ``(n_points, 3)`` and the pruned observations.
+    """
+    n_points: int = obs.point_frame_idx.size
+    current_obs: ObservationSet = obs
+    points_xyz: Float64[ndarray, "n_points 3"] = triangulate_points(current_obs, intrinsics, cam_T_world)
+    for _round_idx in range(ROBUST_TRIANGULATION_ROUNDS):
+        reproj_error: Float64[ndarray, "n_obs"] = reprojection_errors_px(current_obs, points_xyz, intrinsics, cam_T_world)
+        keep_obs_mask: Bool[ndarray, "n_obs"] = np.isfinite(reproj_error)
+
+        kept_count: Int64[ndarray, "n_points"] = np.bincount(current_obs.obs_point_idx[keep_obs_mask], minlength=n_points).astype(np.int64)
+        over_threshold: Bool[ndarray, "n_obs"] = keep_obs_mask & (reproj_error > reproj_threshold_px)
+        offending: Bool[ndarray, "n_points"] = (
+            np.bincount(current_obs.obs_point_idx[over_threshold], minlength=n_points).astype(np.int64) > 0
+        )
+
+        # < 2 kept observations, or an offending 2-view point: drop everything.
+        drop_all: Bool[ndarray, "n_points"] = (kept_count < 2) | (offending & (kept_count == 2))
+        keep_obs_mask &= ~drop_all[current_obs.obs_point_idx]
+
+        # Offending points with >= 3 views: leave-one-out consensus, drop one obs each.
+        leave_one_out: Bool[ndarray, "n_points"] = offending & (kept_count >= 3)
+        if leave_one_out.any():
+            keep_obs_mask[_leave_one_out_drops(current_obs, keep_obs_mask, leave_one_out, intrinsics, cam_T_world)] = False
+
+        kept_per_point: Int64[ndarray, "n_points"] = np.bincount(
+            current_obs.obs_point_idx[keep_obs_mask], minlength=n_points
+        ).astype(np.int64)
+        keep_obs_mask &= kept_per_point[current_obs.obs_point_idx] >= 2
+        pruned_obs: ObservationSet = ObservationSet(
+            point_frame_idx=current_obs.point_frame_idx,
+            point_joint_idx=current_obs.point_joint_idx,
+            obs_point_idx=current_obs.obs_point_idx[keep_obs_mask],
+            obs_view_idx=current_obs.obs_view_idx[keep_obs_mask],
+            obs_xy=current_obs.obs_xy[keep_obs_mask],
+            obs_conf=current_obs.obs_conf[keep_obs_mask],
+        )
+        if pruned_obs.obs_point_idx.size == current_obs.obs_point_idx.size:
+            current_obs = pruned_obs
+            break
+        current_obs = pruned_obs
+        points_xyz = triangulate_points(current_obs, intrinsics, cam_T_world)
+
+    return RobustTriangulationResult(points_xyz=points_xyz, obs=current_obs)
+
+
+def triangulate_frame_keypoints(
+    kp_xy: Float64[ndarray, "v j 2"],
+    conf: Float64[ndarray, "v j"],
+    intrinsics: Float64[ndarray, "v 3 3"],
+    cam_T_world: Float64[ndarray, "v 4 4"],
+    *,
+    min_confidence: float,
+    reproj_threshold_px: float,
+) -> tuple[Float64[ndarray, "j 3"], Float64[ndarray, "j"]]:
+    """Triangulate one multi-view keypoint frame onto its full joint grid.
+
+    Args:
+        kp_xy: Float64 image keypoints with shape ``(v, j, 2)``.
+        conf: Float64 keypoint confidences with shape ``(v, j)``.
+        intrinsics: Float64 camera intrinsics with shape ``(v, 3, 3)``.
+        cam_T_world: Float64 world-to-camera transforms with shape ``(v, 4, 4)``.
+        min_confidence: Inclusive per-view confidence threshold.
+        reproj_threshold_px: Robust-triangulation reprojection threshold.
+
+    Returns:
+        Float64 world keypoints with shape ``(j, 3)`` and median retained
+        confidences with shape ``(j,)``. Untriangulated joint rows are NaN/zero.
+    """
+    num_joints: int = kp_xy.shape[1]
+    points_xyz: Float64[ndarray, "j 3"] = np.full((num_joints, 3), np.nan, dtype=np.float64)
+    points_conf: Float64[ndarray, "j"] = np.zeros(num_joints, dtype=np.float64)
+    usable: Bool[ndarray, "v j"] = (
+        np.isfinite(kp_xy).all(axis=2) & np.isfinite(conf) & (conf >= min_confidence)
+    )
+    triangulatable: Bool[ndarray, "j"] = usable.sum(axis=0) >= 2
+    point_joint_idx: Int64[ndarray, "n"] = np.flatnonzero(triangulatable).astype(np.int64)
+    if point_joint_idx.size == 0:
+        return points_xyz, points_conf
+
+    joint_to_point: Int64[ndarray, "j"] = np.full(num_joints, -1, dtype=np.int64)
+    joint_to_point[point_joint_idx] = np.arange(point_joint_idx.size, dtype=np.int64)
+    obs_view_idx, obs_joint_idx = np.nonzero(usable & triangulatable[None])
+    obs_view_idx = obs_view_idx.astype(np.int64)
+    obs_joint_idx = obs_joint_idx.astype(np.int64)
+    obs: ObservationSet = ObservationSet(
+        point_frame_idx=np.zeros(point_joint_idx.size, dtype=np.int64),
+        point_joint_idx=point_joint_idx,
+        obs_point_idx=joint_to_point[obs_joint_idx],
+        obs_view_idx=obs_view_idx,
+        obs_xy=kp_xy[obs_view_idx, obs_joint_idx],
+        obs_conf=conf[obs_view_idx, obs_joint_idx],
+    )
+    robust_result: RobustTriangulationResult = triangulate_robust(
+        obs, intrinsics, cam_T_world, reproj_threshold_px=reproj_threshold_px
+    )
+    points_xyz[point_joint_idx] = robust_result.points_xyz
+    retained_obs: ObservationSet = robust_result.obs
+    retained_conf: Float64[ndarray, "v n"] = np.full((kp_xy.shape[0], point_joint_idx.size), np.nan, dtype=np.float64)
+    retained_conf[retained_obs.obs_view_idx, retained_obs.obs_point_idx] = retained_obs.obs_conf
+    has_obs: Bool[ndarray, "n"] = np.isfinite(retained_conf).any(axis=0)
+    points_conf[point_joint_idx[has_obs]] = np.nanmedian(retained_conf[:, has_obs], axis=0)
+    points_conf[~np.isfinite(points_xyz).all(axis=1)] = 0.0
+    return points_xyz, points_conf

--- a/packages/exo-calib/tests/conftest.py
+++ b/packages/exo-calib/tests/conftest.py
@@ -1,0 +1,47 @@
+"""Synthetic multi-view scenes shared by the geometry tests."""
+
+import numpy as np
+from jaxtyping import Float64
+from numpy import ndarray
+
+from exo_calib.correspondences import ObservationSet
+
+
+def ring_rig(n_views: int, radius_m: float) -> Float64[ndarray, "v 4 4"]:
+    """Cameras on a horizontal ring of ``radius_m`` around the origin, each looking at the origin (RDF).
+
+    Returns:
+        Float64 world-to-camera transforms with shape ``(v, 4, 4)``.
+    """
+    angles: Float64[ndarray, "v"] = np.arange(n_views, dtype=np.float64) * (2.0 * np.pi / float(n_views))
+    centers: Float64[ndarray, "v 3"] = np.column_stack((radius_m * np.cos(angles), radius_m * np.sin(angles), np.zeros(n_views, dtype=np.float64)))
+    cam_T_world: Float64[ndarray, "v 4 4"] = np.repeat(np.eye(4, dtype=np.float64)[None], n_views, axis=0)
+    world_up: Float64[ndarray, "3"] = np.array([0.0, 0.0, 1.0], dtype=np.float64)
+    for view_idx in range(n_views):
+        forward: Float64[ndarray, "3"] = -centers[view_idx] / np.linalg.norm(centers[view_idx])
+        right: Float64[ndarray, "3"] = np.cross(forward, world_up)
+        down: Float64[ndarray, "3"] = np.cross(forward, right)
+        rotation: Float64[ndarray, "3 3"] = np.stack((right, down, forward))
+        cam_T_world[view_idx, :3, :3] = rotation
+        cam_T_world[view_idx, :3, 3] = -rotation @ centers[view_idx]
+    return cam_T_world
+
+
+def observe_points(
+    points_xyz: Float64[ndarray, "n 3"], intrinsics: Float64[ndarray, "v 3 3"], cam_T_world: Float64[ndarray, "v 4 4"]
+) -> ObservationSet:
+    """Project every point into every view with unit confidence, one point per frame and joint 0 (point-major, view-minor order)."""
+    n_views: int = cam_T_world.shape[0]
+    n_points: int = points_xyz.shape[0]
+    points_homo: Float64[ndarray, "n 4"] = np.column_stack((points_xyz, np.ones(n_points, dtype=np.float64)))
+    points_cam: Float64[ndarray, "v n 3"] = np.einsum("vij,nj->vni", cam_T_world[:, :3], points_homo)
+    projected: Float64[ndarray, "v n 3"] = np.einsum("vij,vnj->vni", intrinsics, points_cam)
+    projected_xy: Float64[ndarray, "v n 2"] = projected[:, :, :2] / projected[:, :, 2:3]
+    return ObservationSet(
+        point_frame_idx=np.arange(n_points, dtype=np.int64),
+        point_joint_idx=np.zeros(n_points, dtype=np.int64),
+        obs_point_idx=np.repeat(np.arange(n_points, dtype=np.int64), n_views),
+        obs_view_idx=np.tile(np.arange(n_views, dtype=np.int64), n_points),
+        obs_xy=projected_xy.transpose(1, 0, 2).reshape(-1, 2),
+        obs_conf=np.ones(n_points * n_views, dtype=np.float64),
+    )

--- a/packages/exo-calib/tests/test_ba.py
+++ b/packages/exo-calib/tests/test_ba.py
@@ -1,0 +1,113 @@
+import numpy as np
+from conftest import observe_points, ring_rig
+from jaxtyping import Float64
+from numpy import ndarray
+
+from exo_calib.ba import BaResult, mean_reprojection_error_px, refine_extrinsics, revert_large_pose_updates
+from exo_calib.correspondences import ObservationSet
+from exo_calib.triangulation import triangulate_points
+
+
+def test_mean_reprojection_error_px_uses_confidence_weights_and_ignores_invalid() -> None:
+    observations: ObservationSet = ObservationSet(
+        point_frame_idx=np.array([0], dtype=np.int64),
+        point_joint_idx=np.array([0], dtype=np.int64),
+        obs_point_idx=np.array([0, 0, 0], dtype=np.int64),
+        obs_view_idx=np.array([0, 1, 1], dtype=np.int64),
+        obs_xy=np.array([[0.0, 0.0], [6.0, 0.0], [np.nan, 0.0]], dtype=np.float64),
+        obs_conf=np.array([1.0, 0.5, 1.0], dtype=np.float64),
+    )
+    points_xyz: Float64[ndarray, "1 3"] = np.array([[0.0, 0.0, 5.0]], dtype=np.float64)
+    intrinsics: Float64[ndarray, "2 3 3"] = np.repeat(np.eye(3, dtype=np.float64)[None], 2, axis=0)
+    cam_T_world: Float64[ndarray, "2 4 4"] = np.repeat(np.eye(4, dtype=np.float64)[None], 2, axis=0)
+
+    actual_error_px: float = mean_reprojection_error_px(observations, points_xyz, intrinsics, cam_T_world)
+
+    assert actual_error_px == 2.0
+
+
+def test_refine_extrinsics_recovers_perturbed_synthetic_rig() -> None:
+    n_views: int = 8
+    n_points: int = 200
+    true_cam_T_world: Float64[ndarray, "8 4 4"] = ring_rig(n_views, radius_m=4.0)
+    intrinsics: Float64[ndarray, "8 3 3"] = np.zeros((n_views, 3, 3), dtype=np.float64)
+    intrinsics[:, 0, 0] = 750.0 + 10.0 * np.arange(n_views, dtype=np.float64)
+    intrinsics[:, 1, 1] = 770.0 + 8.0 * np.arange(n_views, dtype=np.float64)
+    intrinsics[:, 0, 2] = 320.0
+    intrinsics[:, 1, 2] = 240.0
+    intrinsics[:, 2, 2] = 1.0
+    rng: np.random.Generator = np.random.default_rng(12)
+    true_points_xyz: Float64[ndarray, "200 3"] = rng.uniform(-0.6, 0.6, size=(n_points, 3)).astype(np.float64)
+    observations: ObservationSet = observe_points(true_points_xyz, intrinsics, true_cam_T_world)
+
+    initial_cam_T_world: Float64[ndarray, "8 4 4"] = true_cam_T_world.copy()
+    angle_rad: float = np.deg2rad(2.0)
+    for view_idx in range(1, n_views):
+        axis: Float64[ndarray, "3"] = rng.normal(size=3).astype(np.float64)
+        axis /= np.linalg.norm(axis)
+        skew: Float64[ndarray, "3 3"] = np.array(
+            [[0.0, -axis[2], axis[1]], [axis[2], 0.0, -axis[0]], [-axis[1], axis[0], 0.0]], dtype=np.float64
+        )
+        delta_rotation: Float64[ndarray, "3 3"] = (
+            np.eye(3, dtype=np.float64) + np.sin(angle_rad) * skew + (1.0 - np.cos(angle_rad)) * (skew @ skew)
+        )
+        initial_cam_T_world[view_idx, :3, :3] = delta_rotation @ true_cam_T_world[view_idx, :3, :3]
+        initial_cam_T_world[view_idx, :3, 3] += rng.normal(scale=0.05, size=3)
+
+    initial_points_xyz: Float64[ndarray, "200 3"] = triangulate_points(observations, intrinsics, initial_cam_T_world)
+
+    result: BaResult = refine_extrinsics(
+        initial_cam_T_world,
+        intrinsics,
+        observations,
+        initial_points_xyz,
+        rounds=2,
+        robust="huber",
+        robust_scale_px=2.0,
+        fixed_pose_indices=(0,),
+        max_iterations=30,
+    )
+
+    rotation_error_deg: Float64[ndarray, "8"] = np.empty(n_views, dtype=np.float64)
+    for view_idx in range(n_views):
+        relative_rotation: Float64[ndarray, "3 3"] = result.cam_T_world[view_idx, :3, :3] @ true_cam_T_world[view_idx, :3, :3].T
+        cosine: float = float(np.clip((np.trace(relative_rotation) - 1.0) / 2.0, -1.0, 1.0))
+        rotation_error_deg[view_idx] = np.rad2deg(np.arccos(cosine))
+
+    refined_centers: Float64[ndarray, "8 3"] = -np.einsum(
+        "vji,vj->vi", result.cam_T_world[:, :3, :3], result.cam_T_world[:, :3, 3]
+    )
+    true_centers: Float64[ndarray, "8 3"] = -np.einsum(
+        "vji,vj->vi", true_cam_T_world[:, :3, :3], true_cam_T_world[:, :3, 3]
+    )
+    refined_baselines: Float64[ndarray, "8 3"] = refined_centers - refined_centers[0]
+    true_baselines: Float64[ndarray, "8 3"] = true_centers - true_centers[0]
+    alignment_scale: float = float(np.sum(refined_baselines * true_baselines) / np.sum(refined_baselines**2))
+    aligned_centers: Float64[ndarray, "8 3"] = true_centers[0] + alignment_scale * refined_baselines
+    translation_error_m: Float64[ndarray, "8"] = np.linalg.norm(aligned_centers - true_centers, axis=1)
+
+    assert np.max(rotation_error_deg) < 0.1
+    assert np.max(translation_error_m) < 0.005
+    assert len(result.mean_reproj_px_per_round) == 2
+    assert np.all(np.diff(result.mean_reproj_px_per_round) <= 1e-12)
+    assert result.converged
+
+
+def test_revert_large_pose_updates_restores_only_implausible_updates() -> None:
+    initial_cam_T_world: Float64[ndarray, "2 4 4"] = np.repeat(np.eye(4, dtype=np.float64)[None], 2, axis=0)
+    refined_cam_T_world: Float64[ndarray, "2 4 4"] = initial_cam_T_world.copy()
+    small_angle_rad: float = np.deg2rad(5.0)
+    large_angle_rad: float = np.deg2rad(20.0)
+    refined_cam_T_world[0, :2, :2] = np.array(
+        [[np.cos(small_angle_rad), -np.sin(small_angle_rad)], [np.sin(small_angle_rad), np.cos(small_angle_rad)]]
+    )
+    refined_cam_T_world[1, :2, :2] = np.array(
+        [[np.cos(large_angle_rad), -np.sin(large_angle_rad)], [np.sin(large_angle_rad), np.cos(large_angle_rad)]]
+    )
+    refined_cam_T_world[:, :3, 3] = np.array([[0.1, 0.0, 0.0], [0.2, 0.0, 0.0]], dtype=np.float64)
+
+    guarded_cam_T_world, reverted = revert_large_pose_updates(refined_cam_T_world, initial_cam_T_world, maximum_rotation_deg=10.0)
+
+    np.testing.assert_allclose(guarded_cam_T_world[0], refined_cam_T_world[0])
+    np.testing.assert_allclose(guarded_cam_T_world[1], initial_cam_T_world[1])
+    assert reverted == (1,)

--- a/packages/exo-calib/tests/test_boxes.py
+++ b/packages/exo-calib/tests/test_boxes.py
@@ -1,0 +1,122 @@
+import numpy as np
+from jaxtyping import Bool, Float64
+from numpy import ndarray
+
+from exo_calib.boxes import boxes_from_projected_keypoints, boxes_needing_detection, extrapolate_keypoints
+from exo_calib.triangulation import triangulate_frame_keypoints
+
+
+def test_boxes_from_projected_keypoints_filters_confidence_and_pads_about_center() -> None:
+    points_xyz: Float64[ndarray, "4 3"] = np.array(
+        [[-1.0, -0.5, 5.0], [1.0, 0.5, 5.0], [10.0, 10.0, 5.0], [0.0, 0.0, -1.0]], dtype=np.float64
+    )
+    conf: Float64[ndarray, "4"] = np.array([0.9, 0.8, 0.1, 1.0], dtype=np.float64)
+    camera_intrinsics: Float64[ndarray, "3 3"] = np.array([[100.0, 0.0, 50.0], [0.0, 100.0, 40.0], [0.0, 0.0, 1.0]], dtype=np.float64)
+    camera_T_world: Float64[ndarray, "4 4"] = np.eye(4, dtype=np.float64)
+
+    box_xyxy: Float64[ndarray, "4"] = boxes_from_projected_keypoints(
+        points_xyz,
+        conf,
+        camera_intrinsics,
+        camera_T_world,
+        image_wh=(100, 80),
+        pad=1.25,
+        min_joints=2,
+        min_confidence=0.5,
+    )
+
+    np.testing.assert_allclose(box_xyxy, np.array([25.0, 27.5, 75.0, 52.5], dtype=np.float64))
+
+
+def test_boxes_from_projected_keypoints_clips_padding_and_rejects_insufficient_joints() -> None:
+    camera_intrinsics: Float64[ndarray, "3 3"] = np.array([[100.0, 0.0, 50.0], [0.0, 100.0, 40.0], [0.0, 0.0, 1.0]], dtype=np.float64)
+    camera_T_world: Float64[ndarray, "4 4"] = np.eye(4, dtype=np.float64)
+    clipped_points_xyz: Float64[ndarray, "2 3"] = np.array([[-2.25, -1.75, 5.0], [-1.75, -1.25, 5.0]], dtype=np.float64)
+
+    clipped_xyxy: Float64[ndarray, "4"] = boxes_from_projected_keypoints(
+        clipped_points_xyz,
+        np.ones(2, dtype=np.float64),
+        camera_intrinsics,
+        camera_T_world,
+        image_wh=(100, 80),
+        pad=2.0,
+        min_joints=2,
+        min_confidence=0.15,
+    )
+    missing_xyxy: Float64[ndarray, "4"] = boxes_from_projected_keypoints(
+        np.array([[0.0, 0.0, 5.0], [20.0, 0.0, 5.0]], dtype=np.float64),
+        np.ones(2, dtype=np.float64),
+        camera_intrinsics,
+        camera_T_world,
+        image_wh=(100, 80),
+        min_joints=2,
+        pad=1.25,
+        min_confidence=0.15,
+    )
+
+    np.testing.assert_allclose(clipped_xyxy, np.array([0.0, 0.0, 20.0, 20.0], dtype=np.float64))
+    assert np.isnan(missing_xyxy).all()
+
+
+def test_boxes_needing_detection_flags_missing_and_image_boundary_boxes() -> None:
+    boxes: Float64[ndarray, "5 4"] = np.array(
+        [
+            [np.nan, np.nan, np.nan, np.nan],
+            [0.0, 10.0, 80.0, 70.0],
+            [10.0, 0.0, 80.0, 70.0],
+            [10.0, 10.0, 100.0, 80.0],
+            [10.0, 10.0, 80.0, 70.0],
+        ],
+        dtype=np.float64,
+    )
+
+    needs_detection: Bool[ndarray, " n"] = boxes_needing_detection(boxes, image_wh=(100, 80))
+
+    np.testing.assert_array_equal(needs_detection, np.array([True, True, True, True, False]))
+
+
+def test_extrapolate_keypoints_uses_velocity_where_available_and_latest_elsewhere() -> None:
+    latest_points_xyz: Float64[ndarray, "3 3"] = np.array(
+        [[2.0, 3.0, 4.0], [5.0, 6.0, 7.0], [np.nan, np.nan, np.nan]], dtype=np.float64
+    )
+    previous_points_xyz: Float64[ndarray, "3 3"] = np.array(
+        [[1.0, 1.0, 1.0], [np.nan, np.nan, np.nan], [1.0, 2.0, 3.0]], dtype=np.float64
+    )
+
+    predicted_points_xyz: Float64[ndarray, "3 3"] = extrapolate_keypoints(latest_points_xyz, previous_points_xyz, step_ratio=2.0)
+
+    expected_points_xyz: Float64[ndarray, "3 3"] = np.array(
+        [[4.0, 7.0, 10.0], [5.0, 6.0, 7.0], [np.nan, np.nan, np.nan]], dtype=np.float64
+    )
+    np.testing.assert_allclose(predicted_points_xyz, expected_points_xyz, equal_nan=True)
+
+
+def test_triangulate_frame_keypoints_preserves_joint_rows_and_confidence() -> None:
+    points_xyz: Float64[ndarray, "3 3"] = np.array(
+        [[0.0, 0.0, 5.0], [0.5, 0.2, 4.0], [-0.2, 0.1, 6.0]], dtype=np.float64
+    )
+    intrinsics: Float64[ndarray, "3 3 3"] = np.repeat(
+        np.array([[[100.0, 0.0, 50.0], [0.0, 100.0, 40.0], [0.0, 0.0, 1.0]]], dtype=np.float64), 3, axis=0
+    )
+    cam_T_world: Float64[ndarray, "3 4 4"] = np.repeat(np.eye(4, dtype=np.float64)[None], 3, axis=0)
+    cam_T_world[1, 0, 3] = -1.0
+    cam_T_world[2, 1, 3] = -1.0
+    points_homo: Float64[ndarray, "3 4"] = np.column_stack((points_xyz, np.ones(3, dtype=np.float64)))
+    points_cam: Float64[ndarray, "3 3 3"] = np.einsum("vij,nj->vni", cam_T_world[:, :3], points_homo)
+    projected: Float64[ndarray, "3 3 3"] = np.einsum("vij,vnj->vni", intrinsics, points_cam)
+    kp_xy: Float64[ndarray, "3 3 2"] = projected[:, :, :2] / projected[:, :, 2:3]
+    conf: Float64[ndarray, "3 3"] = np.full((3, 3), 0.9, dtype=np.float64)
+    conf[1:, 2] = 0.1
+
+    triangulated_xyz, triangulated_conf = triangulate_frame_keypoints(
+        kp_xy,
+        conf,
+        intrinsics,
+        cam_T_world,
+        min_confidence=0.5,
+        reproj_threshold_px=1.0,
+    )
+
+    np.testing.assert_allclose(triangulated_xyz[:2], points_xyz[:2], atol=1e-8)
+    assert np.isnan(triangulated_xyz[2]).all()
+    np.testing.assert_allclose(triangulated_conf, np.array([0.9, 0.9, 0.0], dtype=np.float64))

--- a/packages/exo-calib/tests/test_confidence.py
+++ b/packages/exo-calib/tests/test_confidence.py
@@ -1,0 +1,112 @@
+import numpy as np
+from jaxtyping import Float64
+from numpy import ndarray
+
+from exo_calib.confidence import (
+    drop_face_confidences,
+    kineo_point_confidence,
+    median_filter_keypoints,
+    modulate_crop_edge_confidence,
+    threshold_rescale_confidence,
+)
+
+
+def test_modulate_crop_edge_confidence_handles_edges_outside_and_nan() -> None:
+    kp_xy: Float64[ndarray, "6 2"] = np.array(
+        [[50.0, 40.0], [5.0, 40.0], [95.0, 40.0], [-1.0, 40.0], [50.0, 81.0], [np.nan, 40.0]], dtype=np.float64
+    )
+    conf: Float64[ndarray, "6"] = np.array([0.8, 0.8, 0.8, 0.8, 0.8, np.nan], dtype=np.float64)
+
+    actual: Float64[ndarray, "6"] = modulate_crop_edge_confidence(kp_xy, conf, crop_wh=(100, 80), margin_px=10.0)
+
+    expected: Float64[ndarray, "6"] = np.array([0.8, 0.4, 0.4, 0.0, 0.0, 0.0], dtype=np.float64)
+    np.testing.assert_allclose(actual, expected)
+
+
+def test_threshold_rescale_confidence_applies_cutoff_and_linear_scale() -> None:
+    conf: Float64[ndarray, "5"] = np.array([0.0, 0.14, 0.15, 0.575, 1.0], dtype=np.float64)
+
+    actual: Float64[ndarray, "5"] = threshold_rescale_confidence(conf, tau=0.15)
+
+    expected: Float64[ndarray, "5"] = np.array([0.0, 0.0, 0.0, 0.5, 1.0], dtype=np.float64)
+    np.testing.assert_allclose(actual, expected)
+
+
+def test_median_filter_keypoints_uses_truncated_windows_and_ignores_nan() -> None:
+    kp_xy: Float64[ndarray, "5 2 2"] = np.array(
+        [
+            [[0.0, 10.0], [np.nan, 0.0]],
+            [[100.0, 10.0], [np.nan, np.nan]],
+            [[2.0, 10.0], [np.nan, 4.0]],
+            [[3.0, 10.0], [np.nan, 6.0]],
+            [[4.0, 10.0], [np.nan, 8.0]],
+        ],
+        dtype=np.float64,
+    )
+
+    actual: Float64[ndarray, "5 2 2"] = median_filter_keypoints(kp_xy, window=3)
+
+    expected: Float64[ndarray, "5 2 2"] = np.array(
+        [
+            [[50.0, 10.0], [np.nan, 0.0]],
+            [[2.0, 10.0], [np.nan, 2.0]],
+            [[3.0, 10.0], [np.nan, 5.0]],
+            [[3.0, 10.0], [np.nan, 6.0]],
+            [[3.5, 10.0], [np.nan, 7.0]],
+        ],
+        dtype=np.float64,
+    )
+    np.testing.assert_allclose(actual, expected, equal_nan=True)
+
+
+def test_kineo_point_confidence_averages_all_view_pairs() -> None:
+    points_xyz: Float64[ndarray, "1 3"] = np.array([[0.0, 0.0, 5.0]], dtype=np.float64)
+    intrinsics: Float64[ndarray, "2 3 3"] = np.repeat(np.diag([100.0, 100.0, 1.0])[None], 2, axis=0)
+    cam_T_world: Float64[ndarray, "2 4 4"] = np.repeat(np.eye(4, dtype=np.float64)[None], 2, axis=0)
+    cam_T_world[1, 0, 3] = -1.0
+    kp_xy: Float64[ndarray, "2 1 2"] = np.array([[[0.0, 0.0]], [[-20.0, 0.0]]], dtype=np.float64)
+    conf: Float64[ndarray, "2 1"] = np.ones((2, 1), dtype=np.float64)
+
+    perfect_conf: Float64[ndarray, "1"] = kineo_point_confidence(points_xyz, kp_xy, conf, intrinsics, cam_T_world, lambda_decay=1.0)
+
+    np.testing.assert_allclose(perfect_conf, np.array([1.0], dtype=np.float64))
+
+    points_xyz = np.repeat(points_xyz, 2, axis=0)
+    intrinsics = np.repeat(np.diag([100.0, 100.0, 1.0])[None], 3, axis=0)
+    cam_T_world = np.repeat(np.eye(4, dtype=np.float64)[None], 3, axis=0)
+    cam_T_world[1, 0, 3] = -1.0
+    cam_T_world[2, 0, 3] = 1.0
+    kp_xy = np.array(
+        [[[0.0, 0.0], [0.0, 0.0]], [[-20.0, 0.0], [-20.0, 0.0]], [[30.0, 0.0], [20.0, 0.0]]], dtype=np.float64
+    )
+    conf = np.array([[1.0, 1.0], [1.0, 0.0], [1.0, 0.0]], dtype=np.float64)
+
+    mixed_conf: Float64[ndarray, "2"] = kineo_point_confidence(points_xyz, kp_xy, conf, intrinsics, cam_T_world, lambda_decay=1.0)
+
+    expected_conf: Float64[ndarray, "2"] = np.array([0.9674862827, 0.0], dtype=np.float64)
+    np.testing.assert_allclose(mixed_conf, expected_conf, atol=1e-10)
+
+
+def test_kineo_point_confidence_invalidates_a_view_behind_the_camera() -> None:
+    points_xyz: Float64[ndarray, "1 3"] = np.array([[0.0, 0.0, 5.0]], dtype=np.float64)
+    intrinsics: Float64[ndarray, "3 3 3"] = np.repeat(np.diag([100.0, 100.0, 1.0])[None], 3, axis=0)
+    cam_T_world: Float64[ndarray, "3 4 4"] = np.repeat(np.eye(4, dtype=np.float64)[None], 3, axis=0)
+    cam_T_world[1, 0, 3] = -1.0
+    cam_T_world[2, :3, :3] = np.diag([-1.0, 1.0, -1.0])
+    kp_xy: Float64[ndarray, "3 1 2"] = np.array([[[0.0, 0.0]], [[-20.0, 0.0]], [[0.0, 0.0]]], dtype=np.float64)
+    conf: Float64[ndarray, "3 1"] = np.ones((3, 1), dtype=np.float64)
+
+    actual_conf: Float64[ndarray, "1"] = kineo_point_confidence(points_xyz, kp_xy, conf, intrinsics, cam_T_world, lambda_decay=1.0)
+
+    np.testing.assert_allclose(actual_conf, np.array([1.0 / 3.0], dtype=np.float64))
+
+
+def test_drop_face_confidences_keeps_body_feet_and_hands() -> None:
+    conf: Float64[ndarray, "1 1 133"] = np.ones((1, 1, 133), dtype=np.float64)
+
+    selected: Float64[ndarray, "1 1 133"] = drop_face_confidences(conf)
+
+    assert np.all(selected[..., :23] == 1.0)
+    assert np.all(selected[..., 23:91] == 0.0)
+    assert np.all(selected[..., 91:] == 1.0)
+    assert np.all(conf == 1.0)

--- a/packages/exo-calib/tests/test_correspondences.py
+++ b/packages/exo-calib/tests/test_correspondences.py
@@ -1,0 +1,28 @@
+import numpy as np
+from jaxtyping import Float64, Int64
+from numpy import ndarray
+
+from exo_calib.correspondences import ObservationSet, build_observations, under_supported_view_indices
+
+
+def test_build_observations_requires_a_strong_cross_view_pair() -> None:
+    kp_xy: Float64[ndarray, "3 1 1 2"] = np.array([[[[10.0, 20.0]]], [[[11.0, 20.0]]], [[[12.0, 20.0]]]], dtype=np.float64)
+    conf: Float64[ndarray, "3 1 1"] = np.array([[[0.4]], [[1.0]], [[1.0]]], dtype=np.float64)
+
+    observations: ObservationSet = build_observations(kp_xy, conf, min_pair_conf=0.9, min_views=2)
+
+    # sqrt(0.4 * 1.0) = 0.63 fails the pair rule; the two confident views form the point.
+    np.testing.assert_array_equal(observations.point_frame_idx, np.array([0], dtype=np.int64))
+    np.testing.assert_array_equal(observations.point_joint_idx, np.array([0], dtype=np.int64))
+    np.testing.assert_array_equal(observations.obs_view_idx, np.array([1, 2], dtype=np.int64))
+    np.testing.assert_allclose(observations.obs_xy, np.array([[11.0, 20.0], [12.0, 20.0]]))
+    np.testing.assert_allclose(observations.obs_conf, np.array([1.0, 1.0]))
+    assert build_observations(kp_xy, conf, min_pair_conf=0.9, min_views=3).point_frame_idx.size == 0
+
+
+def test_under_supported_view_indices_uses_relative_median_support() -> None:
+    view_indices: Int64[ndarray, " n"] = np.repeat(np.arange(6, dtype=np.int64), np.array([200, 180, 170, 15, 1, 0]))
+
+    fixed_views: tuple[int, ...] = under_supported_view_indices(view_indices, n_views=6, minimum_ratio=0.1)
+
+    assert fixed_views == (3, 4, 5)

--- a/packages/exo-calib/tests/test_eval.py
+++ b/packages/exo-calib/tests/test_eval.py
@@ -1,0 +1,108 @@
+import numpy as np
+from jaxtyping import Float64
+from numpy import ndarray
+from simplecv.ops.umeyama import SimilarityTransform
+
+from exo_calib.eval import CameraErrors, RigGeometry, align_rigs, camera_errors, evaluate_rig, rig_geometry
+
+
+def test_evaluate_rig_reports_zero_for_identical_rigs() -> None:
+    centers: Float64[ndarray, "4 3"] = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]], dtype=np.float64
+    )
+    cam_T_world: Float64[ndarray, "4 4 4"] = np.repeat(np.eye(4, dtype=np.float64)[None], 4, axis=0)
+    cam_T_world[:, :3, 3] = -centers
+
+    errors: CameraErrors = evaluate_rig(cam_T_world, cam_T_world, mode="se3")
+
+    np.testing.assert_allclose(errors.rotation_error_deg, np.zeros(4, dtype=np.float64), atol=1e-10)
+    np.testing.assert_allclose(errors.translation_error_cm, np.zeros(4, dtype=np.float64), atol=1e-10)
+    assert errors.alignment_scale == 1.0
+
+
+def test_align_rigs_recovers_known_se3_world_transform() -> None:
+    gt_centers: Float64[ndarray, "4 3"] = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.2, 0.0], [-0.3, 1.7, 0.4], [0.2, -0.5, 2.1]], dtype=np.float64
+    )
+    gt_cam_T_world: Float64[ndarray, "4 4 4"] = np.repeat(np.eye(4, dtype=np.float64)[None], 4, axis=0)
+    gt_cam_T_world[:, :3, 3] = -gt_centers
+    angle_rad: float = np.deg2rad(31.0)
+    rotation: Float64[ndarray, "3 3"] = np.array(
+        [[np.cos(angle_rad), -np.sin(angle_rad), 0.0], [np.sin(angle_rad), np.cos(angle_rad), 0.0], [0.0, 0.0, 1.0]], dtype=np.float64
+    )
+    translation: Float64[ndarray, "3"] = np.array([1.2, -0.7, 0.4], dtype=np.float64)
+    pred_centers: Float64[ndarray, "4 3"] = np.einsum("ij,vj->vi", rotation.T, gt_centers - translation)
+    pred_cam_T_world: Float64[ndarray, "4 4 4"] = np.repeat(np.eye(4, dtype=np.float64)[None], 4, axis=0)
+    pred_cam_T_world[:, :3, :3] = rotation
+    pred_cam_T_world[:, :3, 3] = -np.einsum("vij,vj->vi", pred_cam_T_world[:, :3, :3], pred_centers)
+
+    alignment: SimilarityTransform = align_rigs(pred_cam_T_world, gt_cam_T_world)
+    errors: CameraErrors = evaluate_rig(pred_cam_T_world, gt_cam_T_world, mode="se3")
+
+    np.testing.assert_allclose(alignment.dst_R_src, rotation, atol=1e-12)
+    np.testing.assert_allclose(alignment.dst_t_src, translation, atol=1e-12)
+    assert alignment.scale == 1.0
+    np.testing.assert_allclose(errors.rotation_error_deg, np.zeros(4, dtype=np.float64), atol=1e-10)
+    np.testing.assert_allclose(errors.translation_error_cm, np.zeros(4, dtype=np.float64), atol=1e-10)
+
+
+def test_align_rigs_recovers_known_sim3_scale() -> None:
+    gt_centers: Float64[ndarray, "4 3"] = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.2, 0.0], [-0.3, 1.7, 0.4], [0.2, -0.5, 2.1]], dtype=np.float64
+    )
+    gt_cam_T_world: Float64[ndarray, "4 4 4"] = np.repeat(np.eye(4, dtype=np.float64)[None], 4, axis=0)
+    gt_cam_T_world[:, :3, 3] = -gt_centers
+    expected_scale: float = 1.37
+    translation: Float64[ndarray, "3"] = np.array([-0.8, 1.1, 0.3], dtype=np.float64)
+    pred_centers: Float64[ndarray, "4 3"] = (gt_centers - translation) / expected_scale
+    pred_cam_T_world: Float64[ndarray, "4 4 4"] = np.repeat(np.eye(4, dtype=np.float64)[None], 4, axis=0)
+    pred_cam_T_world[:, :3, 3] = -pred_centers
+
+    alignment: SimilarityTransform = align_rigs(pred_cam_T_world, gt_cam_T_world, with_scale=True)
+    errors: CameraErrors = evaluate_rig(pred_cam_T_world, gt_cam_T_world, mode="sim3")
+
+    np.testing.assert_allclose(alignment.dst_R_src, np.eye(3, dtype=np.float64), atol=1e-12)
+    np.testing.assert_allclose(alignment.dst_t_src, translation, atol=1e-12)
+    assert np.isclose(alignment.scale, expected_scale, atol=1e-12)
+    assert np.isclose(errors.alignment_scale, expected_scale, atol=1e-12)
+    np.testing.assert_allclose(errors.rotation_error_deg, np.zeros(4, dtype=np.float64), atol=1e-10)
+    np.testing.assert_allclose(errors.translation_error_cm, np.zeros(4, dtype=np.float64), atol=1e-10)
+
+
+def test_camera_errors_reports_known_single_camera_rotation() -> None:
+    centers: Float64[ndarray, "4 3"] = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.2, 0.0], [-0.3, 1.7, 0.4], [0.2, -0.5, 2.1]], dtype=np.float64
+    )
+    gt_cam_T_world: Float64[ndarray, "4 4 4"] = np.repeat(np.eye(4, dtype=np.float64)[None], 4, axis=0)
+    gt_cam_T_world[:, :3, 3] = -centers
+    pred_cam_T_world: Float64[ndarray, "4 4 4"] = gt_cam_T_world.copy()
+    expected_angle_deg: float = 7.5
+    angle_rad: float = np.deg2rad(expected_angle_deg)
+    perturbed_rotation: Float64[ndarray, "3 3"] = np.array(
+        [[np.cos(angle_rad), -np.sin(angle_rad), 0.0], [np.sin(angle_rad), np.cos(angle_rad), 0.0], [0.0, 0.0, 1.0]], dtype=np.float64
+    )
+    pred_cam_T_world[2, :3, :3] = perturbed_rotation
+    pred_cam_T_world[2, :3, 3] = -perturbed_rotation @ centers[2]
+    identity: SimilarityTransform = SimilarityTransform(dst_R_src=np.eye(3, dtype=np.float64), dst_t_src=np.zeros(3, dtype=np.float64), scale=1.0)
+
+    errors: CameraErrors = camera_errors(pred_cam_T_world, gt_cam_T_world, gt_T_pred=identity)
+
+    np.testing.assert_allclose(errors.rotation_error_deg, np.array([0.0, 0.0, expected_angle_deg, 0.0], dtype=np.float64), atol=1e-10)
+    np.testing.assert_allclose(errors.translation_error_cm, np.zeros(4, dtype=np.float64), atol=1e-10)
+
+
+def test_rig_geometry_reports_pairwise_distances_and_floor_heights() -> None:
+    cam_T_world: Float64[ndarray, "3 4 4"] = np.repeat(np.eye(4, dtype=np.float64)[None], 3, axis=0)
+    centers: Float64[ndarray, "3 3"] = np.array(
+        [[0.0, 0.0, 1.0], [3.0, 0.0, 2.0], [0.0, 4.0, 3.0]], dtype=np.float64
+    )
+    cam_T_world[:, :3, 3] = -centers
+
+    geometry: RigGeometry = rig_geometry(cam_T_world)
+
+    np.testing.assert_allclose(geometry.camera_centers_m, centers)
+    np.testing.assert_allclose(
+        geometry.pairwise_distance_m,
+        np.array([[0.0, np.sqrt(10.0), np.sqrt(20.0)], [np.sqrt(10.0), 0.0, np.sqrt(26.0)], [np.sqrt(20.0), np.sqrt(26.0), 0.0]]),
+    )
+    np.testing.assert_allclose(geometry.height_above_floor_m, np.array([1.0, 2.0, 3.0]))

--- a/packages/exo-calib/tests/test_focal.py
+++ b/packages/exo-calib/tests/test_focal.py
@@ -1,0 +1,50 @@
+import numpy as np
+from conftest import observe_points
+from jaxtyping import Float64
+from numpy import ndarray
+
+from exo_calib.correspondences import ObservationSet
+from exo_calib.focal import FocalRefinementResult, refine_focals
+
+
+def test_refine_focals_recovers_per_camera_scale_with_fixed_poses_and_points() -> None:
+    n_views: int = 3
+    n_points: int = 80
+    cam_T_world: Float64[ndarray, "3 4 4"] = np.repeat(np.eye(4, dtype=np.float64)[None], n_views, axis=0)
+    cam_T_world[1, 0, 3] = -0.8
+    cam_T_world[2, 1, 3] = -0.6
+    true_intrinsics: Float64[ndarray, "3 3 3"] = np.zeros((n_views, 3, 3), dtype=np.float64)
+    true_intrinsics[:, 0, 0] = np.array([700.0, 760.0, 820.0], dtype=np.float64)
+    true_intrinsics[:, 1, 1] = np.array([710.0, 750.0, 840.0], dtype=np.float64)
+    true_intrinsics[:, 0, 2] = 640.0
+    true_intrinsics[:, 1, 2] = 360.0
+    true_intrinsics[:, 2, 2] = 1.0
+    rng: np.random.Generator = np.random.default_rng(18)
+    points_xyz: Float64[ndarray, "80 3"] = np.column_stack(
+        (rng.uniform(-1.0, 1.0, n_points), rng.uniform(-0.8, 0.8, n_points), rng.uniform(3.0, 6.0, n_points))
+    )
+    observations: ObservationSet = observe_points(points_xyz, true_intrinsics, cam_T_world)
+    initial_intrinsics: Float64[ndarray, "3 3 3"] = true_intrinsics.copy()
+    initial_scale: Float64[ndarray, "3"] = np.array([0.95, 1.04, 0.96], dtype=np.float64)
+    initial_intrinsics[:, 0, 0] *= initial_scale
+    initial_intrinsics[:, 1, 1] *= initial_scale
+
+    result: FocalRefinementResult = refine_focals(
+        initial_intrinsics,
+        cam_T_world,
+        points_xyz,
+        observations,
+        iterations=400,
+        learning_rate=0.05,
+        robust_scale_px=2.0,
+        device="cpu",
+    )
+
+    recovered_error: Float64[ndarray, "3"] = result.intrinsics[:, 0, 0] / true_intrinsics[:, 0, 0] - 1.0
+    assert np.max(np.abs(recovered_error)) < 0.002
+    np.testing.assert_allclose(
+        result.intrinsics[:, 1, 1] / result.intrinsics[:, 0, 0],
+        initial_intrinsics[:, 1, 1] / initial_intrinsics[:, 0, 0],
+        atol=1e-12,
+    )
+    assert result.final_loss < result.initial_loss

--- a/packages/exo-calib/tests/test_keypoints.py
+++ b/packages/exo-calib/tests/test_keypoints.py
@@ -1,0 +1,64 @@
+import numpy as np
+import pytest
+from jaxtyping import Float32, Float64, Int64
+from numpy import ndarray
+
+from exo_calib.keypoints import (
+    CameraKeypoints,
+    postprocess_confidences,
+    sampled_frame_indices,
+    stack_postprocessed,
+)
+
+
+def _camera(num_frames: int = 1) -> CameraKeypoints:
+    kp_xy: Float32[ndarray, "t 133 2"] = np.full((num_frames, 133, 2), np.nan, dtype=np.float32)
+    kp_xy[:, :3] = np.array([[50.0, 40.0], [5.0, 40.0], [-1.0, 40.0]], dtype=np.float32)
+    conf: Float32[ndarray, "t 133"] = np.zeros((num_frames, 133), dtype=np.float32)
+    conf[:, :3] = np.array([0.575, 0.8, 0.8], dtype=np.float32)
+    return CameraKeypoints(
+        sample_indices=np.arange(num_frames, dtype=np.int64),
+        times_ns=np.arange(num_frames, dtype=np.int64),
+        kp_xy=kp_xy,
+        conf=conf,
+        bbox_xyxy=np.tile(np.array([[0.0, 0.0, 100.0, 80.0]], dtype=np.float32), (num_frames, 1)),
+        box_source=("yolox",) * num_frames,
+        crop_origin_xy=np.zeros((num_frames, 2), dtype=np.float32),
+        crop_size_wh=np.tile(np.array([[100.0, 80.0]], dtype=np.float32), (num_frames, 1)),
+        crop_input_wh=np.array([100, 80], dtype=np.int64),
+        video_wh=np.array([100, 80], dtype=np.int64),
+    )
+
+
+def test_postprocess_confidences_applies_crop_margin_then_threshold_rescale() -> None:
+    filtered_xy, post_conf = postprocess_confidences(_camera(), median_window=1, margin_px=10.0, conf_tau=0.15)
+
+    # margin: 0.575 (interior), 0.8 * 5/10 = 0.4 (5 px from the edge), 0 (outside); then (c - 0.15) / 0.85.
+    np.testing.assert_allclose(post_conf[0, :3], np.array([0.5, 0.25 / 0.85, 0.0]), atol=1e-7)
+    np.testing.assert_allclose(filtered_xy[0, :3], np.array([[50.0, 40.0], [5.0, 40.0], [-1.0, 40.0]]))
+    assert np.all(post_conf[0, 3:] == 0.0)
+
+
+def test_sampled_frame_indices_spreads_the_budget_evenly_and_keeps_short_captures_whole() -> None:
+    short: Int64[ndarray, "t"] = sampled_frame_indices(150, 1000)
+    long: Int64[ndarray, "t"] = sampled_frame_indices(4000, 1000)
+
+    np.testing.assert_array_equal(short, np.arange(150, dtype=np.int64))
+    assert long.size == 1000 and long[0] == 0 and long[-1] == 3999
+    assert np.all(np.diff(long) >= 1) and np.unique(np.diff(long)).size <= 2
+    with pytest.raises(ValueError, match="no frames"):
+        sampled_frame_indices(0, 1000)
+
+
+def test_stack_postprocessed_rejects_mismatched_frame_grids() -> None:
+    with pytest.raises(ValueError, match="frame grid"):
+        stack_postprocessed({"a": _camera(2), "b": _camera(3)}, ("a", "b"), 1, 10.0, 0.15)
+    shifted: CameraKeypoints = _camera(2)
+    shifted.sample_indices = shifted.sample_indices + 4  # same length, different frames
+    with pytest.raises(ValueError, match="frame grid"):
+        stack_postprocessed({"a": _camera(2), "b": shifted}, ("a", "b"), 1, 10.0, 0.15)
+
+    kp_xy, conf = stack_postprocessed({"a": _camera(2), "b": _camera(2)}, ("a", "b"), 1, 10.0, 0.15)
+    expected_conf: Float64[ndarray, "3"] = np.array([0.5, 0.25 / 0.85, 0.0])
+    assert kp_xy.shape == (2, 2, 133, 2)
+    np.testing.assert_allclose(conf[:, :, :3], np.broadcast_to(expected_conf, (2, 2, 3)), atol=1e-7)

--- a/packages/exo-calib/tests/test_triangulation.py
+++ b/packages/exo-calib/tests/test_triangulation.py
@@ -1,0 +1,43 @@
+import numpy as np
+from conftest import observe_points, ring_rig
+from jaxtyping import Float64
+from numpy import ndarray
+
+from exo_calib.correspondences import ObservationSet
+from exo_calib.triangulation import RobustTriangulationResult, triangulate_points, triangulate_robust
+
+
+def test_triangulate_points_recovers_exact_synthetic_scene() -> None:
+    n_views: int = 4
+    n_points: int = 20
+    cam_T_world: Float64[ndarray, "4 4 4"] = ring_rig(n_views, radius_m=4.0)
+    camera_intrinsics: Float64[ndarray, "3 3"] = np.array([[800.0, 0.0, 320.0], [0.0, 820.0, 240.0], [0.0, 0.0, 1.0]], dtype=np.float64)
+    intrinsics: Float64[ndarray, "4 3 3"] = np.repeat(camera_intrinsics[None], n_views, axis=0)
+    rng: np.random.Generator = np.random.default_rng(4)
+    points_xyz: Float64[ndarray, "20 3"] = rng.uniform(-0.5, 0.5, size=(n_points, 3)).astype(np.float64)
+    observations: ObservationSet = observe_points(points_xyz, intrinsics, cam_T_world)
+
+    actual_xyz: Float64[ndarray, "20 3"] = triangulate_points(observations, intrinsics, cam_T_world)
+
+    np.testing.assert_allclose(actual_xyz, points_xyz, atol=1e-6)
+
+
+def test_triangulate_robust_drops_one_gross_outlier_and_recovers_point() -> None:
+    n_views: int = 4
+    cam_T_world: Float64[ndarray, "4 4 4"] = ring_rig(n_views, radius_m=4.0)
+    camera_intrinsics: Float64[ndarray, "3 3"] = np.array([[800.0, 0.0, 320.0], [0.0, 820.0, 240.0], [0.0, 0.0, 1.0]], dtype=np.float64)
+    intrinsics: Float64[ndarray, "4 3 3"] = np.repeat(camera_intrinsics[None], n_views, axis=0)
+    points_xyz: Float64[ndarray, "5 3"] = np.array(
+        [[-0.3, -0.2, 0.1], [0.2, -0.1, -0.4], [0.1, 0.3, 0.2], [-0.2, 0.4, -0.1], [0.4, 0.1, 0.3]], dtype=np.float64
+    )
+    observations: ObservationSet = observe_points(points_xyz, intrinsics, cam_T_world)
+    outlier_obs_idx: int = 2 * n_views + 3
+    observations.obs_xy[outlier_obs_idx, 0] += 50.0
+
+    robust: RobustTriangulationResult = triangulate_robust(observations, intrinsics, cam_T_world, reproj_threshold_px=10.0)
+
+    refined_xyz: Float64[ndarray, "5 3"] = robust.points_xyz
+    pruned_observations: ObservationSet = robust.obs
+    assert pruned_observations.obs_point_idx.size == observations.obs_point_idx.size - 1
+    assert np.count_nonzero(pruned_observations.obs_point_idx == 2) == 3
+    np.testing.assert_allclose(refined_xyz, points_xyz, atol=1e-6)


### PR DESCRIPTION
Re-lands #181, whose branch GitHub closed when the stack base branches were deleted after #178 merged; the review discussion and replies are on #. Same commit content, rebased onto main.

The numerical core of exo-calib, no IO. Tuned values are named constants in the stage modules (#182, #183); these functions take them as required arguments.

## What
- `correspondences`: Kineo pair rule over all view pairs; under-supported-view detection.
- `triangulation`: batched confidence-weighted DLT, robust pruning with leave-one-out consensus, single-frame multi-view triangulation for the tracker.
- `ba`: kornia-rs Schur bundle adjustment with soft camera-centre priors and re-triangulation rounds; rotation-update guard.
- `focal`: one log-focal scale per camera with poses and points fixed.
- `confidence`, `boxes`, `keypoints`: AssemblyHands-X gating, temporal median filter, reprojection-driven person boxes, the Stage B record.
- `cameras`, `eval`: the rig container, SE(3) / Sim(3) errors through simplecv's umeyama, rig geometry.

## Verified
ruff, pyrefly; tests on one synthetic ring rig (`conftest.py`) with beartype on. Read in order: correspondences → triangulation → ba → focal.