### PR TITLE
monoprior/zipdepth: explicit output-range margin for the prompted ZipDepth head

### DIFF
--- a/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt.py
+++ b/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt.py
@@ -3,9 +3,16 @@
 The wrapper keeps the vendored ZipDepth-base tensors unchanged, injects a
 normalized metric prompt into all four decoder stages, and returns depth in the
 same units as the prompt (metres for the public API).
+
+The head can only reach depths inside the range it is rescaled into, which by
+default is the prompt's own ``[min, max]``. ``ZipDepthPrompt(range_margin=...)``
+widens that range by a fraction of the prompt span on each side, which ultrawide
+captures need: their prompt covers the image centre, so the periphery is often
+nearer or farther than anything the prompt saw.
 """
 
 from dataclasses import dataclass, field
+from math import isfinite
 from pathlib import Path
 from typing import Self
 
@@ -33,7 +40,11 @@ from monopriors.models.depth_completion.base_completion_depth import (
     PROMPT_INPUT_NAME,
     BaseCompletionPredictor,
 )
-from monopriors.models.zipdepth_checkpoint import load_zipdepth_state_dict
+from monopriors.models.zipdepth_checkpoint import (
+    load_zipdepth_checkpoint,
+    range_margin_from_checkpoint,
+    state_dict_from_checkpoint,
+)
 from monopriors.third_party.zipdepth.architecture import EncoderOutput, FeaturePyramid, ZipDepth, create_model
 from monopriors.third_party.zipdepth.model_utils import StateDict
 
@@ -82,15 +93,36 @@ def _inject_prompt(
 
 
 class ZipDepthPrompt(nn.Module):
-    """ZipDepth-base with PromptDA-style multi-scale metric conditioning."""
+    """ZipDepth-base with PromptDA-style multi-scale metric conditioning.
 
-    def __init__(self, backbone: ZipDepth | None = None) -> None:
+    The head is a sigmoid rescaled into a per-image depth range derived from the
+    prompt. ``range_margin`` widens that output range symmetrically, so predicted
+    depth is no longer trapped inside the prompt's own ``[min, max]``. The prompt
+    *normalization* fed to the four decoder injection branches deliberately keeps
+    the original ``[min, max]``: the prompt itself does not change, only the range
+    the head may reach, and holding the conditioning fixed keeps a margin change
+    from shifting the features a trained model already relies on.
+    """
+
+    def __init__(self, backbone: ZipDepth | None = None, *, range_margin: float = 0.0) -> None:
+        """Build the prompted wrapper.
+
+        Args:
+            backbone: ZipDepth-base network; ``None`` creates a fresh one.
+            range_margin: Fraction of the prompt span by which the head's output
+                range is widened past the prompt's own minimum and maximum. Zero
+                reproduces the prompt-bounded head exactly, emitting none of the
+                widening operations.
+        """
         super().__init__()
         self.backbone: ZipDepth = create_model(variant="base") if backbone is None else backbone
         if self.backbone.variant != "base":
             raise ValueError(f"ZipDepthPrompt requires the base variant, got {self.backbone.variant!r}")
         if not self.backbone.decoder.convex_up.use_unfold:
             raise ValueError("ZipDepthPrompt currently requires ZipDepth's unfold-based convex head")
+        if not isfinite(range_margin) or range_margin < 0.0:
+            raise ValueError(f"range_margin must be finite and non-negative, got {range_margin}")
+        self.range_margin: float = range_margin
         self.prompt_branches: nn.ModuleList = nn.ModuleList(
             [_make_prompt_branch(channels) for channels in (288, 192, 144, 96)]
         )
@@ -130,10 +162,15 @@ class ZipDepthPrompt(nn.Module):
         Float32[Tensor, "b 1 1 1"],
         Float32[Tensor, "b 1 1 1"],
     ]:
-        """Predict metric depth and expose the prompt range for TRT export.
+        """Predict metric depth and expose the head's output range for TRT export.
 
         The two scalar outputs force TensorRT to materialize the input-derived
         reductions. Normal callers use :meth:`forward` and receive depth only.
+
+        Returns:
+            Metric depth, and the minimum and maximum the head can reach. Those
+            two already include ``range_margin``, so ``sigmoid(logits) * (max -
+            min) + min`` reproduces depth from captured logits.
         """
         if image.dtype == torch.uint8:
             image_bchw: Float[Tensor, "b 3 h w"] = image.to(dtype=self.backbone.mean.dtype) / 255.0
@@ -165,6 +202,18 @@ class ZipDepthPrompt(nn.Module):
             0.0,
         )
 
+        # The head may leave the prompt's own range by ``range_margin`` spans on each
+        # side, still clipped to the shared validity window. At zero margin these
+        # operations are skipped entirely, so torch and the exported fp16 graph are
+        # unchanged. Prompt normalization above keeps the un-widened range.
+        min_output_b: Float32[Tensor, "b 1 1 1"] = min_depth_b
+        max_output_b: Float32[Tensor, "b 1 1 1"] = max_depth_b
+        span_output_b: Float32[Tensor, "b 1 1 1"] = span_b
+        if self.range_margin > 0.0:
+            min_output_b = (min_depth_b - self.range_margin * span_b).clamp_min(MIN_METRIC_DEPTH_M)
+            max_output_b = (max_depth_b + self.range_margin * span_b).clamp_max(MAX_METRIC_DEPTH_M)
+            span_output_b = (max_output_b - min_output_b).clamp_min(MIN_PROMPT_SPAN_M)
+
         normalized_image_bchw: Float[Tensor, "b 3 h w"] = (image_bchw - self.backbone.mean).div_(self.backbone.std)
         encoder_output: EncoderOutput = self.backbone.encoder(normalized_image_bchw)
         stem_half_bchw: Float[Tensor, "b c_half h_half w_half"] = encoder_output[0]
@@ -191,8 +240,8 @@ class ZipDepthPrompt(nn.Module):
         depth_logits_half_bchw: Float[Tensor, "b 1 h_half w_half"] = decoder.head_half(f_half_bchw)
         depth_logits_bchw: Float[Tensor, "b 1 h w"] = decoder.convex_up._forward_unfold(f_half_bchw, depth_logits_half_bchw)
         normalized_depth_bchw: Float[Tensor, "b 1 h w"] = torch.sigmoid(depth_logits_bchw)
-        metric_depth_bchw: Float[Tensor, "b 1 h w"] = normalized_depth_bchw * span_b + min_depth_b
-        return metric_depth_bchw, min_depth_b, max_depth_b
+        metric_depth_bchw: Float[Tensor, "b 1 h w"] = normalized_depth_bchw * span_output_b + min_output_b
+        return metric_depth_bchw, min_output_b, max_output_b
 
     def fuse_for_inference(self) -> Self:
         """Fuse the released ZipDepth backbone in place and enter eval mode."""
@@ -201,26 +250,32 @@ class ZipDepthPrompt(nn.Module):
         return self
 
 
-def load_zipdepth_prompt(checkpoint: Path) -> ZipDepthPrompt:
+def load_zipdepth_prompt(checkpoint: Path, range_margin: float | None = None) -> ZipDepthPrompt:
     """Load a complete released ZipDepth-base checkpoint into the wrapper.
 
     Args:
         checkpoint: Bare ZipDepth state dict or trainer checkpoint containing
             ``model_state_dict``. DDP and ``torch.compile`` prefixes are
             accepted.
+        range_margin: Output-range margin override. ``None`` takes the margin
+            the training run recorded in the checkpoint, which is ``0.0`` for
+            bare state dicts and for checkpoints written before the margin
+            existed.
 
     Returns:
         A trainable prompted model. Every released tensor is loaded strictly;
         prompt-branch tensors retain their zero-output initialization.
     """
-    state_dict: StateDict = load_zipdepth_state_dict(checkpoint)
+    loaded: dict[str, object] = load_zipdepth_checkpoint(checkpoint)
+    state_dict: StateDict = state_dict_from_checkpoint(loaded, checkpoint)
+    margin: float = range_margin if range_margin is not None else range_margin_from_checkpoint(loaded, checkpoint)
     if any(key.startswith("backbone.") for key in state_dict):
-        prompted_model: ZipDepthPrompt = ZipDepthPrompt()
+        prompted_model: ZipDepthPrompt = ZipDepthPrompt(range_margin=margin)
         prompted_model.load_state_dict(state_dict, strict=True)
         return prompted_model
     backbone: ZipDepth = create_model(variant="base")
     backbone.load_state_dict(state_dict, strict=True)
-    return ZipDepthPrompt(backbone)
+    return ZipDepthPrompt(backbone, range_margin=margin)
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt.py
+++ b/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt.py
@@ -5,8 +5,8 @@ normalized metric prompt into all four decoder stages, and returns depth in the
 same units as the prompt (metres for the public API).
 
 The head can only reach depths inside the range it is rescaled into, which by
-default is the prompt's own ``[min, max]``. ``ZipDepthPrompt(range_margin=...)``
-widens that range by a fraction of the prompt span on each side, which ultrawide
+default is the prompt's own ``[min, max]``. ``ZipDepthPrompt(range_margin_m=...)``
+widens that range by a fixed number of metres on each side, which ultrawide
 captures need: their prompt covers the image centre, so the periphery is often
 nearer or farther than anything the prompt saw.
 """
@@ -42,7 +42,7 @@ from monopriors.models.depth_completion.base_completion_depth import (
 )
 from monopriors.models.zipdepth_checkpoint import (
     load_zipdepth_checkpoint,
-    range_margin_from_checkpoint,
+    range_margin_m_from_checkpoint,
     state_dict_from_checkpoint,
 )
 from monopriors.third_party.zipdepth.architecture import EncoderOutput, FeaturePyramid, ZipDepth, create_model
@@ -96,23 +96,37 @@ class ZipDepthPrompt(nn.Module):
     """ZipDepth-base with PromptDA-style multi-scale metric conditioning.
 
     The head is a sigmoid rescaled into a per-image depth range derived from the
-    prompt. ``range_margin`` widens that output range symmetrically, so predicted
-    depth is no longer trapped inside the prompt's own ``[min, max]``. The prompt
-    *normalization* fed to the four decoder injection branches deliberately keeps
-    the original ``[min, max]``: the prompt itself does not change, only the range
-    the head may reach, and holding the conditioning fixed keeps a margin change
-    from shifting the features a trained model already relies on.
+    prompt. ``range_margin_m`` widens that output range by a fixed number of
+    metres on each side, so predicted depth is no longer trapped inside the
+    prompt's own ``[min, max]``.
+
+    The margin is absolute rather than a fraction of the prompt span on purpose.
+    A span-relative margin widens least exactly where the need is greatest: a
+    close-up prompt spanning 0.8--1.2 m would reach only 0.6--1.4 m at half a
+    span, leaving a 3.5 m wall in the ultrawide periphery unreachable, while a
+    prompt that already spans most of the window would gain the whole rest of it.
+    Because the widened range is still clipped to ``[MIN_METRIC_DEPTH_M,
+    MAX_METRIC_DEPTH_M]``, any ``range_margin_m >= 3.9`` opens the full
+    ``[0.1, 4.0]`` m window for every image; that is the setting the ultrawide
+    fine-tune uses.
+
+    The prompt *normalization* fed to the four decoder injection branches is
+    unchanged: it deliberately keeps the original ``[min, max]``. The prompt
+    itself does not change, only the range the head may reach, and holding the
+    conditioning fixed keeps a margin change from shifting the features a trained
+    model already relies on.
     """
 
-    def __init__(self, backbone: ZipDepth | None = None, *, range_margin: float = 0.0) -> None:
+    def __init__(self, backbone: ZipDepth | None = None, *, range_margin_m: float = 0.0) -> None:
         """Build the prompted wrapper.
 
         Args:
             backbone: ZipDepth-base network; ``None`` creates a fresh one.
-            range_margin: Fraction of the prompt span by which the head's output
-                range is widened past the prompt's own minimum and maximum. Zero
-                reproduces the prompt-bounded head exactly, emitting none of the
-                widening operations.
+            range_margin_m: Metres by which the head's output range is widened
+                past the prompt's own minimum and maximum, before clipping to the
+                shared validity window. Zero reproduces the prompt-bounded head
+                exactly, emitting none of the widening operations; ``3.9`` or more
+                opens the full window.
         """
         super().__init__()
         self.backbone: ZipDepth = create_model(variant="base") if backbone is None else backbone
@@ -120,9 +134,9 @@ class ZipDepthPrompt(nn.Module):
             raise ValueError(f"ZipDepthPrompt requires the base variant, got {self.backbone.variant!r}")
         if not self.backbone.decoder.convex_up.use_unfold:
             raise ValueError("ZipDepthPrompt currently requires ZipDepth's unfold-based convex head")
-        if not isfinite(range_margin) or range_margin < 0.0:
-            raise ValueError(f"range_margin must be finite and non-negative, got {range_margin}")
-        self.range_margin: float = range_margin
+        if not isfinite(range_margin_m) or range_margin_m < 0.0:
+            raise ValueError(f"range_margin_m must be finite and non-negative, got {range_margin_m}")
+        self.range_margin_m: float = range_margin_m
         self.prompt_branches: nn.ModuleList = nn.ModuleList(
             [_make_prompt_branch(channels) for channels in (288, 192, 144, 96)]
         )
@@ -169,7 +183,7 @@ class ZipDepthPrompt(nn.Module):
 
         Returns:
             Metric depth, and the minimum and maximum the head can reach. Those
-            two already include ``range_margin``, so ``sigmoid(logits) * (max -
+            two already include ``range_margin_m``, so ``sigmoid(logits) * (max -
             min) + min`` reproduces depth from captured logits.
         """
         if image.dtype == torch.uint8:
@@ -202,17 +216,20 @@ class ZipDepthPrompt(nn.Module):
             0.0,
         )
 
-        # The head may leave the prompt's own range by ``range_margin`` spans on each
-        # side, still clipped to the shared validity window. At zero margin these
-        # operations are skipped entirely, so torch and the exported fp16 graph are
-        # unchanged. Prompt normalization above keeps the un-widened range.
+        # The head may leave the prompt's own range by ``range_margin_m`` metres on
+        # each side, still clipped to the shared validity window. At zero margin
+        # these operations are skipped entirely, so torch and the exported fp16
+        # graph are unchanged. Prompt normalization above keeps the un-widened
+        # range. No floor is needed on the widened span: a positive margin always
+        # separates the two bounds, because clipping sends them to opposite edges
+        # of a window that already contains the prompt range.
         min_output_b: Float32[Tensor, "b 1 1 1"] = min_depth_b
         max_output_b: Float32[Tensor, "b 1 1 1"] = max_depth_b
         span_output_b: Float32[Tensor, "b 1 1 1"] = span_b
-        if self.range_margin > 0.0:
-            min_output_b = (min_depth_b - self.range_margin * span_b).clamp_min(MIN_METRIC_DEPTH_M)
-            max_output_b = (max_depth_b + self.range_margin * span_b).clamp_max(MAX_METRIC_DEPTH_M)
-            span_output_b = (max_output_b - min_output_b).clamp_min(MIN_PROMPT_SPAN_M)
+        if self.range_margin_m > 0.0:
+            min_output_b = (min_depth_b - self.range_margin_m).clamp_min(MIN_METRIC_DEPTH_M)
+            max_output_b = (max_depth_b + self.range_margin_m).clamp_max(MAX_METRIC_DEPTH_M)
+            span_output_b = max_output_b - min_output_b
 
         normalized_image_bchw: Float[Tensor, "b 3 h w"] = (image_bchw - self.backbone.mean).div_(self.backbone.std)
         encoder_output: EncoderOutput = self.backbone.encoder(normalized_image_bchw)
@@ -250,17 +267,17 @@ class ZipDepthPrompt(nn.Module):
         return self
 
 
-def load_zipdepth_prompt(checkpoint: Path, range_margin: float | None = None) -> ZipDepthPrompt:
+def load_zipdepth_prompt(checkpoint: Path, *, range_margin_m: float | None = None) -> ZipDepthPrompt:
     """Load a complete released ZipDepth-base checkpoint into the wrapper.
 
     Args:
         checkpoint: Bare ZipDepth state dict or trainer checkpoint containing
             ``model_state_dict``. DDP and ``torch.compile`` prefixes are
             accepted.
-        range_margin: Output-range margin override. ``None`` takes the margin
-            the training run recorded in the checkpoint, which is ``0.0`` for
-            bare state dicts and for checkpoints written before the margin
-            existed.
+        range_margin_m: Output-range margin override, in metres. ``None`` takes
+            the margin the training run recorded in the checkpoint, which is
+            ``0.0`` for bare state dicts and for checkpoints written before the
+            margin existed.
 
     Returns:
         A trainable prompted model. Every released tensor is loaded strictly;
@@ -268,14 +285,14 @@ def load_zipdepth_prompt(checkpoint: Path, range_margin: float | None = None) ->
     """
     loaded: dict[str, object] = load_zipdepth_checkpoint(checkpoint)
     state_dict: StateDict = state_dict_from_checkpoint(loaded, checkpoint)
-    margin: float = range_margin if range_margin is not None else range_margin_from_checkpoint(loaded, checkpoint)
+    margin_m: float = range_margin_m if range_margin_m is not None else range_margin_m_from_checkpoint(loaded, checkpoint)
     if any(key.startswith("backbone.") for key in state_dict):
-        prompted_model: ZipDepthPrompt = ZipDepthPrompt(range_margin=margin)
+        prompted_model: ZipDepthPrompt = ZipDepthPrompt(range_margin_m=margin_m)
         prompted_model.load_state_dict(state_dict, strict=True)
         return prompted_model
     backbone: ZipDepth = create_model(variant="base")
     backbone.load_state_dict(state_dict, strict=True)
-    return ZipDepthPrompt(backbone, range_margin=margin)
+    return ZipDepthPrompt(backbone, range_margin_m=margin_m)
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt_export.py
+++ b/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt_export.py
@@ -15,6 +15,7 @@ from torch import Tensor, nn
 from monopriors.models.depth_completion.base_completion_depth import DEPTH_OUTPUT_NAME, IMAGE_INPUT_NAME, PROMPT_DEPTH_HW, PROMPT_INPUT_NAME
 from monopriors.models.depth_completion.zipdepth_prompt import load_zipdepth_prompt
 from monopriors.models.relative_depth.zipdepth import download_zipdepth_checkpoint
+from monopriors.models.zipdepth_checkpoint import load_zipdepth_checkpoint, range_margin_m_from_checkpoint
 
 ONNX_EXPORT_VERSION: int = 1
 DEFAULT_CACHE_DIR: Path = Path(os.environ.get("ZIPDEPTH_PROMPT_TRT_CACHE", "~/.cache/zipdepth-promptda")).expanduser()
@@ -50,15 +51,23 @@ class PromptedDepthModel(Protocol):
         ...
 
 
-ModelLoader = Callable[[Path], PromptedDepthModel]
+@runtime_checkable
+class ModelLoader(Protocol):
+    """Checkpoint-to-model boundary used by the exporter and its tests."""
+
+    def __call__(self, checkpoint: Path, /, *, range_margin_m: float | None = None) -> PromptedDepthModel:
+        """Load a prompted model, optionally overriding its output-range margin."""
+        ...
+
+
 ExportFn = Callable[..., None]
 
 
 class _ExportOutputs(nn.Module):
     """Expose the head's output-range min/max as TensorRT fusion barriers.
 
-    Those two scalars carry the loaded checkpoint's ``range_margin``, so the graph
-    bakes in the range the model was trained with.
+    Those two scalars carry the loaded checkpoint's ``range_margin_m``, so the
+    graph bakes in the range the model was trained with.
     """
 
     def __init__(self, model: PromptedDepthModel) -> None:
@@ -114,6 +123,7 @@ def export_zipdepth_prompt_onnx(
     image_hw: tuple[int, int] = (768, 1024),
     batch_size: int = 8,
     cache_dir: Path = DEFAULT_CACHE_DIR,
+    range_margin_m: float | None = None,
     model_loader: ModelLoader = load_zipdepth_prompt,
     export_fn: ExportFn | None = None,
     device: str = "cuda",
@@ -125,6 +135,11 @@ def export_zipdepth_prompt_onnx(
         image_hw: Static image height and width.
         batch_size: Batch baked into the graph.
         cache_dir: Portable ONNX cache root.
+        range_margin_m: Output-range margin baked into the graph, in metres. It
+            is both the cache key and the value handed to ``model_loader``, so
+            the filename can never disagree with the graph. ``None`` reads the
+            value the checkpoint recorded, which costs one ``torch.load`` even
+            on a cache hit.
         model_loader: Model loader boundary used by export tests.
         export_fn: ONNX writer boundary; defaults to :func:`trtkit.export_onnx`.
         device: Torch export device.
@@ -137,15 +152,26 @@ def export_zipdepth_prompt_onnx(
     height, width = image_hw
     resolved_checkpoint: Path = checkpoint or download_zipdepth_checkpoint()
     tag: str = _checkpoint_tag(resolved_checkpoint)
+    # The margin changes the graph, so it belongs in the cache key next to the
+    # checkpoint tag: the lookup below short-circuits before the model is loaded,
+    # and an explicit override would otherwise be served a stale graph.
+    resolved_margin_m: float = (
+        range_margin_m
+        if range_margin_m is not None
+        else range_margin_m_from_checkpoint(load_zipdepth_checkpoint(resolved_checkpoint), resolved_checkpoint)
+    )
     onnx_dir: Path = cache_dir / "onnx"
-    onnx_path: Path = onnx_dir / f"zipdepth-prompt_{height}x{width}_b{batch_size}_fp16_v{ONNX_EXPORT_VERSION}_{tag}.onnx"
+    onnx_path: Path = (
+        onnx_dir / f"zipdepth-prompt_{height}x{width}_b{batch_size}_fp16_v{ONNX_EXPORT_VERSION}_{tag}_m{resolved_margin_m:.2f}.onnx"
+    )
     if onnx_path.is_file():
         return onnx_path
 
     resolved_device = torch.device(device)
     if resolved_device.type == "cuda" and not torch.cuda.is_available():
         raise RuntimeError("CUDA is required for the fp16 ZipDepth ONNX export")
-    model: PromptedDepthModel = prepare_zipdepth_prompt_for_export(model_loader(resolved_checkpoint), image_hw, resolved_device)
+    loaded_model: PromptedDepthModel = model_loader(resolved_checkpoint, range_margin_m=resolved_margin_m)
+    model: PromptedDepthModel = prepare_zipdepth_prompt_for_export(loaded_model, image_hw, resolved_device)
     wrapper: nn.Module = _ExportOutputs(model).eval()
     dummy_image_bchw: Float32[Tensor, "b 3 h w"] = torch.rand(
         (batch_size, 3, height, width), dtype=torch.float32, device=resolved_device
@@ -180,6 +206,7 @@ __all__ = (
     "DEFAULT_CACHE_DIR",
     "DEPTH_OUTPUT_NAME",
     "IMAGE_INPUT_NAME",
+    "ModelLoader",
     "ONNX_EXPORT_VERSION",
     "PROMPT_INPUT_NAME",
     "PromptedDepthModel",

--- a/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt_export.py
+++ b/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt_export.py
@@ -38,7 +38,7 @@ class PromptedDepthModel(Protocol):
         image: Float32[Tensor, "b 3 h w"],
         prompt_depth: Float32[Tensor, "b 1 192 256"],
     ) -> tuple[Float32[Tensor, "b 1 h w"], Float32[Tensor, "b 1 1 1"], Float32[Tensor, "b 1 1 1"]]:
-        """Return metric depth and the input-derived minimum and maximum."""
+        """Return metric depth and the input-derived output-range minimum and maximum."""
         ...
 
     def fuse_for_inference(self) -> "PromptedDepthModel":
@@ -55,7 +55,11 @@ ExportFn = Callable[..., None]
 
 
 class _ExportOutputs(nn.Module):
-    """Expose prompt min/max reductions as TensorRT fusion barriers."""
+    """Expose the head's output-range min/max as TensorRT fusion barriers.
+
+    Those two scalars carry the loaded checkpoint's ``range_margin``, so the graph
+    bakes in the range the model was trained with.
+    """
 
     def __init__(self, model: PromptedDepthModel) -> None:
         super().__init__()

--- a/packages/monoprior/monopriors/models/zipdepth_checkpoint.py
+++ b/packages/monoprior/monopriors/models/zipdepth_checkpoint.py
@@ -7,8 +7,8 @@ from torch import Tensor
 
 from monopriors.third_party.zipdepth.model_utils import StateDict, strip_state_dict_prefixes
 
-RANGE_MARGIN_KEY: str = "range_margin"
-"""Trainer-checkpoint key holding the prompted head's output-range margin."""
+RANGE_MARGIN_M_KEY: str = "range_margin_m"
+"""Trainer-checkpoint key holding the prompted head's output-range margin, in metres."""
 
 
 def load_zipdepth_checkpoint(checkpoint: Path) -> dict[str, object]:
@@ -47,22 +47,22 @@ def state_dict_from_checkpoint(loaded: dict[str, object], checkpoint: Path) -> S
     return strip_state_dict_prefixes(state_dict)
 
 
-def range_margin_from_checkpoint(loaded: dict[str, object], checkpoint: Path) -> float:
-    """Read the prompted output-range margin recorded by training.
+def range_margin_m_from_checkpoint(loaded: dict[str, object], checkpoint: Path) -> float:
+    """Read the prompted output-range margin, in metres, recorded by training.
 
     Args:
         loaded: Mapping returned by :func:`load_zipdepth_checkpoint`.
         checkpoint: Source path, used only for error messages.
 
     Returns:
-        The recorded margin, or ``0.0`` for bare state dicts and for
+        The recorded margin in metres, or ``0.0`` for bare state dicts and for
         checkpoints written before the margin existed (for example
         ``zdpda-v4``).
     """
-    raw_margin: object = loaded.get(RANGE_MARGIN_KEY, 0.0)
-    if isinstance(raw_margin, bool) or not isinstance(raw_margin, float | int):
-        raise ValueError(f"checkpoint {RANGE_MARGIN_KEY} must be a number: {checkpoint}")
-    return float(raw_margin)
+    raw_margin_m: object = loaded.get(RANGE_MARGIN_M_KEY, 0.0)
+    if isinstance(raw_margin_m, bool) or not isinstance(raw_margin_m, float | int):
+        raise ValueError(f"checkpoint {RANGE_MARGIN_M_KEY} must be a number: {checkpoint}")
+    return float(raw_margin_m)
 
 
 def load_zipdepth_state_dict(checkpoint: Path) -> StateDict:
@@ -71,10 +71,10 @@ def load_zipdepth_state_dict(checkpoint: Path) -> StateDict:
 
 
 __all__ = (
-    "RANGE_MARGIN_KEY",
+    "RANGE_MARGIN_M_KEY",
     "load_zipdepth_checkpoint",
     "load_zipdepth_state_dict",
     "narrow_zipdepth_state_dict",
-    "range_margin_from_checkpoint",
+    "range_margin_m_from_checkpoint",
     "state_dict_from_checkpoint",
 )

--- a/packages/monoprior/monopriors/models/zipdepth_checkpoint.py
+++ b/packages/monoprior/monopriors/models/zipdepth_checkpoint.py
@@ -7,6 +7,24 @@ from torch import Tensor
 
 from monopriors.third_party.zipdepth.model_utils import StateDict, strip_state_dict_prefixes
 
+RANGE_MARGIN_KEY: str = "range_margin"
+"""Trainer-checkpoint key holding the prompted head's output-range margin."""
+
+
+def load_zipdepth_checkpoint(checkpoint: Path) -> dict[str, object]:
+    """Load a bare state dict or a trainer checkpoint as a raw mapping.
+
+    Args:
+        checkpoint: Path to a ``.pth`` written by ``torch.save``.
+
+    Returns:
+        The deserialized top-level mapping.
+    """
+    loaded: dict[str, object] = torch.load(checkpoint, map_location="cpu", weights_only=True)
+    if not isinstance(loaded, dict):
+        raise ValueError(f"checkpoint must contain a mapping: {checkpoint}")
+    return loaded
+
 
 def narrow_zipdepth_state_dict(raw_state: object, checkpoint: Path) -> dict[str, Tensor]:
     """Validate and type a serialized ZipDepth model state mapping."""
@@ -22,14 +40,41 @@ def narrow_zipdepth_state_dict(raw_state: object, checkpoint: Path) -> dict[str,
     return state_dict
 
 
-def load_zipdepth_state_dict(checkpoint: Path) -> StateDict:
-    """Load, unwrap, and clean a bare or trainer ZipDepth state dictionary."""
-    loaded: dict[str, object] = torch.load(checkpoint, map_location="cpu", weights_only=True)
-    if not isinstance(loaded, dict):
-        raise ValueError(f"checkpoint must contain a mapping: {checkpoint}")
+def state_dict_from_checkpoint(loaded: dict[str, object], checkpoint: Path) -> StateDict:
+    """Unwrap and clean the model state held by an already-loaded checkpoint."""
     raw_state: object = loaded.get("model_state_dict", loaded)
     state_dict: dict[str, Tensor] = narrow_zipdepth_state_dict(raw_state, checkpoint)
     return strip_state_dict_prefixes(state_dict)
 
 
-__all__ = ("load_zipdepth_state_dict", "narrow_zipdepth_state_dict")
+def range_margin_from_checkpoint(loaded: dict[str, object], checkpoint: Path) -> float:
+    """Read the prompted output-range margin recorded by training.
+
+    Args:
+        loaded: Mapping returned by :func:`load_zipdepth_checkpoint`.
+        checkpoint: Source path, used only for error messages.
+
+    Returns:
+        The recorded margin, or ``0.0`` for bare state dicts and for
+        checkpoints written before the margin existed (for example
+        ``zdpda-v4``).
+    """
+    raw_margin: object = loaded.get(RANGE_MARGIN_KEY, 0.0)
+    if isinstance(raw_margin, bool) or not isinstance(raw_margin, float | int):
+        raise ValueError(f"checkpoint {RANGE_MARGIN_KEY} must be a number: {checkpoint}")
+    return float(raw_margin)
+
+
+def load_zipdepth_state_dict(checkpoint: Path) -> StateDict:
+    """Load, unwrap, and clean a bare or trainer ZipDepth state dictionary."""
+    return state_dict_from_checkpoint(load_zipdepth_checkpoint(checkpoint), checkpoint)
+
+
+__all__ = (
+    "RANGE_MARGIN_KEY",
+    "load_zipdepth_checkpoint",
+    "load_zipdepth_state_dict",
+    "narrow_zipdepth_state_dict",
+    "range_margin_from_checkpoint",
+    "state_dict_from_checkpoint",
+)

--- a/packages/zipdepth/tests/test_catalog_train.py
+++ b/packages/zipdepth/tests/test_catalog_train.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 import torch
-from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_KEY
+from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_M_KEY
 from serde.json import from_json, to_json
 from torch import nn, optim
 from torch.utils.data import DataLoader, TensorDataset
@@ -17,11 +17,13 @@ from zipdepth.apis.train_catalog import (
     ResolvedTrainCatalogConfig,
     TrainCatalogConfig,
     TrainingRecipe,
+    UpstreamSchedulerConfig,
     UpstreamTrainConfig,
     _adamw_optimizer,
     _build_scheduler,
     _load_json_config,
     _model_to_device,
+    _restore_resume_state,
     parse_stage_schedule,
     resolve_amp_dtype,
     resolve_max_lr,
@@ -165,8 +167,8 @@ def test_catalog_training_defaults_to_metric_with_an_explicit_ssi_lane() -> None
 
 def test_range_margin_defaults_to_the_prompt_bounded_head_and_survives_resolved_config() -> None:
     """Record the ultrawide output-range margin in the run's resolved_config.json."""
-    assert TrainCatalogConfig().range_margin == 0.0
-    config: TrainCatalogConfig = TrainCatalogConfig(range_margin=0.25)
+    assert TrainCatalogConfig().range_margin_m == 0.0
+    config: TrainCatalogConfig = TrainCatalogConfig(range_margin_m=3.9)
     upstream: UpstreamTrainConfig = _load_json_config(Path("configs/default.json"))
 
     resolved: ResolvedTrainCatalogConfig = ResolvedTrainCatalogConfig(
@@ -179,20 +181,48 @@ def test_range_margin_defaults_to_the_prompt_bounded_head_and_survives_resolved_
     )
 
     restored: ResolvedTrainCatalogConfig = from_json(ResolvedTrainCatalogConfig, to_json(resolved))
-    assert restored.config.range_margin == 0.25
+    assert restored.config.range_margin_m == 3.9
+
+
+def _margin_trainer(range_margin_m: float) -> ZipDepthTrainer:
+    """Build a minimal trainer carrying one output-range margin."""
+    model: nn.Linear = nn.Linear(1, 1)
+    optimizer: optim.SGD = optim.SGD(model.parameters(), lr=0.1)
+    return ZipDepthTrainer(model, [], optimizer, None, "cpu", use_amp=False, range_margin_m=range_margin_m)
 
 
 def test_trainer_records_the_range_margin_in_every_checkpoint(tmp_path: Path) -> None:
     """Let inference rebuild the trained head without repeating the training flag."""
-    model: nn.Linear = nn.Linear(1, 1)
-    optimizer: optim.SGD = optim.SGD(model.parameters(), lr=0.1)
-    trainer: ZipDepthTrainer = ZipDepthTrainer(model, [], optimizer, None, "cpu", use_amp=False, range_margin=0.25)
+    trainer: ZipDepthTrainer = _margin_trainer(3.9)
     checkpoint: Path = tmp_path / "step_1.pth"
 
     trainer.save_checkpoint(str(checkpoint), epoch=0, loss=0.0)
 
     saved: dict[str, object] = torch.load(checkpoint, map_location="cpu", weights_only=True)
-    assert saved[RANGE_MARGIN_KEY] == 0.25
+    assert saved[RANGE_MARGIN_M_KEY] == 3.9
+
+
+def test_resuming_with_a_different_range_margin_is_refused(tmp_path: Path) -> None:
+    """Resuming continues one run, so its head must keep the output range it was trained with."""
+    trainer: ZipDepthTrainer = _margin_trainer(3.9)
+    resume: Path = tmp_path / "step_1.pth"
+    trainer.save_checkpoint(str(resume), epoch=0, loss=0.0)
+    wrapped_model: nn.Linear = nn.Linear(1, 1)
+
+    with pytest.raises(ValueError, match="range_margin_m"):
+        _restore_resume_state(
+            resume,
+            wrapped_model,
+            trainer,
+            total_steps=10,
+            actual_max_lr=1e-5,
+            range_margin_m=0.0,
+            scheduler_config=UpstreamSchedulerConfig(),
+            schedule="onecycle",
+            warmup_pct=0.05,
+            final_div_factor=1000.0,
+            cooldown_pct=0.1,
+        )
 
 
 def test_catalog_training_exposes_only_the_fixed_metric_loss_weight() -> None:

--- a/packages/zipdepth/tests/test_catalog_train.py
+++ b/packages/zipdepth/tests/test_catalog_train.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 import torch
+from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_KEY
+from serde.json import from_json, to_json
 from torch import nn, optim
 from torch.utils.data import DataLoader, TensorDataset
 from tqdm import tqdm
@@ -12,6 +14,7 @@ from zipdepth.apis.train_catalog import (
     CompileMode,
     ConstantCooldownLR,
     ResolutionStage,
+    ResolvedTrainCatalogConfig,
     TrainCatalogConfig,
     TrainingRecipe,
     UpstreamTrainConfig,
@@ -158,6 +161,38 @@ def test_catalog_training_defaults_to_metric_with_an_explicit_ssi_lane() -> None
     """Make prompted metric distillation the default without removing relative training."""
     assert TrainCatalogConfig().target_mode == "metric"
     assert TrainCatalogConfig(target_mode="ssi").target_mode == "ssi"
+
+
+def test_range_margin_defaults_to_the_prompt_bounded_head_and_survives_resolved_config() -> None:
+    """Record the ultrawide output-range margin in the run's resolved_config.json."""
+    assert TrainCatalogConfig().range_margin == 0.0
+    config: TrainCatalogConfig = TrainCatalogConfig(range_margin=0.25)
+    upstream: UpstreamTrainConfig = _load_json_config(Path("configs/default.json"))
+
+    resolved: ResolvedTrainCatalogConfig = ResolvedTrainCatalogConfig(
+        config=config,
+        rank_count=1,
+        steps_per_epoch=10,
+        total_steps=10,
+        resolved_max_lr=1e-5,
+        recipe=resolve_training_recipe(config, upstream.scheduler, upstream.amp),
+    )
+
+    restored: ResolvedTrainCatalogConfig = from_json(ResolvedTrainCatalogConfig, to_json(resolved))
+    assert restored.config.range_margin == 0.25
+
+
+def test_trainer_records_the_range_margin_in_every_checkpoint(tmp_path: Path) -> None:
+    """Let inference rebuild the trained head without repeating the training flag."""
+    model: nn.Linear = nn.Linear(1, 1)
+    optimizer: optim.SGD = optim.SGD(model.parameters(), lr=0.1)
+    trainer: ZipDepthTrainer = ZipDepthTrainer(model, [], optimizer, None, "cpu", use_amp=False, range_margin=0.25)
+    checkpoint: Path = tmp_path / "step_1.pth"
+
+    trainer.save_checkpoint(str(checkpoint), epoch=0, loss=0.0)
+
+    saved: dict[str, object] = torch.load(checkpoint, map_location="cpu", weights_only=True)
+    assert saved[RANGE_MARGIN_KEY] == 0.25
 
 
 def test_catalog_training_exposes_only_the_fixed_metric_loss_weight() -> None:

--- a/packages/zipdepth/tests/test_prompted_model.py
+++ b/packages/zipdepth/tests/test_prompted_model.py
@@ -9,7 +9,7 @@ import torch
 from jaxtyping import Bool, Float32, UInt8
 from monopriors.models.depth_completion.base_completion_depth import MAX_METRIC_DEPTH_M, MIN_METRIC_DEPTH_M
 from monopriors.models.depth_completion.zipdepth_prompt import ZipDepthPrompt, load_zipdepth_prompt
-from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_KEY
+from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_M_KEY
 from monopriors.third_party.zipdepth.architecture import FastConvexUpsample, ZipDepth, create_model
 from torch import Tensor
 
@@ -66,10 +66,10 @@ def _run_capturing_logits(
     return outputs, captured[0]
 
 
-def _prompted_model(range_margin: float, *, seed: int = 0) -> ZipDepthPrompt:
+def _prompted_model(range_margin_m: float, *, seed: int = 0) -> ZipDepthPrompt:
     """Build a deterministically initialized prompted model with live prompt branches."""
     torch.manual_seed(seed)
-    model: ZipDepthPrompt = ZipDepthPrompt(range_margin=range_margin).eval()
+    model: ZipDepthPrompt = ZipDepthPrompt(range_margin_m=range_margin_m).eval()
     # The released initialization zeroes every branch output, which would hide any
     # change in the prompt conditioning; give the branches a signal to carry.
     for parameter in model.prompt_branches.parameters():
@@ -131,6 +131,14 @@ def test_released_zipdepth_state_loads_strictly_into_backbone(tmp_path: Path) ->
         assert torch.equal(prompted_backbone_state[key], released_tensor), key
 
 
+
+def _prompt_spanning(low_m: float, high_m: float) -> Float32[Tensor, "1 1 192 256"]:
+    """Return an otherwise-invalid prompt whose valid pixels span exactly ``[low_m, high_m]``."""
+    prompt_bchw: Float32[Tensor, "1 1 192 256"] = torch.zeros(1, 1, 192, 256)
+    prompt_bchw[:, :, 80:112, 96:160] = torch.linspace(low_m, high_m, 32 * 64).reshape(1, 1, 32, 64)
+    return prompt_bchw
+
+
 def test_zero_range_margin_reproduces_the_prompt_bounded_head_bit_for_bit(monkeypatch: pytest.MonkeyPatch) -> None:
     """Guarantee the default margin leaves today's forward pass untouched."""
     model: ZipDepthPrompt = _prompted_model(0.0)
@@ -177,20 +185,20 @@ def test_zero_range_margin_parity_holds_under_cuda_float16_autocast(monkeypatch:
     assert torch.equal(outputs[0], reference_depth_bchw)
 
 
-def test_range_margin_widens_the_reachable_output_range_by_a_span_fraction(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_range_margin_widens_the_reachable_output_range_by_absolute_metres(monkeypatch: pytest.MonkeyPatch) -> None:
     """Let the periphery of an ultrawide frame leave the prompt's own range."""
-    model: ZipDepthPrompt = _prompted_model(0.25)
+    model: ZipDepthPrompt = _prompted_model(0.5)
     torch.manual_seed(1)
     image_bchw: Float32[Tensor, "1 3 64 96"] = torch.rand(1, 3, 64, 96)
-    prompt_bchw: Float32[Tensor, "1 1 192 256"] = torch.zeros(1, 1, 192, 256)
-    prompt_bchw[:, :, 80:112, 96:160] = torch.linspace(1.0, 2.0, 32 * 64).reshape(1, 1, 32, 64)
+    prompt_bchw: Float32[Tensor, "1 1 192 256"] = _prompt_spanning(1.0, 1.4)
 
     outputs: ModelOutputs
     logits_bchw: Float32[Tensor, "1 1 64 96"]
     outputs, logits_bchw = _run_capturing_logits(model, image_bchw, prompt_bchw, monkeypatch)
 
-    expected_min_b: Float32[Tensor, "1 1 1 1"] = torch.full((1, 1, 1, 1), 1.0 - 0.25)
-    expected_max_b: Float32[Tensor, "1 1 1 1"] = torch.full((1, 1, 1, 1), 2.0 + 0.25)
+    # 0.5 m on each side of [1.0, 1.4], not 0.5 spans (which would only reach [0.8, 1.6]).
+    expected_min_b: Float32[Tensor, "1 1 1 1"] = torch.full((1, 1, 1, 1), 0.5)
+    expected_max_b: Float32[Tensor, "1 1 1 1"] = torch.full((1, 1, 1, 1), 1.9)
     expected_depth_bchw: Float32[Tensor, "1 1 64 96"] = torch.sigmoid(logits_bchw) * (expected_max_b - expected_min_b) + expected_min_b
 
     torch.testing.assert_close(outputs[1], expected_min_b)
@@ -198,19 +206,48 @@ def test_range_margin_widens_the_reachable_output_range_by_a_span_fraction(monke
     torch.testing.assert_close(outputs[0], expected_depth_bchw)
 
 
-def test_range_margin_never_leaves_the_shared_metric_validity_window(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Clip the widened range to the 0.1--4.0 m window the family agrees on."""
-    model: ZipDepthPrompt = _prompted_model(2.0)
+def test_range_margin_widens_a_narrow_prompt_as_much_as_a_wide_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Give a close-up prompt the same extra reach a span-relative margin would deny it."""
+    model: ZipDepthPrompt = _prompted_model(0.5)
     torch.manual_seed(1)
     image_bchw: Float32[Tensor, "1 3 64 96"] = torch.rand(1, 3, 64, 96)
-    prompt_bchw: Float32[Tensor, "1 1 192 256"] = _prompt_with_fixed_range()
+
+    narrow: ModelOutputs = _run_capturing_logits(model, image_bchw, _prompt_spanning(1.0, 1.1), monkeypatch)[0]
+    wide: ModelOutputs = _run_capturing_logits(model, image_bchw, _prompt_spanning(1.0, 2.0), monkeypatch)[0]
+
+    assert float(narrow[1]) == pytest.approx(0.5)
+    assert float(wide[1]) == pytest.approx(0.5)
+    assert float(narrow[2]) == pytest.approx(1.6)
+    assert float(wide[2]) == pytest.approx(2.5)
+
+
+def test_range_margin_never_leaves_the_shared_metric_validity_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clip the widened range to the 0.1--4.0 m window the family agrees on."""
+    model: ZipDepthPrompt = _prompted_model(0.5)
+    torch.manual_seed(1)
+    image_bchw: Float32[Tensor, "2 3 64 96"] = torch.rand(2, 3, 64, 96)
+    # Image 1 has no valid prompt pixel at all, so its range starts at the window edges.
+    prompt_bchw: Float32[Tensor, "2 1 192 256"] = torch.cat([_prompt_spanning(0.3, 3.8), torch.zeros(1, 1, 192, 256)])
 
     outputs: ModelOutputs = _run_capturing_logits(model, image_bchw, prompt_bchw, monkeypatch)[0]
 
-    assert float(outputs[1]) == pytest.approx(MIN_METRIC_DEPTH_M)
-    assert float(outputs[2]) == pytest.approx(MAX_METRIC_DEPTH_M)
+    assert outputs[1].flatten().tolist() == pytest.approx([MIN_METRIC_DEPTH_M, MIN_METRIC_DEPTH_M])
+    assert outputs[2].flatten().tolist() == pytest.approx([MAX_METRIC_DEPTH_M, MAX_METRIC_DEPTH_M])
+    assert torch.isfinite(outputs[0]).all()
     assert float(outputs[0].min()) >= MIN_METRIC_DEPTH_M
     assert float(outputs[0].max()) <= MAX_METRIC_DEPTH_M
+
+
+def test_a_margin_of_the_full_window_width_opens_the_whole_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Document the ultrawide fine-tune setting: 3.9 m reaches every valid depth."""
+    model: ZipDepthPrompt = _prompted_model(MAX_METRIC_DEPTH_M - MIN_METRIC_DEPTH_M)
+    torch.manual_seed(1)
+    image_bchw: Float32[Tensor, "1 3 64 96"] = torch.rand(1, 3, 64, 96)
+
+    outputs: ModelOutputs = _run_capturing_logits(model, image_bchw, _prompt_spanning(1.0, 1.1), monkeypatch)[0]
+
+    assert float(outputs[1]) == pytest.approx(MIN_METRIC_DEPTH_M)
+    assert float(outputs[2]) == pytest.approx(MAX_METRIC_DEPTH_M)
 
 
 def test_range_margin_leaves_the_prompt_conditioning_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -229,20 +266,20 @@ def test_range_margin_leaves_the_prompt_conditioning_unchanged(monkeypatch: pyte
 
 def test_range_margin_rejects_negative_and_non_finite_values() -> None:
     """Fail loudly instead of inverting or poisoning the output range."""
-    with pytest.raises(ValueError, match="range_margin"):
-        ZipDepthPrompt(range_margin=-0.1)
-    with pytest.raises(ValueError, match="range_margin"):
-        ZipDepthPrompt(range_margin=float("nan"))
+    with pytest.raises(ValueError, match="range_margin_m"):
+        ZipDepthPrompt(range_margin_m=-0.1)
+    with pytest.raises(ValueError, match="range_margin_m"):
+        ZipDepthPrompt(range_margin_m=float("nan"))
 
 
 def test_trainer_checkpoints_carry_the_range_margin_to_inference(tmp_path: Path) -> None:
     """Rebuild the trained head from the checkpoint without repeating the flag."""
-    trained: ZipDepthPrompt = ZipDepthPrompt(range_margin=0.35)
+    trained: ZipDepthPrompt = ZipDepthPrompt(range_margin_m=3.9)
     checkpoint: Path = tmp_path / "final_model.pth"
-    torch.save({"model_state_dict": trained.state_dict(), RANGE_MARGIN_KEY: 0.35}, checkpoint)
+    torch.save({"model_state_dict": trained.state_dict(), RANGE_MARGIN_M_KEY: 3.9}, checkpoint)
 
-    assert load_zipdepth_prompt(checkpoint).range_margin == 0.35
-    assert load_zipdepth_prompt(checkpoint, range_margin=0.0).range_margin == 0.0
+    assert load_zipdepth_prompt(checkpoint).range_margin_m == 3.9
+    assert load_zipdepth_prompt(checkpoint, range_margin_m=0.0).range_margin_m == 0.0
 
 
 def test_checkpoints_without_a_recorded_margin_stay_prompt_bounded(tmp_path: Path) -> None:
@@ -253,5 +290,5 @@ def test_checkpoints_without_a_recorded_margin_stay_prompt_bounded(tmp_path: Pat
     legacy: Path = tmp_path / "zdpda_v4.pth"
     torch.save({"model_state_dict": ZipDepthPrompt().state_dict(), "global_step": 70_000}, legacy)
 
-    assert load_zipdepth_prompt(bare).range_margin == 0.0
-    assert load_zipdepth_prompt(legacy).range_margin == 0.0
+    assert load_zipdepth_prompt(bare).range_margin_m == 0.0
+    assert load_zipdepth_prompt(legacy).range_margin_m == 0.0

--- a/packages/zipdepth/tests/test_prompted_model.py
+++ b/packages/zipdepth/tests/test_prompted_model.py
@@ -1,12 +1,20 @@
 """Behavior tests for the prompted metric ZipDepth wrapper."""
 
+from collections.abc import Callable
 from pathlib import Path
+from typing import TypeAlias
 
+import pytest
 import torch
-from jaxtyping import Float32, UInt8
+from jaxtyping import Bool, Float32, UInt8
+from monopriors.models.depth_completion.base_completion_depth import MAX_METRIC_DEPTH_M, MIN_METRIC_DEPTH_M
 from monopriors.models.depth_completion.zipdepth_prompt import ZipDepthPrompt, load_zipdepth_prompt
-from monopriors.third_party.zipdepth.architecture import ZipDepth, create_model
+from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_KEY
+from monopriors.third_party.zipdepth.architecture import FastConvexUpsample, ZipDepth, create_model
 from torch import Tensor
+
+PromptRange: TypeAlias = tuple[Float32[Tensor, "b 1 1 1"], Float32[Tensor, "b 1 1 1"]]
+ModelOutputs: TypeAlias = tuple[Float32[Tensor, "b 1 h w"], Float32[Tensor, "b 1 1 1"], Float32[Tensor, "b 1 1 1"]]
 
 
 def _prompt_with_fixed_range(*, flip: bool = False) -> Float32[Tensor, "1 1 192 256"]:
@@ -15,6 +23,58 @@ def _prompt_with_fixed_range(*, flip: bool = False) -> Float32[Tensor, "1 1 192 
         prompt_bchw = torch.flip(prompt_bchw, dims=(-1,))
     prompt_bchw[:, :, 40:80, 60:120] = 0.0
     return prompt_bchw
+
+
+def _prompt_bounded_range(prompt_bchw: Float32[Tensor, "b 1 192 256"]) -> PromptRange:
+    """Return the pre-margin per-image prompt range, verbatim from the original head."""
+    valid_bchw: Bool[Tensor, "b 1 192 256"] = (
+        torch.isfinite(prompt_bchw) & (prompt_bchw >= MIN_METRIC_DEPTH_M) & (prompt_bchw <= MAX_METRIC_DEPTH_M)
+    )
+    valid_any_b: Bool[Tensor, "b 1 1 1"] = valid_bchw.any(dim=(1, 2, 3), keepdim=True)
+    masked_min_b: Float32[Tensor, "b 1 1 1"] = torch.where(valid_bchw, prompt_bchw, torch.inf).amin(dim=(1, 2, 3), keepdim=True)
+    masked_max_b: Float32[Tensor, "b 1 1 1"] = torch.where(valid_bchw, prompt_bchw, -torch.inf).amax(dim=(1, 2, 3), keepdim=True)
+    min_depth_b: Float32[Tensor, "b 1 1 1"] = torch.where(valid_any_b, masked_min_b, MIN_METRIC_DEPTH_M)
+    max_depth_b: Float32[Tensor, "b 1 1 1"] = torch.where(valid_any_b, masked_max_b, MAX_METRIC_DEPTH_M)
+    return min_depth_b, max_depth_b
+
+
+def _run_capturing_logits(
+    model: ZipDepthPrompt,
+    image_bchw: Float32[Tensor, "b 3 h w"],
+    prompt_bchw: Float32[Tensor, "b 1 192 256"],
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[ModelOutputs, Float32[Tensor, "b 1 h w"]]:
+    """Run the model and also return the pre-sigmoid depth logits it rescaled.
+
+    The convex upsampler is called as a plain method rather than through
+    ``__call__``, so no forward hook sees its output; wrapping the method is the
+    only way to hold the exact logits the output range is applied to.
+    """
+    convex_up: FastConvexUpsample = model.backbone.decoder.convex_up
+    original_unfold: Callable[[Tensor, Tensor], Tensor] = convex_up._forward_unfold
+    captured: list[Float32[Tensor, "b 1 h w"]] = []
+
+    def capturing_unfold(feature_bchw: Tensor, depth_logits_bchw: Tensor) -> Float32[Tensor, "b 1 h w"]:
+        logits_bchw: Float32[Tensor, "b 1 h w"] = original_unfold(feature_bchw, depth_logits_bchw)
+        captured.append(logits_bchw)
+        return logits_bchw
+
+    monkeypatch.setattr(convex_up, "_forward_unfold", capturing_unfold)
+    with torch.inference_mode():
+        outputs: ModelOutputs = model.forward_with_range(image_bchw, prompt_bchw)
+    monkeypatch.undo()
+    return outputs, captured[0]
+
+
+def _prompted_model(range_margin: float, *, seed: int = 0) -> ZipDepthPrompt:
+    """Build a deterministically initialized prompted model with live prompt branches."""
+    torch.manual_seed(seed)
+    model: ZipDepthPrompt = ZipDepthPrompt(range_margin=range_margin).eval()
+    # The released initialization zeroes every branch output, which would hide any
+    # change in the prompt conditioning; give the branches a signal to carry.
+    for parameter in model.prompt_branches.parameters():
+        torch.nn.init.normal_(parameter, std=0.02)
+    return model
 
 
 def test_zero_initialized_prompt_injection_has_no_spatial_contribution() -> None:
@@ -69,3 +129,129 @@ def test_released_zipdepth_state_loads_strictly_into_backbone(tmp_path: Path) ->
     assert prompted_backbone_state.keys() == released_state.keys()
     for key, released_tensor in released_state.items():
         assert torch.equal(prompted_backbone_state[key], released_tensor), key
+
+
+def test_zero_range_margin_reproduces_the_prompt_bounded_head_bit_for_bit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Guarantee the default margin leaves today's forward pass untouched."""
+    model: ZipDepthPrompt = _prompted_model(0.0)
+    torch.manual_seed(1)
+    image_bchw: Float32[Tensor, "2 3 64 96"] = torch.rand(2, 3, 64, 96)
+    prompt_bchw: Float32[Tensor, "2 1 192 256"] = torch.cat([_prompt_with_fixed_range(), _prompt_with_fixed_range(flip=True)])
+
+    outputs: ModelOutputs
+    logits_bchw: Float32[Tensor, "2 1 64 96"]
+    outputs, logits_bchw = _run_capturing_logits(model, image_bchw, prompt_bchw, monkeypatch)
+
+    reference_range: PromptRange = _prompt_bounded_range(prompt_bchw)
+    reference_min_b: Float32[Tensor, "2 1 1 1"] = reference_range[0]
+    reference_max_b: Float32[Tensor, "2 1 1 1"] = reference_range[1]
+    reference_span_b: Float32[Tensor, "2 1 1 1"] = (reference_max_b - reference_min_b).clamp_min(1.0e-6)
+    reference_depth_bchw: Float32[Tensor, "2 1 64 96"] = torch.sigmoid(logits_bchw) * reference_span_b + reference_min_b
+
+    assert torch.equal(outputs[1], reference_min_b)
+    assert torch.equal(outputs[2], reference_max_b)
+    assert torch.equal(outputs[0], reference_depth_bchw)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a CUDA device")
+def test_zero_range_margin_parity_holds_under_cuda_float16_autocast(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Repeat the parity guarantee in the reduced precision the export graph uses."""
+    model: ZipDepthPrompt = _prompted_model(0.0).cuda()
+    torch.manual_seed(1)
+    image_bchw: Float32[Tensor, "1 3 64 96"] = torch.rand(1, 3, 64, 96, device="cuda")
+    prompt_bchw: Float32[Tensor, "1 1 192 256"] = _prompt_with_fixed_range().cuda()
+
+    with torch.autocast(device_type="cuda", dtype=torch.float16):
+        outputs: ModelOutputs
+        logits_bchw: Float32[Tensor, "1 1 64 96"]
+        outputs, logits_bchw = _run_capturing_logits(model, image_bchw, prompt_bchw, monkeypatch)
+
+    reference_range: PromptRange = _prompt_bounded_range(prompt_bchw)
+    reference_min_b: Float32[Tensor, "1 1 1 1"] = reference_range[0]
+    reference_max_b: Float32[Tensor, "1 1 1 1"] = reference_range[1]
+    reference_span_b: Float32[Tensor, "1 1 1 1"] = (reference_max_b - reference_min_b).clamp_min(1.0e-6)
+    reference_depth_bchw: Float32[Tensor, "1 1 64 96"] = torch.sigmoid(logits_bchw) * reference_span_b + reference_min_b
+
+    assert torch.equal(outputs[1], reference_min_b)
+    assert torch.equal(outputs[2], reference_max_b)
+    assert torch.equal(outputs[0], reference_depth_bchw)
+
+
+def test_range_margin_widens_the_reachable_output_range_by_a_span_fraction(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Let the periphery of an ultrawide frame leave the prompt's own range."""
+    model: ZipDepthPrompt = _prompted_model(0.25)
+    torch.manual_seed(1)
+    image_bchw: Float32[Tensor, "1 3 64 96"] = torch.rand(1, 3, 64, 96)
+    prompt_bchw: Float32[Tensor, "1 1 192 256"] = torch.zeros(1, 1, 192, 256)
+    prompt_bchw[:, :, 80:112, 96:160] = torch.linspace(1.0, 2.0, 32 * 64).reshape(1, 1, 32, 64)
+
+    outputs: ModelOutputs
+    logits_bchw: Float32[Tensor, "1 1 64 96"]
+    outputs, logits_bchw = _run_capturing_logits(model, image_bchw, prompt_bchw, monkeypatch)
+
+    expected_min_b: Float32[Tensor, "1 1 1 1"] = torch.full((1, 1, 1, 1), 1.0 - 0.25)
+    expected_max_b: Float32[Tensor, "1 1 1 1"] = torch.full((1, 1, 1, 1), 2.0 + 0.25)
+    expected_depth_bchw: Float32[Tensor, "1 1 64 96"] = torch.sigmoid(logits_bchw) * (expected_max_b - expected_min_b) + expected_min_b
+
+    torch.testing.assert_close(outputs[1], expected_min_b)
+    torch.testing.assert_close(outputs[2], expected_max_b)
+    torch.testing.assert_close(outputs[0], expected_depth_bchw)
+
+
+def test_range_margin_never_leaves_the_shared_metric_validity_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clip the widened range to the 0.1--4.0 m window the family agrees on."""
+    model: ZipDepthPrompt = _prompted_model(2.0)
+    torch.manual_seed(1)
+    image_bchw: Float32[Tensor, "1 3 64 96"] = torch.rand(1, 3, 64, 96)
+    prompt_bchw: Float32[Tensor, "1 1 192 256"] = _prompt_with_fixed_range()
+
+    outputs: ModelOutputs = _run_capturing_logits(model, image_bchw, prompt_bchw, monkeypatch)[0]
+
+    assert float(outputs[1]) == pytest.approx(MIN_METRIC_DEPTH_M)
+    assert float(outputs[2]) == pytest.approx(MAX_METRIC_DEPTH_M)
+    assert float(outputs[0].min()) >= MIN_METRIC_DEPTH_M
+    assert float(outputs[0].max()) <= MAX_METRIC_DEPTH_M
+
+
+def test_range_margin_leaves_the_prompt_conditioning_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Normalize the injected prompt over its own range, not the widened one."""
+    narrow: ZipDepthPrompt = _prompted_model(0.0)
+    wide: ZipDepthPrompt = _prompted_model(0.5)
+    torch.manual_seed(1)
+    image_bchw: Float32[Tensor, "1 3 64 96"] = torch.rand(1, 3, 64, 96)
+    prompt_bchw: Float32[Tensor, "1 1 192 256"] = _prompt_with_fixed_range()
+
+    narrow_logits_bchw: Float32[Tensor, "1 1 64 96"] = _run_capturing_logits(narrow, image_bchw, prompt_bchw, monkeypatch)[1]
+    wide_logits_bchw: Float32[Tensor, "1 1 64 96"] = _run_capturing_logits(wide, image_bchw, prompt_bchw, monkeypatch)[1]
+
+    assert torch.equal(narrow_logits_bchw, wide_logits_bchw)
+
+
+def test_range_margin_rejects_negative_and_non_finite_values() -> None:
+    """Fail loudly instead of inverting or poisoning the output range."""
+    with pytest.raises(ValueError, match="range_margin"):
+        ZipDepthPrompt(range_margin=-0.1)
+    with pytest.raises(ValueError, match="range_margin"):
+        ZipDepthPrompt(range_margin=float("nan"))
+
+
+def test_trainer_checkpoints_carry_the_range_margin_to_inference(tmp_path: Path) -> None:
+    """Rebuild the trained head from the checkpoint without repeating the flag."""
+    trained: ZipDepthPrompt = ZipDepthPrompt(range_margin=0.35)
+    checkpoint: Path = tmp_path / "final_model.pth"
+    torch.save({"model_state_dict": trained.state_dict(), RANGE_MARGIN_KEY: 0.35}, checkpoint)
+
+    assert load_zipdepth_prompt(checkpoint).range_margin == 0.35
+    assert load_zipdepth_prompt(checkpoint, range_margin=0.0).range_margin == 0.0
+
+
+def test_checkpoints_without_a_recorded_margin_stay_prompt_bounded(tmp_path: Path) -> None:
+    """Keep zdpda-v4 and every bare released state dict on the original head."""
+    released: ZipDepth = create_model(variant="base")
+    bare: Path = tmp_path / "zipdepth_base.pth"
+    torch.save(released.state_dict(), bare)
+    legacy: Path = tmp_path / "zdpda_v4.pth"
+    torch.save({"model_state_dict": ZipDepthPrompt().state_dict(), "global_step": 70_000}, legacy)
+
+    assert load_zipdepth_prompt(bare).range_margin == 0.0
+    assert load_zipdepth_prompt(legacy).range_margin == 0.0

--- a/packages/zipdepth/tests/test_prompted_trt.py
+++ b/packages/zipdepth/tests/test_prompted_trt.py
@@ -8,13 +8,16 @@ from typing import TypeAlias
 import pytest
 import torch
 from jaxtyping import Float32
+from monopriors.models.depth_completion.zipdepth_prompt import ZipDepthPrompt
 from monopriors.models.depth_completion.zipdepth_prompt_export import (
     IMAGE_INPUT_NAME,
     PROMPT_INPUT_NAME,
     PromptedDepthModel,
+    _ExportOutputs,
     export_zipdepth_prompt_onnx,
 )
 from monopriors.models.relative_depth.zipdepth import download_zipdepth_checkpoint
+from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_KEY
 from torch import Tensor, nn
 
 from zipdepth.apis import prompted_trt
@@ -115,6 +118,35 @@ def test_export_uses_two_inputs_with_export_dtype_and_static_batch_eight(tmp_pat
     assert all(tensor.dtype == torch.float32 for tensor in call.inputs)
     assert fake_model.fused
     assert fake_model.weight.dtype == torch.float16
+
+
+def test_export_bakes_the_checkpoint_range_margin_into_the_graph(tmp_path: Path) -> None:
+    """Export the head the checkpoint was trained with, keeping the binding names."""
+    trained: ZipDepthPrompt = ZipDepthPrompt(range_margin=0.4)
+    checkpoint: Path = tmp_path / "final_model.pth"
+    torch.save({"model_state_dict": trained.state_dict(), RANGE_MARGIN_KEY: 0.4}, checkpoint)
+    exported_models: list[ZipDepthPrompt] = []
+
+    def fake_export(model: nn.Module, _inputs: ExportInputs, out_path: Path, **kwargs: object) -> None:
+        assert kwargs["input_names"] == [IMAGE_INPUT_NAME, PROMPT_INPUT_NAME]
+        assert kwargs["output_names"] == ["depth", "min_depth", "max_depth"]
+        assert isinstance(model, _ExportOutputs)
+        inner: object = model.model
+        assert isinstance(inner, ZipDepthPrompt)
+        exported_models.append(inner)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_bytes(b"onnx")
+
+    export_zipdepth_prompt_onnx(
+        checkpoint=checkpoint,
+        image_hw=(64, 96),
+        batch_size=1,
+        cache_dir=tmp_path / "cache",
+        export_fn=fake_export,
+        device="cpu",
+    )
+
+    assert exported_models[0].range_margin == 0.4
 
 
 trt_parity = pytest.mark.skipif(

--- a/packages/zipdepth/tests/test_prompted_trt.py
+++ b/packages/zipdepth/tests/test_prompted_trt.py
@@ -12,12 +12,13 @@ from monopriors.models.depth_completion.zipdepth_prompt import ZipDepthPrompt
 from monopriors.models.depth_completion.zipdepth_prompt_export import (
     IMAGE_INPUT_NAME,
     PROMPT_INPUT_NAME,
+    ModelLoader,
     PromptedDepthModel,
     _ExportOutputs,
     export_zipdepth_prompt_onnx,
 )
 from monopriors.models.relative_depth.zipdepth import download_zipdepth_checkpoint
-from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_KEY
+from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_M_KEY
 from torch import Tensor, nn
 
 from zipdepth.apis import prompted_trt
@@ -64,6 +65,15 @@ class _FakePromptModel(nn.Module):
         return depth, prompt_depth.amin(dim=(1, 2, 3), keepdim=True), prompt_depth.amax(dim=(1, 2, 3), keepdim=True)
 
 
+def _fake_loader(fake_model: _FakePromptModel) -> ModelLoader:
+    """Return a loader boundary that ignores the checkpoint and the margin."""
+
+    def load(_checkpoint: Path, *, range_margin_m: float | None = None) -> PromptedDepthModel:
+        return fake_model
+
+    return load
+
+
 def test_fake_model_satisfies_prompted_export_protocol() -> None:
     """Keep exporter tests structural rather than coupled to ZipDepthPrompt."""
     assert isinstance(_FakePromptModel(), PromptedDepthModel)
@@ -103,7 +113,8 @@ def test_export_uses_two_inputs_with_export_dtype_and_static_batch_eight(tmp_pat
         image_hw=(768, 1024),
         batch_size=8,
         cache_dir=tmp_path / "cache",
-        model_loader=lambda _checkpoint: fake_model,
+        range_margin_m=0.0,
+        model_loader=_fake_loader(fake_model),
         export_fn=fake_export,
         device="cpu",
     )
@@ -111,6 +122,7 @@ def test_export_uses_two_inputs_with_export_dtype_and_static_batch_eight(tmp_pat
     call: _ExportCall = calls[0]
     assert onnx_path == call.out_path
     assert "768x1024_b8_fp16" in onnx_path.name
+    assert onnx_path.name.endswith("_m0.00.onnx")
     assert call.input_names == [IMAGE_INPUT_NAME, PROMPT_INPUT_NAME]
     assert call.output_names == ["depth", "min_depth", "max_depth"]
     assert call.dynamic_batch_max is None
@@ -120,11 +132,11 @@ def test_export_uses_two_inputs_with_export_dtype_and_static_batch_eight(tmp_pat
     assert fake_model.weight.dtype == torch.float16
 
 
-def test_export_bakes_the_checkpoint_range_margin_into_the_graph(tmp_path: Path) -> None:
+def test_export_bakes_the_checkpoint_range_margin_into_the_graph_and_its_cache_key(tmp_path: Path) -> None:
     """Export the head the checkpoint was trained with, keeping the binding names."""
-    trained: ZipDepthPrompt = ZipDepthPrompt(range_margin=0.4)
+    trained: ZipDepthPrompt = ZipDepthPrompt(range_margin_m=3.9)
     checkpoint: Path = tmp_path / "final_model.pth"
-    torch.save({"model_state_dict": trained.state_dict(), RANGE_MARGIN_KEY: 0.4}, checkpoint)
+    torch.save({"model_state_dict": trained.state_dict(), RANGE_MARGIN_M_KEY: 3.9}, checkpoint)
     exported_models: list[ZipDepthPrompt] = []
 
     def fake_export(model: nn.Module, _inputs: ExportInputs, out_path: Path, **kwargs: object) -> None:
@@ -137,7 +149,7 @@ def test_export_bakes_the_checkpoint_range_margin_into_the_graph(tmp_path: Path)
         out_path.parent.mkdir(parents=True, exist_ok=True)
         out_path.write_bytes(b"onnx")
 
-    export_zipdepth_prompt_onnx(
+    onnx_path: Path = export_zipdepth_prompt_onnx(
         checkpoint=checkpoint,
         image_hw=(64, 96),
         batch_size=1,
@@ -146,7 +158,36 @@ def test_export_bakes_the_checkpoint_range_margin_into_the_graph(tmp_path: Path)
         device="cpu",
     )
 
-    assert exported_models[0].range_margin == 0.4
+    assert exported_models[0].range_margin_m == 3.9
+    # The cache short-circuits before the model loads, so the margin has to be in the name.
+    assert onnx_path.name.endswith("_m3.90.onnx")
+
+
+def test_export_caches_one_graph_per_margin(tmp_path: Path) -> None:
+    """Never serve a graph built for a different output range out of the cache."""
+    checkpoint: Path = tmp_path / "final_model.pth"
+    torch.save({"model_state_dict": ZipDepthPrompt().state_dict()}, checkpoint)
+    fake_model = _FakePromptModel()
+
+    def fake_export(_model: nn.Module, _inputs: ExportInputs, out_path: Path, **_kwargs: object) -> None:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_bytes(b"onnx")
+
+    paths: list[Path] = [
+        export_zipdepth_prompt_onnx(
+            checkpoint=checkpoint,
+            image_hw=(64, 96),
+            batch_size=1,
+            cache_dir=tmp_path / "cache",
+            range_margin_m=margin_m,
+            model_loader=_fake_loader(fake_model),
+            export_fn=fake_export,
+            device="cpu",
+        )
+        for margin_m in (0.0, 3.9)
+    ]
+
+    assert paths[0] != paths[1]
 
 
 trt_parity = pytest.mark.skipif(

--- a/packages/zipdepth/zipdepth/apis/train_catalog.py
+++ b/packages/zipdepth/zipdepth/apis/train_catalog.py
@@ -13,7 +13,12 @@ import torch
 import torch.distributed as dist
 from monopriors.models.depth_completion.zipdepth_prompt import ZipDepthPrompt, load_zipdepth_prompt
 from monopriors.models.relative_depth.zipdepth import download_zipdepth_checkpoint
-from monopriors.models.zipdepth_checkpoint import load_zipdepth_state_dict, narrow_zipdepth_state_dict
+from monopriors.models.zipdepth_checkpoint import (
+    load_zipdepth_checkpoint,
+    load_zipdepth_state_dict,
+    narrow_zipdepth_state_dict,
+    range_margin_m_from_checkpoint,
+)
 from monopriors.third_party.zipdepth.architecture import ZipDepth, create_model
 from monopriors.third_party.zipdepth.model_utils import strip_state_dict_prefixes
 from serde import field as serde_field
@@ -162,11 +167,14 @@ class TrainCatalogConfig:
     """Maximum completed samples buffered by the current loader."""
     min_depth_span: float = 1.25
     """Minimum valid-depth p95/p5 ratio; zero disables flat-frame filtering."""
-    range_margin: float = 0.0
-    """Widen the head's output range beyond the prompt's own [min, max] by this fraction of
-    the span; needed for ultrawide prompts that cover only the image center. The value is
-    recorded in ``resolved_config.json`` and in every checkpoint this run writes, so
-    inference rebuilds the same head. Zero reproduces the prompt-bounded head exactly."""
+    range_margin_m: float = 0.0
+    """Widen the head's output range beyond the prompt's own [min, max] by this many metres
+    on each side; needed for ultrawide prompts that cover only the image center. The margin
+    is absolute rather than a fraction of the prompt span so that a close-up prompt gains as
+    much reach as a wide one. Clipping to the 0.1--4.0 m validity window means 3.9 or more
+    opens the full window. The value is recorded in ``resolved_config.json`` and in every
+    checkpoint this run writes, so inference rebuilds the same head. Zero reproduces the
+    prompt-bounded head exactly."""
     from_scratch: bool = False
     """Start with random weights instead of the released ZipDepth-base weights."""
     metric_gradient_weight: float = 0.5
@@ -522,13 +530,21 @@ def _restore_resume_state(
     *,
     total_steps: int,
     actual_max_lr: float,
+    range_margin_m: float,
     scheduler_config: UpstreamSchedulerConfig,
     schedule: ScheduleName,
     warmup_pct: float,
     final_div_factor: float,
     cooldown_pct: float,
 ) -> None:
-    """Restore model, optimizer, schedule, and trainer step."""
+    """Restore model, optimizer, schedule, and trainer step.
+
+    Raises:
+        ValueError: If the checkpoint recorded a different output-range margin
+            than this run is configured with. Resuming rewrites the same run, so
+            silently changing the head's output range mid-run would make the
+            optimizer state and the recorded margin describe different models.
+    """
     print_main(f"Resuming from: {resume}", trainer.rank)
     checkpoint: dict[str, object] | None
     if trainer.is_distributed:
@@ -544,6 +560,12 @@ def _restore_resume_state(
         checkpoint = loaded_checkpoint if isinstance(loaded_checkpoint, dict) else None
     if checkpoint is None:
         raise ValueError(f"resume checkpoint must contain a mapping: {resume}")
+    resumed_margin_m: float = range_margin_m_from_checkpoint(checkpoint, resume)
+    if not isclose(resumed_margin_m, range_margin_m, rel_tol=0.0, abs_tol=1e-9):
+        raise ValueError(
+            f"resume checkpoint recorded range_margin_m={resumed_margin_m} but this run is configured with "
+            f"range_margin_m={range_margin_m}; resume with the recorded value or start a new run: {resume}"
+        )
     raw_resume_state: object = checkpoint.get("model_state_dict", checkpoint)
     tensor_state: dict[str, Tensor] = narrow_zipdepth_state_dict(raw_resume_state, resume)
     resume_state: dict[str, Tensor] = fix_state_dict_prefix(strip_state_dict_prefixes(tensor_state), trainer.is_distributed)
@@ -609,10 +631,10 @@ def main(
             raise ValueError("save_every_steps must be non-negative")
         if config.target_mode not in ("ssi", "metric"):
             raise ValueError(f"unknown target mode {config.target_mode!r}")
-        if not isfinite(config.range_margin) or config.range_margin < 0.0:
-            raise ValueError("range_margin must be finite and non-negative")
-        if config.range_margin > 0.0 and config.target_mode != "metric":
-            raise ValueError("range_margin only applies to the prompted metric lane")
+        if not isfinite(config.range_margin_m) or config.range_margin_m < 0.0:
+            raise ValueError("range_margin_m must be finite and non-negative")
+        if config.range_margin_m > 0.0 and config.target_mode != "metric":
+            raise ValueError("range_margin_m only applies to the prompted metric lane")
         torch.backends.cudnn.benchmark = True
         torch.backends.cuda.matmul.allow_tf32 = True
         torch.backends.cudnn.allow_tf32 = True
@@ -744,11 +766,23 @@ def main(
         if config.target_mode == "metric":
             if initialization is not None:
                 print_main(f"Loading prompted trainable initialization: {initialization}", rank)
-                model: nn.Module = load_zipdepth_prompt(initialization, range_margin=config.range_margin)
+                # A fine-tune may deliberately change the margin: v4 recorded none, and the
+                # ultrawide run starts from it with the full window open. Say so loudly
+                # rather than failing, which is what resuming the same run does instead.
+                initialization_margin_m: float = range_margin_m_from_checkpoint(
+                    load_zipdepth_checkpoint(initialization), initialization
+                )
+                if not isclose(initialization_margin_m, config.range_margin_m, rel_tol=0.0, abs_tol=1e-9):
+                    print_main(
+                        f"OVERRIDE: initialization recorded range_margin_m={initialization_margin_m}, "
+                        f"training with range_margin_m={config.range_margin_m}",
+                        rank,
+                    )
+                model: nn.Module = load_zipdepth_prompt(initialization, range_margin_m=config.range_margin_m)
             else:
                 model = ZipDepthPrompt(
                     create_model(variant="base", upsample_unfold=model_config.upsample_unfold),
-                    range_margin=config.range_margin,
+                    range_margin_m=config.range_margin_m,
                 )
                 print_main("Training ZipDepth-PromptDA from scratch", rank)
         else:
@@ -803,7 +837,7 @@ def main(
             target_mode=config.target_mode,
             metric_gradient_weight=config.metric_gradient_weight,
             pin_batchnorm_eval=pin_batchnorm_eval,
-            range_margin=config.range_margin,
+            range_margin_m=config.range_margin_m,
             use_profiler=config.profile,
             profile_dir=str(config.profile_dir),
             profile_wait=config.profile_wait,
@@ -817,6 +851,7 @@ def main(
                 trainer,
                 total_steps=total_steps,
                 actual_max_lr=actual_max_lr,
+                range_margin_m=config.range_margin_m,
                 scheduler_config=scheduler_config,
                 schedule=recipe.schedule,
                 warmup_pct=recipe.warmup_pct,

--- a/packages/zipdepth/zipdepth/apis/train_catalog.py
+++ b/packages/zipdepth/zipdepth/apis/train_catalog.py
@@ -162,6 +162,11 @@ class TrainCatalogConfig:
     """Maximum completed samples buffered by the current loader."""
     min_depth_span: float = 1.25
     """Minimum valid-depth p95/p5 ratio; zero disables flat-frame filtering."""
+    range_margin: float = 0.0
+    """Widen the head's output range beyond the prompt's own [min, max] by this fraction of
+    the span; needed for ultrawide prompts that cover only the image center. The value is
+    recorded in ``resolved_config.json`` and in every checkpoint this run writes, so
+    inference rebuilds the same head. Zero reproduces the prompt-bounded head exactly."""
     from_scratch: bool = False
     """Start with random weights instead of the released ZipDepth-base weights."""
     metric_gradient_weight: float = 0.5
@@ -604,6 +609,10 @@ def main(
             raise ValueError("save_every_steps must be non-negative")
         if config.target_mode not in ("ssi", "metric"):
             raise ValueError(f"unknown target mode {config.target_mode!r}")
+        if not isfinite(config.range_margin) or config.range_margin < 0.0:
+            raise ValueError("range_margin must be finite and non-negative")
+        if config.range_margin > 0.0 and config.target_mode != "metric":
+            raise ValueError("range_margin only applies to the prompted metric lane")
         torch.backends.cudnn.benchmark = True
         torch.backends.cuda.matmul.allow_tf32 = True
         torch.backends.cudnn.allow_tf32 = True
@@ -735,10 +744,11 @@ def main(
         if config.target_mode == "metric":
             if initialization is not None:
                 print_main(f"Loading prompted trainable initialization: {initialization}", rank)
-                model: nn.Module = load_zipdepth_prompt(initialization)
+                model: nn.Module = load_zipdepth_prompt(initialization, range_margin=config.range_margin)
             else:
                 model = ZipDepthPrompt(
-                    create_model(variant="base", upsample_unfold=model_config.upsample_unfold)
+                    create_model(variant="base", upsample_unfold=model_config.upsample_unfold),
+                    range_margin=config.range_margin,
                 )
                 print_main("Training ZipDepth-PromptDA from scratch", rank)
         else:
@@ -793,6 +803,7 @@ def main(
             target_mode=config.target_mode,
             metric_gradient_weight=config.metric_gradient_weight,
             pin_batchnorm_eval=pin_batchnorm_eval,
+            range_margin=config.range_margin,
             use_profiler=config.profile,
             profile_dir=str(config.profile_dir),
             profile_wait=config.profile_wait,

--- a/packages/zipdepth/zipdepth/training/trainer.py
+++ b/packages/zipdepth/zipdepth/training/trainer.py
@@ -17,6 +17,7 @@ try:
 except ImportError:
     WANDB_AVAILABLE = False
 
+from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_KEY
 from monopriors.third_party.zipdepth.model_utils import strip_state_dict_prefixes
 
 from zipdepth.loss import MetricDepthLoss, ZipDepthLoss
@@ -66,6 +67,7 @@ class ZipDepthTrainer:
                 pin_batchnorm_eval: bool = False,
                 compile_mode: CompileMode = 'reduce-overhead',
                 channels_last: bool = False,
+                range_margin: float = 0.0,
                 ):
         """
         Args:
@@ -97,6 +99,8 @@ class ZipDepthTrainer:
             pin_batchnorm_eval: Return BatchNorm modules to eval after entering train mode
             compile_mode: torch.compile mode, or 'off'; dev-mode beartype disables it
             channels_last: Move four-dimensional batches with channels-last strides
+            range_margin: Prompted head output-range margin of the student, recorded in
+                every checkpoint so inference rebuilds the same head
         """
         self.student = student.to(device)
         self.train_loader = train_loader
@@ -128,6 +132,7 @@ class ZipDepthTrainer:
         self.target_mode = target_mode
         self.pin_batchnorm_eval = pin_batchnorm_eval
         self.channels_last = channels_last
+        self.range_margin = range_margin
 
         # Loss function initialization
         self.criterion: nn.Module = (
@@ -462,6 +467,7 @@ class ZipDepthTrainer:
             'model_state_dict': model_state,
             'optimizer_state_dict': self.optimizer.state_dict(),
             'loss': loss,
+            RANGE_MARGIN_KEY: self.range_margin,
         }
 
         if self.scheduler is not None:

--- a/packages/zipdepth/zipdepth/training/trainer.py
+++ b/packages/zipdepth/zipdepth/training/trainer.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     WANDB_AVAILABLE = False
 
-from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_KEY
+from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_M_KEY
 from monopriors.third_party.zipdepth.model_utils import strip_state_dict_prefixes
 
 from zipdepth.loss import MetricDepthLoss, ZipDepthLoss
@@ -67,7 +67,7 @@ class ZipDepthTrainer:
                 pin_batchnorm_eval: bool = False,
                 compile_mode: CompileMode = 'reduce-overhead',
                 channels_last: bool = False,
-                range_margin: float = 0.0,
+                range_margin_m: float = 0.0,
                 ):
         """
         Args:
@@ -99,8 +99,8 @@ class ZipDepthTrainer:
             pin_batchnorm_eval: Return BatchNorm modules to eval after entering train mode
             compile_mode: torch.compile mode, or 'off'; dev-mode beartype disables it
             channels_last: Move four-dimensional batches with channels-last strides
-            range_margin: Prompted head output-range margin of the student, recorded in
-                every checkpoint so inference rebuilds the same head
+            range_margin_m: Prompted head output-range margin of the student, in metres,
+                recorded in every checkpoint so inference rebuilds the same head
         """
         self.student = student.to(device)
         self.train_loader = train_loader
@@ -132,7 +132,7 @@ class ZipDepthTrainer:
         self.target_mode = target_mode
         self.pin_batchnorm_eval = pin_batchnorm_eval
         self.channels_last = channels_last
-        self.range_margin = range_margin
+        self.range_margin_m = range_margin_m
 
         # Loss function initialization
         self.criterion: nn.Module = (
@@ -467,7 +467,7 @@ class ZipDepthTrainer:
             'model_state_dict': model_state,
             'optimizer_state_dict': self.optimizer.state_dict(),
             'loss': loss,
-            RANGE_MARGIN_KEY: self.range_margin,
+            RANGE_MARGIN_M_KEY: self.range_margin_m,
         }
 
         if self.scheduler is not None:


### PR DESCRIPTION
## Why

The prompted ZipDepth head is a sigmoid rescaled into the prompt's own per-image `[min, max]`, so **predicted depth can never leave the range the prompt already covers**. That is fine for ARKit-style prompts that span the whole frame. It is wrong for the ultrawide captures we are about to train on: there the prompt covers only the central region, and the periphery is regularly nearer or farther than anything the prompt saw. Today the head has no way to say so.

## What changed

`ZipDepthPrompt` takes an explicit `range_margin_m: float = 0.0` — **absolute metres**, not a fraction of the prompt span — and rescales the head into a widened range:

```
min_out  = clamp_min(min - range_margin_m, MIN_METRIC_DEPTH_M)   # 0.1 m
max_out  = clamp_max(max + range_margin_m, MAX_METRIC_DEPTH_M)   # 4.0 m
span_out = max_out - min_out
depth    = sigmoid(logits) * span_out + min_out
```

**Why absolute and not span-relative.** A span-relative margin widens least exactly where the need is greatest. A close-up prompt spanning 0.8–1.2 m would reach only 0.6–1.4 m at half a span, leaving a 3.5 m wall in the ultrawide periphery unreachable — while a prompt that already spans most of the window would gain the whole rest of it for free. With absolute metres every image gains the same extra reach, and since the widened range is still clipped to the validity window, **`range_margin_m >= 3.9` opens the full `[0.1, 4.0]` m window**, which is the setting the ultrawide fine-tune will use.

No floor is applied to the widened span. It would be dead code: a positive margin always separates the two bounds, because clipping sends them to opposite edges of a window that already contains the prompt range. `MIN_PROMPT_SPAN_M` therefore keeps its single meaning (the prompt-normalization span).

`forward_with_range` returns the **widened** `min_out` / `max_out`, so the `min_depth` / `max_depth` ONNX outputs stay consistent with the `depth` output and `eval_hard_frames`' reconstruction of half-resolution depth from captured logits keeps working unchanged.

**Prompt normalization is unchanged.** The four decoder injection branches still see `(prompt - min) / span` over the un-widened range. The prompt itself does not change — only the range the head may reach — and holding the conditioning fixed means a margin change never shifts the features a trained model already relies on. A test pins this: the decoder logits are bit-identical between a margin-0.0 and a margin-0.5 model with the same weights.

## Parity at 0.0

At `range_margin_m == 0.0` the widening operations are **not emitted at all** — they sit behind `if self.range_margin_m > 0.0`, and `range_margin_m` is a plain Python float attribute, so the branch is resolved at trace time and the extra ops never enter the graph. So the torch forward pass is literally today's code, and the exported fp16 ONNX graph is structurally unchanged: same `image` / `prompt_depth` inputs, same `depth` / `min_depth` / `max_depth` outputs, same `ONNX_EXPORT_VERSION`.

(This is a structural argument about tracing, not a graph diff — the export test uses a fake `export_fn` and checks the wrapper and binding names, not the emitted ONNX.)

`test_zero_range_margin_reproduces_the_prompt_bounded_head_bit_for_bit` proves the numerics rather than the structure: it wraps the convex upsampler to capture the exact pre-sigmoid logits, recomputes the range with a verbatim copy of the original formula, and asserts `torch.equal` on depth, `min_depth`, and `max_depth` for a random 2-image batch. `test_zero_range_margin_parity_holds_under_cuda_float16_autocast` repeats the same assertions under `torch.autocast(cuda, float16)`.

## How the margin is persisted

One value, written once by training, read everywhere by inference — no new flag at each call site.

| Where | What |
| --- | --- |
| `TrainCatalogConfig.range_margin_m` | new field, default `0.0`; flattened into `resolved_config.json` through `ResolvedTrainCatalogConfig` |
| `ZipDepthTrainer` | new `range_margin_m` argument; `save_checkpoint` writes `range_margin_m` into every step and final checkpoint |
| `load_zipdepth_prompt(checkpoint, *, range_margin_m=None)` | reads the recorded value; explicit keyword-only argument overrides it |
| `monopriors/models/zipdepth_checkpoint.py` | `RANGE_MARGIN_M_KEY`, `load_zipdepth_checkpoint`, `state_dict_from_checkpoint`, `range_margin_m_from_checkpoint` — one `torch.load`, not two |

Old checkpoints (bare released state dicts, `zdpda-v4`) have no such key and default to `0.0`, so `ZipDepthPromptConfig.setup`, `eval_catalog`, `eval_hard_frames`, and `prompted_trt` all keep their current behavior with no change at those sites.

**Resume vs. init.** These are deliberately different:

- `_restore_resume_state` **raises** unless the checkpoint's recorded margin is `math.isclose` to the configured one. Resuming continues a single run, so a silent mid-run change would leave the optimizer state and the recorded margin describing different models.
- The `init_checkpoint` branch runs the same comparison but only prints a loud one-line `OVERRIDE:` notice. A fine-tune is allowed to change the margin — that is exactly our case, starting from v4, which recorded none, with the full window open.

**Export cache key.** `export_zipdepth_prompt_onnx` short-circuits on the ONNX filename before the model is loaded, so the resolved margin is now part of the key: `..._{tag}_m{margin:.2f}.onnx`. `ModelLoader` became a `Protocol` that accepts `range_margin_m`, so the exporter hands the same resolved value to the loader and the filename can never disagree with the graph it names. `ONNX_EXPORT_VERSION` is untouched.

## Test evidence

New tests: 10 in `packages/zipdepth/tests/test_prompted_model.py` (parity fp32 + parity CUDA fp16, absolute-metre widening, equal reach for narrow and wide prompts, clamping to the 0.1–4.0 m window including an all-invalid prompt, the full-window `3.9` case, conditioning invariance, validation, checkpoint round-trip, legacy default), 2 in `test_prompted_trt.py` (the export bakes the checkpoint's margin into the graph *and* its cache key; one cached graph per margin), 3 in `test_catalog_train.py` (`resolved_config.json` round-trip, trainer checkpoint metadata, resume-with-a-different-margin is refused).

Run on **`pablo-dl-server`** (linux-64, RTX 5090) — all clean:

| Command | Result |
| --- | --- |
| `pixi run -e zipdepth-dev lint` | pass |
| `pixi run -e zipdepth-dev typecheck` | 1 error, pre-existing (`torchcodec.decoders` is absent from the env) |
| `pixi run -e zipdepth-dev deadcode` | pass |
| `pixi run -e zipdepth-dev tests` | **103 passed, 4 skipped** (`--ignore=tests/test_infer_rerun_pixels.py`, whose collection fails on `main` too: `omegaconf` is absent from `zipdepth-dev`) |
| `pixi run -e monoprior-dev lint` | pass |
| `pixi run -e monoprior-dev typecheck` | 0 errors |
| `pixi run -e monoprior-dev deadcode` | pass |
| `pixi run -e monoprior-dev tests` | **130 passed, 18 deselected** |

The CUDA parity test executed on the 5090 (14/14 in `test_prompted_model.py`, no skips; the single skip in `test_prompted_trt.py` is the opt-in TensorRT engine test behind `ZIPDEPTH_TRT_PARITY=1`). Lint, typecheck, and the same test selection were also run on a linux-aarch64 GB10 host. No training was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
