### PR TITLE
zipdepth: uw-v1 integration (range margin + ultrawide lane)

### DIFF
--- a/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt.py
+++ b/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt.py
@@ -3,9 +3,16 @@
 The wrapper keeps the vendored ZipDepth-base tensors unchanged, injects a
 normalized metric prompt into all four decoder stages, and returns depth in the
 same units as the prompt (metres for the public API).
+
+The head can only reach depths inside the range it is rescaled into, which by
+default is the prompt's own ``[min, max]``. ``ZipDepthPrompt(range_margin=...)``
+widens that range by a fraction of the prompt span on each side, which ultrawide
+captures need: their prompt covers the image centre, so the periphery is often
+nearer or farther than anything the prompt saw.
 """
 
 from dataclasses import dataclass, field
+from math import isfinite
 from pathlib import Path
 from typing import Self
 
@@ -33,7 +40,11 @@ from monopriors.models.depth_completion.base_completion_depth import (
     PROMPT_INPUT_NAME,
     BaseCompletionPredictor,
 )
-from monopriors.models.zipdepth_checkpoint import load_zipdepth_state_dict
+from monopriors.models.zipdepth_checkpoint import (
+    load_zipdepth_checkpoint,
+    range_margin_from_checkpoint,
+    state_dict_from_checkpoint,
+)
 from monopriors.third_party.zipdepth.architecture import EncoderOutput, FeaturePyramid, ZipDepth, create_model
 from monopriors.third_party.zipdepth.model_utils import StateDict
 
@@ -82,15 +93,36 @@ def _inject_prompt(
 
 
 class ZipDepthPrompt(nn.Module):
-    """ZipDepth-base with PromptDA-style multi-scale metric conditioning."""
+    """ZipDepth-base with PromptDA-style multi-scale metric conditioning.
 
-    def __init__(self, backbone: ZipDepth | None = None) -> None:
+    The head is a sigmoid rescaled into a per-image depth range derived from the
+    prompt. ``range_margin`` widens that output range symmetrically, so predicted
+    depth is no longer trapped inside the prompt's own ``[min, max]``. The prompt
+    *normalization* fed to the four decoder injection branches deliberately keeps
+    the original ``[min, max]``: the prompt itself does not change, only the range
+    the head may reach, and holding the conditioning fixed keeps a margin change
+    from shifting the features a trained model already relies on.
+    """
+
+    def __init__(self, backbone: ZipDepth | None = None, *, range_margin: float = 0.0) -> None:
+        """Build the prompted wrapper.
+
+        Args:
+            backbone: ZipDepth-base network; ``None`` creates a fresh one.
+            range_margin: Fraction of the prompt span by which the head's output
+                range is widened past the prompt's own minimum and maximum. Zero
+                reproduces the prompt-bounded head exactly, emitting none of the
+                widening operations.
+        """
         super().__init__()
         self.backbone: ZipDepth = create_model(variant="base") if backbone is None else backbone
         if self.backbone.variant != "base":
             raise ValueError(f"ZipDepthPrompt requires the base variant, got {self.backbone.variant!r}")
         if not self.backbone.decoder.convex_up.use_unfold:
             raise ValueError("ZipDepthPrompt currently requires ZipDepth's unfold-based convex head")
+        if not isfinite(range_margin) or range_margin < 0.0:
+            raise ValueError(f"range_margin must be finite and non-negative, got {range_margin}")
+        self.range_margin: float = range_margin
         self.prompt_branches: nn.ModuleList = nn.ModuleList(
             [_make_prompt_branch(channels) for channels in (288, 192, 144, 96)]
         )
@@ -130,10 +162,15 @@ class ZipDepthPrompt(nn.Module):
         Float32[Tensor, "b 1 1 1"],
         Float32[Tensor, "b 1 1 1"],
     ]:
-        """Predict metric depth and expose the prompt range for TRT export.
+        """Predict metric depth and expose the head's output range for TRT export.
 
         The two scalar outputs force TensorRT to materialize the input-derived
         reductions. Normal callers use :meth:`forward` and receive depth only.
+
+        Returns:
+            Metric depth, and the minimum and maximum the head can reach. Those
+            two already include ``range_margin``, so ``sigmoid(logits) * (max -
+            min) + min`` reproduces depth from captured logits.
         """
         if image.dtype == torch.uint8:
             image_bchw: Float[Tensor, "b 3 h w"] = image.to(dtype=self.backbone.mean.dtype) / 255.0
@@ -165,6 +202,18 @@ class ZipDepthPrompt(nn.Module):
             0.0,
         )
 
+        # The head may leave the prompt's own range by ``range_margin`` spans on each
+        # side, still clipped to the shared validity window. At zero margin these
+        # operations are skipped entirely, so torch and the exported fp16 graph are
+        # unchanged. Prompt normalization above keeps the un-widened range.
+        min_output_b: Float32[Tensor, "b 1 1 1"] = min_depth_b
+        max_output_b: Float32[Tensor, "b 1 1 1"] = max_depth_b
+        span_output_b: Float32[Tensor, "b 1 1 1"] = span_b
+        if self.range_margin > 0.0:
+            min_output_b = (min_depth_b - self.range_margin * span_b).clamp_min(MIN_METRIC_DEPTH_M)
+            max_output_b = (max_depth_b + self.range_margin * span_b).clamp_max(MAX_METRIC_DEPTH_M)
+            span_output_b = (max_output_b - min_output_b).clamp_min(MIN_PROMPT_SPAN_M)
+
         normalized_image_bchw: Float[Tensor, "b 3 h w"] = (image_bchw - self.backbone.mean).div_(self.backbone.std)
         encoder_output: EncoderOutput = self.backbone.encoder(normalized_image_bchw)
         stem_half_bchw: Float[Tensor, "b c_half h_half w_half"] = encoder_output[0]
@@ -191,8 +240,8 @@ class ZipDepthPrompt(nn.Module):
         depth_logits_half_bchw: Float[Tensor, "b 1 h_half w_half"] = decoder.head_half(f_half_bchw)
         depth_logits_bchw: Float[Tensor, "b 1 h w"] = decoder.convex_up._forward_unfold(f_half_bchw, depth_logits_half_bchw)
         normalized_depth_bchw: Float[Tensor, "b 1 h w"] = torch.sigmoid(depth_logits_bchw)
-        metric_depth_bchw: Float[Tensor, "b 1 h w"] = normalized_depth_bchw * span_b + min_depth_b
-        return metric_depth_bchw, min_depth_b, max_depth_b
+        metric_depth_bchw: Float[Tensor, "b 1 h w"] = normalized_depth_bchw * span_output_b + min_output_b
+        return metric_depth_bchw, min_output_b, max_output_b
 
     def fuse_for_inference(self) -> Self:
         """Fuse the released ZipDepth backbone in place and enter eval mode."""
@@ -201,26 +250,32 @@ class ZipDepthPrompt(nn.Module):
         return self
 
 
-def load_zipdepth_prompt(checkpoint: Path) -> ZipDepthPrompt:
+def load_zipdepth_prompt(checkpoint: Path, range_margin: float | None = None) -> ZipDepthPrompt:
     """Load a complete released ZipDepth-base checkpoint into the wrapper.
 
     Args:
         checkpoint: Bare ZipDepth state dict or trainer checkpoint containing
             ``model_state_dict``. DDP and ``torch.compile`` prefixes are
             accepted.
+        range_margin: Output-range margin override. ``None`` takes the margin
+            the training run recorded in the checkpoint, which is ``0.0`` for
+            bare state dicts and for checkpoints written before the margin
+            existed.
 
     Returns:
         A trainable prompted model. Every released tensor is loaded strictly;
         prompt-branch tensors retain their zero-output initialization.
     """
-    state_dict: StateDict = load_zipdepth_state_dict(checkpoint)
+    loaded: dict[str, object] = load_zipdepth_checkpoint(checkpoint)
+    state_dict: StateDict = state_dict_from_checkpoint(loaded, checkpoint)
+    margin: float = range_margin if range_margin is not None else range_margin_from_checkpoint(loaded, checkpoint)
     if any(key.startswith("backbone.") for key in state_dict):
-        prompted_model: ZipDepthPrompt = ZipDepthPrompt()
+        prompted_model: ZipDepthPrompt = ZipDepthPrompt(range_margin=margin)
         prompted_model.load_state_dict(state_dict, strict=True)
         return prompted_model
     backbone: ZipDepth = create_model(variant="base")
     backbone.load_state_dict(state_dict, strict=True)
-    return ZipDepthPrompt(backbone)
+    return ZipDepthPrompt(backbone, range_margin=margin)
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt.py
+++ b/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt.py
@@ -5,8 +5,8 @@ normalized metric prompt into all four decoder stages, and returns depth in the
 same units as the prompt (metres for the public API).
 
 The head can only reach depths inside the range it is rescaled into, which by
-default is the prompt's own ``[min, max]``. ``ZipDepthPrompt(range_margin=...)``
-widens that range by a fraction of the prompt span on each side, which ultrawide
+default is the prompt's own ``[min, max]``. ``ZipDepthPrompt(range_margin_m=...)``
+widens that range by a fixed number of metres on each side, which ultrawide
 captures need: their prompt covers the image centre, so the periphery is often
 nearer or farther than anything the prompt saw.
 """
@@ -42,7 +42,7 @@ from monopriors.models.depth_completion.base_completion_depth import (
 )
 from monopriors.models.zipdepth_checkpoint import (
     load_zipdepth_checkpoint,
-    range_margin_from_checkpoint,
+    range_margin_m_from_checkpoint,
     state_dict_from_checkpoint,
 )
 from monopriors.third_party.zipdepth.architecture import EncoderOutput, FeaturePyramid, ZipDepth, create_model
@@ -96,23 +96,37 @@ class ZipDepthPrompt(nn.Module):
     """ZipDepth-base with PromptDA-style multi-scale metric conditioning.
 
     The head is a sigmoid rescaled into a per-image depth range derived from the
-    prompt. ``range_margin`` widens that output range symmetrically, so predicted
-    depth is no longer trapped inside the prompt's own ``[min, max]``. The prompt
-    *normalization* fed to the four decoder injection branches deliberately keeps
-    the original ``[min, max]``: the prompt itself does not change, only the range
-    the head may reach, and holding the conditioning fixed keeps a margin change
-    from shifting the features a trained model already relies on.
+    prompt. ``range_margin_m`` widens that output range by a fixed number of
+    metres on each side, so predicted depth is no longer trapped inside the
+    prompt's own ``[min, max]``.
+
+    The margin is absolute rather than a fraction of the prompt span on purpose.
+    A span-relative margin widens least exactly where the need is greatest: a
+    close-up prompt spanning 0.8--1.2 m would reach only 0.6--1.4 m at half a
+    span, leaving a 3.5 m wall in the ultrawide periphery unreachable, while a
+    prompt that already spans most of the window would gain the whole rest of it.
+    Because the widened range is still clipped to ``[MIN_METRIC_DEPTH_M,
+    MAX_METRIC_DEPTH_M]``, any ``range_margin_m >= 3.9`` opens the full
+    ``[0.1, 4.0]`` m window for every image; that is the setting the ultrawide
+    fine-tune uses.
+
+    The prompt *normalization* fed to the four decoder injection branches is
+    unchanged: it deliberately keeps the original ``[min, max]``. The prompt
+    itself does not change, only the range the head may reach, and holding the
+    conditioning fixed keeps a margin change from shifting the features a trained
+    model already relies on.
     """
 
-    def __init__(self, backbone: ZipDepth | None = None, *, range_margin: float = 0.0) -> None:
+    def __init__(self, backbone: ZipDepth | None = None, *, range_margin_m: float = 0.0) -> None:
         """Build the prompted wrapper.
 
         Args:
             backbone: ZipDepth-base network; ``None`` creates a fresh one.
-            range_margin: Fraction of the prompt span by which the head's output
-                range is widened past the prompt's own minimum and maximum. Zero
-                reproduces the prompt-bounded head exactly, emitting none of the
-                widening operations.
+            range_margin_m: Metres by which the head's output range is widened
+                past the prompt's own minimum and maximum, before clipping to the
+                shared validity window. Zero reproduces the prompt-bounded head
+                exactly, emitting none of the widening operations; ``3.9`` or more
+                opens the full window.
         """
         super().__init__()
         self.backbone: ZipDepth = create_model(variant="base") if backbone is None else backbone
@@ -120,9 +134,9 @@ class ZipDepthPrompt(nn.Module):
             raise ValueError(f"ZipDepthPrompt requires the base variant, got {self.backbone.variant!r}")
         if not self.backbone.decoder.convex_up.use_unfold:
             raise ValueError("ZipDepthPrompt currently requires ZipDepth's unfold-based convex head")
-        if not isfinite(range_margin) or range_margin < 0.0:
-            raise ValueError(f"range_margin must be finite and non-negative, got {range_margin}")
-        self.range_margin: float = range_margin
+        if not isfinite(range_margin_m) or range_margin_m < 0.0:
+            raise ValueError(f"range_margin_m must be finite and non-negative, got {range_margin_m}")
+        self.range_margin_m: float = range_margin_m
         self.prompt_branches: nn.ModuleList = nn.ModuleList(
             [_make_prompt_branch(channels) for channels in (288, 192, 144, 96)]
         )
@@ -169,7 +183,7 @@ class ZipDepthPrompt(nn.Module):
 
         Returns:
             Metric depth, and the minimum and maximum the head can reach. Those
-            two already include ``range_margin``, so ``sigmoid(logits) * (max -
+            two already include ``range_margin_m``, so ``sigmoid(logits) * (max -
             min) + min`` reproduces depth from captured logits.
         """
         if image.dtype == torch.uint8:
@@ -202,17 +216,20 @@ class ZipDepthPrompt(nn.Module):
             0.0,
         )
 
-        # The head may leave the prompt's own range by ``range_margin`` spans on each
-        # side, still clipped to the shared validity window. At zero margin these
-        # operations are skipped entirely, so torch and the exported fp16 graph are
-        # unchanged. Prompt normalization above keeps the un-widened range.
+        # The head may leave the prompt's own range by ``range_margin_m`` metres on
+        # each side, still clipped to the shared validity window. At zero margin
+        # these operations are skipped entirely, so torch and the exported fp16
+        # graph are unchanged. Prompt normalization above keeps the un-widened
+        # range. No floor is needed on the widened span: a positive margin always
+        # separates the two bounds, because clipping sends them to opposite edges
+        # of a window that already contains the prompt range.
         min_output_b: Float32[Tensor, "b 1 1 1"] = min_depth_b
         max_output_b: Float32[Tensor, "b 1 1 1"] = max_depth_b
         span_output_b: Float32[Tensor, "b 1 1 1"] = span_b
-        if self.range_margin > 0.0:
-            min_output_b = (min_depth_b - self.range_margin * span_b).clamp_min(MIN_METRIC_DEPTH_M)
-            max_output_b = (max_depth_b + self.range_margin * span_b).clamp_max(MAX_METRIC_DEPTH_M)
-            span_output_b = (max_output_b - min_output_b).clamp_min(MIN_PROMPT_SPAN_M)
+        if self.range_margin_m > 0.0:
+            min_output_b = (min_depth_b - self.range_margin_m).clamp_min(MIN_METRIC_DEPTH_M)
+            max_output_b = (max_depth_b + self.range_margin_m).clamp_max(MAX_METRIC_DEPTH_M)
+            span_output_b = max_output_b - min_output_b
 
         normalized_image_bchw: Float[Tensor, "b 3 h w"] = (image_bchw - self.backbone.mean).div_(self.backbone.std)
         encoder_output: EncoderOutput = self.backbone.encoder(normalized_image_bchw)
@@ -250,17 +267,17 @@ class ZipDepthPrompt(nn.Module):
         return self
 
 
-def load_zipdepth_prompt(checkpoint: Path, range_margin: float | None = None) -> ZipDepthPrompt:
+def load_zipdepth_prompt(checkpoint: Path, *, range_margin_m: float | None = None) -> ZipDepthPrompt:
     """Load a complete released ZipDepth-base checkpoint into the wrapper.
 
     Args:
         checkpoint: Bare ZipDepth state dict or trainer checkpoint containing
             ``model_state_dict``. DDP and ``torch.compile`` prefixes are
             accepted.
-        range_margin: Output-range margin override. ``None`` takes the margin
-            the training run recorded in the checkpoint, which is ``0.0`` for
-            bare state dicts and for checkpoints written before the margin
-            existed.
+        range_margin_m: Output-range margin override, in metres. ``None`` takes
+            the margin the training run recorded in the checkpoint, which is
+            ``0.0`` for bare state dicts and for checkpoints written before the
+            margin existed.
 
     Returns:
         A trainable prompted model. Every released tensor is loaded strictly;
@@ -268,14 +285,14 @@ def load_zipdepth_prompt(checkpoint: Path, range_margin: float | None = None) ->
     """
     loaded: dict[str, object] = load_zipdepth_checkpoint(checkpoint)
     state_dict: StateDict = state_dict_from_checkpoint(loaded, checkpoint)
-    margin: float = range_margin if range_margin is not None else range_margin_from_checkpoint(loaded, checkpoint)
+    margin_m: float = range_margin_m if range_margin_m is not None else range_margin_m_from_checkpoint(loaded, checkpoint)
     if any(key.startswith("backbone.") for key in state_dict):
-        prompted_model: ZipDepthPrompt = ZipDepthPrompt(range_margin=margin)
+        prompted_model: ZipDepthPrompt = ZipDepthPrompt(range_margin_m=margin_m)
         prompted_model.load_state_dict(state_dict, strict=True)
         return prompted_model
     backbone: ZipDepth = create_model(variant="base")
     backbone.load_state_dict(state_dict, strict=True)
-    return ZipDepthPrompt(backbone, range_margin=margin)
+    return ZipDepthPrompt(backbone, range_margin_m=margin_m)
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt_export.py
+++ b/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt_export.py
@@ -15,6 +15,7 @@ from torch import Tensor, nn
 from monopriors.models.depth_completion.base_completion_depth import DEPTH_OUTPUT_NAME, IMAGE_INPUT_NAME, PROMPT_DEPTH_HW, PROMPT_INPUT_NAME
 from monopriors.models.depth_completion.zipdepth_prompt import load_zipdepth_prompt
 from monopriors.models.relative_depth.zipdepth import download_zipdepth_checkpoint
+from monopriors.models.zipdepth_checkpoint import load_zipdepth_checkpoint, range_margin_m_from_checkpoint
 
 ONNX_EXPORT_VERSION: int = 1
 DEFAULT_CACHE_DIR: Path = Path(os.environ.get("ZIPDEPTH_PROMPT_TRT_CACHE", "~/.cache/zipdepth-promptda")).expanduser()
@@ -50,15 +51,23 @@ class PromptedDepthModel(Protocol):
         ...
 
 
-ModelLoader = Callable[[Path], PromptedDepthModel]
+@runtime_checkable
+class ModelLoader(Protocol):
+    """Checkpoint-to-model boundary used by the exporter and its tests."""
+
+    def __call__(self, checkpoint: Path, /, *, range_margin_m: float | None = None) -> PromptedDepthModel:
+        """Load a prompted model, optionally overriding its output-range margin."""
+        ...
+
+
 ExportFn = Callable[..., None]
 
 
 class _ExportOutputs(nn.Module):
     """Expose the head's output-range min/max as TensorRT fusion barriers.
 
-    Those two scalars carry the loaded checkpoint's ``range_margin``, so the graph
-    bakes in the range the model was trained with.
+    Those two scalars carry the loaded checkpoint's ``range_margin_m``, so the
+    graph bakes in the range the model was trained with.
     """
 
     def __init__(self, model: PromptedDepthModel) -> None:
@@ -114,6 +123,7 @@ def export_zipdepth_prompt_onnx(
     image_hw: tuple[int, int] = (768, 1024),
     batch_size: int = 8,
     cache_dir: Path = DEFAULT_CACHE_DIR,
+    range_margin_m: float | None = None,
     model_loader: ModelLoader = load_zipdepth_prompt,
     export_fn: ExportFn | None = None,
     device: str = "cuda",
@@ -125,6 +135,11 @@ def export_zipdepth_prompt_onnx(
         image_hw: Static image height and width.
         batch_size: Batch baked into the graph.
         cache_dir: Portable ONNX cache root.
+        range_margin_m: Output-range margin baked into the graph, in metres. It
+            is both the cache key and the value handed to ``model_loader``, so
+            the filename can never disagree with the graph. ``None`` reads the
+            value the checkpoint recorded, which costs one ``torch.load`` even
+            on a cache hit.
         model_loader: Model loader boundary used by export tests.
         export_fn: ONNX writer boundary; defaults to :func:`trtkit.export_onnx`.
         device: Torch export device.
@@ -137,15 +152,26 @@ def export_zipdepth_prompt_onnx(
     height, width = image_hw
     resolved_checkpoint: Path = checkpoint or download_zipdepth_checkpoint()
     tag: str = _checkpoint_tag(resolved_checkpoint)
+    # The margin changes the graph, so it belongs in the cache key next to the
+    # checkpoint tag: the lookup below short-circuits before the model is loaded,
+    # and an explicit override would otherwise be served a stale graph.
+    resolved_margin_m: float = (
+        range_margin_m
+        if range_margin_m is not None
+        else range_margin_m_from_checkpoint(load_zipdepth_checkpoint(resolved_checkpoint), resolved_checkpoint)
+    )
     onnx_dir: Path = cache_dir / "onnx"
-    onnx_path: Path = onnx_dir / f"zipdepth-prompt_{height}x{width}_b{batch_size}_fp16_v{ONNX_EXPORT_VERSION}_{tag}.onnx"
+    onnx_path: Path = (
+        onnx_dir / f"zipdepth-prompt_{height}x{width}_b{batch_size}_fp16_v{ONNX_EXPORT_VERSION}_{tag}_m{resolved_margin_m:.2f}.onnx"
+    )
     if onnx_path.is_file():
         return onnx_path
 
     resolved_device = torch.device(device)
     if resolved_device.type == "cuda" and not torch.cuda.is_available():
         raise RuntimeError("CUDA is required for the fp16 ZipDepth ONNX export")
-    model: PromptedDepthModel = prepare_zipdepth_prompt_for_export(model_loader(resolved_checkpoint), image_hw, resolved_device)
+    loaded_model: PromptedDepthModel = model_loader(resolved_checkpoint, range_margin_m=resolved_margin_m)
+    model: PromptedDepthModel = prepare_zipdepth_prompt_for_export(loaded_model, image_hw, resolved_device)
     wrapper: nn.Module = _ExportOutputs(model).eval()
     dummy_image_bchw: Float32[Tensor, "b 3 h w"] = torch.rand(
         (batch_size, 3, height, width), dtype=torch.float32, device=resolved_device
@@ -180,6 +206,7 @@ __all__ = (
     "DEFAULT_CACHE_DIR",
     "DEPTH_OUTPUT_NAME",
     "IMAGE_INPUT_NAME",
+    "ModelLoader",
     "ONNX_EXPORT_VERSION",
     "PROMPT_INPUT_NAME",
     "PromptedDepthModel",

--- a/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt_export.py
+++ b/packages/monoprior/monopriors/models/depth_completion/zipdepth_prompt_export.py
@@ -38,7 +38,7 @@ class PromptedDepthModel(Protocol):
         image: Float32[Tensor, "b 3 h w"],
         prompt_depth: Float32[Tensor, "b 1 192 256"],
     ) -> tuple[Float32[Tensor, "b 1 h w"], Float32[Tensor, "b 1 1 1"], Float32[Tensor, "b 1 1 1"]]:
-        """Return metric depth and the input-derived minimum and maximum."""
+        """Return metric depth and the input-derived output-range minimum and maximum."""
         ...
 
     def fuse_for_inference(self) -> "PromptedDepthModel":
@@ -55,7 +55,11 @@ ExportFn = Callable[..., None]
 
 
 class _ExportOutputs(nn.Module):
-    """Expose prompt min/max reductions as TensorRT fusion barriers."""
+    """Expose the head's output-range min/max as TensorRT fusion barriers.
+
+    Those two scalars carry the loaded checkpoint's ``range_margin``, so the graph
+    bakes in the range the model was trained with.
+    """
 
     def __init__(self, model: PromptedDepthModel) -> None:
         super().__init__()

--- a/packages/monoprior/monopriors/models/zipdepth_checkpoint.py
+++ b/packages/monoprior/monopriors/models/zipdepth_checkpoint.py
@@ -7,8 +7,8 @@ from torch import Tensor
 
 from monopriors.third_party.zipdepth.model_utils import StateDict, strip_state_dict_prefixes
 
-RANGE_MARGIN_KEY: str = "range_margin"
-"""Trainer-checkpoint key holding the prompted head's output-range margin."""
+RANGE_MARGIN_M_KEY: str = "range_margin_m"
+"""Trainer-checkpoint key holding the prompted head's output-range margin, in metres."""
 
 
 def load_zipdepth_checkpoint(checkpoint: Path) -> dict[str, object]:
@@ -47,22 +47,22 @@ def state_dict_from_checkpoint(loaded: dict[str, object], checkpoint: Path) -> S
     return strip_state_dict_prefixes(state_dict)
 
 
-def range_margin_from_checkpoint(loaded: dict[str, object], checkpoint: Path) -> float:
-    """Read the prompted output-range margin recorded by training.
+def range_margin_m_from_checkpoint(loaded: dict[str, object], checkpoint: Path) -> float:
+    """Read the prompted output-range margin, in metres, recorded by training.
 
     Args:
         loaded: Mapping returned by :func:`load_zipdepth_checkpoint`.
         checkpoint: Source path, used only for error messages.
 
     Returns:
-        The recorded margin, or ``0.0`` for bare state dicts and for
+        The recorded margin in metres, or ``0.0`` for bare state dicts and for
         checkpoints written before the margin existed (for example
         ``zdpda-v4``).
     """
-    raw_margin: object = loaded.get(RANGE_MARGIN_KEY, 0.0)
-    if isinstance(raw_margin, bool) or not isinstance(raw_margin, float | int):
-        raise ValueError(f"checkpoint {RANGE_MARGIN_KEY} must be a number: {checkpoint}")
-    return float(raw_margin)
+    raw_margin_m: object = loaded.get(RANGE_MARGIN_M_KEY, 0.0)
+    if isinstance(raw_margin_m, bool) or not isinstance(raw_margin_m, float | int):
+        raise ValueError(f"checkpoint {RANGE_MARGIN_M_KEY} must be a number: {checkpoint}")
+    return float(raw_margin_m)
 
 
 def load_zipdepth_state_dict(checkpoint: Path) -> StateDict:
@@ -71,10 +71,10 @@ def load_zipdepth_state_dict(checkpoint: Path) -> StateDict:
 
 
 __all__ = (
-    "RANGE_MARGIN_KEY",
+    "RANGE_MARGIN_M_KEY",
     "load_zipdepth_checkpoint",
     "load_zipdepth_state_dict",
     "narrow_zipdepth_state_dict",
-    "range_margin_from_checkpoint",
+    "range_margin_m_from_checkpoint",
     "state_dict_from_checkpoint",
 )

--- a/packages/monoprior/monopriors/models/zipdepth_checkpoint.py
+++ b/packages/monoprior/monopriors/models/zipdepth_checkpoint.py
@@ -7,6 +7,24 @@ from torch import Tensor
 
 from monopriors.third_party.zipdepth.model_utils import StateDict, strip_state_dict_prefixes
 
+RANGE_MARGIN_KEY: str = "range_margin"
+"""Trainer-checkpoint key holding the prompted head's output-range margin."""
+
+
+def load_zipdepth_checkpoint(checkpoint: Path) -> dict[str, object]:
+    """Load a bare state dict or a trainer checkpoint as a raw mapping.
+
+    Args:
+        checkpoint: Path to a ``.pth`` written by ``torch.save``.
+
+    Returns:
+        The deserialized top-level mapping.
+    """
+    loaded: dict[str, object] = torch.load(checkpoint, map_location="cpu", weights_only=True)
+    if not isinstance(loaded, dict):
+        raise ValueError(f"checkpoint must contain a mapping: {checkpoint}")
+    return loaded
+
 
 def narrow_zipdepth_state_dict(raw_state: object, checkpoint: Path) -> dict[str, Tensor]:
     """Validate and type a serialized ZipDepth model state mapping."""
@@ -22,14 +40,41 @@ def narrow_zipdepth_state_dict(raw_state: object, checkpoint: Path) -> dict[str,
     return state_dict
 
 
-def load_zipdepth_state_dict(checkpoint: Path) -> StateDict:
-    """Load, unwrap, and clean a bare or trainer ZipDepth state dictionary."""
-    loaded: dict[str, object] = torch.load(checkpoint, map_location="cpu", weights_only=True)
-    if not isinstance(loaded, dict):
-        raise ValueError(f"checkpoint must contain a mapping: {checkpoint}")
+def state_dict_from_checkpoint(loaded: dict[str, object], checkpoint: Path) -> StateDict:
+    """Unwrap and clean the model state held by an already-loaded checkpoint."""
     raw_state: object = loaded.get("model_state_dict", loaded)
     state_dict: dict[str, Tensor] = narrow_zipdepth_state_dict(raw_state, checkpoint)
     return strip_state_dict_prefixes(state_dict)
 
 
-__all__ = ("load_zipdepth_state_dict", "narrow_zipdepth_state_dict")
+def range_margin_from_checkpoint(loaded: dict[str, object], checkpoint: Path) -> float:
+    """Read the prompted output-range margin recorded by training.
+
+    Args:
+        loaded: Mapping returned by :func:`load_zipdepth_checkpoint`.
+        checkpoint: Source path, used only for error messages.
+
+    Returns:
+        The recorded margin, or ``0.0`` for bare state dicts and for
+        checkpoints written before the margin existed (for example
+        ``zdpda-v4``).
+    """
+    raw_margin: object = loaded.get(RANGE_MARGIN_KEY, 0.0)
+    if isinstance(raw_margin, bool) or not isinstance(raw_margin, float | int):
+        raise ValueError(f"checkpoint {RANGE_MARGIN_KEY} must be a number: {checkpoint}")
+    return float(raw_margin)
+
+
+def load_zipdepth_state_dict(checkpoint: Path) -> StateDict:
+    """Load, unwrap, and clean a bare or trainer ZipDepth state dictionary."""
+    return state_dict_from_checkpoint(load_zipdepth_checkpoint(checkpoint), checkpoint)
+
+
+__all__ = (
+    "RANGE_MARGIN_KEY",
+    "load_zipdepth_checkpoint",
+    "load_zipdepth_state_dict",
+    "narrow_zipdepth_state_dict",
+    "range_margin_from_checkpoint",
+    "state_dict_from_checkpoint",
+)

--- a/packages/zipdepth/docs/ultrawide.md
+++ b/packages/zipdepth/docs/ultrawide.md
@@ -1,0 +1,218 @@
+# Ultrawide training lane for ZipDepth-PromptDA
+
+## Goal
+
+Teach the prompted student to produce metric depth for the **rectified ultrawide
+camera** while it is prompted with the **wide** camera's ARKit LiDAR map. The
+ultrawide sees about 2.1x the wide field of view on both axes, so most of an
+ultrawide frame has no LiDAR support at all. The model must therefore keep its
+metric scale from the prompted centre and extend it outward from image evidence.
+
+The lane is off by default: `TrainCatalogConfig.cameras` is `"wide"`, and
+`packages/zipdepth/tests/test_catalog_ultrawide.py` proves the wide sample is
+bit-identical with and without an ultrawide policy attached to the builder.
+
+## Data
+
+New catalog layer `ultrawide_depth`, registered on **2,024 of the 2,025**
+PromptDA segments (`43649417` lacks it; the lane logs one warning and skips it).
+Under `world/rig_00/cam_01/pinhole_rect`:
+
+| Entity | Component | Content |
+| --- | --- | --- |
+| `pinhole_rect` | `Pinhole:image_from_camera`, `Pinhole:resolution` | rectified intrinsics |
+| `pinhole_rect/rgb` | `EncodedImage:blob` | JPEG quality 90, 640x480 landscape or 480x640 portrait |
+| `pinhole_rect/depth` | `EncodedDepthImage:blob` | uint16 millimetre PNG, raycast from the PromptDA TSDF mesh; 0 is a miss |
+
+Rows exist only at the ultrawide chosen frames (10 Hz, 480 to 1,840 per segment).
+Those timestamps are **disjoint** from the wide chosen frames — on `47115416`
+only 1 of 651 ultrawide timestamps coincides with a wide one — so the wide and
+ultrawide passes are genuinely different views of a capture, not duplicates.
+
+Portrait captures store the rectified frame as 480x640; the lane rotates it to
+landscape with the same `property:capture:orientation_quarter_turns_ccw` the wide
+path already uses, then resizes to the lane's 768x1024.
+
+## Why the prompt is resized and padded, not reprojected
+
+The prompt could be reprojected into ultrawide pixels, leaving the outer ring
+empty. That is strictly more work and buys nothing, because of where the prompt
+is consumed:
+
+* ZipDepth-PromptDA bilinearly resamples the 192x256 prompt to each decoder
+  feature size. The finest is H/4, which at the 768x1024 training input is
+  192x256 — exactly the canvas size. A prompt canvas that covered the full
+  ultrawide frame would be downsampled to the same 122x91 block of information
+  before the decoder ever reads it.
+* The ARKit map is itself an upsampled product: a few hundred LiDAR returns
+  smeared over 256x192. Reprojecting it to a finer ultrawide grid would invent
+  detail that the sensor never measured.
+
+So the lane resamples the oriented wide prompt to `round(256 * s) x round(192 * s)
+= 122 x 91` with nearest-exact resampling — every output value stays a real LiDAR
+reading — and writes it into a **zeroed** 192x256 canvas at `top=50, left=67`.
+Zero means "no prompt": the model's own `[0.1, 4.0] m` range gate already treats
+0 as invalid, so no extra signalling is needed and `prompt_valid` follows the
+same rule.
+
+Mirroring is applied to the **block**, before padding, so a horizontal flip stays
+exact for any canvas margin (at the default scale the horizontal margin is 67 on
+both sides, but the vertical one is 50/51).
+
+## The 2.1 constant
+
+`ULTRAWIDE_FOV_RATIO = 2.1`, `prompt_scale = 1 / 2.1`.
+
+Measured from the catalog calibration over 24 segments spanning both stored
+orientations, as the per-axis ratio of `resolution / focal_length`:
+
+```
+fov ratio x: mean 2.1087  sd 0.0152  min 2.0688  max 2.1383
+fov ratio y: mean 2.1087  sd 0.0152  min 2.0688  max 2.1383
+principal-point offset from centre: <= 0.66% of width, <= 0.69% of height
+```
+
+x and y agree exactly because both cameras are square-pixel and share a 4:3
+aspect. Example (`47115416`): wide `f = 1590.66` at 1920x1440, ultrawide
+`f = 252.14` at 640x480, giving `(640/252.14) / (1920/1590.66) = 2.103`.
+
+The principal point sits within 0.7% of the image centre, which is why a
+**centred** block is the right model; a per-segment offset block would move the
+prompt by at most 1.3 canvas pixels and is not worth the complexity.
+
+## Prompt timing
+
+The ARKit lowres depth (`cam_00/pinhole_lowres/depth`) runs at 60 Hz, and the
+ultrawide rows are at 10 Hz on their own grid. The query uses
+`reader(index="video_time", fill_latest_at=True)` filtered on the ultrawide depth
+blob being non-null, so each ultrawide frame takes the **nearest LiDAR map at or
+before** its timestamp. Measured staleness on `47115416` and `42444511`:
+`max 16.1 ms, mean 7.0 ms`, i.e. bounded by one 17 ms ARKit interval, with no
+frame preceding the first ARKit sample.
+
+## Mask policy
+
+The raycast target has holes wherever the TSDF mesh has none: glazing, outdoor
+views through windows, and thin structure.
+
+* **Erosion `ultrawide_valid_erosion_px = 1`.** Raycast silhouettes bleed about
+  one output pixel past the mesh, so the boundary ring is the least trustworthy
+  supervision in the frame. Implemented as a max pool over the inverted mask, so
+  the CPU and CUDA builders run the same kernel and agree exactly. Zero padding
+  leaves the image border valid: genuine border holes are already invalid and
+  erode inward on their own.
+* **Drop `ultrawide_min_valid_fraction = 0.7`,** measured on the resized target
+  *before* erosion so the threshold does not move when the erosion radius does.
+  Sampled valid fractions over 41 frames per segment: `47115416` mean 0.914,
+  p10 0.866, min 0.669, 95% of frames at or above 0.7; `42444511` mean 0.958,
+  p10 0.901, min 0.612, 98% above 0.7. The gate therefore costs a few percent of
+  frames and removes the ones that teach the least per decoded frame.
+
+The existing flat-frame filter (`min_depth_span`, p95/p5 of valid depth) applies
+unchanged.
+
+Evaluation defaults `ultrawide_min_valid_fraction` to **0.0**: dropping sparse
+frames is a training data-efficiency choice, not a property of the benchmark.
+Erosion still applies, so eval and training score the same pixels per frame.
+
+## The 50/50 sampler
+
+With `cameras="both"`, each producer prepares a segment once and yields:
+
+* every wide chosen frame, exactly as today; and
+* a **seeded random subsample of the ultrawide chosen frames of the same size**,
+
+round-robin interleaved, after which the existing shuffle buffer mixes them into
+roughly balanced batches. The subsample seed is the segment seed, which already
+mixes run seed, epoch, rank, and segment index, so every pass draws a fresh
+subset and the whole ultrawide set is seen over several epochs. The ultrawide
+augmentation seed stream is offset from the wide one so the two cameras of a
+segment never share an augmentation draw.
+
+In practice the two counts are close already (`47115416`: 651 wide, 651
+ultrawide; `42444511`: 528 and 528), so the subsample mostly reorders rather
+than discards.
+
+## The widened output range
+
+The sibling PR (`zipdepth/uw-1-range`) adds `range_margin_m` to `ZipDepthPrompt`,
+with a matching `TrainCatalogConfig.range_margin_m` and checkpoint key. The
+margin is an **absolute distance in metres**, not a fraction of the prompt span:
+
+```
+min_out = clamp(prompt_min - range_margin_m, min=0.1)
+max_out = clamp(prompt_max + range_margin_m, max=4.0)
+```
+
+The prompted model otherwise gates its output to the prompt's own depth span. On
+an ultrawide frame the prompt covers only the central 1/2.1, so the true depth
+**outside** the footprint routinely falls outside the prompted span — a corridor
+continuing past the prompted wall, or a ceiling entering only at the frame edge.
+
+A span-relative margin does not fix this. Half of a close-up prompt's span turns
+`0.8-1.2 m` into `0.6-1.4 m`, and a far wall in the periphery stays unreachable
+exactly where the ultrawide most needs the room. The uw-v1 fine-tune therefore
+uses `range_margin_m = 3.9`, which opens the head to the full `[0.1, 4.0] m`
+window for every frame.
+
+That does not throw away the prompt: scale still enters through the unchanged
+prompt-normalization path, which is what anchors the prediction metrically. The
+head's range only controls where its sigmoid can land. The cost of the wider
+sigmoid is quantization precision — spreading the same output resolution over
+3.9 m instead of a 0.4 m span — and that works out to a few millimetres, far
+below the lane's ~70 mm edge-MAE gate.
+
+## Training recipe
+
+Fine-tune from `zdpda-v4` (`data/checkpoints/zdpda-v4/final_model.pth`):
+
+```
+--cameras both --preset fast --max-lr 1e-4 --batch-size 8
+--height 768 --width 1024 --total-steps 140000 --freeze-bn --target-mode metric
+--range-margin-m 3.9
+```
+
+(`--range-margin-m` lands with the sibling PR; this lane does not read it.)
+
+Resize-only augmentation (the lane's `build_train_transform`: flip plus mild
+colour, no crop zoom), BatchNorm pinned to the released running statistics, and
+the same AdamW/OneCycle machinery as the wide lane. 140k steps is about one pass
+over the mixed corpus at batch 8.
+
+## Evaluation
+
+20-segment seed-0 holdout, `frame_stride=10`, `--cameras both`.
+
+Ultrawide metrics are reported **split by the prompt footprint**, the centred
+`[200:564, 268:756]` box of the 768x1024 output:
+
+* `ultrawide_whole_*` — AbsRel, delta1, MAE over every valid pixel;
+* `ultrawide_inside_*` — inside the footprint, against
+  `ultrawide_inside_prompt_upsample_*`, the zero-parameter bilinear
+  prompt-upsample floor the student must beat there;
+* `ultrawide_outside_*` — **the headline**: pixels with no prompt at all.
+
+The wide gates are unchanged and must still hold: AbsRel <= 0.0140, edge
+MAE <= 73 mm, hard-20 macro edge MAE <= 128.5 mm.
+
+## Deployment
+
+One static 768x1024 batch-8 TensorRT engine serves both cameras. Ultrawide
+callers upscale their 640x480 rectified frame to 768x1024 on the way in and
+downscale the prediction on the way out; the prompt is padded exactly as in
+training. No second engine shape, no second set of weights.
+
+## Fallback if inside-footprint numbers regress
+
+If the outside-footprint metrics are good but inside-footprint quality drops
+below the wide lane's, the cause is prompt resolution: the 122x91 block is all
+the decoder's finest H/4 level ever sees. The fallback is to run the ultrawide at
+a **higher input resolution** so H/4 grows (e.g. 1536x2048 in, H/4 = 384x512,
+prompt block 244x182). That costs roughly 4x the compute and forces a second
+engine shape, which is why it is the fallback and not the design.
+
+## Naming
+
+Checkpoints from this lane are `zdpda-uw-vN`, kept separate from the wide-only
+`zdpda-vN` series so a wide-lane regression can never be blamed on the mixed
+recipe by accident.

--- a/packages/zipdepth/docs/ultrawide.md
+++ b/packages/zipdepth/docs/ultrawide.md
@@ -29,9 +29,23 @@ Those timestamps are **disjoint** from the wide chosen frames — on `47115416`
 only 1 of 651 ultrawide timestamps coincides with a wide one — so the wide and
 ultrawide passes are genuinely different views of a capture, not duplicates.
 
-Portrait captures store the rectified frame as 480x640; the lane rotates it to
-landscape with the same `property:capture:orientation_quarter_turns_ccw` the wide
-path already uses, then resizes to the lane's 768x1024.
+Portrait captures store the rectified frame as 480x640 — 813 of the 2,024
+segments — because the layer writer (`gauss_surf/apis/ultrawide_depth_batch.py`,
+PR #214) reads `image_wh` straight from the calibration and has no orientation
+guard of its own. The lane rotates to landscape with the same
+`property:capture:orientation_quarter_turns_ccw` the wide path already uses, then
+resizes to the lane's 768x1024. Because nothing upstream enforces this, the
+builders assert that an ultrawide frame **is** landscape after the turns and fail
+loudly otherwise, rather than training on a rotated image.
+
+Rows can also be missing a payload. The ultrawide track has its own
+`drop_leading` and its own 10 Hz selection, so an ultrawide chosen frame can
+precede the first ARKit lowres depth row; latest-at cannot fill a column that has
+not been logged yet, so that row's prompt is null. The lane drops any chosen row
+whose RGB, depth, prompt, or confidence cell is null and counts it in
+`skipped_missing_payload_frames`. A preflight over all 2,024 segments found
+**zero** such rows today (see *Preflight* below), but the guard is what keeps a
+future re-registration from killing a producer mid-run.
 
 ## Why the prompt is resized and padded, not reprojected
 
@@ -132,6 +146,21 @@ segment never share an augmentation draw.
 In practice the two counts are close already (`47115416`: 651 wide, 651
 ultrawide; `42444511`: 528 and 528), so the subsample mostly reorders rather
 than discards.
+
+Two edge cases:
+
+* A segment lacking the `ultrawide_depth` layer (1 of 2,025) **falls back to
+  wide-only** under `both`; under `ultrawide` it yields nothing. Either way the
+  lane warns once for the whole run.
+* A segment with no wide chosen frames is skipped entirely under `both`. There is
+  nothing to balance the ultrawide track against, and streaming its whole 10 Hz
+  selection (up to 1,840 frames) would silently skew the mix.
+
+**Known limitation.** The subsample is seeded by the pass index, so a run resumed
+from a checkpoint restarts at pass 0 and re-draws the subsets the original run
+already used. Over 140k steps that costs some ultrawide coverage after a resume.
+It is not a correctness problem and is left for a follow-up that carries the pass
+index in the checkpoint.
 
 ## Measured cost
 

--- a/packages/zipdepth/docs/ultrawide.md
+++ b/packages/zipdepth/docs/ultrawide.md
@@ -43,9 +43,25 @@ Rows can also be missing a payload. The ultrawide track has its own
 precede the first ARKit lowres depth row; latest-at cannot fill a column that has
 not been logged yet, so that row's prompt is null. The lane drops any chosen row
 whose RGB, depth, prompt, or confidence cell is null and counts it in
-`skipped_missing_payload_frames`. A preflight over all 2,024 segments found
-**zero** such rows today (see *Preflight* below), but the guard is what keeps a
-future re-registration from killing a producer mid-run.
+`skipped_missing_payload_frames`.
+
+**Preflight.** Every one of the 2,024 segments carrying the layer was checked
+against the columns the lane depends on — 1,449,709 ultrawide chosen frames in
+total, 716.3 per segment on average:
+
+```
+chosen frames        1449709
+rgb_mismatch               0   ultrawide rgb timestamps != ultrawide depth timestamps
+rgb_missing                0   chosen frames with no rgb row
+before_first_prompt        0   chosen frames preceding the first ARKit lowres depth row
+before_first_conf          0   chosen frames preceding the first ARKit confidence row
+segments with any problem  0
+```
+
+So the hazard is latent, not active: as registered today no ultrawide chosen
+frame is missing anything, and the ultrawide RGB and depth are logged at exactly
+the same timestamps in every segment. The drop is a guard against a future
+re-registration killing a producer mid-run, not a workaround for current data.
 
 ## Why the prompt is resized and padded, not reprojected
 
@@ -173,7 +189,10 @@ CUDA builder, RTX 5090 (one full pass per configuration):
 | both | 344.2 | 5.00 | 3.64 | 0.39 | 3.29 | 1.14 |
 | ultrawide | 681.3 | 1.73 | 0.00 | 0.75 | 2.50 | 2.24 |
 
-(stage columns in ms/frame.)
+(stage columns in ms/frame.) A 60 s run over 16 segments of mixed stored
+orientation gives 296 frames/s and 18,109 samples built, with 195 frames dropped
+by the valid-fraction gate, 799 by the flat-frame filter, and 0 for a missing
+payload.
 
 The ultrawide lane is far cheaper than the wide one: no NVDEC, a 640x480 JPEG
 instead of a 1920x1440 video frame, and a 640x480 depth PNG instead of a

--- a/packages/zipdepth/docs/ultrawide.md
+++ b/packages/zipdepth/docs/ultrawide.md
@@ -133,6 +133,33 @@ In practice the two counts are close already (`47115416`: 651 wide, 651
 ultrawide; `42444511`: 528 and 528), so the subsample mostly reorders rather
 than discards.
 
+## Measured cost
+
+`tools/catalog_throughput.py`, 8 segments, 8 producers, batch 8, 768x1024 out,
+CUDA builder, RTX 5090 (one full pass per configuration):
+
+| cameras | frames/s | segment_query | video_decode | jpeg_decode | blob_decode | augment |
+| --- | --- | --- | --- | --- | --- | --- |
+| wide | 173.9 | 11.92 | 5.53 | 0.00 | 4.00 | 0.52 |
+| both | 344.2 | 5.00 | 3.64 | 0.39 | 3.29 | 1.14 |
+| ultrawide | 681.3 | 1.73 | 0.00 | 0.75 | 2.50 | 2.24 |
+
+(stage columns in ms/frame.)
+
+The ultrawide lane is far cheaper than the wide one: no NVDEC, a 640x480 JPEG
+instead of a 1920x1440 video frame, and a 640x480 depth PNG instead of a
+1920x1440 one. Mixing the cameras therefore **doubles** loader throughput rather
+than costing anything, and the lane stays comfortably ahead of the ~150 frames/s
+the trainer consumes. JPEG decode is the new stage and is not the bottleneck.
+
+The RGB JPEG is decoded on the **CPU** with `torchvision.io.decode_jpeg`, not on
+the GPU with nvjpeg. Measured on this host: nvjpeg 0.171 ms/frame batched versus
+0.566 ms/frame on the CPU — but nvjpeg's output differs from libjpeg-turbo's by
+up to 27/255 per channel, which would break the CPU/CUDA builder parity the
+probe and evaluation paths rely on, and torchvision's nvjpeg handle is shared
+across the producer threads. Buying 0.4 ms/frame is not worth either risk while
+the loader already runs at twice the trainer's rate.
+
 ## The widened output range
 
 The sibling PR (`zipdepth/uw-1-range`) adds `range_margin_m` to `ZipDepthPrompt`,

--- a/packages/zipdepth/tests/test_catalog_stats.py
+++ b/packages/zipdepth/tests/test_catalog_stats.py
@@ -10,12 +10,14 @@ def _every_field(scale: int) -> CatalogDatasetStats:
     return CatalogDatasetStats(
         segment_query=1.0 * scale,
         video_decode=2.0 * scale,
-        blob_decode=3.0 * scale,
-        augment=4.0 * scale,
-        samples_built=5 * scale,
-        png_fallbacks=6 * scale,
-        skipped_frames=7 * scale,
-        skipped_flat_frames=8 * scale,
+        jpeg_decode=3.0 * scale,
+        blob_decode=4.0 * scale,
+        augment=5.0 * scale,
+        samples_built=6 * scale,
+        png_fallbacks=7 * scale,
+        skipped_frames=8 * scale,
+        skipped_flat_frames=9 * scale,
+        skipped_low_valid_frames=10 * scale,
     )
 
 

--- a/packages/zipdepth/tests/test_catalog_stats.py
+++ b/packages/zipdepth/tests/test_catalog_stats.py
@@ -18,6 +18,7 @@ def _every_field(scale: int) -> CatalogDatasetStats:
         skipped_frames=8 * scale,
         skipped_flat_frames=9 * scale,
         skipped_low_valid_frames=10 * scale,
+        skipped_missing_payload_frames=11 * scale,
     )
 
 

--- a/packages/zipdepth/tests/test_catalog_train.py
+++ b/packages/zipdepth/tests/test_catalog_train.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 import torch
-from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_KEY
+from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_M_KEY
 from serde.json import from_json, to_json
 from torch import nn, optim
 from torch.utils.data import DataLoader, TensorDataset
@@ -17,11 +17,13 @@ from zipdepth.apis.train_catalog import (
     ResolvedTrainCatalogConfig,
     TrainCatalogConfig,
     TrainingRecipe,
+    UpstreamSchedulerConfig,
     UpstreamTrainConfig,
     _adamw_optimizer,
     _build_scheduler,
     _load_json_config,
     _model_to_device,
+    _restore_resume_state,
     parse_stage_schedule,
     resolve_amp_dtype,
     resolve_max_lr,
@@ -165,8 +167,8 @@ def test_catalog_training_defaults_to_metric_with_an_explicit_ssi_lane() -> None
 
 def test_range_margin_defaults_to_the_prompt_bounded_head_and_survives_resolved_config() -> None:
     """Record the ultrawide output-range margin in the run's resolved_config.json."""
-    assert TrainCatalogConfig().range_margin == 0.0
-    config: TrainCatalogConfig = TrainCatalogConfig(range_margin=0.25)
+    assert TrainCatalogConfig().range_margin_m == 0.0
+    config: TrainCatalogConfig = TrainCatalogConfig(range_margin_m=3.9)
     upstream: UpstreamTrainConfig = _load_json_config(Path("configs/default.json"))
 
     resolved: ResolvedTrainCatalogConfig = ResolvedTrainCatalogConfig(
@@ -179,20 +181,48 @@ def test_range_margin_defaults_to_the_prompt_bounded_head_and_survives_resolved_
     )
 
     restored: ResolvedTrainCatalogConfig = from_json(ResolvedTrainCatalogConfig, to_json(resolved))
-    assert restored.config.range_margin == 0.25
+    assert restored.config.range_margin_m == 3.9
+
+
+def _margin_trainer(range_margin_m: float) -> ZipDepthTrainer:
+    """Build a minimal trainer carrying one output-range margin."""
+    model: nn.Linear = nn.Linear(1, 1)
+    optimizer: optim.SGD = optim.SGD(model.parameters(), lr=0.1)
+    return ZipDepthTrainer(model, [], optimizer, None, "cpu", use_amp=False, range_margin_m=range_margin_m)
 
 
 def test_trainer_records_the_range_margin_in_every_checkpoint(tmp_path: Path) -> None:
     """Let inference rebuild the trained head without repeating the training flag."""
-    model: nn.Linear = nn.Linear(1, 1)
-    optimizer: optim.SGD = optim.SGD(model.parameters(), lr=0.1)
-    trainer: ZipDepthTrainer = ZipDepthTrainer(model, [], optimizer, None, "cpu", use_amp=False, range_margin=0.25)
+    trainer: ZipDepthTrainer = _margin_trainer(3.9)
     checkpoint: Path = tmp_path / "step_1.pth"
 
     trainer.save_checkpoint(str(checkpoint), epoch=0, loss=0.0)
 
     saved: dict[str, object] = torch.load(checkpoint, map_location="cpu", weights_only=True)
-    assert saved[RANGE_MARGIN_KEY] == 0.25
+    assert saved[RANGE_MARGIN_M_KEY] == 3.9
+
+
+def test_resuming_with_a_different_range_margin_is_refused(tmp_path: Path) -> None:
+    """Resuming continues one run, so its head must keep the output range it was trained with."""
+    trainer: ZipDepthTrainer = _margin_trainer(3.9)
+    resume: Path = tmp_path / "step_1.pth"
+    trainer.save_checkpoint(str(resume), epoch=0, loss=0.0)
+    wrapped_model: nn.Linear = nn.Linear(1, 1)
+
+    with pytest.raises(ValueError, match="range_margin_m"):
+        _restore_resume_state(
+            resume,
+            wrapped_model,
+            trainer,
+            total_steps=10,
+            actual_max_lr=1e-5,
+            range_margin_m=0.0,
+            scheduler_config=UpstreamSchedulerConfig(),
+            schedule="onecycle",
+            warmup_pct=0.05,
+            final_div_factor=1000.0,
+            cooldown_pct=0.1,
+        )
 
 
 def test_catalog_training_exposes_only_the_fixed_metric_loss_weight() -> None:

--- a/packages/zipdepth/tests/test_catalog_train.py
+++ b/packages/zipdepth/tests/test_catalog_train.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 import torch
+from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_KEY
+from serde.json import from_json, to_json
 from torch import nn, optim
 from torch.utils.data import DataLoader, TensorDataset
 from tqdm import tqdm
@@ -12,6 +14,7 @@ from zipdepth.apis.train_catalog import (
     CompileMode,
     ConstantCooldownLR,
     ResolutionStage,
+    ResolvedTrainCatalogConfig,
     TrainCatalogConfig,
     TrainingRecipe,
     UpstreamTrainConfig,
@@ -158,6 +161,38 @@ def test_catalog_training_defaults_to_metric_with_an_explicit_ssi_lane() -> None
     """Make prompted metric distillation the default without removing relative training."""
     assert TrainCatalogConfig().target_mode == "metric"
     assert TrainCatalogConfig(target_mode="ssi").target_mode == "ssi"
+
+
+def test_range_margin_defaults_to_the_prompt_bounded_head_and_survives_resolved_config() -> None:
+    """Record the ultrawide output-range margin in the run's resolved_config.json."""
+    assert TrainCatalogConfig().range_margin == 0.0
+    config: TrainCatalogConfig = TrainCatalogConfig(range_margin=0.25)
+    upstream: UpstreamTrainConfig = _load_json_config(Path("configs/default.json"))
+
+    resolved: ResolvedTrainCatalogConfig = ResolvedTrainCatalogConfig(
+        config=config,
+        rank_count=1,
+        steps_per_epoch=10,
+        total_steps=10,
+        resolved_max_lr=1e-5,
+        recipe=resolve_training_recipe(config, upstream.scheduler, upstream.amp),
+    )
+
+    restored: ResolvedTrainCatalogConfig = from_json(ResolvedTrainCatalogConfig, to_json(resolved))
+    assert restored.config.range_margin == 0.25
+
+
+def test_trainer_records_the_range_margin_in_every_checkpoint(tmp_path: Path) -> None:
+    """Let inference rebuild the trained head without repeating the training flag."""
+    model: nn.Linear = nn.Linear(1, 1)
+    optimizer: optim.SGD = optim.SGD(model.parameters(), lr=0.1)
+    trainer: ZipDepthTrainer = ZipDepthTrainer(model, [], optimizer, None, "cpu", use_amp=False, range_margin=0.25)
+    checkpoint: Path = tmp_path / "step_1.pth"
+
+    trainer.save_checkpoint(str(checkpoint), epoch=0, loss=0.0)
+
+    saved: dict[str, object] = torch.load(checkpoint, map_location="cpu", weights_only=True)
+    assert saved[RANGE_MARGIN_KEY] == 0.25
 
 
 def test_catalog_training_exposes_only_the_fixed_metric_loss_weight() -> None:

--- a/packages/zipdepth/tests/test_catalog_ultrawide.py
+++ b/packages/zipdepth/tests/test_catalog_ultrawide.py
@@ -1,0 +1,334 @@
+"""Ultrawide prompt placement, mask policy, sampling, and wide-lane bit-identity."""
+
+import numpy as np
+import pytest
+import torch
+from jaxtyping import Bool, Float32, UInt8, UInt16
+from numpy import ndarray
+from numpy.testing import assert_array_equal
+from torch import Tensor
+
+from zipdepth.catalog.ultrawide import (
+    DEFAULT_ULTRAWIDE_PROMPT_SCALE,
+    PROMPT_CANVAS_HW,
+    ULTRAWIDE_FOV_RATIO,
+    PromptPlacement,
+    UltrawidePolicy,
+    erode_valid,
+    footprint_box,
+    interleave,
+    place_wide_prompt,
+    prompt_placement,
+    subsample_indices,
+    valid_fraction,
+)
+
+pytest.importorskip("arkitscenes_download", reason="ARKitScenes catalog dependencies live in the zipdepth catalog lane")
+
+from arkitscenes_download.ingest.depth import encode_depth_png  # noqa: E402
+
+from zipdepth.catalog.builders import CpuSampleBuilder  # noqa: E402
+from zipdepth.catalog.targets import build_eval_transform  # noqa: E402
+
+AGGRESSIVE_POLICY: UltrawidePolicy = UltrawidePolicy(min_valid_fraction=1.0, valid_erosion_px=8, prompt_scale=0.25)
+"""A policy extreme enough that any leak into the wide lane changes its output."""
+
+
+def test_prompt_placement_centres_the_measured_ultrawide_footprint() -> None:
+    """Scale the canvas by the measured field-of-view ratio and centre the block."""
+    placement: PromptPlacement = prompt_placement(DEFAULT_ULTRAWIDE_PROMPT_SCALE)
+
+    assert (placement.height, placement.width) == (91, 122)
+    assert (placement.top, placement.left) == (50, 67)
+    # Horizontal margins are equal, so mirroring the canvas and mirroring the
+    # block land on the same pixels at the default scale.
+    assert PROMPT_CANVAS_HW[1] - placement.left - placement.width == placement.left
+    assert DEFAULT_ULTRAWIDE_PROMPT_SCALE == pytest.approx(1.0 / ULTRAWIDE_FOV_RATIO)
+
+
+@pytest.mark.parametrize("scale", [0.0, -0.5, 1.5, 1.0e-4])
+def test_prompt_placement_rejects_scales_outside_the_usable_range(scale: float) -> None:
+    """Reject a non-positive, oversized, or vanishing prompt scale."""
+    with pytest.raises(ValueError):
+        prompt_placement(scale)
+
+
+def test_ultrawide_policy_rejects_impossible_settings() -> None:
+    """Reject a fraction outside the unit interval and a negative erosion radius."""
+    with pytest.raises(ValueError):
+        UltrawidePolicy(min_valid_fraction=1.5)
+    with pytest.raises(ValueError):
+        UltrawidePolicy(valid_erosion_px=-1)
+    with pytest.raises(ValueError):
+        UltrawidePolicy(prompt_scale=0.0)
+
+
+def test_place_wide_prompt_scales_the_block_and_zeroes_the_rest() -> None:
+    """Write the resampled prompt inside the footprint and leave zeros outside."""
+    placement: PromptPlacement = prompt_placement(DEFAULT_ULTRAWIDE_PROMPT_SCALE)
+    prompt_mm_hw: UInt16[Tensor, "192 256"] = torch.full(PROMPT_CANVAS_HW, 1500, dtype=torch.int32)
+    confidence_hw: UInt8[Tensor, "192 256"] = torch.full(PROMPT_CANVAS_HW, 2, dtype=torch.uint8)
+
+    placed: tuple[Float32[Tensor, "192 256"], Bool[Tensor, "192 256"]] = place_wide_prompt(
+        prompt_mm_hw, confidence_hw, placement, flipped=False
+    )
+    depth_hw: Float32[Tensor, "192 256"] = placed[0]
+    valid_hw: Bool[Tensor, "192 256"] = placed[1]
+    inside_hw: Bool[Tensor, "192 256"] = torch.zeros(PROMPT_CANVAS_HW, dtype=torch.bool)
+    inside_hw[placement.top : placement.top + placement.height, placement.left : placement.left + placement.width] = True
+
+    assert torch.equal(valid_hw, inside_hw)
+    assert torch.all(depth_hw[inside_hw] == 1.5)
+    assert torch.all(depth_hw[~inside_hw] == 0.0)
+
+
+def test_place_wide_prompt_mirrors_the_block_not_the_canvas() -> None:
+    """Mirror the scaled block so a flip stays exact for any canvas margin."""
+    placement: PromptPlacement = prompt_placement(DEFAULT_ULTRAWIDE_PROMPT_SCALE)
+    prompt_mm_hw: UInt16[Tensor, "192 256"] = (
+        torch.arange(PROMPT_CANVAS_HW[0] * PROMPT_CANVAS_HW[1], dtype=torch.int32).reshape(PROMPT_CANVAS_HW) % 3000 + 200
+    )
+    confidence_hw: UInt8[Tensor, "192 256"] = torch.full(PROMPT_CANVAS_HW, 2, dtype=torch.uint8)
+
+    upright: tuple[Float32[Tensor, "192 256"], Bool[Tensor, "192 256"]] = place_wide_prompt(
+        prompt_mm_hw, confidence_hw, placement, flipped=False
+    )
+    flipped: tuple[Float32[Tensor, "192 256"], Bool[Tensor, "192 256"]] = place_wide_prompt(
+        prompt_mm_hw, confidence_hw, placement, flipped=True
+    )
+
+    assert torch.equal(flipped[0], torch.flip(upright[0], dims=(-1,)))
+    assert torch.equal(flipped[1], torch.flip(upright[1], dims=(-1,)))
+
+
+def test_place_wide_prompt_rejects_a_prompt_off_the_canvas_grid() -> None:
+    """Reject prompt planes that are not already on the canvas grid."""
+    placement: PromptPlacement = prompt_placement(DEFAULT_ULTRAWIDE_PROMPT_SCALE)
+    with pytest.raises(ValueError):
+        place_wide_prompt(
+            torch.zeros((256, 192), dtype=torch.int32),
+            torch.zeros((256, 192), dtype=torch.uint8),
+            placement,
+            flipped=False,
+        )
+
+
+def test_erode_valid_removes_only_the_boundary_ring() -> None:
+    """Erode one pixel from a solid block and leave the interior untouched."""
+    valid_chw: Bool[Tensor, "1 h w"] = torch.zeros((1, 7, 7), dtype=torch.bool)
+    valid_chw[0, 2:5, 2:5] = True
+
+    eroded_chw: Bool[Tensor, "1 h w"] = erode_valid(valid_chw, 1)
+
+    expected_chw: Bool[Tensor, "1 h w"] = torch.zeros((1, 7, 7), dtype=torch.bool)
+    expected_chw[0, 3, 3] = True
+    assert torch.equal(eroded_chw, expected_chw)
+
+
+def test_erode_valid_keeps_the_image_border() -> None:
+    """Leave a fully valid frame untouched: only real holes erode inward."""
+    valid_chw: Bool[Tensor, "1 h w"] = torch.ones((1, 5, 6), dtype=torch.bool)
+
+    assert torch.equal(erode_valid(valid_chw, 2), valid_chw)
+
+
+def test_erode_valid_zero_radius_is_the_identity() -> None:
+    """Return the input mask unchanged when no erosion is configured."""
+    valid_chw: Bool[Tensor, "1 h w"] = torch.rand((1, 4, 5)) > 0.5
+
+    assert erode_valid(valid_chw, 0) is valid_chw
+    with pytest.raises(ValueError):
+        erode_valid(valid_chw, -1)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA erosion parity needs a GPU")
+def test_erode_valid_matches_between_cpu_and_cuda() -> None:
+    """Run the same pooling kernel on both devices and get the same mask."""
+    valid_chw: Bool[Tensor, "1 h w"] = torch.rand((1, 33, 41), generator=torch.Generator().manual_seed(5)) > 0.3
+
+    eroded_cpu_chw: Bool[Tensor, "1 h w"] = erode_valid(valid_chw, 2)
+    eroded_cuda_chw: Bool[Tensor, "1 h w"] = erode_valid(valid_chw.to(device="cuda"), 2)
+
+    assert torch.equal(eroded_cuda_chw.cpu(), eroded_cpu_chw)
+
+
+def test_valid_fraction_counts_the_mask() -> None:
+    """Report the fraction of the mask that is valid."""
+    valid_chw: Bool[Tensor, "1 h w"] = torch.zeros((1, 2, 5), dtype=torch.bool)
+    valid_chw[0, 0, :3] = True
+
+    assert valid_fraction(valid_chw) == pytest.approx(0.3)
+
+
+def test_footprint_box_scales_the_placement_to_the_output() -> None:
+    """Map the canvas block onto the training output resolution."""
+    placement: PromptPlacement = prompt_placement(DEFAULT_ULTRAWIDE_PROMPT_SCALE)
+
+    box: tuple[int, int, int, int] = footprint_box(placement, (768, 1024))
+
+    assert box == (200, 268, 564, 756)
+    assert (box[2] - box[0]) / 768 == pytest.approx(placement.height / PROMPT_CANVAS_HW[0], abs=1.0e-3)
+    assert (box[3] - box[1]) / 1024 == pytest.approx(placement.width / PROMPT_CANVAS_HW[1], abs=1.0e-3)
+
+
+def test_subsample_indices_is_seeded_sorted_and_bounded() -> None:
+    """Draw a reproducible, ordered subset that a fresh seed changes."""
+    first: list[int] = subsample_indices(100, 30, seed=11)
+    again: list[int] = subsample_indices(100, 30, seed=11)
+    other: list[int] = subsample_indices(100, 30, seed=12)
+
+    assert first == again
+    assert first != other
+    assert first == sorted(first)
+    assert len(set(first)) == 30
+    assert max(first) < 100
+    assert subsample_indices(5, 9, seed=1) == [0, 1, 2, 3, 4]
+    with pytest.raises(ValueError):
+        subsample_indices(-1, 1, seed=1)
+
+
+def test_interleave_alternates_until_every_source_is_drained() -> None:
+    """Round-robin the sources and keep every item exactly once."""
+    assert list(interleave([iter([1, 3, 5]), iter([2, 4, 6])])) == [1, 2, 3, 4, 5, 6]
+    assert list(interleave([iter([1, 2, 3]), iter(["a"])])) == [1, "a", 2, 3]
+    assert list(interleave([])) == []
+
+
+FRAME_HW: tuple[int, int] = (48, 64)
+"""Synthetic frame size used by the builder tests; large enough for a visible hole."""
+
+BuilderInputs = tuple[UInt8[Tensor, "3 h w"], UInt8[ndarray, "target_n"], UInt8[ndarray, "prompt_n"], UInt8[ndarray, "confidence_n"]]
+"""One synthetic frame, target blob, prompt blob, and flattened confidence."""
+
+
+def _builder_inputs() -> BuilderInputs:
+    """Build one synthetic frame whose target carries a hole the erosion can widen."""
+    rgb_chw: UInt8[Tensor, "3 h w"] = torch.arange(3 * FRAME_HW[0] * FRAME_HW[1], dtype=torch.int32).remainder(256).to(
+        dtype=torch.uint8
+    ).reshape(3, *FRAME_HW)
+    target_mm_hw: UInt16[ndarray, "h w"] = (
+        np.arange(FRAME_HW[0] * FRAME_HW[1], dtype=np.uint16).reshape(FRAME_HW) % 3000 + 300
+    ).astype(np.uint16)
+    target_mm_hw[10:20, 12:30] = 0
+    target_blob_bytes: UInt8[ndarray, "target_n"] = np.frombuffer(encode_depth_png(target_mm_hw), dtype=np.uint8)
+    prompt_mm_hw: UInt16[ndarray, "192 256"] = (np.arange(192 * 256, dtype=np.uint16).reshape(192, 256) % 3000 + 300).astype(np.uint16)
+    prompt_blob_bytes: UInt8[ndarray, "prompt_n"] = np.frombuffer(encode_depth_png(prompt_mm_hw), dtype=np.uint8)
+    confidence: UInt8[ndarray, "confidence_n"] = np.full(192 * 256, 2, dtype=np.uint8)
+    return rgb_chw, target_blob_bytes, prompt_blob_bytes, confidence
+
+
+def test_wide_samples_are_bit_identical_with_and_without_an_ultrawide_policy() -> None:
+    """Prove the wide lane never consults the ultrawide policy.
+
+    The second builder carries a policy that would reject every frame and erode
+    eight pixels if the wide path touched it, so an identical sample is proof
+    that ``cameras="wide"`` still produces the released lane's tensors.
+    """
+    inputs: BuilderInputs = _builder_inputs()
+    baseline: CpuSampleBuilder = CpuSampleBuilder(build_eval_transform(*FRAME_HW), min_depth_span=0.0, target_mode="metric")
+    with_policy: CpuSampleBuilder = CpuSampleBuilder(
+        build_eval_transform(*FRAME_HW), min_depth_span=0.0, target_mode="metric", ultrawide_policy=AGGRESSIVE_POLICY
+    )
+
+    expected: dict[str, Tensor] | None = baseline(*inputs, quarter_turns=1, sample_seed=7)
+    actual: dict[str, Tensor] | None = with_policy(*inputs, quarter_turns=1, sample_seed=7)
+
+    assert expected is not None
+    assert actual is not None
+    assert sorted(actual) == sorted(expected)
+    key: str
+    for key in expected:
+        assert_array_equal(actual[key].numpy(), expected[key].numpy(), err_msg=f"{key} changed in the wide lane")
+
+
+def test_ultrawide_camera_without_a_policy_is_rejected() -> None:
+    """Refuse an ultrawide sample from a builder that has no ultrawide policy."""
+    inputs: BuilderInputs = _builder_inputs()
+    builder: CpuSampleBuilder = CpuSampleBuilder(build_eval_transform(*FRAME_HW), min_depth_span=0.0, target_mode="metric")
+
+    with pytest.raises(ValueError):
+        builder(*inputs, quarter_turns=0, sample_seed=1, camera="ultrawide")
+
+
+def test_ultrawide_sample_pads_the_prompt_and_erodes_the_target_mask() -> None:
+    """Place the prompt in its footprint and erode the surviving target mask."""
+    inputs: BuilderInputs = _builder_inputs()
+    policy: UltrawidePolicy = UltrawidePolicy(min_valid_fraction=0.0, valid_erosion_px=1)
+    builder: CpuSampleBuilder = CpuSampleBuilder(
+        build_eval_transform(*FRAME_HW), min_depth_span=0.0, target_mode="metric", ultrawide_policy=policy
+    )
+    placement: PromptPlacement = prompt_placement(policy.prompt_scale)
+
+    wide_sample: dict[str, Tensor] | None = builder(*inputs, quarter_turns=0, sample_seed=3)
+    ultrawide_sample: dict[str, Tensor] | None = builder(*inputs, quarter_turns=0, sample_seed=3, camera="ultrawide")
+
+    assert wide_sample is not None
+    assert ultrawide_sample is not None
+    # Only the prompt and the target mask differ; the image and target depth do not.
+    assert_array_equal(ultrawide_sample["image"].numpy(), wide_sample["image"].numpy())
+    assert_array_equal(ultrawide_sample["target_depth"].numpy(), wide_sample["target_depth"].numpy())
+    assert bool(wide_sample["prompt_valid"].all())
+    placed_valid_hw: Bool[ndarray, "192 256"] = ultrawide_sample["prompt_valid"][0].numpy()
+    assert not placed_valid_hw[: placement.top].any()
+    assert placed_valid_hw[placement.top : placement.top + placement.height, placement.left : placement.left + placement.width].all()
+    assert placed_valid_hw.mean() == pytest.approx(placement.height * placement.width / (192 * 256))
+    # The eroded ultrawide mask is a strict subset of the wide one: the target's
+    # hole grows by one pixel on every side.
+    wide_valid_hw: Bool[ndarray, "h w"] = wide_sample["target_valid"][0].numpy()
+    ultrawide_valid_hw: Bool[ndarray, "h w"] = ultrawide_sample["target_valid"][0].numpy()
+    assert not bool((ultrawide_valid_hw & ~wide_valid_hw).any())
+    assert int(ultrawide_valid_hw.sum()) < int(wide_valid_hw.sum())
+
+
+def test_ultrawide_sample_drops_a_frame_below_the_valid_fraction() -> None:
+    """Reject a sparse ultrawide frame and count it separately from flat frames."""
+    rgb_chw: UInt8[Tensor, "3 h w"] = torch.zeros((3, *FRAME_HW), dtype=torch.uint8)
+    target_mm_hw: UInt16[ndarray, "h w"] = np.zeros(FRAME_HW, dtype=np.uint16)
+    target_mm_hw[:8] = 1500
+    target_blob_bytes: UInt8[ndarray, "target_n"] = np.frombuffer(encode_depth_png(target_mm_hw), dtype=np.uint8)
+    prompt_mm_hw: UInt16[ndarray, "192 256"] = np.full((192, 256), 1000, dtype=np.uint16)
+    prompt_blob_bytes: UInt8[ndarray, "prompt_n"] = np.frombuffer(encode_depth_png(prompt_mm_hw), dtype=np.uint8)
+    confidence: UInt8[ndarray, "confidence_n"] = np.full(192 * 256, 2, dtype=np.uint8)
+    builder: CpuSampleBuilder = CpuSampleBuilder(
+        build_eval_transform(*FRAME_HW),
+        min_depth_span=0.0,
+        target_mode="metric",
+        ultrawide_policy=UltrawidePolicy(min_valid_fraction=0.7, valid_erosion_px=0),
+    )
+
+    sample: dict[str, Tensor] | None = builder(
+        rgb_chw, target_blob_bytes, prompt_blob_bytes, confidence, quarter_turns=0, sample_seed=1, camera="ultrawide"
+    )
+
+    assert sample is None
+    assert builder.stats.skipped_low_valid_frames == 1
+    assert builder.stats.skipped_flat_frames == 0
+    assert builder.stats.samples_built == 0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA builder parity needs a GPU")
+def test_cuda_and_cpu_builders_place_the_same_ultrawide_prompt() -> None:
+    """Match the CPU builder's placed prompt exactly on the CUDA builder."""
+    from zipdepth.catalog.builders import CudaSampleBuilder
+    from zipdepth.catalog.targets import AugmentPolicy
+
+    inputs: BuilderInputs = _builder_inputs()
+    policy: UltrawidePolicy = UltrawidePolicy(min_valid_fraction=0.0, valid_erosion_px=1)
+    no_augmentation: AugmentPolicy = AugmentPolicy(flip_p=0.0, channel_shuffle_p=0.0, gray_p=0.0)
+    cpu_builder: CpuSampleBuilder = CpuSampleBuilder(
+        build_eval_transform(*FRAME_HW), min_depth_span=0.0, target_mode="metric", ultrawide_policy=policy
+    )
+    cuda_builder: CudaSampleBuilder = CudaSampleBuilder(
+        FRAME_HW, no_augmentation, 0.0, torch.device("cuda"), target_mode="metric", ultrawide_policy=policy
+    )
+
+    expected: dict[str, Tensor] | None = cpu_builder(*inputs, quarter_turns=0, sample_seed=3, camera="ultrawide")
+    actual: dict[str, Tensor] | None = cuda_builder(
+        inputs[0].to(device="cuda"), inputs[1], inputs[2], inputs[3], quarter_turns=0, sample_seed=3, camera="ultrawide"
+    )
+
+    assert expected is not None
+    assert actual is not None
+    assert_array_equal(actual["prompt_depth"].cpu().numpy(), expected["prompt_depth"].numpy())
+    assert_array_equal(actual["prompt_valid"].cpu().numpy(), expected["prompt_valid"].numpy())
+    assert_array_equal(actual["target_valid"].cpu().numpy(), expected["target_valid"].numpy())

--- a/packages/zipdepth/tests/test_catalog_ultrawide.py
+++ b/packages/zipdepth/tests/test_catalog_ultrawide.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 from jaxtyping import Bool, Float32, UInt8, UInt16
 from numpy import ndarray
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_allclose, assert_array_equal
 from torch import Tensor
 
 from zipdepth.catalog.ultrawide import (
@@ -230,8 +230,8 @@ def test_wide_samples_are_bit_identical_with_and_without_an_ultrawide_policy() -
         build_eval_transform(*FRAME_HW), min_depth_span=0.0, target_mode="metric", ultrawide_policy=AGGRESSIVE_POLICY
     )
 
-    expected: dict[str, Tensor] | None = baseline(*inputs, quarter_turns=1, sample_seed=7)
-    actual: dict[str, Tensor] | None = with_policy(*inputs, quarter_turns=1, sample_seed=7)
+    expected: dict[str, Tensor] | None = baseline(*inputs, quarter_turns=0, sample_seed=7)
+    actual: dict[str, Tensor] | None = with_policy(*inputs, quarter_turns=0, sample_seed=7)
 
     assert expected is not None
     assert actual is not None
@@ -329,6 +329,8 @@ def test_cuda_and_cpu_builders_place_the_same_ultrawide_prompt() -> None:
 
     assert expected is not None
     assert actual is not None
-    assert_array_equal(actual["prompt_depth"].cpu().numpy(), expected["prompt_depth"].numpy())
+    # Placement, resampling, and masking agree exactly; the metre conversion is a
+    # float32 divide, whose last bit differs between the CPU and CUDA kernels.
+    assert_allclose(actual["prompt_depth"].cpu().numpy(), expected["prompt_depth"].numpy(), rtol=1.0e-6, atol=0.0)
     assert_array_equal(actual["prompt_valid"].cpu().numpy(), expected["prompt_valid"].numpy())
     assert_array_equal(actual["target_valid"].cpu().numpy(), expected["target_valid"].numpy())

--- a/packages/zipdepth/tests/test_catalog_ultrawide.py
+++ b/packages/zipdepth/tests/test_catalog_ultrawide.py
@@ -306,6 +306,76 @@ def test_ultrawide_sample_drops_a_frame_below_the_valid_fraction() -> None:
     assert builder.stats.samples_built == 0
 
 
+def test_portrait_ultrawide_sample_orients_image_target_and_prompt_together() -> None:
+    """Rotate a stored-portrait ultrawide frame, its target, and its prompt as one.
+
+    813 of the 2,024 registered segments store the rectified ultrawide as 480x640.
+    The layer writer reads ``image_wh`` from the calibration and has no
+    orientation guard, so the lane must do the rotation and must keep the image,
+    the target, and the placed prompt on the same scene coordinates.
+    """
+    stored_hw: tuple[int, int] = (FRAME_HW[1], FRAME_HW[0])
+    rgb_chw: UInt8[Tensor, "3 stored_h stored_w"] = torch.zeros((3, *stored_hw), dtype=torch.uint8)
+    # A bright band on the stored top edge lands on the landscape left edge after
+    # one counter-clockwise turn, which is where the target's near band goes too.
+    rgb_chw[:, :8, :] = 255
+    target_mm_hw: UInt16[ndarray, "stored_h stored_w"] = np.full(stored_hw, 3000, dtype=np.uint16)
+    target_mm_hw[:8, :] = 500
+    target_blob_bytes: UInt8[ndarray, "target_n"] = np.frombuffer(encode_depth_png(target_mm_hw), dtype=np.uint8)
+    prompt_stored_mm_hw: UInt16[ndarray, "256 192"] = np.full((256, 192), 1000, dtype=np.uint16)
+    prompt_blob_bytes: UInt8[ndarray, "prompt_n"] = np.frombuffer(encode_depth_png(prompt_stored_mm_hw), dtype=np.uint8)
+    confidence: UInt8[ndarray, "confidence_n"] = np.full(256 * 192, 2, dtype=np.uint8)
+    policy: UltrawidePolicy = UltrawidePolicy(min_valid_fraction=0.0, valid_erosion_px=0)
+    builder: CpuSampleBuilder = CpuSampleBuilder(
+        build_eval_transform(*FRAME_HW), min_depth_span=0.0, target_mode="metric", ultrawide_policy=policy
+    )
+    placement: PromptPlacement = prompt_placement(policy.prompt_scale)
+
+    sample: dict[str, Tensor] | None = builder(
+        rgb_chw, target_blob_bytes, prompt_blob_bytes, confidence, quarter_turns=1, sample_seed=29, camera="ultrawide"
+    )
+
+    assert sample is not None
+    # Upright landscape output, not the stored portrait shape.
+    assert sample["image"].shape == (3, *FRAME_HW)
+    assert sample["target_depth"].shape == (1, *FRAME_HW)
+    image_hw: UInt8[ndarray, "h w"] = sample["image"][0].numpy()
+    target_hw: Float32[ndarray, "h w"] = sample["target_depth"][0].numpy()
+    # The bright RGB band and the near depth band both land on the left edge.
+    assert image_hw[:, 0].min() == 255
+    assert image_hw[:, -1].max() == 0
+    assert target_hw[:, 0].max() == pytest.approx(0.5)
+    assert target_hw[:, -1].min() == pytest.approx(3.0)
+    # The prompt is still centred on the canvas at the placement.
+    placed_valid_hw: Bool[ndarray, "192 256"] = sample["prompt_valid"][0].numpy()
+    assert placed_valid_hw[placement.top : placement.top + placement.height, placement.left : placement.left + placement.width].all()
+    assert placed_valid_hw.mean() == pytest.approx(placement.height * placement.width / (192 * 256))
+    assert_allclose(sample["prompt_depth"][0].numpy()[placed_valid_hw], 1.0, rtol=1.0e-6)
+
+
+@pytest.mark.parametrize("quarter_turns", [0, 2])
+def test_ultrawide_rejects_a_portrait_frame_that_stays_portrait(quarter_turns: int) -> None:
+    """Fail loudly when the orientation turns do not bring the frame to landscape."""
+    stored_hw: tuple[int, int] = (FRAME_HW[1], FRAME_HW[0])
+    rgb_chw: UInt8[Tensor, "3 stored_h stored_w"] = torch.zeros((3, *stored_hw), dtype=torch.uint8)
+    target_mm_hw: UInt16[ndarray, "stored_h stored_w"] = np.full(stored_hw, 1500, dtype=np.uint16)
+    target_blob_bytes: UInt8[ndarray, "target_n"] = np.frombuffer(encode_depth_png(target_mm_hw), dtype=np.uint8)
+    prompt_mm_hw: UInt16[ndarray, "192 256"] = np.full((192, 256), 1000, dtype=np.uint16)
+    prompt_blob_bytes: UInt8[ndarray, "prompt_n"] = np.frombuffer(encode_depth_png(prompt_mm_hw), dtype=np.uint8)
+    confidence: UInt8[ndarray, "confidence_n"] = np.full(192 * 256, 2, dtype=np.uint8)
+    builder: CpuSampleBuilder = CpuSampleBuilder(
+        build_eval_transform(*FRAME_HW),
+        min_depth_span=0.0,
+        target_mode="metric",
+        ultrawide_policy=UltrawidePolicy(min_valid_fraction=0.0),
+    )
+
+    with pytest.raises(ValueError, match="not landscape"):
+        builder(
+            rgb_chw, target_blob_bytes, prompt_blob_bytes, confidence, quarter_turns=quarter_turns, sample_seed=1, camera="ultrawide"
+        )
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA builder parity needs a GPU")
 def test_cuda_and_cpu_builders_place_the_same_ultrawide_prompt() -> None:
     """Match the CPU builder's placed prompt exactly on the CUDA builder."""

--- a/packages/zipdepth/tests/test_catalog_ultrawide.py
+++ b/packages/zipdepth/tests/test_catalog_ultrawide.py
@@ -43,7 +43,7 @@ def test_prompt_placement_centres_the_measured_ultrawide_footprint() -> None:
     # Horizontal margins are equal, so mirroring the canvas and mirroring the
     # block land on the same pixels at the default scale.
     assert PROMPT_CANVAS_HW[1] - placement.left - placement.width == placement.left
-    assert DEFAULT_ULTRAWIDE_PROMPT_SCALE == pytest.approx(1.0 / ULTRAWIDE_FOV_RATIO)
+    assert pytest.approx(1.0 / ULTRAWIDE_FOV_RATIO) == DEFAULT_ULTRAWIDE_PROMPT_SCALE
 
 
 @pytest.mark.parametrize("scale", [0.0, -0.5, 1.5, 1.0e-4])

--- a/packages/zipdepth/tests/test_prompted_model.py
+++ b/packages/zipdepth/tests/test_prompted_model.py
@@ -9,7 +9,7 @@ import torch
 from jaxtyping import Bool, Float32, UInt8
 from monopriors.models.depth_completion.base_completion_depth import MAX_METRIC_DEPTH_M, MIN_METRIC_DEPTH_M
 from monopriors.models.depth_completion.zipdepth_prompt import ZipDepthPrompt, load_zipdepth_prompt
-from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_KEY
+from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_M_KEY
 from monopriors.third_party.zipdepth.architecture import FastConvexUpsample, ZipDepth, create_model
 from torch import Tensor
 
@@ -66,10 +66,10 @@ def _run_capturing_logits(
     return outputs, captured[0]
 
 
-def _prompted_model(range_margin: float, *, seed: int = 0) -> ZipDepthPrompt:
+def _prompted_model(range_margin_m: float, *, seed: int = 0) -> ZipDepthPrompt:
     """Build a deterministically initialized prompted model with live prompt branches."""
     torch.manual_seed(seed)
-    model: ZipDepthPrompt = ZipDepthPrompt(range_margin=range_margin).eval()
+    model: ZipDepthPrompt = ZipDepthPrompt(range_margin_m=range_margin_m).eval()
     # The released initialization zeroes every branch output, which would hide any
     # change in the prompt conditioning; give the branches a signal to carry.
     for parameter in model.prompt_branches.parameters():
@@ -131,6 +131,14 @@ def test_released_zipdepth_state_loads_strictly_into_backbone(tmp_path: Path) ->
         assert torch.equal(prompted_backbone_state[key], released_tensor), key
 
 
+
+def _prompt_spanning(low_m: float, high_m: float) -> Float32[Tensor, "1 1 192 256"]:
+    """Return an otherwise-invalid prompt whose valid pixels span exactly ``[low_m, high_m]``."""
+    prompt_bchw: Float32[Tensor, "1 1 192 256"] = torch.zeros(1, 1, 192, 256)
+    prompt_bchw[:, :, 80:112, 96:160] = torch.linspace(low_m, high_m, 32 * 64).reshape(1, 1, 32, 64)
+    return prompt_bchw
+
+
 def test_zero_range_margin_reproduces_the_prompt_bounded_head_bit_for_bit(monkeypatch: pytest.MonkeyPatch) -> None:
     """Guarantee the default margin leaves today's forward pass untouched."""
     model: ZipDepthPrompt = _prompted_model(0.0)
@@ -177,20 +185,20 @@ def test_zero_range_margin_parity_holds_under_cuda_float16_autocast(monkeypatch:
     assert torch.equal(outputs[0], reference_depth_bchw)
 
 
-def test_range_margin_widens_the_reachable_output_range_by_a_span_fraction(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_range_margin_widens_the_reachable_output_range_by_absolute_metres(monkeypatch: pytest.MonkeyPatch) -> None:
     """Let the periphery of an ultrawide frame leave the prompt's own range."""
-    model: ZipDepthPrompt = _prompted_model(0.25)
+    model: ZipDepthPrompt = _prompted_model(0.5)
     torch.manual_seed(1)
     image_bchw: Float32[Tensor, "1 3 64 96"] = torch.rand(1, 3, 64, 96)
-    prompt_bchw: Float32[Tensor, "1 1 192 256"] = torch.zeros(1, 1, 192, 256)
-    prompt_bchw[:, :, 80:112, 96:160] = torch.linspace(1.0, 2.0, 32 * 64).reshape(1, 1, 32, 64)
+    prompt_bchw: Float32[Tensor, "1 1 192 256"] = _prompt_spanning(1.0, 1.4)
 
     outputs: ModelOutputs
     logits_bchw: Float32[Tensor, "1 1 64 96"]
     outputs, logits_bchw = _run_capturing_logits(model, image_bchw, prompt_bchw, monkeypatch)
 
-    expected_min_b: Float32[Tensor, "1 1 1 1"] = torch.full((1, 1, 1, 1), 1.0 - 0.25)
-    expected_max_b: Float32[Tensor, "1 1 1 1"] = torch.full((1, 1, 1, 1), 2.0 + 0.25)
+    # 0.5 m on each side of [1.0, 1.4], not 0.5 spans (which would only reach [0.8, 1.6]).
+    expected_min_b: Float32[Tensor, "1 1 1 1"] = torch.full((1, 1, 1, 1), 0.5)
+    expected_max_b: Float32[Tensor, "1 1 1 1"] = torch.full((1, 1, 1, 1), 1.9)
     expected_depth_bchw: Float32[Tensor, "1 1 64 96"] = torch.sigmoid(logits_bchw) * (expected_max_b - expected_min_b) + expected_min_b
 
     torch.testing.assert_close(outputs[1], expected_min_b)
@@ -198,19 +206,48 @@ def test_range_margin_widens_the_reachable_output_range_by_a_span_fraction(monke
     torch.testing.assert_close(outputs[0], expected_depth_bchw)
 
 
-def test_range_margin_never_leaves_the_shared_metric_validity_window(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Clip the widened range to the 0.1--4.0 m window the family agrees on."""
-    model: ZipDepthPrompt = _prompted_model(2.0)
+def test_range_margin_widens_a_narrow_prompt_as_much_as_a_wide_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Give a close-up prompt the same extra reach a span-relative margin would deny it."""
+    model: ZipDepthPrompt = _prompted_model(0.5)
     torch.manual_seed(1)
     image_bchw: Float32[Tensor, "1 3 64 96"] = torch.rand(1, 3, 64, 96)
-    prompt_bchw: Float32[Tensor, "1 1 192 256"] = _prompt_with_fixed_range()
+
+    narrow: ModelOutputs = _run_capturing_logits(model, image_bchw, _prompt_spanning(1.0, 1.1), monkeypatch)[0]
+    wide: ModelOutputs = _run_capturing_logits(model, image_bchw, _prompt_spanning(1.0, 2.0), monkeypatch)[0]
+
+    assert float(narrow[1]) == pytest.approx(0.5)
+    assert float(wide[1]) == pytest.approx(0.5)
+    assert float(narrow[2]) == pytest.approx(1.6)
+    assert float(wide[2]) == pytest.approx(2.5)
+
+
+def test_range_margin_never_leaves_the_shared_metric_validity_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clip the widened range to the 0.1--4.0 m window the family agrees on."""
+    model: ZipDepthPrompt = _prompted_model(0.5)
+    torch.manual_seed(1)
+    image_bchw: Float32[Tensor, "2 3 64 96"] = torch.rand(2, 3, 64, 96)
+    # Image 1 has no valid prompt pixel at all, so its range starts at the window edges.
+    prompt_bchw: Float32[Tensor, "2 1 192 256"] = torch.cat([_prompt_spanning(0.3, 3.8), torch.zeros(1, 1, 192, 256)])
 
     outputs: ModelOutputs = _run_capturing_logits(model, image_bchw, prompt_bchw, monkeypatch)[0]
 
-    assert float(outputs[1]) == pytest.approx(MIN_METRIC_DEPTH_M)
-    assert float(outputs[2]) == pytest.approx(MAX_METRIC_DEPTH_M)
+    assert outputs[1].flatten().tolist() == pytest.approx([MIN_METRIC_DEPTH_M, MIN_METRIC_DEPTH_M])
+    assert outputs[2].flatten().tolist() == pytest.approx([MAX_METRIC_DEPTH_M, MAX_METRIC_DEPTH_M])
+    assert torch.isfinite(outputs[0]).all()
     assert float(outputs[0].min()) >= MIN_METRIC_DEPTH_M
     assert float(outputs[0].max()) <= MAX_METRIC_DEPTH_M
+
+
+def test_a_margin_of_the_full_window_width_opens_the_whole_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Document the ultrawide fine-tune setting: 3.9 m reaches every valid depth."""
+    model: ZipDepthPrompt = _prompted_model(MAX_METRIC_DEPTH_M - MIN_METRIC_DEPTH_M)
+    torch.manual_seed(1)
+    image_bchw: Float32[Tensor, "1 3 64 96"] = torch.rand(1, 3, 64, 96)
+
+    outputs: ModelOutputs = _run_capturing_logits(model, image_bchw, _prompt_spanning(1.0, 1.1), monkeypatch)[0]
+
+    assert float(outputs[1]) == pytest.approx(MIN_METRIC_DEPTH_M)
+    assert float(outputs[2]) == pytest.approx(MAX_METRIC_DEPTH_M)
 
 
 def test_range_margin_leaves_the_prompt_conditioning_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -229,20 +266,20 @@ def test_range_margin_leaves_the_prompt_conditioning_unchanged(monkeypatch: pyte
 
 def test_range_margin_rejects_negative_and_non_finite_values() -> None:
     """Fail loudly instead of inverting or poisoning the output range."""
-    with pytest.raises(ValueError, match="range_margin"):
-        ZipDepthPrompt(range_margin=-0.1)
-    with pytest.raises(ValueError, match="range_margin"):
-        ZipDepthPrompt(range_margin=float("nan"))
+    with pytest.raises(ValueError, match="range_margin_m"):
+        ZipDepthPrompt(range_margin_m=-0.1)
+    with pytest.raises(ValueError, match="range_margin_m"):
+        ZipDepthPrompt(range_margin_m=float("nan"))
 
 
 def test_trainer_checkpoints_carry_the_range_margin_to_inference(tmp_path: Path) -> None:
     """Rebuild the trained head from the checkpoint without repeating the flag."""
-    trained: ZipDepthPrompt = ZipDepthPrompt(range_margin=0.35)
+    trained: ZipDepthPrompt = ZipDepthPrompt(range_margin_m=3.9)
     checkpoint: Path = tmp_path / "final_model.pth"
-    torch.save({"model_state_dict": trained.state_dict(), RANGE_MARGIN_KEY: 0.35}, checkpoint)
+    torch.save({"model_state_dict": trained.state_dict(), RANGE_MARGIN_M_KEY: 3.9}, checkpoint)
 
-    assert load_zipdepth_prompt(checkpoint).range_margin == 0.35
-    assert load_zipdepth_prompt(checkpoint, range_margin=0.0).range_margin == 0.0
+    assert load_zipdepth_prompt(checkpoint).range_margin_m == 3.9
+    assert load_zipdepth_prompt(checkpoint, range_margin_m=0.0).range_margin_m == 0.0
 
 
 def test_checkpoints_without_a_recorded_margin_stay_prompt_bounded(tmp_path: Path) -> None:
@@ -253,5 +290,5 @@ def test_checkpoints_without_a_recorded_margin_stay_prompt_bounded(tmp_path: Pat
     legacy: Path = tmp_path / "zdpda_v4.pth"
     torch.save({"model_state_dict": ZipDepthPrompt().state_dict(), "global_step": 70_000}, legacy)
 
-    assert load_zipdepth_prompt(bare).range_margin == 0.0
-    assert load_zipdepth_prompt(legacy).range_margin == 0.0
+    assert load_zipdepth_prompt(bare).range_margin_m == 0.0
+    assert load_zipdepth_prompt(legacy).range_margin_m == 0.0

--- a/packages/zipdepth/tests/test_prompted_model.py
+++ b/packages/zipdepth/tests/test_prompted_model.py
@@ -1,12 +1,20 @@
 """Behavior tests for the prompted metric ZipDepth wrapper."""
 
+from collections.abc import Callable
 from pathlib import Path
+from typing import TypeAlias
 
+import pytest
 import torch
-from jaxtyping import Float32, UInt8
+from jaxtyping import Bool, Float32, UInt8
+from monopriors.models.depth_completion.base_completion_depth import MAX_METRIC_DEPTH_M, MIN_METRIC_DEPTH_M
 from monopriors.models.depth_completion.zipdepth_prompt import ZipDepthPrompt, load_zipdepth_prompt
-from monopriors.third_party.zipdepth.architecture import ZipDepth, create_model
+from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_KEY
+from monopriors.third_party.zipdepth.architecture import FastConvexUpsample, ZipDepth, create_model
 from torch import Tensor
+
+PromptRange: TypeAlias = tuple[Float32[Tensor, "b 1 1 1"], Float32[Tensor, "b 1 1 1"]]
+ModelOutputs: TypeAlias = tuple[Float32[Tensor, "b 1 h w"], Float32[Tensor, "b 1 1 1"], Float32[Tensor, "b 1 1 1"]]
 
 
 def _prompt_with_fixed_range(*, flip: bool = False) -> Float32[Tensor, "1 1 192 256"]:
@@ -15,6 +23,58 @@ def _prompt_with_fixed_range(*, flip: bool = False) -> Float32[Tensor, "1 1 192 
         prompt_bchw = torch.flip(prompt_bchw, dims=(-1,))
     prompt_bchw[:, :, 40:80, 60:120] = 0.0
     return prompt_bchw
+
+
+def _prompt_bounded_range(prompt_bchw: Float32[Tensor, "b 1 192 256"]) -> PromptRange:
+    """Return the pre-margin per-image prompt range, verbatim from the original head."""
+    valid_bchw: Bool[Tensor, "b 1 192 256"] = (
+        torch.isfinite(prompt_bchw) & (prompt_bchw >= MIN_METRIC_DEPTH_M) & (prompt_bchw <= MAX_METRIC_DEPTH_M)
+    )
+    valid_any_b: Bool[Tensor, "b 1 1 1"] = valid_bchw.any(dim=(1, 2, 3), keepdim=True)
+    masked_min_b: Float32[Tensor, "b 1 1 1"] = torch.where(valid_bchw, prompt_bchw, torch.inf).amin(dim=(1, 2, 3), keepdim=True)
+    masked_max_b: Float32[Tensor, "b 1 1 1"] = torch.where(valid_bchw, prompt_bchw, -torch.inf).amax(dim=(1, 2, 3), keepdim=True)
+    min_depth_b: Float32[Tensor, "b 1 1 1"] = torch.where(valid_any_b, masked_min_b, MIN_METRIC_DEPTH_M)
+    max_depth_b: Float32[Tensor, "b 1 1 1"] = torch.where(valid_any_b, masked_max_b, MAX_METRIC_DEPTH_M)
+    return min_depth_b, max_depth_b
+
+
+def _run_capturing_logits(
+    model: ZipDepthPrompt,
+    image_bchw: Float32[Tensor, "b 3 h w"],
+    prompt_bchw: Float32[Tensor, "b 1 192 256"],
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[ModelOutputs, Float32[Tensor, "b 1 h w"]]:
+    """Run the model and also return the pre-sigmoid depth logits it rescaled.
+
+    The convex upsampler is called as a plain method rather than through
+    ``__call__``, so no forward hook sees its output; wrapping the method is the
+    only way to hold the exact logits the output range is applied to.
+    """
+    convex_up: FastConvexUpsample = model.backbone.decoder.convex_up
+    original_unfold: Callable[[Tensor, Tensor], Tensor] = convex_up._forward_unfold
+    captured: list[Float32[Tensor, "b 1 h w"]] = []
+
+    def capturing_unfold(feature_bchw: Tensor, depth_logits_bchw: Tensor) -> Float32[Tensor, "b 1 h w"]:
+        logits_bchw: Float32[Tensor, "b 1 h w"] = original_unfold(feature_bchw, depth_logits_bchw)
+        captured.append(logits_bchw)
+        return logits_bchw
+
+    monkeypatch.setattr(convex_up, "_forward_unfold", capturing_unfold)
+    with torch.inference_mode():
+        outputs: ModelOutputs = model.forward_with_range(image_bchw, prompt_bchw)
+    monkeypatch.undo()
+    return outputs, captured[0]
+
+
+def _prompted_model(range_margin: float, *, seed: int = 0) -> ZipDepthPrompt:
+    """Build a deterministically initialized prompted model with live prompt branches."""
+    torch.manual_seed(seed)
+    model: ZipDepthPrompt = ZipDepthPrompt(range_margin=range_margin).eval()
+    # The released initialization zeroes every branch output, which would hide any
+    # change in the prompt conditioning; give the branches a signal to carry.
+    for parameter in model.prompt_branches.parameters():
+        torch.nn.init.normal_(parameter, std=0.02)
+    return model
 
 
 def test_zero_initialized_prompt_injection_has_no_spatial_contribution() -> None:
@@ -69,3 +129,129 @@ def test_released_zipdepth_state_loads_strictly_into_backbone(tmp_path: Path) ->
     assert prompted_backbone_state.keys() == released_state.keys()
     for key, released_tensor in released_state.items():
         assert torch.equal(prompted_backbone_state[key], released_tensor), key
+
+
+def test_zero_range_margin_reproduces_the_prompt_bounded_head_bit_for_bit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Guarantee the default margin leaves today's forward pass untouched."""
+    model: ZipDepthPrompt = _prompted_model(0.0)
+    torch.manual_seed(1)
+    image_bchw: Float32[Tensor, "2 3 64 96"] = torch.rand(2, 3, 64, 96)
+    prompt_bchw: Float32[Tensor, "2 1 192 256"] = torch.cat([_prompt_with_fixed_range(), _prompt_with_fixed_range(flip=True)])
+
+    outputs: ModelOutputs
+    logits_bchw: Float32[Tensor, "2 1 64 96"]
+    outputs, logits_bchw = _run_capturing_logits(model, image_bchw, prompt_bchw, monkeypatch)
+
+    reference_range: PromptRange = _prompt_bounded_range(prompt_bchw)
+    reference_min_b: Float32[Tensor, "2 1 1 1"] = reference_range[0]
+    reference_max_b: Float32[Tensor, "2 1 1 1"] = reference_range[1]
+    reference_span_b: Float32[Tensor, "2 1 1 1"] = (reference_max_b - reference_min_b).clamp_min(1.0e-6)
+    reference_depth_bchw: Float32[Tensor, "2 1 64 96"] = torch.sigmoid(logits_bchw) * reference_span_b + reference_min_b
+
+    assert torch.equal(outputs[1], reference_min_b)
+    assert torch.equal(outputs[2], reference_max_b)
+    assert torch.equal(outputs[0], reference_depth_bchw)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a CUDA device")
+def test_zero_range_margin_parity_holds_under_cuda_float16_autocast(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Repeat the parity guarantee in the reduced precision the export graph uses."""
+    model: ZipDepthPrompt = _prompted_model(0.0).cuda()
+    torch.manual_seed(1)
+    image_bchw: Float32[Tensor, "1 3 64 96"] = torch.rand(1, 3, 64, 96, device="cuda")
+    prompt_bchw: Float32[Tensor, "1 1 192 256"] = _prompt_with_fixed_range().cuda()
+
+    with torch.autocast(device_type="cuda", dtype=torch.float16):
+        outputs: ModelOutputs
+        logits_bchw: Float32[Tensor, "1 1 64 96"]
+        outputs, logits_bchw = _run_capturing_logits(model, image_bchw, prompt_bchw, monkeypatch)
+
+    reference_range: PromptRange = _prompt_bounded_range(prompt_bchw)
+    reference_min_b: Float32[Tensor, "1 1 1 1"] = reference_range[0]
+    reference_max_b: Float32[Tensor, "1 1 1 1"] = reference_range[1]
+    reference_span_b: Float32[Tensor, "1 1 1 1"] = (reference_max_b - reference_min_b).clamp_min(1.0e-6)
+    reference_depth_bchw: Float32[Tensor, "1 1 64 96"] = torch.sigmoid(logits_bchw) * reference_span_b + reference_min_b
+
+    assert torch.equal(outputs[1], reference_min_b)
+    assert torch.equal(outputs[2], reference_max_b)
+    assert torch.equal(outputs[0], reference_depth_bchw)
+
+
+def test_range_margin_widens_the_reachable_output_range_by_a_span_fraction(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Let the periphery of an ultrawide frame leave the prompt's own range."""
+    model: ZipDepthPrompt = _prompted_model(0.25)
+    torch.manual_seed(1)
+    image_bchw: Float32[Tensor, "1 3 64 96"] = torch.rand(1, 3, 64, 96)
+    prompt_bchw: Float32[Tensor, "1 1 192 256"] = torch.zeros(1, 1, 192, 256)
+    prompt_bchw[:, :, 80:112, 96:160] = torch.linspace(1.0, 2.0, 32 * 64).reshape(1, 1, 32, 64)
+
+    outputs: ModelOutputs
+    logits_bchw: Float32[Tensor, "1 1 64 96"]
+    outputs, logits_bchw = _run_capturing_logits(model, image_bchw, prompt_bchw, monkeypatch)
+
+    expected_min_b: Float32[Tensor, "1 1 1 1"] = torch.full((1, 1, 1, 1), 1.0 - 0.25)
+    expected_max_b: Float32[Tensor, "1 1 1 1"] = torch.full((1, 1, 1, 1), 2.0 + 0.25)
+    expected_depth_bchw: Float32[Tensor, "1 1 64 96"] = torch.sigmoid(logits_bchw) * (expected_max_b - expected_min_b) + expected_min_b
+
+    torch.testing.assert_close(outputs[1], expected_min_b)
+    torch.testing.assert_close(outputs[2], expected_max_b)
+    torch.testing.assert_close(outputs[0], expected_depth_bchw)
+
+
+def test_range_margin_never_leaves_the_shared_metric_validity_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clip the widened range to the 0.1--4.0 m window the family agrees on."""
+    model: ZipDepthPrompt = _prompted_model(2.0)
+    torch.manual_seed(1)
+    image_bchw: Float32[Tensor, "1 3 64 96"] = torch.rand(1, 3, 64, 96)
+    prompt_bchw: Float32[Tensor, "1 1 192 256"] = _prompt_with_fixed_range()
+
+    outputs: ModelOutputs = _run_capturing_logits(model, image_bchw, prompt_bchw, monkeypatch)[0]
+
+    assert float(outputs[1]) == pytest.approx(MIN_METRIC_DEPTH_M)
+    assert float(outputs[2]) == pytest.approx(MAX_METRIC_DEPTH_M)
+    assert float(outputs[0].min()) >= MIN_METRIC_DEPTH_M
+    assert float(outputs[0].max()) <= MAX_METRIC_DEPTH_M
+
+
+def test_range_margin_leaves_the_prompt_conditioning_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Normalize the injected prompt over its own range, not the widened one."""
+    narrow: ZipDepthPrompt = _prompted_model(0.0)
+    wide: ZipDepthPrompt = _prompted_model(0.5)
+    torch.manual_seed(1)
+    image_bchw: Float32[Tensor, "1 3 64 96"] = torch.rand(1, 3, 64, 96)
+    prompt_bchw: Float32[Tensor, "1 1 192 256"] = _prompt_with_fixed_range()
+
+    narrow_logits_bchw: Float32[Tensor, "1 1 64 96"] = _run_capturing_logits(narrow, image_bchw, prompt_bchw, monkeypatch)[1]
+    wide_logits_bchw: Float32[Tensor, "1 1 64 96"] = _run_capturing_logits(wide, image_bchw, prompt_bchw, monkeypatch)[1]
+
+    assert torch.equal(narrow_logits_bchw, wide_logits_bchw)
+
+
+def test_range_margin_rejects_negative_and_non_finite_values() -> None:
+    """Fail loudly instead of inverting or poisoning the output range."""
+    with pytest.raises(ValueError, match="range_margin"):
+        ZipDepthPrompt(range_margin=-0.1)
+    with pytest.raises(ValueError, match="range_margin"):
+        ZipDepthPrompt(range_margin=float("nan"))
+
+
+def test_trainer_checkpoints_carry_the_range_margin_to_inference(tmp_path: Path) -> None:
+    """Rebuild the trained head from the checkpoint without repeating the flag."""
+    trained: ZipDepthPrompt = ZipDepthPrompt(range_margin=0.35)
+    checkpoint: Path = tmp_path / "final_model.pth"
+    torch.save({"model_state_dict": trained.state_dict(), RANGE_MARGIN_KEY: 0.35}, checkpoint)
+
+    assert load_zipdepth_prompt(checkpoint).range_margin == 0.35
+    assert load_zipdepth_prompt(checkpoint, range_margin=0.0).range_margin == 0.0
+
+
+def test_checkpoints_without_a_recorded_margin_stay_prompt_bounded(tmp_path: Path) -> None:
+    """Keep zdpda-v4 and every bare released state dict on the original head."""
+    released: ZipDepth = create_model(variant="base")
+    bare: Path = tmp_path / "zipdepth_base.pth"
+    torch.save(released.state_dict(), bare)
+    legacy: Path = tmp_path / "zdpda_v4.pth"
+    torch.save({"model_state_dict": ZipDepthPrompt().state_dict(), "global_step": 70_000}, legacy)
+
+    assert load_zipdepth_prompt(bare).range_margin == 0.0
+    assert load_zipdepth_prompt(legacy).range_margin == 0.0

--- a/packages/zipdepth/tests/test_prompted_trt.py
+++ b/packages/zipdepth/tests/test_prompted_trt.py
@@ -8,13 +8,16 @@ from typing import TypeAlias
 import pytest
 import torch
 from jaxtyping import Float32
+from monopriors.models.depth_completion.zipdepth_prompt import ZipDepthPrompt
 from monopriors.models.depth_completion.zipdepth_prompt_export import (
     IMAGE_INPUT_NAME,
     PROMPT_INPUT_NAME,
     PromptedDepthModel,
+    _ExportOutputs,
     export_zipdepth_prompt_onnx,
 )
 from monopriors.models.relative_depth.zipdepth import download_zipdepth_checkpoint
+from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_KEY
 from torch import Tensor, nn
 
 from zipdepth.apis import prompted_trt
@@ -115,6 +118,35 @@ def test_export_uses_two_inputs_with_export_dtype_and_static_batch_eight(tmp_pat
     assert all(tensor.dtype == torch.float32 for tensor in call.inputs)
     assert fake_model.fused
     assert fake_model.weight.dtype == torch.float16
+
+
+def test_export_bakes_the_checkpoint_range_margin_into_the_graph(tmp_path: Path) -> None:
+    """Export the head the checkpoint was trained with, keeping the binding names."""
+    trained: ZipDepthPrompt = ZipDepthPrompt(range_margin=0.4)
+    checkpoint: Path = tmp_path / "final_model.pth"
+    torch.save({"model_state_dict": trained.state_dict(), RANGE_MARGIN_KEY: 0.4}, checkpoint)
+    exported_models: list[ZipDepthPrompt] = []
+
+    def fake_export(model: nn.Module, _inputs: ExportInputs, out_path: Path, **kwargs: object) -> None:
+        assert kwargs["input_names"] == [IMAGE_INPUT_NAME, PROMPT_INPUT_NAME]
+        assert kwargs["output_names"] == ["depth", "min_depth", "max_depth"]
+        assert isinstance(model, _ExportOutputs)
+        inner: object = model.model
+        assert isinstance(inner, ZipDepthPrompt)
+        exported_models.append(inner)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_bytes(b"onnx")
+
+    export_zipdepth_prompt_onnx(
+        checkpoint=checkpoint,
+        image_hw=(64, 96),
+        batch_size=1,
+        cache_dir=tmp_path / "cache",
+        export_fn=fake_export,
+        device="cpu",
+    )
+
+    assert exported_models[0].range_margin == 0.4
 
 
 trt_parity = pytest.mark.skipif(

--- a/packages/zipdepth/tests/test_prompted_trt.py
+++ b/packages/zipdepth/tests/test_prompted_trt.py
@@ -12,12 +12,13 @@ from monopriors.models.depth_completion.zipdepth_prompt import ZipDepthPrompt
 from monopriors.models.depth_completion.zipdepth_prompt_export import (
     IMAGE_INPUT_NAME,
     PROMPT_INPUT_NAME,
+    ModelLoader,
     PromptedDepthModel,
     _ExportOutputs,
     export_zipdepth_prompt_onnx,
 )
 from monopriors.models.relative_depth.zipdepth import download_zipdepth_checkpoint
-from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_KEY
+from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_M_KEY
 from torch import Tensor, nn
 
 from zipdepth.apis import prompted_trt
@@ -64,6 +65,15 @@ class _FakePromptModel(nn.Module):
         return depth, prompt_depth.amin(dim=(1, 2, 3), keepdim=True), prompt_depth.amax(dim=(1, 2, 3), keepdim=True)
 
 
+def _fake_loader(fake_model: _FakePromptModel) -> ModelLoader:
+    """Return a loader boundary that ignores the checkpoint and the margin."""
+
+    def load(_checkpoint: Path, *, range_margin_m: float | None = None) -> PromptedDepthModel:
+        return fake_model
+
+    return load
+
+
 def test_fake_model_satisfies_prompted_export_protocol() -> None:
     """Keep exporter tests structural rather than coupled to ZipDepthPrompt."""
     assert isinstance(_FakePromptModel(), PromptedDepthModel)
@@ -103,7 +113,8 @@ def test_export_uses_two_inputs_with_export_dtype_and_static_batch_eight(tmp_pat
         image_hw=(768, 1024),
         batch_size=8,
         cache_dir=tmp_path / "cache",
-        model_loader=lambda _checkpoint: fake_model,
+        range_margin_m=0.0,
+        model_loader=_fake_loader(fake_model),
         export_fn=fake_export,
         device="cpu",
     )
@@ -111,6 +122,7 @@ def test_export_uses_two_inputs_with_export_dtype_and_static_batch_eight(tmp_pat
     call: _ExportCall = calls[0]
     assert onnx_path == call.out_path
     assert "768x1024_b8_fp16" in onnx_path.name
+    assert onnx_path.name.endswith("_m0.00.onnx")
     assert call.input_names == [IMAGE_INPUT_NAME, PROMPT_INPUT_NAME]
     assert call.output_names == ["depth", "min_depth", "max_depth"]
     assert call.dynamic_batch_max is None
@@ -120,11 +132,11 @@ def test_export_uses_two_inputs_with_export_dtype_and_static_batch_eight(tmp_pat
     assert fake_model.weight.dtype == torch.float16
 
 
-def test_export_bakes_the_checkpoint_range_margin_into_the_graph(tmp_path: Path) -> None:
+def test_export_bakes_the_checkpoint_range_margin_into_the_graph_and_its_cache_key(tmp_path: Path) -> None:
     """Export the head the checkpoint was trained with, keeping the binding names."""
-    trained: ZipDepthPrompt = ZipDepthPrompt(range_margin=0.4)
+    trained: ZipDepthPrompt = ZipDepthPrompt(range_margin_m=3.9)
     checkpoint: Path = tmp_path / "final_model.pth"
-    torch.save({"model_state_dict": trained.state_dict(), RANGE_MARGIN_KEY: 0.4}, checkpoint)
+    torch.save({"model_state_dict": trained.state_dict(), RANGE_MARGIN_M_KEY: 3.9}, checkpoint)
     exported_models: list[ZipDepthPrompt] = []
 
     def fake_export(model: nn.Module, _inputs: ExportInputs, out_path: Path, **kwargs: object) -> None:
@@ -137,7 +149,7 @@ def test_export_bakes_the_checkpoint_range_margin_into_the_graph(tmp_path: Path)
         out_path.parent.mkdir(parents=True, exist_ok=True)
         out_path.write_bytes(b"onnx")
 
-    export_zipdepth_prompt_onnx(
+    onnx_path: Path = export_zipdepth_prompt_onnx(
         checkpoint=checkpoint,
         image_hw=(64, 96),
         batch_size=1,
@@ -146,7 +158,36 @@ def test_export_bakes_the_checkpoint_range_margin_into_the_graph(tmp_path: Path)
         device="cpu",
     )
 
-    assert exported_models[0].range_margin == 0.4
+    assert exported_models[0].range_margin_m == 3.9
+    # The cache short-circuits before the model loads, so the margin has to be in the name.
+    assert onnx_path.name.endswith("_m3.90.onnx")
+
+
+def test_export_caches_one_graph_per_margin(tmp_path: Path) -> None:
+    """Never serve a graph built for a different output range out of the cache."""
+    checkpoint: Path = tmp_path / "final_model.pth"
+    torch.save({"model_state_dict": ZipDepthPrompt().state_dict()}, checkpoint)
+    fake_model = _FakePromptModel()
+
+    def fake_export(_model: nn.Module, _inputs: ExportInputs, out_path: Path, **_kwargs: object) -> None:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_bytes(b"onnx")
+
+    paths: list[Path] = [
+        export_zipdepth_prompt_onnx(
+            checkpoint=checkpoint,
+            image_hw=(64, 96),
+            batch_size=1,
+            cache_dir=tmp_path / "cache",
+            range_margin_m=margin_m,
+            model_loader=_fake_loader(fake_model),
+            export_fn=fake_export,
+            device="cpu",
+        )
+        for margin_m in (0.0, 3.9)
+    ]
+
+    assert paths[0] != paths[1]
 
 
 trt_parity = pytest.mark.skipif(

--- a/packages/zipdepth/zipdepth/apis/catalog_throughput.py
+++ b/packages/zipdepth/zipdepth/apis/catalog_throughput.py
@@ -198,3 +198,4 @@ def main(config: CatalogThroughputConfig) -> None:
     print(f"skipped frames: {samples.skipped_frames}")
     print(f"skipped flat frames: {samples.skipped_flat_frames}")
     print(f"skipped low-valid ultrawide frames: {stats.skipped_low_valid_frames}")
+    print(f"skipped ultrawide frames without a payload: {stats.skipped_missing_payload_frames}")

--- a/packages/zipdepth/zipdepth/apis/catalog_throughput.py
+++ b/packages/zipdepth/zipdepth/apis/catalog_throughput.py
@@ -15,6 +15,7 @@ from zipdepth.catalog.dataset import CatalogPromptDepthDataset
 from zipdepth.catalog.segments import DEFAULT_CATALOG_URL, DEFAULT_DATASET_NAME, PromptDACatalog, load_promptda_catalog
 from zipdepth.catalog.stats import CatalogDatasetStats
 from zipdepth.catalog.targets import AugmentPolicy, build_train_transform
+from zipdepth.catalog.ultrawide import DEFAULT_ULTRAWIDE_PROMPT_SCALE, CameraSelection, UltrawidePolicy
 
 
 @dataclass(slots=True)
@@ -51,8 +52,18 @@ class CatalogThroughputConfig:
     """Fetch the ARKit confidence column; training skips it."""
     min_depth_span: float = 1.25
     """Minimum valid-depth p95/p5 ratio; zero disables flat-frame filtering."""
+    cameras: CameraSelection = "wide"
+    """Cameras streamed per segment; ``both`` adds the ultrawide JPEG decode stage."""
+    ultrawide_min_valid_fraction: float = 0.7
+    """Minimum in-range ultrawide target fraction before erosion."""
+    ultrawide_valid_erosion_px: int = 1
+    """Ultrawide target-mask erosion radius in pixels."""
+    ultrawide_prompt_scale: float = DEFAULT_ULTRAWIDE_PROMPT_SCALE
+    """Wide prompt footprint inside an ultrawide frame, as a fraction per axis."""
     max_batches: int | None = None
     """Optional limit on yielded batches, including shuffle-buffer warmup cost."""
+    max_seconds: float | None = None
+    """Optional wall-clock limit on the measured loop; checked between batches."""
 
 
 def main(config: CatalogThroughputConfig) -> None:
@@ -75,6 +86,21 @@ def main(config: CatalogThroughputConfig) -> None:
         raise ValueError("fetch_block_size must be positive")
     if config.max_batches is not None and config.max_batches <= 0:
         raise ValueError("max_batches must be positive when set")
+    if config.max_seconds is not None and config.max_seconds <= 0.0:
+        raise ValueError("max_seconds must be positive when set")
+    if config.cameras not in ("wide", "ultrawide", "both"):
+        raise ValueError(f"unknown camera selection {config.cameras!r}")
+    if config.cameras != "wide" and config.dataloader == "rerun":
+        raise ValueError("the Rerun dataloader A/B path streams the wide camera only")
+    ultrawide_policy: UltrawidePolicy | None = (
+        None
+        if config.cameras == "wide"
+        else UltrawidePolicy(
+            min_valid_fraction=config.ultrawide_min_valid_fraction,
+            valid_erosion_px=config.ultrawide_valid_erosion_px,
+            prompt_scale=config.ultrawide_prompt_scale,
+        )
+    )
 
     catalog: PromptDACatalog = load_promptda_catalog(config.catalog_url, config.dataset_name)
     if config.segment_ids is None:
@@ -89,10 +115,14 @@ def main(config: CatalogThroughputConfig) -> None:
     policy: AugmentPolicy = AugmentPolicy()
     builder_factory: Callable[[], SampleBuilder]
     if config.builder == "cuda":
-        builder_factory = lambda: CudaSampleBuilder((config.height, config.width), policy, config.min_depth_span, device)  # noqa: E731
+        builder_factory = lambda: CudaSampleBuilder(  # noqa: E731
+            (config.height, config.width), policy, config.min_depth_span, device, ultrawide_policy=ultrawide_policy
+        )
     else:
         builder_factory = lambda: CpuSampleBuilder(  # noqa: E731
-            build_train_transform(config.height, config.width, policy), config.min_depth_span
+            build_train_transform(config.height, config.width, policy),
+            config.min_depth_span,
+            ultrawide_policy=ultrawide_policy,
         )
     setup_started: float = perf_counter()
     samples: CatalogPromptDepthDataset | RerunPromptDepthDataset
@@ -127,6 +157,7 @@ def main(config: CatalogThroughputConfig) -> None:
             num_producers=config.num_producers,
             prefetch_samples=config.prefetch_samples,
             load_confidence=config.load_confidence,
+            cameras=config.cameras,
         )
     setup_elapsed: float = perf_counter() - setup_started
     loader: DataLoader[dict[str, Tensor]] = DataLoader(samples, batch_size=config.batch_size, num_workers=0)
@@ -141,25 +172,29 @@ def main(config: CatalogThroughputConfig) -> None:
         batches += 1
         if config.max_batches is not None and batches >= config.max_batches:
             break
+        if config.max_seconds is not None and perf_counter() - started >= config.max_seconds:
+            break
     elapsed: float = perf_counter() - started
     if frames == 0 or samples.stats.samples_built == 0:
         raise RuntimeError("catalog dataset yielded no training samples")
 
     stats: CatalogDatasetStats = samples.stats
     built_frames: int = stats.samples_built
-    decoded_frames: int = built_frames + stats.skipped_flat_frames
+    decoded_frames: int = built_frames + stats.skipped_flat_frames + stats.skipped_low_valid_frames
     video_attempts: int = decoded_frames + stats.skipped_frames
     print(
-        f"config: dataloader={config.dataloader}, builder={config.builder}, producers={config.num_producers}, "
-        f"prefetch_samples={config.prefetch_samples}, fetch_block_size={config.fetch_block_size}, "
-        f"batch_size={config.batch_size}, out={config.width}x{config.height}"
+        f"config: dataloader={config.dataloader}, builder={config.builder}, cameras={config.cameras}, "
+        f"producers={config.num_producers}, prefetch_samples={config.prefetch_samples}, "
+        f"fetch_block_size={config.fetch_block_size}, batch_size={config.batch_size}, out={config.width}x{config.height}"
     )
     print(f"setup: {setup_elapsed:.3f}s")
     print(f"overall: {frames / elapsed:.2f} frames/s ({frames} yielded, {built_frames} built, {batches} batches, {elapsed:.2f}s)")
     print(f"segment_query: {stats.segment_query * 1000.0 / video_attempts:.3f} ms/frame")
     print(f"video_decode: {stats.video_decode * 1000.0 / video_attempts:.3f} ms/frame")
+    print(f"jpeg_decode: {stats.jpeg_decode * 1000.0 / video_attempts:.3f} ms/frame")
     print(f"blob_decode: {stats.blob_decode * 1000.0 / decoded_frames:.3f} ms/frame")
     print(f"augment: {stats.augment * 1000.0 / decoded_frames:.3f} ms/frame")
     print(f"png fallbacks: {stats.png_fallbacks}")
     print(f"skipped frames: {samples.skipped_frames}")
     print(f"skipped flat frames: {samples.skipped_flat_frames}")
+    print(f"skipped low-valid ultrawide frames: {stats.skipped_low_valid_frames}")

--- a/packages/zipdepth/zipdepth/apis/eval_catalog.py
+++ b/packages/zipdepth/zipdepth/apis/eval_catalog.py
@@ -20,6 +20,15 @@ from torch.utils.data import DataLoader
 
 from zipdepth.catalog.segments import DEFAULT_CATALOG_URL, DEFAULT_DATASET_NAME, PromptDACatalog, load_promptda_catalog, split_holdout_segments
 from zipdepth.catalog.targets import build_eval_transform
+from zipdepth.catalog.ultrawide import (
+    DEFAULT_ULTRAWIDE_PROMPT_SCALE,
+    ULTRAWIDE_LAYER,
+    CameraSelection,
+    PromptPlacement,
+    UltrawidePolicy,
+    footprint_box,
+    prompt_placement,
+)
 from zipdepth.data.transforms import AlbumentationsWrapper
 from zipdepth.evaluation.edge_metrics import EdgeStratifiedResult, edge_stratified_mae
 from zipdepth.evaluation.metrics import abs_relative_difference, align_depth_least_square, delta1_acc, disparity2depth, fit_affine_least_squares
@@ -63,6 +72,18 @@ class EvalCatalogConfig:
     """Deterministic fallback holdout size when no saved manifest exists."""
     holdout_seed: int = 0
     """Deterministic fallback holdout seed."""
+    cameras: CameraSelection = "wide"
+    """Cameras scored. Selecting the ultrawide adds a second, separately reported pass
+    over the same segments; the wide numbers never change. Ultrawide scoring supports
+    the ``metric`` and ``prompt-upsample`` evaluations only."""
+    ultrawide_min_valid_fraction: float = 0.0
+    """Ultrawide frames below this in-range target fraction are skipped. Zero scores
+    every frame: dropping sparse frames is a training data-efficiency choice, not a
+    property of the benchmark."""
+    ultrawide_valid_erosion_px: int = 1
+    """Ultrawide target-mask erosion radius; matches the training lane."""
+    ultrawide_prompt_scale: float = DEFAULT_ULTRAWIDE_PROMPT_SCALE
+    """Wide prompt footprint inside an ultrawide frame, as a fraction per axis."""
 
 
 @dataclass(slots=True, frozen=True)
@@ -214,6 +235,102 @@ def aligned_inverse_diagnostic(
     return score_metric_depth(aligned_depth_hw, target_depth_hw, fit_hw)
 
 
+@dataclass(slots=True, frozen=True)
+class FootprintSplitMetrics:
+    """Ultrawide metric scores split by the wide prompt's footprint.
+
+    ``outside`` is the headline: those pixels have no prompt at all, so they show
+    what the model learned to do with an unprompted part of a prompted frame.
+    """
+
+    whole: MetricCatalogDepthMetrics
+    """Scores over every valid pixel in the frame."""
+    inside: MetricCatalogDepthMetrics
+    """Scores inside the prompt footprint."""
+    outside: MetricCatalogDepthMetrics
+    """Scores outside the prompt footprint."""
+    inside_prompt_upsample: MetricCatalogDepthMetrics
+    """Zero-parameter bilinear prompt-upsample floor inside the footprint."""
+
+
+def _mean_footprint_metrics(records: list[FootprintSplitMetrics]) -> FootprintSplitMetrics:
+    """Average one non-empty list of footprint-split records field by field."""
+    return FootprintSplitMetrics(
+        whole=_mean_metrics([record.whole for record in records]),
+        inside=_mean_metrics([record.inside for record in records]),
+        outside=_mean_metrics([record.outside for record in records]),
+        inside_prompt_upsample=_mean_metrics([record.inside_prompt_upsample for record in records]),
+    )
+
+
+def _footprint_metrics_report(prefix: str, metrics: FootprintSplitMetrics) -> dict[str, float]:
+    """Flatten footprint-split metrics into prefixed report keys."""
+    named: dict[str, MetricCatalogDepthMetrics] = {
+        "whole": metrics.whole,
+        "inside": metrics.inside,
+        "outside": metrics.outside,
+        "inside_prompt_upsample": metrics.inside_prompt_upsample,
+    }
+    return {
+        f"{prefix}_{region}_{field}": getattr(record, field)
+        for region, record in named.items()
+        for field in ("abs_rel", "delta1", "mae")
+    }
+
+
+def footprint_mask(placement: PromptPlacement, height: int, width: int) -> Bool[ndarray, "h w"]:
+    """Return the output pixels the scaled wide prompt covers.
+
+    Args:
+        placement: Prompt block position inside the prompt canvas.
+        height: Output image height.
+        width: Output image width.
+
+    Returns:
+        Boolean mask with shape ``(height, width)`` that is True inside the footprint.
+    """
+    box: tuple[int, int, int, int] = footprint_box(placement, (height, width))
+    inside_hw: Bool[ndarray, "h w"] = np.zeros((height, width), dtype=bool)
+    inside_hw[box[0] : box[2], box[1] : box[3]] = True
+    return inside_hw
+
+
+def score_footprint_split(
+    prediction_depth_hw: Float32[ndarray, "h w"],
+    target_depth_hw: Float32[ndarray, "h w"],
+    target_valid_hw: Bool[ndarray, "h w"],
+    prompt_depth_hw: Float32[ndarray, "192 256"],
+    prompt_valid_hw: Bool[ndarray, "192 256"],
+    inside_hw: Bool[ndarray, "h w"],
+) -> FootprintSplitMetrics | None:
+    """Score one ultrawide frame whole, inside, and outside the prompt footprint.
+
+    Args:
+        prediction_depth_hw: Predicted metric depth in metres.
+        target_depth_hw: Raycast ultrawide target depth in metres.
+        target_valid_hw: Eroded in-range target validity.
+        prompt_depth_hw: Padded prompt canvas depth in metres.
+        prompt_valid_hw: Padded prompt canvas validity.
+        inside_hw: Output pixels the prompt footprint covers.
+
+    Returns:
+        The four scored regions, or None when either region lacks enough valid
+        pixels to score.
+    """
+    height: int = target_depth_hw.shape[0]
+    width: int = target_depth_hw.shape[1]
+    baseline_depth_hw: Float32[ndarray, "h w"] = prompt_upsample_depth(prompt_depth_hw, prompt_valid_hw, height=height, width=width)
+    try:
+        return FootprintSplitMetrics(
+            whole=score_metric_depth(prediction_depth_hw, target_depth_hw, target_valid_hw),
+            inside=score_metric_depth(prediction_depth_hw, target_depth_hw, target_valid_hw & inside_hw),
+            outside=score_metric_depth(prediction_depth_hw, target_depth_hw, target_valid_hw & ~inside_hw),
+            inside_prompt_upsample=score_metric_depth(baseline_depth_hw, target_depth_hw, target_valid_hw & inside_hw),
+        )
+    except ValueError:
+        return None
+
+
 def _selected_segments(config: EvalCatalogConfig, catalog: PromptDACatalog) -> list[str]:
     """Resolve explicit segments or the saved training holdout manifest."""
     if config.segment_ids is None:
@@ -241,12 +358,129 @@ def _selected_segments(config: EvalCatalogConfig, catalog: PromptDACatalog) -> l
     return segment_ids
 
 
+def _evaluate_ultrawide(
+    config: EvalCatalogConfig,
+    catalog: PromptDACatalog,
+    segment_ids: list[str],
+    prompted_model: ZipDepthPrompt | None,
+    device: torch.device,
+) -> tuple[list[dict[str, float | int | str]], dict[str, float | int]]:
+    """Score the rectified ultrawide camera with the wide prompt padded into its footprint.
+
+    Args:
+        config: Evaluation settings, including the ultrawide mask and prompt policy.
+        catalog: Connected PromptDA catalog metadata.
+        segment_ids: Segments to score; those without the ultrawide layer are skipped.
+        prompted_model: Fused prompted model, or None to score the prompt-upsample floor.
+        device: Device the model runs on.
+
+    Returns:
+        Per-segment reports and the overall footprint-split summary.
+
+    Raises:
+        RuntimeError: If no ultrawide frame could be scored.
+    """
+    # Catalog-only imports stay local so pure metric tests run outside the catalog lane.
+    from zipdepth.catalog.builders import CpuSampleBuilder
+    from zipdepth.catalog.dataset import CatalogPromptDepthDataset
+
+    transform: AlbumentationsWrapper = build_eval_transform(config.height, config.width)
+    policy: UltrawidePolicy = UltrawidePolicy(
+        min_valid_fraction=config.ultrawide_min_valid_fraction,
+        valid_erosion_px=config.ultrawide_valid_erosion_px,
+        prompt_scale=config.ultrawide_prompt_scale,
+    )
+    placement: PromptPlacement = prompt_placement(policy.prompt_scale)
+    inside_hw: Bool[ndarray, "h w"] = footprint_mask(placement, config.height, config.width)
+    covered_ids: list[str] = [segment_id for segment_id in segment_ids if ULTRAWIDE_LAYER in catalog.row_by_id[segment_id].layer_names]
+    missing_count: int = len(segment_ids) - len(covered_ids)
+    if missing_count:
+        print(f"ultrawide: skipping {missing_count} segment(s) without the {ULTRAWIDE_LAYER!r} layer")
+
+    per_segment: list[dict[str, float | int | str]] = []
+    all_records: list[FootprintSplitMetrics] = []
+    segment_id: str
+    for segment_id in covered_ids:
+        dataset: CatalogPromptDepthDataset = CatalogPromptDepthDataset(
+            catalog.dataset_entry,
+            [segment_id],
+            catalog.row_by_id,
+            device=device,
+            builder_factory=lambda: CpuSampleBuilder(transform, min_depth_span=0.0, target_mode="metric", ultrawide_policy=policy),
+            shuffle_buffer_size=1,
+            frame_stride=config.frame_stride,
+            num_producers=1,
+            prefetch_samples=4,
+            cameras="ultrawide",
+        )
+        loader: DataLoader[dict[str, Tensor]] = DataLoader(dataset, batch_size=1, num_workers=0)
+        segment_records: list[FootprintSplitMetrics] = []
+        batch: dict[str, Tensor]
+        for batch in loader:
+            target_depth_hw: Float32[ndarray, "h w"] = batch["target_depth"][0, 0].numpy().astype(np.float32, copy=False)
+            target_valid_hw: Bool[ndarray, "h w"] = batch["target_valid"][0, 0].numpy().astype(bool, copy=False)
+            prompt_depth_hw: Float32[ndarray, "192 256"] = batch["prompt_depth"][0, 0].numpy().astype(np.float32, copy=False)
+            prompt_valid_hw: Bool[ndarray, "192 256"] = batch["prompt_valid"][0, 0].numpy().astype(bool, copy=False)
+            if prompted_model is not None:
+                image_bchw: UInt8[Tensor, "b 3 h w"] = batch["image"].to(device=device, non_blocking=True)
+                prompt_depth_bchw: Float32[Tensor, "b 1 192 256"] = batch["prompt_depth"].to(device=device, non_blocking=True)
+                with torch.inference_mode():
+                    prediction_depth_hw: Float32[ndarray, "h w"] = prompted_model(image_bchw, prompt_depth_bchw)[0, 0].float().cpu().numpy()
+            else:
+                prediction_depth_hw = prompt_upsample_depth(
+                    prompt_depth_hw, prompt_valid_hw, height=config.height, width=config.width
+                )
+            scored: FootprintSplitMetrics | None = score_footprint_split(
+                prediction_depth_hw, target_depth_hw, target_valid_hw, prompt_depth_hw, prompt_valid_hw, inside_hw
+            )
+            if scored is not None:
+                segment_records.append(scored)
+        if not segment_records:
+            print(f"{segment_id}: no scorable ultrawide frames")
+            continue
+        segment_metrics: FootprintSplitMetrics = _mean_footprint_metrics(segment_records)
+        segment_report: dict[str, float | int | str] = {
+            "segment_id": segment_id,
+            "frame_count": len(segment_records),
+            **_footprint_metrics_report("ultrawide", segment_metrics),
+        }
+        per_segment.append(segment_report)
+        all_records.extend(segment_records)
+        print(
+            f"{segment_id}: ultrawide AbsRel whole={segment_metrics.whole.abs_rel:.6f} "
+            f"inside={segment_metrics.inside.abs_rel:.6f} outside={segment_metrics.outside.abs_rel:.6f} "
+            f"(inside floor={segment_metrics.inside_prompt_upsample.abs_rel:.6f}) frames={len(segment_records)}"
+        )
+
+    if not all_records:
+        raise RuntimeError("ultrawide evaluation yielded no valid frames")
+    overall_metrics: FootprintSplitMetrics = _mean_footprint_metrics(all_records)
+    overall: dict[str, float | int] = {
+        "ultrawide_frame_count": len(all_records),
+        **_footprint_metrics_report("ultrawide", overall_metrics),
+    }
+    print(
+        f"overall ultrawide: whole AbsRel={overall_metrics.whole.abs_rel:.6f} MAE={overall_metrics.whole.mae:.6f}m | "
+        f"inside AbsRel={overall_metrics.inside.abs_rel:.6f} MAE={overall_metrics.inside.mae:.6f}m "
+        f"(prompt-upsample floor AbsRel={overall_metrics.inside_prompt_upsample.abs_rel:.6f} "
+        f"MAE={overall_metrics.inside_prompt_upsample.mae:.6f}m) | "
+        f"outside AbsRel={overall_metrics.outside.abs_rel:.6f} MAE={overall_metrics.outside.mae:.6f}m "
+        f"delta1={overall_metrics.outside.delta1:.6f} frames={len(all_records)}"
+    )
+    return per_segment, overall
+
+
 def main(config: EvalCatalogConfig) -> Path:
     """Evaluate selected segments, print explicit metric/diagnostic summaries, and write JSON."""
     if config.frame_stride <= 0:
         raise ValueError("frame_stride must be positive")
     if config.height <= 0 or config.width <= 0 or config.input_size <= 0:
         raise ValueError("height, width, and input_size must be positive")
+    if config.cameras not in ("wide", "ultrawide", "both"):
+        raise ValueError(f"unknown camera selection {config.cameras!r}")
+    scores_ultrawide: bool = config.cameras in ("ultrawide", "both")
+    if scores_ultrawide and config.evaluation not in ("metric", "prompt-upsample"):
+        raise ValueError(f"ultrawide scoring supports the metric and prompt-upsample evaluations, not {config.evaluation!r}")
     catalog: PromptDACatalog = load_promptda_catalog(config.catalog_url, config.dataset_name)
     segment_ids: list[str] = _selected_segments(config, catalog)
     transform: AlbumentationsWrapper = build_eval_transform(config.height, config.width)
@@ -275,8 +509,9 @@ def main(config: EvalCatalogConfig) -> Path:
     all_metric_records: list[MetricCatalogDepthMetrics] = []
     all_edge_records: list[dict[str, float]] = []
     all_diagnostic_records: list[MetricCatalogDepthMetrics] = []
+    wide_segment_ids: list[str] = segment_ids if config.cameras in ("wide", "both") else []
     segment_id: str
-    for segment_id in segment_ids:
+    for segment_id in wide_segment_ids:
         dataset: CatalogPromptDepthDataset = CatalogPromptDepthDataset(
             catalog.dataset_entry,
             [segment_id],
@@ -406,15 +641,19 @@ def main(config: EvalCatalogConfig) -> Path:
         per_segment.append(segment_report)
         all_diagnostic_records.extend(segment_diagnostic_records)
 
-    if not all_diagnostic_records:
+    if not all_diagnostic_records and wide_segment_ids:
         raise RuntimeError("evaluation yielded no valid frames")
-    overall_diagnostic: MetricCatalogDepthMetrics = _mean_metrics(all_diagnostic_records)
-    overall: dict[str, float | int] = {
-        "frame_count": len(all_diagnostic_records),
-        "aligned_inverse_diagnostic_abs_rel": overall_diagnostic.abs_rel,
-        "aligned_inverse_diagnostic_delta1": overall_diagnostic.delta1,
-        "aligned_inverse_diagnostic_mae": overall_diagnostic.mae,
-    }
+    overall: dict[str, float | int] = {}
+    if all_diagnostic_records:
+        overall_diagnostic: MetricCatalogDepthMetrics = _mean_metrics(all_diagnostic_records)
+        overall.update(
+            {
+                "frame_count": len(all_diagnostic_records),
+                "aligned_inverse_diagnostic_abs_rel": overall_diagnostic.abs_rel,
+                "aligned_inverse_diagnostic_delta1": overall_diagnostic.delta1,
+                "aligned_inverse_diagnostic_mae": overall_diagnostic.mae,
+            }
+        )
     if all_metric_records:
         overall_metric: MetricCatalogDepthMetrics = _mean_metrics(all_metric_records)
         overall.update(
@@ -440,16 +679,26 @@ def main(config: EvalCatalogConfig) -> Path:
                 f"(baseline/pred {stratified_means['flat_ratio_vs_baseline']:.3f}x) | "
                 f"EWMAE={stratified_means['ewmae']:.6f}m (baseline={stratified_means['baseline_ewmae']:.6f}m)"
             )
-    print(
-        f"overall aligned_inverse_diagnostic: AbsRel={overall['aligned_inverse_diagnostic_abs_rel']:.6f} "
-        f"delta1={overall['aligned_inverse_diagnostic_delta1']:.6f} MAE={overall['aligned_inverse_diagnostic_mae']:.6f}m"
-    )
+    if all_diagnostic_records:
+        print(
+            f"overall aligned_inverse_diagnostic: AbsRel={overall['aligned_inverse_diagnostic_abs_rel']:.6f} "
+            f"delta1={overall['aligned_inverse_diagnostic_delta1']:.6f} MAE={overall['aligned_inverse_diagnostic_mae']:.6f}m"
+        )
+
+    ultrawide_per_segment: list[dict[str, float | int | str]] = []
+    if scores_ultrawide:
+        ultrawide_result: tuple[list[dict[str, float | int | str]], dict[str, float | int]] = _evaluate_ultrawide(
+            config, catalog, segment_ids, prompted_model, device
+        )
+        ultrawide_per_segment = ultrawide_result[0]
+        overall.update(ultrawide_result[1])
 
     config.save_dir.mkdir(parents=True, exist_ok=True)
     output: Path = config.save_dir / f"eval_{config.evaluation}_{output_tag}.json"
     report: dict[str, object] = {
         "config": {**asdict(config), "checkpoint": str(checkpoint) if checkpoint is not None else None, "segment_ids": segment_ids},
         "per_segment": per_segment,
+        "ultrawide_per_segment": ultrawide_per_segment,
         "overall": overall,
     }
     with output.open("w") as file:

--- a/packages/zipdepth/zipdepth/apis/train_catalog.py
+++ b/packages/zipdepth/zipdepth/apis/train_catalog.py
@@ -13,7 +13,12 @@ import torch
 import torch.distributed as dist
 from monopriors.models.depth_completion.zipdepth_prompt import ZipDepthPrompt, load_zipdepth_prompt
 from monopriors.models.relative_depth.zipdepth import download_zipdepth_checkpoint
-from monopriors.models.zipdepth_checkpoint import load_zipdepth_state_dict, narrow_zipdepth_state_dict
+from monopriors.models.zipdepth_checkpoint import (
+    load_zipdepth_checkpoint,
+    load_zipdepth_state_dict,
+    narrow_zipdepth_state_dict,
+    range_margin_m_from_checkpoint,
+)
 from monopriors.third_party.zipdepth.architecture import ZipDepth, create_model
 from monopriors.third_party.zipdepth.model_utils import strip_state_dict_prefixes
 from serde import field as serde_field
@@ -162,11 +167,14 @@ class TrainCatalogConfig:
     """Maximum completed samples buffered by the current loader."""
     min_depth_span: float = 1.25
     """Minimum valid-depth p95/p5 ratio; zero disables flat-frame filtering."""
-    range_margin: float = 0.0
-    """Widen the head's output range beyond the prompt's own [min, max] by this fraction of
-    the span; needed for ultrawide prompts that cover only the image center. The value is
-    recorded in ``resolved_config.json`` and in every checkpoint this run writes, so
-    inference rebuilds the same head. Zero reproduces the prompt-bounded head exactly."""
+    range_margin_m: float = 0.0
+    """Widen the head's output range beyond the prompt's own [min, max] by this many metres
+    on each side; needed for ultrawide prompts that cover only the image center. The margin
+    is absolute rather than a fraction of the prompt span so that a close-up prompt gains as
+    much reach as a wide one. Clipping to the 0.1--4.0 m validity window means 3.9 or more
+    opens the full window. The value is recorded in ``resolved_config.json`` and in every
+    checkpoint this run writes, so inference rebuilds the same head. Zero reproduces the
+    prompt-bounded head exactly."""
     from_scratch: bool = False
     """Start with random weights instead of the released ZipDepth-base weights."""
     metric_gradient_weight: float = 0.5
@@ -522,13 +530,21 @@ def _restore_resume_state(
     *,
     total_steps: int,
     actual_max_lr: float,
+    range_margin_m: float,
     scheduler_config: UpstreamSchedulerConfig,
     schedule: ScheduleName,
     warmup_pct: float,
     final_div_factor: float,
     cooldown_pct: float,
 ) -> None:
-    """Restore model, optimizer, schedule, and trainer step."""
+    """Restore model, optimizer, schedule, and trainer step.
+
+    Raises:
+        ValueError: If the checkpoint recorded a different output-range margin
+            than this run is configured with. Resuming rewrites the same run, so
+            silently changing the head's output range mid-run would make the
+            optimizer state and the recorded margin describe different models.
+    """
     print_main(f"Resuming from: {resume}", trainer.rank)
     checkpoint: dict[str, object] | None
     if trainer.is_distributed:
@@ -544,6 +560,12 @@ def _restore_resume_state(
         checkpoint = loaded_checkpoint if isinstance(loaded_checkpoint, dict) else None
     if checkpoint is None:
         raise ValueError(f"resume checkpoint must contain a mapping: {resume}")
+    resumed_margin_m: float = range_margin_m_from_checkpoint(checkpoint, resume)
+    if not isclose(resumed_margin_m, range_margin_m, rel_tol=0.0, abs_tol=1e-9):
+        raise ValueError(
+            f"resume checkpoint recorded range_margin_m={resumed_margin_m} but this run is configured with "
+            f"range_margin_m={range_margin_m}; resume with the recorded value or start a new run: {resume}"
+        )
     raw_resume_state: object = checkpoint.get("model_state_dict", checkpoint)
     tensor_state: dict[str, Tensor] = narrow_zipdepth_state_dict(raw_resume_state, resume)
     resume_state: dict[str, Tensor] = fix_state_dict_prefix(strip_state_dict_prefixes(tensor_state), trainer.is_distributed)
@@ -609,10 +631,10 @@ def main(
             raise ValueError("save_every_steps must be non-negative")
         if config.target_mode not in ("ssi", "metric"):
             raise ValueError(f"unknown target mode {config.target_mode!r}")
-        if not isfinite(config.range_margin) or config.range_margin < 0.0:
-            raise ValueError("range_margin must be finite and non-negative")
-        if config.range_margin > 0.0 and config.target_mode != "metric":
-            raise ValueError("range_margin only applies to the prompted metric lane")
+        if not isfinite(config.range_margin_m) or config.range_margin_m < 0.0:
+            raise ValueError("range_margin_m must be finite and non-negative")
+        if config.range_margin_m > 0.0 and config.target_mode != "metric":
+            raise ValueError("range_margin_m only applies to the prompted metric lane")
         torch.backends.cudnn.benchmark = True
         torch.backends.cuda.matmul.allow_tf32 = True
         torch.backends.cudnn.allow_tf32 = True
@@ -744,11 +766,23 @@ def main(
         if config.target_mode == "metric":
             if initialization is not None:
                 print_main(f"Loading prompted trainable initialization: {initialization}", rank)
-                model: nn.Module = load_zipdepth_prompt(initialization, range_margin=config.range_margin)
+                # A fine-tune may deliberately change the margin: v4 recorded none, and the
+                # ultrawide run starts from it with the full window open. Say so loudly
+                # rather than failing, which is what resuming the same run does instead.
+                initialization_margin_m: float = range_margin_m_from_checkpoint(
+                    load_zipdepth_checkpoint(initialization), initialization
+                )
+                if not isclose(initialization_margin_m, config.range_margin_m, rel_tol=0.0, abs_tol=1e-9):
+                    print_main(
+                        f"OVERRIDE: initialization recorded range_margin_m={initialization_margin_m}, "
+                        f"training with range_margin_m={config.range_margin_m}",
+                        rank,
+                    )
+                model: nn.Module = load_zipdepth_prompt(initialization, range_margin_m=config.range_margin_m)
             else:
                 model = ZipDepthPrompt(
                     create_model(variant="base", upsample_unfold=model_config.upsample_unfold),
-                    range_margin=config.range_margin,
+                    range_margin_m=config.range_margin_m,
                 )
                 print_main("Training ZipDepth-PromptDA from scratch", rank)
         else:
@@ -803,7 +837,7 @@ def main(
             target_mode=config.target_mode,
             metric_gradient_weight=config.metric_gradient_weight,
             pin_batchnorm_eval=pin_batchnorm_eval,
-            range_margin=config.range_margin,
+            range_margin_m=config.range_margin_m,
             use_profiler=config.profile,
             profile_dir=str(config.profile_dir),
             profile_wait=config.profile_wait,
@@ -817,6 +851,7 @@ def main(
                 trainer,
                 total_steps=total_steps,
                 actual_max_lr=actual_max_lr,
+                range_margin_m=config.range_margin_m,
                 scheduler_config=scheduler_config,
                 schedule=recipe.schedule,
                 warmup_pct=recipe.warmup_pct,

--- a/packages/zipdepth/zipdepth/apis/train_catalog.py
+++ b/packages/zipdepth/zipdepth/apis/train_catalog.py
@@ -27,6 +27,7 @@ from torch.utils.tensorboard import SummaryWriter
 from zipdepth.catalog.instrument import InstrumentedLoader
 from zipdepth.catalog.segments import DEFAULT_CATALOG_URL, DEFAULT_DATASET_NAME, PromptDACatalog, load_promptda_catalog, split_holdout_segments
 from zipdepth.catalog.targets import AugmentPolicy, TargetMode
+from zipdepth.catalog.ultrawide import DEFAULT_ULTRAWIDE_PROMPT_SCALE, CameraSelection, UltrawidePolicy
 from zipdepth.training.distributed import barrier, cleanup_distributed, fix_state_dict_prefix, print_main, setup_distributed
 from zipdepth.training.trainer import ZipDepthTrainer
 
@@ -148,6 +149,22 @@ class TrainCatalogConfig:
     """Samples requested per catalog fetch by the Rerun dataloader path."""
     target_mode: TargetMode = "metric"
     """Prompted metric distillation by default; ``ssi`` retains the legacy RGB-only lane."""
+    cameras: CameraSelection = "wide"
+    """Cameras streamed per segment. ``wide`` reproduces the released lane exactly.
+    ``ultrawide`` trains on the rectified ultrawide frames with the wide LiDAR prompt
+    padded into its footprint. ``both`` interleaves an equal-sized ultrawide subsample
+    with the wide frames, giving roughly balanced batches after the shuffle buffer."""
+    ultrawide_min_valid_fraction: float = 0.7
+    """Reject an ultrawide frame whose in-range target fraction, measured before erosion,
+    falls below this. The raycast depth has holes at glazing and outdoors."""
+    ultrawide_valid_erosion_px: int = 1
+    """Binary-erode the ultrawide target mask by this many pixels; raycast silhouettes
+    bleed about one output pixel past the mesh."""
+    ultrawide_prompt_scale: float = DEFAULT_ULTRAWIDE_PROMPT_SCALE
+    """Prompt block size as a fraction of the prompt canvas per axis. The rectified
+    ultrawide camera sees 2.1x the wide field of view on both axes (measured across
+    landscape and portrait segments; principal point within 0.7% of centre), so the wide
+    LiDAR prompt covers the central 1/2.1 of an ultrawide frame."""
     total_steps: int = 70_000
     """Optimizer steps in the run; the OneCycle schedule spans exactly this many. 70k is about one pass over the 875-segment train split at batch 8 (70.5k steps measured 2026-08-28)."""
     shuffle_buffer_size: int = 256
@@ -604,6 +621,21 @@ def main(
             raise ValueError("save_every_steps must be non-negative")
         if config.target_mode not in ("ssi", "metric"):
             raise ValueError(f"unknown target mode {config.target_mode!r}")
+        if config.cameras not in ("wide", "ultrawide", "both"):
+            raise ValueError(f"unknown camera selection {config.cameras!r}")
+        if config.cameras != "wide" and config.dataloader == "rerun":
+            raise ValueError("the Rerun dataloader A/B path streams the wide camera only")
+        # None keeps the wide lane bit-identical: the builders never consult a policy
+        # they were not given, and they reject an ultrawide request without one.
+        ultrawide_policy: UltrawidePolicy | None = (
+            None
+            if config.cameras == "wide"
+            else UltrawidePolicy(
+                min_valid_fraction=config.ultrawide_min_valid_fraction,
+                valid_erosion_px=config.ultrawide_valid_erosion_px,
+                prompt_scale=config.ultrawide_prompt_scale,
+            )
+        )
         torch.backends.cudnn.benchmark = True
         torch.backends.cuda.matmul.allow_tf32 = True
         torch.backends.cudnn.allow_tf32 = True
@@ -693,6 +725,7 @@ def main(
                         config.min_depth_span,
                         device,
                         target_mode=config.target_mode,
+                        ultrawide_policy=ultrawide_policy,
                     ),
                     shuffle_buffer_size=config.shuffle_buffer_size,
                     seed=config.seed,
@@ -700,6 +733,7 @@ def main(
                     world_size=world_size,
                     num_producers=config.num_producers,
                     prefetch_samples=config.prefetch_samples,
+                    cameras=config.cameras,
                     # Training ignores confidence: the student takes the raw prompt and the model
                     # range-gates internally. Skipping the column drops a column and ~48 KB/frame
                     # off every segment query.

--- a/packages/zipdepth/zipdepth/apis/train_catalog.py
+++ b/packages/zipdepth/zipdepth/apis/train_catalog.py
@@ -162,6 +162,11 @@ class TrainCatalogConfig:
     """Maximum completed samples buffered by the current loader."""
     min_depth_span: float = 1.25
     """Minimum valid-depth p95/p5 ratio; zero disables flat-frame filtering."""
+    range_margin: float = 0.0
+    """Widen the head's output range beyond the prompt's own [min, max] by this fraction of
+    the span; needed for ultrawide prompts that cover only the image center. The value is
+    recorded in ``resolved_config.json`` and in every checkpoint this run writes, so
+    inference rebuilds the same head. Zero reproduces the prompt-bounded head exactly."""
     from_scratch: bool = False
     """Start with random weights instead of the released ZipDepth-base weights."""
     metric_gradient_weight: float = 0.5
@@ -604,6 +609,10 @@ def main(
             raise ValueError("save_every_steps must be non-negative")
         if config.target_mode not in ("ssi", "metric"):
             raise ValueError(f"unknown target mode {config.target_mode!r}")
+        if not isfinite(config.range_margin) or config.range_margin < 0.0:
+            raise ValueError("range_margin must be finite and non-negative")
+        if config.range_margin > 0.0 and config.target_mode != "metric":
+            raise ValueError("range_margin only applies to the prompted metric lane")
         torch.backends.cudnn.benchmark = True
         torch.backends.cuda.matmul.allow_tf32 = True
         torch.backends.cudnn.allow_tf32 = True
@@ -735,10 +744,11 @@ def main(
         if config.target_mode == "metric":
             if initialization is not None:
                 print_main(f"Loading prompted trainable initialization: {initialization}", rank)
-                model: nn.Module = load_zipdepth_prompt(initialization)
+                model: nn.Module = load_zipdepth_prompt(initialization, range_margin=config.range_margin)
             else:
                 model = ZipDepthPrompt(
-                    create_model(variant="base", upsample_unfold=model_config.upsample_unfold)
+                    create_model(variant="base", upsample_unfold=model_config.upsample_unfold),
+                    range_margin=config.range_margin,
                 )
                 print_main("Training ZipDepth-PromptDA from scratch", rank)
         else:
@@ -793,6 +803,7 @@ def main(
             target_mode=config.target_mode,
             metric_gradient_weight=config.metric_gradient_weight,
             pin_batchnorm_eval=pin_batchnorm_eval,
+            range_margin=config.range_margin,
             use_profiler=config.profile,
             profile_dir=str(config.profile_dir),
             profile_wait=config.profile_wait,

--- a/packages/zipdepth/zipdepth/apis/train_catalog_smoke.py
+++ b/packages/zipdepth/zipdepth/apis/train_catalog_smoke.py
@@ -20,6 +20,7 @@ from zipdepth.apis.train_catalog import main as train_catalog
 from zipdepth.apis.train_smoke import check_checkpoint, example_rgb, publish_latest, run_required
 from zipdepth.catalog.segments import DEFAULT_CATALOG_URL, DEFAULT_DATASET_NAME, PromptDACatalog, load_promptda_catalog, split_holdout_segments
 from zipdepth.catalog.targets import build_eval_transform
+from zipdepth.catalog.ultrawide import Camera, CameraSelection, UltrawidePolicy
 from zipdepth.data.transforms import AlbumentationsWrapper
 from zipdepth.loss import ZipDepthLoss
 
@@ -32,6 +33,11 @@ class TrainCatalogSmokeConfig:
     """URL of the live local Rerun catalog server."""
     dataset_name: str = DEFAULT_DATASET_NAME
     """Catalog dataset containing ARKitScenes and PromptDA layers."""
+    segment_ids: list[str] | None = None
+    """Explicit smoke segments; None takes the first ``num_segments`` training segments."""
+    cameras: CameraSelection = "wide"
+    """Cameras every training leg streams. Each selected camera gets its own fixed
+    probe set, and the loss gate must fall for every one of them."""
     work_dir: Path = Path("data/smoke/catalog-runs")
     """Parent directory whose ``latest`` child is published after every gate passes."""
     train_config: Path = Path("configs/default.json")
@@ -79,17 +85,32 @@ def collect_probe_batches(config: TrainCatalogConfig, num_batches: int) -> list[
     if not segment_ids:
         raise RuntimeError("probe selection contains no training segments")
     transform: AlbumentationsWrapper = build_eval_transform(config.height, config.width)
+    ultrawide_policy: UltrawidePolicy | None = (
+        None
+        if config.cameras == "wide"
+        else UltrawidePolicy(
+            min_valid_fraction=config.ultrawide_min_valid_fraction,
+            valid_erosion_px=config.ultrawide_valid_erosion_px,
+            prompt_scale=config.ultrawide_prompt_scale,
+        )
+    )
     dataset: CatalogPromptDepthDataset = CatalogPromptDepthDataset(
         catalog.dataset_entry,
         segment_ids,
         catalog.row_by_id,
         device=torch.device("cuda"),
-        builder_factory=lambda: CpuSampleBuilder(transform, min_depth_span=config.min_depth_span, target_mode=config.target_mode),
+        builder_factory=lambda: CpuSampleBuilder(
+            transform,
+            min_depth_span=config.min_depth_span,
+            target_mode=config.target_mode,
+            ultrawide_policy=ultrawide_policy,
+        ),
         shuffle_buffer_size=1,
         frame_stride=8,
         num_producers=config.num_producers,
         prefetch_samples=config.prefetch_samples,
         load_confidence=False,
+        cameras=config.cameras,
     )
     loader: DataLoader[dict[str, Tensor]] = DataLoader(dataset, batch_size=config.batch_size, num_workers=0, drop_last=True)
     batches: list[dict[str, Tensor]] = []
@@ -141,10 +162,13 @@ def main(config: TrainCatalogSmokeConfig) -> None:
     run_dir: Path = Path(tempfile.mkdtemp(prefix="run-", dir=config.work_dir))
     single_dir: Path = run_dir / "single"
     ddp_dir: Path = run_dir / "ddp"
+    probe_cameras: list[Camera] = ["wide", "ultrawide"] if config.cameras == "both" else [config.cameras]
     base: TrainCatalogConfig = TrainCatalogConfig(
         catalog_url=config.catalog_url,
         dataset_name=config.dataset_name,
         num_segments=2,
+        segment_ids=config.segment_ids,
+        cameras=config.cameras,
         holdout_count=0,
         height=768,
         width=1024,
@@ -162,8 +186,12 @@ def main(config: TrainCatalogSmokeConfig) -> None:
         fused_adamw=config.fused_adamw,
         amp_dtype=config.amp_dtype,
     )
-    probe: list[dict[str, Tensor]] = collect_probe_batches(base, config.probe_batches)
-    released_loss: float = mean_probe_loss(None, probe)
+    # One fixed probe set per selected camera: a mixed set would hide a camera
+    # whose loss rose behind another camera's larger fall.
+    probes: dict[Camera, list[dict[str, Tensor]]] = {
+        camera: collect_probe_batches(replace(base, cameras=camera), config.probe_batches) for camera in probe_cameras
+    }
+    released_losses: dict[Camera, float] = {camera: mean_probe_loss(None, probe) for camera, probe in probes.items()}
 
     latest_checkpoint: Path = train_catalog(base)
     saved: object = torch.load(latest_checkpoint, map_location="cpu", weights_only=True)
@@ -171,10 +199,13 @@ def main(config: TrainCatalogSmokeConfig) -> None:
     if saved_step != config.total_steps:
         raise RuntimeError(f"checkpoint global_step is {saved_step!r}, expected {config.total_steps}")
 
-    trained_loss: float = mean_probe_loss(latest_checkpoint, probe)
-    if not trained_loss < released_loss:
-        raise RuntimeError(f"fixed-probe loss did not fall: released={released_loss:.6f}, trained={trained_loss:.6f}")
-    print(f"loss gate passed on the fixed probe set: released={released_loss:.6f}, trained={trained_loss:.6f}")
+    camera: Camera
+    for camera in probe_cameras:
+        released_loss: float = released_losses[camera]
+        trained_loss: float = mean_probe_loss(latest_checkpoint, probes[camera])
+        if not trained_loss < released_loss:
+            raise RuntimeError(f"{camera} fixed-probe loss did not fall: released={released_loss:.6f}, trained={trained_loss:.6f}")
+        print(f"loss gate passed on the fixed {camera} probe set: released={released_loss:.6f}, trained={trained_loss:.6f}")
 
     expected_resume_step: int = config.total_steps + config.resume_steps
     resume_config: TrainCatalogConfig = replace(
@@ -237,7 +268,11 @@ def main(config: TrainCatalogSmokeConfig) -> None:
         str(resumed_checkpoint),
         "--compile-mode",
         ddp.compile_mode,
+        "--cameras",
+        ddp.cameras,
     ]
+    if ddp.segment_ids is not None:
+        command.extend(["--segment-ids", *ddp.segment_ids])
     if ddp.channels_last:
         command.append("--channels-last")
     if ddp.fused_adamw:

--- a/packages/zipdepth/zipdepth/catalog/builders.py
+++ b/packages/zipdepth/zipdepth/catalog/builders.py
@@ -6,7 +6,7 @@ from typing import Protocol, runtime_checkable
 import numpy as np
 import torch
 from arkitscenes_download.ingest.depth import ArkitDepthConfidence, decode_depth_png, decode_depth_png_fast, inflate_depth_png_rows
-from jaxtyping import Float32, Int32, UInt8, UInt16
+from jaxtyping import Bool, Float32, Int32, UInt8, UInt16
 from numpy import ndarray
 from torch import Tensor
 
@@ -20,6 +20,14 @@ from zipdepth.catalog.targets import (
     build_training_sample_cuda,
     depth_span_ratio,
     depth_span_ratio_cuda,
+)
+from zipdepth.catalog.ultrawide import (
+    Camera,
+    PromptPlacement,
+    UltrawidePolicy,
+    erode_valid,
+    prompt_placement,
+    valid_fraction,
 )
 from zipdepth.data.transforms import AlbumentationsWrapper
 
@@ -39,15 +47,61 @@ class SampleBuilder(Protocol):
         confidence: UInt8[ndarray, "confidence_n"] | None,
         quarter_turns: int,
         sample_seed: int,
+        *,
+        camera: Camera = "wide",
     ) -> dict[str, Tensor] | None:
-        """Build a sample, or return None when the flat-depth filter rejects it."""
+        """Build a sample, or return None when a frame filter rejects it."""
+
+
+def _resolve_placement(camera: Camera, policy: UltrawidePolicy | None) -> PromptPlacement | None:
+    """Return the prompt placement one camera needs, or None for the full-canvas wide prompt.
+
+    Raises:
+        ValueError: If an ultrawide sample is requested from a builder that was
+            not configured with an ultrawide policy.
+    """
+    if camera == "wide":
+        return None
+    if policy is None:
+        raise ValueError("this builder was not configured with an ultrawide policy")
+    return prompt_placement(policy.prompt_scale)
+
+
+def _apply_ultrawide_mask_policy(sample: dict[str, Tensor], policy: UltrawidePolicy, stats: BuilderStats) -> dict[str, Tensor] | None:
+    """Drop a sparse ultrawide frame, then erode the surviving target mask.
+
+    The valid fraction is measured on the resized target before erosion, so the
+    threshold describes the supervision the loss would actually see and does not
+    move when the erosion radius changes.
+
+    Args:
+        sample: Built sample carrying ``target_valid`` (metric) or ``mask`` (SSI).
+        policy: Minimum valid fraction and erosion radius.
+        stats: Builder counters incremented when the frame is rejected.
+
+    Returns:
+        The sample with an eroded mask, or None when the frame is too sparse.
+    """
+    valid_key: str = "target_valid" if "target_valid" in sample else "mask"
+    valid_chw: Bool[Tensor, "1 h w"] = sample[valid_key]
+    if valid_fraction(valid_chw) < policy.min_valid_fraction:
+        stats.skipped_low_valid_frames += 1
+        return None
+    sample[valid_key] = erode_valid(valid_chw, policy.valid_erosion_px)
+    return sample
 
 
 class CpuSampleBuilder:
     """Decode depth and build samples on the CPU."""
 
-    def __init__(self, transform: AlbumentationsWrapper, min_depth_span: float, target_mode: TargetMode = "ssi") -> None:
-        """Configure deterministic transform and optional flat-depth filtering."""
+    def __init__(
+        self,
+        transform: AlbumentationsWrapper,
+        min_depth_span: float,
+        target_mode: TargetMode = "ssi",
+        ultrawide_policy: UltrawidePolicy | None = None,
+    ) -> None:
+        """Configure deterministic transform, flat-depth filtering, and ultrawide policy."""
         if min_depth_span < 0.0:
             raise ValueError("min_depth_span must be non-negative")
         if target_mode not in ("ssi", "metric"):
@@ -55,6 +109,7 @@ class CpuSampleBuilder:
         self._transform: AlbumentationsWrapper = transform
         self._min_depth_span: float = min_depth_span
         self._target_mode: TargetMode = target_mode
+        self._ultrawide_policy: UltrawidePolicy | None = ultrawide_policy
         self.stats: BuilderStats = BuilderStats()
         """Counters local to this builder."""
 
@@ -66,9 +121,12 @@ class CpuSampleBuilder:
         confidence: UInt8[ndarray, "confidence_n"] | None,
         quarter_turns: int,
         sample_seed: int,
+        *,
+        camera: Camera = "wide",
     ) -> dict[str, Tensor] | None:
         """Decode, orient, filter, and transform one CPU sample."""
         del sample_seed
+        placement: PromptPlacement | None = _resolve_placement(camera, self._ultrawide_policy)
         started: float = perf_counter()
         depth_mm_hw: UInt16[ndarray, "h w"] | None = decode_depth_png_fast(target_blob_bytes)
         if depth_mm_hw is None:
@@ -108,6 +166,7 @@ class CpuSampleBuilder:
                 prompt_landscape_mm_hw,
                 confidence_landscape_hw,
                 self._transform,
+                prompt_placement=placement,
             )
         else:
             sample = build_training_sample(
@@ -116,8 +175,14 @@ class CpuSampleBuilder:
                 self._transform,
                 prompt_depth_mm_hw=prompt_landscape_mm_hw,
                 prompt_confidence_hw=confidence_landscape_hw,
+                prompt_placement=placement,
             )
         self.stats.augment += perf_counter() - started
+        if camera == "ultrawide" and self._ultrawide_policy is not None:
+            accepted: dict[str, Tensor] | None = _apply_ultrawide_mask_policy(sample, self._ultrawide_policy, self.stats)
+            if accepted is None:
+                return None
+            sample = accepted
         self.stats.samples_built += 1
         return sample
 
@@ -132,8 +197,9 @@ class CudaSampleBuilder:
         min_depth_span: float,
         device: torch.device,
         target_mode: TargetMode = "ssi",
+        ultrawide_policy: UltrawidePolicy | None = None,
     ) -> None:
-        """Configure output shape, augmentation, filtering, and CUDA state."""
+        """Configure output shape, augmentation, filtering, ultrawide policy, and CUDA state."""
         if out_hw[0] <= 0 or out_hw[1] <= 0:
             raise ValueError("output height and width must be positive")
         if min_depth_span < 0.0:
@@ -147,6 +213,7 @@ class CudaSampleBuilder:
         self._min_depth_span: float = min_depth_span
         self._device: torch.device = device
         self._target_mode: TargetMode = target_mode
+        self._ultrawide_policy: UltrawidePolicy | None = ultrawide_policy
         self._generator: torch.Generator = torch.Generator()
         self._stream: torch.cuda.Stream = torch.cuda.Stream(device=device)
         self.stats: BuilderStats = BuilderStats()
@@ -160,8 +227,11 @@ class CudaSampleBuilder:
         confidence: UInt8[ndarray, "confidence_n"] | None,
         quarter_turns: int,
         sample_seed: int,
+        *,
+        camera: Camera = "wide",
     ) -> dict[str, Tensor] | None:
         """Inflate, unfilter, filter, and augment one CUDA sample."""
+        placement: PromptPlacement | None = _resolve_placement(camera, self._ultrawide_policy)
         self._stream.wait_stream(torch.cuda.current_stream(self._device))
         frame_chw.record_stream(self._stream)
         started: float = perf_counter()
@@ -218,12 +288,18 @@ class CudaSampleBuilder:
                 prompt_depth_mm_hw=prompt_depth_cuda_hw,
                 prompt_confidence_hw=prompt_confidence_cuda_hw,
                 target_mode=self._target_mode,
+                prompt_placement=placement,
             )
             self._stream.synchronize()
         self.stats.augment += perf_counter() - started
         if span_ratio is not None and float(span_ratio.item()) < self._min_depth_span:
             self.stats.skipped_flat_frames += 1
             return None
+        if camera == "ultrawide" and self._ultrawide_policy is not None:
+            accepted: dict[str, Tensor] | None = _apply_ultrawide_mask_policy(sample, self._ultrawide_policy, self.stats)
+            if accepted is None:
+                return None
+            sample = accepted
         self.stats.samples_built += 1
         return sample
 

--- a/packages/zipdepth/zipdepth/catalog/builders.py
+++ b/packages/zipdepth/zipdepth/catalog/builders.py
@@ -67,6 +67,31 @@ def _resolve_placement(camera: Camera, policy: UltrawidePolicy | None) -> Prompt
     return prompt_placement(policy.prompt_scale)
 
 
+def _require_landscape_after_rotation(frame_chw: UInt8[Tensor, "3 h w"], quarter_turns: int) -> None:
+    """Reject an ultrawide frame that the orientation turns do not bring to landscape.
+
+    The ``ultrawide_depth`` layer stores 640x480 for landscape captures and
+    480x640 for portrait ones and carries no orientation guard of its own, so a
+    segment whose stored orientation disagrees with its capture property would
+    otherwise train silently on a rotated image.
+
+    Args:
+        frame_chw: Decoded rectified frame with shape ``(3, H, W)``.
+        quarter_turns: Counter-clockwise turns applied before resizing.
+
+    Raises:
+        ValueError: If the frame is not landscape after the turns.
+    """
+    height: int = int(frame_chw.shape[-2])
+    width: int = int(frame_chw.shape[-1])
+    if quarter_turns % 2 == 1:
+        height, width = width, height
+    if height >= width:
+        raise ValueError(
+            f"ultrawide frame {tuple(frame_chw.shape[-2:])} is {height}x{width} after {quarter_turns} quarter turns, which is not landscape"
+        )
+
+
 def _apply_ultrawide_mask_policy(sample: dict[str, Tensor], policy: UltrawidePolicy, stats: BuilderStats) -> dict[str, Tensor] | None:
     """Drop a sparse ultrawide frame, then erode the surviving target mask.
 
@@ -127,6 +152,8 @@ class CpuSampleBuilder:
         """Decode, orient, filter, and transform one CPU sample."""
         del sample_seed
         placement: PromptPlacement | None = _resolve_placement(camera, self._ultrawide_policy)
+        if camera == "ultrawide":
+            _require_landscape_after_rotation(frame_chw, quarter_turns)
         started: float = perf_counter()
         depth_mm_hw: UInt16[ndarray, "h w"] | None = decode_depth_png_fast(target_blob_bytes)
         if depth_mm_hw is None:
@@ -232,6 +259,8 @@ class CudaSampleBuilder:
     ) -> dict[str, Tensor] | None:
         """Inflate, unfilter, filter, and augment one CUDA sample."""
         placement: PromptPlacement | None = _resolve_placement(camera, self._ultrawide_policy)
+        if camera == "ultrawide":
+            _require_landscape_after_rotation(frame_chw, quarter_turns)
         self._stream.wait_stream(torch.cuda.current_stream(self._device))
         frame_chw.record_stream(self._stream)
         started: float = perf_counter()

--- a/packages/zipdepth/zipdepth/catalog/dataset.py
+++ b/packages/zipdepth/zipdepth/catalog/dataset.py
@@ -13,6 +13,7 @@ from warnings import warn
 
 import numpy as np
 import pyarrow as pa
+import pyarrow.compute as pc
 import torch
 from arkitscenes_download.ingest.paths import (
     CONFIDENCE,
@@ -187,6 +188,25 @@ def component_bytes_views(column: pa.ChunkedArray, column_name: str) -> list[UIn
     return views
 
 
+def _drop_null_payload_rows(table: pa.Table, payload_columns: list[str]) -> pa.Table:
+    """Keep only rows whose every payload column carries a value.
+
+    Args:
+        table: Query result whose rows may be missing a payload column.
+        payload_columns: Columns that must be non-null on a usable row.
+
+    Returns:
+        The input table when nothing is null, otherwise a filtered copy.
+    """
+    if all(table.column(column_name).null_count == 0 for column_name in payload_columns):
+        return table
+    keep: pa.ChunkedArray = pc.is_valid(table.column(payload_columns[0]))
+    column_name: str
+    for column_name in payload_columns[1:]:
+        keep = pc.and_(keep, pc.is_valid(table.column(column_name)))
+    return table.filter(keep)
+
+
 def promptda_blob_views(column: pa.ChunkedArray) -> list[UInt8[ndarray, "n_bytes"]]:
     """Return zero-copy PromptDA blob views, retaining the established public helper."""
     return component_bytes_views(column, PROMPTDA_BLOB_COLUMN)
@@ -316,7 +336,7 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
             + self._segment_seed_index[segment_id] * 100_000_007
         )
 
-    def _ordered_times(self, table: pa.Table, segment_id: str) -> Shaped[ndarray, "n_rows"]:
+    def _require_ordered_rows(self, table: pa.Table, segment_id: str) -> Shaped[ndarray, "n_rows"]:
         """Return the reader's index column, rejecting any out-of-order response."""
         all_times_n: Shaped[ndarray, "n_rows"] = table_timestamps(table)
         if np.any(all_times_n[1:] < all_times_n[:-1]):
@@ -363,7 +383,7 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
         if table.num_rows == 0:
             return None
 
-        all_times_n: Shaped[ndarray, "n_rows"] = self._ordered_times(table, segment_id)
+        all_times_n: Shaped[ndarray, "n_rows"] = self._require_ordered_rows(table, segment_id)
         chosen_times_n: Shaped[ndarray, "n_chosen"] = all_times_n[:: self._frame_stride]
         target_blobs: list[UInt8[ndarray, "target_n_bytes"]] = component_bytes_views(table.column(PROMPTDA_BLOB_COLUMN), PROMPTDA_BLOB_COLUMN)[
             :: self._frame_stride
@@ -411,11 +431,10 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
         confidence: UInt8[ndarray, "confidence_n_values"] | None
         packet_index: np.int64
         first_decode_error_reported: bool = False
-        started: float = perf_counter()
         sample_inputs = zip(prepared.target_blobs, prepared.prompt_blobs, prepared.confidences, prepared.packet_indices, strict=True)
         for sample_index, (target_blob_bytes, prompt_blob_bytes, confidence, packet_index) in enumerate(sample_inputs):
             try:
-                started = perf_counter()
+                started: float = perf_counter()
                 frame_chw: UInt8[Tensor, "3 stored_h stored_w"] = prepared.decoder.get_frame_at(int(packet_index)).data
                 stats.video_decode += perf_counter() - started
             except BeartypeException:
@@ -461,7 +480,13 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
         if self._load_confidence:
             contents.append(f"/{CONFIDENCE}")
             columns.append(CONFIDENCE_COLUMN)
-        table: pa.Table = (
+        # Every payload column must be present on a kept row. The ultrawide track
+        # has its own drop_leading and its own 10 Hz selection, so a chosen frame
+        # can precede the first ARKit lowres row; latest-at cannot fill what has
+        # not been logged yet, and component_bytes_views rejects a null outer row.
+        # A null row carries no payload bytes, so dropping these client-side costs
+        # the same transfer as a server-side filter and still yields the count.
+        chosen: pa.Table = (
             self._dataset_entry.filter_segments(segment_id)
             .filter_contents(contents)
             .reader(index=TIMELINE, fill_latest_at=True)
@@ -470,9 +495,11 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
             .to_arrow_table()
         )
         stats.segment_query += perf_counter() - started
+        table: pa.Table = _drop_null_payload_rows(chosen, columns[1:])
+        stats.skipped_missing_payload_frames += chosen.num_rows - table.num_rows
         if table.num_rows == 0:
             return None
-        self._ordered_times(table, segment_id)
+        self._require_ordered_rows(table, segment_id)
 
         rgb_blobs: list[UInt8[ndarray, "rgb_n_bytes"]] = component_bytes_views(
             table.column(ULTRAWIDE_RGB_BLOB_COLUMN), ULTRAWIDE_RGB_BLOB_COLUMN
@@ -559,10 +586,16 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
             wants_ultrawide = False
         wide_prepared: _WideSegment | None = self._prepare_wide(segment_id, stats) if wants_wide else None
         # Match the ultrawide count to the wide count so a mixed pass is about
-        # half of each camera after the shuffle buffer.
-        frame_limit: int | None = (
-            len(wide_prepared.target_blobs) if self._cameras == "both" and wide_prepared is not None else None
-        )
+        # half of each camera after the shuffle buffer. Without wide frames there
+        # is nothing to balance against, and streaming the whole ultrawide track
+        # (up to 1,840 frames) would silently skew the mix, so skip the segment.
+        frame_limit: int | None = None
+        if self._cameras == "both":
+            if wide_prepared is None:
+                warn(f"{segment_id}: no wide chosen frames, skipping its ultrawide frames too", RuntimeWarning, stacklevel=2)
+                wants_ultrawide = False
+            else:
+                frame_limit = len(wide_prepared.target_blobs)
         ultrawide_prepared: _UltrawideSegment | None = (
             self._prepare_ultrawide(segment_id, stats, frame_limit) if wants_ultrawide else None
         )

--- a/packages/zipdepth/zipdepth/catalog/dataset.py
+++ b/packages/zipdepth/zipdepth/catalog/dataset.py
@@ -13,7 +13,6 @@ from warnings import warn
 
 import numpy as np
 import pyarrow as pa
-import pyarrow.compute as pc
 import torch
 from arkitscenes_download.ingest.paths import (
     CONFIDENCE,
@@ -27,7 +26,7 @@ from arkitscenes_download.ingest.paths import (
 from arkitscenes_download.ingest.timestamps import match_exact_timestamps, table_timestamps
 from beartype.roar import BeartypeException
 from datafusion import col
-from jaxtyping import Int64, Shaped, UInt8
+from jaxtyping import Bool, Int64, Shaped, UInt8
 from numpy import ndarray
 from rerun.catalog import DatasetEntry
 from simplecv.rerun_dataloader import open_segment_decoder
@@ -200,11 +199,11 @@ def _drop_null_payload_rows(table: pa.Table, payload_columns: list[str]) -> pa.T
     """
     if all(table.column(column_name).null_count == 0 for column_name in payload_columns):
         return table
-    keep: pa.ChunkedArray = pc.is_valid(table.column(payload_columns[0]))
+    keep_n: Bool[ndarray, "n_rows"] = np.ones(table.num_rows, dtype=bool)
     column_name: str
-    for column_name in payload_columns[1:]:
-        keep = pc.and_(keep, pc.is_valid(table.column(column_name)))
-    return table.filter(keep)
+    for column_name in payload_columns:
+        keep_n &= table.column(column_name).is_valid().to_numpy(zero_copy_only=False).astype(bool)
+    return table.filter(pa.array(keep_n))
 
 
 def promptda_blob_views(column: pa.ChunkedArray) -> list[UInt8[ndarray, "n_bytes"]]:
@@ -433,8 +432,8 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
         first_decode_error_reported: bool = False
         sample_inputs = zip(prepared.target_blobs, prepared.prompt_blobs, prepared.confidences, prepared.packet_indices, strict=True)
         for sample_index, (target_blob_bytes, prompt_blob_bytes, confidence, packet_index) in enumerate(sample_inputs):
+            started: float = perf_counter()
             try:
-                started: float = perf_counter()
                 frame_chw: UInt8[Tensor, "3 stored_h stored_w"] = prepared.decoder.get_frame_at(int(packet_index)).data
                 stats.video_decode += perf_counter() - started
             except BeartypeException:

--- a/packages/zipdepth/zipdepth/catalog/dataset.py
+++ b/packages/zipdepth/zipdepth/catalog/dataset.py
@@ -1,6 +1,6 @@
 """Stream chosen-frame PromptDA targets from a Rerun catalog."""
 
-from collections.abc import Callable, Generator, Iterator
+from collections.abc import Callable, Generator, Iterable, Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from functools import partial
@@ -522,9 +522,10 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
             # The Arrow view is read-only, and decode_jpeg needs an owned uint8
             # tensor. Copying one ~50 KB blob costs far less than the decode.
             encoded_n: UInt8[Tensor, "rgb_n_bytes"] = torch.frombuffer(bytearray(rgb_blob_bytes), dtype=torch.uint8)
-            frame_chw: UInt8[Tensor, "3 stored_h stored_w"] = decode_jpeg(encoded_n, mode=ImageReadMode.RGB).to(
-                device=self._device, non_blocking=True
-            )
+            decoded: Tensor | list[Tensor] = decode_jpeg(encoded_n, mode=ImageReadMode.RGB)
+            if not isinstance(decoded, Tensor):
+                raise TypeError("decode_jpeg returned a batch for one encoded ultrawide frame")
+            frame_chw: UInt8[Tensor, "3 stored_h stored_w"] = decoded.to(device=self._device, non_blocking=True)
             stats.jpeg_decode += perf_counter() - started
             sample: dict[str, Tensor] | None = builder(
                 frame_chw,
@@ -565,7 +566,7 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
         ultrawide_prepared: _UltrawideSegment | None = (
             self._prepare_ultrawide(segment_id, stats, frame_limit) if wants_ultrawide else None
         )
-        streams: list[Generator[dict[str, Tensor], None, None]] = []
+        streams: list[Iterable[dict[str, Tensor]]] = []
         if wide_prepared is not None:
             streams.append(self._build_wide_samples(segment_id, wide_prepared, builder, stats))
         if ultrawide_prepared is not None:

--- a/packages/zipdepth/zipdepth/catalog/dataset.py
+++ b/packages/zipdepth/zipdepth/catalog/dataset.py
@@ -14,7 +14,15 @@ from warnings import warn
 import numpy as np
 import pyarrow as pa
 import torch
-from arkitscenes_download.ingest.paths import CONFIDENCE, DEPTH, DEPTH_PROMPTDA, TIMELINE, VIDEO_WIDE
+from arkitscenes_download.ingest.paths import (
+    CONFIDENCE,
+    DEPTH,
+    DEPTH_PROMPTDA,
+    DEPTH_ULTRAWIDE_RECT,
+    RGB_ULTRAWIDE_RECT,
+    TIMELINE,
+    VIDEO_WIDE,
+)
 from arkitscenes_download.ingest.timestamps import match_exact_timestamps, table_timestamps
 from beartype.roar import BeartypeException
 from datafusion import col
@@ -25,11 +33,13 @@ from simplecv.rerun_dataloader import open_segment_decoder
 from torch import Tensor
 from torch.utils.data import IterableDataset, get_worker_info
 from torchcodec.decoders import VideoDecoder
+from torchvision.io import ImageReadMode, decode_jpeg
 
 from zipdepth.catalog.builders import SampleBuilder
 from zipdepth.catalog.segments import SegmentRow
 from zipdepth.catalog.stats import CatalogDatasetStats, total
 from zipdepth.catalog.threaded import iter_threaded
+from zipdepth.catalog.ultrawide import ULTRAWIDE_LAYER, CameraSelection, interleave, subsample_indices
 
 PROMPTDA_BLOB_COLUMN: str = f"/{DEPTH_PROMPTDA}:EncodedDepthImage:blob"
 """Catalog column containing uint16 PromptDA PNG blobs."""
@@ -37,8 +47,14 @@ PROMPT_BLOB_COLUMN: str = f"/{DEPTH}:EncodedDepthImage:blob"
 """Catalog column containing uint16 ARKit LiDAR prompt PNG blobs."""
 CONFIDENCE_COLUMN: str = f"/{CONFIDENCE}:SegmentationImage:buffer"
 """Catalog column containing flattened uint8 ARKit depth confidence."""
+ULTRAWIDE_DEPTH_BLOB_COLUMN: str = f"/{DEPTH_ULTRAWIDE_RECT}:EncodedDepthImage:blob"
+"""Catalog column containing uint16 millimetre rectified-ultrawide depth PNG blobs."""
+ULTRAWIDE_RGB_BLOB_COLUMN: str = f"/{RGB_ULTRAWIDE_RECT}:EncodedImage:blob"
+"""Catalog column containing rectified-ultrawide JPEG blobs."""
 NATIVE_VIDEO_FPS: int = 60
 """Nominal frame rate used when wrapping the segment's encoded AV1 packets."""
+ULTRAWIDE_SEED_OFFSET: int = 500_000_011
+"""Separates the ultrawide augmentation seed stream from the wide one within a segment."""
 ItemT = TypeVar("ItemT")
 
 
@@ -81,6 +97,44 @@ class _ProducerSlot:
     """Dataset counters accumulated across passes."""
     owner: Thread | None = None
     """Producer thread currently driving this builder; None when idle."""
+
+
+@dataclass(slots=True)
+class _WideSegment:
+    """Wide-camera inputs for one segment after its query and decoder open."""
+
+    quarter_turns: int
+    """Counter-clockwise turns that bring the stored frame to landscape."""
+    segment_seed: int
+    """Base augmentation seed for this segment, pass, and rank."""
+    target_blobs: list[UInt8[ndarray, "target_n_bytes"]]
+    """Chosen-frame PromptDA depth PNG blobs."""
+    prompt_blobs: list[UInt8[ndarray, "prompt_n_bytes"]]
+    """Latest-at ARKit LiDAR depth PNG blobs aligned with the chosen frames."""
+    confidences: list[UInt8[ndarray, "confidence_n_values"] | None]
+    """Flattened ARKit confidence per chosen frame, or None when not fetched."""
+    packet_indices: Int64[ndarray, "n_chosen"]
+    """Video packet index per chosen frame."""
+    decoder: VideoDecoder
+    """Whole-segment video decoder owned by the calling producer."""
+
+
+@dataclass(slots=True)
+class _UltrawideSegment:
+    """Rectified ultrawide inputs for one segment after its catalog query."""
+
+    quarter_turns: int
+    """Counter-clockwise turns that bring the stored frame to landscape."""
+    segment_seed: int
+    """Base augmentation seed for this segment, pass, and rank."""
+    rgb_blobs: list[UInt8[ndarray, "rgb_n_bytes"]]
+    """Rectified ultrawide JPEG blobs."""
+    target_blobs: list[UInt8[ndarray, "target_n_bytes"]]
+    """Raycast ultrawide depth PNG blobs aligned with the JPEG blobs."""
+    prompt_blobs: list[UInt8[ndarray, "prompt_n_bytes"]]
+    """Latest-at ARKit LiDAR depth PNG blobs aligned with the chosen frames."""
+    confidences: list[UInt8[ndarray, "confidence_n_values"] | None]
+    """Flattened ARKit confidence per chosen frame, or None when not fetched."""
 
 
 def component_bytes_views(column: pa.ChunkedArray, column_name: str) -> list[UInt8[ndarray, "n_bytes"]]:
@@ -164,6 +218,7 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
         num_producers: int = 6,
         prefetch_samples: int = 256,
         load_confidence: bool = True,
+        cameras: CameraSelection = "wide",
     ) -> None:
         """Configure catalog streaming without opening the server or decoder.
 
@@ -185,10 +240,19 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
                 so leaving it out drops a column and ~48 KB/frame off every segment
                 query. Evaluation keeps it for the affine-reference and prompt-upsample
                 diagnostics, which do consume ``prompt_valid``.
+            cameras: Cameras streamed per segment. ``wide`` is the historical
+                lane. ``ultrawide`` streams the rectified ultrawide chosen frames.
+                ``both`` streams the wide frames plus a fresh seeded ultrawide
+                subsample of equal size, interleaved, so the shuffle buffer mixes
+                them into roughly balanced batches. The builder must accept the
+                ultrawide camera when this selects it.
 
         Raises:
-            ValueError: If sizes or distributed shard settings are invalid.
+            ValueError: If sizes, camera selection, or distributed shard settings
+                are invalid.
         """
+        if cameras not in ("wide", "ultrawide", "both"):
+            raise ValueError(f"unknown camera selection {cameras!r}")
         if shuffle_buffer_size <= 0:
             raise ValueError("shuffle_buffer_size must be positive")
         if world_size <= 0 or not 0 <= rank < world_size:
@@ -205,6 +269,8 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
         self._device: torch.device = device
         self._builder_factory: Callable[[], SampleBuilder] = builder_factory
         self._load_confidence: bool = load_confidence
+        self._cameras: CameraSelection = cameras
+        self._missing_ultrawide_reported: bool = False
         self._shuffle_buffer_size: int = shuffle_buffer_size
         self._seed: int = seed
         self._rank: int = rank
@@ -232,17 +298,33 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
         """Return the number of frames rejected by the depth-span filter."""
         return self.stats.skipped_flat_frames
 
+    @property
+    def skipped_low_valid_frames(self) -> int:
+        """Return the number of ultrawide frames rejected for sparse valid depth."""
+        return self.stats.skipped_low_valid_frames
+
     def set_epoch(self, epoch: int) -> None:
         """Set the pass index used to seed segment and sample shuffling."""
         self._epoch = epoch
 
-    def _iter_segment(
-        self,
-        segment_id: str,
-        builder: SampleBuilder,
-        stats: CatalogDatasetStats,
-    ) -> Generator[dict[str, Tensor], None, None]:
-        """Run the complete query, decode, filter, and build pipeline for one segment."""
+    def _segment_seed(self, segment_id: str) -> int:
+        """Return the augmentation seed base for one segment, pass, and rank."""
+        return (
+            self._seed
+            + self._epoch * 1_000_003
+            + self._rank * 10_000_019
+            + self._segment_seed_index[segment_id] * 100_000_007
+        )
+
+    def _ordered_times(self, table: pa.Table, segment_id: str) -> Shaped[ndarray, "n_rows"]:
+        """Return the reader's index column, rejecting any out-of-order response."""
+        all_times_n: Shaped[ndarray, "n_rows"] = table_timestamps(table)
+        if np.any(all_times_n[1:] < all_times_n[:-1]):
+            raise ValueError(f"segment {segment_id}: reader returned rows out of {TIMELINE} order; the no-sort fast path assumes index order")
+        return all_times_n
+
+    def _prepare_wide(self, segment_id: str, stats: CatalogDatasetStats) -> _WideSegment | None:
+        """Query one segment's chosen PromptDA rows and open its video decoder."""
         started: float = perf_counter()
         contents: list[str] = [f"/{DEPTH_PROMPTDA}", f"/{DEPTH}"]
         columns: list[str] = [TIMELINE, PROMPTDA_BLOB_COLUMN, PROMPT_BLOB_COLUMN]
@@ -279,11 +361,9 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
             table: pa.Table = table_future.result()
         stats.segment_query += perf_counter() - started
         if table.num_rows == 0:
-            return
+            return None
 
-        all_times_n: Shaped[ndarray, "n_rows"] = table_timestamps(table)
-        if np.any(all_times_n[1:] < all_times_n[:-1]):
-            raise ValueError(f"segment {segment_id}: reader returned rows out of {TIMELINE} order; the no-sort fast path assumes index order")
+        all_times_n: Shaped[ndarray, "n_rows"] = self._ordered_times(table, segment_id)
         chosen_times_n: Shaped[ndarray, "n_chosen"] = all_times_n[:: self._frame_stride]
         target_blobs: list[UInt8[ndarray, "target_n_bytes"]] = component_bytes_views(table.column(PROMPTDA_BLOB_COLUMN), PROMPTDA_BLOB_COLUMN)[
             :: self._frame_stride
@@ -303,25 +383,40 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
         decoder: VideoDecoder = decoder_result[3]
         del decoder_result
         packet_indices_n: Int64[ndarray, "n_chosen"] = match_exact_timestamps(packet_times_n, chosen_times_n)
-        segment_row: SegmentRow = self._row_by_id[segment_id]
-        quarter_turns: int = 0 if segment_row.orientation == "landscape" else (-segment_row.orientation_quarter_turns_ccw) % 4
-        segment_seed: int = (
-            self._seed
-            + self._epoch * 1_000_003
-            + self._rank * 10_000_019
-            + self._segment_seed_index[segment_id] * 100_000_007
+        return _WideSegment(
+            quarter_turns=self._quarter_turns(segment_id),
+            segment_seed=self._segment_seed(segment_id),
+            target_blobs=target_blobs,
+            prompt_blobs=prompt_blobs,
+            confidences=confidences,
+            packet_indices=packet_indices_n,
+            decoder=decoder,
         )
 
+    def _quarter_turns(self, segment_id: str) -> int:
+        """Return the counter-clockwise turns that bring stored frames to landscape."""
+        segment_row: SegmentRow = self._row_by_id[segment_id]
+        return 0 if segment_row.orientation == "landscape" else (-segment_row.orientation_quarter_turns_ccw) % 4
+
+    def _build_wide_samples(
+        self,
+        segment_id: str,
+        prepared: _WideSegment,
+        builder: SampleBuilder,
+        stats: CatalogDatasetStats,
+    ) -> Generator[dict[str, Tensor], None, None]:
+        """Decode video frames and build one wide sample per chosen frame."""
         target_blob_bytes: UInt8[ndarray, "target_n_bytes"]
         prompt_blob_bytes: UInt8[ndarray, "prompt_n_bytes"]
         confidence: UInt8[ndarray, "confidence_n_values"] | None
         packet_index: np.int64
         first_decode_error_reported: bool = False
-        sample_inputs = zip(target_blobs, prompt_blobs, confidences, packet_indices_n, strict=True)
+        started: float = perf_counter()
+        sample_inputs = zip(prepared.target_blobs, prepared.prompt_blobs, prepared.confidences, prepared.packet_indices, strict=True)
         for sample_index, (target_blob_bytes, prompt_blob_bytes, confidence, packet_index) in enumerate(sample_inputs):
             try:
                 started = perf_counter()
-                frame_chw: UInt8[Tensor, "3 stored_h stored_w"] = decoder.get_frame_at(int(packet_index)).data
+                frame_chw: UInt8[Tensor, "3 stored_h stored_w"] = prepared.decoder.get_frame_at(int(packet_index)).data
                 stats.video_decode += perf_counter() - started
             except BeartypeException:
                 raise
@@ -337,11 +432,148 @@ class CatalogPromptDepthDataset(IterableDataset[dict[str, Tensor]]):
                 target_blob_bytes,
                 prompt_blob_bytes,
                 confidence,
-                quarter_turns,
-                (segment_seed + sample_index) % (2**63 - 1),
+                prepared.quarter_turns,
+                (prepared.segment_seed + sample_index) % (2**63 - 1),
             )
             if sample is not None:
                 yield sample
+
+    def _prepare_ultrawide(self, segment_id: str, stats: CatalogDatasetStats, frame_limit: int | None) -> _UltrawideSegment | None:
+        """Query one segment's rectified-ultrawide chosen rows and their latest-at prompts.
+
+        The ultrawide rows are logged at their own 10 Hz selection, disjoint from
+        the wide chosen frames, so the ARKit prompt is taken latest-at-or-before
+        each ultrawide timestamp. The ARKit stream runs at 60 Hz, which bounds the
+        staleness at one frame interval.
+
+        Args:
+            segment_id: Segment to query.
+            stats: Producer counters that accumulate the query time.
+            frame_limit: Keep a seeded random subset of this size; None keeps all
+                chosen frames.
+
+        Returns:
+            The prepared inputs, or None when the segment has no ultrawide rows.
+        """
+        started: float = perf_counter()
+        contents: list[str] = [f"/{DEPTH_ULTRAWIDE_RECT}", f"/{RGB_ULTRAWIDE_RECT}", f"/{DEPTH}"]
+        columns: list[str] = [TIMELINE, ULTRAWIDE_DEPTH_BLOB_COLUMN, ULTRAWIDE_RGB_BLOB_COLUMN, PROMPT_BLOB_COLUMN]
+        if self._load_confidence:
+            contents.append(f"/{CONFIDENCE}")
+            columns.append(CONFIDENCE_COLUMN)
+        table: pa.Table = (
+            self._dataset_entry.filter_segments(segment_id)
+            .filter_contents(contents)
+            .reader(index=TIMELINE, fill_latest_at=True)
+            .filter(col(f'"{ULTRAWIDE_DEPTH_BLOB_COLUMN}"').is_not_null())
+            .select(*columns)
+            .to_arrow_table()
+        )
+        stats.segment_query += perf_counter() - started
+        if table.num_rows == 0:
+            return None
+        self._ordered_times(table, segment_id)
+
+        rgb_blobs: list[UInt8[ndarray, "rgb_n_bytes"]] = component_bytes_views(
+            table.column(ULTRAWIDE_RGB_BLOB_COLUMN), ULTRAWIDE_RGB_BLOB_COLUMN
+        )[:: self._frame_stride]
+        target_blobs: list[UInt8[ndarray, "target_n_bytes"]] = component_bytes_views(
+            table.column(ULTRAWIDE_DEPTH_BLOB_COLUMN), ULTRAWIDE_DEPTH_BLOB_COLUMN
+        )[:: self._frame_stride]
+        prompt_blobs: list[UInt8[ndarray, "prompt_n_bytes"]] = component_bytes_views(table.column(PROMPT_BLOB_COLUMN), PROMPT_BLOB_COLUMN)[
+            :: self._frame_stride
+        ]
+        confidences: list[UInt8[ndarray, "confidence_n_values"] | None]
+        if self._load_confidence:
+            confidences = list(component_bytes_views(table.column(CONFIDENCE_COLUMN), CONFIDENCE_COLUMN)[:: self._frame_stride])
+        else:
+            confidences = [None] * len(prompt_blobs)
+
+        segment_seed: int = self._segment_seed(segment_id)
+        if frame_limit is not None:
+            kept: list[int] = subsample_indices(len(target_blobs), frame_limit, segment_seed)
+            rgb_blobs = [rgb_blobs[index] for index in kept]
+            target_blobs = [target_blobs[index] for index in kept]
+            prompt_blobs = [prompt_blobs[index] for index in kept]
+            confidences = [confidences[index] for index in kept]
+        return _UltrawideSegment(
+            quarter_turns=self._quarter_turns(segment_id),
+            segment_seed=segment_seed,
+            rgb_blobs=rgb_blobs,
+            target_blobs=target_blobs,
+            prompt_blobs=prompt_blobs,
+            confidences=confidences,
+        )
+
+    def _build_ultrawide_samples(
+        self,
+        prepared: _UltrawideSegment,
+        builder: SampleBuilder,
+        stats: CatalogDatasetStats,
+    ) -> Generator[dict[str, Tensor], None, None]:
+        """Decode rectified JPEG frames and build one ultrawide sample per chosen frame."""
+        rgb_blob_bytes: UInt8[ndarray, "rgb_n_bytes"]
+        target_blob_bytes: UInt8[ndarray, "target_n_bytes"]
+        prompt_blob_bytes: UInt8[ndarray, "prompt_n_bytes"]
+        confidence: UInt8[ndarray, "confidence_n_values"] | None
+        sample_inputs = zip(prepared.rgb_blobs, prepared.target_blobs, prepared.prompt_blobs, prepared.confidences, strict=True)
+        for sample_index, (rgb_blob_bytes, target_blob_bytes, prompt_blob_bytes, confidence) in enumerate(sample_inputs):
+            started: float = perf_counter()
+            # The Arrow view is read-only, and decode_jpeg needs an owned uint8
+            # tensor. Copying one ~50 KB blob costs far less than the decode.
+            encoded_n: UInt8[Tensor, "rgb_n_bytes"] = torch.frombuffer(bytearray(rgb_blob_bytes), dtype=torch.uint8)
+            frame_chw: UInt8[Tensor, "3 stored_h stored_w"] = decode_jpeg(encoded_n, mode=ImageReadMode.RGB).to(
+                device=self._device, non_blocking=True
+            )
+            stats.jpeg_decode += perf_counter() - started
+            sample: dict[str, Tensor] | None = builder(
+                frame_chw,
+                target_blob_bytes,
+                prompt_blob_bytes,
+                confidence,
+                prepared.quarter_turns,
+                (prepared.segment_seed + ULTRAWIDE_SEED_OFFSET + sample_index) % (2**63 - 1),
+                camera="ultrawide",
+            )
+            if sample is not None:
+                yield sample
+
+    def _iter_segment(
+        self,
+        segment_id: str,
+        builder: SampleBuilder,
+        stats: CatalogDatasetStats,
+    ) -> Generator[dict[str, Tensor], None, None]:
+        """Stream the configured cameras for one segment, interleaved when both are on."""
+        wants_wide: bool = self._cameras in ("wide", "both")
+        wants_ultrawide: bool = self._cameras in ("ultrawide", "both")
+        if wants_ultrawide and ULTRAWIDE_LAYER not in self._row_by_id[segment_id].layer_names:
+            if not self._missing_ultrawide_reported:
+                self._missing_ultrawide_reported = True
+                warn(
+                    f"skipping ultrawide frames for segments without the {ULTRAWIDE_LAYER!r} layer, starting with {segment_id}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+            wants_ultrawide = False
+        wide_prepared: _WideSegment | None = self._prepare_wide(segment_id, stats) if wants_wide else None
+        # Match the ultrawide count to the wide count so a mixed pass is about
+        # half of each camera after the shuffle buffer.
+        frame_limit: int | None = (
+            len(wide_prepared.target_blobs) if self._cameras == "both" and wide_prepared is not None else None
+        )
+        ultrawide_prepared: _UltrawideSegment | None = (
+            self._prepare_ultrawide(segment_id, stats, frame_limit) if wants_ultrawide else None
+        )
+        streams: list[Generator[dict[str, Tensor], None, None]] = []
+        if wide_prepared is not None:
+            streams.append(self._build_wide_samples(segment_id, wide_prepared, builder, stats))
+        if ultrawide_prepared is not None:
+            streams.append(self._build_ultrawide_samples(ultrawide_prepared, builder, stats))
+        if len(streams) == 1:
+            yield from streams[0]
+        elif streams:
+            yield from interleave(streams)
 
     def _iter_parallel(self, segment_ids: list[str]) -> Generator[dict[str, Tensor], None, None]:
         """Yield complete samples from independent whole-segment worker threads."""

--- a/packages/zipdepth/zipdepth/catalog/instrument.py
+++ b/packages/zipdepth/zipdepth/catalog/instrument.py
@@ -137,7 +137,10 @@ class InstrumentedLoader:
         print(
             f"[catalog io step {self._global_step}] wait={data_wait_ms:.1f}ms compute={compute_ms:.1f}ms "
             f"throughput={frames_per_s:.2f} frames/s gpu={gpu_text} "
-            f"{stage_text} skipped={current_stats.skipped_frames}"
+            f"{stage_text} skipped={current_stats.skipped_frames} "
+            f"skipped_flat={current_stats.skipped_flat_frames} "
+            f"skipped_low_valid={current_stats.skipped_low_valid_frames} "
+            f"skipped_missing_payload={current_stats.skipped_missing_payload_frames}"
         )
         if self._writer is None:
             return
@@ -146,6 +149,9 @@ class InstrumentedLoader:
             "io/compute_ms": compute_ms,
             "io/frames_per_s": frames_per_s,
             "io/skipped_frames": float(current_stats.skipped_frames),
+            "io/skipped_flat_frames": float(current_stats.skipped_flat_frames),
+            "io/skipped_low_valid_frames": float(current_stats.skipped_low_valid_frames),
+            "io/skipped_missing_payload_frames": float(current_stats.skipped_missing_payload_frames),
         }
         name: str
         for name in STAGE_FIELDS:

--- a/packages/zipdepth/zipdepth/catalog/stats.py
+++ b/packages/zipdepth/zipdepth/catalog/stats.py
@@ -49,6 +49,12 @@ class CatalogDatasetStats:
     """Frames rejected by the configured depth-span filter."""
     skipped_low_valid_frames: int = 0
     """Ultrawide frames rejected by the minimum valid-target-fraction gate."""
+    skipped_missing_payload_frames: int = 0
+    """Ultrawide chosen frames dropped because a payload column was null.
+
+    Latest-at cannot fill a column that has not been logged yet, so an ultrawide
+    frame preceding the first ARKit lowres depth row has no prompt.
+    """
 
     @classmethod
     def from_builder(cls, builder_stats: BuilderStats) -> "CatalogDatasetStats":
@@ -68,6 +74,7 @@ class CatalogDatasetStats:
             skipped_frames=self.skipped_frames + other.skipped_frames,
             skipped_flat_frames=self.skipped_flat_frames + other.skipped_flat_frames,
             skipped_low_valid_frames=self.skipped_low_valid_frames + other.skipped_low_valid_frames,
+            skipped_missing_payload_frames=self.skipped_missing_payload_frames + other.skipped_missing_payload_frames,
         )
 
 

--- a/packages/zipdepth/zipdepth/catalog/stats.py
+++ b/packages/zipdepth/zipdepth/catalog/stats.py
@@ -3,7 +3,7 @@
 from collections.abc import Iterable
 from dataclasses import asdict, dataclass
 
-STAGE_FIELDS: tuple[str, ...] = ("segment_query", "video_decode", "blob_decode", "augment")
+STAGE_FIELDS: tuple[str, ...] = ("segment_query", "video_decode", "jpeg_decode", "blob_decode", "augment")
 """Floating-point stage timers reported by catalog instrumentation."""
 
 
@@ -21,6 +21,8 @@ class BuilderStats:
     """PromptDA frames handled by the general PNG decoder."""
     skipped_flat_frames: int = 0
     """Frames rejected by the configured depth-span filter."""
+    skipped_low_valid_frames: int = 0
+    """Ultrawide frames rejected by the minimum valid-target-fraction gate."""
 
 
 @dataclass(slots=True)
@@ -31,6 +33,8 @@ class CatalogDatasetStats:
     """Target/video catalog query and decoder-initialization time in seconds."""
     video_decode: float = 0.0
     """Video frame decode time in seconds."""
+    jpeg_decode: float = 0.0
+    """Rectified ultrawide JPEG decode time in seconds."""
     blob_decode: float = 0.0
     """PromptDA PNG blob decode time in seconds."""
     augment: float = 0.0
@@ -43,6 +47,8 @@ class CatalogDatasetStats:
     """Video frames skipped after decode errors."""
     skipped_flat_frames: int = 0
     """Frames rejected by the configured depth-span filter."""
+    skipped_low_valid_frames: int = 0
+    """Ultrawide frames rejected by the minimum valid-target-fraction gate."""
 
     @classmethod
     def from_builder(cls, builder_stats: BuilderStats) -> "CatalogDatasetStats":
@@ -54,12 +60,14 @@ class CatalogDatasetStats:
         return CatalogDatasetStats(
             segment_query=self.segment_query + other.segment_query,
             video_decode=self.video_decode + other.video_decode,
+            jpeg_decode=self.jpeg_decode + other.jpeg_decode,
             blob_decode=self.blob_decode + other.blob_decode,
             augment=self.augment + other.augment,
             samples_built=self.samples_built + other.samples_built,
             png_fallbacks=self.png_fallbacks + other.png_fallbacks,
             skipped_frames=self.skipped_frames + other.skipped_frames,
             skipped_flat_frames=self.skipped_flat_frames + other.skipped_flat_frames,
+            skipped_low_valid_frames=self.skipped_low_valid_frames + other.skipped_low_valid_frames,
         )
 
 

--- a/packages/zipdepth/zipdepth/catalog/targets.py
+++ b/packages/zipdepth/zipdepth/catalog/targets.py
@@ -136,9 +136,11 @@ def _prompt_tensors(
             f"oriented prompt depth and confidence must both be 192x256, got {prompt_depth_mm_hw.shape} and {prompt_confidence_hw.shape}"
         )
     if prompt_placement is not None:
+        # Copy rather than view: an unrotated prompt is still the read-only Arrow
+        # buffer, and torch.from_numpy warns on non-writable arrays.
         placed: tuple[Float32[Tensor, "192 256"], Bool[Tensor, "192 256"]] = place_wide_prompt(
-            torch.from_numpy(np.ascontiguousarray(prompt_depth_mm_hw)),
-            torch.from_numpy(np.ascontiguousarray(prompt_confidence_hw)),
+            torch.from_numpy(prompt_depth_mm_hw.copy()),
+            torch.from_numpy(prompt_confidence_hw.copy()),
             prompt_placement,
             flipped=flipped,
         )

--- a/packages/zipdepth/zipdepth/catalog/targets.py
+++ b/packages/zipdepth/zipdepth/catalog/targets.py
@@ -11,6 +11,7 @@ from monopriors.models.depth_completion.base_completion_depth import MAX_METRIC_
 from numpy import ndarray
 from torch import Tensor
 
+from zipdepth.catalog.ultrawide import PromptPlacement, place_wide_prompt
 from zipdepth.data.transforms import AlbumentationsWrapper, resize_rgb_and_depth_exact
 
 MIN_DEPTH_MM: int = int(MIN_METRIC_DEPTH_M * 1000)
@@ -121,12 +122,29 @@ def _prompt_tensors(
     prompt_confidence_hw: UInt8[ndarray, "192 256"],
     *,
     flipped: bool,
+    prompt_placement: PromptPlacement | None = None,
 ) -> dict[str, Tensor]:
-    """Convert one oriented native-grid LiDAR prompt to collatable tensors."""
+    """Convert one oriented native-grid LiDAR prompt to collatable tensors.
+
+    With a placement the prompt is scaled into its ultrawide footprint on a zero
+    canvas instead of filling it, using the shared torch helper so this path
+    stays bit-identical to the CUDA builder's.
+    """
     if prompt_depth_mm_hw.shape != (192, 256) or prompt_confidence_hw.shape != (192, 256):
         raise ValueError(
             f"oriented prompt depth and confidence must both be 192x256, got {prompt_depth_mm_hw.shape} and {prompt_confidence_hw.shape}"
         )
+    if prompt_placement is not None:
+        placed: tuple[Float32[Tensor, "192 256"], Bool[Tensor, "192 256"]] = place_wide_prompt(
+            torch.from_numpy(np.ascontiguousarray(prompt_depth_mm_hw)),
+            torch.from_numpy(np.ascontiguousarray(prompt_confidence_hw)),
+            prompt_placement,
+            flipped=flipped,
+        )
+        return {
+            "prompt_depth": placed[0].unsqueeze(0).contiguous(),
+            "prompt_valid": placed[1].unsqueeze(0).contiguous(),
+        }
     prompt_depth_m_hw: Float32[ndarray, "192 256"] = prompt_depth_mm_hw.astype(np.float32) / 1000.0
     prompt_valid_hw: Bool[ndarray, "192 256"] = (
         (prompt_confidence_hw >= 1) & (prompt_depth_mm_hw >= MIN_DEPTH_MM) & (prompt_depth_mm_hw <= MAX_DEPTH_MM)
@@ -205,6 +223,7 @@ def build_training_sample(
     *,
     prompt_depth_mm_hw: UInt16[ndarray, "192 256"] | None = None,
     prompt_confidence_hw: UInt8[ndarray, "192 256"] | None = None,
+    prompt_placement: PromptPlacement | None = None,
 ) -> dict[str, Tensor]:
     """Augment aligned RGB and inverse depth, then build one collatable sample.
 
@@ -241,7 +260,9 @@ def build_training_sample(
     if (prompt_depth_mm_hw is None) != (prompt_confidence_hw is None):
         raise ValueError("prompt depth and confidence must be provided together")
     if prompt_depth_mm_hw is not None and prompt_confidence_hw is not None:
-        sample.update(_prompt_tensors(prompt_depth_mm_hw, prompt_confidence_hw, flipped=transformed[2]))
+        sample.update(
+            _prompt_tensors(prompt_depth_mm_hw, prompt_confidence_hw, flipped=transformed[2], prompt_placement=prompt_placement)
+        )
     return sample
 
 
@@ -251,6 +272,8 @@ def build_metric_training_sample(
     prompt_depth_mm_hw: UInt16[ndarray, "192 256"],
     prompt_confidence_hw: UInt8[ndarray, "192 256"],
     transform: AlbumentationsWrapper,
+    *,
+    prompt_placement: PromptPlacement | None = None,
 ) -> dict[str, Tensor]:
     """Build a metric prompted sample without inverse-depth quantization.
 
@@ -290,7 +313,7 @@ def build_metric_training_sample(
         "target_depth": torch.from_numpy(target_depth_chw),
         "target_valid": torch.from_numpy(target_valid_chw),
     }
-    sample.update(_prompt_tensors(prompt_depth_mm_hw, prompt_confidence_hw, flipped=transformed[2]))
+    sample.update(_prompt_tensors(prompt_depth_mm_hw, prompt_confidence_hw, flipped=transformed[2], prompt_placement=prompt_placement))
     return sample
 
 
@@ -305,6 +328,7 @@ def build_training_sample_cuda(
     prompt_depth_mm_hw: Shaped[Tensor, "prompt_h prompt_w"] | None = None,
     prompt_confidence_hw: UInt8[Tensor, "prompt_h prompt_w"] | None = None,
     target_mode: TargetMode = "ssi",
+    prompt_placement: PromptPlacement | None = None,
 ) -> dict[str, Tensor]:
     """Build one augmented training sample without leaving CUDA.
 
@@ -374,28 +398,30 @@ def build_training_sample_cuda(
         raise RuntimeError("exact resize dropped the depth target")
     prompt_depth_m_hw: Float32[Tensor, "192 256"] | None = None
     prompt_valid_hw: Bool[Tensor, "192 256"] | None = None
+    rotated_prompt_mm_hw: Shaped[Tensor, "oriented_prompt_h oriented_prompt_w"] | None = None
+    rotated_confidence_hw: UInt8[Tensor, "oriented_prompt_h oriented_prompt_w"] | None = None
     if prompt_depth_mm_hw is not None and prompt_confidence_hw is not None:
-        rotated_prompt_mm_hw: Shaped[Tensor, "oriented_prompt_h oriented_prompt_w"] = torch.rot90(
-            prompt_depth_mm_hw, turns, dims=(-2, -1)
-        )
-        rotated_confidence_hw: UInt8[Tensor, "oriented_prompt_h oriented_prompt_w"] = torch.rot90(
-            prompt_confidence_hw, turns, dims=(-2, -1)
-        )
+        rotated_prompt_mm_hw = torch.rot90(prompt_depth_mm_hw, turns, dims=(-2, -1))
+        rotated_confidence_hw = torch.rot90(prompt_confidence_hw, turns, dims=(-2, -1))
         if tuple(rotated_prompt_mm_hw.shape) != (192, 256) or tuple(rotated_confidence_hw.shape) != (192, 256):
             raise ValueError(
                 f"oriented prompt depth and confidence must both be 192x256, got {tuple(rotated_prompt_mm_hw.shape)} and {tuple(rotated_confidence_hw.shape)}"
             )
-        prompt_depth_m_hw = rotated_prompt_mm_hw.to(dtype=torch.float32) / 1000.0
-        prompt_valid_hw = (
-            (rotated_confidence_hw >= 1)
-            & (rotated_prompt_mm_hw >= MIN_DEPTH_MM)
-            & (rotated_prompt_mm_hw <= MAX_DEPTH_MM)
-        )
+        # A placed prompt is built after augmentation: mirroring the scaled block
+        # instead of the canvas keeps the flip exact for any canvas margin.
+        if prompt_placement is None:
+            prompt_depth_m_hw = rotated_prompt_mm_hw.to(dtype=torch.float32) / 1000.0
+            prompt_valid_hw = (
+                (rotated_confidence_hw >= 1)
+                & (rotated_prompt_mm_hw >= MIN_DEPTH_MM)
+                & (rotated_prompt_mm_hw <= MAX_DEPTH_MM)
+            )
 
     random_values_n: Float32[Tensor, "3"] = torch.rand(3, device=generator.device, generator=generator)
     random_values: list[float] = random_values_n.cpu().tolist()
+    flip_applied: bool = random_values[0] < policy.flip_p
 
-    if random_values[0] < policy.flip_p:
+    if flip_applied:
         resized_rgb_chw = torch.flip(resized_rgb_chw, dims=(-1,))
         resized_target_hw = torch.flip(resized_target_hw, dims=(-1,))
         if prompt_depth_m_hw is not None and prompt_valid_hw is not None:
@@ -412,6 +438,13 @@ def build_training_sample_cuda(
             0.299 * rgb_for_gray_chw[0] + 0.587 * rgb_for_gray_chw[1] + 0.114 * rgb_for_gray_chw[2]
         )
         resized_rgb_chw = torch.round(gray_hw).clamp_(0.0, 255.0).to(dtype=torch.uint8).expand_as(resized_rgb_chw)
+
+    if prompt_placement is not None and rotated_prompt_mm_hw is not None and rotated_confidence_hw is not None:
+        placed: tuple[Float32[Tensor, "192 256"], Bool[Tensor, "192 256"]] = place_wide_prompt(
+            rotated_prompt_mm_hw, rotated_confidence_hw, prompt_placement, flipped=flip_applied
+        )
+        prompt_depth_m_hw = placed[0]
+        prompt_valid_hw = placed[1]
 
     image_chw: UInt8[Tensor, "3 out_h out_w"] = resized_rgb_chw.contiguous()
     if target_mode == "ssi":

--- a/packages/zipdepth/zipdepth/catalog/targets.py
+++ b/packages/zipdepth/zipdepth/catalog/targets.py
@@ -127,8 +127,9 @@ def _prompt_tensors(
     """Convert one oriented native-grid LiDAR prompt to collatable tensors.
 
     With a placement the prompt is scaled into its ultrawide footprint on a zero
-    canvas instead of filling it, using the shared torch helper so this path
-    stays bit-identical to the CUDA builder's.
+    canvas instead of filling it, through the same torch helper the CUDA builder
+    calls, so both paths agree on placement, resampling, and validity. Only the
+    final metre divide can differ, by one float32 unit in the last place.
     """
     if prompt_depth_mm_hw.shape != (192, 256) or prompt_confidence_hw.shape != (192, 256):
         raise ValueError(

--- a/packages/zipdepth/zipdepth/catalog/ultrawide.py
+++ b/packages/zipdepth/zipdepth/catalog/ultrawide.py
@@ -229,9 +229,10 @@ def erode_valid(valid_chw: Bool[Tensor, "1 h w"], erosion_px: int) -> Bool[Tenso
     """Binary-erode a validity mask with a ``2 * erosion_px + 1`` square element.
 
     Implemented as a max pool over the inverted mask, which runs on CPU and CUDA
-    through one kernel so both sample builders agree exactly. Zero padding on the
-    inverted mask leaves the image border valid: the rectified frame's genuine
-    border holes are already invalid and erode inward on their own.
+    through one kernel so both sample builders agree exactly. ``max_pool2d`` pads
+    with negative infinity, so padding never wins the maximum over a 0/1 mask and
+    the image border stays valid: the rectified frame's genuine border holes are
+    already invalid and erode inward on their own.
 
     Args:
         valid_chw: Boolean validity with shape ``(1, H, W)``.

--- a/packages/zipdepth/zipdepth/catalog/ultrawide.py
+++ b/packages/zipdepth/zipdepth/catalog/ultrawide.py
@@ -9,7 +9,7 @@ than reprojected: zero reads as "no prompt" through the model's own metric
 range gate. ``docs/ultrawide.md`` records the measurement and the alternatives.
 """
 
-from collections.abc import Generator, Iterable, Iterator
+from collections.abc import Generator, Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from random import Random
 from typing import Literal, TypeAlias, TypeVar
@@ -286,7 +286,9 @@ def subsample_indices(available: int, wanted: int, seed: int) -> list[int]:
     return sorted(Random(seed).sample(range(available), wanted))
 
 
-def interleave(iterables: list[Iterable[ItemT]]) -> Generator[ItemT, None, None]:
+def interleave(  # noqa: UP047 — beartype does not support PEP 695 type parameters
+    iterables: Sequence[Iterable[ItemT]],
+) -> Generator[ItemT, None, None]:
     """Yield round-robin from every iterable until all are exhausted.
 
     Args:

--- a/packages/zipdepth/zipdepth/catalog/ultrawide.py
+++ b/packages/zipdepth/zipdepth/catalog/ultrawide.py
@@ -1,0 +1,310 @@
+"""Ultrawide-camera policy, prompt placement, and mask helpers for the catalog lane.
+
+The rectified ultrawide camera sees about ``ULTRAWIDE_FOV_RATIO`` times the wide
+camera's field of view on both axes, so the wide LiDAR prompt only covers the
+centre of an ultrawide frame. ZipDepth-PromptDA takes a fixed
+``PROMPT_CANVAS_HW`` prompt that it bilinearly resamples to its decoder feature
+sizes, so the prompt is placed as a scaled block inside a zero canvas rather
+than reprojected: zero reads as "no prompt" through the model's own metric
+range gate. ``docs/ultrawide.md`` records the measurement and the alternatives.
+"""
+
+from collections.abc import Generator, Iterable, Iterator
+from dataclasses import dataclass
+from random import Random
+from typing import Literal, TypeAlias, TypeVar
+
+import torch
+from jaxtyping import Bool, Float32, Shaped
+from monopriors.models.depth_completion.base_completion_depth import MAX_METRIC_DEPTH_M, MIN_METRIC_DEPTH_M
+from torch import Tensor
+from torch.nn import functional as F
+
+ItemT = TypeVar("ItemT")
+
+Camera: TypeAlias = Literal["wide", "ultrawide"]
+"""One physical ARKitScenes camera contributing training samples."""
+CameraSelection: TypeAlias = Literal["wide", "ultrawide", "both"]
+"""Cameras a catalog dataset streams; ``both`` interleaves them per segment."""
+
+ULTRAWIDE_LAYER: str = "ultrawide_depth"
+"""Catalog layer carrying the rectified ultrawide RGB and raycast depth."""
+
+PROMPT_CANVAS_HW: tuple[int, int] = (192, 256)
+"""Prompt grid the prompted ZipDepth decoder expects, in ``(height, width)``."""
+ULTRAWIDE_FOV_RATIO: float = 2.1
+"""Ultrawide-to-wide field-of-view ratio per axis, measured from the catalog calibration.
+
+Over 24 segments spanning both stored orientations the per-axis ratio
+``(resolution / focal_length)_ultrawide / (resolution / focal_length)_wide`` is
+2.109 +/- 0.015 (2.069 to 2.138), identical on x and y because both cameras are
+square-pixel and share a 4:3 aspect. The rectified ultrawide principal point sits
+within 0.7% of the image centre, so a centred prompt block is the right model.
+"""
+DEFAULT_ULTRAWIDE_PROMPT_SCALE: float = 1.0 / ULTRAWIDE_FOV_RATIO
+"""Fraction of an ultrawide frame the wide LiDAR prompt covers on each axis."""
+
+
+@dataclass(frozen=True, slots=True)
+class PromptPlacement:
+    """Where the scaled wide prompt sits inside the fixed prompt canvas."""
+
+    top: int
+    """First canvas row occupied by the prompt block."""
+    left: int
+    """First canvas column occupied by the prompt block."""
+    height: int
+    """Prompt block height in canvas rows."""
+    width: int
+    """Prompt block width in canvas columns."""
+
+
+@dataclass(frozen=True, slots=True)
+class UltrawidePolicy:
+    """Mask and prompt-placement policy applied to ultrawide samples only."""
+
+    min_valid_fraction: float = 0.7
+    """Reject an ultrawide frame whose in-range target fraction, measured before
+    erosion, falls below this. The raycast depth has holes at glazing and
+    outdoors; sparse frames teach the loss almost nothing per decoded frame."""
+    valid_erosion_px: int = 1
+    """Binary-erode the ultrawide target mask by this many pixels (a 3x3
+    structuring element per pixel). Raycast silhouettes bleed one output pixel
+    past the mesh, so the boundary ring is the least trustworthy supervision."""
+    prompt_scale: float = DEFAULT_ULTRAWIDE_PROMPT_SCALE
+    """Prompt block size as a fraction of the canvas, per axis."""
+
+    def __post_init__(self) -> None:
+        """Reject a fraction outside the unit interval or a negative erosion."""
+        if not 0.0 <= self.min_valid_fraction <= 1.0:
+            raise ValueError("min_valid_fraction must be in [0, 1]")
+        if self.valid_erosion_px < 0:
+            raise ValueError("valid_erosion_px must be non-negative")
+        if not 0.0 < self.prompt_scale <= 1.0:
+            raise ValueError("prompt_scale must be in (0, 1]")
+
+
+def prompt_placement(scale: float, canvas_hw: tuple[int, int] = PROMPT_CANVAS_HW) -> PromptPlacement:
+    """Centre a ``scale``-sized prompt block inside the prompt canvas.
+
+    Args:
+        scale: Prompt block size as a fraction of the canvas, per axis.
+        canvas_hw: Prompt canvas ``(height, width)``.
+
+    Returns:
+        The block's top-left corner and size in canvas pixels.
+
+    Raises:
+        ValueError: If the scale is outside ``(0, 1]`` or rounds to an empty block.
+    """
+    if not 0.0 < scale <= 1.0:
+        raise ValueError("prompt scale must be in (0, 1]")
+    height: int = int(round(canvas_hw[0] * scale))
+    width: int = int(round(canvas_hw[1] * scale))
+    if height <= 0 or width <= 0:
+        raise ValueError(f"prompt scale {scale} rounds to an empty block on a {canvas_hw} canvas")
+    return PromptPlacement(top=(canvas_hw[0] - height) // 2, left=(canvas_hw[1] - width) // 2, height=height, width=width)
+
+
+def resize_prompt_block(values_hw: Shaped[Tensor, "h w"], placement: PromptPlacement) -> Float32[Tensor, "block_h block_w"]:
+    """Nearest-exact resample one prompt plane down to the placement block.
+
+    Nearest resampling keeps every output value a real LiDAR reading, which
+    matters because the block feeds the same metric range gate as the wide path.
+
+    Args:
+        values_hw: Prompt millimetres or confidence with shape ``(H, W)``.
+        placement: Block size the values are resampled to.
+
+    Returns:
+        Float32 values with shape ``(placement.height, placement.width)`` on the
+        input's device.
+    """
+    resampled: Float32[Tensor, "1 1 block_h block_w"] = F.interpolate(
+        values_hw.to(dtype=torch.float32).unsqueeze(0).unsqueeze(0),
+        size=(placement.height, placement.width),
+        mode="nearest-exact",
+    )
+    return resampled.squeeze(0).squeeze(0)
+
+
+def pad_prompt_block(
+    block_hw: Float32[Tensor, "block_h block_w"],
+    placement: PromptPlacement,
+    canvas_hw: tuple[int, int] = PROMPT_CANVAS_HW,
+) -> Float32[Tensor, "canvas_h canvas_w"]:
+    """Write one prompt block into a zeroed canvas at its placement.
+
+    Args:
+        block_hw: Prompt values with shape ``(placement.height, placement.width)``.
+        placement: Where the block sits in the canvas.
+        canvas_hw: Prompt canvas ``(height, width)``.
+
+    Returns:
+        The canvas with the block written in and zeros elsewhere.
+
+    Raises:
+        ValueError: If the block does not match the placement size.
+    """
+    if tuple(block_hw.shape) != (placement.height, placement.width):
+        raise ValueError(f"prompt block {tuple(block_hw.shape)} does not match placement {(placement.height, placement.width)}")
+    canvas_hw_tensor: Float32[Tensor, "canvas_h canvas_w"] = torch.zeros(canvas_hw, dtype=block_hw.dtype, device=block_hw.device)
+    canvas_hw_tensor[placement.top : placement.top + placement.height, placement.left : placement.left + placement.width] = block_hw
+    return canvas_hw_tensor
+
+
+def place_wide_prompt(
+    prompt_depth_mm_hw: Shaped[Tensor, "canvas_h canvas_w"],
+    prompt_confidence_hw: Shaped[Tensor, "canvas_h canvas_w"],
+    placement: PromptPlacement,
+    *,
+    flipped: bool,
+    canvas_hw: tuple[int, int] = PROMPT_CANVAS_HW,
+) -> tuple[Float32[Tensor, "canvas_h canvas_w"], Bool[Tensor, "canvas_h canvas_w"]]:
+    """Scale the oriented wide prompt into its ultrawide footprint on a zero canvas.
+
+    Validity is derived after resampling, from the resampled millimetres and
+    confidence, so depth and validity always describe the same LiDAR reading.
+    Mirroring is applied to the block rather than the canvas, which keeps the
+    flip exact even when the canvas margin is odd.
+
+    Args:
+        prompt_depth_mm_hw: Oriented wide LiDAR depth in millimetres, on the
+            prompt canvas grid.
+        prompt_confidence_hw: Oriented ARKit confidence on the same grid.
+        placement: Where the scaled block sits inside the canvas.
+        flipped: Whether the aligned RGB and target were mirrored horizontally.
+        canvas_hw: Prompt canvas ``(height, width)``.
+
+    Returns:
+        Prompt depth in metres and its validity, both on the canvas grid, with
+        zeros and ``False`` outside the footprint.
+
+    Raises:
+        ValueError: If either input does not match the canvas grid.
+    """
+    if tuple(prompt_depth_mm_hw.shape) != canvas_hw or tuple(prompt_confidence_hw.shape) != canvas_hw:
+        raise ValueError(
+            f"oriented prompt depth and confidence must both be {canvas_hw}, "
+            f"got {tuple(prompt_depth_mm_hw.shape)} and {tuple(prompt_confidence_hw.shape)}"
+        )
+    block_mm_hw: Float32[Tensor, "block_h block_w"] = resize_prompt_block(prompt_depth_mm_hw, placement)
+    block_confidence_hw: Float32[Tensor, "block_h block_w"] = resize_prompt_block(prompt_confidence_hw, placement)
+    block_depth_m_hw: Float32[Tensor, "block_h block_w"] = block_mm_hw / 1000.0
+    block_valid_hw: Bool[Tensor, "block_h block_w"] = (
+        (block_confidence_hw >= 1.0) & (block_mm_hw >= MIN_METRIC_DEPTH_M * 1000.0) & (block_mm_hw <= MAX_METRIC_DEPTH_M * 1000.0)
+    )
+    if flipped:
+        block_depth_m_hw = torch.flip(block_depth_m_hw, dims=(-1,))
+        block_valid_hw = torch.flip(block_valid_hw, dims=(-1,))
+    canvas_depth_m_hw: Float32[Tensor, "canvas_h canvas_w"] = pad_prompt_block(block_depth_m_hw, placement, canvas_hw)
+    canvas_valid_hw: Bool[Tensor, "canvas_h canvas_w"] = (
+        pad_prompt_block(block_valid_hw.to(dtype=torch.float32), placement, canvas_hw) > 0.5
+    )
+    return canvas_depth_m_hw, canvas_valid_hw
+
+
+def footprint_box(placement: PromptPlacement, out_hw: tuple[int, int], canvas_hw: tuple[int, int] = PROMPT_CANVAS_HW) -> tuple[int, int, int, int]:
+    """Map the prompt block onto an output image as ``(top, left, bottom, right)``.
+
+    Args:
+        placement: Prompt block position inside the canvas.
+        out_hw: Output image ``(height, width)``.
+        canvas_hw: Prompt canvas ``(height, width)``.
+
+    Returns:
+        Half-open output pixel bounds covered by the prompt.
+    """
+    scale_y: float = out_hw[0] / canvas_hw[0]
+    scale_x: float = out_hw[1] / canvas_hw[1]
+    return (
+        int(round(placement.top * scale_y)),
+        int(round(placement.left * scale_x)),
+        int(round((placement.top + placement.height) * scale_y)),
+        int(round((placement.left + placement.width) * scale_x)),
+    )
+
+
+def erode_valid(valid_chw: Bool[Tensor, "1 h w"], erosion_px: int) -> Bool[Tensor, "1 h w"]:
+    """Binary-erode a validity mask with a ``2 * erosion_px + 1`` square element.
+
+    Implemented as a max pool over the inverted mask, which runs on CPU and CUDA
+    through one kernel so both sample builders agree exactly. Zero padding on the
+    inverted mask leaves the image border valid: the rectified frame's genuine
+    border holes are already invalid and erode inward on their own.
+
+    Args:
+        valid_chw: Boolean validity with shape ``(1, H, W)``.
+        erosion_px: Erosion radius in pixels; zero returns the input unchanged.
+
+    Returns:
+        The eroded validity mask with the input's shape, dtype, and device.
+
+    Raises:
+        ValueError: If the radius is negative or the mask is not ``(1, H, W)``.
+    """
+    if erosion_px < 0:
+        raise ValueError("erosion_px must be non-negative")
+    if valid_chw.ndim != 3 or valid_chw.shape[0] != 1:
+        raise ValueError(f"validity mask must have shape (1, H, W), got {tuple(valid_chw.shape)}")
+    if erosion_px == 0:
+        return valid_chw
+    invalid_bchw: Float32[Tensor, "1 1 h w"] = (~valid_chw).to(dtype=torch.float32).unsqueeze(0)
+    dilated_bchw: Float32[Tensor, "1 1 h w"] = F.max_pool2d(
+        invalid_bchw,
+        kernel_size=2 * erosion_px + 1,
+        stride=1,
+        padding=erosion_px,
+    )
+    return dilated_bchw.squeeze(0) < 0.5
+
+
+def valid_fraction(valid_chw: Bool[Tensor, "1 h w"]) -> float:
+    """Return the fraction of the mask that is valid."""
+    return float(valid_chw.to(dtype=torch.float32).mean().item())
+
+
+def subsample_indices(available: int, wanted: int, seed: int) -> list[int]:
+    """Pick a seeded, sorted subset of frame positions.
+
+    Args:
+        available: Number of candidate frames in the segment.
+        wanted: Frames to keep; values at or above ``available`` keep all of them.
+        seed: Seed mixing the run seed, epoch, rank, and segment.
+
+    Returns:
+        Sorted candidate positions, so a producer still reads the segment in
+        index order and keeps its decode locality.
+
+    Raises:
+        ValueError: If either count is negative.
+    """
+    if available < 0 or wanted < 0:
+        raise ValueError("available and wanted frame counts must be non-negative")
+    if wanted >= available:
+        return list(range(available))
+    return sorted(Random(seed).sample(range(available), wanted))
+
+
+def interleave(iterables: list[Iterable[ItemT]]) -> Generator[ItemT, None, None]:
+    """Yield round-robin from every iterable until all are exhausted.
+
+    Args:
+        iterables: Sources drained one item at a time in the given order.
+
+    Yields:
+        Items alternating between the sources that still have output.
+    """
+    iterators: list[Iterator[ItemT]] = [iter(iterable) for iterable in iterables]
+    while iterators:
+        remaining: list[Iterator[ItemT]] = []
+        iterator: Iterator[ItemT]
+        for iterator in iterators:
+            item: ItemT
+            try:
+                item = next(iterator)
+            except StopIteration:
+                continue
+            remaining.append(iterator)
+            yield item
+        iterators = remaining

--- a/packages/zipdepth/zipdepth/training/trainer.py
+++ b/packages/zipdepth/zipdepth/training/trainer.py
@@ -17,6 +17,7 @@ try:
 except ImportError:
     WANDB_AVAILABLE = False
 
+from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_KEY
 from monopriors.third_party.zipdepth.model_utils import strip_state_dict_prefixes
 
 from zipdepth.loss import MetricDepthLoss, ZipDepthLoss
@@ -66,6 +67,7 @@ class ZipDepthTrainer:
                 pin_batchnorm_eval: bool = False,
                 compile_mode: CompileMode = 'reduce-overhead',
                 channels_last: bool = False,
+                range_margin: float = 0.0,
                 ):
         """
         Args:
@@ -97,6 +99,8 @@ class ZipDepthTrainer:
             pin_batchnorm_eval: Return BatchNorm modules to eval after entering train mode
             compile_mode: torch.compile mode, or 'off'; dev-mode beartype disables it
             channels_last: Move four-dimensional batches with channels-last strides
+            range_margin: Prompted head output-range margin of the student, recorded in
+                every checkpoint so inference rebuilds the same head
         """
         self.student = student.to(device)
         self.train_loader = train_loader
@@ -128,6 +132,7 @@ class ZipDepthTrainer:
         self.target_mode = target_mode
         self.pin_batchnorm_eval = pin_batchnorm_eval
         self.channels_last = channels_last
+        self.range_margin = range_margin
 
         # Loss function initialization
         self.criterion: nn.Module = (
@@ -462,6 +467,7 @@ class ZipDepthTrainer:
             'model_state_dict': model_state,
             'optimizer_state_dict': self.optimizer.state_dict(),
             'loss': loss,
+            RANGE_MARGIN_KEY: self.range_margin,
         }
 
         if self.scheduler is not None:

--- a/packages/zipdepth/zipdepth/training/trainer.py
+++ b/packages/zipdepth/zipdepth/training/trainer.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     WANDB_AVAILABLE = False
 
-from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_KEY
+from monopriors.models.zipdepth_checkpoint import RANGE_MARGIN_M_KEY
 from monopriors.third_party.zipdepth.model_utils import strip_state_dict_prefixes
 
 from zipdepth.loss import MetricDepthLoss, ZipDepthLoss
@@ -67,7 +67,7 @@ class ZipDepthTrainer:
                 pin_batchnorm_eval: bool = False,
                 compile_mode: CompileMode = 'reduce-overhead',
                 channels_last: bool = False,
-                range_margin: float = 0.0,
+                range_margin_m: float = 0.0,
                 ):
         """
         Args:
@@ -99,8 +99,8 @@ class ZipDepthTrainer:
             pin_batchnorm_eval: Return BatchNorm modules to eval after entering train mode
             compile_mode: torch.compile mode, or 'off'; dev-mode beartype disables it
             channels_last: Move four-dimensional batches with channels-last strides
-            range_margin: Prompted head output-range margin of the student, recorded in
-                every checkpoint so inference rebuilds the same head
+            range_margin_m: Prompted head output-range margin of the student, in metres,
+                recorded in every checkpoint so inference rebuilds the same head
         """
         self.student = student.to(device)
         self.train_loader = train_loader
@@ -132,7 +132,7 @@ class ZipDepthTrainer:
         self.target_mode = target_mode
         self.pin_batchnorm_eval = pin_batchnorm_eval
         self.channels_last = channels_last
-        self.range_margin = range_margin
+        self.range_margin_m = range_margin_m
 
         # Loss function initialization
         self.criterion: nn.Module = (
@@ -467,7 +467,7 @@ class ZipDepthTrainer:
             'model_state_dict': model_state,
             'optimizer_state_dict': self.optimizer.state_dict(),
             'loss': loss,
-            RANGE_MARGIN_KEY: self.range_margin,
+            RANGE_MARGIN_M_KEY: self.range_margin_m,
         }
 
         if self.scheduler is not None:


### PR DESCRIPTION
Integration branch for the `zdpda-uw-v1` training run. This is the merge of
#215 (`zipdepth/uw-1-range` @ 2b99705) and #216 (`zipdepth/uw-2-lane` @ 566640f)
onto `main`, and carries **no new work of its own** beyond conflict resolution.

It exists so the long fine-tune can run against both features at once while the
two PRs are still in review. It will be rebased once #215 and #216 land, and
closed rather than merged if they land cleanly on their own.

## Conflict resolution

The only conflict was in `packages/zipdepth/zipdepth/apis/train_catalog.py`, in
the validation block at the top of `main()`, where both sides added adjacent
validation. The resolution keeps both, in order: the `range_margin_m`
finite/non-negative and metric-lane checks from #215, then the `cameras`
selection and Rerun-dataloader checks plus the `UltrawidePolicy` construction
from #216. Everything else auto-merged. The second merge (#216 @ 566640f, the
null-payload / orientation-assert / skip-counter fixes) was conflict-free.

Post-merge invariants checked:
- `TrainCatalogConfig` carries both `range_margin_m` and the `cameras` /
  `ultrawide_*` group.
- `ResolvedTrainCatalogConfig` flattens `TrainCatalogConfig`, so
  `resolved_config.json` records both.
- The resume margin guard (`_restore_resume_state`) and the init-time
  `OVERRIDE:` notice are intact.
- The checkpoint records `range_margin_m`, and the trainer still receives it.

## Gate results, and why uw-v1 trains at `range_margin_m = 0.0`

A 600-step real fine-tune from `zdpda-v4` was run as a gate before committing to
the 140k-step run. All numbers below use the same 4 holdout segments,
`--frame-stride 60`, 51 frames, `--cameras both`, evaluated with
`tools/eval_catalog.py`.

| checkpoint | steps | margin | lr | wide AbsRel | wide δ1 | wide MAE | uw whole | uw inside | uw outside | uw δ1 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| `zdpda-v4` (baseline) | — | 0.0 | — | **0.012690** | 0.9942 | 0.0243 m | 0.7707 | 0.1478 | **0.9577** | 0.2528 |
| gate, as originally specified | 600 | 3.9 | 1e-4 | **0.1937** | 0.5970 | 0.3602 m | 0.4810 | 0.2745 | 0.5445 | 0.3692 |
| control, margin 0 | 600 | **0.0** | 1e-4 | **0.015466** | 0.9922 | 0.0292 m | 0.3445 | 0.1431 | **0.4072** | 0.5534 |
| control, margin 3.9 at v4 lr | 600 | 3.9 | 1e-5 | 0.2158 | 0.5448 | 0.4203 m | 0.3343 | 0.2811 | 0.3515 | 0.4532 |

The gate's pass criterion was "ultrawide outside-footprint AbsRel clearly below
v4's, and wide AbsRel not worse than v4 by more than 0.002". At
`range_margin_m = 3.9` the ultrawide half passes and the wide half fails by two
orders of magnitude.

**The cause is the margin, not the ultrawide data and not the learning rate.**
The margin-0 control — same `--cameras both`, same `fast` learning rate, same 600
steps — holds wide at 0.015466 (only +0.0028 over v4) while still delivering most
of the outside-footprint win (0.4072 against v4's 0.9577, δ1 0.5534 against
0.2528), and brings ultrawide inside-footprint AbsRel to 0.1431, just below the
zero-parameter prompt-upsample floor of 0.1540. Margin 3.9 breaks the wide lane
at **both** learning rates tested.

Mechanism: `zdpda-v4`'s weights were trained with the head's sigmoid spanning
`[prompt_min, prompt_max]`. A 3.9 m margin re-spans it to `[0.1, 4.0]` on every
frame, so an unchanged activation now decodes to a different depth — the model's
operating point moves and the mapping has to be relearned (step-1 L1 is 0.857 m).
`docs/ultrawide.md` argues the cost of the wider sigmoid "works out to a few
millimetres" of quantization precision; that reasoning accounts for output
resolution but not for the operating-point shift, and the measurement contradicts
it. Supporting evidence: the affine-aligned diagnostic for the margin-3.9 gate is
0.0740 while its raw metric AbsRel is 0.19–0.28, i.e. structure survives and it is
scale and offset that are wrong.

**uw-v1 therefore trains with `--range-margin-m 0.0`.** Whether a widened output
range helps once the model has had time to relearn the mapping is a separate
question, deferred to a uw-v2 experiment with a clean multi-thousand-step probe.

One measurement caveat, chased down and resolved: the margin-3.9 checkpoint does
not evaluate reproducibly (three runs gave 0.2832, 0.1937, 0.1937), whereas
`zdpda-v4` and the margin-0 control both repeat **bit-identically** across runs.
The harness is deterministic; the instability belongs to the margin-3.9 model.
The table quotes the margin-3.9 gate's best of three, and the conclusion holds at
either value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
