### PR TITLE
dataforge: hf_fetch, pipe-fed AV1 encoder, exact video timestamps, magnetometer, multi-layer register (msd 1/3)

### DIFF
--- a/packages/dataforge/README.md
+++ b/packages/dataforge/README.md
@@ -58,7 +58,7 @@ That registers dataset `wildcap-<corpus>`. `.mov` is skipped with a warning
 | --- | --- | --- |
 | `DATAFORGE_OUTPUT_ROOT` | `packages/dataforge/data/dataforge/rrd` | where rrds and blueprints go; set it for convert **and** register |
 | `DATAFORGE_RAW_ROOT` | `packages/dataforge/data/raw` | where raw corpora are fetched to |
-| `DATAFORGE_FFMPEG` | the env's ffmpeg | an ffmpeg with hardware encoding, used both to re-encode B-frame sources (most phone HEVC) and to encode image sequences. Without `av1_nvenc` the encoder refuses to start rather than falling back to a software encode that looks like a hang |
+| `DATAFORGE_FFMPEG` | the env's ffmpeg | an ffmpeg with hardware encoding, used both to re-encode B-frame sources (most phone HEVC) and to encode image sequences. Without `av1_nvenc` the encoder refuses to start rather than falling back to a software encode that looks like a hang. Check yours with `ffmpeg -hide_banner -encoders \| grep av1_nvenc` |
 
 Paths in `--root`/`--sequence` and the defaults above are relative to
 `packages/dataforge/` (the tasks run there).

--- a/packages/dataforge/README.md
+++ b/packages/dataforge/README.md
@@ -58,7 +58,7 @@ That registers dataset `wildcap-<corpus>`. `.mov` is skipped with a warning
 | --- | --- | --- |
 | `DATAFORGE_OUTPUT_ROOT` | `packages/dataforge/data/dataforge/rrd` | where rrds and blueprints go; set it for convert **and** register |
 | `DATAFORGE_RAW_ROOT` | `packages/dataforge/data/raw` | where raw corpora are fetched to |
-| `DATAFORGE_FFMPEG` | the env's ffmpeg | an ffmpeg with hardware encoding. Sources with B-frames (most phone HEVC) must be re-encoded; the env's ffmpeg does that on the CPU, silently and slowly |
+| `DATAFORGE_FFMPEG` | the env's ffmpeg | an ffmpeg with hardware encoding, used both to re-encode B-frame sources (most phone HEVC) and to encode image sequences. Without `av1_nvenc` the encoder refuses to start rather than falling back to a software encode that looks like a hang |
 
 Paths in `--root`/`--sequence` and the defaults above are relative to
 `packages/dataforge/` (the tasks run there).
@@ -67,10 +67,19 @@ Paths in `--root`/`--sequence` and the defaults above are relative to
 
 **Contracts** (`dataforge/`): `identity.py` (one `SequenceIdentity` derives the
 sequence key, the Rerun recording id, and the rrd filename), `paths.py` (the
-layer-major output tree), `schema.py` (the `exoego:v2` entity paths and the
-single `video_time` timeline, as code), `writing.py` (atomic publication and the
-capture/convert recording properties), `logging_toolkit.py` (the shared rig-node,
-video-stream, and IMU writers), and `transports.py` (`local_verify`).
+layer-major output tree: `base/` and its sibling `gt/`), `schema.py` (the
+`exoego:v2` entity paths and the single `video_time` timeline, as code),
+`writing.py` (atomic publication and the capture/convert recording properties),
+`logging_toolkit.py` (the shared rig-node, video-stream, IMU, and magnetometer
+writers, plus the AV1 encoder), and `transports.py` (`local_verify` and
+`hf_fetch`).
+
+Two of those carry their weight for datasets that do not ship video.
+`encode_frames_to_mp4` pipes PNG or raw frames straight into ffmpeg's stdin, so
+an image-sequence dataset is encoded (AV1, NVENC, no B-frames) without an
+intermediate frame tree on disk; `log_video_stream(..., times_ns=...)` then
+stamps each sample with its real capture time, because the container's own PTS
+is a nominal-rate fiction for such a file.
 
 **Datasets** (`dataforge/datasets/`), one config + one dataset class each:
 
@@ -88,7 +97,10 @@ wildcap derives `wildcap-<corpus>`.
 `convert` writes `<DATAFORGE_OUTPUT_ROOT>/base/<recording_id>.rrd` through a
 temp file that atomically replaces the target, so "exists = done" and a re-run
 never truncates a file the catalog server holds open. Derived layers (slam,
-pose, labels) stack onto the same entities as sibling layers; v1 emits `base`.
+pose, labels) stack onto the same entities as sibling layers. `register` walks
+every layer directory it knows — `base`, which is required, then `gt` — and
+registers each under its own layer name, so a corpus with no ground-truth pass
+registers exactly as before.
 
 ## Blueprints
 

--- a/packages/dataforge/dataforge/apis/register.py
+++ b/packages/dataforge/dataforge/apis/register.py
@@ -1,4 +1,11 @@
-"""``dataforge-register``: register base-layer rrds into a local Rerun catalog."""
+"""``dataforge-register``: register a dataset's rrd layers into a local Rerun catalog.
+
+One catalog dataset holds every layer under ``output_root()``, keyed by the
+directory it sits in: ``base`` is the sensor recording each converter writes and
+is required, and each derived layer (today: ``gt``) stacks onto the same
+entities as a sibling. A layer with no files is simply not registered, so a
+corpus that has not been through a ground-truth pass registers exactly as before.
+"""
 
 from __future__ import annotations
 
@@ -23,21 +30,26 @@ class Config:
 
 
 def main(config: Config) -> None:
-    """Create the dataset if needed and register every base-layer rrd (idempotent)."""
+    """Create the dataset if needed and register every layer's rrds (idempotent)."""
     dataset_config: DataforgeDatasetConfig = config.dataset
     name: str = dataset_config.name
-    layer_root: Path = paths.output_root() / paths.BASE_LAYER
-    rrd_paths: list[Path] = sorted(layer_root.glob(f"{name}__*.rrd"))
-    if not rrd_paths:
-        raise FileNotFoundError(f"no {paths.BASE_LAYER}-layer rrds for {name} under {layer_root}")
+    output_root: Path = paths.output_root()
+    paths_by_layer: dict[str, list[Path]] = {
+        layer: sorted((output_root / layer).glob(f"{name}__*.rrd")) for layer in (paths.BASE_LAYER, paths.GT_LAYER)
+    }
+    if not paths_by_layer[paths.BASE_LAYER]:
+        raise FileNotFoundError(f"no {paths.BASE_LAYER}-layer rrds for {name} under {output_root / paths.BASE_LAYER}")
 
     client: CatalogClient = CatalogClient(config.catalog_url)
     entry: DatasetEntry = client.create_dataset(name, exist_ok=True)
-    entry.register(
-        [path.resolve().as_uri() for path in rrd_paths],
-        layer_name=paths.BASE_LAYER,
-        on_duplicate=OnDuplicateSegmentLayer.SKIP,
-    ).wait()
+    for layer, rrd_paths in paths_by_layer.items():
+        if not rrd_paths:
+            continue  # a derived layer nobody has produced yet
+        entry.register(
+            [path.resolve().as_uri() for path in rrd_paths],
+            layer_name=layer,
+            on_duplicate=OnDuplicateSegmentLayer.SKIP,
+        ).wait()
 
     dataset: DataforgeDataset = dataset_config.setup()
     # Blueprints register once: every register_blueprint call adds a NEW entry to the
@@ -46,13 +58,14 @@ def main(config: Config) -> None:
     # To refresh a blueprint, delete the dataset and re-register. A re-register must
     # also never truncate an .rbl a live catalog server holds open.
     if entry.default_blueprint() is None:
-        blueprint_path: Path = paths.blueprint_path(paths.output_root(), name)
+        blueprint_path: Path = paths.blueprint_path(output_root, name)
         with writing.atomic_write(blueprint_path) as temp_path:
             dataset.default_blueprint().save(name, str(temp_path))
         entry.register_blueprint(blueprint_path.resolve().as_uri(), set_default=True)
     if entry.default_segment_table_blueprint() is None:
-        table_path: Path = paths.blueprint_path(paths.output_root(), name, segment_table=True)
+        table_path: Path = paths.blueprint_path(output_root, name, segment_table=True)
         with writing.atomic_write(table_path) as temp_path:
             dataset.table_blueprint().save(name, str(temp_path))
         entry.register_blueprint(table_path.resolve().as_uri(), segment_table=True)
-    print(f"registered {len(rrd_paths)} {paths.BASE_LAYER}-layer rrds into '{name}' at {config.catalog_url}")
+    counted: str = ", ".join(f"{len(found)} {layer}" for layer, found in paths_by_layer.items() if found)
+    print(f"registered {counted} rrds into '{name}' at {config.catalog_url}")

--- a/packages/dataforge/dataforge/logging_toolkit.py
+++ b/packages/dataforge/dataforge/logging_toolkit.py
@@ -1,17 +1,28 @@
-"""Shared exoego:v2 writers every dataforge converter reuses: rig node, video, IMU.
+"""Shared exoego:v2 writers every dataforge converter reuses, plus the video encoder.
 
-These three taps live together because both datasets need them *identically* and
-each one hides an invariant that is easy to break silently: the rig node's honest
-key set, the ``Mp4Reader`` → ``send_chunks`` pass-through (which must not mint
-fresh row ids), and the IMU node's mandatory static ``rig_T_imu``.
+These taps live together because every dataset needs them *identically* and each
+one hides an invariant that is easy to break silently: the rig node's honest key
+set, the ``Mp4Reader`` → ``send_chunks`` pass-through (which must not mint fresh
+row ids), the IMU/magnetometer nodes' mandatory static ``rig_T_sensor``, and the
+encoder's ban on B-frames.
+
+Datasets that ship image sequences instead of video get here through
+``encode_frames_to_mp4``: frames are piped straight into ffmpeg's stdin, so a
+converter never materializes a decoded frame tree on disk.
 """
 
 from __future__ import annotations
 
 import os
+import shutil
+import subprocess
+import threading
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal, TypeAlias
 
+import av
 import numpy as np
 import pyarrow as pa
 import rerun as rr
@@ -20,8 +31,205 @@ from numpy import ndarray
 
 from dataforge import schema
 
+FrameKind: TypeAlias = Literal["png", "gray8", "rgb24"]
+"""How one element of an encoder frame iterable is laid out."""
+
+RAW_PIXEL_FORMATS: dict[FrameKind, str] = {"gray8": "gray", "rgb24": "rgb24"}
+"""ffmpeg ``-pix_fmt`` name for each rawvideo frame kind."""
+
+VIDEO_SAMPLE_COMPONENT: str = "VideoStream:sample"
+"""Component that marks an ``Mp4Reader`` chunk as carrying samples, not keyframe flags."""
+
 IDENTITY_TRANSFORM: rr.Transform3D = rr.Transform3D(translation=[0.0, 0.0, 0.0], mat3x3=np.eye(3, dtype=np.float32))
 """Explicit identity pose; an argument-less ``Transform3D`` logs no components at all."""
+
+
+@dataclass(frozen=True, slots=True)
+class FrameSource:
+    """How the caller's frame iterable is laid out for ffmpeg's stdin."""
+
+    kind: FrameKind
+    """``"png"`` feeds encoded PNG bytes through ``image2pipe``; the raw kinds feed ``rawvideo`` planes."""
+    width: int | None = None
+    """Frame width in pixels; required for the raw kinds, which carry no header."""
+    height: int | None = None
+    """Frame height in pixels; required for the raw kinds, which carry no header."""
+
+    def __post_init__(self) -> None:
+        if self.kind == "png":
+            return
+        if self.width is None:
+            raise ValueError(f"a {self.kind} source needs an explicit width: rawvideo frames carry no header")
+        if self.height is None:
+            raise ValueError(f"a {self.kind} source needs an explicit height: rawvideo frames carry no header")
+
+    def input_args(self, *, fps: int) -> list[str]:
+        """ffmpeg input-side arguments that describe this layout on ``pipe:0``."""
+        if self.kind == "png":
+            return ["-f", "image2pipe", "-framerate", str(fps), "-c:v", "png", "-i", "pipe:0"]
+        return [
+            "-f",
+            "rawvideo",
+            "-pix_fmt",
+            RAW_PIXEL_FORMATS[self.kind],
+            "-s",
+            f"{self.width}x{self.height}",
+            "-framerate",
+            str(fps),
+            "-i",
+            "pipe:0",
+        ]
+
+
+def resolve_ffmpeg() -> Path:
+    """Locate the ffmpeg to encode with: ``DATAFORGE_FFMPEG`` first, then ``PATH``."""
+    override: str | None = os.environ.get("DATAFORGE_FFMPEG")
+    if override:
+        return Path(override)
+    found: str | None = shutil.which("ffmpeg")
+    if found is None:
+        raise FileNotFoundError("no ffmpeg on PATH; set DATAFORGE_FFMPEG to an NVENC-capable binary")
+    return Path(found)
+
+
+def require_av1_nvenc(ffmpeg: Path) -> None:
+    """Refuse an ffmpeg that cannot encode AV1 on the GPU, before any frame is read.
+
+    Checked up front because the alternative failure is a software AV1 encode
+    that takes hours on a full sequence and looks like a hang.
+
+    Args:
+        ffmpeg: Binary to interrogate with ``-encoders``.
+    """
+    listed: subprocess.CompletedProcess[str] = subprocess.run(
+        [str(ffmpeg), "-hide_banner", "-encoders"], capture_output=True, text=True, check=False
+    )
+    if "av1_nvenc" in listed.stdout:
+        return
+    raise RuntimeError(
+        f"{ffmpeg} lists no av1_nvenc encoder; many conda-forge ffmpeg builds ship without NVENC. "
+        "Point DATAFORGE_FFMPEG at a binary that has it (e.g. the fleet's ~/.pixi/bin/ffmpeg)."
+    )
+
+
+def encode_frames_to_mp4(
+    frames: Iterable[bytes],
+    output: Path,
+    *,
+    source: FrameSource,
+    fps: int,
+    gop: int = 30,
+    cq: int = 32,
+    ffmpeg: Path | None = None,
+) -> int:
+    """Encode an iterable of frames into an AV1 mp4 by piping them through ffmpeg.
+
+    Nothing is written to disk but the mp4: a dataset that ships PNG or raw
+    frames streams straight from its archive into ffmpeg's stdin. Two properties
+    are load-bearing for the Rerun side:
+
+    * **No B-frames** (``-bf 0``). ``rr.VideoStream`` rejects reordered samples,
+      and ``Mp4Reader`` would otherwise have to re-encode the file it was just
+      handed.
+    * **Sample count is verified** against the mp4 after ffmpeg exits, so a
+      short pipe (a truncated archive, a dead encoder) fails here rather than as
+      a silent timestamp/sample misalignment in ``log_video_stream``.
+
+    ffmpeg's stderr is drained by a thread while frames go into its stdin: both
+    pipes are finite, so writing a large frame while stderr sits full deadlocks.
+
+    Args:
+        frames: One encoded PNG (``kind="png"``) or one raw plane per frame.
+        output: mp4 to write; its parent directory must exist.
+        source: Layout of the ``frames`` elements.
+        fps: Nominal frame rate stamped into the container. Real per-sample
+            timestamps are applied later by ``log_video_stream(times_ns=...)``.
+        gop: Keyframe interval in frames.
+        cq: NVENC constant-quality target; lower is bigger and better.
+        ffmpeg: Binary to use; ``None`` resolves via ``resolve_ffmpeg()``.
+
+    Returns:
+        Number of frames fed into the encoder.
+    """
+    binary: Path = resolve_ffmpeg() if ffmpeg is None else ffmpeg
+    require_av1_nvenc(binary)
+    command: list[str] = [
+        str(binary),
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        *source.input_args(fps=fps),
+        "-vf",
+        "pad=ceil(iw/2)*2:ceil(ih/2)*2,format=yuv420p",
+        "-c:v",
+        "av1_nvenc",
+        "-preset",
+        "p4",
+        "-rc",
+        "vbr",
+        "-cq",
+        str(cq),
+        "-bf",
+        "0",
+        "-g",
+        str(gop),
+        "-movflags",
+        "+faststart",
+        str(output),
+    ]
+    complaints: list[bytes] = []
+    fed: int = 0
+    process: subprocess.Popen[bytes] = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    assert process.stdin is not None and process.stderr is not None
+    drain: threading.Thread = threading.Thread(target=lambda: complaints.append(process.stderr.read()), daemon=True)  # pyrefly: ignore
+    drain.start()
+    try:
+        for frame in frames:
+            process.stdin.write(frame)
+            fed += 1
+    except BrokenPipeError:
+        pass  # ffmpeg already died; its stderr below says why
+    finally:
+        process.stdin.close()
+        returncode: int = process.wait()
+        drain.join()
+    if returncode != 0:
+        stderr_text: str = b"".join(complaints).decode(errors="replace").strip()
+        raise RuntimeError(f"ffmpeg exited {returncode} while encoding {output.name} after {fed} frames:\n{stderr_text}")
+
+    written: int = mp4_frame_count(output)
+    if written != fed:
+        raise ValueError(f"{output} holds {written} samples but {fed} frames were fed; the pipe lost data")
+    return fed
+
+
+def mp4_frame_count(path: Path) -> int:
+    """Number of video samples in an mp4, from the container index."""
+    with av.open(str(path)) as container:
+        stream: av.video.stream.VideoStream = container.streams.video[0]
+        if stream.frames:
+            return stream.frames
+        return sum(1 for packet in container.demux(stream) if packet.pts is not None)
+
+
+def encode_image_files_to_mp4(paths: Sequence[Path], output: Path, *, fps: int, gop: int = 30, cq: int = 32, ffmpeg: Path | None = None) -> int:
+    """Encode a PNG sequence already on disk, reading one file at a time.
+
+    Args:
+        paths: PNG files in presentation order.
+        output: mp4 to write.
+        fps: Nominal frame rate; see ``encode_frames_to_mp4``.
+        gop: Keyframe interval in frames.
+        cq: NVENC constant-quality target.
+        ffmpeg: Binary to use; ``None`` resolves via ``resolve_ffmpeg()``.
+
+    Returns:
+        Number of frames fed into the encoder.
+    """
+    return encode_frames_to_mp4(
+        (path.read_bytes() for path in paths), output, source=FrameSource("png"), fps=fps, gop=gop, cq=cq, ffmpeg=ffmpeg
+    )
 
 
 def log_rig_node(
@@ -61,10 +269,17 @@ def log_rig_node(
     )
 
 
-def log_video_stream(recording: rr.RecordingStream, video_path: Path, entity_path: str, *, shift_ns: int = 0) -> int:
+def log_video_stream(
+    recording: rr.RecordingStream,
+    video_path: Path,
+    entity_path: str,
+    *,
+    shift_ns: int = 0,
+    times_ns: Int64[ndarray, "n_samples"] | None = None,
+) -> int:
     """Remux one mp4 as a ``VideoStream``, optionally retimed, and count its samples.
 
-    Four invariants ride along, in the order they bite:
+    Five invariants ride along, in the order they bite:
 
     1. ``Mp4Reader`` emits one **static** codec chunk that carries no index; it
        must pass through untouched (its ``timeline_names`` is empty).
@@ -77,31 +292,67 @@ def log_video_stream(recording: rr.RecordingStream, video_path: Path, entity_pat
     4. Raw sample PTS is wall clock only when ``shift_ns == 0``. A non-zero
        shift means the file's PTS are offsets from a capture epoch, and the
        ``video_time`` column is rewritten to the absolute clock.
+    5. Not every indexed chunk is a sample: after the per-GOP ``VideoStream:sample``
+       chunks the reader emits one trailing ``VideoStream:is_keyframe`` chunk,
+       indexed on the same timeline, with one row per keyframe. Only the sample
+       chunks count toward ``sample_count`` and consume ``times_ns``; the keyframe
+       chunk is retimed by looking its PTS up among the samples already seen.
+
+    ``shift_ns`` and ``times_ns`` answer different questions and cannot be
+    combined: a shift means "the file's own PTS are right, the origin is not",
+    while ``times_ns`` means "the file's PTS are a nominal-rate fiction" — which
+    is the case for any mp4 this package encoded from an image sequence, where
+    the real capture times live in a separate timestamp file.
 
     Args:
         recording: Destination recording stream.
         video_path: mp4 to remux (no decode, no re-encode).
         entity_path: ``.../pinhole/video`` entity to log under.
         shift_ns: Nanoseconds added to every indexed chunk's ``video_time``.
+        times_ns: Exact ``video_time`` per sample, in presentation order; must
+            hold one value per sample in the file.
 
     Returns:
         Number of video samples written.
+
+    Raises:
+        ValueError: If both retiming modes are given, or if ``times_ns`` does not
+            have exactly one value per sample in the mp4.
     """
+    if times_ns is not None and shift_ns != 0:
+        raise ValueError("shift_ns and times_ns are mutually exclusive: a per-sample clock is not an offset from the file's own")
     sample_count: int = 0
+    consumed: int = 0
+    new_time_by_pts: dict[int, int] = {}
+
+    def retimed(record_batch: pa.RecordBatch, index: int, values_ns: Int64[ndarray, "n_rows"]) -> list[rr.experimental.Chunk]:
+        """Same batch, same row ids, new index values (still a ``duration("ns")``)."""
+        column: pa.Array = pa.array(values_ns, type=pa.duration("ns"))
+        return rr.experimental.Chunk.from_record_batch(record_batch.set_column(index, record_batch.schema.field(index), column))  # invariant 3
 
     def tap(chunk: rr.experimental.Chunk) -> list[rr.experimental.Chunk]:
-        nonlocal sample_count
+        nonlocal sample_count, consumed
         if schema.TIMELINE not in chunk.timeline_names:
             return [chunk]  # invariant 1: the static codec chunk carries no index
-        if shift_ns == 0:
-            sample_count += chunk.num_rows
-            return [chunk]
         record_batch: pa.RecordBatch = chunk.to_record_batch()
         index: int = record_batch.schema.get_field_index(schema.TIMELINE)
-        shifted: pa.Array = pa.array(np.asarray(record_batch.column(index).cast(pa.int64())) + shift_ns, type=pa.duration("ns"))
-        sample_count += record_batch.num_rows
-        retimed: pa.RecordBatch = record_batch.set_column(index, record_batch.schema.field(index), shifted)
-        return rr.experimental.Chunk.from_record_batch(retimed)  # invariant 3
+        original_ns: Int64[ndarray, "n_rows"] = np.asarray(record_batch.column(index).cast(pa.int64()))
+        is_sample_chunk: bool = VIDEO_SAMPLE_COMPONENT in record_batch.schema.names  # invariant 5
+        if is_sample_chunk:
+            sample_count += record_batch.num_rows
+        if times_ns is None:
+            return [chunk] if shift_ns == 0 else retimed(record_batch, index, original_ns + shift_ns)
+        if is_sample_chunk:
+            if consumed + record_batch.num_rows > times_ns.size:
+                raise ValueError(f"{video_path.name} has more samples than the {times_ns.size} timestamps given")
+            replacement: Int64[ndarray, "n_rows"] = times_ns[consumed : consumed + record_batch.num_rows]
+            consumed += record_batch.num_rows
+            new_time_by_pts.update(zip(original_ns.tolist(), replacement.tolist(), strict=True))
+            return retimed(record_batch, index, replacement)
+        unseen: list[int] = [pts for pts in original_ns.tolist() if pts not in new_time_by_pts]
+        if unseen:
+            raise ValueError(f"{video_path.name}: keyframe PTS {unseen[:4]} precede their samples; the reader's chunk order changed")
+        return retimed(record_batch, index, np.array([new_time_by_pts[pts] for pts in original_ns.tolist()], dtype=np.int64))
 
     # A B-frame source (iPhone/insta360 HEVC) forces Mp4Reader into an FFmpeg
     # re-encode; everything else passes through untouched, and then these options
@@ -117,6 +368,8 @@ def log_video_stream(recording: rr.RecordingStream, video_path: Path, entity_pat
         transcode=rr.experimental.Mp4TranscodeOptions(try_gpu=True, ffmpeg_override=ffmpeg_override),
     )
     recording.send_chunks(reader.stream().flat_map(tap))  # invariant 2
+    if times_ns is not None and consumed != times_ns.size:
+        raise ValueError(f"{video_path.name} holds {consumed} samples but {times_ns.size} timestamps were given")
     return sample_count
 
 

--- a/packages/dataforge/dataforge/logging_toolkit.py
+++ b/packages/dataforge/dataforge/logging_toolkit.py
@@ -13,6 +13,7 @@ converter never materializes a decoded frame tree on disk.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import shutil
 import subprocess
@@ -107,8 +108,8 @@ def require_av1_nvenc(ffmpeg: Path) -> None:
     if "av1_nvenc" in listed.stdout:
         return
     raise RuntimeError(
-        f"{ffmpeg} lists no av1_nvenc encoder; many conda-forge ffmpeg builds ship without NVENC. "
-        "Point DATAFORGE_FFMPEG at a binary that has it (e.g. the fleet's ~/.pixi/bin/ffmpeg)."
+        f"{ffmpeg} lists no av1_nvenc encoder; point DATAFORGE_FFMPEG at an NVENC-capable ffmpeg "
+        "(for example ~/.pixi/bin/ffmpeg on the fleet)."
     )
 
 
@@ -191,7 +192,10 @@ def encode_frames_to_mp4(
     except BrokenPipeError:
         pass  # ffmpeg already died; its stderr below says why
     finally:
-        process.stdin.close()
+        # Closing flushes, so an encoder that already died would raise here and
+        # mask the RuntimeError below that carries its stderr.
+        with contextlib.suppress(BrokenPipeError):
+            process.stdin.close()
         returncode: int = process.wait()
         drain.join()
     if returncode != 0:
@@ -358,7 +362,7 @@ def log_video_stream(
     # A B-frame source (iPhone/insta360 HEVC) forces Mp4Reader into an FFmpeg
     # re-encode; everything else passes through untouched, and then these options
     # are documented no-ops. try_gpu turns that unavoidable re-encode into NVENC
-    # when the ffmpeg build has it — conda-forge's does not, so DATAFORGE_FFMPEG
+    # when the ffmpeg build has it, which not every build does, so DATAFORGE_FFMPEG
     # points at an NVENC-capable binary (e.g. the fleet's ~/.pixi/bin/ffmpeg).
     ffmpeg_override: str | None = os.environ.get("DATAFORGE_FFMPEG")
     reader: rr.experimental.Mp4Reader = rr.experimental.Mp4Reader(
@@ -462,7 +466,7 @@ def log_magnetometer(
         measured: Bool[ndarray, "n_samples"] = norms > 0.0
         if measured.any():
             headings: Float64[ndarray, "n_headings 3"] = field.values_xyz[measured] / norms[measured, None] * heading_length_m
-            rr.log(node + "/heading", rr.Arrows3D.from_fields(colors=HEADING_COLOR), static=True, recording=recording)
+            rr.log(schema.heading_path(rig, mag), rr.Arrows3D.from_fields(colors=HEADING_COLOR), static=True, recording=recording)
             rr.send_columns(
                 schema.heading_path(rig, mag),
                 indexes=[rr.TimeColumn(schema.TIMELINE, duration=field.times_ns[measured].astype("timedelta64[ns]"))],

--- a/packages/dataforge/dataforge/logging_toolkit.py
+++ b/packages/dataforge/dataforge/logging_toolkit.py
@@ -26,7 +26,7 @@ import av
 import numpy as np
 import pyarrow as pa
 import rerun as rr
-from jaxtyping import Float64, Int64
+from jaxtyping import Bool, Float64, Int64
 from numpy import ndarray
 
 from dataforge import schema
@@ -259,8 +259,9 @@ def log_rig_node(
         name: Optional human device label (``"robocap"``, ``"oak"``, an iPhone name).
         kind: Optional device role (``"exo"`` / ``"ego"`` / ``"quest"``).
     """
-    # AnyValues drops None-valued kwargs, so name/kind simply stay off the node
-    # when a dataset has nothing meaningful to say.
+    # AnyValues omits a None-valued kwarg while its key is still untyped, so name/kind
+    # simply stay off the node when a dataset has nothing meaningful to say. The registry
+    # is process-global: once any recording types the key, later Nones arrive as nulls.
     rr.log(
         schema.rig_path(rig),
         rr.AnyValues(schema_version=schema.EXOEGO_SCHEMA_VERSION, reference=reference, num_cameras=num_cameras, name=name, kind=kind),
@@ -409,3 +410,64 @@ def log_imu(recording: rr.RecordingStream, rig: int, imu: int, *, gyro: ImuChann
         )
     rr.log(schema.imu_path(rig, imu), IDENTITY_TRANSFORM, static=True, recording=recording)
     rr.log(schema.imu_path(rig, imu), rr.AnyValues(name=name, kind="imu"), static=True, recording=recording)
+
+
+HEADING_COLOR: tuple[int, int, int] = (255, 128, 0)
+"""Fixed arrow tint for every magnetometer heading; the field is one quantity, not a per-row class."""
+
+
+def log_magnetometer(
+    recording: rr.RecordingStream,
+    rig: int,
+    mag: int,
+    *,
+    field: ImuChannel,
+    name: str,
+    unit: str | None = None,
+    heading_length_m: float = 0.15,
+) -> None:
+    """Log one magnetometer node: the raw field, a heading arrow, and the node metadata.
+
+    The field is logged in the **sensor's own units** — consumer hardware
+    ships unlabelled counts, and inventing a calibration would be worse than
+    saying so — with the optional ``unit`` AnyValue recording what they are.
+    ``heading`` is a derived convenience: the same samples normalized to a fixed
+    length so the field direction is visible in the 3D view, riding the rig like
+    every other child. Zero-norm rows (a dropout) get no arrow rather than a NaN.
+
+    The static identity ``rig_T_mag`` is **not** optional, for the same reason as
+    the IMU's: a reader resolves the sensor's place in the rig frame without
+    special-casing the writer.
+
+    Args:
+        recording: Destination recording stream.
+        rig: Rig index owning the magnetometer.
+        mag: Magnetometer index within the rig.
+        field: Timestamped 3-axis field samples; an empty channel logs only the
+            static node.
+        name: Human label for the device (e.g. ``"reverb-g2"``).
+        unit: Physical unit of the samples when it is known (e.g. ``"mG"``);
+            ``None`` leaves the key off rather than guessing.
+        heading_length_m: Length of the heading arrows, in metres.
+    """
+    node: str = schema.mag_path(rig, mag)
+    if field.times_ns.size:
+        rr.send_columns(
+            schema.field_path(rig, mag),
+            indexes=[rr.TimeColumn(schema.TIMELINE, duration=field.times_ns.astype("timedelta64[ns]"))],
+            columns=rr.Scalars.columns(scalars=field.values_xyz),
+            recording=recording,
+        )
+        norms: Float64[ndarray, "n_samples"] = np.linalg.norm(field.values_xyz, axis=1)
+        measured: Bool[ndarray, "n_samples"] = norms > 0.0
+        if measured.any():
+            headings: Float64[ndarray, "n_headings 3"] = field.values_xyz[measured] / norms[measured, None] * heading_length_m
+            rr.log(node + "/heading", rr.Arrows3D.from_fields(colors=HEADING_COLOR), static=True, recording=recording)
+            rr.send_columns(
+                schema.heading_path(rig, mag),
+                indexes=[rr.TimeColumn(schema.TIMELINE, duration=field.times_ns[measured].astype("timedelta64[ns]"))],
+                columns=rr.Arrows3D.columns(vectors=headings),
+                recording=recording,
+            )
+    rr.log(node, IDENTITY_TRANSFORM, static=True, recording=recording)
+    rr.log(node, rr.AnyValues(name=name, kind="mag", unit=unit), static=True, recording=recording)

--- a/packages/dataforge/dataforge/paths.py
+++ b/packages/dataforge/dataforge/paths.py
@@ -4,7 +4,7 @@ Layout (relative to the overridable roots; defaults are package-local because
 pixi tasks run with ``cwd = packages/dataforge``):
 
     data/raw/<dataset>/...            upstream layout, untouched
-    data/dataforge/rrd/<layer>/<recording_id>.rrd
+    data/dataforge/rrd/<layer>/<recording_id>.rrd   layer in {base, gt}
     data/dataforge/rrd/blueprints/<name>[-table].rbl
 """
 
@@ -16,7 +16,10 @@ from pathlib import Path
 from dataforge.identity import SequenceIdentity
 
 BASE_LAYER: str = "base"
-"""The only layer dataforge v1 emits; the first path component under ``output_root()``."""
+"""Sensor layer: the recording every dataset emits; the first path component under ``output_root()``."""
+
+GT_LAYER: str = "gt"
+"""Ground-truth trajectory layer; sibling of base (same recording ids, own directory)."""
 
 
 def output_root() -> Path:

--- a/packages/dataforge/dataforge/schema.py
+++ b/packages/dataforge/dataforge/schema.py
@@ -4,7 +4,8 @@ The authoritative prose spec is ``packages/simplecv/docs/exoego_schema.md``:
 one ``video_time`` timestamp timeline everywhere, world-anchored rigs at
 ``/world/rig_NN``, cameras at ``.../cam_MM/pinhole/video``, and IMUs at the
 (previously reserved) ``.../imu_MM/{gyro,accel}``. dataforge is the first
-emitter of the IMU section.
+emitter of the IMU section (§8) and of the magnetometer section (§9), whose
+``.../mag_MM/{field,heading}`` is the same peer-sensor shape.
 """
 
 from __future__ import annotations
@@ -58,6 +59,21 @@ def gyro_path(rig: int, imu: int) -> str:
 def accel_path(rig: int, imu: int) -> str:
     """``.../imu_MM/accel`` — m/s^2 Scalars on ``video_time``."""
     return f"{imu_path(rig, imu)}/accel"
+
+
+def mag_path(rig: int, mag: int) -> str:
+    """``/world/rig_NN/mag_MM`` — carries the static ``rig_T_mag`` transform."""
+    return f"{rig_path(rig)}/mag_{_index(mag, 'mag')}"
+
+
+def field_path(rig: int, mag: int) -> str:
+    """``.../mag_MM/field`` — 3-component Scalars in the sensor's native units."""
+    return f"{mag_path(rig, mag)}/field"
+
+
+def heading_path(rig: int, mag: int) -> str:
+    """``.../mag_MM/heading`` — the field direction as a fixed-length Arrows3D."""
+    return f"{mag_path(rig, mag)}/heading"
 
 
 def run_path(source: str) -> str:

--- a/packages/dataforge/dataforge/transports.py
+++ b/packages/dataforge/dataforge/transports.py
@@ -1,4 +1,4 @@
-"""Download transports. v1 ships ``local_verify``; the fetchers land with HOCap.
+"""Download transports. v1 shipped ``local_verify``; ``hf_fetch`` lands with MSD.
 
 Planned surface (from the design report): ``hf_fetch`` (HuggingFace snapshots),
 ``http_fetch``, ``gdrive_fetch``, ``api_fetch``, and ``local_verify`` for
@@ -7,8 +7,11 @@ datasets that are already on disk (robocap's download verb is verify-only).
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+import os
+from collections.abc import Iterable, Sequence
 from pathlib import Path
+
+from huggingface_hub import snapshot_download
 
 
 def local_verify(root: Path, *, required: Iterable[str]) -> list[str]:
@@ -16,9 +19,49 @@ def local_verify(root: Path, *, required: Iterable[str]) -> list[str]:
     return [pattern for pattern in required if not any(root.glob(pattern))]
 
 
-def hf_fetch() -> None:
-    """HuggingFace snapshot fetch — lands with the HOCap dataset (next PR)."""
-    raise NotImplementedError("hf_fetch lands with the HOCap dataset")
+def hf_fetch(
+    repo_id: str,
+    *,
+    allow_patterns: Sequence[str],
+    local_dir: Path,
+    repo_type: str = "dataset",
+    revision: str | None = None,
+) -> Path:
+    """Fetch a subset of a HuggingFace repo into a plain directory tree.
+
+    ``local_dir`` mode on purpose: files land at ``local_dir/<path-in-repo>``
+    rather than in the symlinked hub cache, so a converter globs the raw tree
+    exactly as it would a locally recorded corpus, and a partial fetch of a
+    multi-hundred-GB dataset costs one copy of what it asked for. The call runs
+    with ``HF_HUB_ENABLE_HF_TRANSFER=1`` unless the caller already set the
+    variable; an explicit ``0`` still wins.
+
+    Caveat on the installed hub: huggingface_hub 1.28 dropped hf-transfer for
+    Xet and reads ``HF_HUB_ENABLE_HF_TRANSFER`` (and its successor
+    ``HF_XET_HIGH_PERFORMANCE``) once, at import. Setting it here is therefore
+    inert for the current process and only reaches subprocesses; the effective
+    place for either knob is the environment dataforge is launched with.
+
+    Args:
+        repo_id: Hub repo, e.g. ``"collabora/monado-slam-datasets"``.
+        allow_patterns: Glob patterns of repo-relative paths to fetch; an empty
+            sequence fetches nothing (``snapshot_download``'s own semantics).
+        local_dir: Destination directory; created by ``snapshot_download``.
+        repo_type: ``"dataset"`` (default), ``"model"``, or ``"space"``.
+        revision: Branch, tag, or commit; ``None`` takes the default branch.
+
+    Returns:
+        ``local_dir``, so callers can chain the fetch into a glob.
+    """
+    os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
+    snapshot_download(
+        repo_id,
+        repo_type=repo_type,
+        allow_patterns=list(allow_patterns),
+        local_dir=str(local_dir),
+        revision=revision,
+    )
+    return local_dir
 
 
 def http_fetch() -> None:

--- a/packages/dataforge/dataforge/transports.py
+++ b/packages/dataforge/dataforge/transports.py
@@ -7,7 +7,6 @@ datasets that are already on disk (robocap's download verb is verify-only).
 
 from __future__ import annotations
 
-import os
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 
@@ -32,15 +31,10 @@ def hf_fetch(
     ``local_dir`` mode on purpose: files land at ``local_dir/<path-in-repo>``
     rather than in the symlinked hub cache, so a converter globs the raw tree
     exactly as it would a locally recorded corpus, and a partial fetch of a
-    multi-hundred-GB dataset costs one copy of what it asked for. The call runs
-    with ``HF_HUB_ENABLE_HF_TRANSFER=1`` unless the caller already set the
-    variable; an explicit ``0`` still wins.
-
-    Caveat on the installed hub: huggingface_hub 1.28 dropped hf-transfer for
-    Xet and reads ``HF_HUB_ENABLE_HF_TRANSFER`` (and its successor
-    ``HF_XET_HIGH_PERFORMANCE``) once, at import. Setting it here is therefore
-    inert for the current process and only reaches subprocesses; the effective
-    place for either knob is the environment dataforge is launched with.
+    multi-hundred-GB dataset costs one copy of what it asked for. Transfer
+    acceleration is not set here but is a launch-environment knob
+    (``HF_XET_HIGH_PERFORMANCE=1``), which the dataforge pixi feature sets in
+    ``[feature.dataforge.activation.env]``.
 
     Args:
         repo_id: Hub repo, e.g. ``"collabora/monado-slam-datasets"``.
@@ -53,7 +47,6 @@ def hf_fetch(
     Returns:
         ``local_dir``, so callers can chain the fetch into a glob.
     """
-    os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
     snapshot_download(
         repo_id,
         repo_type=repo_type,

--- a/packages/dataforge/pyproject.toml
+++ b/packages/dataforge/pyproject.toml
@@ -29,8 +29,21 @@ ignore = [
 
 [tool.vulture]
 paths = ["dataforge", "tests"]
-# Tyro-facing verb entry points and config fields; the CLI shims call them.
-ignore_names = ["main", "rr_config", "sequence", "force", "catalog_url", "dataset", "root", "_target"]
+# Tyro-facing verb entry points and config fields (the CLI shims call them), plus the
+# keyword-only parameters a test fake must accept to match the real catalog API.
+ignore_names = [
+    "main",
+    "rr_config",
+    "sequence",
+    "force",
+    "catalog_url",
+    "dataset",
+    "root",
+    "_target",
+    "on_duplicate",
+    "set_default",
+    "exist_ok",
+]
 exclude = ["*/.pixi/*", "*/__pycache__/*", "*/build/*", "*/dist/*", "*/node_modules/*"]
 sort_by_size = true
 min_confidence = 60

--- a/packages/dataforge/tests/test_encoding.py
+++ b/packages/dataforge/tests/test_encoding.py
@@ -8,6 +8,7 @@ ffmpeg has no ``av1_nvenc``.
 from __future__ import annotations
 
 import os
+import time
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -109,9 +110,11 @@ def test_require_av1_nvenc_rejects_an_encoder_less_ffmpeg(tmp_path: Path) -> Non
     fake: Path = tmp_path / "ffmpeg"
     fake.write_text("#!/bin/sh\necho ' V..... libsvtav1  SVT-AV1 encoder (codec av1)'\n")
     fake.chmod(0o755)
+    # The message must name both the knob and a binary that works, or the reader
+    # is left guessing which ffmpeg to point it at.
     with pytest.raises(RuntimeError, match="DATAFORGE_FFMPEG"):
         require_av1_nvenc(fake)
-    with pytest.raises(RuntimeError, match="conda-forge"):
+    with pytest.raises(RuntimeError, match="av1_nvenc"):
         require_av1_nvenc(fake)
 
 
@@ -197,6 +200,47 @@ def test_a_failing_encode_reports_ffmpeg_stderr(tmp_path: Path, nvenc_ffmpeg: Pa
     with pytest.raises(RuntimeError) as failure:
         encode_frames_to_mp4([b"\x00" * 7], output, source=source, fps=FPS, ffmpeg=nvenc_ffmpeg)
     assert "ffmpeg" in str(failure.value)
+
+
+def test_garbage_frames_report_ffmpeg_stderr(tmp_path: Path, nvenc_ffmpeg: Path) -> None:
+    """ffmpeg rejects the first non-PNG frame and closes the pipe under us.
+
+    Closing our end of a pipe whose reader is gone raises too, so this is the
+    path where a careless ``finally`` would mask ffmpeg's complaint.
+    """
+    # Deliberately small: the frames sit in Python's write buffer, so the dead
+    # reader is only discovered when close() flushes them.
+    output: Path = tmp_path / "garbage.mp4"
+    garbage: list[bytes] = [b"\x89not-a-png"] * 4
+    with pytest.raises(RuntimeError) as failure:
+        encode_frames_to_mp4(garbage, output, source=FrameSource("png"), fps=FPS, ffmpeg=nvenc_ffmpeg)
+    message: str = str(failure.value)
+    assert "ffmpeg exited" in message
+    assert message.strip().splitlines()[1:], f"ffmpeg's own complaint is missing from: {message}"
+
+
+def test_a_reader_that_dies_before_the_pipe_drains_still_reports_stderr(tmp_path: Path) -> None:
+    """An encoder that exits without draining stdin breaks the pipe at close().
+
+    Small payloads sit in Python's write buffer, so the EPIPE surfaces from
+    ``close()`` rather than from ``write()``; an unguarded close would replace
+    the RuntimeError carrying ffmpeg's stderr with a bare BrokenPipeError.
+    """
+    quitter: Path = tmp_path / "ffmpeg"
+    quitter.write_text(
+        '#!/bin/sh\ncase "$*" in *-encoders*) echo " V....D av1_nvenc  NVIDIA NVENC av1 encoder";; *) echo "died early" >&2; exit 3;; esac\n'
+    )
+    quitter.chmod(0o755)
+
+    def slow_frames() -> Iterator[bytes]:
+        """Outlive the child, so the buffered bytes meet a closed pipe at flush."""
+        yield b"tiny"
+        time.sleep(0.5)
+        yield b"tiny"
+
+    output: Path = tmp_path / "dead.mp4"
+    with pytest.raises(RuntimeError, match="died early"):
+        encode_frames_to_mp4(slow_frames(), output, source=FrameSource("png"), fps=FPS, ffmpeg=quitter)
 
 
 def test_env_var_ffmpeg_is_used_when_no_binary_is_passed(tmp_path: Path, monkeypatch, nvenc_ffmpeg: Path) -> None:

--- a/packages/dataforge/tests/test_encoding.py
+++ b/packages/dataforge/tests/test_encoding.py
@@ -1,0 +1,206 @@
+"""Pipe-fed AV1 encoder: ffmpeg discovery, the NVENC gate, and both frame sources.
+
+Every encode here is real (there is no fake encoder worth trusting for "no
+B-frames" and "the sample count survives"), so the tests skip when the resolved
+ffmpeg has no ``av1_nvenc``.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import av
+import cv2
+import numpy as np
+import pytest
+from jaxtyping import UInt8
+from numpy import ndarray
+
+from dataforge.logging_toolkit import (
+    FrameSource,
+    encode_frames_to_mp4,
+    encode_image_files_to_mp4,
+    require_av1_nvenc,
+    resolve_ffmpeg,
+)
+
+NUM_FRAMES: int = 48
+"""Long enough to span two GOPs at the default gop=30, so keyframe cadence is observable."""
+WIDTH: int = 321
+"""Odd on purpose: the encoder pads to even dimensions, and NVENC has a minimum frame size."""
+HEIGHT: int = 193
+FPS: int = 24
+
+
+def gray_frame(index: int) -> UInt8[ndarray, "193 321"]:
+    """A horizontal gradient with a moving square, so no two frames are identical."""
+    frame: UInt8[ndarray, "193 321"] = np.tile(np.linspace(0, 255, WIDTH, dtype=np.uint8), (HEIGHT, 1))
+    left: int = (index * 4) % (WIDTH - 16)
+    frame[8:24, left : left + 16] = np.uint8(255 - (index * 5) % 256)
+    return frame
+
+
+def gray_frames() -> Iterator[UInt8[ndarray, "193 321"]]:
+    """The synthetic clip, frame by frame."""
+    for index in range(NUM_FRAMES):
+        yield gray_frame(index)
+
+
+def png_bytes() -> Iterator[bytes]:
+    """The same clip as encoded PNG bytes, the ``image2pipe`` input form."""
+    for frame in gray_frames():
+        success, buffer = cv2.imencode(".png", frame)
+        assert success
+        yield buffer.tobytes()
+
+
+def raw_gray_bytes() -> Iterator[bytes]:
+    """The same clip as raw ``gray8`` planes, the ``rawvideo`` input form."""
+    for frame in gray_frames():
+        yield frame.tobytes()
+
+
+@pytest.fixture(scope="module")
+def nvenc_ffmpeg() -> Path:
+    """The resolved ffmpeg, or a skip when this machine cannot encode AV1 on the GPU."""
+    ffmpeg: Path = resolve_ffmpeg()
+    try:
+        require_av1_nvenc(ffmpeg)
+    except RuntimeError as error:
+        pytest.skip(f"no av1_nvenc: {error}")
+    return ffmpeg
+
+
+def video_stream_facts(path: Path) -> tuple[str, int, list[int]]:
+    """Canonical codec name, decoded frame count, and every packet pts, in stream order."""
+    pts_values: list[int] = []
+    decoded: int = 0
+    with av.open(str(path)) as container:
+        stream: av.video.stream.VideoStream = container.streams.video[0]
+        # ``.name`` is the *decoder* PyAV picked (``libdav1d``); the canonical name is the codec.
+        codec_name: str = stream.codec_context.codec.canonical_name
+        for packet in container.demux(stream):
+            if packet.pts is not None:
+                pts_values.append(packet.pts)
+            decoded += len(packet.decode())
+    return codec_name, decoded, pts_values
+
+
+# ── ffmpeg discovery and the NVENC gate ───────────────────────────────────
+
+
+def test_resolve_ffmpeg_honors_the_env_var(tmp_path: Path, monkeypatch) -> None:
+    override: Path = tmp_path / "my-ffmpeg"
+    override.write_text("#!/bin/sh\n")
+    monkeypatch.setenv("DATAFORGE_FFMPEG", str(override))
+    assert resolve_ffmpeg() == override
+
+
+def test_resolve_ffmpeg_names_the_env_var_when_nothing_is_found(monkeypatch) -> None:
+    monkeypatch.delenv("DATAFORGE_FFMPEG", raising=False)
+    monkeypatch.setenv("PATH", "")
+    with pytest.raises(FileNotFoundError, match="DATAFORGE_FFMPEG"):
+        resolve_ffmpeg()
+
+
+def test_require_av1_nvenc_rejects_an_encoder_less_ffmpeg(tmp_path: Path) -> None:
+    fake: Path = tmp_path / "ffmpeg"
+    fake.write_text("#!/bin/sh\necho ' V..... libsvtav1  SVT-AV1 encoder (codec av1)'\n")
+    fake.chmod(0o755)
+    with pytest.raises(RuntimeError, match="DATAFORGE_FFMPEG"):
+        require_av1_nvenc(fake)
+    with pytest.raises(RuntimeError, match="conda-forge"):
+        require_av1_nvenc(fake)
+
+
+def test_encode_fails_before_spawning_when_the_encoder_is_missing(tmp_path: Path) -> None:
+    fake: Path = tmp_path / "ffmpeg"
+    fake.write_text("#!/bin/sh\necho ' V..... libsvtav1  SVT-AV1 encoder (codec av1)'\n")
+    fake.chmod(0o755)
+    output: Path = tmp_path / "out.mp4"
+    with pytest.raises(RuntimeError, match="av1_nvenc"):
+        encode_frames_to_mp4(png_bytes(), output, source=FrameSource("png"), fps=FPS, ffmpeg=fake)
+    assert not output.exists()
+
+
+# ── the two frame sources ─────────────────────────────────────────────────
+
+
+def test_png_pipe_encodes_every_frame(tmp_path: Path, nvenc_ffmpeg: Path) -> None:
+    output: Path = tmp_path / "png.mp4"
+    fed: int = encode_frames_to_mp4(png_bytes(), output, source=FrameSource("png"), fps=FPS, ffmpeg=nvenc_ffmpeg)
+    assert fed == NUM_FRAMES
+    codec_name, decoded, pts_values = video_stream_facts(output)
+    assert codec_name == "av1"
+    assert decoded == NUM_FRAMES
+    assert len(pts_values) == NUM_FRAMES
+
+
+def test_gray8_rawvideo_encodes_every_frame(tmp_path: Path, nvenc_ffmpeg: Path) -> None:
+    output: Path = tmp_path / "gray.mp4"
+    source: FrameSource = FrameSource("gray8", width=WIDTH, height=HEIGHT)
+    fed: int = encode_frames_to_mp4(raw_gray_bytes(), output, source=source, fps=FPS, ffmpeg=nvenc_ffmpeg)
+    assert fed == NUM_FRAMES
+    codec_name, decoded, _ = video_stream_facts(output)
+    assert codec_name == "av1"
+    assert decoded == NUM_FRAMES
+
+
+def test_encoded_stream_has_no_reordered_samples(tmp_path: Path, nvenc_ffmpeg: Path) -> None:
+    """rr.VideoStream rejects reordered samples, so ``-bf 0`` is mandatory."""
+    output: Path = tmp_path / "monotonic.mp4"
+    encode_frames_to_mp4(raw_gray_bytes(), output, source=FrameSource("gray8", width=WIDTH, height=HEIGHT), fps=FPS, ffmpeg=nvenc_ffmpeg)
+    _, _, pts_values = video_stream_facts(output)
+    assert len(pts_values) == NUM_FRAMES
+    assert all(later > earlier for earlier, later in zip(pts_values, pts_values[1:], strict=False))
+
+
+def test_gop_sets_the_keyframe_cadence(tmp_path: Path, nvenc_ffmpeg: Path) -> None:
+    output: Path = tmp_path / "gop.mp4"
+    encode_frames_to_mp4(
+        raw_gray_bytes(), output, source=FrameSource("gray8", width=WIDTH, height=HEIGHT), fps=FPS, gop=16, ffmpeg=nvenc_ffmpeg
+    )
+    with av.open(str(output)) as container:
+        keyframes: list[int] = [index for index, packet in enumerate(container.demux(container.streams.video[0])) if packet.is_keyframe]
+    assert keyframes == [0, 16, 32]
+
+
+def test_raw_sources_require_their_dimensions(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="width"):
+        FrameSource("gray8")
+    with pytest.raises(ValueError, match="height"):
+        FrameSource("rgb24", width=WIDTH)
+
+
+def test_encode_image_files_reads_each_png_from_disk(tmp_path: Path, nvenc_ffmpeg: Path) -> None:
+    frame_dir: Path = tmp_path / "frames"
+    frame_dir.mkdir()
+    paths: list[Path] = []
+    for index, blob in enumerate(png_bytes()):
+        frame_path: Path = frame_dir / f"{index:05d}.png"
+        frame_path.write_bytes(blob)
+        paths.append(frame_path)
+    output: Path = tmp_path / "files.mp4"
+    fed: int = encode_image_files_to_mp4(paths, output, fps=FPS, ffmpeg=nvenc_ffmpeg)
+    assert fed == NUM_FRAMES
+    codec_name, decoded, _ = video_stream_facts(output)
+    assert codec_name == "av1"
+    assert decoded == NUM_FRAMES
+
+
+def test_a_failing_encode_reports_ffmpeg_stderr(tmp_path: Path, nvenc_ffmpeg: Path) -> None:
+    """Wrong raw dimensions make ffmpeg exit non-zero; its complaint must survive."""
+    output: Path = tmp_path / "bad.mp4"
+    source: FrameSource = FrameSource("gray8", width=WIDTH, height=HEIGHT)
+    with pytest.raises(RuntimeError) as failure:
+        encode_frames_to_mp4([b"\x00" * 7], output, source=source, fps=FPS, ffmpeg=nvenc_ffmpeg)
+    assert "ffmpeg" in str(failure.value)
+
+
+def test_env_var_ffmpeg_is_used_when_no_binary_is_passed(tmp_path: Path, monkeypatch, nvenc_ffmpeg: Path) -> None:
+    monkeypatch.setenv("DATAFORGE_FFMPEG", str(nvenc_ffmpeg))
+    output: Path = tmp_path / "env.mp4"
+    assert encode_frames_to_mp4(png_bytes(), output, source=FrameSource("png"), fps=FPS) == NUM_FRAMES
+    assert os.environ["DATAFORGE_FFMPEG"] == str(nvenc_ffmpeg)

--- a/packages/dataforge/tests/test_logging_toolkit.py
+++ b/packages/dataforge/tests/test_logging_toolkit.py
@@ -60,10 +60,18 @@ def clip(tmp_path_factory) -> Path:
     return output
 
 
+def read_back(rrd: Path) -> rr.experimental.ChunkStore:
+    """Load a saved rrd the way a consumer does: reader → store → queryable views.
+
+    The stream is materialized because ``from_chunks`` declares ``Sequence[Chunk]``;
+    these recordings are a few dozen rows, so the list costs nothing.
+    """
+    return rr.experimental.ChunkStore.from_chunks(list(rr.experimental.RrdReader(rrd).stream()))
+
+
 def index_column(rrd: Path, index: str = schema.TIMELINE) -> Int64[ndarray, "n_rows"]:
     """Every value of one index in a saved rrd, ascending."""
-    store: rr.experimental.ChunkStore = rr.experimental.ChunkStore.from_chunks(rr.experimental.RrdReader(rrd).stream())
-    table: pa.Table = store.reader(index=index).to_arrow_table().sort_by(index)
+    table: pa.Table = read_back(rrd).reader(index=index).to_arrow_table().sort_by(index)
     return table.column(index).combine_chunks().cast(pa.int64()).to_numpy()
 
 
@@ -152,8 +160,7 @@ def synthetic_field(count: int) -> ImuChannel:
 
 def entity_rows(rrd: Path, entity_path: str, component: str) -> pa.Table:
     """Rows of one component column, index-sorted, from a saved rrd."""
-    store: rr.experimental.ChunkStore = rr.experimental.ChunkStore.from_chunks(rr.experimental.RrdReader(rrd).stream())
-    table: pa.Table = store.reader(index=schema.TIMELINE).to_arrow_table().sort_by(schema.TIMELINE)
+    table: pa.Table = read_back(rrd).reader(index=schema.TIMELINE).to_arrow_table().sort_by(schema.TIMELINE)
     return table.select([schema.TIMELINE, f"{entity_path}:{component}"]).drop_null()
 
 
@@ -182,7 +189,7 @@ def test_magnetometer_node_carries_its_static_pose_and_metadata(tmp_path: Path) 
     with rr.RecordingStream("dataforge", recording_id="mag_static") as recording:
         recording.save(target)
         log_magnetometer(recording, RIG, MAG, field=synthetic_field(8), name="odyssey", unit=None)
-    store: rr.experimental.ChunkStore = rr.experimental.ChunkStore.from_chunks(rr.experimental.RrdReader(target).stream())
+    store: rr.experimental.ChunkStore = read_back(target)
     columns: set[str] = {str(column) for column in store.schema()}
     node: str = schema.mag_path(RIG, MAG)
     assert any(f"Column name: {node}:Transform3D:" in column for column in columns), "rig_T_mag is mandatory, like the IMU's"
@@ -202,7 +209,7 @@ def test_empty_magnetometer_logs_only_the_static_node(tmp_path: Path) -> None:
     with rr.RecordingStream("dataforge", recording_id="mag_empty") as recording:
         recording.save(target)
         log_magnetometer(recording, RIG, MAG, field=empty, name="none")
-    store: rr.experimental.ChunkStore = rr.experimental.ChunkStore.from_chunks(rr.experimental.RrdReader(target).stream())
+    store: rr.experimental.ChunkStore = read_back(target)
     columns: set[str] = {str(column) for column in store.schema()}
     assert any(f"{schema.mag_path(RIG, MAG)}:Transform3D:" in column for column in columns)
     assert not any(schema.field_path(RIG, MAG) in column for column in columns)

--- a/packages/dataforge/tests/test_logging_toolkit.py
+++ b/packages/dataforge/tests/test_logging_toolkit.py
@@ -1,0 +1,129 @@
+"""The shared writers: video remux timing, and the magnetometer node.
+
+Every assertion reads the written rrd back through the public reader
+(``RrdReader`` → ``ChunkStore`` → a datafusion view over one index), so these
+test what a consumer sees rather than what the writer intended.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pyarrow as pa
+import pytest
+import rerun as rr
+from jaxtyping import Float64, Int64, UInt8
+from numpy import ndarray
+
+from dataforge import schema
+from dataforge.logging_toolkit import (
+    FrameSource,
+    encode_frames_to_mp4,
+    log_video_stream,
+    require_av1_nvenc,
+    resolve_ffmpeg,
+)
+
+NUM_FRAMES: int = 24
+WIDTH: int = 321
+HEIGHT: int = 193
+FPS: int = 30
+ENTITY: str = "/world/rig_00/cam_00/pinhole/video"
+
+
+def png_bytes() -> Iterator[bytes]:
+    """A short synthetic clip as PNG bytes; every frame differs."""
+    for index in range(NUM_FRAMES):
+        frame: UInt8[ndarray, "193 321"] = np.tile(np.linspace(0, 255, WIDTH, dtype=np.uint8), (HEIGHT, 1))
+        left: int = (index * 4) % (WIDTH - 16)
+        frame[8:24, left : left + 16] = np.uint8(255 - (index * 7) % 256)
+        success, buffer = cv2.imencode(".png", frame)
+        assert success
+        yield buffer.tobytes()
+
+
+@pytest.fixture(scope="module")
+def clip(tmp_path_factory) -> Path:
+    """One AV1 mp4 of ``NUM_FRAMES`` samples; skipped when the GPU encoder is absent."""
+    ffmpeg: Path = resolve_ffmpeg()
+    try:
+        require_av1_nvenc(ffmpeg)
+    except RuntimeError as error:
+        pytest.skip(f"no av1_nvenc: {error}")
+    output: Path = tmp_path_factory.mktemp("clip") / "clip.mp4"
+    encode_frames_to_mp4(png_bytes(), output, source=FrameSource("png"), fps=FPS, gop=10, ffmpeg=ffmpeg)
+    return output
+
+
+def index_column(rrd: Path, index: str = schema.TIMELINE) -> Int64[ndarray, "n_rows"]:
+    """Every value of one index in a saved rrd, ascending."""
+    store: rr.experimental.ChunkStore = rr.experimental.ChunkStore.from_chunks(rr.experimental.RrdReader(rrd).stream())
+    table: pa.Table = store.reader(index=index).to_arrow_table().sort_by(index)
+    return table.column(index).combine_chunks().cast(pa.int64()).to_numpy()
+
+
+def irregular_times_ns(count: int) -> Int64[ndarray, "n_samples"]:
+    """Ascending 33 ms steps with per-sample jitter — a real device's capture clock."""
+    jitter: Int64[ndarray, "n_samples"] = (np.arange(count, dtype=np.int64) * 7919 % 900_000) - 450_000
+    return 1_700_000_000_000_000_000 + np.arange(count, dtype=np.int64) * 33_000_000 + jitter
+
+
+# ── log_video_stream retiming ─────────────────────────────────────────────
+
+
+def test_sample_count_excludes_the_keyframe_chunk(tmp_path: Path, clip: Path) -> None:
+    """``Mp4Reader`` emits a trailing keyframe chunk that is indexed but is not a sample."""
+    target: Path = tmp_path / "count.rrd"
+    with rr.RecordingStream("dataforge", recording_id="count") as recording:
+        recording.save(target)
+        written: int = log_video_stream(recording, clip, ENTITY)
+    assert written == NUM_FRAMES
+
+
+def test_times_ns_replaces_every_sample_timestamp(tmp_path: Path, clip: Path) -> None:
+    times_ns: Int64[ndarray, "n_samples"] = irregular_times_ns(NUM_FRAMES)
+    target: Path = tmp_path / "retimed.rrd"
+    with rr.RecordingStream("dataforge", recording_id="retimed") as recording:
+        recording.save(target)
+        written: int = log_video_stream(recording, clip, ENTITY, times_ns=times_ns)
+    assert written == NUM_FRAMES
+    assert np.array_equal(index_column(target), times_ns)
+
+
+def test_shift_ns_still_offsets_the_container_pts(tmp_path: Path, clip: Path) -> None:
+    shift_ns: int = 1_700_000_000_000_000_000
+    plain: Path = tmp_path / "plain.rrd"
+    shifted: Path = tmp_path / "shifted.rrd"
+    for target, shift in ((plain, 0), (shifted, shift_ns)):
+        with rr.RecordingStream("dataforge", recording_id=target.stem) as recording:
+            recording.save(target)
+            log_video_stream(recording, clip, ENTITY, shift_ns=shift)
+    assert np.array_equal(index_column(shifted), index_column(plain) + shift_ns)
+
+
+def test_times_ns_and_shift_ns_are_mutually_exclusive(tmp_path: Path, clip: Path) -> None:
+    target: Path = tmp_path / "both.rrd"
+    with rr.RecordingStream("dataforge", recording_id="both") as recording:
+        recording.save(target)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            log_video_stream(recording, clip, ENTITY, shift_ns=5, times_ns=irregular_times_ns(NUM_FRAMES))
+
+
+def test_too_few_timestamps_is_an_error(tmp_path: Path, clip: Path) -> None:
+    target: Path = tmp_path / "short.rrd"
+    with rr.RecordingStream("dataforge", recording_id="short") as recording:
+        recording.save(target)
+        # The tap raises mid-stream; a swallowed exception would show up as the trailing count check instead.
+        with pytest.raises(ValueError, match="more samples than the 21 timestamps"):
+            log_video_stream(recording, clip, ENTITY, times_ns=irregular_times_ns(NUM_FRAMES - 3))
+
+
+def test_too_many_timestamps_is_an_error(tmp_path: Path, clip: Path) -> None:
+    target: Path = tmp_path / "long.rrd"
+    with rr.RecordingStream("dataforge", recording_id="long") as recording:
+        recording.save(target)
+        with pytest.raises(ValueError, match="holds 24 samples but 27 timestamps"):
+            log_video_stream(recording, clip, ENTITY, times_ns=irregular_times_ns(NUM_FRAMES + 3))

--- a/packages/dataforge/tests/test_logging_toolkit.py
+++ b/packages/dataforge/tests/test_logging_toolkit.py
@@ -21,7 +21,9 @@ from numpy import ndarray
 from dataforge import schema
 from dataforge.logging_toolkit import (
     FrameSource,
+    ImuChannel,
     encode_frames_to_mp4,
+    log_magnetometer,
     log_video_stream,
     require_av1_nvenc,
     resolve_ffmpeg,
@@ -127,3 +129,81 @@ def test_too_many_timestamps_is_an_error(tmp_path: Path, clip: Path) -> None:
         recording.save(target)
         with pytest.raises(ValueError, match="holds 24 samples but 27 timestamps"):
             log_video_stream(recording, clip, ENTITY, times_ns=irregular_times_ns(NUM_FRAMES + 3))
+
+
+# ── log_magnetometer ──────────────────────────────────────────────────────
+
+
+RIG: int = 0
+MAG: int = 0
+HEADING_LENGTH_M: float = 0.15
+
+
+def synthetic_field(count: int) -> ImuChannel:
+    """A slowly rotating field of roughly constant magnitude, plus one dead sample."""
+    angle: Float64[ndarray, "n_samples"] = np.linspace(0.0, 2.0 * np.pi, count)
+    values_xyz: Float64[ndarray, "n_samples 3"] = np.stack(
+        [300.0 * np.cos(angle), 300.0 * np.sin(angle), np.full(count, -40.0)], axis=1
+    )
+    values_xyz[3] = 0.0  # a dropout: zero field, whose direction is undefined
+    times_ns: Int64[ndarray, "n_samples"] = 1_700_000_000_000_000_000 + np.arange(count, dtype=np.int64) * 20_000_000
+    return ImuChannel(times_ns=times_ns, values_xyz=values_xyz)
+
+
+def entity_rows(rrd: Path, entity_path: str, component: str) -> pa.Table:
+    """Rows of one component column, index-sorted, from a saved rrd."""
+    store: rr.experimental.ChunkStore = rr.experimental.ChunkStore.from_chunks(rr.experimental.RrdReader(rrd).stream())
+    table: pa.Table = store.reader(index=schema.TIMELINE).to_arrow_table().sort_by(schema.TIMELINE)
+    return table.select([schema.TIMELINE, f"{entity_path}:{component}"]).drop_null()
+
+
+def test_magnetometer_logs_field_and_heading(tmp_path: Path) -> None:
+    field: ImuChannel = synthetic_field(50)
+    target: Path = tmp_path / "mag.rrd"
+    with rr.RecordingStream("dataforge", recording_id="mag") as recording:
+        recording.save(target)
+        log_magnetometer(recording, RIG, MAG, field=field, name="reverb-g2", unit="mG", heading_length_m=HEADING_LENGTH_M)
+
+    scalars: pa.Table = entity_rows(target, schema.field_path(RIG, MAG), "Scalars:scalars")
+    assert scalars.num_rows == field.times_ns.size
+    assert np.array_equal(scalars.column(schema.TIMELINE).combine_chunks().cast(pa.int64()).to_numpy(), field.times_ns)
+
+    arrows: pa.Table = entity_rows(target, schema.heading_path(RIG, MAG), "Arrows3D:vectors")
+    # The zero-field sample has no direction, so it is not given an arrow.
+    assert arrows.num_rows == field.times_ns.size - 1
+    vectors: Float64[ndarray, "n_arrows 3"] = np.asarray(
+        [row[0] for row in arrows.column(f"{schema.heading_path(RIG, MAG)}:Arrows3D:vectors").to_pylist()], dtype=np.float64
+    )
+    assert np.allclose(np.linalg.norm(vectors, axis=1), HEADING_LENGTH_M, atol=1e-5)
+
+
+def test_magnetometer_node_carries_its_static_pose_and_metadata(tmp_path: Path) -> None:
+    target: Path = tmp_path / "mag_static.rrd"
+    with rr.RecordingStream("dataforge", recording_id="mag_static") as recording:
+        recording.save(target)
+        log_magnetometer(recording, RIG, MAG, field=synthetic_field(8), name="odyssey", unit=None)
+    store: rr.experimental.ChunkStore = rr.experimental.ChunkStore.from_chunks(rr.experimental.RrdReader(target).stream())
+    columns: set[str] = {str(column) for column in store.schema()}
+    node: str = schema.mag_path(RIG, MAG)
+    assert any(f"Column name: {node}:Transform3D:" in column for column in columns), "rig_T_mag is mandatory, like the IMU's"
+    assert any(f"Column name: {node}:name" in column for column in columns)
+    assert any(f"Column name: {node}:kind" in column for column in columns)
+    # A None unit carries no value. AnyValues only *omits* the key while it is
+    # untyped: once anything in the process logs a unit string the key becomes
+    # typed and later Nones arrive as nulls, so assert on the value, not the column.
+    table: pa.Table = store.reader(index=schema.TIMELINE).to_arrow_table()
+    unit_column: str = f"{node}:unit"
+    assert unit_column not in table.column_names or table.column(unit_column).null_count == table.num_rows
+
+
+def test_empty_magnetometer_logs_only_the_static_node(tmp_path: Path) -> None:
+    empty: ImuChannel = ImuChannel(times_ns=np.zeros(0, dtype=np.int64), values_xyz=np.zeros((0, 3), dtype=np.float64))
+    target: Path = tmp_path / "mag_empty.rrd"
+    with rr.RecordingStream("dataforge", recording_id="mag_empty") as recording:
+        recording.save(target)
+        log_magnetometer(recording, RIG, MAG, field=empty, name="none")
+    store: rr.experimental.ChunkStore = rr.experimental.ChunkStore.from_chunks(rr.experimental.RrdReader(target).stream())
+    columns: set[str] = {str(column) for column in store.schema()}
+    assert any(f"{schema.mag_path(RIG, MAG)}:Transform3D:" in column for column in columns)
+    assert not any(schema.field_path(RIG, MAG) in column for column in columns)
+    assert not any(schema.heading_path(RIG, MAG) in column for column in columns)

--- a/packages/dataforge/tests/test_paths.py
+++ b/packages/dataforge/tests/test_paths.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
-from dataforge.paths import output_root, raw_root
+from dataforge.identity import SequenceIdentity
+from dataforge.paths import BASE_LAYER, GT_LAYER, output_root, raw_root, rrd_path
 
 
 def test_output_root_defaults_to_package_local_data(monkeypatch) -> None:
@@ -19,3 +20,14 @@ def test_raw_root_defaults_and_overrides(monkeypatch) -> None:
     assert raw_root() == Path("data/raw")
     monkeypatch.setenv("DATAFORGE_RAW_ROOT", "/mnt/nas/datasets")
     assert raw_root() == Path("/mnt/nas/datasets")
+
+
+def test_rrd_paths_are_layer_major() -> None:
+    identity: SequenceIdentity = SequenceIdentity(dataset="msd", parts=("MI_valid_01",))
+    root: Path = Path("/out")
+    assert rrd_path(root, layer=BASE_LAYER, identity=identity) == root / "base" / f"{identity.recording_id}.rrd"
+    assert rrd_path(root, layer=GT_LAYER, identity=identity) == root / "gt" / f"{identity.recording_id}.rrd"
+
+
+def test_base_and_gt_are_sibling_layers() -> None:
+    assert (BASE_LAYER, GT_LAYER) == ("base", "gt")

--- a/packages/dataforge/tests/test_register.py
+++ b/packages/dataforge/tests/test_register.py
@@ -1,0 +1,132 @@
+"""``dataforge-register`` layer fan-out, against a fake catalog client (no server)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, ClassVar
+
+import pytest
+import rerun.blueprint as rrb
+
+from dataforge import paths
+from dataforge.apis import register
+from dataforge.apis.register import Config
+from dataforge.datasets.robocap import RobocapConfig
+
+
+@dataclass
+class FakeRegistration:
+    """Stand-in for the task ``DatasetEntry.register`` returns."""
+
+    def wait(self) -> None:
+        """The real call returns a task the caller must drive to completion."""
+
+
+@dataclass
+class FakeEntry:
+    """Records every registration so a test can assert the per-layer fan-out."""
+
+    registered: dict[str, list[str]] = field(default_factory=dict)
+    blueprints: list[tuple[str, bool]] = field(default_factory=list)
+    opened_as: tuple[str, str] = ("", "")
+    """``(catalog url, dataset name)`` the client was asked for."""
+
+    def register(self, uris: list[str], *, layer_name: str, on_duplicate: Any) -> FakeRegistration:
+        self.registered[layer_name] = list(uris)
+        return FakeRegistration()
+
+    def default_blueprint(self) -> None:
+        return None
+
+    def default_segment_table_blueprint(self) -> None:
+        return None
+
+    def register_blueprint(self, uri: str, *, set_default: bool = False, segment_table: bool = False) -> None:
+        self.blueprints.append((uri, segment_table))
+
+
+@dataclass
+class FakeClient:
+    """``CatalogClient`` replacement that hands out one shared entry."""
+
+    url: str
+    shared: ClassVar[FakeEntry] = FakeEntry()
+    """The entry every instance returns; the fixture replaces it per test."""
+
+    def create_dataset(self, name: str, *, exist_ok: bool = False) -> FakeEntry:
+        FakeClient.shared.opened_as = (self.url, name)
+        return FakeClient.shared
+
+
+@pytest.fixture
+def catalog(tmp_path: Path, monkeypatch) -> FakeEntry:
+    """Point the output root at a tmp tree and swap the catalog types for fakes.
+
+    Both names are patched, not just the client: ``main`` annotates its locals
+    (``client: CatalogClient``, ``entry: DatasetEntry``) and beartype checks
+    every one of those under ``PIXI_DEV_MODE``, so a fake that the annotation
+    does not admit fails before the code under test runs.
+    """
+    monkeypatch.setenv("DATAFORGE_OUTPUT_ROOT", str(tmp_path))
+    entry: FakeEntry = FakeEntry()
+    monkeypatch.setattr(FakeClient, "shared", entry)
+    monkeypatch.setattr(register, "CatalogClient", FakeClient)
+    monkeypatch.setattr(register, "DatasetEntry", FakeEntry)
+    return entry
+
+
+def make_rrds(root: Path, layer: str, names: list[str]) -> list[Path]:
+    """Create empty rrds for one layer, plus a decoy another dataset owns."""
+    layer_root: Path = root / layer
+    layer_root.mkdir(parents=True, exist_ok=True)
+    (layer_root / "selfcap__other.rrd").write_bytes(b"")
+    written: list[Path] = []
+    for name in names:
+        target: Path = layer_root / name
+        target.write_bytes(b"")
+        written.append(target)
+    return written
+
+
+def test_registers_base_and_gt_as_separate_layers(tmp_path: Path, catalog: FakeEntry) -> None:
+    base: list[Path] = make_rrds(tmp_path, paths.BASE_LAYER, ["robocap__a.rrd", "robocap__b.rrd"])
+    gt: list[Path] = make_rrds(tmp_path, paths.GT_LAYER, ["robocap__a.rrd"])
+    register.main(Config(dataset=RobocapConfig()))
+    assert catalog.registered[paths.BASE_LAYER] == [path.resolve().as_uri() for path in base]
+    assert catalog.registered[paths.GT_LAYER] == [path.resolve().as_uri() for path in gt]
+    # The dataset's registry key is its catalog name, and the decoy rrds are another dataset's.
+    assert catalog.opened_as == ("rerun+http://127.0.0.1:51235", "robocap")
+
+
+def test_gt_is_optional(tmp_path: Path, catalog: FakeEntry) -> None:
+    make_rrds(tmp_path, paths.BASE_LAYER, ["robocap__a.rrd"])
+    register.main(Config(dataset=RobocapConfig()))
+    assert paths.GT_LAYER not in catalog.registered
+
+
+def test_base_is_required(tmp_path: Path, catalog: FakeEntry) -> None:
+    make_rrds(tmp_path, paths.GT_LAYER, ["robocap__a.rrd"])
+    with pytest.raises(FileNotFoundError, match=paths.BASE_LAYER):
+        register.main(Config(dataset=RobocapConfig()))
+
+
+def test_blueprints_are_registered_once_each(tmp_path: Path, catalog: FakeEntry) -> None:
+    make_rrds(tmp_path, paths.BASE_LAYER, ["robocap__a.rrd"])
+    register.main(Config(dataset=RobocapConfig()))
+    assert [segment_table for _, segment_table in catalog.blueprints] == [False, True]
+    assert all(Path(paths.blueprint_path(tmp_path, "robocap", segment_table=table)).exists() for table in (False, True))
+
+
+def test_reports_a_count_per_layer(tmp_path: Path, catalog: FakeEntry, capsys) -> None:
+    make_rrds(tmp_path, paths.BASE_LAYER, ["robocap__a.rrd", "robocap__b.rrd"])
+    make_rrds(tmp_path, paths.GT_LAYER, ["robocap__a.rrd"])
+    register.main(Config(dataset=RobocapConfig()))
+    printed: str = capsys.readouterr().out
+    assert f"2 {paths.BASE_LAYER}" in printed
+    assert f"1 {paths.GT_LAYER}" in printed
+
+
+def test_default_blueprint_is_a_blueprint() -> None:
+    """Guards the fake above: the real entry receives a saved rrb.Blueprint."""
+    assert isinstance(RobocapConfig().setup().default_blueprint(), rrb.Blueprint)

--- a/packages/dataforge/tests/test_schema.py
+++ b/packages/dataforge/tests/test_schema.py
@@ -6,8 +6,11 @@ from dataforge.schema import (
     accel_path,
     cam_path,
     capture_property,
+    field_path,
     gyro_path,
+    heading_path,
     imu_path,
+    mag_path,
     pinhole_path,
     rig_path,
     run_path,
@@ -30,6 +33,9 @@ def test_entity_paths_are_zero_padded_exoego_v2() -> None:
     assert imu_path(0, 0) == "/world/rig_00/imu_00"
     assert gyro_path(0, 0) == "/world/rig_00/imu_00/gyro"
     assert accel_path(0, 0) == "/world/rig_00/imu_00/accel"
+    assert mag_path(0, 1) == "/world/rig_00/mag_01"
+    assert field_path(0, 1) == "/world/rig_00/mag_01/field"
+    assert heading_path(0, 1) == "/world/rig_00/mag_01/heading"
 
 
 def test_indices_must_be_nonnegative() -> None:
@@ -46,3 +52,10 @@ def test_run_paths_are_nested_below_the_source() -> None:
     assert run_path("basalt") == "/world/runs/basalt"
     assert trajectory_path("basalt") == "/world/runs/basalt/trajectory"
     assert trail_path("basalt") == "/world/runs/basalt/trail"
+
+
+def test_magnetometer_is_a_peer_sensor_of_the_imu() -> None:
+    """exoego:v2 hangs every sensor off the rig, never off another sensor."""
+    assert mag_path(2, 0).rsplit("/", 1)[0] == rig_path(2)
+    with pytest.raises(ValueError, match="non-negative"):
+        mag_path(0, -1)

--- a/packages/dataforge/tests/test_transports.py
+++ b/packages/dataforge/tests/test_transports.py
@@ -1,7 +1,10 @@
+import os
 from pathlib import Path
+from typing import Any
 
 import pytest
 
+from dataforge import transports
 from dataforge.transports import gdrive_fetch, hf_fetch, http_fetch, local_verify
 
 
@@ -23,6 +26,55 @@ def test_local_verify_missing_root(tmp_path: Path) -> None:
 
 
 def test_unbuilt_transports_raise() -> None:
-    for fetch in (hf_fetch, http_fetch, gdrive_fetch):
+    for fetch in (http_fetch, gdrive_fetch):
         with pytest.raises(NotImplementedError):
             fetch()
+
+
+@pytest.fixture
+def recorded_snapshot(monkeypatch) -> dict[str, Any]:
+    """Replace ``snapshot_download`` with a recorder that touches one file."""
+    recorded: dict[str, Any] = {}
+
+    def fake_snapshot_download(repo_id: str, **kwargs: Any) -> str:
+        recorded["repo_id"] = repo_id
+        recorded.update(kwargs)
+        recorded["hf_transfer"] = os.environ.get("HF_HUB_ENABLE_HF_TRANSFER")
+        local_dir: Path = Path(kwargs["local_dir"])
+        landed: Path = local_dir / "MI_valid_01" / "camera_calibration.json"
+        landed.parent.mkdir(parents=True, exist_ok=True)
+        landed.write_text("{}")
+        return str(local_dir)
+
+    monkeypatch.setattr(transports, "snapshot_download", fake_snapshot_download)
+    return recorded
+
+
+def test_hf_fetch_lands_files_at_local_dir(tmp_path: Path, recorded_snapshot: dict[str, Any]) -> None:
+    returned: Path = hf_fetch("collabora/monado-slam-datasets", allow_patterns=("MI_valid_01/**",), local_dir=tmp_path)
+    assert returned == tmp_path
+    # local_dir mode, not the symlinked cache tree: the file sits at <local_dir>/<path-in-repo>.
+    assert (tmp_path / "MI_valid_01" / "camera_calibration.json").is_file()
+    assert recorded_snapshot["repo_id"] == "collabora/monado-slam-datasets"
+    assert recorded_snapshot["repo_type"] == "dataset"
+    assert recorded_snapshot["allow_patterns"] == ["MI_valid_01/**"]
+    assert recorded_snapshot["local_dir"] == str(tmp_path)
+    assert recorded_snapshot["revision"] is None
+
+
+def test_hf_fetch_enables_hf_transfer_for_the_call(tmp_path: Path, monkeypatch, recorded_snapshot: dict[str, Any]) -> None:
+    monkeypatch.delenv("HF_HUB_ENABLE_HF_TRANSFER", raising=False)
+    hf_fetch("collabora/monado-slam-datasets", allow_patterns=("*.json",), local_dir=tmp_path)
+    assert recorded_snapshot["hf_transfer"] == "1"
+
+
+def test_hf_fetch_keeps_an_explicit_hf_transfer_setting(tmp_path: Path, monkeypatch, recorded_snapshot: dict[str, Any]) -> None:
+    monkeypatch.setenv("HF_HUB_ENABLE_HF_TRANSFER", "0")
+    hf_fetch("collabora/monado-slam-datasets", allow_patterns=("*.json",), local_dir=tmp_path)
+    assert recorded_snapshot["hf_transfer"] == "0"
+
+
+def test_hf_fetch_passes_the_revision_through(tmp_path: Path, recorded_snapshot: dict[str, Any]) -> None:
+    hf_fetch("collabora/monado-slam-datasets", allow_patterns=("*.json",), local_dir=tmp_path, repo_type="model", revision="refs/pr/1")
+    assert recorded_snapshot["repo_type"] == "model"
+    assert recorded_snapshot["revision"] == "refs/pr/1"

--- a/packages/dataforge/tests/test_transports.py
+++ b/packages/dataforge/tests/test_transports.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import Any
 
@@ -39,7 +38,6 @@ def recorded_snapshot(monkeypatch) -> dict[str, Any]:
     def fake_snapshot_download(repo_id: str, **kwargs: Any) -> str:
         recorded["repo_id"] = repo_id
         recorded.update(kwargs)
-        recorded["hf_transfer"] = os.environ.get("HF_HUB_ENABLE_HF_TRANSFER")
         local_dir: Path = Path(kwargs["local_dir"])
         landed: Path = local_dir / "MI_valid_01" / "camera_calibration.json"
         landed.parent.mkdir(parents=True, exist_ok=True)
@@ -60,18 +58,6 @@ def test_hf_fetch_lands_files_at_local_dir(tmp_path: Path, recorded_snapshot: di
     assert recorded_snapshot["allow_patterns"] == ["MI_valid_01/**"]
     assert recorded_snapshot["local_dir"] == str(tmp_path)
     assert recorded_snapshot["revision"] is None
-
-
-def test_hf_fetch_enables_hf_transfer_for_the_call(tmp_path: Path, monkeypatch, recorded_snapshot: dict[str, Any]) -> None:
-    monkeypatch.delenv("HF_HUB_ENABLE_HF_TRANSFER", raising=False)
-    hf_fetch("collabora/monado-slam-datasets", allow_patterns=("*.json",), local_dir=tmp_path)
-    assert recorded_snapshot["hf_transfer"] == "1"
-
-
-def test_hf_fetch_keeps_an_explicit_hf_transfer_setting(tmp_path: Path, monkeypatch, recorded_snapshot: dict[str, Any]) -> None:
-    monkeypatch.setenv("HF_HUB_ENABLE_HF_TRANSFER", "0")
-    hf_fetch("collabora/monado-slam-datasets", allow_patterns=("*.json",), local_dir=tmp_path)
-    assert recorded_snapshot["hf_transfer"] == "0"
 
 
 def test_hf_fetch_passes_the_revision_through(tmp_path: Path, recorded_snapshot: dict[str, Any]) -> None:

--- a/packages/simplecv/docs/exoego_schema.md
+++ b/packages/simplecv/docs/exoego_schema.md
@@ -71,6 +71,7 @@ world_T_cam  = world_T_rig @ rig_T_cam           # composes along the entity tre
     /cam_01                     fixed rig_T_cam offset (multi-camera ego devices)
       /pinhole/video, /pinhole/coco133_uv
     /imu_00                     peer sensor (IMU — see §8; emitted by dataforge)
+    /mag_00                     peer sensor (magnetometer — see §9; emitted by dataforge)
   /gt                           ground-truth annotations (UNCHANGED from v1, see §5)
 ```
 
@@ -138,6 +139,13 @@ When ingesting a recording:
    error.
 4. GT tensors resolve under `/world/gt/...` when `config.load_labels` is true.
 5. Timeline is `video_time` everywhere.
+6. Every non-camera peer sensor (`/world/rig_*/imu_*`, `/world/rig_*/mag_*`) has a
+   static `Transform3D` (`rig_T_imu` / `rig_T_mag`) and a static `kind`
+   (`"imu"` / `"mag"`); a sensor node without its transform is an error, because a
+   reader then cannot place its samples in the rig frame. A magnetometer's `field`
+   is in the sensor's native units, which are only known when it carries a `unit`
+   AnyValue — treat an absent `unit` as uncalibrated counts, never as tesla. The
+   optional `heading` child is derived, so a reader may ignore it entirely.
 
 The read side of these rules is `simplecv/catalog_rig_layout.py`: `parse_rig_layout`
 turns a catalog schema back into typed cameras (video stream, moving rig, rig `kind`,
@@ -199,5 +207,43 @@ actually emits it; simplecv's own exo/ego writer still does not.
   per IMU) are still TODO. RoboCap's IMU and camera clocks differ by a fixed
   14,902,432 ns offset (basalt's `kCameraToImuOffsetNs`); dataforge picks the raw
   **camera** clock for `video_time` and subtracts the offset from IMU timestamps.
+
+## 9. Magnetometer *(emitted — first writer: dataforge / Monado SLAM Datasets)*
+
+The magnetometer is the second peer sensor, and it needed no new vocabulary beyond
+the `"mag"` kind: it is an IMU-shaped stream (timestamps plus xyz) that happens to
+measure a field rather than motion. Headsets carry one next to the IMU — the
+**Monado SLAM Datasets** ship one per sequence for the Reverb G2 and the Odyssey+ —
+and it is the only sensor that observes an absolute heading, so a downstream
+yaw-drift evaluation wants it beside the video and the inertial data.
+
+**Layout** (the §8 shape, one entity down):
+
+```
+/world/rig_NN/mag_MM        Transform3D = rig_T_mag (static) + AnyValues{name, kind="mag", unit?}
+  /field                    Scalars (3-component, sensor's native units) — video_time
+  /heading                  Arrows3D (unit field direction × a fixed length) — video_time, derived
+```
+
+- The magnetometer is a **peer of the cameras and the IMU** (`/world/rig_NN/mag_MM`),
+  with its own mandatory static `rig_T_mag`, exactly as §8 requires of `imu_MM`.
+  `mag_MM` is zero-padded via `entity_id("mag", j)` and peer-indexed independently.
+- `field` is logged **raw, at its native rate, without interpolation, in the sensor's
+  own units**. Consumer headsets ship unlabelled counts, and inventing a calibration
+  would be worse than saying so; the optional `unit` AnyValue records the units when a
+  dataset actually documents them. MSD's Reverb G2 / Odyssey+ files are unlabelled
+  50 Hz xyz whose total field sits around 300 — consistent with milligauss, which is
+  an inference and not a claim the files make, so dataforge writes no `unit` for them.
+- `heading` is a **derived visualization aid**, not data: the same samples normalized
+  and scaled to a fixed length (0.15 m by default) so the field direction is legible
+  in the 3D view while riding the rig's `world_T_rig(t)`. Rows whose field norm is 0
+  (a dropout) get no arrow rather than a NaN direction. A reader that wants the field
+  reads `field`; `heading` may be dropped or regenerated at will.
+- Emitting a magnetometer did not change any existing path, so the schema version
+  stays `exoego:v2`.
+- **Status / TODO:** `SensorKind` in `simplecv/rig.py` now lists `"mag"` beside
+  `"imu"`, but simplecv's own exo/ego writer still emits neither; dataforge
+  (`packages/dataforge/dataforge/logging_toolkit.py`, `log_magnetometer`) is the only
+  writer.
 
 Any change to the layout should increment the schema version and update this doc.

--- a/packages/simplecv/simplecv/rig.py
+++ b/packages/simplecv/simplecv/rig.py
@@ -37,9 +37,10 @@ from simplecv.camera_parameters import Extrinsics, Fisheye62Parameters, Intrinsi
 
 #: Reserved sensor kinds describing image *content* (not projection model — a
 #: fisheye RGB camera is still ``"rgb"``). Only ``rgb``/``grayscale`` cameras are
-#: emitted today; ``depth``/``imu`` are reserved so a future backend slots a new
-#: peer sensor in (e.g. ``/world/rig_00/imu_00``) without a vocabulary change.
-SensorKind = Literal["rgb", "grayscale", "depth", "imu"]
+#: emitted by this package; ``depth``/``imu``/``mag`` name the peer sensors that slot
+#: in beside the cameras (e.g. ``/world/rig_00/imu_00``, ``/world/rig_00/mag_00``)
+#: without a vocabulary change — dataforge writes the latter two.
+SensorKind = Literal["rgb", "grayscale", "depth", "imu", "mag"]
 
 #: Zero-padded width for rig/sensor entity indices (``rig_00``, ``cam_00``,
 #: ``imu_00``). Two digits so ids sort lexicographically for any realistic rig

--- a/pixi.toml
+++ b/pixi.toml
@@ -2755,6 +2755,9 @@ dataforge = { path = "packages/dataforge", editable = true }
 
 [feature.dataforge.activation.env]
 PACKAGE_DIR = "packages/dataforge"
+# huggingface_hub reads its transfer knobs once, at import, so hf_fetch cannot turn
+# this on from inside the call; it has to be in the environment dataforge launches with.
+HF_XET_HIGH_PERFORMANCE = "1"
 
 [feature.dataforge.tasks.dataforge-download]
 cmd = "python tools/apps/download.py"


### PR DESCRIPTION
First of three PRs that bring the Monado SLAM Datasets (`collabora/monado-slam-datasets`) into dataforge. This one is shared infrastructure only; the `msd` dataset lands in 2/3 and its ground-truth layer in 3/3. The Lamaria (Aria VRS) dataset stacks on this branch too.

## What changes

- **`transports.hf_fetch`** is real: `snapshot_download` into a plain `local_dir` tree, keyword-only options, returns the path. Transfer acceleration is a launch-environment knob, so `HF_XET_HIGH_PERFORMANCE=1` is set in the dataforge feature's activation env (huggingface_hub 1.28 ignores the old hf-transfer switch).
- **`logging_toolkit.encode_frames_to_mp4`**: frames (PNG bytes or raw gray8/rgb24 planes) are piped into ffmpeg's stdin and encoded with `av1_nvenc`, no B-frames, fixed GOP. Nothing but the mp4 touches disk, so an image-sequence dataset never needs a frame tree extracted. Fails fast without `av1_nvenc`; verifies the sample count after encoding.
- **`log_video_stream(..., times_ns=...)`**: exact per-sample `video_time` from a timestamp array, for files whose container PTS is a nominal-rate fiction. Mutually exclusive with `shift_ns`, which is unchanged.
- **Fix:** `Mp4Reader` emits a trailing indexed `VideoStream:is_keyframe` chunk after the sample chunks. The old tap counted its rows as samples, so `num_frames` in robocap's capture properties was high by the number of keyframes. Only sample chunks count now.
- **Magnetometer** as a new exoego:v2 peer sensor: `/world/rig_NN/mag_MM/{field,heading}` with the mandatory static `rig_T_mag`; `exoego_schema.md` gains §9 and validation rule 6; `SensorKind` gains `"mag"`.
- **`paths.GT_LAYER`** and **`register`** walking every layer (`base` required, `gt` optional), each under its own layer name.

## Test plan

- `DATAFORGE_FFMPEG=~/.pixi/bin/ffmpeg pixi run -e dataforge-dev --frozen tests`: 86 passed, 0 skipped (encoder and remux tests run real NVENC encodes on the GB10 and read the rrd back through `RrdReader`).
- `lint`, `typecheck`, `deadcode` clean; `pixi lock --check` up to date (lock untouched).
- Reviewed in-session: encoder pipe handling, keyframe-chunk retiming order assertion, register layer loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)