### PR TITLE
exo-calib: catalog IO, layer contract, Stage A (G3T + MoGe-2 init), Stage B (tracked RTMW-x keypoints) (re-land of #182)

### DIFF
--- a/packages/exo-calib/exo_calib/apis/calibrate_init.py
+++ b/packages/exo-calib/exo_calib/apis/calibrate_init.py
@@ -1,0 +1,228 @@
+"""Stage A: self-contained initial exo-camera calibration.
+
+One synchronized frame from each exo video (read from the catalog, NVDEC) goes
+through the gravity-aligned multi-view backend (G3T), MoGe-2 metric depth fixes
+the global scale, and a RANSAC ground plane puts gravity on +Z with the floor at
+z=0 — the ``monopriors.apis.calibrate_synced_videos`` metric route, catalog-native.
+Ground truth is never read here; the result is evaluated against GT elsewhere.
+"""
+
+from dataclasses import dataclass, field
+from typing import NamedTuple
+
+import numpy as np
+import open3d as o3d
+import rerun as rr
+import tyro
+from jaxtyping import Bool, Float64, UInt8
+from numpy import ndarray
+from simplecv.camera_orient_utils import rotation_matrix_between
+
+from exo_calib.cameras import RigCameras, camera_centers
+from exo_calib.catalog_io import StageConfig, StageContext, stage_context
+from exo_calib.layer_io import INIT_LAYER, VARIANT_COLOR, exocalib_entity, log_cameras_layer, new_layer_recording, register_layer
+from exo_calib.video_io import ExoVideoStreams, open_exo_streams
+
+KEEP_TOP_PERCENT: float = 30.0
+"""Percentage of high-confidence pixels the multi-view geometry pass retains."""
+GROUND_DISTANCE_M: float = 0.06
+"""RANSAC inlier distance (meters) for the ground-plane fit."""
+MAX_GROUND_TILT_DEG: float = 60.0
+"""Largest angle between a candidate floor normal and G3T's gravity before the
+plane is rejected as a wall or table and the next-largest plane is tried."""
+UNPROJECT_STRIDE: int = 24
+"""Pixel stride when unprojecting depth to the ground-fit point cloud."""
+UP: Float64[ndarray, "3"] = np.array([0.0, 0.0, 1.0])
+"""G3T normalizes its predicted gravity to +Z; the floor fit refines that direction."""
+GROUND_PLANE_ATTEMPTS: int = 5
+"""Largest RANSAC planes tried before falling back to the gravity prior and the lowest camera."""
+
+
+@dataclass
+class InitCalibrationConfig:
+    """Config for the Stage A initial calibration tool."""
+
+    stage: tyro.conf.OmitArgPrefixes[StageConfig] = field(default_factory=StageConfig)
+    """Shared stage flags (catalog, dataset, segment, rigs, output, register); the CLI shows them unprefixed."""
+    frame_index: int = 0
+    """Sample index of the synchronized frame used for calibration (rig is static)."""
+
+
+class InitEstimate(NamedTuple):
+    """Stage A's output: the metric, +Z-up rig (ground at z=0) and the MoGe-2 scale that made it metric."""
+
+    cameras: RigCameras
+    metric_scale: float
+
+
+def _unproject_world(
+    depth: Float64[ndarray, "h w"],
+    intrinsics: Float64[ndarray, "3 3"],
+    cam_T_world: Float64[ndarray, "4 4"],
+    valid: Bool[ndarray, "h w"],
+    stride: int,
+) -> Float64[ndarray, "n 3"]:
+    """Lift confident depth pixels of one view to world points."""
+    from monopriors.models.multiview.multiview_pointcloud import unproject_selected_pixels
+
+    ys, xs = np.where(valid)
+    ys, xs = ys[::stride], xs[::stride]
+    world_T_cam: Float64[ndarray, "4 4"] = np.linalg.inv(cam_T_world)
+    return unproject_selected_pixels(depth, intrinsics, world_T_cam, ys, xs).astype(np.float64, copy=False)
+
+
+def select_ground_plane(
+    cloud: Float64[ndarray, "n 3"],
+    camera_centers: Float64[ndarray, "v 3"],
+    up_prior: Float64[ndarray, "3"],
+    *,
+    distance_threshold: float,
+    max_tilt_deg: float,
+    max_attempts: int = GROUND_PLANE_ATTEMPTS,
+) -> tuple[Float64[ndarray, "3"], Float64[ndarray, "3"]]:
+    """Pick the floor: the largest RANSAC plane whose normal agrees with the gravity prior.
+
+    Planes tilted more than ``max_tilt_deg`` from ``up_prior`` (walls, shelves)
+    have their inliers removed and the fit repeats on the remainder. When no
+    plane qualifies, the prior itself is the up direction and the ground passes
+    through the lowest camera center.
+
+    Args:
+        cloud: Float64 metric world points with shape ``(n, 3)``.
+        camera_centers: Float64 camera centers with shape ``(v, 3)``.
+        up_prior: Float64 gravity-up direction with shape ``(3,)``.
+        distance_threshold: RANSAC inlier distance in meters.
+        max_tilt_deg: Maximum accepted angle between the plane normal and the prior.
+        max_attempts: Number of successive plane fits before falling back.
+
+    Returns:
+        Float64 up direction with shape ``(3,)`` and a point on the ground with shape ``(3,)``.
+    """
+    up_prior = up_prior / np.linalg.norm(up_prior)
+    remaining_points: Float64[ndarray, "m 3"] = cloud
+    min_cosine: float = float(np.cos(np.radians(max_tilt_deg)))
+    for _attempt in range(max_attempts):
+        if remaining_points.shape[0] < 3:
+            break
+        pcd = o3d.geometry.PointCloud()
+        pcd.points = o3d.utility.Vector3dVector(remaining_points)
+        plane, inliers = pcd.segment_plane(distance_threshold=distance_threshold, ransac_n=3, num_iterations=2000)
+        normal: Float64[ndarray, "3"] = np.array(plane[:3], dtype=np.float64)
+        normal /= np.linalg.norm(normal)
+        if float(np.dot(normal, up_prior)) < 0.0:
+            normal = -normal
+        ground_point: Float64[ndarray, "3"] = remaining_points[inliers].mean(axis=0)
+        if float(np.dot(normal, up_prior)) >= min_cosine:
+            return normal, ground_point
+        keep_mask: Bool[ndarray, " n"] = np.ones(remaining_points.shape[0], dtype=bool)
+        keep_mask[np.asarray(inliers, dtype=np.int64)] = False
+        remaining_points = remaining_points[keep_mask]
+    lowest_camera: Float64[ndarray, "3"] = camera_centers[np.argmin(camera_centers @ up_prior)]
+    return up_prior, lowest_camera
+
+
+def estimate_init_cameras(frames_rgb: list[UInt8[ndarray, "h w 3"]], names: tuple[str, ...]) -> InitEstimate:
+    """Estimate metric, gravity-aligned exo cameras from one synchronized frame set.
+
+    Args:
+        frames_rgb: One RGB frame per camera, native video resolution.
+        names: Camera entity names, index-aligned with ``frames_rgb``.
+
+    Returns:
+        Estimated cameras with intrinsics rescaled to the native video resolution.
+    """
+    import cv2
+    from monopriors.apis.multiview_geometry import MultiviewGeometryConfig, MultiviewGeometryResult, run_multiview_geometry
+    from monopriors.models.metric_depth.moge_v2 import MoGeV2MetricPredictor
+    from monopriors.models.multiview.multiview_predictor import MultiviewPredictor, MultiviewPredictorConfig
+
+    predictor: MultiviewPredictor = MultiviewPredictor(MultiviewPredictorConfig(model_name="g3t"))
+    geo: MultiviewGeometryResult = run_multiview_geometry(
+        rgb_list=frames_rgb,
+        multiview_predictor=predictor,
+        config=MultiviewGeometryConfig(keep_top_percent=KEEP_TOP_PERCENT),
+    )
+    mv = geo.mv_pred_list
+    intrinsics_per_view: list[Float64[ndarray, "3 3"]] = [np.asarray(p.pinhole_param.intrinsics.k_matrix, dtype=np.float64) for p in mv]
+    cam_T_world_per_view: list[Float64[ndarray, "4 4"]] = [np.asarray(p.pinhole_param.extrinsics.cam_T_world, dtype=np.float64) for p in mv]
+
+    # MoGe-2 metric depth -> one global scale (median over views of per-view median ratio).
+    moge: MoGeV2MetricPredictor = MoGeV2MetricPredictor(device="cuda")
+    metric_per: list[Float64[ndarray, "h w"]] = []
+    valid_per: list[Bool[ndarray, "h w"]] = []
+    per_view_scale: list[float] = []
+    for i, pred in enumerate(mv):
+        metric_depth: Float64[ndarray, "h w"] = moge(frames_rgb[i], K_33=intrinsics_per_view[i].astype(np.float32)).depth_meters.astype(np.float64)
+        mv_depth: Float64[ndarray, "h w"] = np.asarray(pred.depth_map, dtype=np.float64)
+        if metric_depth.shape != mv_depth.shape:
+            metric_depth = cv2.resize(metric_depth, (mv_depth.shape[1], mv_depth.shape[0]), interpolation=cv2.INTER_NEAREST)
+        valid: Bool[ndarray, "h w"] = (
+            (np.asarray(geo.depth_confidences[i]) > 0) & np.isfinite(metric_depth) & np.isfinite(mv_depth) & (mv_depth > 1e-6) & (metric_depth > 1e-6)
+        )
+        metric_per.append(metric_depth)
+        valid_per.append(valid)
+        if int(valid.sum()) >= 100:
+            per_view_scale.append(float(np.median(metric_depth[valid] / mv_depth[valid])))
+    if not per_view_scale:
+        raise RuntimeError("no view yielded enough confident pixels for the metric scale")
+    scale: float = float(np.median(per_view_scale))
+    print(f"metric scale s={scale:.4f} (per-view {min(per_view_scale):.3f}..{max(per_view_scale):.3f}, n={len(per_view_scale)})")
+
+    metric_cam_T_world: list[Float64[ndarray, "4 4"]] = []
+    for estimated_cam_T_world in cam_T_world_per_view:
+        scaled_cam_T_world: Float64[ndarray, "4 4"] = estimated_cam_T_world.copy()
+        scaled_cam_T_world[:3, 3] *= scale
+        metric_cam_T_world.append(scaled_cam_T_world)
+    estimated_camera_centers: Float64[ndarray, "v 3"] = camera_centers(np.stack(metric_cam_T_world))
+
+    # Floor from the metric cloud. G3T already normalizes its predicted gravity to
+    # +Z, so the plane fit only fixes the ground height (plus a small tilt
+    # correction); a dominant wall or table is rejected by the gravity prior.
+    cloud: Float64[ndarray, "n 3"] = np.concatenate(
+        [_unproject_world(metric_per[i], intrinsics_per_view[i], metric_cam_T_world[i], valid_per[i], UNPROJECT_STRIDE) for i in range(len(mv))], axis=0
+    )
+    cloud = cloud[np.isfinite(cloud).all(1)]
+    up, ground_point = select_ground_plane(
+        cloud, estimated_camera_centers, UP, distance_threshold=GROUND_DISTANCE_M, max_tilt_deg=MAX_GROUND_TILT_DEG
+    )
+    gravity_rotation: Float64[ndarray, "3 3"] = rotation_matrix_between(up, UP)
+    shift: Float64[ndarray, "3"] = np.array([0.0, 0.0, -float((gravity_rotation @ ground_point)[2])])
+    print(f"ground plane: up={np.round(up, 3)} ({np.degrees(np.arccos(np.clip(up[2], -1.0, 1.0))):.1f} deg from G3T gravity), ground z={ground_point[2]:.3f} m")
+
+    cam_T_world_list: list[Float64[ndarray, "4 4"]] = []
+    video_intrinsics_list: list[Float64[ndarray, "3 3"]] = []
+    for i in range(len(mv)):
+        new_rotation: Float64[ndarray, "3 3"] = metric_cam_T_world[i][:3, :3] @ gravity_rotation.T
+        new_translation: Float64[ndarray, "3"] = metric_cam_T_world[i][:3, 3] - new_rotation @ shift
+        cam_T_world: Float64[ndarray, "4 4"] = np.eye(4, dtype=np.float64)
+        cam_T_world[:3, :3] = new_rotation
+        cam_T_world[:3, 3] = new_translation
+        cam_T_world_list.append(cam_T_world)
+        # Rescale the estimated K from the geometry pass resolution to the native video resolution.
+        video_h, video_w = frames_rgb[i].shape[:2]
+        pass_w: int = int(mv[i].pinhole_param.intrinsics.width)
+        pass_h: int = int(mv[i].pinhole_param.intrinsics.height)
+        scale_wh: Float64[ndarray, "3 3"] = np.diag([video_w / pass_w, video_h / pass_h, 1.0])
+        video_intrinsics_list.append(scale_wh @ intrinsics_per_view[i])
+
+    return InitEstimate(cameras=RigCameras(names=names, intrinsics=np.stack(video_intrinsics_list), cam_T_world=np.stack(cam_T_world_list)), metric_scale=scale)
+
+
+def main(config: InitCalibrationConfig) -> None:
+    """Run Stage A and (optionally) register the ``exocalib_init`` layer."""
+    context: StageContext = stage_context(config.stage)
+    streams: ExoVideoStreams = open_exo_streams(context.dataset, context.segment_id, context.layout.exo_camera_names)
+    frames_rgb: list[UInt8[ndarray, "h w 3"]] = [streams.frame_rgb(i, config.frame_index) for i in range(len(streams.names))]
+    print(f"segment {context.segment_id}: calibrating from frame {config.frame_index} of {len(frames_rgb)} exo views")
+
+    estimate: InitEstimate = estimate_init_cameras(frames_rgb, streams.names)
+
+    recording, rrd_path = new_layer_recording(context.segment_id, context.segment_dir / f"{INIT_LAYER}.rrd")
+    recording.log(exocalib_entity("init"), rr.AnyValues(metric_scale=np.array([estimate.metric_scale])), static=True)
+    video_h, video_w = frames_rgb[0].shape[:2]
+    log_cameras_layer(estimate.cameras, (video_w, video_h), exocalib_entity("init"), recording, color=VARIANT_COLOR["init"])
+    recording.flush(timeout_sec=30.0)
+    print(f"wrote {rrd_path}")
+    if config.stage.register:
+        register_layer(context.dataset, rrd_path, INIT_LAYER)
+        print(f"registered layer {INIT_LAYER}")

--- a/packages/exo-calib/exo_calib/apis/keypoints2d.py
+++ b/packages/exo-calib/exo_calib/apis/keypoints2d.py
@@ -1,0 +1,298 @@
+"""Stage B: per-view 2D whole-body keypoints on the exo videos.
+
+All exo cameras are processed in lockstep over the whole capture: frames stream
+from the catalog (NVDEC), the person box per view comes from projecting the
+skeleton tracked in 3D (YOLOX detects when a projection is missing or clipped,
+and re-anchors every view at least every ``DETECTOR_REANCHOR_INTERVAL_S`` of
+capture time), and RTMW-x (TensorRT) produces COCO-133 keypoints with
+confidences. Everything downstream needs — raw keypoints, confidences, boxes,
+and the crop rectangles the AssemblyHands-X margin rule operates on — is logged
+into the ``exocalib_kp2d`` layer's ``…_raw`` entities, which the refine stage
+queries back: the catalog is the stage store, not a side channel.
+"""
+
+from dataclasses import dataclass, field
+from typing import NamedTuple
+
+import numpy as np
+import rerun as rr
+import torch
+import tyro
+from jaxtyping import Bool, Float32, Float64, Int64, UInt8
+from numpy import ndarray
+from posekit.models.base import PersonDetector
+from posekit.models.rtmpose import RtmPose2d
+from posekit.predictions import BoxDetections
+from simplecv.rerun_custom_types import Points2DWithConfidence
+from torch import Tensor
+
+from exo_calib.boxes import boxes_from_projected_keypoints, boxes_needing_detection, crop_rectangles, extrapolate_keypoints
+from exo_calib.cameras import RigCameras
+from exo_calib.catalog_io import StageConfig, StageContext, stage_context
+from exo_calib.keypoints import (
+    AHX_CONF_TAU,
+    AHX_MARGIN_PX,
+    AHX_MEDIAN_WINDOW,
+    STAGE_B_FRAME_BUDGET,
+    BoxSource,
+    CameraKeypoints,
+    GatedKeypoints,
+    postprocess_confidences,
+    sampled_frame_indices,
+)
+from exo_calib.kp2d_layer import KP2D_LABEL, RAW_COLOR, kp2d_entity, log_keypoints_record
+from exo_calib.layer_io import (
+    KP2D_LAYER,
+    TIMELINE,
+    CalibrationVariant,
+    ClassSpec,
+    log_coco133_class_context,
+    new_layer_recording,
+    read_rig_cameras,
+    register_layer,
+)
+from exo_calib.triangulation import triangulate_frame_keypoints
+from exo_calib.video_io import ExoVideoStreams, open_exo_streams
+
+DETECTION_SCORE_THRESHOLD: float = 0.1
+"""Minimum YOLOX person score."""
+DETECTOR_REANCHOR_INTERVAL_S: float = 2.0
+"""Run YOLOX on every view at least this often in capture time, so a drifting tracked box cannot survive indefinitely."""
+BOX_PADDING: float = 1.25
+"""Padding multiplier applied about projected-keypoint box centers."""
+BOX_MIN_JOINTS: int = 4
+"""Minimum confident projected joints inside a view before its tracked box is used."""
+BOX_CONFIDENCE_TAU: float = 0.15
+"""Minimum confidence for joints used by tracking triangulation and box projection."""
+TRACKING_REPROJECTION_THRESHOLD_PX: float = 100.0
+"""Robust-triangulation reprojection threshold used by the online tracker."""
+OVERLAY_LOG_STRIDE: int = 5
+"""Every N-th processed frame gets the gated / rejected keypoint overlay; the raw record covers every frame."""
+OVERLAY_COLOR: tuple[int, int, int] = (240, 140, 60)
+
+
+@dataclass
+class Keypoints2dConfig:
+    """Config for the Stage B 2D keypoint tool."""
+
+    stage: tyro.conf.OmitArgPrefixes[StageConfig] = field(default_factory=StageConfig)
+    """Shared stage flags (catalog, dataset, segment, rigs, output, register); the CLI shows them unprefixed."""
+    batch_size: int = 32
+    """Largest inference batch the TensorRT engines are built for (at least the number of exo views)."""
+
+
+class TrackedFrame(NamedTuple):
+    """The online tracker's memory of one processed frame."""
+
+    sample_idx: int
+    points_xyz: Float64[ndarray, "133 3"]
+    conf: Float64[ndarray, "133"]
+
+
+def _best_box_per_frame(detections: BoxDetections, num_frames: int) -> Float32[ndarray, "t 4"]:
+    """Pick the highest-scoring box per frame; NaN rows where a frame has none."""
+    xyxy: Float32[ndarray, "n 4"] = detections.xyxy.cpu().numpy()
+    scores: Float32[ndarray, "n"] = detections.scores.cpu().numpy()
+    frame_indices: Int64[ndarray, "n"] = detections.frame_indices.cpu().numpy()
+    best_xyxy: Float32[ndarray, "t 4"] = np.full((num_frames, 4), np.nan, dtype=np.float32)
+    for frame in range(num_frames):
+        rows: Int64[ndarray, " m"] = np.nonzero(frame_indices == frame)[0]
+        if rows.size:
+            best_xyxy[frame] = xyxy[int(rows[np.argmax(scores[rows])])]
+    return best_xyxy
+
+
+def track_multiview_keypoints(streams: ExoVideoStreams, detector: PersonDetector, pose: RtmPose2d, cameras: RigCameras) -> dict[str, CameraKeypoints]:
+    """Run lockstep multi-view pose with reprojection-driven person boxes.
+
+    Args:
+        streams: Open NVDEC decoders over the segment.
+        detector: Person detector used for initialization and re-anchoring.
+        pose: RTMW-x top-down pose model (its crop spec sizes the crop rectangles).
+        cameras: Pipeline cameras used for triangulation and projection.
+
+    Returns:
+        Raw per-camera keypoints, boxes, crop rectangles, and box provenance.
+
+    Raises:
+        ValueError: If the exo cameras do not share one video resolution.
+    """
+    # One index set for every view, spread over the shortest stream so each index exists in all of them.
+    sample_indices: Int64[ndarray, "t"] = sampled_frame_indices(min(len(times) for times in streams.times_ns), STAGE_B_FRAME_BUDGET)
+    frame_times_ns: Int64[ndarray, "t"] = streams.times_ns[0][sample_indices].astype("timedelta64[ns]").astype(np.int64)
+    num_frames: int = sample_indices.size
+    num_views: int = len(streams.names)
+    kp_xy: Float32[ndarray, "v t 133 2"] = np.full((num_views, num_frames, 133, 2), np.nan, dtype=np.float32)
+    conf: Float32[ndarray, "v t 133"] = np.zeros((num_views, num_frames, 133), dtype=np.float32)
+    bbox_xyxy: Float32[ndarray, "v t 4"] = np.full((num_views, num_frames, 4), np.nan, dtype=np.float32)
+    box_sources: list[list[BoxSource]] = [[] for _ in range(num_views)]
+    video_wh: Int64[ndarray, "2"] | None = None
+    history: list[TrackedFrame] = []
+    last_anchor_ns: int | None = None
+    reanchor_interval_ns: int = int(DETECTOR_REANCHOR_INTERVAL_S * 1e9)
+
+    for frame_idx, sample_idx_value in enumerate(sample_indices):
+        sample_idx: int = int(sample_idx_value)
+        frames: list[UInt8[Tensor, "3 h w"]] = [streams.decoders[view_idx].get_frames_at([sample_idx]).data[0] for view_idx in range(num_views)]
+        if len({tuple(frame.shape) for frame in frames}) != 1:
+            raise ValueError(f"exo cameras must share one video resolution; got {[tuple(frame.shape[1:]) for frame in frames]}")
+        frames_hwc: UInt8[Tensor, "v h w 3"] = torch.stack(frames).permute(0, 2, 3, 1).contiguous()
+        frame_wh: Int64[ndarray, "2"] = np.array([frames_hwc.shape[2], frames_hwc.shape[1]], dtype=np.int64)
+        video_wh = frame_wh
+        image_wh: tuple[int, int] = (int(frame_wh[0]), int(frame_wh[1]))
+        boxes: Float64[ndarray, "v 4"] = np.full((num_views, 4), np.nan, dtype=np.float64)
+        frame_box_sources: list[BoxSource] = ["none"] * num_views
+
+        if history:
+            latest: TrackedFrame = history[-1]
+            predicted_xyz: Float64[ndarray, "133 3"] = latest.points_xyz
+            if len(history) >= 2:
+                previous: TrackedFrame = history[-2]
+                history_interval: int = latest.sample_idx - previous.sample_idx
+                step_ratio: float = (sample_idx - latest.sample_idx) / float(history_interval) if history_interval > 0 else 1.0
+                predicted_xyz = extrapolate_keypoints(latest.points_xyz, previous.points_xyz, step_ratio=step_ratio)
+            for view_idx in range(num_views):
+                boxes[view_idx] = boxes_from_projected_keypoints(
+                    predicted_xyz,
+                    latest.conf,
+                    cameras.intrinsics[view_idx],
+                    cameras.cam_T_world[view_idx],
+                    image_wh,
+                    pad=BOX_PADDING,
+                    min_joints=BOX_MIN_JOINTS,
+                    min_confidence=BOX_CONFIDENCE_TAU,
+                )
+                if np.isfinite(boxes[view_idx]).all():
+                    frame_box_sources[view_idx] = "tracked"
+
+        detector_view_mask: Bool[ndarray, "v"] = boxes_needing_detection(boxes, image_wh)
+        frame_time_ns: int = int(frame_times_ns[frame_idx])
+        if last_anchor_ns is None or frame_time_ns - last_anchor_ns >= reanchor_interval_ns:
+            detector_view_mask[:] = True
+            last_anchor_ns = frame_time_ns
+        detector_view_idx: Int64[ndarray, "d"] = np.flatnonzero(detector_view_mask).astype(np.int64)
+        if detector_view_idx.size:
+            detector_frames_hwc: UInt8[Tensor, "d h w 3"] = frames_hwc[torch.as_tensor(detector_view_idx, dtype=torch.long, device=frames_hwc.device)]
+            detected_boxes: Float32[ndarray, "d 4"] = _best_box_per_frame(detector(detector_frames_hwc), detector_view_idx.size)
+            for detector_row, view_idx_value in enumerate(detector_view_idx):
+                view_idx: int = int(view_idx_value)
+                if np.isfinite(detected_boxes[detector_row]).all():
+                    boxes[view_idx] = detected_boxes[detector_row]
+                    frame_box_sources[view_idx] = "yolox"
+
+        usable_view_idx: Int64[ndarray, "u"] = np.flatnonzero(np.isfinite(boxes).all(axis=1)).astype(np.int64)
+        if usable_view_idx.size:
+            pose_boxes: BoxDetections = BoxDetections(
+                xyxy=torch.as_tensor(boxes[usable_view_idx], dtype=torch.float32, device=frames_hwc.device),
+                scores=torch.ones(usable_view_idx.size, dtype=torch.float32, device=frames_hwc.device),
+                frame_indices=torch.as_tensor(usable_view_idx, dtype=torch.long, device=frames_hwc.device),
+            )
+            keypoints = pose(frames_hwc, pose_boxes)
+            keypoint_view_idx: Int64[ndarray, "u"] = keypoints.frame_indices.cpu().numpy().astype(np.int64, copy=False)
+            kp_xy[keypoint_view_idx, frame_idx] = keypoints.xy.cpu().numpy().astype(np.float32, copy=False)
+            conf[keypoint_view_idx, frame_idx] = keypoints.scores.cpu().numpy().astype(np.float32, copy=False)
+
+        bbox_xyxy[:, frame_idx] = boxes.astype(np.float32)
+        for view_idx in range(num_views):
+            box_sources[view_idx].append(frame_box_sources[view_idx])
+
+        tracked_xyz, tracked_conf = triangulate_frame_keypoints(
+            kp_xy[:, frame_idx].astype(np.float64),
+            conf[:, frame_idx].astype(np.float64),
+            cameras.intrinsics,
+            cameras.cam_T_world,
+            min_confidence=BOX_CONFIDENCE_TAU,
+            reproj_threshold_px=TRACKING_REPROJECTION_THRESHOLD_PX,
+        )
+        if int(np.isfinite(tracked_xyz).all(axis=1).sum()) >= BOX_MIN_JOINTS:
+            history.append(TrackedFrame(sample_idx=sample_idx, points_xyz=tracked_xyz, conf=tracked_conf))
+            history = history[-2:]
+
+    assert video_wh is not None  # num_frames >= 1: sampled_frame_indices rejects empty captures
+    per_camera: dict[str, CameraKeypoints] = {}
+    for view_idx, name in enumerate(streams.names):
+        crop_origin_xy, crop_size_wh = crop_rectangles(bbox_xyxy[view_idx], pose.crop_spec)
+        per_camera[name] = CameraKeypoints(
+            sample_indices=sample_indices,
+            times_ns=streams.times_ns[view_idx][sample_indices].astype("timedelta64[ns]").astype(np.int64),
+            kp_xy=kp_xy[view_idx],
+            conf=conf[view_idx],
+            bbox_xyxy=bbox_xyxy[view_idx],
+            box_source=tuple(box_sources[view_idx]),
+            crop_origin_xy=crop_origin_xy,
+            crop_size_wh=crop_size_wh,
+            crop_input_wh=np.asarray(pose.crop_spec.input_size, dtype=np.int64),
+            video_wh=video_wh,
+        )
+    return per_camera
+
+
+def log_keypoints_overlay(per_camera: dict[str, CameraKeypoints], recording: rr.RecordingStream) -> None:
+    """Draw the AssemblyHands-X-gated skeleton on every ``OVERLAY_LOG_STRIDE``-th frame, with the rejected joints beside it.
+
+    Visualization only: the refine stage recomputes the same gate from the raw
+    record. Joints the gate zeroes are NaN'd on the skeleton entity (the only
+    per-keypoint mechanism that also suppresses their edges) and shown raw,
+    connectionless, on the ``…_rejected`` sibling.
+    """
+    for name, cam in per_camera.items():
+        entity: str = kp2d_entity(name)
+        rejected_entity: str = f"{entity}_rejected"
+        log_coco133_class_context(recording, entity, (ClassSpec(0, KP2D_LABEL, OVERLAY_COLOR),))
+        log_coco133_class_context(recording, rejected_entity, (ClassSpec(0, f"{KP2D_LABEL} rejected", RAW_COLOR),), connections=False)
+        gated: GatedKeypoints = postprocess_confidences(cam, AHX_MEDIAN_WINDOW, AHX_MARGIN_PX, AHX_CONF_TAU)
+        for t in range(0, len(cam.sample_indices), OVERLAY_LOG_STRIDE):
+            if not np.isfinite(cam.kp_xy[t]).any():
+                continue
+            keep_mask: Bool[ndarray, "133"] = gated.conf[t] > 0.0
+            gated_xy: Float64[ndarray, "133 2"] = gated.xy[t].copy()
+            gated_xy[~keep_mask] = np.nan
+            rejected_mask: Bool[ndarray, "133"] = ~keep_mask & np.isfinite(cam.kp_xy[t]).all(axis=1)
+            recording.set_time(TIMELINE, duration=1e-9 * float(cam.times_ns[t]))
+            recording.log(entity, Points2DWithConfidence(positions=gated_xy, confidences=gated.conf[t], class_ids=0, keypoint_ids=np.arange(133), radii=2.0))
+            recording.log(
+                rejected_entity,
+                Points2DWithConfidence(
+                    positions=cam.kp_xy[t][rejected_mask],
+                    confidences=cam.conf[t][rejected_mask],
+                    class_ids=0,
+                    keypoint_ids=np.flatnonzero(rejected_mask),
+                    radii=1.5,
+                ),
+            )
+
+
+def main(config: Keypoints2dConfig, camera_variant: CalibrationVariant = "init") -> None:
+    """Run Stage B over all exo cameras and (optionally) register the layer.
+
+    ``camera_variant`` selects the rig the tracker projects through: the Stage A
+    estimate on the first pass, the refined rig on the second (the pipeline
+    driver runs both).
+    """
+    from posekit.models.rtmpose import RtmPoseConfig
+    from posekit.models.yolox import YoloxDetectorConfig
+    from posekit.runtimes import TensorRtBackendConfig
+
+    context: StageContext = stage_context(config.stage)
+    names: tuple[str, ...] = context.layout.exo_camera_names
+    streams: ExoVideoStreams = open_exo_streams(context.dataset, context.segment_id, names)
+    detector: PersonDetector = YoloxDetectorConfig(score_thr=DETECTION_SCORE_THRESHOLD, backend=TensorRtBackendConfig(max_batch_size=config.batch_size)).setup()
+    pose: RtmPose2d = RtmPoseConfig(variant="rtmw-x-coco133", backend=TensorRtBackendConfig(max_batch_size=config.batch_size)).setup()
+    cameras: RigCameras = read_rig_cameras(context.dataset, context.segment_id, names, source=camera_variant)
+
+    per_camera: dict[str, CameraKeypoints] = track_multiview_keypoints(streams, detector, pose, cameras)
+    for name, cam in per_camera.items():
+        detected: int = int(np.isfinite(cam.bbox_xyxy).all(axis=1).sum())
+        tracked: int = sum(source == "tracked" for source in cam.box_source)
+        positive_conf: Float32[ndarray, " n"] = cam.conf[cam.conf > 0]
+        mean_conf: float = float(positive_conf.mean()) if positive_conf.size else 0.0
+        print(f"{name}: {detected}/{len(cam.sample_indices)} frames with a box (tracked {tracked}, yolox {detected - tracked}), mean conf {mean_conf:.3f}")
+
+    recording, rrd_path = new_layer_recording(context.segment_id, context.segment_dir / f"{KP2D_LAYER}.rrd")
+    log_keypoints_record(per_camera, recording)
+    log_keypoints_overlay(per_camera, recording)
+    recording.flush(timeout_sec=30.0)
+    print(f"wrote {rrd_path}")
+    if config.stage.register:
+        register_layer(context.dataset, rrd_path, KP2D_LAYER)
+        print(f"registered layer {KP2D_LAYER}")

--- a/packages/exo-calib/exo_calib/catalog_io.py
+++ b/packages/exo-calib/exo_calib/catalog_io.py
@@ -1,0 +1,132 @@
+"""Catalog access for the exo-calib pipeline: the shared stage config, connection, segment selection, and rig discovery.
+
+The rig schema itself (``/world/rig_XX/cam_YY``, moving rigs, calibration
+presence, rig kinds) is parsed by ``simplecv.catalog_rig_layout``; this module
+adds the exo-calib policy of which rigs are the exo cameras to calibrate.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pyarrow as pa
+from rerun.catalog import CatalogClient, DatasetEntry
+from simplecv.catalog_rig_layout import CatalogRigLayout, catalog_components, parse_rig_layout, read_rig_kinds
+
+from exo_calib.layer_io import PIPELINE_CALIBRATION_MARKER
+
+DEFAULT_CATALOG_URL: str = "rerun+http://127.0.0.1:9988"
+DEFAULT_DATASET_NAME: str = "assembly101"
+
+
+@dataclass
+class StageConfig:
+    """What every exo-calib stage needs to find its segment; stage configs add their own knobs on top."""
+
+    catalog_url: str = DEFAULT_CATALOG_URL
+    """Rerun catalog server URL."""
+    dataset_name: str = DEFAULT_DATASET_NAME
+    """Catalog dataset holding the registered segment."""
+    segment_id: str | None = None
+    """Segment to process; ``None`` uses the dataset's single segment."""
+    exo_rigs: tuple[str, ...] | None = None
+    """Explicit exo rig names such as ``rig_00 rig_01``; ``None`` discovers them from catalog metadata."""
+    output_dir: Path = Path("data/outputs")
+    """Directory for the generated layer RRDs (one subdirectory per segment) and ``eval.json``."""
+    register: bool = True
+    """Register what the stage writes into the catalog; off for a dry run that only writes files."""
+
+
+@dataclass(slots=True, frozen=True)
+class RigLayout:
+    """Discovered exo and ego camera entity names for one catalog segment."""
+
+    exo_camera_names: tuple[str, ...]
+    """Exo camera names under ``/world``, in rig/camera index order."""
+    ego_camera_names: tuple[str, ...]
+    """Ego camera names under ``/world``, in rig/camera index order."""
+    calibrated_camera_names: tuple[str, ...]
+    """Cameras whose base layer already carries a static ``Transform3D`` and a
+    ``Pinhole`` (dataset ground truth). Cameras missing from this tuple have no
+    calibration on their base node, so the pipeline may write its own there."""
+
+
+@dataclass(slots=True, frozen=True)
+class StageContext:
+    """A stage's resolved target: the connected dataset, the one segment, its rig layout, and its output directory."""
+
+    dataset: DatasetEntry
+    segment_id: str
+    layout: RigLayout
+    segment_dir: Path
+
+
+def select_rig_layout(layout: CatalogRigLayout, *, exo_rigs: tuple[str, ...] | None = None) -> RigLayout:
+    """Split a catalog rig layout into the exo cameras to calibrate and the ego cameras.
+
+    Exo rigs are those the writer tagged ``kind == "exo"``, plus any untagged static
+    rig with dataset calibration (a base layer that predates rig kinds). Tagged
+    ``ego`` and ``quest`` rigs are worn devices and never exo. Calibration the
+    pipeline wrote itself (marked ``exocalib_written``) does not count as dataset
+    ground truth.
+
+    Args:
+        layout: Every rig camera with a video stream.
+        exo_rigs: Explicit exo rig names such as ``("rig_00", "rig_01")`` — the
+            escape hatch for recordings without rig kinds or calibration.
+
+    Returns:
+        Exo, ego, and ground-truth-calibrated camera names.
+    """
+    if not layout.cameras:
+        raise ValueError("no rig camera videos were found in the catalog schema")
+    calibrated: tuple[str, ...] = tuple(
+        camera.name for camera in layout.cameras if camera.has_calibration and PIPELINE_CALIBRATION_MARKER not in camera.camera_node_components
+    )
+    if exo_rigs is not None:
+        selected_exo_rigs: set[str] = {rig.removeprefix("/world/") for rig in exo_rigs}
+        unknown_rigs: set[str] = selected_exo_rigs - set(layout.rigs)
+        if unknown_rigs:
+            raise ValueError(f"exo-rigs override names rigs without video: {sorted(unknown_rigs)}")
+    else:
+        selected_exo_rigs = {camera.rig for camera in layout.cameras if camera.rig_kind == "exo"}
+        selected_exo_rigs.update(
+            camera.rig for camera in layout.cameras if camera.name in calibrated and not camera.rig_is_moving and camera.rig_kind is None
+        )
+    if not selected_exo_rigs:
+        raise ValueError("could not discover any exo rigs; pass --exo-rigs explicitly")
+    return RigLayout(
+        exo_camera_names=tuple(camera.name for camera in layout.cameras if camera.rig in selected_exo_rigs),
+        ego_camera_names=tuple(camera.name for camera in layout.cameras if camera.rig not in selected_exo_rigs),
+        calibrated_camera_names=calibrated,
+    )
+
+
+def discover_rig_layout(dataset: DatasetEntry, segment_id: str, *, exo_rigs: tuple[str, ...] | None = None) -> RigLayout:
+    """Discover one segment's exo/ego camera layout from its catalog schema and rig-kind metadata."""
+    components = catalog_components(dataset.schema())
+    rigs: tuple[str, ...] = parse_rig_layout(components).rigs
+    layout: CatalogRigLayout = parse_rig_layout(components, read_rig_kinds(dataset, segment_id, rigs))
+    return select_rig_layout(layout, exo_rigs=exo_rigs)
+
+
+def connect_dataset(catalog_url: str = DEFAULT_CATALOG_URL, dataset_name: str = DEFAULT_DATASET_NAME) -> DatasetEntry:
+    """Connect to the running catalog and return the dataset entry."""
+    client: CatalogClient = CatalogClient(catalog_url)
+    return client.get_dataset(dataset_name)
+
+
+def only_segment_id(dataset: DatasetEntry) -> str:
+    """Return the id of the dataset's single segment, failing on any other count."""
+    table: pa.Table = pa.Table.from_batches(dataset.segment_table().collect())
+    segment_ids: list[str] = [str(v) for v in table.column("rerun_segment_id").to_pylist()]
+    if len(segment_ids) != 1:
+        raise ValueError(f"expected exactly one segment, found {segment_ids}")
+    return segment_ids[0]
+
+
+def stage_context(config: StageConfig) -> StageContext:
+    """Resolve a stage config: connect, pick the segment (``None`` means the dataset's only one), discover the rig."""
+    dataset: DatasetEntry = connect_dataset(config.catalog_url, config.dataset_name)
+    segment_id: str = config.segment_id or only_segment_id(dataset)
+    layout: RigLayout = discover_rig_layout(dataset, segment_id, exo_rigs=config.exo_rigs)
+    return StageContext(dataset=dataset, segment_id=segment_id, layout=layout, segment_dir=config.output_dir / segment_id)

--- a/packages/exo-calib/exo_calib/kp2d_layer.py
+++ b/packages/exo-calib/exo_calib/kp2d_layer.py
@@ -1,0 +1,130 @@
+"""Stage B's catalog record: the ``exocalib_kp2d`` layer's ``…_raw`` entities, written once and queried back by refinement.
+
+Every array :func:`log_keypoints_record` writes round-trips exactly through
+:func:`load_stage_b` (all components are logged at their native dtypes). The
+gated skeleton overlay that shares the layer is visualization owned by the
+Stage B tool, not part of this record.
+"""
+
+
+import numpy as np
+import pyarrow as pa
+import rerun as rr
+from jaxtyping import Int64
+from numpy import ndarray
+from rerun.catalog import DatasetEntry
+from simplecv.rerun_custom_types import Points2DWithConfidence
+from simplecv.rrd_query_utils import first_valid_value_as
+
+from exo_calib.keypoints import BOX_SOURCE_BY_NAME, BoxSource, CameraKeypoints
+from exo_calib.layer_io import KP2D_LAYER, TIMELINE, ClassSpec, log_coco133_class_context, pinhole_entity
+
+KP2D_LABEL: str = "rtmw-x kp2d"
+RAW_COLOR: tuple[int, int, int] = (110, 110, 110)
+
+
+def kp2d_entity(camera_name: str) -> str:
+    """Stage B's gated overlay entity under a camera's pinhole; ``_raw`` / ``_bbox`` / ``_crop`` / ``_rejected`` are its siblings."""
+    return f"{pinhole_entity(camera_name)}/{KP2D_LAYER}"
+
+
+def kp2d_raw_entity(camera_name: str) -> str:
+    """Stage B's queryable data record for one camera."""
+    return f"{kp2d_entity(camera_name)}_raw"
+
+
+def log_keypoints_record(per_camera: dict[str, CameraKeypoints], recording: rr.RecordingStream) -> None:
+    """Log every frame's raw keypoints, confidences, box and crop rectangle under each camera's ``…_raw`` entity.
+
+    The person box and crop rectangle are also drawn as ``Boxes2D`` siblings so the
+    tracked / detected provenance is visible per frame.
+    """
+    for name, cam in per_camera.items():
+        entity: str = kp2d_entity(name)
+        raw_entity: str = kp2d_raw_entity(name)
+        log_coco133_class_context(recording, raw_entity, (ClassSpec(0, f"{KP2D_LABEL} raw", RAW_COLOR),), connections=False)
+        recording.log(raw_entity, rr.AnyValues(crop_input_wh=cam.crop_input_wh, video_wh=cam.video_wh), static=True)
+        for t in range(len(cam.sample_indices)):
+            box_source: BoxSource = cam.box_source[t]
+            recording.set_time(TIMELINE, duration=1e-9 * float(cam.times_ns[t]))
+            recording.log(
+                raw_entity,
+                Points2DWithConfidence(positions=cam.kp_xy[t], confidences=cam.conf[t], class_ids=0, keypoint_ids=np.arange(133), radii=1.0),
+            )
+            recording.log(
+                raw_entity,
+                rr.AnyValues(
+                    sample_idx=cam.sample_indices[t : t + 1],
+                    box_source=box_source,
+                    bbox_xyxy=cam.bbox_xyxy[t],
+                    crop_origin_xy=cam.crop_origin_xy[t],
+                    crop_size_wh=cam.crop_size_wh[t],
+                ),
+            )
+            detected: bool = bool(np.isfinite(cam.bbox_xyxy[t]).all())
+            recording.log(
+                f"{entity}_bbox",
+                rr.Boxes2D(
+                    array=cam.bbox_xyxy[t : t + 1] if detected else np.zeros((0, 4), dtype=np.float32),
+                    array_format=rr.Box2DFormat.XYXY,
+                    colors=(0, 200, 255) if box_source == "tracked" else (240, 140, 60),
+                    labels=[box_source] if detected else [],
+                ),
+            )
+            recording.log(f"{entity}_bbox", rr.AnyValues(box_source=box_source))
+            recording.log(
+                f"{entity}_crop",
+                rr.Boxes2D(
+                    array=np.concatenate((cam.crop_origin_xy[t], cam.crop_size_wh[t]))[None] if detected else np.zeros((0, 4), dtype=np.float32),
+                    array_format=rr.Box2DFormat.XYWH,
+                    colors=RAW_COLOR,
+                ),
+            )
+
+
+def load_stage_b(dataset: DatasetEntry, segment_id: str, names: tuple[str, ...]) -> dict[str, CameraKeypoints]:
+    """Query Stage B's raw record back from the registered ``exocalib_kp2d`` layer.
+
+    Raises:
+        ValueError: If a camera's record is missing a component, or the reader returned rows out of timeline order.
+    """
+    return {name: _load_camera_keypoints(dataset, segment_id, name) for name in names}
+
+
+def _load_camera_keypoints(dataset: DatasetEntry, segment_id: str, name: str) -> CameraKeypoints:
+    raw_entity: str = kp2d_raw_entity(name)
+    view = dataset.filter_segments(segment_id).filter_contents([raw_entity])
+    # No client-side sort: the reader yields index order (simplecv's segment decoder relies on the same
+    # contract), and a sort would re-materialize the per-frame keypoint columns. The guard below fails loudly.
+    table: pa.Table = view.reader(index=TIMELINE).to_arrow_table()
+    times_ns: Int64[ndarray, "t"] = table.column(TIMELINE).combine_chunks().cast(pa.int64()).to_numpy().astype(np.int64)
+    if np.any(times_ns[1:] < times_ns[:-1]):
+        raise ValueError(f"{raw_entity}: reader returned rows out of timeline order in segment {segment_id}")
+
+    def column(field_name: str) -> pa.ChunkedArray:
+        column_name: str = f"{raw_entity}:{field_name}"
+        if column_name not in table.column_names:
+            raise ValueError(f"{column_name} is missing from segment {segment_id}; rerun Stage B")
+        return table.column(column_name)
+
+    def static_wh(field_name: str) -> Int64[ndarray, "2"]:
+        return np.asarray(first_valid_value_as(column(field_name), list, component_name=f"{raw_entity}:{field_name}"), dtype=np.int64).reshape(2)
+
+    box_source: list[BoxSource] = []
+    for name in np.asarray(column("box_source").to_pylist(), dtype=str).reshape(-1):
+        source: BoxSource | None = BOX_SOURCE_BY_NAME.get(str(name))
+        if source is None:
+            raise ValueError(f"{raw_entity}: unknown box source {name!r}")
+        box_source.append(source)
+    return CameraKeypoints(
+        sample_indices=np.asarray([v[0] for v in column("sample_idx").to_pylist()], dtype=np.int64),
+        times_ns=times_ns,
+        kp_xy=np.asarray(column("Points2D:positions").to_pylist(), dtype=np.float32),
+        conf=np.asarray(column("simplecv.KeypointConfidence2D:confidences").to_pylist(), dtype=np.float32),
+        bbox_xyxy=np.asarray(column("bbox_xyxy").to_pylist(), dtype=np.float32),
+        box_source=tuple(box_source),
+        crop_origin_xy=np.asarray(column("crop_origin_xy").to_pylist(), dtype=np.float32),
+        crop_size_wh=np.asarray(column("crop_size_wh").to_pylist(), dtype=np.float32),
+        crop_input_wh=static_wh("crop_input_wh"),
+        video_wh=static_wh("video_wh"),
+    )

--- a/packages/exo-calib/exo_calib/layer_io.py
+++ b/packages/exo-calib/exo_calib/layer_io.py
@@ -1,0 +1,259 @@
+"""The exocalib catalog layers: names, entity paths, and each stage's record.
+
+Every stage writes one layer onto the source segment and later stages query it
+back — the catalog is the pipeline's only stage store. This module owns that
+contract: which layer carries what, under which entity, with which components.
+Stage B's keypoint record lives in :mod:`exo_calib.kp2d_layer`.
+
+Base layer (written by the dataset converter; read here for the cameras):
+- exo videos:   ``/world/rig_XX/cam_YY/pinhole/video`` (``VideoStream``)
+- intrinsics:   ``/world/rig_XX/cam_YY/pinhole:Pinhole:image_from_camera``
+- extrinsics:   ``/world/rig_XX/cam_YY:Transform3D:{mat3x3,translation}`` — logged by
+  simplecv ``log_pinhole`` with ``from_parent=True``, so they ARE cam_R_world / cam_t_world.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, NamedTuple, TypeAlias, get_args
+
+import numpy as np
+import pyarrow as pa
+import rerun as rr
+from jaxtyping import Bool, Float64, Int64
+from numpy import ndarray
+from rerun.catalog import DatasetEntry, OnDuplicateSegmentLayer
+from simplecv.camera_parameters import Extrinsics, Intrinsics, PinholeParameters
+from simplecv.catalog_calibration import read_camera_calibration
+from simplecv.data.skeleton.coco_133 import COCO_133_ID2NAME, COCO_133_LINKS
+from simplecv.rerun_custom_types import Points3DWithConfidence
+from simplecv.rerun_log_utils import log_pinhole
+from simplecv.rrd_query_utils import first_valid_value_as
+
+from exo_calib.cameras import RigCameras
+from exo_calib.correspondences import ObservationSet
+
+TIMELINE: str = "video_time"
+APPLICATION_ID: str = "exocalib"
+EXOCALIB_ROOT: str = "/world/exocalib"
+INIT_LAYER: str = "exocalib_init"
+KP2D_LAYER: str = "exocalib_kp2d"
+REFINED_LAYER: str = "exocalib_refined"
+ALIGN_LAYER: str = "exocalib_align"
+PIPELINE_CALIBRATION_MARKER: str = "exocalib_written"
+"""Static ``AnyValues`` field the refine stage logs on a base camera node whose
+``Transform3D``/``Pinhole`` it wrote itself (no dataset ground truth there).
+Discovery excludes such cameras from ``calibrated_camera_names``."""
+IMAGE_PLANE_DISTANCE_M: float = 0.1
+"""Frustum size of the pipeline's camera layers; the base layer's GT frusta use the same, so the two compare visually."""
+
+CalibrationVariant: TypeAlias = Literal["init", "refined"]
+"""The two camera sets the pipeline writes: Stage A's estimate and the refined rig."""
+CALIBRATION_VARIANTS: tuple[CalibrationVariant, ...] = get_args(CalibrationVariant)
+VARIANT_COLOR: dict[CalibrationVariant, tuple[int, int, int]] = {"init": (255, 214, 0), "refined": (0, 200, 255)}
+"""One colour per variant for everything the viewer draws about it: frusta, 3D keypoints, error lines."""
+CalibrationSource: TypeAlias = CalibrationVariant | Literal["ground_truth"]
+"""Where :func:`read_rig_cameras` reads from: a pipeline layer, or the dataset's base layer (evaluation only)."""
+
+
+class ClassSpec(NamedTuple):
+    """One class of a COCO-133 annotation context: id, viewer label, skeleton colour."""
+
+    class_id: int
+    label: str
+    color: tuple[int, int, int]
+
+
+def pinhole_entity(camera_name: str) -> str:
+    """Log-side entity path of a camera's pinhole node."""
+    return f"/world/{camera_name}/pinhole"
+
+
+def exocalib_entity(variant: CalibrationVariant) -> str:
+    """Entity path of an exocalib camera-rig variant."""
+    return f"{EXOCALIB_ROOT}/{variant}"
+
+
+def kp3d_entity(variant: CalibrationVariant) -> str:
+    """Entity path of an exocalib triangulated-keypoint variant."""
+    return f"{EXOCALIB_ROOT}/kp3d_{variant}"
+
+
+def new_layer_recording(segment_id: str, rrd_path: Path) -> tuple[rr.RecordingStream, Path]:
+    """Create a recording that saves near ``rrd_path`` and registers as a layer of ``segment_id``.
+
+    The recording id must equal the source segment id so the catalog attaches the
+    layer to the existing segment (mv-api ``catalog_prediction_layer`` pattern).
+    If ``rrd_path`` exists, a ``-N``-suffixed sibling is written instead: the
+    in-memory catalog server caches layer-file descriptors, so overwriting a
+    registered rrd in place serves stale data. Returns the recording and the
+    path actually written.
+    """
+    rrd_path.parent.mkdir(parents=True, exist_ok=True)
+    actual_path: Path = rrd_path
+    counter: int = 1
+    while actual_path.exists():
+        actual_path = rrd_path.with_name(f"{rrd_path.stem}-{counter}{rrd_path.suffix}")
+        counter += 1
+    recording: rr.RecordingStream = rr.RecordingStream(application_id=APPLICATION_ID, recording_id=segment_id)
+    recording.save(actual_path)
+    return recording, actual_path
+
+
+def register_layer(dataset: DatasetEntry, rrd_path: Path, layer_name: str) -> None:
+    """Register a generated RRD as a catalog layer, replacing any existing one."""
+    dataset.register([rrd_path.resolve().as_uri()], layer_name=layer_name, on_duplicate=OnDuplicateSegmentLayer.REPLACE).wait()
+
+
+def log_coco133_class_context(recording: rr.RecordingStream, entity: str, classes: tuple[ClassSpec, ...], connections: bool = True) -> None:
+    """Log a COCO-133 annotation context the simplecv exoego way.
+
+    One class per skeleton instance: keypoint links render in the class color,
+    so each logged keypoint set (GT / init / refined / 2D detections) is
+    distinguishable by the color of its skeleton. ``connections=False`` keeps
+    the keypoint names (hover) but draws no skeleton edges.
+    """
+    recording.log(
+        entity,
+        rr.AnnotationContext(
+            [
+                rr.ClassDescription(
+                    info=rr.AnnotationInfo(id=spec.class_id, label=spec.label, color=spec.color),
+                    keypoint_annotations=[rr.AnnotationInfo(id=i, label=n) for i, n in COCO_133_ID2NAME.items()],
+                    keypoint_connections=COCO_133_LINKS if connections else [],
+                )
+                for spec in classes
+            ]
+        ),
+        static=True,
+    )
+
+
+def log_cameras_layer(
+    cameras: RigCameras, resolution_wh: tuple[int, int], entity_prefix: str, recording: rr.RecordingStream, *, color: tuple[int, int, int]
+) -> None:
+    """Log a camera rig as static pinhole frusta under ``entity_prefix``, drawn in ``color`` (see :data:`VARIANT_COLOR`)."""
+    for i, name in enumerate(cameras.names):
+        pinhole_intrinsics: Intrinsics = Intrinsics(
+            camera_conventions="RDF", k_matrix=cameras.intrinsics[i], width=resolution_wh[0], height=resolution_wh[1]
+        )
+        extrinsics: Extrinsics = Extrinsics(cam_R_world=cameras.cam_T_world[i][:3, :3], cam_t_world=cameras.cam_T_world[i][:3, 3])
+        pinhole: PinholeParameters = PinholeParameters(name=name.replace("/", "_"), intrinsics=pinhole_intrinsics, extrinsics=extrinsics)
+        log_pinhole(pinhole, Path(f"{entity_prefix}/{name}"), image_plane_distance=IMAGE_PLANE_DISTANCE_M, static=True, recording=recording)
+        recording.log(f"{entity_prefix}/{name}/pinhole", rr.Pinhole.from_fields(color=color), static=True)
+
+
+def read_rig_cameras(dataset: DatasetEntry, segment_id: str, names: tuple[str, ...], *, source: CalibrationSource) -> RigCameras:
+    """Read a rig's intrinsics and extrinsics back from a catalog layer.
+
+    Args:
+        dataset: Catalog dataset entry.
+        segment_id: Segment to read.
+        names: Camera entity names, e.g. ``rig_00/cam_00``.
+        source: ``"init"`` / ``"refined"`` read the pipeline's own frusta layers (the stage store for
+            camera parameters); ``"ground_truth"`` reads the dataset's base layer — evaluation only,
+            never inside the pipeline.
+
+    Returns:
+        The rig's camera parameters in float64.
+    """
+    root: str = "/world" if source == "ground_truth" else exocalib_entity(source)
+    calibration: dict[str, PinholeParameters] = read_camera_calibration(dataset, segment_id, [f"{root}/{name}" for name in names])
+    intrinsics: Float64[ndarray, "v 3 3"] = np.stack([np.asarray(calibration[f"{root}/{name}"].intrinsics.k_matrix, dtype=np.float64) for name in names])
+    cam_T_world: Float64[ndarray, "v 4 4"] = np.stack([np.asarray(calibration[f"{root}/{name}"].extrinsics.cam_T_world, dtype=np.float64) for name in names])
+    return RigCameras(names=names, intrinsics=intrinsics, cam_T_world=cam_T_world)
+
+
+@dataclass(slots=True, frozen=True)
+class RefinementDiagnostics:
+    """What the refine stage reports about its own run; static ``AnyValues`` on the refined rig entity, copied into ``eval.json``."""
+
+    init_reprojection_px: float
+    """Mean reprojection error of the robustly triangulated points against the Stage A cameras."""
+    ba_reprojection_px: list[float]
+    """Mean reprojection error after each bundle-adjustment round, then after the focal stage (and the rotation guard, when it fired)."""
+    observation_count_per_view: list[int]
+    """Observations that survived robust triangulation, per camera."""
+    metric_rescale_fix: float
+    """Global scale applied after BA from MoGe-2 depth; ``1.0`` when the estimate was skipped."""
+    focal_scale: list[float]
+    """Per-camera focal multiplier from the focal stage."""
+
+
+def log_refinement_diagnostics(recording: rr.RecordingStream, diagnostics: RefinementDiagnostics) -> None:
+    """Write the refinement diagnostics next to the refined cameras."""
+    recording.log(
+        exocalib_entity("refined"),
+        rr.AnyValues(
+            init_reprojection_px=np.array([diagnostics.init_reprojection_px]),
+            ba_reprojection_px=np.asarray(diagnostics.ba_reprojection_px, dtype=np.float64),
+            observation_count_per_view=np.asarray(diagnostics.observation_count_per_view, dtype=np.int64),
+            metric_rescale_fix=np.array([diagnostics.metric_rescale_fix]),
+            focal_scale=np.asarray(diagnostics.focal_scale, dtype=np.float64),
+        ),
+        static=True,
+    )
+
+
+def read_refinement_diagnostics(dataset: DatasetEntry, segment_id: str) -> RefinementDiagnostics:
+    """Read the diagnostics written by :func:`log_refinement_diagnostics`.
+
+    Raises:
+        ValueError: If the refined layer is missing a diagnostic column (rerun the refine stage).
+    """
+    entity: str = exocalib_entity("refined")
+    table: pa.Table = dataset.filter_segments(segment_id).filter_contents([entity]).reader(index=None).to_arrow_table()
+
+    def static_list(field_name: str) -> list[float]:
+        column_name: str = f"{entity}:{field_name}"
+        if column_name not in table.column_names:
+            raise ValueError(f"{column_name} is missing from segment {segment_id}; rerun the refine stage")
+        return np.asarray(first_valid_value_as(table.column(column_name), list, component_name=column_name), dtype=np.float64).reshape(-1).tolist()
+
+    return RefinementDiagnostics(
+        init_reprojection_px=static_list("init_reprojection_px")[0],
+        ba_reprojection_px=static_list("ba_reprojection_px"),
+        observation_count_per_view=[int(item) for item in static_list("observation_count_per_view")],
+        metric_rescale_fix=static_list("metric_rescale_fix")[0],
+        focal_scale=static_list("focal_scale"),
+    )
+
+
+def log_point_tracks(
+    recording: rr.RecordingStream,
+    entity: str,
+    obs: ObservationSet,
+    points_xyz: Float64[ndarray, "n 3"],
+    conf: Float64[ndarray, " n"],
+    times_ns: Int64[ndarray, "t"],
+    class_id: int,
+) -> None:
+    """Log triangulated points frame-by-frame with per-point Kineo confidences."""
+    for frame in np.unique(obs.point_frame_idx):
+        rows: Int64[ndarray, " m"] = np.nonzero(obs.point_frame_idx == frame)[0]
+        points: Float64[ndarray, "m 3"] = points_xyz[rows]
+        keep: Bool[ndarray, " m"] = np.isfinite(points).all(axis=1)
+        if not keep.any():
+            continue
+        recording.set_time(TIMELINE, duration=1e-9 * float(times_ns[int(frame)]))
+        recording.log(
+            entity,
+            Points3DWithConfidence(
+                positions=points[keep],
+                confidences=conf[rows][keep],
+                class_ids=class_id,
+                keypoint_ids=obs.point_joint_idx[rows][keep].astype(np.int64),
+                radii=0.008,
+            ),
+        )
+
+
+def write_base_calibration(recording: rr.RecordingStream, cameras: RigCameras, resolution_wh: tuple[int, int]) -> None:
+    """Write a refined calibration onto base camera nodes that carry no dataset ground truth.
+
+    Datasets without ground truth (wildcap) leave the base camera nodes bare, so
+    their video and 2D keypoints cannot be placed in 3D. The marker tells rig
+    discovery that this calibration is the pipeline's own, not ground truth.
+    """
+    log_cameras_layer(cameras, resolution_wh, "/world", recording, color=VARIANT_COLOR["refined"])
+    for name in cameras.names:
+        recording.log(f"/world/{name}", rr.AnyValues(**{PIPELINE_CALIBRATION_MARKER: True}), static=True)

--- a/packages/exo-calib/exo_calib/video_io.py
+++ b/packages/exo-calib/exo_calib/video_io.py
@@ -1,0 +1,62 @@
+"""NVDEC video streams over the catalog's exo cameras.
+
+Split from ``catalog_io`` so CLIs that never decode video (report, blueprint)
+do not pay the torch + torchcodec import cost (~1.2 s warm).
+"""
+
+from dataclasses import dataclass
+
+import torch
+from jaxtyping import Shaped, UInt8
+from numpy import ndarray
+from rerun.catalog import DatasetEntry
+from torch import Tensor
+from torchcodec.decoders import VideoDecoder
+
+from exo_calib.layer_io import TIMELINE
+
+MP4_NOMINAL_FPS: int = 30
+"""Frame rate written into the MP4 wrapper around the catalog packets. Frames are addressed by sample
+index and timestamps come from the catalog, so this only labels the container; it is not a capture property."""
+
+
+@dataclass(slots=True)
+class ExoVideoStreams:
+    """Per-camera NVDEC decoders over one segment's exo videos."""
+
+    names: tuple[str, ...]
+    """Camera entity names, index-aligned with ``decoders``."""
+    times_ns: list[Shaped[ndarray, " n_samples"]]
+    """Per-camera sample timestamps (timedelta64[ns], timeline order)."""
+    decoders: list[VideoDecoder]
+    """One whole-segment torchcodec GPU decoder per camera."""
+
+    def frame_rgb(self, cam_idx: int, sample_idx: int) -> UInt8[ndarray, "h w 3"]:
+        """Decode one frame to a uint8 RGB HWC numpy array."""
+        frame: UInt8[Tensor, "3 h w"] = self.decoders[cam_idx].get_frame_at(sample_idx).data
+        return frame.permute(1, 2, 0).contiguous().cpu().numpy()
+
+
+def open_exo_streams(dataset: DatasetEntry, segment_id: str, names: tuple[str, ...]) -> ExoVideoStreams:
+    """Open one NVDEC decoder per exo camera from catalog video packets.
+
+    Each stream is fetched with one catalog query and muxed in its own codec
+    (``VideoStream:codec``: AV1, H.264 or H.265) by simplecv's segment decoder.
+
+    Args:
+        dataset: Catalog dataset entry.
+        segment_id: Segment whose packets are fetched.
+        names: Camera entity names under ``/world``.
+
+    Returns:
+        Decoders and per-camera sample timestamps.
+    """
+    from simplecv.rerun_dataloader import open_segment_decoder
+
+    times_per_camera: list[Shaped[ndarray, " n_samples"]] = []
+    decoders: list[VideoDecoder] = []
+    for name in names:
+        times, _, _, decoder = open_segment_decoder(dataset, segment_id, f"world/{name}/pinhole/video", TIMELINE, torch.device("cuda"), MP4_NOMINAL_FPS)
+        times_per_camera.append(times)
+        decoders.append(decoder)
+    return ExoVideoStreams(names=names, times_ns=times_per_camera, decoders=decoders)

--- a/packages/exo-calib/tests/test_catalog_io.py
+++ b/packages/exo-calib/tests/test_catalog_io.py
@@ -1,0 +1,96 @@
+from simplecv.catalog_rig_layout import CatalogCamera, CatalogRigLayout
+
+from exo_calib.catalog_io import RigLayout, select_rig_layout
+from exo_calib.layer_io import PIPELINE_CALIBRATION_MARKER
+
+
+def _camera(
+    rig: str,
+    camera: str = "cam_00",
+    *,
+    kind: str | None = None,
+    moving: bool = False,
+    calibrated: bool = False,
+    markers: tuple[str, ...] = (),
+) -> CatalogCamera:
+    return CatalogCamera(
+        rig=rig,
+        camera=camera,
+        rig_kind=kind,
+        rig_is_moving=moving,
+        has_calibration=calibrated,
+        camera_node_components=frozenset(("Transform3D:translation", *markers) if calibrated else markers),
+    )
+
+
+def test_static_calibrated_rigs_are_exo_and_the_moving_rig_is_ego() -> None:
+    layout: CatalogRigLayout = CatalogRigLayout(
+        cameras=(
+            _camera("rig_00", calibrated=True),
+            _camera("rig_01", calibrated=True),
+            _camera("rig_02", calibrated=True),
+            _camera("rig_03", moving=True),
+            _camera("rig_03", "cam_01", moving=True),
+        )
+    )
+
+    selected: RigLayout = select_rig_layout(layout)
+
+    assert selected.exo_camera_names == ("rig_00/cam_00", "rig_01/cam_00", "rig_02/cam_00")
+    assert selected.ego_camera_names == ("rig_03/cam_00", "rig_03/cam_01")
+    assert selected.calibrated_camera_names == selected.exo_camera_names
+
+
+def test_rig_kinds_select_exo_rigs_without_calibration() -> None:
+    layout: CatalogRigLayout = CatalogRigLayout(
+        cameras=(_camera("rig_00", kind="exo"), _camera("rig_01", kind="exo"), _camera("rig_02", kind="ego"))
+    )
+
+    selected: RigLayout = select_rig_layout(layout)
+
+    assert selected.exo_camera_names == ("rig_00/cam_00", "rig_01/cam_00")
+    assert selected.ego_camera_names == ("rig_02/cam_00",)
+    assert selected.calibrated_camera_names == ()
+
+
+def test_tagged_ego_and_quest_rigs_are_never_exo_even_when_calibrated() -> None:
+    layout: CatalogRigLayout = CatalogRigLayout(
+        cameras=(_camera("rig_00", kind="exo", calibrated=True), _camera("rig_01", kind="quest", calibrated=True), _camera("rig_02", kind="ego", calibrated=True))
+    )
+
+    selected: RigLayout = select_rig_layout(layout)
+
+    assert selected.exo_camera_names == ("rig_00/cam_00",)
+    assert selected.ego_camera_names == ("rig_01/cam_00", "rig_02/cam_00")
+
+
+def test_exo_rigs_override_is_the_escape_hatch() -> None:
+    layout: CatalogRigLayout = CatalogRigLayout(cameras=tuple(_camera(f"rig_{idx:02d}") for idx in range(3)))
+
+    selected: RigLayout = select_rig_layout(layout, exo_rigs=("rig_00", "rig_02"))
+
+    assert selected.exo_camera_names == ("rig_00/cam_00", "rig_02/cam_00")
+    assert selected.ego_camera_names == ("rig_01/cam_00",)
+
+
+def test_calibrated_cameras_are_reported_beside_kind_tagged_rigs() -> None:
+    layout: CatalogRigLayout = CatalogRigLayout(
+        cameras=(_camera("rig_00", calibrated=True), _camera("rig_01", kind="exo"), _camera("rig_02", kind="ego"))
+    )
+
+    selected: RigLayout = select_rig_layout(layout)
+
+    assert selected.exo_camera_names == ("rig_00/cam_00", "rig_01/cam_00")
+    assert selected.ego_camera_names == ("rig_02/cam_00",)
+    assert selected.calibrated_camera_names == ("rig_00/cam_00",)
+
+
+def test_pipeline_written_base_calibration_is_not_ground_truth() -> None:
+    layout: CatalogRigLayout = CatalogRigLayout(
+        cameras=(_camera("rig_00", kind="exo", calibrated=True, markers=(PIPELINE_CALIBRATION_MARKER,)),)
+    )
+
+    selected: RigLayout = select_rig_layout(layout)
+
+    assert selected.exo_camera_names == ("rig_00/cam_00",)
+    assert selected.calibrated_camera_names == ()

--- a/packages/exo-calib/tests/test_ground_plane.py
+++ b/packages/exo-calib/tests/test_ground_plane.py
@@ -1,0 +1,52 @@
+"""Ground-plane selection must respect G3T's gravity prior, not just plane size."""
+
+import numpy as np
+import pytest
+
+from exo_calib.apis.calibrate_init import select_ground_plane
+
+UP = np.array([0.0, 0.0, 1.0])
+
+
+def _plane_points(normal: np.ndarray, point: np.ndarray, extent: float, n: int, rng: np.random.Generator) -> np.ndarray:
+    normal = normal / np.linalg.norm(normal)
+    helper = np.array([1.0, 0.0, 0.0]) if abs(normal[0]) < 0.9 else np.array([0.0, 1.0, 0.0])
+    u = np.cross(normal, helper)
+    u /= np.linalg.norm(u)
+    v = np.cross(normal, u)
+    coords = rng.uniform(-extent, extent, size=(n, 2))
+    return point[None] + coords[:, :1] * u[None] + coords[:, 1:] * v[None] + rng.normal(0.0, 0.005, size=(n, 1)) * normal[None]
+
+
+def test_dominant_wall_is_rejected_in_favour_of_the_floor() -> None:
+    rng = np.random.default_rng(0)
+    floor = _plane_points(UP, np.zeros(3), 2.0, 2000, rng)
+    wall = _plane_points(np.array([0.0, 1.0, 0.0]), np.array([0.0, 3.0, 1.5]), 3.0, 8000, rng)
+    cloud = np.concatenate([floor, wall])
+    camera_centers = np.array([[0.0, -2.0, 1.5], [1.0, -2.0, 1.4], [-1.0, -2.0, 1.6]])
+
+    up, ground_point = select_ground_plane(cloud, camera_centers, UP, distance_threshold=0.03, max_tilt_deg=60.0)
+
+    assert np.dot(up, UP) > 0.99
+    assert abs(ground_point[2]) < 0.05
+
+
+def test_floor_below_cameras_is_accepted_first_try() -> None:
+    rng = np.random.default_rng(1)
+    cloud = _plane_points(UP, np.zeros(3), 2.0, 3000, rng)
+    camera_centers = np.array([[0.0, -2.0, 1.5], [1.0, -2.0, 1.4]])
+
+    up, _ = select_ground_plane(cloud, camera_centers, UP, distance_threshold=0.03, max_tilt_deg=60.0)
+
+    assert np.dot(up, UP) > 0.99
+
+
+def test_no_acceptable_plane_falls_back_to_prior_and_lowest_camera() -> None:
+    rng = np.random.default_rng(2)
+    wall = _plane_points(np.array([0.0, 1.0, 0.0]), np.array([0.0, 3.0, 1.5]), 3.0, 3000, rng)
+    camera_centers = np.array([[0.0, -2.0, 1.5], [1.0, -2.0, 1.4]])
+
+    up, ground_point = select_ground_plane(wall, camera_centers, UP, distance_threshold=0.03, max_tilt_deg=60.0)
+
+    assert np.dot(up, UP) > 0.99
+    assert ground_point[2] == pytest.approx(camera_centers[:, 2].min(), abs=1e-9)

--- a/packages/exo-calib/tools/apps/calibrate_init.py
+++ b/packages/exo-calib/tools/apps/calibrate_init.py
@@ -1,0 +1,6 @@
+import tyro
+
+from exo_calib.apis.calibrate_init import InitCalibrationConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(InitCalibrationConfig, description="Stage A: G3T + MoGe-2 metric initial exo-camera calibration from the catalog."))

--- a/packages/exo-calib/tools/apps/keypoints2d.py
+++ b/packages/exo-calib/tools/apps/keypoints2d.py
@@ -1,0 +1,6 @@
+import tyro
+
+from exo_calib.apis.keypoints2d import Keypoints2dConfig, main
+
+if __name__ == "__main__":
+    main(tyro.cli(Keypoints2dConfig, description="Stage B: YOLOX + reprojection-tracked boxes + RTMW-x COCO-133 keypoints over the exo videos, from the catalog."))

--- a/pixi.toml
+++ b/pixi.toml
@@ -1432,6 +1432,18 @@ vggt = { git = "https://github.com/pablovela5620/vggt.git", rev = "5ed6ec88a951f
 PACKAGE_DIR = "packages/exo-calib"
 PYREFLY_TARGET = "exo_calib"
 
+[feature.exo-calib.tasks.exocalib-init]
+cmd = "python tools/apps/calibrate_init.py"
+cwd = "packages/exo-calib"
+env = { RERUN_INSECURE_SKIP_HOST_CHECK = "1" }
+description = "Stage A: G3T + MoGe-2 initial extrinsics/intrinsics, registered as exocalib_init"
+
+[feature.exo-calib.tasks.exocalib-kp2d]
+cmd = "python tools/apps/keypoints2d.py"
+cwd = "packages/exo-calib"
+env = { RERUN_INSECURE_SKIP_HOST_CHECK = "1" }
+description = "Stage B: reprojection-tracked boxes (YOLOX re-anchoring) + RTMW-x (TensorRT) COCO-133 keypoints over the whole capture, registered as exocalib_kp2d"
+
 # ═══════════════════════════════════════════════════════════════════════════
 # vistadream
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Re-lands #182, whose branch GitHub closed when the stack base branches were deleted after #178 merged; the review discussion and replies are on #. Same commit content, rebased onto main.

## What
- `catalog_io`: `StageConfig` (the six flags every stage shares) and `stage_context()` (connect, pick the segment, discover the rig). Exo/ego selection via `simplecv.catalog_rig_layout`; calibration the pipeline wrote never counts as ground truth.
- `layer_io`: the exocalib layer contract (layer names, entity paths, `CalibrationVariant`, camera frusta, `RefinementDiagnostics`, 3D tracks, base-node calibration write). `kp2d_layer`: the Stage B record round-trip.
- `video_io`: one NVDEC decoder per exo camera over catalog packets.
- Stage A `calibrate_init`: one synchronized frame per view → G3T → MoGe-2 metric scale → gravity-checked RANSAC floor → `exocalib_init`.
- Stage B `keypoints2d`: all views in lockstep; boxes projected from the 3D-tracked skeleton with a YOLOX re-anchor every 2 s; RTMW-x (TensorRT) COCO-133 keypoints → `exocalib_kp2d` plus a gated overlay.
- pixi tasks `exocalib-init`, `exocalib-kp2d`.

## Verified
ruff, pyrefly, vulture; 36 tests with beartype on (whole stack). End-to-end numbers are in #183.