### PR TITLE
slam-rs: the catalog feed, the Vio binding, the Rerun rungs and the replay tool

### DIFF
--- a/packages/simplecv/simplecv/catalog_video_codec.py
+++ b/packages/simplecv/simplecv/catalog_video_codec.py
@@ -1,12 +1,20 @@
-"""The catalog's ``VideoStream:codec`` component, mapped to the codec names the decoders take.
+"""The catalog's ``VideoStream:codec`` component, and the MP4 wrapper its samples are decoded through.
 
 Rerun stores the codec as a big-endian FourCC integer (``rr.VideoCodec``). Both
 video paths in the workspace — simplecv's segment-wide NVDEC decoder and rerun's
-``VideoFrameDecoder`` — accept the same three names.
+``VideoFrameDecoder`` — accept the same three names, and both reach their
+decoder through :func:`wrap_mp4`. This module is deliberately light: a CPU lane
+that wants the muxer must not be made to install torchcodec and torchvision to
+get it, which is why it lives here and not beside the GPU decoder that also
+calls it.
 """
 
+from collections.abc import Buffer, Sequence
+from fractions import Fraction
+from io import BytesIO
 from typing import Literal, TypeAlias
 
+import av
 import rerun as rr
 
 CatalogCodecName: TypeAlias = Literal["av1", "h264", "hevc"]
@@ -25,3 +33,43 @@ def catalog_codec_name(fourcc: int) -> CatalogCodecName:
     if codec not in _CODEC_NAME:
         raise ValueError(f"unsupported catalog video codec {codec.name} ({int(fourcc):#x})")
     return _CODEC_NAME[codec]
+
+
+def wrap_mp4(samples: Sequence[Buffer], keyframes: list[bool], fps: int, codec: CatalogCodecName) -> bytes:
+    """Mux pre-encoded samples into an in-memory MP4 with positional pts (no re-encode).
+
+    ``add_mux_stream`` muxes without instantiating an encoder. The nominal 16x16
+    stream dimensions are irrelevant: decoders read the real dimensions from the
+    bitstream (parameter sets travel in-band).
+
+    Args:
+        samples: Encoded video samples in decode order; the first must be a
+            keyframe. Anything with a buffer — ``bytes``, or a view into the
+            column they were read from — because ``av.Packet`` copies into its
+            own buffer either way, and a ``bytes`` copy on the way in is one
+            full copy of a window's encoded bytes per camera for nothing.
+        keyframes: Keyframe flag per sample.
+        fps: Frame rate for the muxed track and its time base.
+        codec: Codec name of the pre-encoded samples.
+
+    Returns:
+        The complete MP4 file as bytes.
+    """
+    buffer: BytesIO = BytesIO()
+    # Pin the mp4 track timescale to fps: the muxer otherwise picks its own (15360)
+    # without rescaling our positional pts, and the track then claims a ~0.1s
+    # duration. Index-seeking decoders never notice; timestamp readers do.
+    with av.open(buffer, "w", format="mp4", options={"video_track_timescale": str(fps)}) as container:
+        stream = container.add_mux_stream(codec, rate=fps, width=16, height=16)
+        stream.time_base = Fraction(1, fps)
+        for sample_index, (sample, is_keyframe) in enumerate(zip(samples, keyframes, strict=True)):
+            # PyAV's stub says `bytes`; the constructor takes any buffer and
+            # copies into the packet's own (`av.Packet(memoryview)` is documented).
+            packet: av.Packet = av.Packet(sample)  # pyrefly: ignore[bad-argument-type]
+            packet.pts = packet.dts = sample_index
+            packet.duration = 1
+            packet.time_base = stream.time_base
+            packet.stream = stream
+            packet.is_keyframe = is_keyframe
+            container.mux(packet)
+    return buffer.getvalue()

--- a/packages/simplecv/simplecv/rerun_dataloader.py
+++ b/packages/simplecv/simplecv/rerun_dataloader.py
@@ -20,12 +20,9 @@ slower than this segment-wide torchcodec/NVDEC path.
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from fractions import Fraction
-from io import BytesIO
 from time import perf_counter
 from typing import TypeAlias
 
-import av
 import numpy as np
 import pyarrow as pa
 import torch
@@ -36,7 +33,7 @@ from rerun.experimental.dataloader import ColumnDecoder, DecodeRequest, FieldBat
 from torch import Tensor
 from torchcodec.decoders import VideoDecoder
 
-from simplecv.catalog_video_codec import CatalogCodecName, catalog_codec_name
+from simplecv.catalog_video_codec import catalog_codec_name, wrap_mp4
 
 TimedeltaNs: TypeAlias = Shaped[ndarray, " n_samples"]
 """Sample timestamps in timeline order, dtype ``timedelta64[ns]`` (jaxtyping has no timedelta dtype)."""
@@ -93,40 +90,6 @@ def open_segment_decoder(
         num_ffmpeg_threads=0,
     )
     return times, samples, keyframes, decoder
-
-
-def wrap_mp4(samples: list[bytes], keyframes: list[bool], fps: int, codec: CatalogCodecName) -> bytes:
-    """Mux pre-encoded samples into an in-memory MP4 with positional pts (no re-encode).
-
-    ``add_mux_stream`` muxes without instantiating an encoder. The nominal 16x16
-    stream dimensions are irrelevant: decoders read the real dimensions from the
-    bitstream (parameter sets travel in-band).
-
-    Args:
-        samples: Encoded video samples in decode order.
-        keyframes: Keyframe flag per sample.
-        fps: Frame rate for the muxed track and its time base.
-        codec: Codec name of the pre-encoded samples.
-
-    Returns:
-        The complete MP4 file as bytes.
-    """
-    buffer: BytesIO = BytesIO()
-    # Pin the mp4 track timescale to fps: the muxer otherwise picks its own (15360)
-    # without rescaling our positional pts, and the track then claims a ~0.1s
-    # duration. Index-seeking decoders never notice; timestamp readers do.
-    with av.open(buffer, "w", format="mp4", options={"video_track_timescale": str(fps)}) as container:
-        stream = container.add_mux_stream(codec, rate=fps, width=16, height=16)
-        stream.time_base = Fraction(1, fps)
-        for sample_index, (sample, is_keyframe) in enumerate(zip(samples, keyframes, strict=True)):
-            packet: av.Packet = av.Packet(sample)
-            packet.pts = packet.dts = sample_index
-            packet.duration = 1
-            packet.time_base = stream.time_base
-            packet.stream = stream
-            packet.is_keyframe = is_keyframe
-            container.mux(packet)
-    return buffer.getvalue()
 
 
 class SegmentNvdecDecoder(ColumnDecoder[FrameRgbChw]):

--- a/packages/slam-rs/README.md
+++ b/packages/slam-rs/README.md
@@ -11,6 +11,32 @@ estimate against the ground truth and against the basalt C++ reference on the
 same frames. On the smoke segment it is 0.31 cm from the C++ trajectory and
 1.50 cm from ground truth, where the C++ itself is 1.43 cm.
 
+## How data gets in and out
+
+The library reads one thing: a recording in the dataforge rig schema. One base
+`.rrd` per sequence carries the rig calibration, one video stream per camera and
+the IMU stream. Ground truth and results are separate layer files that stack onto
+the same entity paths.
+
+Raw data, whatever its files look like (an EuRoC folder, a ROS bag, a vendor
+SDK), is converted into that recording once, with a dataforge ingester. After
+that every tool reads the same bytes: the viewer, this estimator, the C++
+reference.
+
+- One sequence: `tools/apps/replay.py --stage vio --rrd base.rrd [--gt-rrd gt.rrd]`.
+  The feed serves the files from an in-process server; no catalog server is
+  needed.
+- Many sequences: register the base and layer files on a catalog server and
+  address them by segment id through the reference manifest.
+
+The estimate comes back the same way: a trajectory CSV, and a Rerun recording
+that layers the estimated poses, the landmarks and the window onto the input,
+beside the ground truth and the C++ run.
+
+In code the contract is three calls: `Calibration` is the rig, `Vio.push_imu`
+takes one IMU sample, `Vio.track` takes one synchronized frameset of `uint8`
+images. The feed is the only adapter between the recording and those calls.
+
 ## Core modules
 
 The core is being filled in stage by stage, bottom up. What is in it today:

--- a/packages/slam-rs/README.md
+++ b/packages/slam-rs/README.md
@@ -5,6 +5,12 @@ basalt VIO fork: pure Rust, CPU first, N-camera from the start. Python owns the
 plumbing — catalog feed, decode, evaluation and Rerun logging — and talks to the
 core through a PyO3 extension module.
 
+The whole pipeline runs from Python: `_core.Vio` consumes IMU samples and
+framesets and reports a pose, and `tools/apps/replay.py --stage vio` draws the
+estimate against the ground truth and against the basalt C++ reference on the
+same frames. On the smoke segment it is 0.31 cm from the C++ trajectory and
+1.50 cm from ground truth, where the C++ itself is 1.43 cm.
+
 ## Core modules
 
 The core is being filled in stage by stage, bottom up. What is in it today:
@@ -355,6 +361,84 @@ pixi run -e slam-rs-dev --frozen slam-rs-version    # print the core version
 
 ## Python API
 
+```python
+from pathlib import Path
+
+from slam_rs import _core
+
+calibration = _core.Calibration.from_catalog(feed.cameras, feed.imu)  # the feed's dataclasses
+config = _core.VioConfig.from_json(Path("configs/msdmi_config.json").read_text())  # the file the C++ ran
+config.optical_flow_image_safe_radius = 472.0    # settable per device, though the shipped file carries it
+
+vio = _core.Vio(calibration, config, threads=1)
+vio.push_imu_batch(t_ns, gyro, accel)     # int64[n], float64[n, 3], float64[n, 3], uncalibrated
+result = vio.track(t_ns, [left, right])   # uint8[h, w] per camera
+result.status, result.world_from_rig      # VioStatus, [tx ty tz qx qy qz qw]
+```
+
+One `track` call is basalt's whole pipeline for one frameset — the frontend's
+own preintegration and pose prediction, `processFrame`, then the estimator's
+`measure` — in the calling thread (Offline mode, D17), so every result is final
+and a repeat run over the same input is bit-identical.
+
+`VioStatus` has two states. basalt's estimator initialises inside the same
+`process_frame` that measures, so a measured frameset always has a state and an
+uncovered one never does: `NeedMoreImu` where basalt would block on its IMU
+queue, `Tracking` otherwise. `NeedMoreImu` moves nothing — not the frontend,
+neither IMU buffer, not the estimator — so the frameset is pushed again once its
+samples arrive and tracks as it would have with them all along (D17). A caller
+that drops it instead loses the frame; `replay.py` holds it and retries.
+
+Two accessors carry what a Rerun rung draws, both copies rather than views:
+
+```python
+snapshot = vio.snapshot()       # None until a frameset has measured
+snapshot.window_t_ns            # int64[n], the 15-dof states then the pose blocks
+snapshot.window_poses           # float64[n, 7], [tx ty tz qx qy qz qw]
+snapshot.window_keyframe        # bool[n]: a keyframe, and window_long_term for a long-term one
+snapshot.kf_ids, snapshot.marginalized                   # the keyframes as ids, plus what left
+snapshot.landmark_ids, snapshot.landmark_positions       # int64[p], float64[p, 3] world
+snapshot.landmark_hosts         # int64[p], the hosting keyframe's timestamp
+snapshot.lm_iterations, snapshot.lm_lambda, snapshot.num_observations
+snapshot.lm_error_before, snapshot.lm_error_after
+snapshot.timings_ms             # the six estimator stages, milliseconds
+
+frame = vio.flow_frame()        # the keypoints of the last accepted frameset, or None
+```
+
+`snapshot()` describes the last frameset that **measured**, which
+`snapshot.t_ns` names; on a `NeedMoreImu` frameset it is the previous one.
+
+Images are copied in and the GIL is released around the core call, so a decoder
+thread keeps running. Wrong dtype, rank, shape or memory layout raises
+`ValueError`; IMU samples must be strictly increasing in time.
+
+**Every refusal is an exception, not a panic.** A Rust panic crosses PyO3 as
+`pyo3_runtime.PanicException`, which derives from `BaseException` and so walks
+straight through an `except Exception` handler, and a panic on a rayon worker
+inside the released-GIL region aborts the process outright (decision D32). So
+every value that sizes a buffer, bounds a loop or spawns a thread — the
+calibration included, since it shapes the occupancy grid — is checked in the
+core before it is used. The refusal is a `ValueError`, or the `TypeError`,
+`OverflowError` or `IndexError` PyO3 itself raises for an object of the wrong
+type, an integer outside the parameter's own type, or a camera past the end of
+the rig:
+
+| what | ceiling or rule | why the core cannot just try it |
+|---|---|---|
+| `max_keypoints` | `tracker::MAX_CAPACITY` = 1,048,576 | every per-patch buffer is preallocated from it; `Vec::with_capacity(2**63)` panics with `capacity overflow` |
+| `threads` | `parallel::MAX_THREADS` = 1024 | rayon spawns exactly what it is asked for, so 100,000 workers wedge the machine rather than erroring |
+| `optical_flow_levels` | at most 23 reductions, i.e. `tracker::MAX_LEVELS` = 24 stored levels | it multiplies every buffer, each sized with `levels + 1`; a `Vec` whose bytes do not exist **aborts** instead of unwinding |
+| `optical_flow_detection_min_threshold` | at least 1 | the detector halves the FAST threshold until it drops below this, and zero halves to zero for ever — `keypoints.cpp:162,187` has the same non-terminating loop, so basalt hangs on it too |
+| `optical_flow_detection_max_threshold` | at least `min_threshold` | otherwise the ladder never runs and the detector can never add a keypoint |
+| frameset image size | exactly the calibration's, per camera | the camera model, the detection grid and the occupancy matrix are all the calibrated geometry |
+| the calibrated resolution over `optical_flow_detection_grid_size` | `detect::MAX_CELLS` = 1,048,576 cells per camera | the occupancy counts are one `i32` per cell per camera, so a calibration is a memory request too: a one-pixel grid over a 4,294,967,294-pixel-square frame asked for 2^64 counts and `vec![0; rows * columns]` panicked with `capacity overflow` with no image in sight |
+
+`tests/test_frontend_boundary.py` walks the whole surface against hostile
+integers, objects and arrays and fails on anything that is not one of the four
+exceptions above. That is a walk over the surface, not a proof about every
+object a caller could construct.
+
 The frontend alone is driven the same way, for a run that needs no backend:
 
 ```python
@@ -373,6 +457,13 @@ Any `int64` is a timestamp, negative ones included: the frontend's clock is an
 which read every negative timestamp as "no previous frame" and so restarted
 tracking on each one. Framesets must still arrive strictly in order, and a
 refused frameset leaves the frontend exactly as the last accepted one did.
+
+`Calibration.from_catalog` reads `slam_rs.catalog_feed.CameraCalib` and
+`ImuCalib` attribute by attribute and hands them to `Calibration::from_catalog_parts`,
+so the catalog-to-basalt rules — the rotation-matrix check, the model names, the
+isotropic noise densities — are not written a second time in Python. One of
+basalt's own files is read by `Calibration.from_json` or `VioConfig.from_json`,
+which is what the frontend's constructor then takes.
 
 ## The reference set
 
@@ -436,6 +527,143 @@ on the **absolute** device clock; on the Index smoke segment the two differ by
 10,433,867,587,166 ns, so a trajectory exported on the wrong clock associates with
 nothing at all. The feed works in `video_time` throughout and
 `trajectory.shift_clock` converts once, at the CSV boundary.
+
+## The feed, the metrics and the replay tool
+
+`slam_rs.catalog_feed` turns one segment into calibration and grayscale
+framesets, reading a catalog URL or local `.rrd` files served in process (no
+catalog server needed); its module docstring states the decisions that silently
+change the numbers — the pinned `gray8` dav1d path, the one-query windows whose
+edges land on frames that are keyframes in every camera, the rig shape and the
+two clocks. `slam_rs.trajectory` reads and writes basalt's CSV form (w-first,
+integer nanoseconds) and reports the rigid-aligned ATE the gate is written
+against, in `golden_compare.py`'s own arithmetic rather than the shared
+`simplecv` helper, whose variance floor would reject a stationary rig that the
+fork passes.
+
+```bash
+pixi run -e slam-rs-dev --frozen python tools/apps/replay.py \
+    --rr-config.headless --rr-config.save data/replay-smoke.rrd
+```
+
+Both `--rr-config.headless` and `--rr-config.save` are honoured; in a shell
+without `DISPLAY`, pass `--rr-config.headless` or the spawned viewer wedges the
+recording stream.
+
+### `--stage frontend`, and the C++ overlay
+
+`--stage input` (the default) logs what the estimator is fed. `--stage frontend`
+runs the optical flow over the same framesets and logs what it produced, under
+the dataset's own entity tree so nothing needs a second coordinate convention:
+
+| entity | what |
+|---|---|
+| `/world/rig_00/cam_MM/pinhole/image` | the frame the frontend tracked, **full resolution** (JPEG), because the keypoints are in its pixels |
+| `.../keypoints` | `Points2D`, 2 px, one stable colour per track id from a hash of the id |
+| `.../trails` | `LineStrips2D`, the last ten positions of every live track, in the track's own colour |
+| `.../cells` | `Boxes2D` over the occupied cells of basalt's centred detection grid |
+| `.../keypoints_cpp` | what the C++ fork's `dump_flow.cpp` produced for the same frameset, in one contrasting magenta |
+| `/stats/frontend/...` | `num_tracks` and `num_new` per camera, and `frontend_ms` |
+
+The overlay is the parity claim made visible, and it is only ever drawn on the
+recording it came from: the eight committed dumps under
+`crates/slam-rs/tests/fixtures/flow/dumps/` name their segment in
+`dumps/source.json`, and `slam_rs.frontend_log`'s module docstring says why a
+`video_time` timestamp is not an association and what a directory from another
+recording, another rig or no `source.json` gets instead. On the smoke segment the
+port hands out 175 keypoint ids over the first eight framesets where the C++
+hands out 174, and every magenta ring in the viewer carries a coloured port dot
+at its centre bar a handful — the detector gap the flow gate measures.
+
+A blueprint is sent with the recording: one 2D view per camera plus the counters,
+panels collapsed. The whole 412-frameset smoke segment is 34.5 MiB of `.rrd` and
+takes 17.5 s, of which 29.5 ms per frameset is the frontend itself.
+
+```bash
+pixi run -e slam-rs-dev --frozen python tools/apps/replay.py \
+    --stage frontend --rr-config.headless --rr-config.save data/replay-frontend.rrd
+```
+
+### `--stage vio`, and the three trajectories
+
+`--stage vio` runs the whole pipeline and draws what the estimator decided, under
+the same tree:
+
+| entity | what |
+|---|---|
+| `/world/runs/slam_rs/trajectory` | the estimate so far, one green `LineStrips3D` |
+| `/world/runs/gt/trajectory` | the ground truth up to the cursor, near-white |
+| `/world/runs/basalt_cpp/trajectory` | the C++ reference up to the cursor, orange |
+| `/world/runs/slam_rs/rig` (+ `/cam_MM`) | the estimated rig's current pose, as `Pinhole` frusta from the calibration |
+| `/world/runs/slam_rs/window` | one frustum wireframe per window frame, blue for a keyframe, yellow for a long-term one, grey for a pose block |
+| `/world/runs/slam_rs/marginalized` | the frames the last marginalization removed, the same wireframes faded |
+| `/world/runs/slam_rs/landmarks` | `Points3D` in the world frame, coloured by the keyframe that hosts them |
+| `/world/rig_00/cam_MM/pinhole/keypoints` | the estimator's own frontend output, in the frontend rung's palette |
+| `/stats/vio/...` | landmark, observation and keyframe counts, LM iterations, lambda and the error before and after, the six `stage_ms/*`, `track_ms`, and `ate_cm/{gt,cpp}` |
+
+The three trajectories do not start in one frame — basalt initialises its world
+at the identity with gravity along z, the ground truth is in the capture rig's
+own frame — so the run and the C++ reference carry the rigid alignment onto the
+ground truth as a `Transform3D`, refreshed every 30 framesets, and a run visibly
+settles into place over its first second. All three are drawn only up to the
+cursor and thinned to the frameset cadence: 1.04 MB each over the 412-frameset
+smoke segment, against the 17.20 MB of that recording's 54.13 MB that re-logging
+the 917 Hz ground truth whole cost, and about 100 MB each over a 4,000-frameset
+clip, so a long segment still wants `--max-framesets`. `slam_rs.vio_log`'s module
+docstring carries the reasoning, the visible time range that makes a per-frameset
+segment render as a path, and why the window is wireframes and the rig is not.
+
+```bash
+pixi run -e slam-rs-dev --frozen python tools/apps/replay.py \
+    --stage vio --rr-config.headless --rr-config.save data/replay-vio.rrd
+```
+
+## The V2 gate
+
+`tests/test_v2_gate.py` is the milestone (D14, D35, D36, D58). Per gated clip,
+driving `_core.Vio` and the feed directly with nothing logged: every frameset
+resolved, a refusal for want of IMU held and tracked again once the samples
+arrive (D17); at most 2 cm of ATE RMSE against the basalt C++ trajectory fed the
+same decoded pixels, and only where the C++ meets that against itself, which is
+clips under `PATH_BOUND_MAX_CLIP_S` = 100 seconds of replayed footage — on the
+410-second `MIO14` its own two precisions are 4.24 cm apart; against the `gt.csv`
+sidecar, inside **the C++'s own precision band** (`rmse_cm` and `rmse_cm_f64`,
+the same code on the same pixels with `use-double` flipped) or within
+`GT_BAND_RATIO` = 1.2 of the band's worst member, whichever is looser, which is
+the second alone since the ratio is above one — the band is 0.00007 cm wide on
+`MIO10` and 2.3 cm wide on `MIO14`, so "inside the band" on its own would gate
+the tight clips on rounding; and speed, the replay's own feed loop (decode plus
+`track`, nothing logged, the loop the C++ recorded as `run.feed_wall_time_s`)
+within 1.2x the C++ single-thread wall for the same footage (D58), never left
+off. The clauses, the association convention, the `no_divergence` pair's
+exception and the "every named clip is asserted" rule (C56) are stated once in
+the test's own module docstring.
+
+The tolerances live in `slam_rs/reference.py` (`ATE_VS_CPP_CM`,
+`PATH_BOUND_MAX_CLIP_S`, `GT_BAND_RATIO`, `SPEED_TOLERANCE`,
+`DIVERGENCE_FACTOR`), not in the test: they are the milestone's verdict, and S15
+measured what a meaningful band is (D60). Every row prints what it was judged on:
+`tracked, vs C++ <cm> (bound 2 cm | no bound, <n> s clip), vs GT <cm> (band [f32,
+f64], allowed <cm>), wall, C++ wall, ratio`.
+
+The lanes are D59's iteration rule. The default is the **iteration set** — MIO10
+whole plus the first ten seconds of one two-camera and one four-camera clip,
+about 1,650 framesets — because finding out at the end of a ten-clip run that
+everything failed is the way not to iterate. Either lane runs **shortest clip
+first** and asserts each clip as soon as it is measured, so the first clip that
+misses stops the run with its own row printed and is the one that gets fixed.
+
+```bash
+cd packages/slam-rs
+pytest -m slow -q -s tests/test_v2_gate.py                    # the iteration set
+SLAM_RS_V2_ALL=1 pytest -m slow -q -s tests/test_v2_gate.py   # all ten, whole, shortest first
+SLAM_RS_V2_WINDOW_S=5 SLAM_RS_V2_ALL=1 pytest -m slow -q -s tests/test_v2_gate.py   # all ten, first 5 s each
+```
+
+`SLAM_RS_V2_WINDOW_S` cuts every clip to its first N seconds and recomputes the
+C++'s own ground-truth error over exactly that span, so a windowed run is gated
+against the budget it actually had.
+
 
 ## Tests
 

--- a/packages/slam-rs/crates/slam-rs-py/src/lib.rs
+++ b/packages/slam-rs/crates/slam-rs-py/src/lib.rs
@@ -11,8 +11,9 @@ use numpy::{
 };
 use pyo3::exceptions::{PyIndexError, PyValueError};
 use pyo3::prelude::*;
-use slam_rs::FrontendLane;
-use slam_rs::calib::Calibration as CoreCalibration;
+use slam_rs::calib::{
+    Calibration as CoreCalibration, CameraParts as CoreCameraParts, ImuParts as CoreImuParts,
+};
 use slam_rs::config::VioConfig as CoreVioConfig;
 use slam_rs::frontend::detect::CellGrid;
 use slam_rs::frontend::flow::{
@@ -20,10 +21,621 @@ use slam_rs::frontend::flow::{
     PosePrediction,
 };
 use slam_rs::image::ImageU16;
+use slam_rs::{FrontendLane, ImageView, VioError};
 
 /// Map any core error onto `ValueError`, which is what every refusal here is.
 fn value_error<E: std::fmt::Display>(error: E) -> PyErr {
     PyValueError::new_err(error.to_string())
+}
+
+/// How far the estimator has got.
+#[pyclass(module = "slam_rs._core", eq, eq_int, skip_from_py_object)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum VioStatus {
+    /// The frame arrived before the IMU samples that cover it.
+    NeedMoreImu,
+    /// The returned pose is an estimate.
+    Tracking,
+}
+
+impl From<slam_rs::VioStatus> for VioStatus {
+    fn from(status: slam_rs::VioStatus) -> Self {
+        match status {
+            slam_rs::VioStatus::NeedMoreImu => Self::NeedMoreImu,
+            slam_rs::VioStatus::Tracking => Self::Tracking,
+        }
+    }
+}
+
+/// What one `track` call produced.
+#[pyclass(module = "slam_rs._core", frozen, skip_from_py_object)]
+#[derive(Debug, Clone, Copy)]
+pub struct VioResult {
+    inner: slam_rs::VioResult,
+}
+
+#[pymethods]
+impl VioResult {
+    /// Estimator state for this frame.
+    #[getter]
+    fn status(&self) -> VioStatus {
+        self.inner.status.into()
+    }
+
+    /// Timestamp of the frameset, in nanoseconds.
+    #[getter]
+    fn t_ns(&self) -> i64 {
+        self.inner.t_ns
+    }
+
+    /// Rig pose in the world frame as `[tx, ty, tz, qx, qy, qz, qw]`.
+    #[getter]
+    fn world_from_rig<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        self.inner.world_from_rig.as_slice().to_pyarray(py)
+    }
+
+    /// Rig velocity in the world frame, m/s.
+    #[getter]
+    fn velocity<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        self.inner.velocity.as_slice().to_pyarray(py)
+    }
+
+    /// Gyroscope bias estimate, rad/s.
+    #[getter]
+    fn gyro_bias<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        self.inner.gyro_bias.as_slice().to_pyarray(py)
+    }
+
+    /// Accelerometer bias estimate, m/s².
+    #[getter]
+    fn accel_bias<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        self.inner.accel_bias.as_slice().to_pyarray(py)
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "VioResult(status=VioStatus.{:?}, t_ns={})",
+            self.inner.status, self.inner.t_ns
+        )
+    }
+}
+
+/// The estimator, driven one frameset at a time (D16, D17).
+///
+/// Offline mode: the frontend and the backend run to completion in the calling
+/// thread, so every `track` result is final and a repeat run over the same input
+/// is bit-identical. The GIL is released around the whole call, so a decoder
+/// thread keeps running while the frameset is tracked.
+#[pyclass(module = "slam_rs._core")]
+pub struct Vio {
+    inner: slam_rs::Vio<f32>,
+}
+
+#[pymethods]
+impl Vio {
+    /// Build the pipeline from basalt's own calibration and config.
+    ///
+    /// The two objects are the ones [`OpticalFlow`] takes: basalt's files arrive
+    /// through [`Calibration::from_json`] and [`VioConfig::from_json`], and the
+    /// catalog's own dataclasses through [`Calibration::from_catalog`]. The
+    /// estimator runs in single precision, which is the precision every
+    /// reference run was produced at (`use-double` false).
+    #[new]
+    #[pyo3(signature = (calibration, config, *, threads = 1, max_keypoints = None))]
+    fn new(
+        calibration: PyRef<'_, Calibration>,
+        config: PyRef<'_, VioConfig>,
+        threads: usize,
+        max_keypoints: Option<usize>,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            inner: slam_rs::Vio::new(
+                config.inner.clone(),
+                calibration.inner.clone(),
+                frontend_options(threads, max_keypoints),
+            )
+            .map_err(value_error)?,
+        })
+    }
+
+    /// Cameras this estimator expects in every frameset.
+    ///
+    /// Read off the frontend rather than mirrored, so it cannot drift from the
+    /// calibration the rig was built with.
+    #[getter]
+    fn camera_count(&self) -> usize {
+        self.inner.frontend().camera_count()
+    }
+
+    /// Add one IMU sample: `gyro` in rad/s, `accel` in m/s², both in the rig
+    /// frame and uncalibrated — the static bias calibration is applied inside.
+    fn push_imu(&mut self, t_ns: i64, gyro: [f64; 3], accel: [f64; 3]) -> PyResult<()> {
+        self.inner.push_imu(t_ns, gyro, accel).map_err(value_error)
+    }
+
+    /// Add `n` IMU samples at once: `t_ns` is `int64[n]`, `gyro` and `accel` are `float64[n, 3]`.
+    ///
+    /// All or nothing: a batch the core would refuse anywhere is refused whole,
+    /// so the estimator is left where it was and the batch can be corrected and
+    /// pushed again.
+    fn push_imu_batch(
+        &mut self,
+        py: Python<'_>,
+        t_ns: &Bound<'_, PyAny>,
+        gyro: &Bound<'_, PyAny>,
+        accel: &Bound<'_, PyAny>,
+    ) -> PyResult<()> {
+        let times: Vec<i64> = int64_column(t_ns, "t_ns")?;
+        let gyro_rows: Vec<[f64; 3]> = float64_triples(gyro, "gyro")?;
+        let accel_rows: Vec<[f64; 3]> = float64_triples(accel, "accel")?;
+        if times.len() != gyro_rows.len() || times.len() != accel_rows.len() {
+            return Err(PyValueError::new_err(format!(
+                "t_ns, gyro and accel must have the same length, got {}, {} and {}",
+                times.len(),
+                gyro_rows.len(),
+                accel_rows.len()
+            )));
+        }
+        py.detach(|| {
+            // All or nothing. Pushing as it goes leaves the samples before a bad
+            // one in the estimator and the frontier past them, so the caller can
+            // neither retry the batch nor correct it: `[10, 20, 20, 30]` raised
+            // at the duplicate and then refused 10 and 20 as too old. The whole
+            // batch is decided first, each sample against the one before it and
+            // the frontier.
+            let mut previous_t_ns: Option<i64> = self.inner.last_imu_t_ns();
+            for ((&t, gyro_sample), accel_sample) in
+                times.iter().zip(gyro_rows.iter()).zip(accel_rows.iter())
+            {
+                slam_rs::check_imu_sample(t, gyro_sample, accel_sample, previous_t_ns)?;
+                previous_t_ns = Some(t);
+            }
+            for ((&t, &gyro_sample), &accel_sample) in
+                times.iter().zip(gyro_rows.iter()).zip(accel_rows.iter())
+            {
+                self.inner.push_imu(t, gyro_sample, accel_sample)?;
+            }
+            Ok::<(), VioError>(())
+        })
+        .map_err(value_error)
+    }
+
+    /// Process one frameset: `images` holds one `uint8[h, w]` array per camera.
+    ///
+    /// The pixels are copied out of numpy while the GIL is held — one copy — and
+    /// the whole pipeline then runs without it. A frameset the core refuses
+    /// leaves the estimator exactly as the last accepted one did.
+    ///
+    /// On a GPU lane a device that dies mid-run is a `ValueError` here as well:
+    /// CubeCL panics on a lost device rather than returning an error, and every
+    /// GPU stage runs inside a guard that turns that into the core's typed error
+    /// before it can unwind through the released GIL (decision D32).
+    fn track(
+        &mut self,
+        py: Python<'_>,
+        t_ns: i64,
+        images: Vec<Bound<'_, PyAny>>,
+    ) -> PyResult<VioResult> {
+        let mut frames: Vec<GrayImage> = Vec::with_capacity(images.len());
+        for (index, image) in images.iter().enumerate() {
+            frames.push(gray_image(image, index)?);
+        }
+        let result: slam_rs::VioResult = py
+            .detach(|| {
+                let views: Vec<ImageView<'_>> = frames
+                    .iter()
+                    .map(|frame| ImageView {
+                        width: frame.width,
+                        height: frame.height,
+                        stride: frame.width,
+                        data: &frame.pixels,
+                    })
+                    .collect();
+                self.inner.track(t_ns, &views)
+            })
+            .map_err(value_error)?;
+        Ok(VioResult { inner: result })
+    }
+
+    /// The keypoints the frontend tracked on the last accepted frameset.
+    ///
+    /// `None` before the first one. The estimator drives its own frontend, so
+    /// this is where a Rerun rung reads the keypoints it draws over the images;
+    /// they are copied out on every call, as [`OpticalFlow::process`] copies them
+    /// out of the same buffers.
+    fn flow_frame(&self) -> PyResult<Option<FlowFrame>> {
+        let Some(t_ns) = self.inner.frontend().t_ns() else {
+            return Ok(None);
+        };
+        flow_frame(self.inner.frontend(), t_ns)
+            .map(Some)
+            .map_err(PyErr::from)
+    }
+
+    /// The window, its landmarks and the last measured frame's statistics.
+    ///
+    /// `None` until a frameset has been measured: before that the window is
+    /// empty and there are no statistics to report. Everything is copied, so a
+    /// snapshot stays valid across the next `track`.
+    fn snapshot(&self) -> PyResult<Option<VioSnapshot>> {
+        let Some(stats) = self.inner.last_stats() else {
+            return Ok(None);
+        };
+        VioSnapshot::build(
+            &self.inner.estimator().snapshot(),
+            stats,
+            self.inner.frontend_timings(),
+        )
+        .map(Some)
+    }
+
+    fn __repr__(&self) -> String {
+        format!("Vio(camera_count={})", self.camera_count())
+    }
+}
+
+/// The estimator's window and last frame, copied out for the Rerun rung (D51).
+///
+/// Everything is a flat array or a scalar: the core logs nothing itself (D03),
+/// so this is what the Python layer draws from. The window is the 15-dof states
+/// followed by the pose-only blocks, each oldest first; `keyframe`/`long_term`
+/// say what each frame is, and `kf_ids` is the keyframes as an id list, which is
+/// what a count wants.
+#[pyclass(module = "slam_rs._core", frozen, skip_from_py_object)]
+#[derive(Debug)]
+pub struct VioSnapshot {
+    t_ns: i64,
+    window_t_ns: Vec<i64>,
+    /// `[tx, ty, tz, qx, qy, qz, qw]` per window frame.
+    window_poses: Vec<f64>,
+    window_keyframe: Vec<bool>,
+    window_long_term: Vec<bool>,
+    kf_ids: Vec<i64>,
+    marginalized: Vec<i64>,
+    landmark_ids: Vec<i64>,
+    landmark_hosts: Vec<i64>,
+    /// `[x, y, z]` per landmark, world frame.
+    landmark_positions: Vec<f64>,
+    lm_iterations: usize,
+    lm_lambda: f64,
+    lm_error_before: f64,
+    lm_error_after: f64,
+    num_observations: usize,
+    timings: slam_rs::estimator::StageTimings,
+    frontend_timings: slam_rs::FrontendTimings,
+}
+
+impl VioSnapshot {
+    /// Flatten one window snapshot and the frame that produced it.
+    ///
+    /// # Errors
+    ///
+    /// `ValueError` when a landmark id has outgrown the `int64` the boundary
+    /// hands to numpy, which is the same refusal `OpticalFlow` makes for the
+    /// keypoint ids the landmarks inherit.
+    fn build(
+        window: &slam_rs::estimator::WindowSnapshot<f32>,
+        stats: &slam_rs::estimator::FrameStats<f32>,
+        frontend_timings: slam_rs::FrontendTimings,
+    ) -> PyResult<Self> {
+        let frames: usize = window.states.len() + window.poses.len();
+        let mut window_t_ns: Vec<i64> = Vec::with_capacity(frames);
+        let mut window_poses: Vec<f64> = Vec::with_capacity(7 * frames);
+        let mut window_keyframe: Vec<bool> = Vec::with_capacity(frames);
+        let mut window_long_term: Vec<bool> = Vec::with_capacity(frames);
+        for state in window.states.iter().chain(window.poses.iter()) {
+            let quaternion: [f32; 4] = state.t_w_i.rotation.quaternion_xyzw();
+            window_t_ns.push(state.t_ns);
+            window_poses.extend_from_slice(&[
+                f64::from(state.t_w_i.translation.x),
+                f64::from(state.t_w_i.translation.y),
+                f64::from(state.t_w_i.translation.z),
+                f64::from(quaternion[0]),
+                f64::from(quaternion[1]),
+                f64::from(quaternion[2]),
+                f64::from(quaternion[3]),
+            ]);
+            window_keyframe.push(state.keyframe);
+            window_long_term.push(state.long_term_keyframe);
+        }
+        let mut landmark_ids: Vec<i64> = Vec::with_capacity(window.landmarks.len());
+        let mut landmark_hosts: Vec<i64> = Vec::with_capacity(window.landmarks.len());
+        let mut landmark_positions: Vec<f64> = Vec::with_capacity(3 * window.landmarks.len());
+        for landmark in &window.landmarks {
+            landmark_ids.push(i64::try_from(landmark.id.0).map_err(|_| {
+                PyValueError::new_err(format!(
+                    "landmark id {} does not fit in an int64",
+                    landmark.id.0
+                ))
+            })?);
+            landmark_hosts.push(landmark.host.frame_id);
+            landmark_positions.extend_from_slice(&[
+                f64::from(landmark.position_w.x),
+                f64::from(landmark.position_w.y),
+                f64::from(landmark.position_w.z),
+            ]);
+        }
+        Ok(Self {
+            t_ns: window.t_ns,
+            window_t_ns,
+            window_poses,
+            window_keyframe,
+            window_long_term,
+            kf_ids: stats.kf_ids.clone(),
+            marginalized: window.marginalized.clone(),
+            landmark_ids,
+            landmark_hosts,
+            landmark_positions,
+            lm_iterations: stats.lm.len(),
+            // The trail is empty for the first four framesets, where `opt_started`
+            // is still false and no linearization ran at all.
+            lm_lambda: stats.lm.last().map_or(0.0, |step| f64::from(step.lambda)),
+            lm_error_before: stats
+                .lm
+                .first()
+                .map_or(0.0, |step| f64::from(step.error_before)),
+            lm_error_after: stats
+                .lm
+                .last()
+                .map_or(0.0, |step| f64::from(step.error_after)),
+            num_observations: stats.num_observations,
+            timings: stats.timings,
+            frontend_timings,
+        })
+    }
+}
+
+#[pymethods]
+impl VioSnapshot {
+    /// Frameset timestamp of the newest state in the window.
+    #[getter]
+    fn t_ns(&self) -> i64 {
+        self.t_ns
+    }
+
+    /// Timestamps of the window's frames: `int64[n]`.
+    #[getter]
+    fn window_t_ns<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<i64>> {
+        self.window_t_ns.to_pyarray(py)
+    }
+
+    /// Rig poses of the window's frames, `[tx, ty, tz, qx, qy, qz, qw]`: `float64[n, 7]`.
+    #[getter]
+    fn window_poses<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        self.window_poses
+            .to_pyarray(py)
+            .reshape((self.window_t_ns.len(), 7))
+    }
+
+    /// Whether each window frame is a keyframe: `bool[n]`.
+    ///
+    /// The estimator answers this per frame, so nothing downstream has to join
+    /// [`VioSnapshot::kf_ids`] back onto [`VioSnapshot::window_t_ns`].
+    #[getter]
+    fn window_keyframe<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<bool>> {
+        self.window_keyframe.to_pyarray(py)
+    }
+
+    /// Whether each window frame is a long-term keyframe: `bool[n]`.
+    #[getter]
+    fn window_long_term<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<bool>> {
+        self.window_long_term.to_pyarray(py)
+    }
+
+    /// The keyframes' timestamps, oldest first: `int64[k]`.
+    #[getter]
+    fn kf_ids<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<i64>> {
+        self.kf_ids.to_pyarray(py)
+    }
+
+    /// Frames the last marginalization removed from the window: `int64[m]`.
+    #[getter]
+    fn marginalized<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<i64>> {
+        self.marginalized.to_pyarray(py)
+    }
+
+    /// Landmark ids, which are the ids of the keypoints that spawned them: `int64[p]`.
+    #[getter]
+    fn landmark_ids<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<i64>> {
+        self.landmark_ids.to_pyarray(py)
+    }
+
+    /// Timestamp of the keyframe hosting each landmark: `int64[p]`.
+    #[getter]
+    fn landmark_hosts<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<i64>> {
+        self.landmark_hosts.to_pyarray(py)
+    }
+
+    /// Landmark positions in the world frame, metres: `float64[p, 3]`.
+    #[getter]
+    fn landmark_positions<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        self.landmark_positions
+            .to_pyarray(py)
+            .reshape((self.landmark_ids.len(), 3))
+    }
+
+    /// Levenberg-Marquardt steps the last frame took, accepted and rejected alike.
+    #[getter]
+    fn lm_iterations(&self) -> usize {
+        self.lm_iterations
+    }
+
+    /// Damping the last step solved with; zero when no step ran.
+    #[getter]
+    fn lm_lambda(&self) -> f64 {
+        self.lm_lambda
+    }
+
+    /// Total cost before the first step; zero when no step ran.
+    #[getter]
+    fn lm_error_before(&self) -> f64 {
+        self.lm_error_before
+    }
+
+    /// Total cost after the last step; zero when no step ran.
+    #[getter]
+    fn lm_error_after(&self) -> f64 {
+        self.lm_error_after
+    }
+
+    /// Landmark observations the window holds after the last frame.
+    #[getter]
+    fn num_observations(&self) -> usize {
+        self.num_observations
+    }
+
+    /// Wall time each stage took on the last frame, milliseconds.
+    ///
+    /// The estimator's six, and the frontend lane's four under a
+    /// `frontend_` prefix: the pyramid build, the FAST detection, every KLT
+    /// call, and the preintegration that seeds the KLT. The four are the same
+    /// kind of measurement as the six and are read the same way, which is why
+    /// they come back in one map; they do not add up to the frame, because the
+    /// bookkeeping between the phases is nobody's stage.
+    #[getter]
+    fn timings_ms(&self) -> std::collections::BTreeMap<&'static str, f64> {
+        [
+            ("back_substitution", self.timings.back_substitution_ns),
+            ("error", self.timings.error_ns),
+            ("linearize", self.timings.linearize_ns),
+            ("marginalize", self.timings.marginalize_ns),
+            ("measure", self.timings.measure_ns),
+            ("solver", self.timings.solver_ns),
+            ("frontend_pyramid", self.frontend_timings.pyramid_ns),
+            ("frontend_detect", self.frontend_timings.detect_ns),
+            ("frontend_track", self.frontend_timings.track_ns),
+            ("frontend_imu", self.frontend_timings.imu_ns),
+        ]
+        .into_iter()
+        .map(|(name, ns)| (name, ns as f64 / 1e6))
+        .collect()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "VioSnapshot(t_ns={}, window={}, keyframes={}, landmarks={})",
+            self.t_ns,
+            self.window_t_ns.len(),
+            self.kf_ids.len(),
+            self.landmark_ids.len()
+        )
+    }
+}
+
+/// The frontend options both entry points build, from the two knobs they expose.
+///
+/// Everything else in `FrontendOptions` is a property of the port rather than of
+/// a run, so `None` means the default rather than "unset". `threads` is read by
+/// `CpuPatchTracker::new` alone, so it does nothing on the GPU lane.
+fn frontend_options(threads: usize, max_keypoints: Option<usize>) -> FrontendOptions {
+    let defaults: FrontendOptions = FrontendOptions::default();
+    FrontendOptions {
+        threads,
+        max_keypoints: max_keypoints.unwrap_or(defaults.max_keypoints),
+        ..defaults
+    }
+}
+
+/// One grayscale frame copied out of Python, packed (stride == width).
+struct GrayImage {
+    width: usize,
+    height: usize,
+    pixels: Vec<u8>,
+}
+
+/// The C-contiguous elements of an array borrowed out of Python.
+///
+/// Both halves of one check, so the refusal has one wording. `as_slice` alone
+/// accepts Fortran order, whose bytes run down the columns and would transpose
+/// every row-major read here, so the C flag is asked explicitly; `as_slice`'s
+/// own refusal — which the flag has already ruled out — lands on the same
+/// sentence rather than a second copy of it. `what` names the array in the
+/// message and `hint` is what the caller should wrap.
+fn contiguous<'a, T, D>(
+    readonly: &'a numpy::PyReadonlyArray<'_, T, D>,
+    what: &str,
+    hint: &str,
+) -> PyResult<&'a [T]>
+where
+    T: numpy::Element,
+    D: numpy::ndarray::Dimension,
+{
+    let refused = || {
+        PyValueError::new_err(format!(
+            "{what} must be C-contiguous; pass numpy.ascontiguousarray({hint})"
+        ))
+    };
+    if !readonly.is_c_contiguous() {
+        return Err(refused());
+    }
+    readonly.as_slice().map_err(|_| refused())
+}
+
+/// Borrow one `uint8[h, w]` array out of Python: rank and dtype checked.
+///
+/// The two consumers differ only in what they do with the bytes — [`Vio::track`]
+/// copies them into a `Vec`, [`OpticalFlow::process`] widens them straight into a
+/// reused [`ImageU16`] — so the checks live here and neither repeats them. The
+/// layout is [`gray_pixels`]' half of the same pair.
+fn gray_array<'py>(
+    object: &Bound<'py, PyAny>,
+    index: usize,
+) -> PyResult<PyReadonlyArray2<'py, u8>> {
+    let array: &Bound<'py, PyArray2<u8>> = object.cast::<PyArray2<u8>>().map_err(|_| {
+        PyValueError::new_err(format!("image {index} must be a 2-D uint8 numpy array"))
+    })?;
+    Ok(array.readonly())
+}
+
+/// The pixels, width and height of an array [`gray_array`] has accepted.
+fn gray_pixels<'a>(
+    readonly: &'a PyReadonlyArray2<'_, u8>,
+    index: usize,
+) -> PyResult<(&'a [u8], usize, usize)> {
+    let shape: &[usize] = readonly.shape();
+    let pixels: &[u8] = contiguous(readonly, &format!("image {index}"), "image")?;
+    Ok((pixels, shape[1], shape[0]))
+}
+
+/// Copy one C-contiguous `uint8[h, w]` array out of Python.
+fn gray_image(object: &Bound<'_, PyAny>, index: usize) -> PyResult<GrayImage> {
+    let readonly: PyReadonlyArray2<'_, u8> = gray_array(object, index)?;
+    let (pixels, width, height) = gray_pixels(&readonly, index)?;
+    Ok(GrayImage {
+        width,
+        height,
+        pixels: pixels.to_vec(),
+    })
+}
+
+/// Copy a C-contiguous `int64[n]` array out of Python.
+fn int64_column(object: &Bound<'_, PyAny>, name: &str) -> PyResult<Vec<i64>> {
+    let array: &Bound<'_, PyArray1<i64>> = object
+        .cast::<PyArray1<i64>>()
+        .map_err(|_| PyValueError::new_err(format!("{name} must be a 1-D int64 numpy array")))?;
+    let readonly = array.readonly();
+    Ok(contiguous(&readonly, name, name)?.to_vec())
+}
+
+/// Copy a C-contiguous `float64[n, 3]` array out of Python, row by row.
+fn float64_triples(object: &Bound<'_, PyAny>, name: &str) -> PyResult<Vec<[f64; 3]>> {
+    let array: &Bound<'_, PyArray2<f64>> = object
+        .cast::<PyArray2<f64>>()
+        .map_err(|_| PyValueError::new_err(format!("{name} must be a 2-D float64 numpy array")))?;
+    let shape: &[usize] = array.shape();
+    if shape[1] != 3 {
+        return Err(PyValueError::new_err(format!(
+            "{name} must have shape (n, 3), got {shape:?}"
+        )));
+    }
+    // Fortran order passes as_slice() but its bytes run down the columns, which
+    // would turn the chunks below into transposed samples.
+    let readonly = array.readonly();
+    let values: &[f64] = contiguous(&readonly, name, name)?;
+    Ok(values
+        .chunks_exact(3)
+        .map(|row| [row[0], row[1], row[2]])
+        .collect())
 }
 
 /// basalt's `VioConfig`, as `data/**/*_config.json` carries it.
@@ -88,6 +700,13 @@ impl VioConfig {
 }
 
 /// basalt's camera-IMU calibration: extrinsics, intrinsics and the noise model.
+///
+/// Either read from one of basalt's calibration files, or built from what the
+/// catalog feed reports. The second path takes
+/// `slam_rs.catalog_feed.CameraCalib` and `ImuCalib` field by field, so the
+/// catalog-to-basalt rules — the rotation-matrix check, the model names, the
+/// isotropic noise densities — stay in the Rust that is tested against basalt's
+/// own JSON rather than being written a second time in Python.
 #[pyclass(module = "slam_rs._core", skip_from_py_object)]
 #[derive(Debug, Clone)]
 pub struct Calibration {
@@ -101,6 +720,23 @@ impl Calibration {
     fn from_json(text: &str) -> PyResult<Self> {
         Ok(Self {
             inner: CoreCalibration::<f64>::from_json_str(text).map_err(value_error)?,
+        })
+    }
+
+    /// Build the calibration from the feed's dataclasses.
+    ///
+    /// `cameras` are `CameraCalib` in rig order and `imu` is an `ImuCalib`; only
+    /// the fields basalt models are read, so `ImuCalib.imu_T_body` is ignored —
+    /// the rig reference frame *is* the IMU on every recording the feed reads.
+    #[staticmethod]
+    fn from_catalog(cameras: Vec<Bound<'_, PyAny>>, imu: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let mut parts: Vec<CoreCameraParts<f64>> = Vec::with_capacity(cameras.len());
+        for (index, camera) in cameras.iter().enumerate() {
+            parts.push(camera_parts(camera, index)?);
+        }
+        Ok(Self {
+            inner: CoreCalibration::from_catalog_parts(&parts, &imu_parts(imu)?)
+                .map_err(value_error)?,
         })
     }
 
@@ -128,74 +764,6 @@ impl Calibration {
     fn __repr__(&self) -> String {
         format!("Calibration(camera_count={})", self.inner.camera_count())
     }
-}
-
-/// The frontend options both entry points build, from the two knobs they expose.
-///
-/// Everything else in `FrontendOptions` is a property of the port rather than of
-/// a run, so `None` means the default rather than "unset". `threads` is read by
-/// `CpuPatchTracker::new` alone, so it does nothing on the GPU lane.
-fn frontend_options(threads: usize, max_keypoints: Option<usize>) -> FrontendOptions {
-    let defaults: FrontendOptions = FrontendOptions::default();
-    FrontendOptions {
-        threads,
-        max_keypoints: max_keypoints.unwrap_or(defaults.max_keypoints),
-        ..defaults
-    }
-}
-
-/// The C-contiguous elements of an array borrowed out of Python.
-///
-/// Both halves of one check, so the refusal has one wording. `as_slice` alone
-/// accepts Fortran order, whose bytes run down the columns and would transpose
-/// every row-major read here, so the C flag is asked explicitly; `as_slice`'s
-/// own refusal — which the flag has already ruled out — lands on the same
-/// sentence rather than a second copy of it. `what` names the array in the
-/// message and `hint` is what the caller should wrap.
-fn contiguous<'a, T, D>(
-    readonly: &'a numpy::PyReadonlyArray<'_, T, D>,
-    what: &str,
-    hint: &str,
-) -> PyResult<&'a [T]>
-where
-    T: numpy::Element,
-    D: numpy::ndarray::Dimension,
-{
-    let refused = || {
-        PyValueError::new_err(format!(
-            "{what} must be C-contiguous; pass numpy.ascontiguousarray({hint})"
-        ))
-    };
-    if !readonly.is_c_contiguous() {
-        return Err(refused());
-    }
-    readonly.as_slice().map_err(|_| refused())
-}
-
-/// Borrow one `uint8[h, w]` array out of Python: rank and dtype checked.
-///
-/// The two consumers differ only in what they do with the bytes — [`Vio::track`]
-/// copies them into a `Vec`, [`OpticalFlow::process`] widens them straight into a
-/// reused [`ImageU16`] — so the checks live here and neither repeats them. The
-/// layout is [`gray_pixels`]' half of the same pair.
-fn gray_array<'py>(
-    object: &Bound<'py, PyAny>,
-    index: usize,
-) -> PyResult<PyReadonlyArray2<'py, u8>> {
-    let array: &Bound<'py, PyArray2<u8>> = object.cast::<PyArray2<u8>>().map_err(|_| {
-        PyValueError::new_err(format!("image {index} must be a 2-D uint8 numpy array"))
-    })?;
-    Ok(array.readonly())
-}
-
-/// The pixels, width and height of an array [`gray_array`] has accepted.
-fn gray_pixels<'a>(
-    readonly: &'a PyReadonlyArray2<'_, u8>,
-    index: usize,
-) -> PyResult<(&'a [u8], usize, usize)> {
-    let shape: &[usize] = readonly.shape();
-    let pixels: &[u8] = contiguous(readonly, &format!("image {index}"), "image")?;
-    Ok((pixels, shape[1], shape[0]))
 }
 
 /// One camera's keypoints for one frameset, copied out of the frontend.
@@ -516,13 +1084,95 @@ fn flow_frame(flow: &FrontendLane, t_ns: i64) -> Result<FlowFrame, ProcessError>
     })
 }
 
+/// One `slam_rs.catalog_feed.CameraCalib`, read attribute by attribute.
+fn camera_parts(object: &Bound<'_, PyAny>, index: usize) -> PyResult<CoreCameraParts<f64>> {
+    let what: String = format!("camera {index}");
+    let rows: Vec<Vec<f64>> = extract_attribute(object, "imu_T_cam", &what, "a 4x4 float matrix")?;
+    if rows.len() != 4 || rows.iter().any(|row| row.len() != 4) {
+        return Err(wrong_type(&what, "imu_T_cam", "a 4x4 float matrix"));
+    }
+    let mut imu_t_cam_row_major: [f64; 16] = [0.0; 16];
+    for (row, values) in rows.iter().enumerate() {
+        imu_t_cam_row_major[4 * row..4 * row + 4].copy_from_slice(values);
+    }
+    Ok(CoreCameraParts {
+        width: extract_attribute(object, "width", &what, "a non-negative integer")?,
+        height: extract_attribute(object, "height", &what, "a non-negative integer")?,
+        fx: extract_attribute(object, "fx", &what, "a float")?,
+        fy: extract_attribute(object, "fy", &what, "a float")?,
+        cx: extract_attribute(object, "cx", &what, "a float")?,
+        cy: extract_attribute(object, "cy", &what, "a float")?,
+        model: extract_attribute(object, "model", &what, "a string")?,
+        distortion: extract_attribute(object, "distortion", &what, "a float sequence")?,
+        distortion_valid_radius: extract_attribute(
+            object,
+            "distortion_valid_radius",
+            &what,
+            "a float or None",
+        )?,
+        imu_t_cam_row_major,
+    })
+}
+
+/// One `slam_rs.catalog_feed.ImuCalib`, read attribute by attribute.
+///
+/// `imu_T_body` is not read: basalt's calibration has no such field, because the
+/// rig reference frame *is* the IMU on every recording the feed reads.
+fn imu_parts(object: &Bound<'_, PyAny>) -> PyResult<CoreImuParts<f64>> {
+    let what: &str = "imu";
+    Ok(CoreImuParts {
+        frequency_hz: extract_attribute(object, "frequency_hz", what, "a float")?,
+        gyro_noise_std: extract_attribute(object, "gyro_noise_std", what, "a float")?,
+        accel_noise_std: extract_attribute(object, "accel_noise_std", what, "a float")?,
+        gyro_bias_std: extract_attribute(object, "gyro_bias_std", what, "a float")?,
+        accel_bias_std: extract_attribute(object, "accel_bias_std", what, "a float")?,
+        cam_time_offset_ns: extract_attribute(object, "cam_time_offset_ns", what, "an integer")?,
+    })
+}
+
+/// One attribute of a calibration dataclass, named in the error when it is absent.
+fn attribute<'py>(
+    object: &Bound<'py, PyAny>,
+    name: &str,
+    what: &str,
+) -> PyResult<Bound<'py, PyAny>> {
+    object
+        .getattr(name)
+        .map_err(|_| PyValueError::new_err(format!("{what}: no attribute {name:?}")))
+}
+
+/// One attribute of a calibration dataclass, as the type the field it feeds asks for.
+///
+/// `expected` is how that type reads in the refusal: the caller names it, because
+/// `u32` is "a non-negative integer" to a caller who typed a pixel count and
+/// `Option<f64>` is "a float or None".
+fn extract_attribute<'py, T: FromPyObjectOwned<'py>>(
+    object: &Bound<'py, PyAny>,
+    name: &str,
+    what: &str,
+    expected: &str,
+) -> PyResult<T> {
+    attribute(object, name, what)?
+        .extract()
+        .map_err(|_| wrong_type(what, name, expected))
+}
+
+/// The one shape every calibration-attribute error takes.
+fn wrong_type(what: &str, name: &str, expected: &str) -> PyErr {
+    PyValueError::new_err(format!("{what}.{name} must be {expected}"))
+}
+
 /// The compiled core of the `slam_rs` package.
 #[pymodule]
 fn _core(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add("__version__", slam_rs::VERSION)?;
+    module.add_class::<Vio>()?;
+    module.add_class::<VioResult>()?;
+    module.add_class::<VioStatus>()?;
     module.add_class::<Calibration>()?;
     module.add_class::<VioConfig>()?;
     module.add_class::<OpticalFlow>()?;
     module.add_class::<FlowFrame>()?;
+    module.add_class::<VioSnapshot>()?;
     Ok(())
 }

--- a/packages/slam-rs/slam_rs/_core.pyi
+++ b/packages/slam-rs/slam_rs/_core.pyi
@@ -5,11 +5,209 @@ exact: no ``Any``, and every array carries its dtype.
 """
 
 from collections.abc import Sequence
+from typing import ClassVar
 
-from jaxtyping import Float32, Int32, Int64, UInt8
+from jaxtyping import Bool, Float32, Float64, Int32, Int64, UInt8
 from numpy import ndarray
 
+from slam_rs.catalog_feed import CameraCalib, ImuCalib
+
 __version__: str
+
+class VioStatus:
+    """How far the estimator has got.
+
+    Offline mode has exactly these two states: a measured frameset always has a
+    state and an uncovered one never does, so there is no third, "initialising"
+    status to branch on.
+
+    A PyO3 enum, not a ``enum.Enum``: it carries no ``name`` or ``value``, it is
+    unhashable, and ``VioStatus(1)`` raises ``TypeError``. It does convert to
+    ``int`` and compares equal both to its own variants and to their ordinals.
+    """
+
+    NeedMoreImu: ClassVar[VioStatus]
+    Tracking: ClassVar[VioStatus]
+    __hash__: ClassVar[None]
+
+    def __int__(self) -> int: ...
+    def __eq__(self, other: object) -> bool: ...
+    def __repr__(self) -> str: ...
+
+class VioResult:
+    """What one :meth:`Vio.track` call produced."""
+
+    @property
+    def status(self) -> VioStatus: ...
+    @property
+    def t_ns(self) -> int: ...
+    @property
+    def world_from_rig(self) -> Float64[ndarray, " 7"]:
+        """``[tx, ty, tz, qx, qy, qz, qw]``, metres and a unit quaternion (xyzw)."""
+
+    @property
+    def velocity(self) -> Float64[ndarray, " 3"]:
+        """Rig velocity in the world frame, m/s."""
+
+    @property
+    def gyro_bias(self) -> Float64[ndarray, " 3"]:
+        """Gyroscope bias estimate, rad/s."""
+
+    @property
+    def accel_bias(self) -> Float64[ndarray, " 3"]:
+        """Accelerometer bias estimate, m/s^2."""
+
+    def __repr__(self) -> str: ...
+
+class VioSnapshot:
+    """The estimator's window, its landmarks and the last measured frame's statistics.
+
+    The window is the 15-dof states followed by the pose-only blocks, each oldest
+    first; :attr:`window_keyframe` and :attr:`window_long_term` say what each
+    frame is, :attr:`kf_ids` is the keyframes as an id list, and
+    :attr:`marginalized` is what the last marginalization removed. Everything is
+    a copy, so a snapshot stays valid across the next :meth:`Vio.track`.
+    """
+
+    @property
+    def t_ns(self) -> int:
+        """Frameset timestamp of the newest state in the window."""
+
+    @property
+    def window_t_ns(self) -> Int64[ndarray, " n_frames"]: ...
+    @property
+    def window_poses(self) -> Float64[ndarray, "n_frames 7"]:
+        """``[tx, ty, tz, qx, qy, qz, qw]`` per window frame, metres and a unit quaternion (xyzw)."""
+
+    @property
+    def window_keyframe(self) -> Bool[ndarray, " n_frames"]:
+        """Whether each window frame is a keyframe, as the estimator itself answers it."""
+
+    @property
+    def window_long_term(self) -> Bool[ndarray, " n_frames"]:
+        """Whether each window frame is a long-term keyframe."""
+
+    @property
+    def kf_ids(self) -> Int64[ndarray, " n_keyframes"]:
+        """The keyframes' timestamps, oldest first."""
+
+    @property
+    def marginalized(self) -> Int64[ndarray, " n_marginalized"]:
+        """Frames the last marginalization removed from the window."""
+
+    @property
+    def landmark_ids(self) -> Int64[ndarray, " n_landmarks"]:
+        """Landmark ids, which are the ids of the keypoints that spawned them."""
+
+    @property
+    def landmark_hosts(self) -> Int64[ndarray, " n_landmarks"]:
+        """Timestamp of the keyframe hosting each landmark."""
+
+    @property
+    def landmark_positions(self) -> Float64[ndarray, "n_landmarks 3"]:
+        """Landmark positions in the world frame, metres."""
+
+    @property
+    def lm_iterations(self) -> int:
+        """Levenberg-Marquardt steps the last frame took; the rejected ones are the rest."""
+
+    @property
+    def lm_lambda(self) -> float:
+        """Damping the last step solved with; ``0.0`` when no step ran."""
+
+    @property
+    def lm_error_before(self) -> float:
+        """Total cost before the first step; ``0.0`` when no step ran."""
+
+    @property
+    def lm_error_after(self) -> float:
+        """Total cost after the last step; ``0.0`` when no step ran."""
+
+    @property
+    def num_observations(self) -> int:
+        """Landmark observations the window holds."""
+
+    @property
+    def timings_ms(self) -> dict[str, float]:
+        """Wall time each stage took on the last frame, in milliseconds.
+
+        The estimator's six — ``back_substitution``, ``error``, ``linearize``,
+        ``marginalize``, ``measure``, ``solver`` — and the frontend lane's four:
+        ``frontend_pyramid``, ``frontend_detect``, ``frontend_track`` and
+        ``frontend_imu``. They do not sum to the frame: what happens between the
+        phases is nobody's stage.
+        """
+
+    def __repr__(self) -> str: ...
+
+class Vio:
+    """basalt's VIO pipeline, driven one frameset at a time.
+
+    Offline mode (D17): the frontend and the backend run to completion in the
+    calling thread, so every result is final and a repeat run over the same
+    input is bit-identical.
+
+    The refusals are the ones :class:`OpticalFlow` makes — a value the core
+    refuses is a ``ValueError``, an object of the wrong type a ``TypeError`` and
+    an integer outside the parameter's own type an ``OverflowError`` — never a
+    Rust panic.
+    """
+
+    def __init__(
+        self,
+        calibration: Calibration,
+        config: VioConfig,
+        *,
+        threads: int = 1,
+        max_keypoints: int | None = None,
+    ) -> None:
+        """Build the pipeline for one rig; basalt's own files arrive through ``from_json``.
+
+        Raises ``ValueError`` on everything :class:`OpticalFlow` refuses, and on
+        a config asking for a path this port does not have:
+        ``vio_linearization_type`` other than ``ABS_QR``, ``vio_sqrt_marg``
+        false, or ``vio_enforce_realtime``, which Offline mode cannot honour.
+        """
+
+    @property
+    def camera_count(self) -> int: ...
+    def push_imu(self, t_ns: int, gyro: Sequence[float], accel: Sequence[float]) -> None:
+        """Add one uncalibrated IMU sample.
+
+        Raises ``ValueError`` unless ``t_ns`` strictly follows the last sample
+        and every component is finite.
+        """
+
+    def push_imu_batch(
+        self,
+        t_ns: Int64[ndarray, " n_samples"],
+        gyro: Float64[ndarray, "n_samples 3"],
+        accel: Float64[ndarray, "n_samples 3"],
+    ) -> None:
+        """Add a batch of samples, all or nothing.
+
+        Raises what :meth:`push_imu` raises, for any sample of the batch, and
+        keeps none of it when it does: the estimator is left where it was, so the
+        batch can be corrected and pushed again.
+        """
+
+    def track(self, t_ns: int, images: Sequence[UInt8[ndarray, "h w"]]) -> VioResult:
+        """Process one frameset of ``camera_count`` C-contiguous ``(h, w)`` uint8 images.
+
+        Raises ``ValueError`` on a bad dtype, rank or layout, on the wrong number
+        of images, unless every image is the size the calibration gives its
+        camera, and unless ``t_ns`` is strictly after the last accepted frameset.
+        On a GPU lane a device that dies mid-run raises ``ValueError`` here as
+        well, never a ``PanicException``.
+        """
+
+    def snapshot(self) -> VioSnapshot | None:
+        """The window and the last measured frame, or None before the first one."""
+
+    def flow_frame(self) -> FlowFrame | None:
+        """The keypoints the frontend tracked on the last accepted frameset, or None before the first."""
+
+    def __repr__(self) -> str: ...
 
 class VioConfig:
     """basalt's ``VioConfig``, as ``data/**/*_config.json`` carries it."""
@@ -35,6 +233,10 @@ class Calibration:
     @staticmethod
     def from_json(text: str) -> Calibration:
         """Read one of basalt's calibration files."""
+
+    @staticmethod
+    def from_catalog(cameras: Sequence[CameraCalib], imu: ImuCalib) -> Calibration:
+        """Build the calibration from the feed's dataclasses; ``imu.imu_T_body`` is unused."""
 
     def to_json(self) -> str:
         """Write the calibration back in basalt's shape, ``value0`` wrapper and all."""

--- a/packages/slam-rs/slam_rs/apis/replay.py
+++ b/packages/slam-rs/slam_rs/apis/replay.py
@@ -126,12 +126,17 @@ class FrontendStage:
         )
 
 
-def _cpp_trajectory(manifest: ReferenceManifest, segment: ReferenceSegment, capture_start_time_ns: int) -> Trajectory:
+def _cpp_trajectory(manifest: ReferenceManifest, segment: ReferenceSegment, capture_start_time_ns: int, replayed_segment_id: str) -> Trajectory:
     """The basalt C++ reference for one segment, moved onto the replay's ``video_time`` clock.
 
-    Empty, with one printed line, when the trajectory is not on this machine: the
-    two long-tier segments keep theirs in the reference bundle.
+    Empty, with one printed line, when the trajectory is not on this machine (the
+    two long-tier segments keep theirs in the reference bundle), or when ``--rrd``
+    replays another segment than the manifest entry: a C++ run of one clip says
+    nothing about another, and associating the two only fails.
     """
+    if replayed_segment_id != segment.segment_id:
+        print(f"no C++ comparison: the recording is {replayed_segment_id}, the C++ run is {segment.segment_id}")
+        return empty_trajectory()
     resolved: BundleFile = manifest.cpp_trajectory(segment)
     if not resolved.available:
         print(f"no C++ trajectory to compare against: {resolved.reason}")
@@ -215,7 +220,7 @@ def main(config: Config) -> None:
                 logger=VioLogger(
                     cameras=feed.cameras,
                     ground_truth=truth,
-                    cpp=_cpp_trajectory(manifest, segment, feed.capture_start_time_ns),
+                    cpp=_cpp_trajectory(manifest, segment, feed.capture_start_time_ns, feed.segment_id),
                     frame_t_ns=feed.frame_t_ns,
                 ),
             )

--- a/packages/slam-rs/slam_rs/apis/replay.py
+++ b/packages/slam-rs/slam_rs/apis/replay.py
@@ -1,0 +1,246 @@
+"""Replay one reference segment through the Rust core and log it to Rerun.
+
+The tool is the end-to-end wiring of everything else in the package: the frozen
+manifest picks the segment and the IMU noise model, the feed decodes it on the
+pinned CPU ``gray8`` path, the core consumes framesets and IMU batches, and the
+result is logged under paths that mirror the dataset so a run sits beside the
+ground truth in one viewer.
+
+``--stage input`` logs only what the estimator is fed — the frames, the IMU and
+the ground truth — and builds no core object at all: it is the cheapest way to
+look at a segment, and it is what the plumbing was first written against.
+
+``--stage frontend`` runs :class:`slam_rs._core.OpticalFlow` over the same
+framesets and hands what it produced to :mod:`slam_rs.frontend_log`, which draws
+the keypoints, their trails, the occupancy grid and — on the one recording the
+C++ fork dumped its own keypoints from — the two frontends' keypoints side by
+side; :attr:`Config.rrd` states how that recording is recognised.
+
+``--stage vio`` is the whole pipeline: :class:`slam_rs._core.Vio` consumes the
+IMU and the framesets, :mod:`slam_rs.vio_log` draws the estimated trajectory
+against both the ground truth and the basalt C++ reference, the keyframe window,
+the landmarks and the per-stage timings, and the run ends with the two ATE
+numbers the V2 gate is written against.
+"""
+
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal, TypeAlias
+
+import numpy as np
+import rerun as rr
+from simplecv.rerun_log_utils import RerunTyroConfig
+
+from slam_rs import _core
+from slam_rs.catalog_feed import (
+    DEFAULT_WINDOW_S,
+    Frameset,
+    LocalSegment,
+    SegmentFeed,
+    open_segment,
+)
+from slam_rs.frontend_log import FrontendLogger, frontend_blueprint
+from slam_rs.reference import SMOKE_SEGMENTS, ReferenceManifest, ReferenceSegment, flow_config, load_manifest
+from slam_rs.reference_bundle import BundleFile
+from slam_rs.tracking import Lockstep
+from slam_rs.trajectory import Trajectory, ate, coverage, empty_trajectory, read_trajectory, shift_clock, write_trajectory
+from slam_rs.vio_log import FrameMode, VioLogger, VioStage, log_calibration, log_frameset_inputs, vio_blueprint
+
+SMOKE_SEGMENT: str = SMOKE_SEGMENTS[1]
+"""Default segment: the 7.6 s rotation-dominated panorama from the smoke tier."""
+
+Stage: TypeAlias = Literal["input", "frontend", "vio"]
+"""How far a replay runs: the estimator's inputs, the optical-flow frontend over them, or the whole pipeline."""
+
+
+@dataclass(slots=True)
+class Config:
+    """Replay a reference segment through the slam-rs core."""
+
+    rr_config: RerunTyroConfig = field(default_factory=RerunTyroConfig)
+    """Viewer, save and headless behaviour."""
+    artifact_root: Path | None = None
+    """Read every recording and sidecar from one directory per segment; see :func:`slam_rs.reference.relocate`."""
+    stage: Stage = "input"
+    """``input`` logs what the estimator is fed, ``frontend`` runs the optical flow over it, ``vio`` runs the whole pipeline.
+
+    The two stages that track log full-resolution frames, because their keypoints
+    are in the pixels of the frame they tracked, not of a downscaled copy of it.
+    """
+    segment: str = SMOKE_SEGMENT
+    """Segment id from ``reference_segments.toml``; also names the IMU parameters used for ``--rrd``."""
+    rrd: Path | None = None
+    """Base-layer ``.rrd`` to replay instead of the manifest's, keeping ``--segment``'s IMU parameters.
+
+    The C++ overlay is drawn only where the replayed recording's own segment id —
+    the one inside the file, not the name the file is filed under — is the one the
+    dumps came from. So another recording's frames get no overlay however the
+    file is spelled, and this recording's own ``.rrd`` still gets one.
+    """
+    gt_rrd: Path | None = None
+    """Ground-truth ``.rrd`` for ``--rrd``; the manifest's own path is used when neither is given."""
+    max_framesets: int | None = None
+    """Stop after this many framesets; None replays the whole segment."""
+    frame_stride: int = 1
+    """Replay every n-th frameset. Every frame is still decoded: decimated AV1 decode is unreliable."""
+    window_s: float = DEFAULT_WINDOW_S
+    """Longest time window fetched from the catalog in one round trip."""
+    output_csv: Path | None = None
+    """Where the estimated trajectory is written; defaults to ``data/<segment>/slam_rs.csv``."""
+
+@dataclass(slots=True)
+class FrontendStage:
+    """The optical-flow frontend over one segment, and the Rerun layer it draws.
+
+    One value rather than three: the frontend, its logger and its timings only
+    ever exist together, on ``--stage frontend``.
+    """
+
+    flow: _core.OpticalFlow
+    """The frontend every frameset goes through."""
+    logger: FrontendLogger
+    """Where its keypoints, trails, occupancy and counters go."""
+    elapsed_ms: list[float] = field(default_factory=list)
+    """Wall time each ``process`` call took, in frameset order."""
+
+    def run(self, frameset: Frameset) -> None:
+        """Track one frameset and log what it produced, at the caller's time cursor.
+
+        Args:
+            frameset: The frameset to track.
+        """
+        started: float = time.monotonic()
+        frame: _core.FlowFrame = self.flow.process(frameset.t_ns, frameset.images)
+        self.elapsed_ms.append(1e3 * (time.monotonic() - started))
+        self.logger.log(frame, self.elapsed_ms[-1])
+
+    def summary(self) -> str:
+        """One line on what the stage did, for the end of a replay."""
+        if not self.elapsed_ms:
+            return "frontend: no frameset reached it"
+        return (
+            f"frontend: {self.flow.last_keypoint_id} keypoint ids handed out, "
+            f"{np.mean(self.elapsed_ms):.1f} ms per frameset "
+            f"(median {np.median(self.elapsed_ms):.1f}, max {np.max(self.elapsed_ms):.1f})"
+        )
+
+
+def _cpp_trajectory(manifest: ReferenceManifest, segment: ReferenceSegment, capture_start_time_ns: int) -> Trajectory:
+    """The basalt C++ reference for one segment, moved onto the replay's ``video_time`` clock.
+
+    Empty, with one printed line, when the trajectory is not on this machine: the
+    two long-tier segments keep theirs in the reference bundle.
+    """
+    resolved: BundleFile = manifest.cpp_trajectory(segment)
+    if not resolved.available:
+        print(f"no C++ trajectory to compare against: {resolved.reason}")
+        return empty_trajectory()
+    return shift_clock(read_trajectory(resolved.path), -capture_start_time_ns)
+
+
+def _replay(feed: SegmentFeed, config: Config, stage: FrontendStage | VioStage | None) -> int:
+    """Log every frameset's inputs and drive whichever stage was built over them.
+
+    Args:
+        feed: Open segment feed.
+        config: Parsed CLI options.
+        stage: The frontend or the whole pipeline, or None for ``--stage input``.
+
+    Returns:
+        Framesets replayed. Everything a stage produced is on the stage itself.
+    """
+    started: float = time.monotonic()
+    replayed: int = 0
+    # `--max-framesets` is a count and the feed reads by time; the feed is what
+    # converts one to the other, so this loop and `tracking._drive` cannot
+    # disagree about which frameset a count ends on.
+    stop_ns: int | None = feed.stop_ns_after(config.max_framesets)
+    # The stage that tracks needs the pixels its keypoints were computed on.
+    mode: FrameMode = "downscaled" if config.stage == "input" else "jpeg"
+    frameset: Frameset
+    for frameset in feed.framesets(stop_ns):
+        if config.max_framesets is not None and replayed >= config.max_framesets:
+            break
+        replayed += 1
+        log_frameset_inputs(feed, frameset, mode)
+        if stage is not None:
+            stage.run(frameset)
+
+    elapsed: float = time.monotonic() - started
+    print(f"{replayed} framesets in {elapsed:.1f} s ({replayed / max(elapsed, 1e-9):.1f} fps)")
+    if stage is not None:
+        print(stage.summary())
+    return replayed
+
+
+def main(config: Config) -> None:
+    """Replay one segment, log it, write the trajectory and report the error.
+
+    Args:
+        config: Parsed CLI options.
+    """
+    manifest: ReferenceManifest = load_manifest(artifact_root=config.artifact_root)
+    segment: ReferenceSegment = manifest.by_id(config.segment)
+    source: LocalSegment = LocalSegment(
+        base_rrd=config.rrd if config.rrd is not None else segment.base_path,
+        gt_rrd=config.gt_rrd if config.gt_rrd is not None else (None if config.rrd is not None else segment.gt_path),
+    )
+    output_csv: Path = config.output_csv if config.output_csv is not None else Path("data") / segment.segment_id / "slam_rs.csv"
+    print(f"replaying {segment.segment_id} ({segment.tier} tier) from {source.base_rrd}")
+
+    with open_segment(source, segment.imu, frame_stride=config.frame_stride, window_s=config.window_s) as feed:
+        print(
+            f"{len(feed.cameras)} cameras, {len(feed.frame_t_ns)} framesets, ground truth "
+            f"{'attached' if feed.has_ground_truth else 'absent'}, clock offset {feed.capture_start_time_ns} ns"
+        )
+        log_calibration(feed.cameras)
+        stage: FrontendStage | VioStage | None = None
+        if config.stage == "frontend":
+            stage = FrontendStage(
+                flow=_core.OpticalFlow(_core.Calibration.from_catalog(feed.cameras, feed.imu), flow_config(manifest, segment)),
+                logger=FrontendLogger(len(feed.cameras), feed.segment_id),
+            )
+            rr.send_blueprint(frontend_blueprint(feed.cameras))
+        elif config.stage == "vio":
+            truth: Trajectory = feed.ground_truth_between(int(feed.frame_t_ns[0]), int(feed.frame_t_ns[-1]))
+            # Everything this constructor refuses is the caller's own request —
+            # a configuration this port does not run, or ``--gpu`` on a host
+            # with no driver, no device or no adapter — and the shim
+            # (:func:`slam_rs.apis.run`) is what turns it into one sentence and a
+            # non-zero exit rather than a traceback through the feed.
+            vio: _core.Vio = _core.Vio(_core.Calibration.from_catalog(feed.cameras, feed.imu), flow_config(manifest, segment))
+            stage = VioStage(
+                lockstep=Lockstep(vio=vio),
+                logger=VioLogger(
+                    cameras=feed.cameras,
+                    ground_truth=truth,
+                    cpp=_cpp_trajectory(manifest, segment, feed.capture_start_time_ns),
+                    frame_t_ns=feed.frame_t_ns,
+                ),
+            )
+            rr.send_blueprint(vio_blueprint(feed.cameras))
+        _replay(feed, config, stage)
+        if not isinstance(stage, VioStage):
+            return
+        # The per-frameset segments show where the run had got to; these show
+        # where it went, at every cursor and for one copy of each path.
+        stage.logger.log_complete_paths()
+        stage.refuse_lost_framesets()
+
+        # Exports carry the absolute device clock, the one every basalt CSV and
+        # every gt.csv sidecar uses. Writing video_time here would produce a file
+        # that associates with none of them. How far that is from video_time is
+        # the recording's own fact (`SegmentFeed.export_offset_ns`), which is why
+        # the RoboCap probe can share this rule instead of stating its own.
+        estimate: Trajectory = stage.logger.estimated()
+        write_trajectory(output_csv, shift_clock(estimate, feed.export_offset_ns))
+        print(f"{len(estimate)} tracked poses -> {output_csv} (absolute ns)")
+        if len(estimate) == 0:
+            print("no ATE: the estimator reported no tracked pose")
+            return
+        for name, reference in (("ground truth", stage.logger.ground_truth), ("basalt C++", stage.logger.cpp)):
+            if len(reference) == 0:
+                continue
+            print(f"vs {name}, {coverage(reference, estimate):.1%} of its span covered")
+            print(ate(estimate, reference).summary())

--- a/packages/slam-rs/slam_rs/catalog_feed.py
+++ b/packages/slam-rs/slam_rs/catalog_feed.py
@@ -1,0 +1,1406 @@
+"""One ``dataforge:v1`` segment as calibration, IMU, ground truth and grayscale framesets.
+
+The feed is the Python half of the estimator's data contract: it reads a segment
+either from a catalog URL or from a local ``.rrd`` served in process, and hands
+the Rust core CPU grayscale images with integer-nanosecond timestamps.
+
+Three decisions are frozen here because each one silently changes the numbers:
+
+* **Pixels.** AV1 samples are muxed without re-encoding and decoded by
+  single-threaded dav1d to ``gray8``. The MSD streams are limited-range
+  ``yuv420p`` with flat chroma, so the ``gray8`` reformat (limited to full
+  expansion) is what recovers the original grayscale; the raw Y plane is off by
+  up to 17 LSB. dav1d also pads rows, so the decoded plane's ``line_size``
+  exceeds the frame width and the copy honours it.
+* **Round trips.** Video, IMU and ground truth for one time window arrive in one
+  query each, and long segments are cut into windows on ``video_time`` whose
+  edges land on frames that are keyframes in *every* camera, so a window decodes
+  standalone. Decimated AV1 decode is a known upstream hazard: every frame is
+  decoded and ``frame_stride`` only decides which framesets are yielded.
+* **Rig shape.** A rig is not always four hardware-synced cameras fed at their
+  stored resolution on one IMU clock. :class:`RigProfile` carries the four things
+  that differ and default to what MSD is: which cameras of the rig are fed and in
+  what order, the integer downscale applied to frames *and* intrinsics, whether
+  the accelerometer has to be interpolated onto the gyroscope's clock, and how
+  far apart two cameras' frames may be and still be one frameset.
+* **Clocks.** ``video_time`` is the IMU's clock. Frames and ground truth reach it
+  by adding ``cam_time_offset_ns``, which is what "added to a camera timestamp to
+  reach the IMU clock" means and what basalt's own RoboCap reader does
+  (``frameset_t = median(camera_t) + kCameraToImuOffsetNs``, the IMU untouched).
+  MSD's offset is zero, so every MSD number is unchanged by this.
+* **Geometry.** ``Pinhole:image_from_camera`` is column-major, ``Pinhole:resolution``
+  is ``(width, height)`` while the decoded array is ``(height, width)``, and the
+  camera ``Transform3D`` is ``ChildFromParent`` — that is ``cam_T_imu``, and it is
+  inverted here. msd-g2 stores its images rotated into portrait with the
+  calibration rotated to match, so nothing may assume a landscape frame or a
+  shared orientation across cameras.
+"""
+
+import hashlib
+import math
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from io import BytesIO
+from os import PathLike
+from pathlib import Path
+from typing import Literal, TypeAlias
+
+import av
+import numpy as np
+import pyarrow as pa
+import rerun as rr
+from datafusion import col, lit
+from jaxtyping import Bool, Float64, Int64, UInt8
+from numpy import ndarray
+from rerun.catalog import CatalogClient, DatasetEntry
+from simplecv.catalog_video_codec import CatalogCodecName, catalog_codec_name, wrap_mp4
+
+from slam_rs.reference import ImuParameters
+from slam_rs.trajectory import ASSOCIATION_TOLERANCE_NS, Trajectory, empty_trajectory, shift_clock
+
+RIG_ENTITY: str = "/world/rig_00"
+"""Rig node of the ``exoego:v2`` tree; its reference frame is the IMU."""
+IMU_ENTITY: str = "/world/rig_00/imu_00"
+"""IMU node, whose transform is the identity because the IMU *is* the rig frame."""
+TIMELINE: str = "video_time"
+"""The one index both datasets carry: nanoseconds since ``property:capture:start_time_ns``."""
+CHILD_FROM_PARENT: int = 2
+"""``rr.TransformRelation.ChildFromParent``; the only relation the extrinsic inversion is valid for."""
+DEFAULT_WINDOW_S: float = 60.0
+"""Time window a long segment is cut into: a 7.6 s two-camera segment is 8.5 MB, so a 2,000 s one is not one query."""
+
+CameraModelName: TypeAlias = Literal["kb4", "radtan8"]
+"""Projection models V0 supports, named as basalt names them."""
+
+_MODEL_BY_DISTORTION: dict[str, tuple[CameraModelName, int]] = {"kannala_brandt": ("kb4", 4), "brown_conrady": ("radtan8", 8)}
+"""``simplecv.components.DistortionModel`` string to the model and the number of coefficients it uses."""
+
+
+@dataclass(slots=True, frozen=True)
+class CameraStatics:
+    """One camera node's static components, exactly as the catalog stores them.
+
+    This is the untouched read side: column-major matrices, ``(width, height)``
+    resolution, the raw relation code and the full fixed-width coefficient list.
+    :func:`camera_calib` is the only place the conversion rules live, which is
+    what lets them be tested without a catalog.
+    """
+
+    distortion_model: str
+    """``simplecv.components.DistortionModel``, e.g. ``kannala_brandt``.
+
+    The projection model comes from here and not from the camera node's own
+    ``camera_model`` string, which the RoboCap conversion predates and some
+    writers omit.
+    """
+    distortion_coefficients: Float64[ndarray, " n_slots"]
+    """Fixed-width coefficient list; the unused tail is zero."""
+    image_from_camera: Float64[ndarray, " 9"]
+    """``Pinhole:image_from_camera``, flat and **column-major**."""
+    resolution_wh: Float64[ndarray, " 2"]
+    """``Pinhole:resolution``, ``(width, height)`` in pixels."""
+    transform_mat3x3: Float64[ndarray, " 9"]
+    """Camera ``Transform3D:mat3x3``, flat and **column-major**."""
+    transform_translation: Float64[ndarray, " 3"]
+    """Camera ``Transform3D:translation``."""
+    transform_relation: int
+    """``Transform3D:relation``; must be :data:`CHILD_FROM_PARENT`."""
+    distortion_valid_radius: float | None
+    """basalt's ``rpmax``; present on msd-g2 only."""
+
+
+@dataclass(slots=True, frozen=True)
+class CameraCalib:
+    """One camera as the estimator wants it: metric intrinsics and ``imu_T_cam``."""
+
+    index: int
+    """Camera number the estimator knows this camera by, matching the order of a frameset's images.
+
+    On a rig fed whole that is also the rig index. Where
+    :attr:`RigProfile.camera_names` feeds a subset it is the position in that
+    list, and :attr:`SegmentFeed.camera_positions` maps it back to the rig — so
+    the keypoints, the images and the blueprint views all speak the estimator's
+    numbering and only the catalog reads speak the rig's.
+    """
+    width: int
+    """Decoded frame width in pixels."""
+    height: int
+    """Decoded frame height in pixels."""
+    fx: float
+    """Focal length along image x, pixels."""
+    fy: float
+    """Focal length along image y, pixels."""
+    cx: float
+    """Principal point x, pixels."""
+    cy: float
+    """Principal point y, pixels."""
+    model: CameraModelName
+    """Projection model."""
+    distortion: Float64[ndarray, " n_coeffs"]
+    """Exactly the coefficients the model uses: 4 for kb4, ``k1 k2 p1 p2 k3 k4 k5 k6`` for radtan8."""
+    distortion_valid_radius: float | None
+    """basalt's ``rpmax``, when the recording carries one."""
+    imu_T_cam: Float64[ndarray, "4 4"]
+    """Camera pose in the IMU frame: the inverse of the stored ``ChildFromParent`` transform."""
+
+
+@dataclass(slots=True, frozen=True)
+class ImuCalib:
+    """The IMU as the estimator wants it: noise model plus the body transform."""
+
+    frequency_hz: float
+    """Nominal update rate, from the reference manifest."""
+    gyro_noise_std: float
+    """Gyroscope noise density."""
+    accel_noise_std: float
+    """Accelerometer noise density."""
+    gyro_bias_std: float
+    """Gyroscope bias random walk."""
+    accel_bias_std: float
+    """Accelerometer bias random walk."""
+    cam_time_offset_ns: int
+    """Added to a camera timestamp to reach the IMU clock."""
+    imu_T_body: Float64[ndarray, "4 4"]
+    """Body pose in the IMU frame; the identity whenever the rig reference is the IMU."""
+
+
+@dataclass(slots=True, frozen=True)
+class ImuStream:
+    """A segment's paired inertial measurements on one clock."""
+
+    t_ns: Int64[ndarray, " n_samples"]
+    """Sample timestamps, strictly increasing."""
+    gyro_rad_s: Float64[ndarray, "n_samples 3"]
+    """Angular velocity, rad/s."""
+    accel_m_s2: Float64[ndarray, "n_samples 3"]
+    """Linear acceleration, m/s^2."""
+
+    def __len__(self) -> int:
+        return int(self.t_ns.shape[0])
+
+    def between(self, first_ns: int, last_ns: int) -> "ImuStream":
+        """The samples with ``first_ns < t <= last_ns``, half-open at the start."""
+        keep: Bool[ndarray, " n_samples"] = (self.t_ns > first_ns) & (self.t_ns <= last_ns)
+        return ImuStream(t_ns=self.t_ns[keep], gyro_rad_s=self.gyro_rad_s[keep], accel_m_s2=self.accel_m_s2[keep])
+
+
+@dataclass(slots=True, frozen=True)
+class Frameset:
+    """One synchronised multi-camera capture, decoded to grayscale."""
+
+    t_ns: int
+    """Shared capture timestamp of every image, on the ``video_time`` clock."""
+    images: list[UInt8[ndarray, "h w"]]
+    """One C-contiguous grayscale image per camera, in rig camera order."""
+    imu: ImuStream
+    """Inertial samples since the previous frameset, running one sample past :attr:`t_ns`.
+
+    The lead sample matters: a backend that integrates up to the frame time and
+    blocks until it can deadlocks on the very first frameset if it is only ever
+    given samples at or before that time.
+    """
+    ground_truth: Float64[ndarray, " 7"] | None
+    """Nearest ground-truth pose as ``[tx, ty, tz, qw, qx, qy, qz]``, or None without a ``gt`` layer."""
+
+    def image_digests(self) -> tuple[str, ...]:
+        """Digest of each camera's gray8 bytes, in the same order as :attr:`images`.
+
+        This is the unit the basalt C++ reference records in its
+        ``frames.sha256`` (one ``t_ns,cam_index,sha256`` line per decoded frame),
+        so the two decoders can be compared frame by frame rather than only in
+        aggregate. Only the pixel-parity tests and the clip dumper ask for it,
+        which is why it is hashed on demand rather than in the feed loop: that
+        loop is what a gate's wall time and every fleet row's realtime factor
+        measure, and 0.68 ms a frameset of SHA-256 over 2x960x960 is decode plus
+        `track` and something else.
+
+        The array's own buffer is hashed rather than a ``tobytes()`` copy of it —
+        the same bytes and the same digest, and a non-contiguous frame raises
+        here rather than being hashed in a different order.
+
+        Returns:
+            One hex digest per camera.
+        """
+        return tuple(hashlib.sha256(image).hexdigest() for image in self.images)
+
+    def digest(self) -> str:
+        """Digest of the timestamp and the per-camera digests: one value per frameset.
+
+        Returns:
+            One hex digest for the whole frameset.
+        """
+        rolled = hashlib.sha256(np.int64(self.t_ns).tobytes())
+        for camera_digest in self.image_digests():
+            rolled.update(bytes.fromhex(camera_digest))
+        return rolled.hexdigest()
+
+
+@dataclass(slots=True, frozen=True)
+class LocalSegment:
+    """A segment read from ``.rrd`` files on disk, served in process."""
+
+    base_rrd: Path
+    """Base layer: video, IMU and calibration."""
+    gt_rrd: Path | None = None
+    """Ground-truth layer; omitted when the dataset has none."""
+
+
+@dataclass(slots=True, frozen=True)
+class CatalogSegment:
+    """A segment read from a running catalog server."""
+
+    url: str
+    """Catalog URL, e.g. ``rerun+http://dgx-spark:9988``."""
+    dataset_name: str
+    """Dataset entry name on that server."""
+    segment_id: str
+    """Segment within the dataset."""
+
+
+SegmentSource: TypeAlias = LocalSegment | CatalogSegment
+"""Where a feed gets its data; the rest of the module does not care which."""
+
+
+@dataclass(slots=True, frozen=True)
+class RigProfile:
+    """How one rig's recording has to be read, where reading it whole is wrong.
+
+    The default is MSD: every camera the rig declares, at its stored resolution,
+    on one hardware-synced clock, with both inertial channels already paired.
+    RoboCap is none of those, and each departure is a number a caller must state
+    rather than a branch the feed guesses.
+    """
+
+    camera_names: tuple[str, ...] | None = None
+    """Cameras to feed, by their ``name`` static, in the order the estimator gets them; None feeds every camera in rig order."""
+    downscale: int = 1
+    """Integer factor applied to the decoded frames and to the intrinsics; 1 feeds the stored resolution."""
+    interpolate_accel_onto_gyro: bool = False
+    """Interpolate the accelerometer onto the gyroscope's timestamps instead of requiring one shared clock."""
+    frameset_tolerance_ns: int = 0
+    """How far a camera's frame may sit from the anchor camera's and still join that frameset; 0 demands identical timestamps."""
+    video_time_is_absolute: bool = False
+    """Whether ``video_time`` already **is** the device clock, so an export adds nothing to it.
+
+    False is MSD, whose ``video_time`` is relative to
+    ``property:capture:start_time_ns``; RoboCap records the device clock itself,
+    and that is what every basalt CSV beside it carries.
+    """
+
+    def __post_init__(self) -> None:
+        """Refuse a profile the feed cannot honour, before anything reads a recording with it.
+
+        Raises:
+            ValueError: If ``downscale`` is below one or ``frameset_tolerance_ns`` is negative.
+        """
+        if self.downscale < 1:
+            raise ValueError(f"downscale must be at least 1; got {self.downscale}")
+        if self.frameset_tolerance_ns < 0:
+            raise ValueError(f"frameset_tolerance_ns cannot be negative; got {self.frameset_tolerance_ns}")
+
+
+MSD_RIG: RigProfile = RigProfile()
+"""The Monado SLAM Dataset rigs: every camera, native resolution, one clock, paired inertial channels."""
+
+
+def scale_principal_point(value: float, downscale: int) -> float:
+    """One principal-point coordinate at ``1 / downscale`` of its resolution.
+
+    The pixel's own centre is what scales, not its index: a pixel at ``c`` covers
+    ``[c, c + 1)`` whose centre is ``c + 0.5``, and the downscaled pixel centre
+    ``(c + 0.5) / d`` is at index ``(c + 0.5) / d - 0.5``. This is the convention
+    the fork's ``basalt_convert_robocap_calib.py`` writes, and reproducing it from
+    the recording's own native statics returns that file's digits exactly
+    (``tests/test_catalog_feed.py``).
+    """
+    return (value + 0.5) / downscale - 0.5
+
+
+def camera_calib(index: int, statics: CameraStatics, downscale: int = 1) -> CameraCalib:
+    """Apply the catalog-to-estimator mapping rules to one camera's statics.
+
+    The rules, each of which has cost someone a wrong trajectory: reshape
+    ``image_from_camera`` column-major, read the resolution as ``(width, height)``,
+    map the distortion model string and assert the coefficient tail is zero
+    rather than truncating it, and invert the ``ChildFromParent`` transform to get
+    ``imu_T_cam``.
+
+    A ``downscale`` above one scales the resolution and the intrinsics to the
+    frames the feed will actually decode, KB4's resolution-invariant coefficients
+    untouched.
+
+    Args:
+        index: Camera index on the rig.
+        statics: Raw static components of the camera node.
+        downscale: Integer factor the frames are decoded at.
+
+    Returns:
+        The camera calibration in the estimator's conventions.
+
+    Raises:
+        ValueError: If the distortion model is unknown, the coefficient tail is
+            non-zero, the transform relation is not ``ChildFromParent``, or
+            ``downscale`` is below one.
+    """
+    if downscale < 1:
+        raise ValueError(f"cam_{index:02d}: downscale must be at least 1; got {downscale}")
+    width: int = int(statics.resolution_wh[0])
+    height: int = int(statics.resolution_wh[1])
+    if width // downscale < 1 or height // downscale < 1:
+        raise ValueError(f"cam_{index:02d}: downscale {downscale} leaves nothing of the {width}x{height} frame")
+    if statics.distortion_model not in _MODEL_BY_DISTORTION:
+        raise ValueError(f"cam_{index:02d}: unsupported distortion model {statics.distortion_model!r}, known: {sorted(_MODEL_BY_DISTORTION)}")
+    model: CameraModelName = _MODEL_BY_DISTORTION[statics.distortion_model][0]
+    n_coeffs: int = _MODEL_BY_DISTORTION[statics.distortion_model][1]
+    if statics.distortion_coefficients.shape[0] < n_coeffs:
+        raise ValueError(f"cam_{index:02d}: {model} needs {n_coeffs} coefficients, got {statics.distortion_coefficients.shape[0]}")
+    tail: Float64[ndarray, " n_tail"] = statics.distortion_coefficients[n_coeffs:]
+    # A "kannala_brandt" string does not imply KB4 — Aria's Fisheye624 carries the
+    # same string with eight live coefficients. Reject the tail, never truncate it.
+    if not np.allclose(tail, 0.0):
+        raise ValueError(f"cam_{index:02d}: {model} uses {n_coeffs} coefficients but the tail is non-zero: {tail.tolist()}")
+    if statics.transform_relation != CHILD_FROM_PARENT:
+        raise ValueError(f"cam_{index:02d}: Transform3D relation {statics.transform_relation} is not ChildFromParent({CHILD_FROM_PARENT})")
+    k_matrix: Float64[ndarray, "3 3"] = statics.image_from_camera.reshape(3, 3, order="F")
+    cam_R_imu: Float64[ndarray, "3 3"] = statics.transform_mat3x3.reshape(3, 3, order="F")
+    imu_T_cam: Float64[ndarray, "4 4"] = np.eye(4, dtype=np.float64)
+    imu_T_cam[:3, :3] = cam_R_imu.T
+    imu_T_cam[:3, 3] = -cam_R_imu.T @ statics.transform_translation
+    return CameraCalib(
+        index=index,
+        width=width // downscale,
+        height=height // downscale,
+        fx=float(k_matrix[0, 0]) / downscale,
+        fy=float(k_matrix[1, 1]) / downscale,
+        cx=scale_principal_point(float(k_matrix[0, 2]), downscale),
+        cy=scale_principal_point(float(k_matrix[1, 2]), downscale),
+        model=model,
+        distortion=statics.distortion_coefficients[:n_coeffs].copy(),
+        distortion_valid_radius=statics.distortion_valid_radius,
+        imu_T_cam=imu_T_cam,
+    )
+
+
+def imu_calib(parameters: ImuParameters, imu_T_body: Float64[ndarray, "4 4"]) -> ImuCalib:
+    """Combine the manifest's frozen noise model with the recording's IMU transform.
+
+    Args:
+        parameters: Frozen IMU parameters from the reference manifest.
+        imu_T_body: Body pose in the IMU frame, the identity when the rig reference is the IMU.
+
+    Returns:
+        The IMU calibration the estimator is configured with.
+    """
+    return ImuCalib(
+        frequency_hz=parameters.rate_hz,
+        gyro_noise_std=parameters.gyro_noise_std,
+        accel_noise_std=parameters.accel_noise_std,
+        gyro_bias_std=parameters.gyro_bias_std,
+        accel_bias_std=parameters.accel_bias_std,
+        cam_time_offset_ns=parameters.cam_time_offset_ns,
+        imu_T_body=imu_T_body,
+    )
+
+
+def _flat_float(column: pa.Array) -> Float64[ndarray, " n_values"]:
+    """Every non-null value of a temporal component column, flat and float64.
+
+    Rerun nests a component's values one list deep and the component's own arity
+    another (``list<fixed_size_list<3>>`` for a ``Transform3D:translation``,
+    ``list<double>`` for ``Scalars:scalars``), so the unwrapping is a loop rather
+    than a fixed number of ``flatten`` calls.
+    """
+    values: pa.Array = column.drop_null()
+    while pa.types.is_list(values.type) or pa.types.is_large_list(values.type) or pa.types.is_fixed_size_list(values.type):
+        values = values.flatten()
+    return np.asarray(values.to_numpy(zero_copy_only=False), dtype=np.float64)
+
+
+def _static_cell(statics: pa.Table, column: str) -> pa.Scalar:
+    """Row zero of one static component column.
+
+    A static is logged once, so row zero is the value — but a rig node that
+    carries no statics at all reached ``statics[column][0]`` as an ``IndexError``
+    out of pyarrow with nothing in it that says which component was being read.
+    The three readers below differ only in what they make of the cell.
+
+    Args:
+        statics: Single-row table from ``filter_contents(...).reader(index=None)``.
+        column: Component column name, e.g. ``/world/rig_00:reference``.
+
+    Returns:
+        The cell, valid.
+
+    Raises:
+        ValueError: If the column is absent, the table has no rows, or the cell is null.
+    """
+    if column not in statics.column_names:
+        raise ValueError(f"static column {column} is missing")
+    if statics.num_rows == 0:
+        raise ValueError(f"static column {column} has no rows")
+    cell: pa.Scalar = statics[column][0]
+    if not cell.is_valid:
+        raise ValueError(f"static column {column} is null")
+    return cell
+
+
+def _static_scalar(cell: pa.Scalar) -> object:
+    """The one Python value in a static cell, whether or not Rerun wrapped it in a list."""
+    return cell.values.to_pylist()[0] if isinstance(cell, pa.ListScalar | pa.LargeListScalar) else cell.as_py()
+
+
+def _static_values(statics: pa.Table, column: str) -> Float64[ndarray, " n"]:
+    """One static list component as a flat float64 array."""
+    return np.asarray(_static_cell(statics, column).values.to_pylist(), dtype=np.float64).ravel()
+
+
+def _static_string(statics: pa.Table, column: str) -> str:
+    """One static string component, bare or wrapped in a single-element list."""
+    value: object = _static_scalar(_static_cell(statics, column))
+    if not isinstance(value, str):
+        raise ValueError(f"static column {column} is not a string: {value!r}")
+    return value
+
+
+def _static_int(statics: pa.Table, column: str) -> int:
+    """One static integer component, read without passing through float64.
+
+    A device clock is around 1e13 ns today, which float64 holds exactly, but the
+    margin to 2^53 is only three decades and the whole point of this value is that
+    it is added to timestamps that must stay exact.
+    """
+    value: object = _static_scalar(_static_cell(statics, column))
+    if not isinstance(value, int):
+        raise ValueError(f"static column {column} is not an integer: {value!r}")
+    return value
+
+
+def read_camera_statics(statics: pa.Table, entity: str) -> CameraStatics:
+    """Pull one camera node's static components out of a statics table.
+
+    Args:
+        statics: Single-row table from ``filter_contents(...).reader(index=None)``.
+        entity: Camera node entity path, e.g. ``/world/rig_00/cam_00``.
+
+    Returns:
+        The raw statics, unconverted.
+    """
+    optional_radius: str = f"{entity}:distortion_valid_radius"
+    return CameraStatics(
+        distortion_model=_static_string(statics, f"{entity}/pinhole:simplecv.components.DistortionModel"),
+        distortion_coefficients=_static_values(statics, f"{entity}/pinhole:simplecv.components.DistortionCoefficients"),
+        image_from_camera=_static_values(statics, f"{entity}/pinhole:Pinhole:image_from_camera"),
+        resolution_wh=_static_values(statics, f"{entity}/pinhole:Pinhole:resolution"),
+        transform_mat3x3=_static_values(statics, f"{entity}:Transform3D:mat3x3"),
+        transform_translation=_static_values(statics, f"{entity}:Transform3D:translation"),
+        transform_relation=int(_static_values(statics, f"{entity}:Transform3D:relation")[0]),
+        distortion_valid_radius=float(_static_values(statics, optional_radius)[0]) if optional_radius in statics.column_names else None,
+    )
+
+
+def decode_gray(mp4_bytes: bytes, downscale: int = 1) -> Iterator[UInt8[ndarray, "h w"]]:
+    """Decode an in-memory MP4 to C-contiguous ``gray8`` frames, one decoder thread.
+
+    ``reformat(format="gray8")`` performs the limited-to-full range expansion the
+    MSD streams need; reading the raw Y plane instead is a systematic photometric
+    shift of up to 17 LSB. dav1d pads each row, so the plane's ``line_size``
+    exceeds the frame width and the visible columns are sliced out.
+
+    The plane is read through the buffer protocol and the visible columns are
+    copied once (T06): ``bytes(plane)`` used to copy the padded plane first, at
+    0.751 ms a frame against 0.677 ms. The copy is explicit rather than
+    :func:`numpy.ascontiguousarray`, which would return the slice untouched on a
+    frame the decoder did not pad — a view into memory the decoder reuses for the
+    next frame.
+
+    A ``downscale`` above one asks the same ``swscale`` call for the smaller frame
+    with ``SWS_AREA``: one conversion, colour and size together, which is the
+    operation basalt's own RoboCap reader performs
+    (``cpu_gray8_swscale_area_downscale3``). Converting first and resampling
+    afterwards is a second, different filter and a different trajectory.
+
+    Args:
+        mp4_bytes: MP4 produced by :func:`wrap_mp4`.
+        downscale: Integer factor to shrink each frame by.
+
+    Yields:
+        One grayscale image per frame, in decode order.
+
+    Raises:
+        ValueError: If ``downscale`` is below one.
+    """
+    if downscale < 1:
+        raise ValueError(f"downscale must be at least 1; got {downscale}")
+    container: av.container.InputContainer = av.open(BytesIO(mp4_bytes), mode="r")
+    with container:
+        stream = container.streams.video[0]
+        stream.thread_count = 1
+        stream.thread_type = "NONE"
+        for frame in container.decode(stream):
+            gray = (
+                frame.reformat(format="gray8")
+                if downscale == 1
+                else frame.reformat(
+                    width=max(frame.width // downscale, 1),
+                    height=max(frame.height // downscale, 1),
+                    format="gray8",
+                    interpolation="AREA",
+                )
+            )
+            plane = gray.planes[0]
+            padded: UInt8[ndarray, "h stride"] = np.frombuffer(plane, dtype=np.uint8).reshape(gray.height, plane.line_size)
+            yield padded[:, : gray.width].copy()
+
+
+@dataclass(slots=True, frozen=True)
+class _VideoIndex:
+    """Frameset timing, read without touching a single encoded sample.
+
+    A frameset is one row: its ``video_time``, and the frame each fed camera
+    contributes to it. On a hardware-synced rig fed whole that is the identity —
+    frameset ``i`` is frame ``i`` of every camera — and on RoboCap it is the
+    nearest-match table basalt's reader builds.
+    """
+
+    t_ns: Int64[ndarray, " n_framesets"]
+    """Frameset timestamps on ``video_time``: the median of the frames in each one."""
+    frame_index: Int64[ndarray, "n_framesets n_cameras"]
+    """Which frame of each fed camera belongs to each frameset, non-decreasing down each column."""
+    camera_t_ns: tuple[Int64[ndarray, " n_frames"], ...]
+    """Every fed camera's own frame timestamps, in the order they are fed."""
+    keyframe: Bool[ndarray, " n_framesets"]
+    """True where each fed camera's frame in this frameset is a keyframe, so a window may start there."""
+    codec: CatalogCodecName
+    """Codec of the elementary stream."""
+    fps: int
+    """Nominal frame rate, rounded from the timestamps."""
+
+
+@dataclass(slots=True, frozen=True)
+class SegmentFeed:
+    """One segment's calibration, inertial data, ground truth and grayscale framesets."""
+
+    segment_id: str
+    """Segment this feed reads."""
+    cameras: tuple[CameraCalib, ...]
+    """Camera calibrations, in rig order; a frameset's images follow the same order."""
+    imu: ImuCalib
+    """IMU calibration, noise model included."""
+    capture_start_time_ns: int
+    """``property:capture:start_time_ns``: add it to a ``video_time`` to reach the absolute device clock."""
+    export_offset_ns: int
+    """What an exported trajectory adds to its ``video_time`` stamps to land on the clock the C++ CSVs use.
+
+    :attr:`capture_start_time_ns` on a rig whose ``video_time`` is relative to it,
+    and zero on one that records the device clock directly
+    (:attr:`RigProfile.video_time_is_absolute`). The rule is the recording's, not
+    the tool's: two tools reading it from the feed cannot disagree about it.
+    """
+    frame_t_ns: Int64[ndarray, " n_frames"]
+    """Timestamp of every frameset on the inertial clock, before ``frame_stride`` is applied.
+
+    That is ``video_time`` plus :attr:`ImuCalib.cam_time_offset_ns`, which is the
+    clock the estimator, the exported trajectory and every basalt CSV are on.
+    """
+    camera_positions: tuple[int, ...]
+    """Rig index of each fed camera, in the order a frameset's images arrive."""
+    rig_cameras: int
+    """Cameras the rig declares, of which :attr:`camera_positions` are the fed ones."""
+    profile: RigProfile
+    """How this rig had to be read, exactly as the caller stated it.
+
+    Held rather than copied field by field: a rig knob is one declaration, and a
+    feed that carried its own copy of two of them made the profile three
+    declarations, of which only one is the caller's.
+    """
+    frame_stride: int
+    """Yield every n-th frameset. Every frame is still decoded: decimated AV1 decode is unreliable."""
+    dataset: DatasetEntry
+    """Dataset the video samples are fetched from."""
+    gt_dataset: DatasetEntry | None
+    """Dataset the ground-truth poses come from; None when the source has no ``gt`` layer."""
+    index: _VideoIndex
+    """Frameset timing, the per-camera frames behind it, and the codec."""
+    window_ns: int
+    """Longest time window fetched in one round trip."""
+
+    @property
+    def has_ground_truth(self) -> bool:
+        """Whether a ``gt`` layer is attached."""
+        return self.gt_dataset is not None
+
+    def stop_ns_after(self, max_framesets: int | None) -> int | None:
+        """When a count of framesets runs out, as a time :meth:`framesets` can stop at.
+
+        A caller counts framesets and the feed reads by time, so the count has to
+        become the timestamp of the last frameset that will be yielded. Without
+        it the feed is told to run to the end of the segment and fetches a whole
+        window nothing below will decode — on the RoboCap rig, thirty seconds of
+        four 1080p H.264 streams.
+
+        Args:
+            max_framesets: Framesets the caller will consume; None to run on.
+
+        Returns:
+            The last yielded frameset's timestamp, or None where the caller set
+            no count.
+        """
+        if max_framesets is None:
+            return None
+        last_index: int = min(max(max_framesets - 1, 0) * self.frame_stride, len(self.frame_t_ns) - 1)
+        return int(self.frame_t_ns[last_index])
+
+    def imu_between(self, first_ns: int, last_ns: int) -> ImuStream:
+        """Every inertial sample with ``first_ns <= t <= last_ns``, on the inertial clock."""
+        return _read_imu(self.dataset, self.segment_id, self.profile.interpolate_accel_onto_gyro, first_ns, last_ns)
+
+    def ground_truth_between(self, first_ns: int, last_ns: int) -> Trajectory:
+        """Ground-truth rig poses over ``[first_ns, last_ns]`` of the inertial clock.
+
+        The layer stores them on ``video_time``, like the frames, so the window is
+        asked for in that clock and the answer comes back in the inertial one.
+        Empty where there is nothing to give: no ``gt`` layer at all, or a window
+        the layer does not cover. Whether the segment *has* a layer is
+        :attr:`has_ground_truth`, which is the distinction a caller acts on;
+        callers of this test :func:`len`.
+
+        Raises:
+            ValueError: If the layer's translation and rotation are not valid on
+                the same rows, so no pose can be read off it
+                (:func:`_rig_trajectory`).
+        """
+        if self.gt_dataset is None:
+            return empty_trajectory()
+        offset_ns: int = self.imu.cam_time_offset_ns
+        return shift_clock(_read_ground_truth(self.gt_dataset, self.segment_id, first_ns - offset_ns, last_ns - offset_ns), offset_ns)
+
+    def framesets(self, stop_ns: int | None = None) -> Iterator[Frameset]:
+        """Decode the segment and yield one frameset at a time.
+
+        Video, inertial samples and ground truth are all fetched one window at a
+        time, so ``window_s`` really does bound memory and startup cost — reading
+        a 586 s segment's IMU whole is 500k+ samples before the first frame comes
+        out. Window edges land on frames that are keyframes in every camera, so
+        each window decodes standalone; inside a window the cameras are decoded in
+        lockstep, so only one frame per camera is ever resident.
+
+        Each frameset carries the inertial samples since the previous one, running
+        one sample past its own timestamp, and the nearest ground-truth pose.
+
+        A caller that stops early states where, because the fetch is a window
+        ahead of what it yields: a consumer breaking out of the loop has already
+        paid for a whole window of encoded samples — 30 s x 30 fps x 4 cameras of
+        1080p on a RoboCap run — that nothing will read.
+
+        Args:
+            stop_ns: Last frameset time worth reading, on the inertial clock; a
+                window opening past it is not fetched at all. None reads to the
+                end of the segment. Framesets up to the end of the window that
+                covers it are still yielded, because a window is the unit that is
+                read.
+
+        Yields:
+            Framesets in time order, every :attr:`frame_stride`-th one.
+
+        Raises:
+            ValueError: If a camera's decoder runs dry before the window ends, a
+                decoded frame disagrees with the calibrated resolution, or a
+                window's inertial read leaves a gap at the boundary.
+        """
+        # Each read reaches past both ends of its window. Forward, because a
+        # frameset needs one sample beyond its own timestamp. Backward by a whole
+        # frame period, because the first frameset of a window owns the samples
+        # since the *previous* window's last frameset, which is one frame earlier —
+        # a margin of a few IMU periods silently drops 16 ms of every boundary at
+        # 54 Hz, which is what the gap check below is here to catch.
+        frame_period_ns: int = int(1e9 / max(self.index.fps, 1))
+        imu_period_ns: int = int(1e9 / max(self.imu.frequency_hz, 1.0))
+        margin_ns: int = max(2 * frame_period_ns + 2 * imu_period_ns, 2_000_000)
+        emitted_imu_t_ns: int = -(2**62)
+        for start, stop in _window_bounds(self.index, self.window_ns):
+            window_first_ns: int = int(self.frame_t_ns[start])
+            if stop_ns is not None and window_first_ns > stop_ns:
+                break
+            window_last_ns: int = int(self.frame_t_ns[stop - 1])
+            window_imu: ImuStream = self.imu_between(window_first_ns - margin_ns, window_last_ns + margin_ns)
+            if len(window_imu) and emitted_imu_t_ns > -(2**62) and int(window_imu.t_ns[0]) > emitted_imu_t_ns + 1:
+                raise ValueError(
+                    f"{self.segment_id}: inertial gap at the window starting {window_first_ns} ns — "
+                    f"the read begins at {int(window_imu.t_ns[0])} but the last emitted sample was {emitted_imu_t_ns}"
+                )
+            window_gt: Trajectory = self.ground_truth_between(window_first_ns - margin_ns, window_last_ns + margin_ns)
+
+            decoders: list[Iterator[UInt8[ndarray, "h w"]]] = []
+            for position in range(len(self.cameras)):
+                samples, keyframes = self._fetch_samples(position, start, stop)
+                decoders.append(decode_gray(wrap_mp4(samples, keyframes, fps=self.index.fps, codec=self.index.codec), self.profile.downscale))
+            # One frame per camera resident, and one decode cursor per camera: a
+            # camera that contributes no frame to this frameset still has its own
+            # frames decoded in order, because dropping one breaks the next.
+            decoded: list[UInt8[ndarray, "h w"] | None] = [None] * len(self.cameras)
+            cursor: list[int] = [int(self.index.frame_index[start, position]) - 1 for position in range(len(self.cameras))]
+            for frameset_index in range(start, stop):
+                images: list[UInt8[ndarray, "h w"]] = []
+                for position, (camera, decoder) in enumerate(zip(self.cameras, decoders, strict=True)):
+                    rig_camera: int = self.camera_positions[position]
+                    wanted: int = int(self.index.frame_index[frameset_index, position])
+                    while cursor[position] < wanted:
+                        image: UInt8[ndarray, "h w"] | None = next(decoder, None)
+                        if image is None:
+                            raise ValueError(f"{self.segment_id}: cam_{rig_camera:02d} ran out of frames at its frame {cursor[position] + 1}")
+                        decoded[position] = image
+                        cursor[position] += 1
+                    current: UInt8[ndarray, "h w"] | None = decoded[position]
+                    assert current is not None, f"cam_{rig_camera:02d} has no frame for frameset {frameset_index}"
+                    if current.shape != (camera.height, camera.width):
+                        raise ValueError(
+                            f"{self.segment_id}: cam_{rig_camera:02d} decoded {current.shape}, calibration says {(camera.height, camera.width)}"
+                        )
+                    images.append(current)
+                if frameset_index % self.frame_stride:
+                    continue
+                t_ns: int = int(self.frame_t_ns[frameset_index])
+                lead_index: int = int(np.searchsorted(window_imu.t_ns, t_ns, side="right"))
+                lead_ns: int = int(window_imu.t_ns[min(lead_index, len(window_imu) - 1)]) if len(window_imu) else t_ns
+                frame_imu: ImuStream = window_imu.between(emitted_imu_t_ns, max(lead_ns, t_ns))
+                if len(frame_imu):
+                    emitted_imu_t_ns = int(frame_imu.t_ns[-1])
+                yield Frameset(
+                    t_ns=t_ns,
+                    images=images,
+                    imu=frame_imu,
+                    ground_truth=_nearest_pose(window_gt, t_ns),
+                )
+
+    def _fetch_samples(self, position: int, start: int, stop: int) -> tuple[list[UInt8[ndarray, " n_sample_bytes"]], list[bool]]:
+        """Encoded samples and keyframe flags of one fed camera, over the framesets ``[start, stop)``.
+
+        The range is contiguous in that camera's own frames, from the frame the
+        first frameset takes to the frame the last one does, so the decoder gets
+        every frame the ones it must produce depend on.
+        """
+        camera_index: int = self.camera_positions[position]
+        camera_t_ns: Int64[ndarray, " n_frames"] = self.index.camera_t_ns[position]
+        first_frame: int = int(self.index.frame_index[start, position])
+        last_frame: int = int(self.index.frame_index[stop - 1, position])
+        entity: str = f"{RIG_ENTITY}/cam_{camera_index:02d}/pinhole/video"
+        first_ns: int = int(camera_t_ns[first_frame])
+        last_ns: int = int(camera_t_ns[last_frame])
+        table: pa.Table = (
+            self.dataset.filter_segments([self.segment_id])
+            .filter_contents(entity)
+            .reader(index=TIMELINE)
+            .select(TIMELINE, f"{entity}:VideoStream:sample", f"{entity}:VideoStream:is_keyframe")
+            .filter(col(TIMELINE).cast(pa.int64()).between(lit(first_ns), lit(last_ns)))
+            .to_arrow_table()
+        )
+        times: Int64[ndarray, " n_window"] = np.asarray(table[TIMELINE].combine_chunks().cast(pa.int64()))
+        if not np.array_equal(times, camera_t_ns[first_frame : last_frame + 1]):
+            raise ValueError(
+                f"{self.segment_id}: cam_{camera_index:02d} returned {len(times)} samples for its frames [{first_frame}, {last_frame}]"
+            )
+        # Arrow has no list<u8> -> binary cast, so slice the child buffer by the list
+        # offsets. large_list keeps 64-bit offsets: one camera of a multi-hour session
+        # exceeds the default int32's 2 GiB.
+        blobs: pa.LargeListArray = table[1].combine_chunks().cast(pa.list_(pa.large_list(pa.uint8()))).flatten()
+        data: UInt8[ndarray, " n_bytes"] = blobs.values.to_numpy(zero_copy_only=True)
+        offsets: Int64[ndarray, " n_offsets"] = blobs.offsets.to_numpy(zero_copy_only=True)
+        # Views into the column, not copies of it: `av.Packet` takes any buffer
+        # and copies into its own, so a `tobytes()` here would be a second copy
+        # of every encoded byte. The views keep `data` alive while they live.
+        samples: list[UInt8[ndarray, " n_sample_bytes"]] = [data[begin:end] for begin, end in zip(offsets[:-1], offsets[1:], strict=True)]
+        # is_keyframe is logged only on keyframes, so its validity is the flag.
+        keyframes: list[bool] = table[2].combine_chunks().is_valid().to_pylist()
+        return samples, keyframes
+
+
+def _window_bounds(index: _VideoIndex, window_ns: int) -> list[tuple[int, int]]:
+    """Cut the frame index into half-open ranges that each start on a shared keyframe."""
+    keyframe_indices: list[int] = [position for position in np.flatnonzero(index.keyframe).tolist() if position > 0]
+    bounds: list[tuple[int, int]] = []
+    start: int = 0
+    while start < len(index.t_ns):
+        deadline: int = int(index.t_ns[start]) + window_ns
+        stop: int = len(index.t_ns)
+        for candidate in keyframe_indices:
+            if candidate > start and int(index.t_ns[candidate]) >= deadline:
+                stop = candidate
+                break
+        bounds.append((start, stop))
+        start = stop
+    return bounds
+
+
+def _frame_nearest_anchor(times: Int64[ndarray, " n_frames"], cursor: int, anchor_t_ns: int, tolerance_ns: int) -> tuple[int | None, int]:
+    """The frame one camera contributes to one anchor, and where its cursor goes if the frameset falls.
+
+    The camera walks forward from ``cursor`` while the next frame is no farther
+    from the anchor than the current one — ties take the later frame, which is
+    basalt's ``<=`` (``dataset_io_robocap.cpp:422-426``) — and contributes that
+    frame if it sits within ``tolerance_ns`` (inclusive, ``:427``).
+
+    When it does not, the cursor moves only if that nearest frame is *earlier*
+    than the anchor (``:428``): such a frame is farther from every later anchor
+    still, so no anchor can ever take it, while a camera running ahead keeps its
+    frame for the next anchor. The returned cursor is therefore where this camera
+    stands once the frameset falls; a caller whose frameset stands ignores it and
+    moves the cursor past the frame it took (``selected + 1``, ``:439``).
+
+    Args:
+        times: The camera's frame timestamps, in time order.
+        cursor: The first frame no earlier frameset has consumed.
+        anchor_t_ns: Camera 0's frame timestamp.
+        tolerance_ns: How far a frame may sit from the anchor's and still join it.
+
+    Returns:
+        The frame this camera contributes, or ``None`` if it has none within the
+        tolerance, and the cursor this camera stands on if the frameset falls.
+    """
+    index: int = cursor
+    if index >= len(times):
+        return None, cursor
+    while index + 1 < len(times) and abs(int(times[index + 1]) - anchor_t_ns) <= abs(int(times[index]) - anchor_t_ns):
+        index += 1
+    if abs(int(times[index]) - anchor_t_ns) > tolerance_ns:
+        return None, (index + 1 if int(times[index]) < anchor_t_ns else cursor)
+    return index, cursor
+
+
+def match_framesets(camera_t_ns: Sequence[Int64[ndarray, " n_frames"]], tolerance_ns: int) -> tuple[Int64[ndarray, " n_framesets"], Int64[ndarray, "n_framesets n_cameras"]]:
+    """Group frames into framesets the way basalt's multi-camera reader does.
+
+    Camera 0 is the anchor. Every other camera advances to the frame nearest the
+    anchor's, and the frameset exists only if every camera has one within
+    ``tolerance_ns``. Its timestamp is the median of the frames in it, which for
+    an even number of cameras is the lower middle plus half the gap to the upper
+    one — the arithmetic is basalt's, and reproducing it exactly is what makes the
+    port's frameset times equal the C++'s to the nanosecond.
+
+    A frame joins one frameset only: a complete frameset moves every non-anchor
+    cursor past the frame it took (``selected + 1``,
+    ``dataset_io_robocap.cpp:439``). An incomplete one moves a cursor only where
+    that camera's nearest frame is *earlier* than the anchor and can therefore
+    never partner a later one; a camera running ahead keeps its frame for the
+    next anchor.
+
+    An incomplete frameset whose anchor lies inside every camera's own span is an
+    interior drop, and basalt allows one per thousand interior anchors before it
+    calls the run unusable.
+
+    Args:
+        camera_t_ns: Each fed camera's frame timestamps, in time order.
+        tolerance_ns: How far a frame may sit from the anchor's and still join it.
+
+    Returns:
+        The frameset timestamps, and the frame each camera contributes to each.
+
+    Raises:
+        ValueError: If no camera was given, a camera has no frames, the frameset
+            timestamps do not strictly increase, too many interior framesets are
+            incomplete, or no frameset is complete.
+    """
+    if not camera_t_ns:
+        raise ValueError("a frameset needs at least one camera")
+    for position, times in enumerate(camera_t_ns):
+        if times.size == 0:
+            raise ValueError(f"camera {position} has no frames, so it is not part of this recording")
+    # The span every camera covers: only an anchor inside it can be expected to
+    # have partners, so only a drop inside it counts against the run.
+    overlap_start: int = max(int(times[0]) for times in camera_t_ns)
+    overlap_end: int = min(int(times[-1]) for times in camera_t_ns)
+    cursors: list[int] = [0] * len(camera_t_ns)
+    t_ns: list[int] = []
+    rows: list[list[int]] = []
+    interior_anchors: int = 0
+    interior_drops: int = 0
+    for anchor_index, anchor_t_ns in enumerate(camera_t_ns[0].tolist()):
+        interior: bool = overlap_start <= anchor_t_ns <= overlap_end
+        interior_anchors += interior
+        row: list[int] = [anchor_index]
+        # Where each camera would land: basalt commits these to the cursors only
+        # once the whole frameset stands.
+        selected: list[int] = list(cursors)
+        for position in range(1, len(camera_t_ns)):
+            # The cursor this camera stands on if the frameset falls: a camera that
+            # fell behind can never catch this anchor again, one running ahead keeps
+            # its frame. On the frameset standing, that value is where it already was.
+            index, cursors[position] = _frame_nearest_anchor(camera_t_ns[position], cursors[position], anchor_t_ns, tolerance_ns)
+            if index is None:
+                break
+            selected[position] = index
+            row.append(index)
+        if len(row) != len(camera_t_ns):
+            interior_drops += interior
+            continue
+        for position in range(1, len(camera_t_ns)):
+            cursors[position] = selected[position] + 1
+        members: list[int] = sorted(int(camera_t_ns[position][frame]) for position, frame in enumerate(row))
+        middle: int = len(members) // 2
+        frameset_t_ns: int = members[middle] if len(members) % 2 else members[middle - 1] + (members[middle] - members[middle - 1]) // 2
+        if t_ns and frameset_t_ns <= t_ns[-1]:
+            raise ValueError(f"frameset timestamps are not strictly increasing: {frameset_t_ns} follows {t_ns[-1]}")
+        t_ns.append(frameset_t_ns)
+        rows.append(row)
+    # basalt's own allowance, in its own arithmetic: one in a thousand, at least one.
+    allowed_drops: int = max(1, math.ceil(interior_anchors * 0.001))
+    if interior_drops > allowed_drops:
+        raise ValueError(
+            f"{interior_drops} of {interior_anchors} interior framesets are incomplete, more than the {allowed_drops} "
+            f"basalt allows: the cameras are not one recording within {tolerance_ns} ns"
+        )
+    if not rows:
+        raise ValueError(f"no frameset has all {len(camera_t_ns)} cameras within {tolerance_ns} ns of camera 0")
+    return np.array(t_ns, dtype=np.int64), np.array(rows, dtype=np.int64)
+
+
+def _video_codec(table: pa.Table, entity: str) -> CatalogCodecName:
+    """The codec every sample of one camera's stream is in.
+
+    ``VideoStream:codec`` is logged once, as a static, so the value is row zero
+    of the non-null codecs — and a recording that carries neither the samples nor
+    the codec has to say which camera it was asked about rather than raise an
+    index error out of pyarrow.
+
+    Args:
+        table: The three columns ``_read_video_index`` selects: the timeline, ``is_keyframe``, ``codec``.
+        entity: The camera's video entity path, for the error.
+
+    Returns:
+        The codec name the sample wrapper needs.
+
+    Raises:
+        ValueError: If the stream has no samples or carries no codec.
+    """
+    if table.num_rows == 0:
+        raise ValueError(f"{entity}: the recording carries no video samples")
+    codecs: pa.Array = table[2].combine_chunks().drop_null().flatten()
+    if len(codecs) == 0:
+        raise ValueError(f"{entity}: the video stream carries no codec, so its samples cannot be decoded")
+    return catalog_codec_name(int(codecs[0].as_py()))
+
+
+def _shared_codec(per_camera: Sequence[tuple[int, CatalogCodecName]], segment_id: str) -> CatalogCodecName:
+    """The one codec every fed camera's stream is in.
+
+    :attr:`_VideoIndex.codec` names the codec :meth:`SegmentFeed._fetch_samples`
+    muxes *every* camera's samples under, so a rig whose cameras disagree cannot
+    be decoded from one index and has to name the two that differ rather than
+    silently decode three of four streams as the fourth.
+
+    Args:
+        per_camera: ``(camera_index, codec)`` in feed order, at least one entry.
+        segment_id: Segment the cameras belong to, for the error.
+
+    Returns:
+        The codec the sample wrapper needs.
+
+    Raises:
+        ValueError: If two fed cameras carry different codecs.
+    """
+    first_camera, codec = per_camera[0]
+    for camera_index, other in per_camera[1:]:
+        if other != codec:
+            raise ValueError(
+                f"{segment_id}: cam_{camera_index:02d} is {other} where cam_{first_camera:02d} is {codec}; "
+                f"one video index carries one codec for every camera"
+            )
+    return codec
+
+
+def _read_video_index(dataset: DatasetEntry, segment_id: str, camera_positions: Sequence[int], tolerance_ns: int) -> _VideoIndex:
+    """Frameset timing, per-camera frames, shared keyframes and codec, fetched without any sample bytes."""
+    per_camera_times: list[Int64[ndarray, " n_frames"]] = []
+    per_camera_keyframe: list[Bool[ndarray, " n_frames"]] = []
+    per_camera_codec: list[tuple[int, CatalogCodecName]] = []
+    for camera_index in camera_positions:
+        entity: str = f"{RIG_ENTITY}/cam_{camera_index:02d}/pinhole/video"
+        table: pa.Table = (
+            dataset.filter_segments([segment_id])
+            .filter_contents(entity)
+            .reader(index=TIMELINE)
+            .select(TIMELINE, f"{entity}:VideoStream:is_keyframe", f"{entity}:VideoStream:codec")
+            .to_arrow_table()
+        )
+        per_camera_times.append(np.asarray(table[TIMELINE].combine_chunks().cast(pa.int64())))
+        per_camera_keyframe.append(np.asarray(table[1].combine_chunks().is_valid().to_numpy(zero_copy_only=False), dtype=bool))
+        per_camera_codec.append((camera_index, _video_codec(table, entity)))
+    if not per_camera_codec:
+        raise ValueError(f"{segment_id}: no camera was selected, so no video columns were read")
+    codec: CatalogCodecName = _shared_codec(per_camera_codec, segment_id)
+    if tolerance_ns == 0:
+        # MSD is hardware-synced: a frameset is "all cameras at the same
+        # video_time", and the identity table is what a matcher would return.
+        for position, times in enumerate(per_camera_times[1:], start=1):
+            if not np.array_equal(times, per_camera_times[0]):
+                raise ValueError(
+                    f"{segment_id}: cam_{camera_positions[position]:02d} timestamps differ from cam_{camera_positions[0]:02d}; "
+                    f"this rig needs RigProfile.frameset_tolerance_ns"
+                )
+        frameset_t_ns: Int64[ndarray, " n_framesets"] = per_camera_times[0]
+        frame_index: Int64[ndarray, "n_framesets n_cameras"] = np.tile(
+            np.arange(len(frameset_t_ns), dtype=np.int64).reshape(-1, 1), (1, len(per_camera_times))
+        )
+    else:
+        frameset_t_ns, frame_index = match_framesets(per_camera_times, tolerance_ns)
+    if len(frameset_t_ns) < 2:
+        raise ValueError(f"{segment_id}: {len(frameset_t_ns)} framesets is not a segment")
+    keyframe: Bool[ndarray, " n_framesets"] = np.ones(len(frameset_t_ns), dtype=bool)
+    for position, flags in enumerate(per_camera_keyframe):
+        keyframe &= flags[frame_index[:, position]]
+    fps: int = max(1, round((len(frameset_t_ns) - 1) * 1e9 / float(frameset_t_ns[-1] - frameset_t_ns[0])))
+    return _VideoIndex(
+        t_ns=frameset_t_ns,
+        frame_index=frame_index,
+        camera_t_ns=tuple(per_camera_times),
+        keyframe=keyframe,
+        codec=codec,
+        fps=fps,
+    )
+
+
+def _nearest_pose(trajectory: Trajectory, t_ns: int, tolerance_ns: int = ASSOCIATION_TOLERANCE_NS) -> Float64[ndarray, " 7"] | None:
+    """The pose closest in time to ``t_ns`` as ``[tx, ty, tz, qw, qx, qy, qz]``, or None if none is close enough.
+
+    The tolerance is the gate's own association tolerance. Without it a frameset
+    outside the ground truth's span would silently receive a stale pose: on the
+    Index smoke segment the ground truth starts 17.5 ms after ``video_time`` zero,
+    so the very first frameset has no truth and must say so rather than borrow one.
+    """
+    if len(trajectory) == 0:
+        return None
+    nearest: int = int(np.abs(trajectory.t_ns - t_ns).argmin())
+    if abs(int(trajectory.t_ns[nearest]) - t_ns) > tolerance_ns:
+        return None
+    return np.concatenate([trajectory.position_m[nearest], trajectory.quaternion_wxyz[nearest]])
+
+
+def _read_imu(dataset: DatasetEntry, segment_id: str, interpolate_accel: bool, first_ns: int, last_ns: int) -> ImuStream:
+    """Gyroscope and accelerometer over one time window, on the gyroscope's clock.
+
+    ``video_time`` **is** the inertial clock, so nothing is shifted here; the
+    frames come to it (:attr:`SegmentFeed.frame_t_ns`).
+    """
+    table: pa.Table = (
+        dataset.filter_segments([segment_id])
+        .filter_contents([f"{IMU_ENTITY}/gyro", f"{IMU_ENTITY}/accel"])
+        .reader(index=TIMELINE)
+        .filter(col(TIMELINE).cast(pa.int64()).between(lit(first_ns), lit(last_ns)))
+        .to_arrow_table()
+    )
+    row_t_ns: Int64[ndarray, " n_rows"] = np.asarray(table[TIMELINE].combine_chunks().cast(pa.int64()))
+    order: Int64[ndarray, " n_rows"] = np.argsort(row_t_ns, kind="stable")
+    row_t_ns = row_t_ns[order]
+    streams: dict[str, tuple[Int64[ndarray, " n_samples"], Float64[ndarray, "n_samples 3"]]] = {}
+    for sensor in ("gyro", "accel"):
+        column: pa.Array = table[f"{IMU_ENTITY}/{sensor}:Scalars:scalars"].combine_chunks().take(pa.array(order))
+        valid: Bool[ndarray, " n_rows"] = column.is_valid().to_numpy(zero_copy_only=False)
+        values: Float64[ndarray, "n_samples 3"] = _flat_float(column).reshape(-1, 3)
+        streams[sensor] = (row_t_ns[valid], values)
+    gyro_t_ns: Int64[ndarray, " n_samples"] = streams["gyro"][0]
+    accel_t_ns: Int64[ndarray, " n_samples"] = streams["accel"][0]
+    if gyro_t_ns.size and not bool(np.all(np.diff(gyro_t_ns) > 0)):
+        raise ValueError(f"{segment_id}: IMU timestamps are not strictly increasing")
+    # MSD logs both sensors on identical timestamps, so pairing is an assertion.
+    # RoboCap's two channels run on their own clocks (10,745 gyro against 10,751
+    # accel on session 15), and basalt's reader interpolates the accelerometer
+    # onto the gyroscope's timestamps; the core only ever sees the paired form.
+    if not interpolate_accel:
+        if not np.array_equal(gyro_t_ns, accel_t_ns):
+            raise ValueError(
+                f"{segment_id}: {len(gyro_t_ns)} gyro and {len(accel_t_ns)} accel samples are not on identical timestamps; pair them before feeding"
+            )
+        return ImuStream(t_ns=gyro_t_ns, gyro_rad_s=streams["gyro"][1], accel_m_s2=streams["accel"][1])
+    return pair_accel_onto_gyro(gyro_t_ns, streams["gyro"][1], accel_t_ns, streams["accel"][1])
+
+
+def pair_accel_onto_gyro(
+    gyro_t_ns: Int64[ndarray, " n_gyro"],
+    gyro_rad_s: Float64[ndarray, "n_gyro 3"],
+    accel_t_ns: Int64[ndarray, " n_accel"],
+    accel_m_s2: Float64[ndarray, "n_accel 3"],
+) -> ImuStream:
+    """Linearly interpolate the accelerometer onto the gyroscope's timestamps.
+
+    A gyroscope sample outside the accelerometer's own span is dropped rather
+    than held at an endpoint: ``numpy.interp`` clamps, which would feed the
+    estimator a constant acceleration over a stretch it has no measurement for.
+    This is basalt's rule for RoboCap, whose file reader skips a gyroscope sample
+    that has no accelerometer sample on both sides of it.
+
+    Args:
+        gyro_t_ns: Gyroscope timestamps, strictly increasing.
+        gyro_rad_s: Angular velocity, rad/s.
+        accel_t_ns: Accelerometer timestamps, non-decreasing; a repeated one keeps its first sample.
+        accel_m_s2: Linear acceleration, m/s^2.
+
+    Returns:
+        One stream on the gyroscope's clock, covering only the overlap.
+
+    Raises:
+        ValueError: If a channel is too short to interpolate with, or the two
+            spans do not overlap, so the paired stream would be empty.
+    """
+    # basalt deduplicates both raw channels before it pairs them
+    # (`sort_and_deduplicate`, `dataset_io_robocap.cpp:472`), keeping the first
+    # sample of each equal-timestamp run. That is what its `interval == 0` guard
+    # reads as alpha 0, and it is the whole difference from `numpy.interp`, which
+    # takes the second of a duplicated pair and then interpolates the next
+    # gyroscope sample from the wrong end of the gap.
+    first_of_run: Bool[ndarray, " n_accel"] = np.ones(accel_t_ns.size, dtype=bool)
+    first_of_run[1:] = np.diff(accel_t_ns) != 0
+    accel_t_ns = accel_t_ns[first_of_run]
+    accel_m_s2 = accel_m_s2[first_of_run]
+    if gyro_t_ns.size == 0 or accel_t_ns.size < 2:
+        raise ValueError(
+            f"pairing needs a gyroscope sample and two accelerometer samples to interpolate between; "
+            f"got {gyro_t_ns.size} gyro and {accel_t_ns.size} accel samples"
+        )
+    inside: Bool[ndarray, " n_gyro"] = (gyro_t_ns >= accel_t_ns[0]) & (gyro_t_ns <= accel_t_ns[-1])
+    if not bool(inside.any()):
+        # basalt errors instead of handing the estimator an empty inertial stream
+        # (`dataset_io_robocap.cpp:496`); a rig with no IMU is not this rig.
+        raise ValueError(
+            f"the two inertial channels do not overlap, so nothing pairs: the gyroscope spans "
+            f"{int(gyro_t_ns[0])}..{int(gyro_t_ns[-1])} ns and the accelerometer {int(accel_t_ns[0])}..{int(accel_t_ns[-1])} ns"
+        )
+    paired_t_ns: Int64[ndarray, " n_paired"] = gyro_t_ns[inside]
+    interpolated: Float64[ndarray, "n_paired 3"] = np.column_stack(
+        [np.interp(paired_t_ns, accel_t_ns, accel_m_s2[:, axis]) for axis in range(accel_m_s2.shape[1])]
+    )
+    return ImuStream(t_ns=paired_t_ns, gyro_rad_s=gyro_rad_s[inside], accel_m_s2=interpolated)
+
+
+def _read_ground_truth(dataset: DatasetEntry, segment_id: str, first_ns: int, last_ns: int) -> Trajectory:
+    """Ground-truth rig poses over one window on ``video_time``, converted from Rerun's XYZW to w-first.
+
+    Empty when the layer carries no rig transform at all and when this window
+    holds no pose: the two are the same answer to "what is the truth here", and
+    the layer's own absence is :attr:`SegmentFeed.has_ground_truth`.
+    """
+    table: pa.Table = (
+        dataset.filter_segments([segment_id])
+        .filter_contents([RIG_ENTITY])
+        .reader(index=TIMELINE)
+        .filter(col(TIMELINE).cast(pa.int64()).between(lit(first_ns), lit(last_ns)))
+        .to_arrow_table()
+    )
+    return _rig_trajectory(table, segment_id)
+
+
+def _rig_trajectory(table: pa.Table, segment_id: str) -> Trajectory:
+    """One window of the ``gt`` layer's rig transforms as a trajectory, Rerun's XYZW converted to w-first.
+
+    Empty when the layer carries neither component and when the window holds no
+    pose at all.
+
+    Args:
+        table: The window's rows, one Rerun ``Transform3D`` per row.
+        segment_id: Which segment the rows came from, for the refusal below.
+
+    Returns:
+        The poses the window carries, on ``video_time``.
+
+    Raises:
+        ValueError: If the two components are not valid on the same rows. A pose
+            is one row's translation and that same row's rotation, and the two
+            components are read by dropping each column's own nulls — so two
+            masks with equal counts on different rows flatten to equal lengths
+            and every pose silently takes another row's rotation. Rerun stores
+            components independently and lets either one be logged or cleared
+            alone, so the layout is one a valid recording can hold; a refusal
+            naming the row is the only reading of it that cannot be wrong
+            (S25 review).
+    """
+    translation_column: str = f"{RIG_ENTITY}:Transform3D:translation"
+    quaternion_column: str = f"{RIG_ENTITY}:Transform3D:quaternion"
+    if translation_column not in table.column_names or quaternion_column not in table.column_names:
+        return empty_trajectory()
+    row_t_ns: Int64[ndarray, " n_rows"] = np.asarray(table[TIMELINE].combine_chunks().cast(pa.int64()))
+    translations: pa.Array = table[translation_column].combine_chunks()
+    quaternions: pa.Array = table[quaternion_column].combine_chunks()
+    valid: Bool[ndarray, " n_rows"] = translations.is_valid().to_numpy(zero_copy_only=False)
+    quaternion_valid: Bool[ndarray, " n_rows"] = quaternions.is_valid().to_numpy(zero_copy_only=False)
+    if not np.array_equal(valid, quaternion_valid):
+        disagreeing: Int64[ndarray, " n_disagreeing"] = np.flatnonzero(valid != quaternion_valid)
+        raise ValueError(
+            f"{segment_id}: {disagreeing.size} of {row_t_ns.size} rig rows carry a translation without a quaternion or "
+            f"a quaternion without a translation, the first at {int(row_t_ns[disagreeing[0]])} ns; a pose needs both, "
+            f"and reading each component off its own rows would give it another row's rotation"
+        )
+    # One mask for the timestamps and both components: each column's own null
+    # removal drops exactly `valid`'s false rows, because the two masks are
+    # equal by here.
+    position_m: Float64[ndarray, "n_poses 3"] = _flat_float(translations).reshape(-1, 3)
+    if position_m.shape[0] == 0:
+        return empty_trajectory()
+    quaternion_xyzw: Float64[ndarray, "n_poses 4"] = _flat_float(quaternions).reshape(-1, 4)
+    return Trajectory(
+        t_ns=row_t_ns[valid],
+        position_m=position_m,
+        quaternion_wxyz=np.column_stack([quaternion_xyzw[:, 3], quaternion_xyzw[:, 0:3]]),
+    )
+
+
+def select_cameras(statics: pa.Table, camera_count: int, camera_names: tuple[str, ...] | None) -> tuple[int, ...]:
+    """Rig indices of the named cameras, in the caller's order.
+
+    Names are read from each camera node's ``name`` static and compared with
+    hyphens normalised to underscores **on both sides**, because the rig writes
+    ``left-front`` where basalt's driver spells it ``left_front`` and a caller
+    may reasonably spell it either way.
+
+    Args:
+        statics: Single-row table holding every camera node's statics.
+        camera_count: Cameras the rig declares.
+        camera_names: Names to feed in order, or None for every camera in rig order.
+
+    Returns:
+        One rig index per fed camera.
+
+    Raises:
+        ValueError: If a name is asked for that the recording does not carry, or
+            two cameras answer to the same name.
+    """
+    if camera_names is None:
+        return tuple(range(camera_count))
+    by_name: dict[str, int] = {}
+    for position in range(camera_count):
+        name: str = _static_string(statics, f"{RIG_ENTITY}/cam_{position:02d}:name").replace("-", "_")
+        if name in by_name:
+            raise ValueError(f"cameras cam_{by_name[name]:02d} and cam_{position:02d} are both named {name!r}")
+        by_name[name] = position
+    wanted: tuple[str, ...] = tuple(name.replace("-", "_") for name in camera_names)
+    missing: list[str] = [name for name, key in zip(camera_names, wanted, strict=True) if key not in by_name]
+    if missing:
+        raise ValueError(f"the recording has no camera named {missing}; it carries {sorted(by_name)}")
+    return tuple(by_name[key] for key in wanted)
+
+
+def _build_feed(
+    sensor_dataset: DatasetEntry,
+    gt_dataset: DatasetEntry | None,
+    segment_id: str,
+    parameters: ImuParameters,
+    profile: RigProfile,
+    frame_stride: int,
+    window_s: float,
+) -> SegmentFeed:
+    """Read calibration, IMU, ground truth and frameset timing for one segment."""
+    if frame_stride < 1:
+        raise ValueError(f"frame_stride must be at least 1; got {frame_stride}")
+    rig_statics: pa.Table = sensor_dataset.filter_segments([segment_id]).filter_contents([RIG_ENTITY, IMU_ENTITY]).reader(index=None).to_arrow_table()
+    reference: str = _static_string(rig_statics, f"{RIG_ENTITY}:reference")
+    if reference != "imu_00":
+        raise ValueError(f"{segment_id}: rig reference is {reference!r}, but the feed assumes the IMU is the rig frame")
+    camera_count: int = int(_static_values(rig_statics, f"{RIG_ENTITY}:num_cameras")[0])
+    rig_entities: list[str] = [f"{RIG_ENTITY}/cam_{position:02d}" for position in range(camera_count)]
+    camera_statics: pa.Table = (
+        sensor_dataset.filter_segments([segment_id])
+        .filter_contents(rig_entities + [f"{entity}/pinhole" for entity in rig_entities])
+        .reader(index=None)
+        .to_arrow_table()
+    )
+    camera_positions: tuple[int, ...] = select_cameras(camera_statics, camera_count, profile.camera_names)
+    index: _VideoIndex = _read_video_index(sensor_dataset, segment_id, camera_positions, profile.frameset_tolerance_ns)
+    cameras: tuple[CameraCalib, ...] = tuple(
+        camera_calib(number, read_camera_statics(camera_statics, rig_entities[position]), profile.downscale)
+        for number, position in enumerate(camera_positions)
+    )
+    imu_T_body: Float64[ndarray, "4 4"] = np.eye(4, dtype=np.float64)
+    imu_T_body[:3, :3] = _static_values(rig_statics, f"{IMU_ENTITY}:Transform3D:mat3x3").reshape(3, 3, order="F")
+    imu_T_body[:3, 3] = _static_values(rig_statics, f"{IMU_ENTITY}:Transform3D:translation")
+    properties: pa.Table = (
+        sensor_dataset.filter_segments([segment_id]).filter_contents(["/__properties", "/__properties/**"]).reader(index=None).to_arrow_table()
+    )
+    capture_start_time_ns: int = _static_int(properties, "property:capture:start_time_ns")
+    return SegmentFeed(
+        segment_id=segment_id,
+        cameras=cameras,
+        imu=imu_calib(parameters, imu_T_body),
+        capture_start_time_ns=capture_start_time_ns,
+        export_offset_ns=0 if profile.video_time_is_absolute else capture_start_time_ns,
+        frame_t_ns=index.t_ns + parameters.cam_time_offset_ns,
+        camera_positions=camera_positions,
+        rig_cameras=camera_count,
+        profile=profile,
+        frame_stride=frame_stride,
+        dataset=sensor_dataset,
+        gt_dataset=gt_dataset,
+        index=index,
+        window_ns=int(window_s * 1e9),
+    )
+
+
+@contextmanager
+def open_segment(
+    source: SegmentSource,
+    parameters: ImuParameters,
+    profile: RigProfile = MSD_RIG,
+    frame_stride: int = 1,
+    window_s: float = DEFAULT_WINDOW_S,
+) -> Iterator[SegmentFeed]:
+    """Open one segment for reading, from local ``.rrd`` files or from a catalog server.
+
+    A local source is served by an in-process ``rr.server.Server`` on an ephemeral
+    port that shuts down when the context exits, so no catalog server is needed.
+    The base and ground-truth layers become two datasets there, because one
+    in-process dataset takes a single layer per segment.
+
+    Args:
+        source: Where the segment lives.
+        parameters: Frozen IMU parameters, normally from the reference manifest.
+        profile: How this rig has to be read; the default is what MSD is.
+        frame_stride: Yield every n-th frameset; every frame is still decoded.
+        window_s: Longest time window fetched in one round trip.
+
+    Yields:
+        The open feed.
+
+    Raises:
+        ValueError: If a local base ``.rrd`` does not hold exactly one segment.
+    """
+    if isinstance(source, LocalSegment):
+        datasets: dict[str, str | PathLike[str] | Sequence[str | PathLike[str]]] = {"base": [str(source.base_rrd)]}
+        if source.gt_rrd is not None:
+            datasets["gt"] = [str(source.gt_rrd)]
+        with rr.server.Server(datasets=datasets) as server:
+            client: CatalogClient = server.client()
+            base: DatasetEntry = client.get_dataset("base")
+            ground_truth: DatasetEntry | None = client.get_dataset("gt") if source.gt_rrd is not None else None
+            segment_ids: list[str] = list(base.segment_ids())
+            if len(segment_ids) != 1:
+                raise ValueError(f"{source.base_rrd} holds {len(segment_ids)} segments; the feed reads one")
+            yield _build_feed(base, ground_truth, segment_ids[0], parameters, profile, frame_stride, window_s)
+    else:
+        dataset: DatasetEntry = CatalogClient(source.url).get_dataset(source.dataset_name)
+        yield _build_feed(dataset, dataset, source.segment_id, parameters, profile, frame_stride, window_s)
+
+
+def read_rig_trajectory(rrd: Path) -> Trajectory:
+    """Every rig pose on one ``.rrd`` layer, on the ``video_time`` the layer stores.
+
+    The RoboCap ``slam`` layer is a trajectory and nothing else, on the same
+    ``video_time`` as the base layer it sits beside, so it is read the way the
+    ground-truth layer is. Moving it onto another clock is the caller's own step
+    (:func:`slam_rs.trajectory.shift_clock`) rather than a parameter here: reading
+    a layer and moving a clock are two things.
+
+    Args:
+        rrd: Layer holding the rig's ``Transform3D`` rows.
+
+    Returns:
+        The whole trajectory, oldest pose first.
+
+    Raises:
+        ValueError: If the file does not hold exactly one segment, or holds no rig poses.
+    """
+    with rr.server.Server(datasets={"layer": [str(rrd)]}) as server:
+        dataset: DatasetEntry = server.client().get_dataset("layer")
+        segment_ids: list[str] = list(dataset.segment_ids())
+        if len(segment_ids) != 1:
+            raise ValueError(f"{rrd} holds {len(segment_ids)} segments; a trajectory layer holds one")
+        found: Trajectory = _read_ground_truth(dataset, segment_ids[0], -(2**62), 2**62)
+    if len(found) == 0:
+        raise ValueError(f"{rrd} carries no {RIG_ENTITY} Transform3D rows")
+    return found

--- a/packages/slam-rs/slam_rs/frontend_log.py
+++ b/packages/slam-rs/slam_rs/frontend_log.py
@@ -1,0 +1,339 @@
+"""Rerun logging for the optical-flow frontend: keypoints, trails, occupancy and the C++ overlay.
+
+All Rerun logging is Python (D03), so the core returns arrays and this module
+decides what they look like. Everything is logged under the dataset's own entity
+tree — ``/world/rig_00/cam_MM/pinhole/...`` — so a frontend run and the recording
+it came from sit in one viewer without a second coordinate convention.
+
+The C++ overlay is what makes a parity claim visible rather than asserted: the
+basalt fork's ``tools/dump_flow.cpp`` dumped its own keypoints for the first eight
+framesets of the smoke segment, those dumps are committed next to the Rust flow
+gate, and this module draws them in one contrasting colour beside the port's own.
+Where the two agree the magenta sits under the coloured dot; where they disagree
+it stands alone.
+
+An overlay is only ever drawn on the segment it was recorded from. The dumps carry
+no segment of their own — ``dump_flow.cpp`` writes a frame index and a timestamp —
+so the fixture directory names it in :data:`SOURCE_FILE`, and the logger compares
+that name once, when it is built, with the segment id the replayed recording
+carries. Timestamps alone are not an association: the feed reports ``video_time``,
+which starts at zero on every segment, so the smoke segment's first-frame
+keypoints landed on the first frame of every other segment too and read as a
+parity claim about a recording the C++ never saw.
+"""
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import rerun as rr
+import rerun.blueprint as rrb
+from jaxtyping import Float32, Int32, Int64, UInt8, UInt64
+from numpy import ndarray
+
+from slam_rs import _core
+from slam_rs.catalog_feed import RIG_ENTITY, CameraCalib
+
+TRAIL_LENGTH: int = 10
+"""Positions kept per track for the trail behind it."""
+KEYPOINT_RADIUS_PX: float = 2.0
+"""Radius of a tracked keypoint, in image pixels."""
+CPP_RADIUS_PX: float = 3.5
+"""Radius of a C++ keypoint: larger, so the port's dot sits inside it when they agree."""
+CPP_COLOR: tuple[int, int, int] = (255, 0, 255)
+"""The one colour the C++ overlay is drawn in; nothing else in the view is magenta."""
+CELL_COLOR: tuple[int, int, int, int] = (70, 190, 255, 110)
+"""Occupied detection cells, drawn as translucent outlines."""
+DEFAULT_DUMPS_DIR: Path = Path(__file__).resolve().parents[1] / "crates/slam-rs/tests/fixtures/flow/dumps"
+"""The eight committed dumps the Rust flow gate runs off."""
+SOURCE_FILE: str = "source.json"
+"""Names the segment a dump directory was recorded from; its ``segment_id`` key is read."""
+STATS_ENTITY: str = "/stats/frontend"
+"""Where the per-frame counters go, off the dataset's own tree."""
+
+
+def camera_entity(index: int) -> str:
+    """The dataset's own path for one camera's image plane."""
+    return f"{RIG_ENTITY}/cam_{index:02d}/pinhole"
+
+
+_rising: UInt8[ndarray, " 255"] = np.arange(255, dtype=np.uint8)
+_falling: UInt8[ndarray, " 255"] = 255 - _rising
+_full: UInt8[ndarray, " 255"] = np.full(255, 255, dtype=np.uint8)
+_zero: UInt8[ndarray, " 255"] = np.zeros(255, dtype=np.uint8)
+HUE_RAMP: UInt8[ndarray, "1275 3"] = np.concatenate(
+    [
+        np.stack([_full, _rising, _zero], axis=1),
+        np.stack([_falling, _full, _zero], axis=1),
+        np.stack([_zero, _full, _rising], axis=1),
+        np.stack([_zero, _falling, _full], axis=1),
+        np.stack([_rising, _zero, _full], axis=1),
+    ]
+)
+"""Five of the hue circle's six 255-long ramps, red round to blue.
+
+The sixth ramp runs from magenta back to red and starts at exactly
+:data:`CPP_COLOR`, so a track drawn from it would read as the C++ overlay. Built
+once at import: the ramp is fixed, and it was rebuilt per camera per frameset.
+"""
+
+
+def track_colors(ids: Int64[ndarray, " n_tracks"]) -> UInt8[ndarray, "n_tracks 3"]:
+    """A stable, saturated colour per track id, from a 32-bit hash of the id.
+
+    Hue only, so every colour is equally readable over grey imagery, and two
+    neighbouring ids get unrelated hues — which is what makes an id swap visible
+    rather than a smooth gradient.
+
+    Args:
+        ids: Track ids.
+
+    Returns:
+        One ``uint8`` RGB triple per id, never :data:`CPP_COLOR`.
+    """
+    hashed: UInt64[ndarray, " n_tracks"] = (ids.astype(np.uint64) * np.uint64(2654435761)) % np.uint64(2**32)
+    return HUE_RAMP[hashed % np.uint64(len(HUE_RAMP))]
+
+
+def log_keypoints(frame: _core.FlowFrame) -> None:
+    """Draw one frameset's tracked keypoints on the camera images.
+
+    Two rungs draw this layer — the frontend's own and the estimator's, whose
+    frontend is the same code — so it is drawn once here: a keypoint then has the
+    same colour, the same radius and the same entity path in both recordings, and
+    the two views can be read side by side. What stays with the frontend rung is
+    its own evidence: the trails, the occupancy grid and the C++ overlay.
+
+    Args:
+        frame: What a frontend produced for one frameset.
+    """
+    for index in range(frame.camera_count):
+        ids: Int64[ndarray, " n_tracks"] = frame.ids(index)
+        rr.log(
+            f"{camera_entity(index)}/keypoints",
+            rr.Points2D(frame.positions(index), colors=track_colors(ids), radii=KEYPOINT_RADIUS_PX),
+        )
+
+
+def dumps_source(directory: Path | None = None) -> str:
+    """Which segment a directory of C++ dumps was recorded from.
+
+    The dumps are on the same ``video_time`` clock the feed reports, which starts
+    at zero on every segment, so the timestamp alone does not say which recording
+    a dump belongs to. :data:`SOURCE_FILE` in the directory does, and it is a
+    fact about the directory rather than about each dump in it.
+
+    Args:
+        directory: Where ``frame_XXX.json`` and :data:`SOURCE_FILE` live; the
+            committed fixtures by default.
+
+    Returns:
+        The segment the dumps came from, or the empty string when the directory
+        holds none.
+
+    Raises:
+        ValueError: The directory holds dumps but no :data:`SOURCE_FILE` naming
+            the segment they came from, so nothing could be associated with them.
+    """
+    source: Path = directory if directory is not None else DEFAULT_DUMPS_DIR
+    # A missing directory globs to nothing, which is what a directory holding no
+    # dumps is: the committed fixtures are the only ones that always exist.
+    frames: list[Path] = list(source.glob("frame_*.json"))
+    if not frames:
+        return ""
+    provenance: Path = source / SOURCE_FILE
+    if not provenance.is_file():
+        raise ValueError(
+            f"{source} holds {len(frames)} C++ dumps but no {SOURCE_FILE}; write one with a "
+            '"segment_id" key naming the segment they were dumped from, or the overlay would '
+            "be drawn over whatever segment happens to be replayed"
+        )
+    segment_id: object = json.loads(provenance.read_text()).get("segment_id")
+    if not isinstance(segment_id, str):
+        raise ValueError(f'{provenance} must carry a "segment_id" string naming the segment the dumps were dumped from')
+    return segment_id
+
+
+def read_cpp_dumps(camera_count: int, directory: Path | None = None) -> dict[int, list[Float32[ndarray, "n_keypoints 2"]]]:
+    """Read the basalt C++ frontend's own keypoints, by frameset ``t_ns``.
+
+    Called once :func:`dumps_source` has said the dumps are of the recording
+    being replayed, and not before: the rig check below is a fact about the
+    overlay that will be drawn, so dumps of another recording must not refuse a
+    replay they would draw nothing on.
+
+    Args:
+        camera_count: Cameras on the rig being replayed; every dump must carry
+            exactly that many, or one camera would keep a stale overlay.
+        directory: Where the ``frame_XXX.json`` live; the committed fixtures by default.
+
+    Returns:
+        One ``[x, y]`` array per camera, per frameset ``t_ns``; empty when the
+        directory holds no dumps.
+
+    Raises:
+        ValueError: A dump carries no timestamp, or another rig's cameras.
+    """
+    source: Path = directory if directory is not None else DEFAULT_DUMPS_DIR
+    dumps: dict[int, list[Float32[ndarray, "n_keypoints 2"]]] = {}
+    for path in sorted(source.glob("frame_*.json")):
+        dump: dict[str, object] = json.loads(path.read_text())
+        t_ns: object = dump.get("t_ns")
+        if not isinstance(t_ns, int):
+            raise ValueError(f'{path} must carry an integer "t_ns", the frameset time the keypoints were dumped at')
+        cameras: object = dump.get("cameras")
+        if not isinstance(cameras, list) or len(cameras) != camera_count:
+            raise ValueError(f"{path} holds {len(cameras) if isinstance(cameras, list) else 0} cameras, the rig being replayed has {camera_count}")
+        dumps[t_ns] = [
+            np.array([[keypoint["x"], keypoint["y"]] for keypoint in camera["keypoints"]], dtype=np.float32).reshape(-1, 2)
+            for camera in cameras
+        ]
+    return dumps
+
+
+@dataclass(slots=True)
+class FrontendLogger:
+    """Logs one frameset's frontend output, and carries the trail history between them."""
+
+    camera_count: int
+    """Cameras on the rig."""
+    source_segment: str
+    """Segment id the replayed recording carries; only dumps recorded from it are drawn."""
+    dumps_dir: Path | None = None
+    """Where the C++ dumps are read from; the committed fixtures by default."""
+    cpp_dumps: dict[int, list[Float32[ndarray, "n_keypoints 2"]]] = field(init=False)
+    """This recording's C++ keypoints by frameset ``t_ns``; empty when the dumps are another's."""
+    trails: list[dict[int, list[tuple[float, float]]]] = field(init=False)
+    """Per camera, the last :data:`TRAIL_LENGTH` positions of every live track."""
+    cpp_logged: bool = False
+    """Whether an overlay has been drawn, so it can be cleared once the dumps run out."""
+
+    def __post_init__(self) -> None:
+        """Associate the dumps with the recording once, and read their bodies only if they are of it."""
+        dumped_from: str = dumps_source(self.dumps_dir)
+        of_this_recording: bool = dumped_from == self.source_segment
+        if dumped_from != "" and not of_this_recording:
+            print(f"dumps are from {dumped_from}, replaying {self.source_segment}: no overlay")
+        # Only the dumps that will be drawn are read: their camera count is a
+        # fact about the overlay, so another recording's dumps would otherwise
+        # refuse the replay of a rig they say nothing about.
+        self.cpp_dumps = read_cpp_dumps(self.camera_count, self.dumps_dir) if of_this_recording else {}
+        self.trails = [{} for _ in range(self.camera_count)]
+
+    def log(self, frame: _core.FlowFrame, elapsed_ms: float) -> None:
+        """Log one frameset's keypoints, trails, occupancy and counters.
+
+        The caller has already set the timeline, so this writes at the current
+        cursor and nowhere else.
+
+        Args:
+            frame: What the frontend produced for this frameset.
+            elapsed_ms: Wall time the ``process`` call took.
+        """
+        log_keypoints(frame)
+        for index in range(self.camera_count):
+            ids: Int64[ndarray, " n_tracks"] = frame.ids(index)
+            positions: Float32[ndarray, "n_tracks 2"] = frame.positions(index)
+            colors: UInt8[ndarray, "n_tracks 3"] = track_colors(ids)
+            self._log_trails(index, ids, positions, colors)
+            self._log_cells(index, frame)
+            rr.log(f"{STATS_ENTITY}/cam_{index:02d}/num_tracks", rr.Scalars(float(frame.num_tracks(index))))
+            rr.log(f"{STATS_ENTITY}/cam_{index:02d}/num_new", rr.Scalars(float(frame.num_new(index))))
+        rr.log(f"{STATS_ENTITY}/frontend_ms", rr.Scalars(elapsed_ms))
+        self._log_cpp(frame.t_ns)
+
+    def _log_trails(
+        self,
+        index: int,
+        ids: Int64[ndarray, " n_tracks"],
+        positions: Float32[ndarray, "n_tracks 2"],
+        colors: UInt8[ndarray, "n_tracks 3"],
+    ) -> None:
+        """Extend every live track's trail by one position and log the strips."""
+        # Rebuilt from the live ids alone, so a track that dies takes its history
+        # with it and the dictionary cannot grow over a long segment.
+        history: dict[int, list[tuple[float, float]]] = self.trails[index]
+        updated: dict[int, list[tuple[float, float]]] = {}
+        strips: list[Float32[ndarray, "n_points 2"]] = []
+        strip_colors: list[UInt8[ndarray, " 3"]] = []
+        for slot, identifier in enumerate(ids.tolist()):
+            trail: list[tuple[float, float]] = history.get(identifier, [])[-(TRAIL_LENGTH - 1) :]
+            trail.append((float(positions[slot, 0]), float(positions[slot, 1])))
+            updated[identifier] = trail
+            if len(trail) > 1:
+                strips.append(np.array(trail, dtype=np.float32))
+                strip_colors.append(colors[slot])
+        self.trails[index] = updated
+        rr.log(f"{camera_entity(index)}/trails", rr.LineStrips2D(strips, colors=strip_colors, radii=1.0))
+
+    def _log_cells(self, index: int, frame: _core.FlowFrame) -> None:
+        """Draw the occupied detection cells over the image."""
+        occupancy: Int32[ndarray, "rows columns"] = frame.occupancy(index)
+        occupied: tuple[Int64[ndarray, " n_cells"], ...] = np.nonzero(occupancy)
+        rows: Int64[ndarray, " n_cells"] = occupied[0]
+        columns: Int64[ndarray, " n_cells"] = occupied[1]
+        cell: int = frame.cell_size
+        origin: tuple[int, int] = frame.cell_origin
+        mins: Float32[ndarray, "n_cells 2"] = np.stack([origin[0] + columns * cell, origin[1] + rows * cell], axis=1).astype(np.float32)
+        rr.log(
+            f"{camera_entity(index)}/cells",
+            rr.Boxes2D(mins=mins, sizes=np.full_like(mins, float(cell)), colors=CELL_COLOR),
+        )
+
+    def _log_cpp(self, t_ns: int) -> None:
+        """Draw the C++ frontend's own keypoints for this frameset, if it dumped any.
+
+        Only this recording's dumps are here: another's were never read, however
+        well the two clocks line up.
+        """
+        dump: list[Float32[ndarray, "n_keypoints 2"]] | None = self.cpp_dumps.get(t_ns)
+        if dump is None:
+            # Latest-at would keep the last overlay on screen for the rest of the
+            # segment, which reads as a parity claim about framesets that have no
+            # dump at all; one empty batch ends it.
+            if self.cpp_logged:
+                for index in range(self.camera_count):
+                    rr.log(f"{camera_entity(index)}/keypoints_cpp", rr.Points2D(np.zeros((0, 2), dtype=np.float32)))
+                self.cpp_logged = False
+            return
+        for index in range(self.camera_count):
+            rr.log(
+                f"{camera_entity(index)}/keypoints_cpp",
+                rr.Points2D(dump[index], colors=CPP_COLOR, radii=CPP_RADIUS_PX),
+            )
+        self.cpp_logged = True
+
+
+def camera_views(cameras: tuple[CameraCalib, ...]) -> list[rrb.View]:
+    """One 2D view per camera, named and origined on the camera's own entity.
+
+    The panel layout of a camera is a convention both rungs share, so both
+    blueprints build their views here.
+
+    Args:
+        cameras: The rig's cameras, in rig order.
+
+    Returns:
+        The views, in the same order.
+    """
+    return [rrb.Spatial2DView(origin=camera_entity(camera.index), name=f"cam {camera.index:02d}") for camera in cameras]
+
+
+def frontend_blueprint(cameras: tuple[CameraCalib, ...]) -> rrb.Blueprint:
+    """One 2D view per camera over the images, keypoints, trails and overlay, plus the counters.
+
+    Args:
+        cameras: The rig's cameras, in rig order.
+
+    Returns:
+        A blueprint with the panels collapsed, so the frame is all content.
+    """
+    return rrb.Blueprint(
+        rrb.Vertical(
+            rrb.Horizontal(*camera_views(cameras)),
+            rrb.TimeSeriesView(origin=STATS_ENTITY, name="frontend"),
+            row_shares=[3, 1],
+        ),
+        collapse_panels=True,
+    )

--- a/packages/slam-rs/slam_rs/tracking.py
+++ b/packages/slam-rs/slam_rs/tracking.py
@@ -1,0 +1,205 @@
+"""Driving the estimator over a frameset feed in lockstep, with the D17 hold.
+
+Offline mode consumes one frameset at a time in the calling thread, and a
+frameset the estimator refuses for want of inertial samples is **held, not
+dropped** (D17). That rule is the contract, not a detail of one caller: the
+replay tool draws a Rerun rung from what tracked and the V2 gate asserts numbers
+on it, and both have to hold and retry identically or the gate stops measuring
+the tool. It therefore lives here once, and :class:`Lockstep` is what both
+drive.
+
+:func:`_drive` is the loop over that hold with nothing logged — the one the C++
+reference timed — and it is here for the same reason: the V2 gate reads its
+numbers and :mod:`slam_rs.apis.fleet_check` reports them from another machine, so
+the two must feed the estimator identically or they are measuring different runs.
+:func:`run_segment` drives it over an MSD clip and :func:`run_robocap` over a
+RoboCap session, and the second exists because the fleet has to replay a
+four-camera fisheye rig on a device with no viewer and no repository.
+"""
+
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+
+import numpy as np
+from jaxtyping import Float64
+from numpy import ndarray
+
+from slam_rs import _core
+from slam_rs.catalog_feed import Frameset, LocalSegment, SegmentFeed, open_segment
+from slam_rs.reference import ReferenceManifest, ReferenceSegment, flow_config
+from slam_rs.trajectory import Trajectory, shift_clock
+
+MAX_HELD_FRAMESETS: int = 2
+"""Most framesets the hold may ever carry: one refused, plus the one whose samples unblock it."""
+
+
+@dataclass(slots=True)
+class Lockstep:
+    """One estimator, driven frameset by frameset, holding a refused frameset.
+
+    Everything a driver needs to report afterwards is on this value: what was
+    pushed, what tracked and how long it took, how many retries it cost, and
+    what is still held. The tracked count is ``len(elapsed_ms)``: the same branch
+    that times a ``track`` call is the one that accepts its pose.
+    """
+
+    vio: _core.Vio
+    """The estimator every frameset and every inertial sample goes through."""
+    pending: list[Frameset] = field(default_factory=list)
+    """Framesets refused for want of IMU, oldest first, waiting for the samples that cover them."""
+    imu_samples: int = 0
+    """Inertial samples pushed so far."""
+    retries: int = 0
+    """How many framesets were refused for want of IMU, and so had to be tracked a second time."""
+    elapsed_ms: list[float] = field(default_factory=list)
+    """Wall time each ``track`` call that tracked took, in the order they tracked."""
+
+    def push(self, frameset: Frameset) -> Iterator[tuple[Frameset, _core.VioResult]]:
+        """Push the frameset's inertial samples, then yield everything they now cover.
+
+        A frameset the estimator refuses is **held, not dropped** (D17): the next
+        frameset's batch runs one sample past its own frame time and therefore
+        past this one's, so the held frameset tracks then — and before the
+        frameset whose samples unblocked it, because time order is the
+        trajectory. Nothing moved on the refusal, so the retry produces the pose
+        a run that had the samples all along would have produced.
+
+        Args:
+            frameset: The frameset to track, with the samples since the previous one.
+
+        Yields:
+            Each frameset that tracked and what ``track`` returned for it, in
+            trajectory order. A refused frameset yields nothing until its samples
+            arrive.
+
+        Raises:
+            ValueError: If the hold ever carries more than
+                :data:`MAX_HELD_FRAMESETS` framesets, which the feed's one-sample
+                lead makes impossible.
+        """
+        if len(frameset.imu):
+            # The feed already hands over the samples since the previous frameset,
+            # running one past this frame time: a backend that integrates up to the
+            # frame and blocks until it can deadlocks on the first frameset otherwise.
+            self.vio.push_imu_batch(
+                frameset.imu.t_ns,
+                np.ascontiguousarray(frameset.imu.gyro_rad_s),
+                np.ascontiguousarray(frameset.imu.accel_m_s2),
+            )
+            self.imu_samples += len(frameset.imu)
+        self.pending.append(frameset)
+        if len(self.pending) > MAX_HELD_FRAMESETS:
+            # Every batch runs one sample past its own frame time and therefore
+            # past the previous frameset's, so a second refusal in a row cannot
+            # happen; a deeper hold would silently retain whole decoded framesets
+            # (~1.8 MB each) until the end of the segment.
+            raise ValueError(
+                f"frameset {frameset.t_ns} takes the hold to {len(self.pending)} framesets, past the {MAX_HELD_FRAMESETS} "
+                f"the feed's one-sample lead allows; held {[held.t_ns for held in self.pending]}"
+            )
+        while self.pending:
+            held: Frameset = self.pending[0]
+            started: float = time.monotonic()
+            result: _core.VioResult = self.vio.track(held.t_ns, held.images)
+            elapsed_ms: float = 1e3 * (time.monotonic() - started)
+            if result.status != _core.VioStatus.Tracking:
+                self.retries += 1
+                return
+            self.pending.pop(0)
+            self.elapsed_ms.append(elapsed_ms)
+            yield held, result
+
+
+@dataclass(slots=True, frozen=True)
+class SegmentRun:
+    """What one clip through the whole pipeline produced, on the absolute device clock."""
+
+    estimate: Trajectory
+    """Every pose the estimator reported, in frameset order."""
+    framesets: int
+    """Framesets replayed."""
+    lost: int
+    """Framesets that never produced a pose: the estimator was still waiting for
+    inertial samples covering them when the clip ended."""
+    wall_s: float
+    """Wall time the feed loop took: decode plus ``track``, nothing logged."""
+
+
+def _drive(feed: SegmentFeed, lockstep: Lockstep, stop_ns: int | None = None, max_framesets: int | None = None) -> SegmentRun:
+    """Feed one open segment through the estimator with nothing logged, and time it.
+
+    This is the loop the C++ reference timed, so the wall starts with the first
+    frameset and not with opening the segment, and nothing between the two calls
+    logs, encodes or draws. The poses come back on the absolute device clock the
+    **feed** names: ``video_time`` plus ``capture_start_time_ns`` on MSD, and
+    ``video_time`` unchanged on a rig that records the device clock itself.
+
+    Args:
+        feed: An open segment, already configured for its rig.
+        lockstep: The estimator to drive, already built from that rig's calibration and config.
+        stop_ns: Stop before a frameset past this feed timestamp; None replays the segment.
+        max_framesets: Stop after this many framesets; None replays the segment.
+
+    Returns:
+        The estimated trajectory, the two counts the gate reads, and the wall time.
+    """
+    t_ns: list[int] = []
+    positions: list[Float64[ndarray, " 3"]] = []
+    quaternions: list[Float64[ndarray, " 4"]] = []
+    replayed: int = 0
+    # A count is asked of the feed as a time, or it fetches a window nothing here
+    # reads. The in-loop breaks still make the cut, because the feed yields to
+    # the end of the window that covers `stop_ns`.
+    counted_ns: int | None = feed.stop_ns_after(max_framesets)
+    if counted_ns is not None:
+        stop_ns = counted_ns if stop_ns is None else min(stop_ns, counted_ns)
+    started: float = time.monotonic()
+    for frameset in feed.framesets(stop_ns):
+        if max_framesets is not None and replayed >= max_framesets:
+            break
+        if stop_ns is not None and frameset.t_ns > stop_ns:
+            break
+        replayed += 1
+        for _tracked, result in lockstep.push(frameset):
+            pose: Float64[ndarray, " 7"] = result.world_from_rig
+            t_ns.append(result.t_ns)
+            # The slice is a view onto a 7-float buffer the estimator would
+            # otherwise keep alive per pose, so it is copied; `np.roll` already
+            # returns a new array, so the second copy would be a second one.
+            positions.append(pose[0:3].copy())
+            quaternions.append(np.roll(pose[3:7], 1))
+    wall_s: float = time.monotonic() - started
+    estimate: Trajectory = Trajectory(
+        t_ns=np.array(t_ns, dtype=np.int64),
+        position_m=np.array(positions, dtype=np.float64).reshape(-1, 3),
+        quaternion_wxyz=np.array(quaternions, dtype=np.float64).reshape(-1, 4),
+    )
+    # Whatever is still held never got samples covering it, so it produced no
+    # pose: that, and only that, is a lost frameset.
+    return SegmentRun(estimate=shift_clock(estimate, feed.export_offset_ns), framesets=replayed, lost=len(lockstep.pending), wall_s=wall_s)
+
+
+def run_segment(
+    manifest: ReferenceManifest,
+    segment: ReferenceSegment,
+    window_s: float | None = None,
+    max_framesets: int | None = None,
+) -> SegmentRun:
+    """Drive one MSD reference clip through :class:`slam_rs._core.Vio`.
+
+    Args:
+        manifest: The reference set, which resolves the dataset's basalt config.
+        segment: Manifest entry naming the layers, the IMU model and the device's
+            image safe radius.
+        window_s: Stop after this many seconds of the clip; None replays it whole.
+        max_framesets: Stop after this many framesets; None replays the clip.
+
+    Returns:
+        What :func:`_drive` produced over that clip.
+    """
+    source: LocalSegment = LocalSegment(base_rrd=segment.base_path, gt_rrd=segment.gt_path)
+    feed: SegmentFeed
+    with open_segment(source, segment.imu) as feed:
+        lockstep: Lockstep = Lockstep(vio=_core.Vio(_core.Calibration.from_catalog(feed.cameras, feed.imu), flow_config(manifest, segment)))
+        return _drive(feed, lockstep, None if window_s is None else int(window_s * 1e9), max_framesets)

--- a/packages/slam-rs/slam_rs/vio_log.py
+++ b/packages/slam-rs/slam_rs/vio_log.py
@@ -1,0 +1,743 @@
+"""Rerun logging for the estimator: the input rung, three trajectories, the keyframe window, the landmarks and the counters.
+
+All Rerun logging is Python (D03), so the core returns arrays and this module
+decides what they look like. It holds the whole drawn account of a replay — the
+rig's static geometry, the frames and the inertial samples the estimator is fed
+(:func:`log_frameset_inputs`), the drive that tracks them (:class:`VioStage`)
+and what the estimator decided — so the two tools that replay a segment draw one
+rung rather than two copies of one, and ``apis/`` is CLIs over it. The estimate is logged under ``/world/runs/slam_rs``,
+beside the dataset's own ``/world/runs/gt``, and the basalt C++ reference under
+``/world/runs/basalt_cpp``: the three trajectories are then one 3D view with
+three colours, and the viewer's own entity tree says which is which.
+
+The comparison is the point of the rung. Ground truth and the C++ trajectory are
+both known before the replay starts, so they are drawn **up to the cursor** just
+as the estimate is: at any time in the timeline the three lines have seen exactly
+the same interval, which is what makes a divergence readable rather than a matter
+of where the eye starts. Each frameset logs the one segment its line gained, and
+:func:`vio_blueprint` gives the three ``trajectory`` entities a visible time
+range running from the start of the recording to the cursor, which is what turns
+those segments back into the path so far — Rerun's default for a view that is
+not a time series is latest-at, under which a two-point strip renders alone. The
+rung is then linear in the frameset count, where re-logging each whole strip was
+quadratic: the ground truth alone cost 17.20 MB of the smoke recording's 54.13 MB
+of rows, and a 4,000-frameset segment paid about 100 MB a line.
+
+The two references are still thinned to the frameset cadence
+(:func:`at_frameset_cadence`), which is also what makes a segment a segment: the
+ground truth runs at 917 Hz against 54 Hz of framesets, so an unthinned line
+costs 17x the estimate's rows to draw what no viewer can resolve.
+:meth:`VioLogger.log_complete_paths` puts each whole path in once, static, at the
+end of a replay, so a viewer that opens the file anywhere still sees where each
+run went.
+
+The three do not start in one frame. basalt initialises its world at the identity
+with gravity along z, while the ground truth is in the capture rig's own frame,
+so an unaligned overlay puts the estimate metres away from the truth it is being
+compared with. The run and the C++ reference therefore carry a
+:class:`rerun.Transform3D` — the rigid alignment onto the ground truth, the same
+one the ATE reports — and everything under them (the trajectory, the rig, the
+window and the landmarks) is logged in the estimator's own frame and drawn in the
+dataset's. The alignment is refreshed every :data:`ATE_EVERY` framesets and is
+the identity until enough poses have been associated, so the run visibly settles
+into place over the first second.
+
+The keyframe window is drawn as frustum wireframes rather than
+:class:`rerun.Pinhole` frusta: a ``Pinhole`` carries no colour, and colour is how
+a keyframe, a demoted pose block and the frames the last marginalization removed
+are told apart. The estimated rig's own cameras are real ``Pinhole`` frusta,
+because there the camera is what is being drawn.
+"""
+
+from dataclasses import dataclass, field
+from typing import Literal, TypeAlias
+
+import numpy as np
+import rerun as rr
+import rerun.blueprint as rrb
+from jaxtyping import Float64, Int64, UInt8
+from numpy import ndarray
+from scipy.spatial.transform import Rotation
+from simplecv.ops.umeyama import SimilarityTransform
+
+from slam_rs import _core
+from slam_rs.catalog_feed import IMU_ENTITY, RIG_ENTITY, TIMELINE, CameraCalib, Frameset, ImuStream, SegmentFeed
+from slam_rs.frontend_log import camera_entity, camera_views, log_keypoints, track_colors
+from slam_rs.tracking import Lockstep
+from slam_rs.trajectory import MIN_ASSOCIATED_POSES, Association, AteResult, Trajectory, associate, ate, rigid_alignment
+
+FrameMode: TypeAlias = Literal["downscaled", "jpeg", "off"]
+"""How a replay's input rung draws the frames it was fed.
+
+``downscaled`` is half resolution and uncompressed, which is enough to see what
+a segment is; ``jpeg`` is full resolution, which is what a stage that tracks
+needs, because its keypoints are in the pixels of the frame it tracked and not
+of a downscaled copy; ``off`` logs no image at all, which is how a tool measures
+the estimator without paying for the encode.
+"""
+IMAGE_DOWNSCALE: int = 2
+"""Divisor of the ``downscaled`` mode: the viewer does not need full-resolution pixels to show what was fed."""
+JPEG_QUALITY: int = 85
+"""Quality of the full-resolution frames the tracking stages log; 960x960 grayscale lands around 38 kB."""
+
+RUN_ENTITY: str = "/world/runs/slam_rs"
+"""Where this run's estimate goes, beside the dataset's own ``/world/runs/gt``."""
+GT_ENTITY: str = "/world/runs/gt"
+"""The dataset's own ground-truth run, which the base recording already names."""
+CPP_ENTITY: str = "/world/runs/basalt_cpp"
+"""The basalt C++ reference trajectory for the same segment."""
+VIO_STATS_ENTITY: str = "/stats/vio"
+"""Where the per-frame counters go, off the dataset's own tree and beside the frontend's.
+
+Named for the rung it belongs to, not for what it is: this module already imports
+three names from :mod:`slam_rs.frontend_log`, which has its own ``STATS_ENTITY``
+and its own ``CPP_COLOR`` with different values, and one unqualified import of
+either would have been silently wrong.
+"""
+
+ESTIMATE_COLOR: tuple[int, int, int] = (70, 220, 130)
+"""The port's own trajectory: green."""
+GT_COLOR: tuple[int, int, int] = (235, 235, 235)
+"""Ground truth: near-white, the reference every error is measured against."""
+CPP_TRAJECTORY_COLOR: tuple[int, int, int] = (255, 150, 40)
+"""The basalt C++ trajectory: orange, and not the frontend rung's magenta ``CPP_COLOR``."""
+KEYFRAME_COLOR: tuple[int, int, int, int] = (90, 200, 255, 255)
+"""A keyframe still inside the window."""
+LTKF_COLOR: tuple[int, int, int, int] = (255, 235, 90, 255)
+"""A long-term keyframe, which the pose budget never evicts."""
+POSE_COLOR: tuple[int, int, int, int] = (150, 150, 165, 200)
+"""A window frame that is not a keyframe: a state awaiting its vote, or a demoted pose block."""
+MARGINALIZED_COLOR: tuple[int, int, int, int] = (255, 90, 90, 70)
+"""A frame the last marginalization removed: the same wireframe, faded out."""
+
+FRUSTUM_DEPTH_M: float = 0.08
+"""How far a window frame's wireframe extends, metres. An orientation marker, not a claim about range."""
+IMAGE_PLANE_M: float = 0.1
+"""How far a rig camera's ``Pinhole`` frustum extends, metres: Rerun's default grows with the scene, so they changed size as landmarks came in."""
+ATE_EVERY: int = 30
+"""Framesets between two ATE-so-far points: about one a second, and each costs a rigid alignment."""
+ROUTE_ALPHA: int = 40
+"""How opaque a whole path is (:meth:`VioLogger.log_complete_paths`) beside the trail drawn up to the cursor."""
+ROUTE_RADIUS_M: float = 0.0015
+"""How thick a whole path is, metres: under half the trail's, so the two read as one line and its ghost."""
+
+IDENTITY: SimilarityTransform = SimilarityTransform(dst_R_src=np.eye(3), dst_t_src=np.zeros(3), scale=1.0)
+"""The alignment a run carries before enough of it has been associated with the ground truth."""
+
+
+def alignment_onto(source: Trajectory, target: Trajectory) -> SimilarityTransform:
+    """The rigid transform taking one trajectory into another's frame.
+
+    The association is driven by ``source`` — each of its poses takes the nearest
+    ``target`` pose within the tolerance — which is the convention the reference
+    manifest's own numbers were produced with.
+
+    Args:
+        source: Trajectory to move, e.g. the estimate.
+        target: Trajectory whose frame to move it into, e.g. the ground truth.
+
+    Returns:
+        The alignment, or the identity when too few poses associate for one to
+        mean anything.
+    """
+    if len(source) == 0 or len(target) == 0:
+        return IDENTITY
+    association: Association = associate(source, target)
+    if association.count < MIN_ASSOCIATED_POSES:
+        return IDENTITY
+    return rigid_alignment(
+        source.position_m[association.matched],
+        target.position_m[association.candidate_index[association.matched]],
+    )
+
+
+def at_frameset_cadence(trajectory: Trajectory, frame_t_ns: Int64[ndarray, " n_frames"]) -> Trajectory:
+    """Thin a reference to one pose per frameset: the last one at or before each frame time.
+
+    Only what is **drawn** is thinned. The ATE and the alignment are computed
+    against the whole reference, because there the truth's own density is the
+    thing being measured against; a line drawn one segment a frameset can only
+    move by one pose a frameset, so the poses between them would never be drawn
+    at all.
+
+    Args:
+        trajectory: The reference to thin; an empty one comes back unchanged.
+        frame_t_ns: The segment's frameset times, ascending.
+
+    Returns:
+        The reference's poses at the frameset cadence, in time order.
+    """
+    if len(trajectory) == 0:
+        return trajectory
+    latest: Int64[ndarray, " n_frames"] = np.searchsorted(trajectory.t_ns, frame_t_ns, side="right") - 1
+    keep: Int64[ndarray, " n_kept"] = np.unique(latest[latest >= 0])
+    return Trajectory(
+        t_ns=trajectory.t_ns[keep],
+        position_m=trajectory.position_m[keep],
+        quaternion_wxyz=trajectory.quaternion_wxyz[keep],
+    )
+
+
+def inverted(alignment: SimilarityTransform) -> SimilarityTransform:
+    """The rigid alignment the other way round.
+
+    :func:`slam_rs.trajectory.ate` solves the reference onto the estimate, which
+    is the direction its residuals are measured in; a run's subtree is drawn in
+    the reference's frame, which is this direction. Rigid only — the scale is
+    fixed at one, so the inverse is the transposed rotation.
+
+    Args:
+        alignment: A rigid alignment, ``scale == 1``.
+
+    Returns:
+        The alignment mapping the destination frame back into the source's.
+    """
+    return SimilarityTransform(
+        dst_R_src=alignment.dst_R_src.T,
+        dst_t_src=-alignment.dst_R_src.T @ alignment.dst_t_src,
+        scale=1.0,
+    )
+
+
+def log_alignment(entity: str, alignment: SimilarityTransform) -> None:
+    """Place one run's whole subtree in the frame its alignment maps into."""
+    rr.log(entity, rr.Transform3D(translation=alignment.dst_t_src, mat3x3=alignment.dst_R_src))
+
+
+def frustum_strip(camera: CameraCalib, depth_m: float = FRUSTUM_DEPTH_M) -> Float64[ndarray, "10 3"]:
+    """One camera's frustum wireframe in rig coordinates, as a single line strip.
+
+    Ten points: the four image-plane corners closed into a rectangle, then the
+    four rays back to the apex. Tracing it as one strip repeats the corner-to-corner
+    edge once, which is invisible and cheaper than eight separate segments.
+
+    The corners are the pinhole rays through the calibrated intrinsics. On a
+    fisheye that under-states the real field of view — the wireframe says where
+    the camera is and where it looks, not what it can see.
+
+    Args:
+        camera: The camera to draw, with its ``imu_T_cam``.
+        depth_m: How far the wireframe extends along the optical axis.
+
+    Returns:
+        Ten points in the rig (IMU) frame, in strip order.
+    """
+    corners_px: Float64[ndarray, "4 2"] = np.array(
+        [[0.0, 0.0], [camera.width, 0.0], [camera.width, camera.height], [0.0, camera.height]], dtype=np.float64
+    )
+    corners_cam: Float64[ndarray, "4 3"] = depth_m * np.column_stack(
+        [(corners_px[:, 0] - camera.cx) / camera.fx, (corners_px[:, 1] - camera.cy) / camera.fy, np.ones(4)]
+    )
+    apex: Float64[ndarray, " 3"] = np.zeros(3)
+    strip_cam: Float64[ndarray, "10 3"] = np.array(
+        [corners_cam[0], corners_cam[1], corners_cam[2], corners_cam[3], corners_cam[0], apex, corners_cam[1], corners_cam[2], apex, corners_cam[3]]
+    )
+    return strip_cam @ camera.imu_T_cam[:3, :3].T + camera.imu_T_cam[:3, 3]
+
+
+def log_rig(cameras: tuple[CameraCalib, ...], entity_prefix: str, pinhole_child: str = "") -> None:
+    """Log a rig's static camera geometry, so whatever moves it draws as frusta.
+
+    Two rigs are drawn from the same calibration and this is the one place that
+    spells it: the dataset's own under ``/world/rig_00``, whose ``Pinhole`` sits
+    on the ``pinhole`` child the images and keypoints hang under, and the
+    estimated run's own copy under its run entity — without which the estimate
+    and the ground truth would move the same frusta.
+
+    Args:
+        cameras: The rig's cameras, in rig order.
+        entity_prefix: What ``cam_MM`` hangs under.
+        pinhole_child: Child entity the ``Pinhole`` goes on; empty puts it on the
+            camera itself, which is what a rig with no images wants.
+    """
+    for camera in cameras:
+        node: str = f"{entity_prefix}/cam_{camera.index:02d}"
+        rr.log(
+            node,
+            rr.Transform3D(translation=camera.imu_T_cam[:3, 3], mat3x3=camera.imu_T_cam[:3, :3]),
+            static=True,
+        )
+        image_from_camera: Float64[ndarray, "3 3"] = np.array(
+            [[camera.fx, 0.0, camera.cx], [0.0, camera.fy, camera.cy], [0.0, 0.0, 1.0]], dtype=np.float64
+        )
+        rr.log(
+            f"{node}{pinhole_child}",
+            rr.Pinhole(
+                image_from_camera=image_from_camera,
+                resolution=[camera.width, camera.height],
+                camera_xyz=rr.ViewCoordinates.RDF,
+                image_plane_distance=IMAGE_PLANE_M,
+            ),
+            static=True,
+        )
+
+
+@dataclass(slots=True)
+class VioLogger:
+    """Logs one frameset's estimator output, and carries the paths between them.
+
+    The two reference trajectories are handed over whole, on the same
+    ``video_time`` clock the replay logs on; the estimate accumulates as it is
+    produced. Every ``log`` call writes at the caller's time cursor and nowhere
+    else.
+    """
+
+    cameras: tuple[CameraCalib, ...]
+    """The rig's cameras, in rig order."""
+    ground_truth: Trajectory
+    """Ground truth for the whole segment, on ``video_time``; may be empty."""
+    cpp: Trajectory
+    """The basalt C++ trajectory for the whole segment, on ``video_time``; may be empty."""
+    frame_t_ns: Int64[ndarray, " n_frames"]
+    """The segment's frameset times: the cadence the two references are drawn at."""
+    estimate_t_ns: list[int] = field(default_factory=list)
+    """Timestamps of the poses reported so far, in replay order."""
+    estimate_position_m: list[Float64[ndarray, " 3"]] = field(default_factory=list)
+    """Positions of the poses reported so far."""
+    estimate_quaternion_wxyz: list[Float64[ndarray, " 4"]] = field(default_factory=list)
+    """Rotations of the poses reported so far, w-first as :mod:`slam_rs.trajectory` stores them."""
+    window_strip: Float64[ndarray, "10 3"] = field(init=False)
+    """Camera 0's frustum wireframe in rig coordinates, drawn at every window pose."""
+    ground_truth_strip: Trajectory = field(init=False)
+    """The ground truth thinned to the frameset cadence: what the drawn strip is taken from."""
+    cpp_strip: Trajectory = field(init=False)
+    """The C++ trajectory thinned the same way."""
+    previous_strips: dict[int, Float64[ndarray, " 10 3"]] = field(default_factory=dict)
+    """The last frameset's window wireframes by timestamp: where a marginalized frame is drawn from."""
+    framesets: int = 0
+    """Framesets logged, which paces the ATE-so-far."""
+
+    def __post_init__(self) -> None:
+        """Log the estimated rig's static geometry, precompute the window wireframe and thin the references."""
+        log_rig(self.cameras, f"{RUN_ENTITY}/rig")
+        self.window_strip = frustum_strip(self.cameras[0])
+        self.ground_truth_strip = at_frameset_cadence(self.ground_truth, self.frame_t_ns)
+        self.cpp_strip = at_frameset_cadence(self.cpp, self.frame_t_ns)
+
+    def log(self, result: _core.VioResult, snapshot: _core.VioSnapshot, frame: _core.FlowFrame, elapsed_ms: float) -> None:
+        """Log one tracked frameset: the keypoints, the three paths, the rig, the window, the landmarks and the counters.
+
+        Args:
+            result: What ``track`` returned; only called where it tracked.
+            snapshot: The window and the frame's statistics behind that result.
+            frame: The keypoints the estimator's own frontend tracked.
+            elapsed_ms: Wall time the ``track`` call took.
+        """
+        self.framesets += 1
+        if self.framesets == 1:
+            # Both the C++ trajectory and the ground truth are known before the
+            # replay starts, so this alignment is a constant of the run; it is
+            # written here rather than at construction because a row needs the
+            # caller's time cursor. The run's own alignment has no row until the
+            # first ATE, and a missing transform is the identity.
+            log_alignment(CPP_ENTITY, alignment_onto(self.cpp, self.ground_truth))
+        pose: Float64[ndarray, " 7"] = result.world_from_rig
+        self.estimate_t_ns.append(result.t_ns)
+        self.estimate_position_m.append(pose[0:3].copy())
+        self.estimate_quaternion_wxyz.append(np.roll(pose[3:7], 1).copy())
+
+        rr.log(f"{RUN_ENTITY}/rig", rr.Transform3D(translation=pose[0:3], quaternion=rr.Quaternion(xyzw=pose[3:7])))
+        # The estimator's own frontend output, on the frontend rung's paths and
+        # in its palette (:func:`slam_rs.frontend_log.log_keypoints`).
+        log_keypoints(frame)
+        self._log_paths()
+        self._log_window(snapshot)
+        self._log_landmarks(snapshot)
+        self._log_scalars(snapshot, elapsed_ms)
+        if self.framesets % ATE_EVERY == 0:
+            # The only two readers of the whole estimate, and the reason it is
+            # not built every frameset: three arrays over lists that grow with
+            # the run cost 1.64 s over a 4,648-frameset clip to draw a segment
+            # from the last two poses.
+            estimated: Trajectory = self.estimated()
+            # The ATE against the ground truth has already solved this alignment,
+            # in the direction its own residuals are measured in; drawing it is
+            # that solution inverted, not a second association and a second SVD.
+            against_truth: AteResult | None = self._log_ate(estimated)
+            log_alignment(RUN_ENTITY, IDENTITY if against_truth is None else inverted(against_truth.alignment))
+
+    def estimated(self) -> Trajectory:
+        """Everything reported so far, on the replay's ``video_time`` clock."""
+        return Trajectory(
+            t_ns=np.array(self.estimate_t_ns, dtype=np.int64),
+            position_m=np.array(self.estimate_position_m, dtype=np.float64).reshape(-1, 3),
+            quaternion_wxyz=np.array(self.estimate_quaternion_wxyz, dtype=np.float64).reshape(-1, 4),
+        )
+
+    def log_complete_paths(self) -> None:
+        """Log each whole path once, static, so all three are visible at every cursor.
+
+        The per-frameset segments show where each run had got to; these show
+        where it went. Static rows have no timestamp, so they cost one copy of
+        each path however long the clip is.
+
+        They are drawn faded and thin (:data:`ROUTE_ALPHA`,
+        :data:`ROUTE_RADIUS_M`) for the same reason the frames the last
+        marginalization removed are: two things in one place have to be told
+        apart. At full colour and radius the route covers the trail exactly, and
+        a cursor halfway through a clip looks like a cursor at the end of it.
+        """
+        for entity, trajectory, color in (
+            (f"{RUN_ENTITY}/path", self.estimated(), ESTIMATE_COLOR),
+            (f"{GT_ENTITY}/path", self.ground_truth_strip, GT_COLOR),
+            (f"{CPP_ENTITY}/path", self.cpp_strip, CPP_TRAJECTORY_COLOR),
+        ):
+            if len(trajectory) < 2:
+                continue
+            rr.log(entity, rr.LineStrips3D([trajectory.position_m], colors=(*color, ROUTE_ALPHA), radii=ROUTE_RADIUS_M), static=True)
+
+    def _log_paths(self) -> None:
+        """Draw the segment each of the three trajectories gained at this cursor.
+
+        One two-point strip a line a frameset, ending on the newest pose at or
+        before the cursor: the view's visible time range (:func:`vio_blueprint`)
+        is what accumulates them into the path so far, and a reference that has
+        no second pose yet draws nothing. Each is logged in its own frame; the
+        run entities' alignment transforms are what bring the three together in
+        the dataset's world.
+
+        The estimate's segment is taken from the two poses this run last
+        appended, not from :meth:`estimated`: a segment needs two poses, not the
+        whole trajectory rebuilt behind them.
+        """
+        t_ns: int = self.estimate_t_ns[-1]
+        if len(self.estimate_position_m) >= 2:
+            segment: Float64[ndarray, "2 3"] = np.array(self.estimate_position_m[-2:], dtype=np.float64)
+            rr.log(f"{RUN_ENTITY}/trajectory", rr.LineStrips3D([segment], colors=ESTIMATE_COLOR, radii=0.004))
+        for entity, trajectory, color in ((GT_ENTITY, self.ground_truth_strip, GT_COLOR), (CPP_ENTITY, self.cpp_strip, CPP_TRAJECTORY_COLOR)):
+            drawn: int = int(np.searchsorted(trajectory.t_ns, t_ns, side="right"))
+            if drawn >= 2:
+                rr.log(f"{entity}/trajectory", rr.LineStrips3D([trajectory.position_m[drawn - 2 : drawn]], colors=color, radii=0.004))
+
+    def _log_window(self, snapshot: _core.VioSnapshot) -> None:
+        """Draw a frustum wireframe at every window pose, coloured by what the frame is."""
+        poses: Float64[ndarray, "n_frames 7"] = snapshot.window_poses
+        # A measured frameset always leaves at least its own state in the window,
+        # so this is never empty; the reshape is for the one-frame case, where
+        # scipy drops the batch axis.
+        rotations: Float64[ndarray, "n_frames 3 3"] = Rotation.from_quat(poses[:, 3:7]).as_matrix().reshape(-1, 3, 3)
+        strips: list[Float64[ndarray, "10 3"]] = [
+            self.window_strip @ rotation.T + translation for rotation, translation in zip(rotations, poses[:, 0:3], strict=True)
+        ]
+        t_ns: Int64[ndarray, " n_frames"] = snapshot.window_t_ns
+        colors: UInt8[ndarray, "n_frames 4"] = np.where(snapshot.window_keyframe[:, None], KEYFRAME_COLOR, POSE_COLOR).astype(np.uint8)
+        colors[snapshot.window_long_term] = LTKF_COLOR
+        rr.log(f"{RUN_ENTITY}/window", rr.LineStrips3D(strips, colors=colors, radii=0.001))
+
+        # The frames that left this step are gone from the window above, so they
+        # are drawn from the poses they held when it was taken: the previous
+        # frameset's window, the last snapshot that still had them.
+        leaving: set[int] = set(snapshot.marginalized.tolist())
+        rr.log(
+            f"{RUN_ENTITY}/marginalized",
+            rr.LineStrips3D(
+                [strip for held_t_ns, strip in self.previous_strips.items() if held_t_ns in leaving],
+                colors=MARGINALIZED_COLOR,
+                radii=0.001,
+            ),
+        )
+        self.previous_strips = dict(zip(t_ns.tolist(), strips, strict=True))
+
+    def _log_landmarks(self, snapshot: _core.VioSnapshot) -> None:
+        """Draw the window's landmarks, coloured by the keyframe that hosts them."""
+        rr.log(
+            f"{RUN_ENTITY}/landmarks",
+            rr.Points3D(snapshot.landmark_positions, colors=track_colors(snapshot.landmark_hosts), radii=0.008),
+        )
+
+    def _log_scalars(self, snapshot: _core.VioSnapshot, elapsed_ms: float) -> None:
+        """Log the counters the time-series views plot.
+
+        The estimator's velocity and its two biases used to be logged here, under
+        the 3D subtree, where no view could reach them. Plotting them would take
+        three more views and not one — metres a second, radians a second and
+        metres a second squared share no axis, which is the mixing C73's split
+        into seven views undid — so they are dropped instead; the pose they
+        belong to is on the trajectory either way.
+        """
+        rr.log(f"{VIO_STATS_ENTITY}/num_landmarks", rr.Scalars(float(len(snapshot.landmark_ids))))
+        rr.log(f"{VIO_STATS_ENTITY}/num_observations", rr.Scalars(float(snapshot.num_observations)))
+        rr.log(f"{VIO_STATS_ENTITY}/num_keyframes", rr.Scalars(float(len(snapshot.kf_ids))))
+        rr.log(f"{VIO_STATS_ENTITY}/lm_iterations", rr.Scalars(float(snapshot.lm_iterations)))
+        rr.log(f"{VIO_STATS_ENTITY}/lm_lambda", rr.Scalars(snapshot.lm_lambda))
+        # The cost the frame started and ended the LM loop at: the pair is the
+        # convergence trace, and :func:`vio_blueprint` gives it an axis of its
+        # own. Both are negative on most frames, which is basalt's own convention
+        # and not a sign error: the marginalization prior term deliberately drops
+        # the 1/2 r^T r (``crates/slam-rs/src/estimator/optimize.rs:71``, D20).
+        rr.log(f"{VIO_STATS_ENTITY}/lm_error_before", rr.Scalars(snapshot.lm_error_before))
+        rr.log(f"{VIO_STATS_ENTITY}/lm_error_after", rr.Scalars(snapshot.lm_error_after))
+        rr.log(f"{VIO_STATS_ENTITY}/track_ms", rr.Scalars(elapsed_ms))
+        for stage, milliseconds in snapshot.timings_ms.items():
+            rr.log(f"{VIO_STATS_ENTITY}/stage_ms/{stage}", rr.Scalars(milliseconds))
+
+    def _log_ate(self, estimated: Trajectory) -> AteResult | None:
+        """Log the rigid-aligned error of everything reported so far, against both references.
+
+        Args:
+            estimated: Everything reported so far.
+
+        Returns:
+            The error against the ground truth, whose alignment is also what
+            places the run's subtree, or None where too few poses associated for
+            either number to mean anything.
+        """
+        scored: AteResult | None = None
+        for name, reference in (("gt", self.ground_truth), ("cpp", self.cpp)):
+            if len(reference) == 0 or len(estimated) < MIN_ASSOCIATED_POSES:
+                continue
+            result: AteResult = ate(estimated, reference)
+            if result.n_associated >= MIN_ASSOCIATED_POSES:
+                rr.log(f"{VIO_STATS_ENTITY}/ate_cm/{name}", rr.Scalars(100.0 * result.rmse_m))
+                if name == "gt":
+                    scored = result
+        return scored
+
+
+def log_calibration(cameras: tuple[CameraCalib, ...]) -> None:
+    """Log the rig's static geometry so the images sit in the right place in 3D.
+
+    The ``Pinhole`` goes on the ``pinhole`` child, which is the dataset's own
+    layout: the images and the keypoints hang under it, so they are the pixels of
+    the camera that projects them.
+    """
+    rr.log("/", rr.ViewCoordinates.RUB, static=True)
+    log_rig(cameras, RIG_ENTITY, pinhole_child="/pinhole")
+
+
+@dataclass(slots=True)
+class VioStage:
+    """The whole pipeline over one segment, and the Rerun layer it draws.
+
+    The estimator, its logger and its timings only ever exist together, on
+    ``--stage vio``.
+    """
+
+    lockstep: Lockstep
+    """The estimator and the D17 hold, which the V2 gate drives the same way."""
+    logger: VioLogger
+    """Where the trajectories, the window, the landmarks and the counters go."""
+
+    @property
+    def elapsed_ms(self) -> list[float]:
+        """Wall time each ``track`` call that tracked took, in frameset order."""
+        return self.lockstep.elapsed_ms
+
+    @property
+    def pending(self) -> list[Frameset]:
+        """Framesets still held for want of the inertial samples that cover them."""
+        return self.lockstep.pending
+
+    def run(self, frameset: Frameset) -> None:
+        """Track the frameset and everything its samples now cover, and log each one.
+
+        Args:
+            frameset: The frameset to track, with the samples since the previous one.
+        """
+        for held, result in self.lockstep.push(frameset):
+            # The rows belong at the frameset's own time, which is the caller's
+            # cursor for all but a retried one.
+            rr.set_time(TIMELINE, duration=np.timedelta64(held.t_ns, "ns"))
+            # Both are present on a frameset that tracked — the snapshot because it
+            # measured, the keypoints because the frontend accepted it — so a
+            # missing one is a broken invariant, not a rung to skip (D32).
+            snapshot: _core.VioSnapshot | None = self.lockstep.vio.snapshot()
+            frame: _core.FlowFrame | None = self.lockstep.vio.flow_frame()
+            assert snapshot is not None, f"frameset {held.t_ns} tracked without a window snapshot"
+            assert frame is not None, f"frameset {held.t_ns} tracked without the keypoints it tracked on"
+            self.logger.log(result, snapshot, frame, self.lockstep.elapsed_ms[-1])
+
+    def refuse_lost_framesets(self) -> None:
+        """Stop the run when a frameset never got the inertial samples that cover it.
+
+        Every frameset either produced a pose or is still held (D17); one still
+        held at the end of a segment is a lost frameset, not a count to print,
+        and both tools that drive this stage end on the same rule.
+
+        Raises:
+            SystemExit: If any frameset is still held.
+        """
+        if self.pending:
+            raise SystemExit(f"{len(self.pending)} framesets never got the inertial samples that cover them")
+
+    def summary(self) -> str:
+        """One line on what the stage did, for the end of a replay.
+
+        The empty case is this stage's own to report: the run that tracked
+        nothing is the one whose held framesets most need naming, and a caller
+        that guarded the call on ``elapsed_ms`` suppressed exactly that line.
+        """
+        unresolved: str = ""
+        if self.pending:
+            unresolved = f", {len(self.pending)} FRAMESETS NEVER COVERED BY THE IMU at {[held.t_ns for held in self.pending]}"
+        if not self.elapsed_ms:
+            return f"vio: {self.lockstep.imu_samples} IMU samples pushed, nothing tracked{unresolved}"
+        return (
+            f"vio: {self.lockstep.imu_samples} IMU samples pushed, {len(self.elapsed_ms)} tracked, "
+            f"{self.lockstep.retries} retries, {np.mean(self.elapsed_ms):.1f} ms per frameset "
+            f"(median {np.median(self.elapsed_ms):.1f}, max {np.max(self.elapsed_ms):.1f})"
+            f"{unresolved}"
+        )
+
+
+def log_imu(imu: ImuStream) -> None:
+    """Log one frameset's inertial samples, one column per channel.
+
+    Two ``send_columns`` calls instead of a ``set_time`` and two ``log`` calls per
+    sample — about 57 samples a frameset at 1 kHz, so 171 calls become 2, and the
+    frameset's inertial rung goes from 0.446 ms to 0.037 ms. The rows are the
+    same rows: each timestamp still carries its three components, which is what
+    the partition says.
+
+    Args:
+        imu: The samples since the previous frameset, on the ``video_time`` clock.
+    """
+    if not len(imu):
+        return
+    times: rr.TimeColumn = rr.TimeColumn(TIMELINE, duration=imu.t_ns.astype("timedelta64[ns]"))
+    components: int = imu.gyro_rad_s.shape[1]
+    for entity, channel in ((f"{IMU_ENTITY}/gyro", imu.gyro_rad_s), (f"{IMU_ENTITY}/accel", imu.accel_m_s2)):
+        rr.send_columns(entity, indexes=[times], columns=rr.Scalars.columns(scalars=channel.reshape(-1)).partition([components] * len(imu)))
+
+
+def log_frameset_inputs(feed: SegmentFeed, frameset: Frameset, mode: FrameMode) -> None:
+    """Log what the estimator is fed for one frameset, at the frameset's own time.
+
+    Every replay draws this rung whether or not a stage consumes it, and the two
+    tools that drive a stage draw the same one: a channel added here reaches both
+    rather than one of them.
+
+    Args:
+        feed: The open feed, for the cameras the images belong to.
+        frameset: The frameset, with the inertial samples since the previous one.
+        mode: How to draw the frames; see :data:`FrameMode`.
+    """
+    # The samples are what the estimator is fed, so they are logged in every
+    # stage whether or not one consumes them.
+    log_imu(frameset.imu)
+    rr.set_time(TIMELINE, duration=np.timedelta64(frameset.t_ns, "ns"))
+    for camera, image in zip(feed.cameras, frameset.images, strict=True):
+        entity: str = f"{camera_entity(camera.index)}/image"
+        if mode == "downscaled":
+            small: UInt8[ndarray, "h w"] = np.ascontiguousarray(image[::IMAGE_DOWNSCALE, ::IMAGE_DOWNSCALE])
+            rr.log(entity, rr.Image(small, color_model="L"))
+        elif mode == "jpeg":
+            # Full resolution, or the keypoints would sit two pixels off the
+            # corner they were computed on; JPEG keeps a whole segment small.
+            # The encode costs 3.9 ms a frameset on the replay thread and is
+            # deliberate: no lane that reports a wall time comes through here,
+            # because the V2 gate drives the feed and `Vio` itself with
+            # nothing logged.
+            rr.log(entity, rr.Image(image, color_model="L").compress(jpeg_quality=JPEG_QUALITY))
+    if frameset.ground_truth is not None:
+        pose_wxyz: Float64[ndarray, " 7"] = frameset.ground_truth
+        rr.log(
+            RIG_ENTITY,
+            rr.Transform3D(translation=pose_wxyz[0:3], quaternion=rr.Quaternion(xyzw=np.roll(pose_wxyz[3:7], -1))),
+        )
+
+
+def vio_blueprint(cameras: tuple[CameraCalib, ...]) -> rrb.Blueprint:
+    """One 3D view of the world, the camera images beside it, and the counters below.
+
+    The counters are one time-series view per magnitude rather than one view for
+    all of them. Rerun gives a view a single y-axis, and the widest series in it
+    sets the scale for every other: with all fifteen in one view the LM cost's
+    -68,000 left the landmark counts, the millisecond stage times and the
+    centimetre ATE as one flat line on the zero, and the legend named seven of
+    the fifteen. One axis per magnitude is the only lever there is, so the split
+    follows what the smoke segment actually measures — counts in the hundreds,
+    keyframes and LM steps in single digits, the frame and its two dominant
+    stages in tens of milliseconds, the four remaining stages in fractions of
+    one, the cost in tens of thousands, the damping over seven decades, and the
+    ATE in centimetres.
+
+    The seven sit in a row across the band the single view had, so the world view
+    and the two camera views keep exactly the space they had. At 1920x1080 that
+    is 274x250 each, where a two-row grid in the same band would be 135 px tall:
+    a plot spends its first ~60 vertical pixels on the time axis and its labels,
+    so height is what a trace can least spare. Narrowing the views also shrinks
+    each legend, because a view of one magnitude holds few series.
+
+    The three trajectories are logged one segment a frameset, so each of them
+    carries a visible time range reaching from the start of the recording to the
+    cursor: without it Rerun's default for a 3D view is latest-at, under which
+    each segment renders alone. The range goes on the three entities rather than
+    on the view, because everything else the view holds — the window frusta, the
+    strips of the frames the last marginalization removed, the landmarks — is a
+    whole state re-logged every frameset, and a window reaching back to the start
+    would draw every copy of it at once.
+
+    Args:
+        cameras: The rig's cameras, in rig order.
+
+    Returns:
+        A blueprint with the panels collapsed, so the frame is all content.
+    """
+    views: list[rrb.View] = camera_views(cameras)
+    trail: rrb.VisibleTimeRanges = rrb.VisibleTimeRanges(
+        rrb.VisibleTimeRange(TIMELINE, start=rrb.TimeRangeBoundary.infinite(), end=rrb.TimeRangeBoundary.cursor_relative())
+    )
+    return rrb.Blueprint(
+        rrb.Vertical(
+            rrb.Horizontal(
+                rrb.Spatial3DView(
+                    origin="/world",
+                    name="world",
+                    overrides={f"{run}/trajectory": trail for run in (RUN_ENTITY, GT_ENTITY, CPP_ENTITY)},
+                ),
+                rrb.Vertical(*views),
+                column_shares=[2, 1],
+            ),
+            rrb.Horizontal(
+                rrb.TimeSeriesView(
+                    origin=VIO_STATS_ENTITY,
+                    contents=[f"{VIO_STATS_ENTITY}/num_landmarks", f"{VIO_STATS_ENTITY}/num_observations"],
+                    name="counts",
+                ),
+                rrb.TimeSeriesView(
+                    origin=VIO_STATS_ENTITY,
+                    contents=[f"{VIO_STATS_ENTITY}/num_keyframes", f"{VIO_STATS_ENTITY}/lm_iterations"],
+                    name="keyframes & LM steps",
+                ),
+                rrb.TimeSeriesView(
+                    origin=VIO_STATS_ENTITY,
+                    contents=[f"{VIO_STATS_ENTITY}/track_ms", f"{VIO_STATS_ENTITY}/stage_ms/measure", f"{VIO_STATS_ENTITY}/stage_ms/solver"],
+                    name="timing (ms)",
+                ),
+                # Naming the stages rather than globbing ``stage_ms/**`` is what
+                # makes a stage nobody gave a view a failing test rather than a
+                # flat line: ``test_vio_log`` reads this partition off the views.
+                rrb.TimeSeriesView(
+                    origin=VIO_STATS_ENTITY,
+                    contents=[f"{VIO_STATS_ENTITY}/stage_ms/{stage}" for stage in ("back_substitution", "error", "linearize", "marginalize")],
+                    name="solve stages (ms)",
+                ),
+                # The frontend's four in their own view for the same reason the
+                # solver's four have one: on a 640x360 fisheye rig the KLT and
+                # the detector are tens of milliseconds where the preintegration
+                # is a fiftieth of one, and one axis for both hides the smaller.
+                rrb.TimeSeriesView(
+                    origin=VIO_STATS_ENTITY,
+                    contents=[f"{VIO_STATS_ENTITY}/stage_ms/frontend_{stage}" for stage in ("pyramid", "detect", "track", "imu")],
+                    name="frontend stages (ms)",
+                ),
+                rrb.TimeSeriesView(
+                    origin=VIO_STATS_ENTITY,
+                    contents=[f"{VIO_STATS_ENTITY}/lm_error_before", f"{VIO_STATS_ENTITY}/lm_error_after"],
+                    name="LM cost",
+                ),
+                # The damping is its own view because it is not a cost: it runs
+                # from 1e-5 to 74 on this segment, which the cost's own axis
+                # would put on the zero line just as flatly.
+                rrb.TimeSeriesView(origin=VIO_STATS_ENTITY, contents=[f"{VIO_STATS_ENTITY}/lm_lambda"], name="LM damping"),
+                rrb.TimeSeriesView(
+                    origin=VIO_STATS_ENTITY,
+                    contents=[f"{VIO_STATS_ENTITY}/ate_cm/gt", f"{VIO_STATS_ENTITY}/ate_cm/cpp"],
+                    name="ATE (cm)",
+                ),
+            ),
+            row_shares=[3, 1],
+        ),
+        collapse_panels=True,
+    )

--- a/packages/slam-rs/tests/conftest.py
+++ b/packages/slam-rs/tests/conftest.py
@@ -17,8 +17,17 @@ and :func:`manifest` — five suites read the frozen reference set and parsing i
 once a session is both cheaper and one account of what "the manifest" means.
 """
 
-import pytest
+from pathlib import Path
 
+import numpy as np
+import pytest
+import rerun.experimental as rx
+from fixture_types import FRAME, CameraFactory, FrontendFactory, PipelineFactory, RigFactory, Row, Rows, RowsReader, TextureFactory
+from jaxtyping import Float64, UInt8
+from numpy import ndarray
+
+from slam_rs import _core
+from slam_rs.catalog_feed import TIMELINE, CameraCalib, ImuCalib
 from slam_rs.reference import ReferenceManifest, load_manifest
 
 
@@ -26,3 +35,128 @@ from slam_rs.reference import ReferenceManifest, load_manifest
 def manifest() -> ReferenceManifest:
     """The frozen reference set, parsed once for the whole session."""
     return load_manifest()
+
+
+@pytest.fixture(scope="session")
+def camera() -> CameraFactory:
+    """A 200x200 pinhole-like camera: kb4 with every coefficient zero."""
+
+    def build(index: int, baseline_m: float) -> CameraCalib:
+        imu_T_cam: Float64[ndarray, "4 4"] = np.eye(4, dtype=np.float64)
+        imu_T_cam[0, 3] = baseline_m
+        return CameraCalib(
+            index=index,
+            width=FRAME,
+            height=FRAME,
+            fx=100.0,
+            fy=100.0,
+            cx=FRAME / 2,
+            cy=FRAME / 2,
+            model="kb4",
+            distortion=np.zeros(4, dtype=np.float64),
+            distortion_valid_radius=None,
+            imu_T_cam=imu_T_cam,
+        )
+
+    return build
+
+
+@pytest.fixture(scope="session")
+def imu() -> ImuCalib:
+    """The Index device's frozen noise model, which no test here is sensitive to."""
+    return ImuCalib(
+        frequency_hz=1000.0,
+        gyro_noise_std=0.000282,
+        accel_noise_std=0.016,
+        gyro_bias_std=0.0001,
+        accel_bias_std=0.001,
+        cam_time_offset_ns=0,
+        imu_T_body=np.eye(4, dtype=np.float64),
+    )
+
+
+@pytest.fixture(scope="session")
+def rig(camera: CameraFactory, imu: ImuCalib) -> RigFactory:
+    """A calibration for ``camera_count`` identical cameras, 10 cm apart."""
+
+    def build(camera_count: int) -> _core.Calibration:
+        return _core.Calibration.from_catalog([camera(index, 0.1 * index) for index in range(camera_count)], imu)
+
+    return build
+
+
+@pytest.fixture(scope="session")
+def frontend(rig: RigFactory) -> FrontendFactory:
+    """A frontend on a rig of ``camera_count`` identical cameras."""
+
+    def build(camera_count: int) -> _core.OpticalFlow:
+        return _core.OpticalFlow(rig(camera_count), _core.VioConfig())
+
+    return build
+
+
+@pytest.fixture(scope="session")
+def pipeline(rig: RigFactory) -> PipelineFactory:
+    """The whole pipeline on a rig of ``camera_count`` identical cameras.
+
+    Two cameras at least: the epipolar filter is a hard precondition
+    (``optical_flow.h:210``), so a one-camera rig is a refusal to assert on, not
+    a fixture to build from.
+    """
+
+    def build(camera_count: int) -> _core.Vio:
+        return _core.Vio(rig(camera_count), _core.VioConfig())
+
+    return build
+
+
+@pytest.fixture(scope="session")
+def read_rows() -> RowsReader:
+    """Read every non-static row of a recording, grouped by entity path.
+
+    A component a row did not set comes back as a null and is dropped, so a
+    missing key means the row really did not carry that component.
+
+    Returns:
+        A function of an ``.rrd`` written by :func:`rerun.save`, giving each
+        entity path's rows in ``video_time`` order.
+    """
+
+    def read(path: Path) -> Rows:
+        rows: Rows = {}
+        for chunk in rx.RrdReader(path).stream().collect().stream():
+            if chunk.is_static:
+                continue
+            batch = chunk.to_record_batch()
+            if TIMELINE not in batch.schema.names:
+                # A row written before the caller set a cursor sits on no timeline.
+                continue
+            times: list = batch.column(TIMELINE).to_pylist()
+            components: dict[str, list] = {
+                name: batch.column(name).to_pylist() for name in batch.schema.names if ":" in name and not name.startswith("rerun.")
+            }
+            for index, time in enumerate(times):
+                values: dict[str, list] = {name: column[index] for name, column in components.items() if column[index] is not None}
+                rows.setdefault(chunk.entity_path, []).append(Row(t_ns=int(np.timedelta64(time, "ns").astype(np.int64)), values=values))
+        for entity in rows:
+            rows[entity].sort(key=lambda row: row.t_ns)
+        return rows
+
+    return read
+
+
+@pytest.fixture(scope="session")
+def texture() -> TextureFactory:
+    """One fixed blocky-noise scene, shifted by whole pixels.
+
+    Blocky **noise**, not a lattice: a repeating pattern gives every corner the
+    same score, and basalt's suppression is strictly-greater-than, so a tie kills
+    both sides and a perfectly regular scene detects almost nothing.
+    """
+
+    def build(shift_x: int, shift_y: int) -> UInt8[ndarray, "h w"]:
+        blocks: UInt8[ndarray, "b b"] = np.random.default_rng(20250907).integers(0, 256, (FRAME // 2, FRAME // 2), dtype=np.uint8)
+        image: UInt8[ndarray, "h w"] = np.repeat(np.repeat(blocks, 2, axis=0), 2, axis=1)
+        return np.ascontiguousarray(np.roll(image, (shift_y, shift_x), axis=(0, 1)))
+
+    return build

--- a/packages/slam-rs/tests/fixture_types.py
+++ b/packages/slam-rs/tests/fixture_types.py
@@ -1,0 +1,88 @@
+"""Types, sizes, periods and the two stand-ins the suites share.
+
+:mod:`conftest` injects the fixtures themselves, but a ``TypeAlias`` is not
+something pytest can inject and every suite that annotates a factory has to
+name its type. They live here once, so ``PipelineFactory`` means one thing
+across the suite; the synthetic rig's frame size and the two sample periods come
+with them, because a test that builds a batch by hand needs the same numbers the
+fixtures were built for. This is not a test module, so conftest's rule that no
+test module sits on another one's import path still holds, and it is where
+:func:`gravity_batch` and :func:`never` sit for the same reason: both are called
+from module-level helpers a fixture cannot reach.
+"""
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import NamedTuple, TypeAlias
+
+import numpy as np
+from jaxtyping import Float64, Int64, UInt8
+from numpy import ndarray
+
+from slam_rs import _core
+from slam_rs.catalog_feed import CameraCalib
+
+FRAME: int = 200
+"""Side of the synthetic frame, which is the size the fixture rig is calibrated for: four whole 50-pixel detection cells."""
+IMU_PERIOD_NS: int = 1_000_000
+"""Synthetic IMU period: 1 kHz, the Index device's own rate."""
+FRAME_PERIOD_NS: int = 33_000_000
+"""Synthetic frame period: about 30 Hz."""
+
+CameraFactory: TypeAlias = Callable[[int, float], CameraCalib]
+"""One camera of the synthetic rig, by rig index and baseline in metres."""
+RigFactory: TypeAlias = Callable[[int], _core.Calibration]
+"""A calibration for a rig of the given camera count."""
+FrontendFactory: TypeAlias = Callable[[int], _core.OpticalFlow]
+"""A frontend on a rig of the given camera count."""
+PipelineFactory: TypeAlias = Callable[[int], _core.Vio]
+"""The whole pipeline on a rig of the given camera count."""
+TextureFactory: TypeAlias = Callable[[int, int], UInt8[ndarray, "h w"]]
+"""The synthetic scene, shifted by whole pixels in x and y."""
+
+
+class Row(NamedTuple):
+    """One logged row of one entity, as :func:`conftest.read_rows` hands it back."""
+
+    t_ns: int
+    """Where on ``video_time`` the row sits, in nanoseconds."""
+    values: dict[str, list]
+    """The components this row set, by their short name (``Points2D:positions`` and such)."""
+
+
+Rows: TypeAlias = dict[str, list[Row]]
+"""Per entity path, its non-static rows in ``video_time`` order."""
+RowsReader: TypeAlias = Callable[[Path], Rows]
+"""The :mod:`conftest` fixture that reads a recording back."""
+
+
+def never(message: str) -> Callable[..., object]:
+    """A stand-in for a call that must not happen, which fails the test if it does.
+
+    What a monkeypatched function a case is asserting is *never* reached becomes.
+    The message names the rule the call would have broken, so the failure reads
+    as the rule rather than as a traceback through the tool.
+
+    Args:
+        message: What calling it would mean, in the failure's own words.
+
+    Returns:
+        A callable accepting anything and raising :class:`AssertionError`.
+    """
+
+    def called(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError(message)
+
+    return called
+
+
+def gravity_batch(t_ns: Int64[ndarray, " n_samples"]) -> tuple[Float64[ndarray, "n_samples 3"], Float64[ndarray, "n_samples 3"]]:
+    """A still rig: no rotation, and gravity along the rig's z axis.
+
+    Args:
+        t_ns: Sample timestamps, which only fix the batch's length here.
+
+    Returns:
+        The gyroscope and accelerometer blocks, C-contiguous.
+    """
+    return np.zeros((len(t_ns), 3), dtype=np.float64), np.tile(np.array([0.0, 0.0, 9.81]), (len(t_ns), 1))

--- a/packages/slam-rs/tests/test_boundary_properties.py
+++ b/packages/slam-rs/tests/test_boundary_properties.py
@@ -1,0 +1,187 @@
+"""Property tests of the estimator's inertial boundary, driven through ``slam_rs._core`` (D23).
+
+Hypothesis drives the PyO3 boundary directly: no CLI oracle. Examples are capped
+so the whole file stays inside the default, seconds-long suite. The image rules
+both entry points share — rank, dtype, layout, the frameset's width and the
+calibrated frame size — are parametrized over ``Vio.track`` and
+``OpticalFlow.process`` in ``test_frontend_boundary.py`` rather than written once
+per entry point; what is left here is the IMU clock and the determinism of a run,
+which only the estimator has.
+"""
+
+from typing import cast
+
+import numpy as np
+import pytest
+from fixture_types import FRAME_PERIOD_NS, IMU_PERIOD_NS, PipelineFactory, TextureFactory, gravity_batch
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+from jaxtyping import Float64, Int64, UInt8
+from numpy import ndarray
+from numpy.typing import NDArray
+
+from slam_rs import _core
+
+MAX_EXAMPLES: int = 50
+
+gaps = st.lists(st.integers(min_value=1, max_value=10**6), min_size=1, max_size=20)
+starts = st.integers(min_value=-(10**9), max_value=10**9)
+positions = st.integers(min_value=0, max_value=1000)
+
+def increasing(start: int, steps: list[int]) -> NDArray[np.int64]:
+    """Timestamps that strictly increase from ``start`` by the given positive steps."""
+    return np.array(np.cumsum([start, *steps]), dtype=np.int64)
+
+
+def zeros(count: int) -> NDArray[np.float64]:
+    """A C-contiguous ``(count, 3)`` block of zeros."""
+    return np.zeros((count, 3), dtype=np.float64)
+
+
+@settings(max_examples=MAX_EXAMPLES, deadline=None)
+@given(start=starts, steps=gaps)
+def test_strictly_increasing_timestamps_are_accepted(pipeline: PipelineFactory, start: int, steps: list[int]) -> None:
+    vio: _core.Vio = pipeline(2)
+    for t_ns in increasing(start, steps):
+        vio.push_imu(int(t_ns), [0.0, 0.0, 0.0], [0.0, 0.0, 9.81])
+
+
+@settings(max_examples=MAX_EXAMPLES, deadline=None)
+@given(start=starts, steps=gaps, back=st.integers(min_value=0, max_value=10**6))
+def test_any_non_increasing_timestamp_is_rejected(pipeline: PipelineFactory, start: int, steps: list[int], back: int) -> None:
+    vio: _core.Vio = pipeline(2)
+    times: NDArray[np.int64] = increasing(start, steps)
+    for t_ns in times:
+        vio.push_imu(int(t_ns), [0.0, 0.0, 0.0], [0.0, 0.0, 9.81])
+    with pytest.raises(ValueError, match="does not follow"):
+        vio.push_imu(int(times[-1]) - back, [0.0, 0.0, 0.0], [0.0, 0.0, 9.81])
+
+
+@settings(max_examples=MAX_EXAMPLES, deadline=None)
+@given(start=starts, steps=gaps)
+def test_an_increasing_batch_is_accepted(pipeline: PipelineFactory, start: int, steps: list[int]) -> None:
+    vio: _core.Vio = pipeline(2)
+    times: NDArray[np.int64] = increasing(start, steps)
+    vio.push_imu_batch(times, zeros(len(times)), zeros(len(times)))
+
+
+@settings(max_examples=MAX_EXAMPLES, deadline=None)
+@given(start=starts, steps=gaps, index=positions)
+def test_a_batch_that_repeats_one_timestamp_keeps_none_of_it(pipeline: PipelineFactory, start: int, steps: list[int], index: int) -> None:
+    """A rejected batch is rejected whole, wherever the bad sample sits in it.
+
+    The batch used to be pushed sample by sample and to return at the first
+    refusal, so the samples before it stayed and the frontier moved past them:
+    the caller could then neither retry the batch nor correct it, because its own
+    first samples had become too old. The state that says so is the frontier, and
+    what reads it is the same batch, corrected: it is accepted here from its very
+    first sample, which it could not be if anything of the rejected one had been
+    kept.
+    """
+    times: NDArray[np.int64] = increasing(start, steps)  # at least two samples
+    position: int = 1 + index % (len(times) - 1)
+    broken: NDArray[np.int64] = times.copy()
+    broken[position] = broken[position - 1]
+    vio: _core.Vio = pipeline(2)
+    with pytest.raises(ValueError, match="does not follow"):
+        vio.push_imu_batch(broken, zeros(len(broken)), zeros(len(broken)))
+    vio.push_imu_batch(times, zeros(len(times)), zeros(len(times)))
+
+
+def test_a_rejected_batch_leaves_the_frontier_where_it_was(pipeline: PipelineFactory) -> None:
+    """Codex's case verbatim: ``[10, 20, 20, 30]`` raised at the duplicate and kept 10 and 20.
+
+    Retrying either of them then failed as older than a frontier the caller never
+    asked for, which is how the partial commit was found.
+    """
+    vio: _core.Vio = pipeline(2)
+    with pytest.raises(ValueError, match="does not follow"):
+        vio.push_imu_batch(np.array([10, 20, 20, 30], dtype=np.int64), zeros(4), zeros(4))
+    vio.push_imu(10, [0.0, 0.0, 0.0], [0.0, 0.0, 9.81])
+    vio.push_imu(20, [0.0, 0.0, 0.0], [0.0, 0.0, 9.81])
+
+
+@settings(max_examples=MAX_EXAMPLES, deadline=None)
+@given(start=starts, steps=gaps, index=positions, component=st.sampled_from([np.nan, np.inf, -np.inf]))
+def test_a_batch_carrying_a_value_that_is_not_a_number_keeps_none_of_it(
+    pipeline: PipelineFactory, start: int, steps: list[int], index: int, component: float
+) -> None:
+    """One non-finite component refuses the batch, and refuses it whole.
+
+    A NaN reaches both preintegrators and poisons every state after it with
+    nothing to undo it, so it is bad input rather than a value the estimator is
+    asked to survive (D32) — and being bad input, it has to be found before the
+    batch is pushed, or it takes the samples before it down with it.
+    """
+    times: NDArray[np.int64] = increasing(start, steps)
+    position: int = index % len(times)
+    gyro: NDArray[np.float64] = zeros(len(times))
+    gyro[position, index % 3] = component
+    vio: _core.Vio = pipeline(2)
+    with pytest.raises(ValueError, match="non-finite gyro"):
+        vio.push_imu_batch(times, gyro, zeros(len(times)))
+    vio.push_imu_batch(times, zeros(len(times)), zeros(len(times)))
+
+
+@settings(max_examples=MAX_EXAMPLES, deadline=None)
+@given(times=st.integers(min_value=1, max_value=8), rows=st.integers(min_value=1, max_value=8))
+def test_mismatched_batch_lengths_are_rejected(pipeline: PipelineFactory, times: int, rows: int) -> None:
+    assume(times != rows)
+    vio: _core.Vio = pipeline(2)
+    with pytest.raises(ValueError, match="same length"):
+        vio.push_imu_batch(np.arange(times, dtype=np.int64), zeros(rows), zeros(rows))
+
+
+@settings(max_examples=MAX_EXAMPLES, deadline=None)
+@given(dtype=st.sampled_from([np.int32, np.float64, np.uint64]), count=st.integers(min_value=1, max_value=8))
+def test_batch_timestamps_of_the_wrong_dtype_are_rejected(pipeline: PipelineFactory, dtype: type, count: int) -> None:
+    vio: _core.Vio = pipeline(2)
+    wrong: NDArray[np.int64] = cast("NDArray[np.int64]", np.arange(count, dtype=dtype))
+    with pytest.raises(ValueError, match="1-D int64"):
+        vio.push_imu_batch(wrong, zeros(count), zeros(count))
+
+
+@settings(max_examples=MAX_EXAMPLES, deadline=None)
+@given(count=st.integers(min_value=2, max_value=4), t_ns=starts)
+def test_a_frameset_of_the_calibrated_size_is_accepted_at_any_timestamp(
+    pipeline: PipelineFactory, texture: TextureFactory, count: int, t_ns: int
+) -> None:
+    """Any ``int64`` is a frameset timestamp, negative ones included.
+
+    Without inertial samples covering it the frameset cannot measure, which is
+    what :attr:`slam_rs._core.VioStatus.NeedMoreImu` says; the point here is that
+    it is an answer rather than a refusal.
+    """
+    vio: _core.Vio = pipeline(count)
+    result: _core.VioResult = vio.track(t_ns, [texture(0, 0)] * count)
+    assert result.status == _core.VioStatus.NeedMoreImu
+    assert result.t_ns == t_ns
+
+
+@settings(max_examples=3, deadline=None)
+@given(shifts=st.lists(st.integers(min_value=0, max_value=4), min_size=6, max_size=6))
+def test_two_runs_over_the_same_input_agree_exactly(pipeline: PipelineFactory, texture: TextureFactory, shifts: list[int]) -> None:
+    """Offline mode has no queues and no threads, so a repeat run is bit-identical (D17).
+
+    Two estimators are driven over one sequence of framesets and inertial
+    batches, and every pose is compared exactly rather than to a tolerance: this
+    is the property that makes a reference run reproducible, and a scheduling
+    dependency would break it by an ulp long before it broke an ATE gate.
+
+    The same claim over a real segment, byte for byte through the CSV writer, is
+    ``tests/test_v2_gate.py``'s; this one is fast and runs every commit.
+    """
+    frames: list[list[UInt8[ndarray, "h w"]]] = [[texture(shift, 0), texture(shift + 1, 0)] for shift in shifts]
+    runs: list[list[Float64[ndarray, " 7"]]] = []
+    for _ in range(2):
+        vio: _core.Vio = pipeline(2)
+        poses: list[Float64[ndarray, " 7"]] = []
+        for index, images in enumerate(frames):
+            t_ns: int = index * FRAME_PERIOD_NS
+            samples: Int64[ndarray, " n_samples"] = np.arange(t_ns, t_ns + FRAME_PERIOD_NS, IMU_PERIOD_NS, dtype=np.int64)
+            vio.push_imu_batch(samples, *gravity_batch(samples))
+            poses.append(vio.track(t_ns, images).world_from_rig)
+        runs.append(poses)
+    assert len(runs[0]) == len(frames)
+    for index, (first, second) in enumerate(zip(runs[0], runs[1], strict=True)):
+        assert np.array_equal(first, second), f"frameset {index} differed between two runs of the same input"

--- a/packages/slam-rs/tests/test_catalog_feed.py
+++ b/packages/slam-rs/tests/test_catalog_feed.py
@@ -454,7 +454,7 @@ def test_a_replay_export_associates_with_the_ground_truth_sidecar(manifest: Refe
             logger=VioLogger(
                 cameras=feed.cameras,
                 ground_truth=truth,
-                cpp=_cpp_trajectory(manifest, segment, feed.capture_start_time_ns),
+                cpp=_cpp_trajectory(manifest, segment, feed.capture_start_time_ns, feed.segment_id),
                 frame_t_ns=feed.frame_t_ns,
             ),
         )

--- a/packages/slam-rs/tests/test_catalog_feed.py
+++ b/packages/slam-rs/tests/test_catalog_feed.py
@@ -1,0 +1,479 @@
+"""The catalog-to-estimator mapping rules, on synthetic statics, plus one real smoke segment."""
+
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+import pytest
+from jaxtyping import Float64, Int64
+from numpy import ndarray
+from simplecv.rerun_log_utils import RerunTyroConfig
+
+from slam_rs import _core
+from slam_rs.apis.replay import Config, _cpp_trajectory, _replay
+from slam_rs.catalog_feed import (
+    CHILD_FROM_PARENT,
+    RIG_ENTITY,
+    TIMELINE,
+    CameraCalib,
+    CameraStatics,
+    Frameset,
+    ImuStream,
+    LocalSegment,
+    SegmentFeed,
+    _rig_trajectory,
+    _shared_codec,
+    _static_int,
+    _static_string,
+    _static_values,
+    _video_codec,
+    camera_calib,
+    imu_calib,
+    open_segment,
+)
+from slam_rs.reference import SMOKE_SEGMENTS, ReferenceManifest, ReferenceSegment, flow_config
+from slam_rs.tracking import Lockstep
+from slam_rs.trajectory import AteResult, Trajectory, associate, ate, read_trajectory, shift_clock, write_trajectory
+from slam_rs.vio_log import VioLogger, VioStage
+
+SMOKE_SEGMENT: str = SMOKE_SEGMENTS[1]
+"""The 7.6 s two-camera segment the smoke tier runs on."""
+
+
+def _kb4_statics(
+    distortion_model: str = "kannala_brandt",
+    distortion_coefficients: Float64[ndarray, " n_slots"] | None = None,
+    transform_relation: int = CHILD_FROM_PARENT,
+    distortion_valid_radius: float | None = None,
+) -> CameraStatics:
+    """msd-index cam0's statics, exactly as the catalog stores them.
+
+    Args:
+        distortion_model: ``simplecv.components.DistortionModel`` string to store.
+        distortion_coefficients: Fixed-width coefficient list; defaults to msd-index cam0's KB4 values with a zero tail.
+        transform_relation: ``Transform3D:relation`` code to store.
+        distortion_valid_radius: basalt's ``rpmax``, when the recording carries one.
+
+    Returns:
+        Synthetic statics with the storage conventions the catalog really uses.
+    """
+    coefficients: Float64[ndarray, " n_slots"] = (
+        np.array([0.192938, 0.042115, -0.233115, 0.095410, 0.0, 0.0, 0.0, 0.0]) if distortion_coefficients is None else distortion_coefficients
+    )
+    return CameraStatics(
+        distortion_model=distortion_model,
+        distortion_coefficients=coefficients,
+        # Column-major: reading it row-major would swap (fx, fy) with (cx, cy).
+        image_from_camera=np.array([420.5274, 0.0, 0.0, 0.0, 420.6685, 0.0, 469.4826, 479.1369, 1.0]),
+        resolution_wh=np.array([960.0, 960.0]),
+        transform_mat3x3=np.array([0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]),
+        transform_translation=np.array([1.0, 2.0, 3.0]),
+        transform_relation=transform_relation,
+        distortion_valid_radius=distortion_valid_radius,
+    )
+
+
+def test_the_intrinsics_are_read_column_major() -> None:
+    calib: CameraCalib = camera_calib(0, _kb4_statics())
+    assert (calib.fx, calib.fy) == pytest.approx((420.5274, 420.6685))
+    assert (calib.cx, calib.cy) == pytest.approx((469.4826, 479.1369))
+    assert (calib.width, calib.height) == (960, 960)
+
+
+def test_kb4_keeps_four_coefficients_and_rejects_a_live_tail() -> None:
+    calib: CameraCalib = camera_calib(0, _kb4_statics())
+    assert calib.model == "kb4"
+    assert calib.distortion.shape == (4,)
+    # Aria's Fisheye624 carries the same "kannala_brandt" string with eight live
+    # coefficients, so a non-zero tail must fail loudly instead of truncating.
+    aria_like: Float64[ndarray, " 8"] = np.array([-0.0248, 0.0963, -0.0633, 0.0062, 0.00349, -0.00073, -0.00036, 0.000895])
+    with pytest.raises(ValueError, match="tail is non-zero"):
+        camera_calib(0, _kb4_statics(distortion_coefficients=aria_like))
+
+
+def test_radtan8_keeps_eight_coefficients() -> None:
+    coefficients: Float64[ndarray, " 14"] = np.zeros(14, dtype=np.float64)
+    coefficients[:8] = np.array([0.3022, -0.0215, 6e-05, 0.00025, 0.01582, 0.57506, -0.06264, 0.03385])
+    statics: CameraStatics = _kb4_statics(distortion_model="brown_conrady", distortion_coefficients=coefficients, distortion_valid_radius=2.72764)
+    calib: CameraCalib = camera_calib(0, statics)
+    assert calib.model == "radtan8"
+    np.testing.assert_allclose(calib.distortion, coefficients[:8])
+    assert calib.distortion_valid_radius == pytest.approx(2.72764)
+
+
+def test_an_unknown_distortion_model_is_rejected() -> None:
+    with pytest.raises(ValueError, match="unsupported distortion model"):
+        camera_calib(0, _kb4_statics(distortion_model="double_sphere"))
+
+
+def test_the_extrinsic_is_inverted_only_for_child_from_parent() -> None:
+    """The stored transform is ``cam_T_imu``; the feed hands the estimator ``imu_T_cam``."""
+    statics: CameraStatics = _kb4_statics()
+    calib: CameraCalib = camera_calib(0, statics)
+    cam_R_imu: Float64[ndarray, "3 3"] = statics.transform_mat3x3.reshape(3, 3, order="F")
+    cam_T_imu: Float64[ndarray, "4 4"] = np.eye(4)
+    cam_T_imu[:3, :3] = cam_R_imu
+    cam_T_imu[:3, 3] = statics.transform_translation
+    np.testing.assert_allclose(calib.imu_T_cam @ cam_T_imu, np.eye(4), atol=1e-12)
+    with pytest.raises(ValueError, match="is not ChildFromParent"):
+        camera_calib(0, _kb4_statics(transform_relation=0))
+
+
+def _rotate_pinhole_clockwise(
+    fx: float, fy: float, cx: float, cy: float, width: int, height: int, rotation_cw_deg: int
+) -> tuple[float, float, float, float]:
+    """Rotate a landscape pinhole calibration into the frame the images are stored in.
+
+    msd-g2's video is stored rotated into portrait and its catalog calibration is
+    rotated to match, so this is the arithmetic that reconciles a raw-MSD
+    calibration with a catalog one. The feed itself never needs it — the catalog
+    already stores the rotated values — so it lives here, beside the test that is
+    its only caller: any A/B against a C++ basalt run fed from raw MSD needs the
+    convention, and pinning it keeps it from drifting.
+
+    Args:
+        fx: Focal length along x before rotation.
+        fy: Focal length along y before rotation.
+        cx: Principal point x before rotation.
+        cy: Principal point y before rotation.
+        width: Image width before rotation.
+        height: Image height before rotation.
+        rotation_cw_deg: Clockwise rotation applied to the image, 0, 90, 180 or 270.
+
+    Returns:
+        ``(fx, fy, cx, cy)`` in the rotated frame.
+
+    Raises:
+        ValueError: If the rotation is not a multiple of 90 degrees.
+    """
+    if rotation_cw_deg == 0:
+        return fx, fy, cx, cy
+    if rotation_cw_deg == 90:
+        return fy, fx, (height - 1) - cy, cx
+    if rotation_cw_deg == 180:
+        return fx, fy, (width - 1) - cx, (height - 1) - cy
+    if rotation_cw_deg == 270:
+        return fy, fx, cy, (width - 1) - cx
+    raise ValueError(f"image rotation must be 0, 90, 180 or 270 degrees clockwise; got {rotation_cw_deg}")
+
+def test_the_msd_g2_rotation_arithmetic() -> None:
+    """basalt's landscape msd-g2 calibration, rotated, is the catalog's portrait calibration."""
+    landscape_width: int = 640
+    landscape_height: int = 480
+    # cam0 and cam1 are stored 90 degrees clockwise, cam2 and cam3 270.
+    cam0: tuple[float, float, float, float] = _rotate_pinhole_clockwise(269.6842, 269.7883, 322.5579, 228.8732, landscape_width, landscape_height, 90)
+    assert cam0 == pytest.approx((269.7883, 269.6842, 250.1268, 322.5579), abs=1e-4)
+    # The rule itself: cx' = (H-1) - cy and cy' = cx at 90 clockwise.
+    assert cam0[2] == pytest.approx(landscape_height - 1 - 228.8732, abs=1e-9)
+    assert cam0[3] == pytest.approx(322.5579, abs=1e-9)
+
+    rotated_270: tuple[float, float, float, float] = _rotate_pinhole_clockwise(100.0, 200.0, 300.0, 150.0, landscape_width, landscape_height, 270)
+    assert rotated_270 == pytest.approx((200.0, 100.0, 150.0, landscape_width - 1 - 300.0))
+
+    # Two turns of 90 clockwise are one turn of 180, in the rotated frame's size.
+    once: tuple[float, float, float, float] = _rotate_pinhole_clockwise(100.0, 200.0, 300.0, 150.0, landscape_width, landscape_height, 90)
+    twice: tuple[float, float, float, float] = _rotate_pinhole_clockwise(*once, landscape_height, landscape_width, 90)
+    assert twice == pytest.approx(_rotate_pinhole_clockwise(100.0, 200.0, 300.0, 150.0, landscape_width, landscape_height, 180))
+
+    assert _rotate_pinhole_clockwise(1.0, 2.0, 3.0, 4.0, 8, 6, 0) == (1.0, 2.0, 3.0, 4.0)
+    with pytest.raises(ValueError, match="must be 0, 90, 180 or 270"):
+        _rotate_pinhole_clockwise(1.0, 2.0, 3.0, 4.0, 8, 6, 45)
+
+
+def test_the_imu_calibration_carries_the_manifests_frozen_numbers(manifest: ReferenceManifest) -> None:
+    segment: ReferenceSegment = manifest.by_id(SMOKE_SEGMENT)
+    calib = imu_calib(segment.imu, np.eye(4))
+    assert calib.frequency_hz == 1000.0
+    assert calib.gyro_noise_std == 0.000282
+    assert calib.accel_noise_std == 0.016
+    assert calib.cam_time_offset_ns == 0
+    np.testing.assert_array_equal(calib.imu_T_body, np.eye(4))
+
+
+def test_a_static_table_with_no_rows_names_the_entity() -> None:
+    """A recording whose rig node carries no statics reached `statics[column][0]`.
+
+    Row zero of an empty table is an `IndexError` out of pyarrow with nothing in
+    it that says which entity was being read.
+    """
+    empty: pa.Table = pa.table({"/rig:num_cameras": pa.array([], type=pa.list_(pa.float64()))})
+    with pytest.raises(ValueError, match="/rig:num_cameras has no rows"):
+        _static_values(empty, "/rig:num_cameras")
+    with pytest.raises(ValueError, match="/rig:reference has no rows"):
+        _static_string(pa.table({"/rig:reference": pa.array([], type=pa.string())}), "/rig:reference")
+    with pytest.raises(ValueError, match="property:capture:start_time_ns has no rows"):
+        _static_int(pa.table({"property:capture:start_time_ns": pa.array([], type=pa.int64())}), "property:capture:start_time_ns")
+
+
+def test_a_video_stream_with_no_codec_names_the_entity() -> None:
+    """The codec is read from row zero of this camera's non-null codecs; both can be empty."""
+    entity: str = "/rig/cam_00/pinhole/video"
+    columns: list[str] = ["video_time", f"{entity}:VideoStream:is_keyframe", f"{entity}:VideoStream:codec"]
+    no_rows: pa.Table = pa.table({name: pa.array([], type=pa.int64()) for name in columns})
+    with pytest.raises(ValueError, match=f"{entity}: the recording carries no video samples"):
+        _video_codec(no_rows, entity)
+
+    no_codec: pa.Table = pa.table(
+        {
+            columns[0]: pa.array([1, 2], type=pa.int64()),
+            columns[1]: pa.array([None, None], type=pa.int64()),
+            columns[2]: pa.array([None, None], type=pa.list_(pa.uint32())),
+        }
+    )
+    with pytest.raises(ValueError, match=f"{entity}: the video stream carries no codec"):
+        _video_codec(no_codec, entity)
+
+
+def test_a_rig_whose_cameras_disagree_on_the_codec_names_both() -> None:
+    """One index carries one codec, so a mixed rig must say which two cameras differ.
+
+    Every current rig is uniform (MSD is AV1, RoboCap H.264), so the muxer would
+    otherwise write the last camera's codec over every camera's samples.
+    """
+    assert _shared_codec([(0, "av1"), (2, "av1")], SMOKE_SEGMENT) == "av1"
+    with pytest.raises(ValueError, match="cam_02 is h264 where cam_00 is av1"):
+        _shared_codec([(0, "av1"), (2, "h264")], SMOKE_SEGMENT)
+
+
+def _transform_rows(
+    t_ns: list[int], translations: list[list[float] | None], quaternions: list[list[float] | None]
+) -> pa.Table:
+    """One window of the ``gt`` layer, with each component present on the rows the caller names.
+
+    Rerun nests a component's instances one list deep, so a row carrying one
+    translation is ``[[x, y, z]]`` and a row carrying none is null — which is what
+    component-level logging or a clear produces, and the two components need not
+    be null on the same rows.
+
+    Args:
+        t_ns: ``video_time`` of each row.
+        translations: Per row, the rig position in metres, or None where the row carries no translation.
+        quaternions: Per row, the XYZW rotation, or None where the row carries no quaternion.
+
+    Returns:
+        The window in the shape the reader hands :func:`_rig_trajectory`.
+    """
+    return pa.table(
+        {
+            TIMELINE: pa.array(t_ns, type=pa.int64()),
+            f"{RIG_ENTITY}:Transform3D:translation": pa.array(
+                [None if value is None else [value] for value in translations], type=pa.list_(pa.list_(pa.float64(), 3))
+            ),
+            f"{RIG_ENTITY}:Transform3D:quaternion": pa.array(
+                [None if value is None else [value] for value in quaternions], type=pa.list_(pa.list_(pa.float64(), 4))
+            ),
+        }
+    )
+
+
+def test_a_ground_truth_window_reads_both_components_off_the_same_rows() -> None:
+    """A pose is a translation and a rotation from one row, and the reader used to pair them by position.
+
+    The timestamps came from the translation column's validity mask while the
+    quaternion column was flattened with its own null removal, so two components
+    valid on *different* rows still flattened to the same length and the pose at
+    ``t0`` was handed ``t1``'s rotation: a plausible layout — component-level
+    logging or a clear writes it, and the public ``--gt-rrd`` path reads it —
+    silently attached a rotation from the wrong time to every pose (S25 review).
+    """
+    aligned: Trajectory = _rig_trajectory(
+        _transform_rows(
+            [10, 20, 30],
+            [[1.0, 0.0, 0.0], None, [3.0, 0.0, 0.0]],
+            [[0.0, 0.0, 0.0, 1.0], None, [0.0, 0.0, 1.0, 0.0]],
+        ),
+        SMOKE_SEGMENT,
+    )
+    np.testing.assert_array_equal(aligned.t_ns, np.array([10, 30], dtype=np.int64))
+    np.testing.assert_array_equal(aligned.position_m[:, 0], np.array([1.0, 3.0]))
+    # w-first in memory, from Rerun's XYZW on the wire.
+    np.testing.assert_array_equal(aligned.quaternion_wxyz[:, 0], np.array([1.0, 0.0]))
+
+    # Two masks, two valid rows each, one row in common: the counts match, so
+    # nothing downstream could notice the swap.
+    with pytest.raises(ValueError, match=f"{SMOKE_SEGMENT}: 2 of 3 rig rows.*translation.*quaternion.*first at 10 ns"):
+        _rig_trajectory(
+            _transform_rows(
+                [10, 20, 30],
+                [[1.0, 0.0, 0.0], None, [3.0, 0.0, 0.0]],
+                [None, [0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 1.0, 0.0]],
+            ),
+            SMOKE_SEGMENT,
+        )
+
+
+def test_a_ground_truth_window_with_no_pose_in_it_is_empty() -> None:
+    """A window the layer does not cover is the same answer as a layer that is not there."""
+    assert len(_rig_trajectory(_transform_rows([10, 20], [None, None], [None, None]), SMOKE_SEGMENT)) == 0
+    assert len(_rig_trajectory(pa.table({TIMELINE: pa.array([10], type=pa.int64())}), SMOKE_SEGMENT)) == 0
+
+
+@pytest.mark.slow
+def test_the_smoke_segment_decodes_from_the_nas(manifest: ReferenceManifest) -> None:
+    """One real segment end to end: frame count, shape, dtype and paired IMU timestamps."""
+    segment: ReferenceSegment = manifest.by_id(SMOKE_SEGMENT)
+    if not segment.base_path.is_file():
+        pytest.skip(f"{segment.base_path} is not mounted on this host")
+    gt_path = segment.gt_path if segment.gt_path.is_file() else None
+
+    with open_segment(LocalSegment(base_rrd=segment.base_path, gt_rrd=gt_path), segment.imu) as feed:
+        assert isinstance(feed, SegmentFeed)
+        assert len(feed.cameras) == segment.capture.num_cameras
+        assert len(feed.frame_t_ns) == segment.capture.num_frames
+        assert feed.capture_start_time_ns == segment.capture.start_time_ns
+        # MSD's video_time is relative to that, so an export has to add it back.
+        assert feed.export_offset_ns == segment.capture.start_time_ns
+        for camera in feed.cameras:
+            assert (camera.width, camera.height) == (960, 960)
+            assert camera.model == "kb4"
+        # Gyroscope and accelerometer share timestamps on MSD; the feed refuses to
+        # build an ImuStream otherwise, so reaching here is the assertion.
+        whole_imu: ImuStream = feed.imu_between(-(2**62), 2**62)
+        assert len(whole_imu) > 7_000
+        assert whole_imu.t_ns.dtype == np.int64
+
+        # A count of framesets is a time to the feed, or it is told to run to
+        # the end of the segment and fetches a window nothing decodes. The
+        # hundredth frameset with no stride, and the segment's last when the
+        # count runs past its end.
+        assert feed.stop_ns_after(None) is None
+        assert feed.stop_ns_after(100) == int(feed.frame_t_ns[99])
+        assert feed.stop_ns_after(len(feed.frame_t_ns) + 1) == int(feed.frame_t_ns[-1])
+        assert feed.stop_ns_after(1) == int(feed.frame_t_ns[0])
+        assert whole_imu.gyro_rad_s.shape == (len(whole_imu), 3)
+        assert whole_imu.accel_m_s2.shape == (len(whole_imu), 3)
+        whole_gt: Trajectory = feed.ground_truth_between(-(2**62), 2**62)
+        assert len(whole_gt)
+        assert len(whole_gt) == segment.gt.num_poses
+
+        digests: list[str] = []
+        with_truth: int = 0
+        frameset: Frameset
+        for frameset in feed.framesets():
+            assert len(frameset.images) == segment.capture.num_cameras
+            for image in frameset.images:
+                assert image.shape == (960, 960)
+                assert image.dtype == np.uint8
+                assert image.flags["C_CONTIGUOUS"]
+            if frameset.ground_truth is not None:
+                assert frameset.ground_truth.shape == (7,)
+                with_truth += 1
+            digests.append(frameset.digest())
+        assert len(digests) == segment.capture.num_frames
+        # Ground truth starts 17.5 ms into the segment, so only the first frameset
+        # is without it; a frameset outside the truth's span reports None rather
+        # than borrowing a stale pose.
+        assert with_truth == segment.capture.num_frames - 1
+
+
+@pytest.mark.slow
+def test_the_window_size_does_not_change_a_single_pixel_or_an_imu_sample(manifest: ReferenceManifest) -> None:
+    """Cutting the segment into 2 s windows must reproduce the pixels and the inertial stream exactly."""
+    segment: ReferenceSegment = manifest.by_id(SMOKE_SEGMENT)
+    if not segment.base_path.is_file():
+        pytest.skip(f"{segment.base_path} is not mounted on this host")
+    digests: dict[float, list[tuple[int, str]]] = {}
+    imu_t_ns: dict[float, Int64[ndarray, " n_samples"]] = {}
+    for window_s in (60.0, 2.0):
+        with open_segment(LocalSegment(base_rrd=segment.base_path), segment.imu, window_s=window_s) as feed:
+            per_frameset: list[tuple[int, str]] = []
+            emitted: list[Int64[ndarray, " n"]] = []
+            for frameset in feed.framesets():
+                per_frameset.append((frameset.t_ns, frameset.digest()))
+                emitted.append(frameset.imu.t_ns)
+            digests[window_s] = per_frameset
+            imu_t_ns[window_s] = np.concatenate(emitted)
+    assert digests[60.0] == digests[2.0]
+    assert len(digests[60.0]) == segment.capture.num_frames
+
+    # A bounded read is the same read, stopped: the same rows in the same order,
+    # and no window opening past the bound is fetched at all — with 2 s windows
+    # over a 7.6 s segment, a bound at 2.5 s leaves the last two windows unread.
+    first_ns: int = digests[2.0][0][0]
+    bounded_ns: int = first_ns + 2_500_000_000
+    with open_segment(LocalSegment(base_rrd=segment.base_path), segment.imu, window_s=2.0) as feed:
+        bounded: list[tuple[int, str]] = [(frameset.t_ns, frameset.digest()) for frameset in feed.framesets(bounded_ns)]
+    assert bounded == digests[2.0][: len(bounded)]
+    assert bounded_ns <= bounded[-1][0] < bounded_ns + 2_000_000_000
+    assert len(bounded) < len(digests[2.0])
+
+    # The inertial samples handed out across window boundaries must form one
+    # stream: strictly increasing, no sample delivered twice, and the same set
+    # whatever the window size. A window that failed to reach back would drop
+    # samples here instead of silently under-integrating.
+    for window_s, times in imu_t_ns.items():
+        assert bool(np.all(np.diff(times) > 0)), f"window {window_s}s emitted non-monotonic IMU timestamps"
+    np.testing.assert_array_equal(imu_t_ns[60.0], imu_t_ns[2.0])
+
+
+@pytest.mark.slow
+def test_the_absolute_clock_matches_the_ground_truth_sidecar(manifest: ReferenceManifest) -> None:
+    """The feed's ground truth, shifted by the capture start time, is the ``gt.csv`` sidecar."""
+    segment: ReferenceSegment = manifest.by_id(SMOKE_SEGMENT)
+    if not segment.base_path.is_file() or not segment.gt_csv.is_file():
+        pytest.skip(f"{segment.base_path} or {segment.gt_csv} is not mounted on this host")
+    sidecar: Trajectory = read_trajectory(segment.gt_csv)
+    assert len(sidecar) == segment.gt.num_poses
+
+    with open_segment(LocalSegment(base_rrd=segment.base_path, gt_rrd=segment.gt_path), segment.imu) as feed:
+        relative: Trajectory = feed.ground_truth_between(-(2**62), 2**62)
+        assert len(relative)
+        absolute: Trajectory = shift_clock(relative, feed.capture_start_time_ns)
+
+    # Exact, not approximate: video_time + capture.start_time_ns is the sidecar's
+    # clock by construction, so every one of the 6,998 timestamps must land.
+    np.testing.assert_array_equal(absolute.t_ns, sidecar.t_ns)
+    assert associate(sidecar, absolute).count == len(sidecar)
+    # Without the shift the two share no instant at all.
+    assert associate(sidecar, relative).count == 0
+    # The rrd stores float32 positions; the sidecar keeps more digits.
+    result: AteResult = ate(absolute, sidecar)
+    assert result.n_associated == len(absolute)
+    assert result.rmse_m < 1e-5
+
+
+@pytest.mark.slow
+def test_a_replay_export_associates_with_the_ground_truth_sidecar(manifest: ReferenceManifest, tmp_path: Path) -> None:
+    """The replay's own export path, end to end, lands on the sidecar's clock.
+
+    Forty framesets of the smoke segment through the whole pipeline: enough for
+    the estimator to initialise and produce poses, which is what gets exported.
+    Written with ``video_time`` the file associates with **nothing**, which is
+    the regression being pinned.
+    """
+    segment: ReferenceSegment = manifest.by_id(SMOKE_SEGMENT)
+    if not segment.base_path.is_file() or not segment.gt_csv.is_file():
+        pytest.skip(f"{segment.base_path} or {segment.gt_csv} is not mounted on this host")
+
+    config: Config = Config(rr_config=RerunTyroConfig(headless=True), segment=SMOKE_SEGMENT, stage="vio", max_framesets=40)
+    with open_segment(LocalSegment(base_rrd=segment.base_path, gt_rrd=segment.gt_path), segment.imu) as feed:
+        truth: Trajectory = feed.ground_truth_between(int(feed.frame_t_ns[0]), int(feed.frame_t_ns[-1]))
+        assert len(truth)
+        stage: VioStage = VioStage(
+            lockstep=Lockstep(vio=_core.Vio(_core.Calibration.from_catalog(feed.cameras, feed.imu), flow_config(manifest, segment))),
+            logger=VioLogger(
+                cameras=feed.cameras,
+                ground_truth=truth,
+                cpp=_cpp_trajectory(manifest, segment, feed.capture_start_time_ns),
+                frame_t_ns=feed.frame_t_ns,
+            ),
+        )
+        replayed: int = _replay(feed, config, stage)
+        estimate: Trajectory = stage.logger.estimated()
+        exported: Path = tmp_path / "slam_rs.csv"
+        write_trajectory(exported, shift_clock(estimate, feed.capture_start_time_ns))
+        relative_export: Path = tmp_path / "relative.csv"
+        write_trajectory(relative_export, estimate)
+
+    assert replayed == 40
+    assert stage.lockstep.imu_samples > 0
+    # One pose per frameset: every frameset's own batch runs past its frame time,
+    # and one that did not would be held and tracked again rather than lost (D17).
+    assert len(estimate) == replayed
+    assert not stage.pending
+    sidecar: Trajectory = read_trajectory(segment.gt_csv)
+    # All but the first pose, which sits on the capture's start time — 17 ms
+    # before the sidecar's first row, so it has nothing to associate with. The
+    # ground truth does not cover the whole segment (D36).
+    assert associate(read_trajectory(exported), sidecar).count == len(estimate) - 1
+    assert associate(read_trajectory(relative_export), sidecar).count == 0

--- a/packages/slam-rs/tests/test_cpp_reference.py
+++ b/packages/slam-rs/tests/test_cpp_reference.py
@@ -1,0 +1,300 @@
+"""The basalt C++ reference runs: the numbers this port is measured against.
+
+Two things are pinned here. First, that ``slam_rs.trajectory`` reproduces the
+fork's own ATE arithmetic on the fork's own outputs — if it does not, every gate
+number in the manifest means something different from what the C++ side measured.
+Second, that the feed decodes the same pixels the C++ run consumed, frame for
+frame, which is what makes an A/B between the two estimators about the estimator
+rather than about the decoder.
+
+The association is driven by the estimate, matching the reference: each basalt
+pose takes the nearest ground-truth pose within 5 ms.
+"""
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from slam_rs import reference_bundle
+from slam_rs.catalog_feed import Frameset, LocalSegment, open_segment
+from slam_rs.reference import SMOKE_SEGMENTS, CppAte, ReferenceManifest, ReferenceSegment
+from slam_rs.trajectory import AteResult, Trajectory, ate, read_trajectory
+
+RMSE_TOLERANCE_CM: float = 0.005
+"""Rounding slack when reproducing a published centimetre figure."""
+WALL_TOLERANCE_S: float = 0.001
+"""Rounding slack on the manifest's copy of the run's wall time, which is recorded to the millisecond."""
+
+
+def _assert_reproduces(result: AteResult, expected: CppAte, segment_id: str) -> None:
+    """The recomputed error must be the published one, to the precision it was published at."""
+    assert result.n_associated == expected.associated, segment_id
+    assert result.n_estimate == expected.total, segment_id
+    assert result.rmse_m * 100 == pytest.approx(expected.rmse_cm, abs=RMSE_TOLERANCE_CM), segment_id
+    assert result.max_m * 100 == pytest.approx(expected.max_cm, abs=RMSE_TOLERANCE_CM), segment_id
+    assert result.median_m * 100 == pytest.approx(expected.median_cm, abs=RMSE_TOLERANCE_CM), segment_id
+
+
+def test_every_segment_has_a_reference_run(manifest: ReferenceManifest) -> None:
+    for segment in manifest.segments:
+        run: Path = manifest.package_root / segment.reference.run_json
+        assert run.is_file(), segment.segment_id
+        # The manifest's own claims must match the run it points at.
+        recorded: dict[str, Any] = json.loads(run.read_text())
+        assert recorded["segment"] == segment.segment_id
+        assert recorded["decode_path"] == segment.reference.decode_path == segment.decode_path
+        assert recorded["fork"]["commit"] == segment.reference.fork_commit
+        assert recorded["capture"]["start_time_ns"] == segment.capture.start_time_ns
+        assert recorded["capture"]["num_frames"] == segment.capture.num_frames
+        assert recorded["run"]["poses"] == segment.reference.expected_cpp_ate.total
+        assert recorded["run"]["status"] == "ok"
+        # The wall the speed clause is measured against is this run's own.
+        assert recorded["run"]["feed_wall_time_s"] == pytest.approx(segment.reference.expected_cpp_wall_s, abs=WALL_TOLERANCE_S)
+        assert recorded["outputs"]["trajectory_sha256"] == segment.reference.trajectory_sha256
+        # The IMU model the C++ run was tuned with is the one the manifest freezes.
+        assert recorded["imu"]["gyro_noise_std"] == segment.imu.gyro_noise_std
+        assert recorded["imu"]["accel_noise_std"] == segment.imu.accel_noise_std
+        assert recorded["imu"]["cam_time_offset_ns"] == segment.imu.cam_time_offset_ns
+        assert recorded["deterministic"]["deterministic"] is segment.reference.deterministic
+        assert recorded["deterministic"]["num_threads"] == segment.reference.num_threads
+        assert recorded["deterministic"]["use_double"] is segment.reference.use_double
+
+
+def test_the_vendored_configs_are_the_ones_the_cpp_runs_used(manifest: ReferenceManifest) -> None:
+    """Every ``config.*`` key of every C++ run, against the file the port loads.
+
+    The run manifests embed the whole configuration document the C++ binary read,
+    so this compares documents rather than the four fields the run summarises and
+    the one the binding exposes: a key the Rust struct does not model yet is
+    compared here too. What it stops from coming back is C72 — the Python path
+    built ``_core.VioConfig()``, basalt's constructor defaults, which differ from
+    the shipped MSD files in ``vio_marg_lost_landmarks`` and put the port 1.41 to
+    12.05 cm from the C++ instead of 0.31 to 5.19 cm.
+    """
+    compared: int = 0
+    for segment in manifest.segments:
+        vendored: dict[str, Any] = json.loads(manifest.vio_config_text(segment.dataset_name))["value0"]
+        recorded: dict[str, Any] = json.loads((manifest.package_root / segment.reference.run_json).read_text())["vio_config"]
+        # The run names the config by its path inside the fork; the manifest names
+        # this repository's copy of that same file.
+        assert Path(recorded["path"]) == Path(segment.reference.vio_config), segment.segment_id
+        assert Path(recorded["path"]).name == manifest.dataset(segment.dataset_name).vio_config.name, segment.segment_id
+        assert set(vendored) == set(recorded["json"]), segment.segment_id
+        differing: dict[str, tuple[Any, Any]] = {
+            key: (value, recorded["json"][key]) for key, value in vendored.items() if value != recorded["json"][key]
+        }
+        assert not differing, f"{segment.segment_id}: vendored config disagrees with the C++ run, (vendored, run) = {differing}"
+        # Named rather than left implicit: this is the key the constructor's
+        # defaults get wrong, and the reason this test exists.
+        assert vendored["config.vio_marg_lost_landmarks"] is True, segment.segment_id
+        assert vendored["config.optical_flow_image_safe_radius"] == segment.reference.optical_flow_image_safe_radius, segment.segment_id
+        compared += len(vendored)
+    # Ten runs, 68 keys each: the whole document, every time.
+    assert compared == 10 * 68
+
+
+def test_the_committed_run_manifests_carry_the_bundles_configuration(manifest: ReferenceManifest) -> None:
+    """Where the reference bundle is on this host, its run manifests agree with the committed ones.
+
+    The committed ``run.json`` copies are what
+    :func:`test_the_vendored_configs_are_the_ones_the_cpp_runs_used` compares
+    against, and they are editable text in this repository. The bundle holds the
+    originals the C++ runs wrote, so this closes the loop for whichever segments
+    the bundle root on this host holds — the two long-tier runs were re-run into a
+    second root, so which segments resolve depends on where
+    ``SLAM_RS_REFERENCE_DIR`` points. Only the configuration is compared: the
+    long-tier copies carry fewer summary keys than the committed ones.
+    """
+    compared: list[str] = []
+    for segment in manifest.segments:
+        resolved: reference_bundle.BundleFile = reference_bundle.resolve(segment.segment_id, reference_bundle.RUN_JSON)
+        if not resolved.available:
+            continue
+        original: dict[str, Any] = json.loads(resolved.path.read_text())["vio_config"]
+        committed: dict[str, Any] = json.loads((manifest.package_root / segment.reference.run_json).read_text())["vio_config"]
+        assert original["json"] == committed["json"], segment.segment_id
+        assert original["path"] == committed["path"], segment.segment_id
+        compared.append(segment.segment_id)
+    if not compared:
+        pytest.skip(f"no run manifest resolves through {reference_bundle.bundle_root()}")
+
+
+def test_only_the_long_tier_is_bundle_only(manifest: ReferenceManifest) -> None:
+    bundled: set[str] = {s.segment_id for s in manifest.segments if s.reference.bundle_only}
+    assert bundled == {s.segment_id for s in manifest.in_tier("long")}
+    for segment in manifest.segments:
+        if segment.reference.bundle_only:
+            # Committed instead: a README saying where the trajectory lives.
+            assert ((manifest.package_root / segment.reference.run_json).parent / "README").is_file()
+        else:
+            assert (manifest.package_root / segment.reference.trajectory_csv).is_file()
+
+
+def test_the_gate_policy_matches_what_basalt_can_actually_do(manifest: ReferenceManifest) -> None:
+    """A tight gate is only allowed where the C++ reference is itself accurate."""
+    policies: dict[str, str] = {s.segment_id: s.reference.gate_policy for s in manifest.segments}
+    assert policies["msd-index__MIO_others__MIO10_short_2_panorama"] == "tight"
+    assert policies["msd-g2__MGO_others__MGO09_short_1_updown"] == "tight"
+    assert policies["msd-index__MIO_others__MIO07_mapping_easy"] == "tight"
+    assert policies["msd-g2__MGO_others__MGO07_mapping_easy"] == "tight"
+    # basalt is near failure on these two: 43 cm and 78 cm here, 68 cm for the C++
+    # binary on the raw files, and 32 cm / 18 cm of spread between two legitimate
+    # decode paths of the same estimator. A tolerance would measure noise.
+    assert policies["msd-g2__MGO_others__MGO01_low_light"] == "no_divergence"
+    assert policies["msd-g2__MGO_others__MGO13_sudden_movements"] == "no_divergence"
+
+    for segment in manifest.segments:
+        rmse_cm: float = segment.reference.expected_cpp_ate.rmse_cm
+        if segment.reference.gate_policy == "tight":
+            assert rmse_cm < 3.0, f"{segment.segment_id} is gated tight but basalt scores {rmse_cm:.2f} cm"
+        if segment.reference.gate_policy == "no_divergence":
+            assert rmse_cm > 30.0, f"{segment.segment_id} is only gated for divergence but basalt scores {rmse_cm:.2f} cm"
+
+
+def test_the_reference_runs_tracked_every_frameset(manifest: ReferenceManifest) -> None:
+    """One pose per frameset, and near-total ground-truth coverage."""
+    for segment in manifest.segments:
+        expected: CppAte = segment.reference.expected_cpp_ate
+        assert expected.total == segment.capture.num_frames, segment.segment_id
+        # MIO14's sidecar has real gaps: 148 of 22,117 poses have no truth within
+        # 5 ms. Everything else is within one pose of complete.
+        assert expected.associated / expected.total > 0.99, segment.segment_id
+
+
+@pytest.mark.parametrize("segment_id", SMOKE_SEGMENTS)
+def test_the_smoke_tier_numbers_reproduce_offline(manifest: ReferenceManifest, segment_id: str) -> None:
+    """The published smoke figures, from committed files only: no NAS, no catalog."""
+    segment: ReferenceSegment = manifest.by_id(segment_id)
+    assert segment.reference.gt_csv_fixture is not None
+    estimate: Trajectory = read_trajectory(manifest.package_root / segment.reference.trajectory_csv)
+    truth: Trajectory = read_trajectory(manifest.package_root / segment.reference.gt_csv_fixture)
+    assert len(truth) == segment.gt.num_poses
+    _assert_reproduces(ate(estimate, truth), segment.reference.expected_cpp_ate, segment_id)
+
+
+def test_the_committed_gt_fixtures_are_the_sidecars_the_runs_used(manifest: ReferenceManifest) -> None:
+    """The committed ``gt.csv`` copies name the same NAS path the C++ runs read."""
+    for segment_id in SMOKE_SEGMENTS:
+        segment: ReferenceSegment = manifest.by_id(segment_id)
+        recorded: dict[str, Any] = json.loads((manifest.package_root / segment.reference.run_json).read_text())
+        assert Path(recorded["ate_vs_gt"]["gt_csv"]) == segment.gt_csv
+
+
+@pytest.mark.parametrize("segment_id", SMOKE_SEGMENTS)
+def test_the_committed_frame_digests_cover_every_camera_frame(manifest: ReferenceManifest, segment_id: str) -> None:
+    """One digest per (frameset, camera), on the absolute clock, and nothing repeated."""
+    segment: ReferenceSegment = manifest.by_id(segment_id)
+    assert segment.reference.frames_sha256 is not None
+    digests: dict[tuple[int, int], str] = _read_frame_digests(manifest.package_root / segment.reference.frames_sha256)
+    assert len(digests) == segment.capture.num_frames * segment.capture.num_cameras
+    timestamps: set[int] = {t_ns for t_ns, _ in digests}
+    assert len(timestamps) == segment.capture.num_frames
+    # Absolute device-clock timestamps, inside the capture window. Video does not
+    # necessarily start at video_time zero: on MIO10 it does, on MGO09 the first
+    # frame is 17.5 ms in.
+    assert min(timestamps) >= segment.capture.start_time_ns
+    assert max(timestamps) <= segment.capture.start_time_ns + segment.capture.duration_ns
+    assert {camera for _, camera in digests} == set(range(segment.capture.num_cameras))
+    assert all(len(digest) == 64 for digest in digests.values())
+    recorded: dict[str, Any] = json.loads((manifest.package_root / segment.reference.run_json).read_text())
+    assert recorded["outputs"]["frame_hashes"] == len(digests)
+
+
+def _read_frame_digests(path: Path) -> dict[tuple[int, int], str]:
+    """``t_ns,cam_index,sha256`` lines, keyed by (absolute timestamp, camera)."""
+    digests: dict[tuple[int, int], str] = {}
+    for line in path.read_text().splitlines():
+        if not line or line.startswith("#"):
+            continue
+        t_ns, camera, digest = line.split(",")
+        digests[(int(t_ns), int(camera))] = digest
+    return digests
+
+
+def test_the_long_tier_trajectories_resolve_through_the_bundle(manifest: ReferenceManifest) -> None:
+    """Present or not, the resolution has to name a path and a reason."""
+    for segment in manifest.in_tier("long"):
+        resolved = reference_bundle.resolve(segment.segment_id, reference_bundle.TRAJECTORY_CSV)
+        assert resolved.path.name == "basalt_traj.csv"
+        assert resolved.path.parent.name == segment.segment_id
+        if not resolved.available:
+            assert reference_bundle.BUNDLE_DIR_VARIABLE in (resolved.reason or "")
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("segment_id", SMOKE_SEGMENTS)
+def test_a_redecode_reproduces_the_cpp_pixel_digests(manifest: ReferenceManifest, segment_id: str) -> None:
+    """The feed hands the core byte-identical pixels to what the C++ reference consumed.
+
+    This is the load-bearing claim behind every A/B between the two estimators: if
+    the digests match, a trajectory difference is the estimator, not the decoder.
+    """
+    segment: ReferenceSegment = manifest.by_id(segment_id)
+    if not segment.base_path.is_file():
+        pytest.skip(f"{segment.base_path} is not mounted on this host")
+    assert segment.reference.frames_sha256 is not None
+    expected: dict[tuple[int, int], str] = _read_frame_digests(manifest.package_root / segment.reference.frames_sha256)
+
+    compared: int = 0
+    frameset: Frameset
+    with open_segment(LocalSegment(base_rrd=segment.base_path), segment.imu) as feed:
+        offset: int = feed.capture_start_time_ns
+        for frameset in feed.framesets():
+            for camera, digest in zip(feed.cameras, frameset.image_digests(), strict=True):
+                key: tuple[int, int] = (frameset.t_ns + offset, camera.index)
+                assert key in expected, f"{segment_id}: the reference has no frame at {key}"
+                assert digest == expected[key], f"{segment_id}: pixels differ at {key}"
+                compared += 1
+    assert compared == len(expected)
+
+
+@pytest.mark.slow
+def test_every_committed_trajectory_reproduces_its_published_ate(manifest: ReferenceManifest) -> None:
+    """All eight committed runs against the NAS sidecars, plus the long pair when bundled."""
+    checked: list[str] = []
+    for segment in manifest.segments:
+        if segment.reference.bundle_only:
+            resolved = reference_bundle.resolve(segment.segment_id, reference_bundle.TRAJECTORY_CSV)
+            if not resolved.available:
+                continue
+            trajectory_path: Path = resolved.path
+        else:
+            trajectory_path = manifest.package_root / segment.reference.trajectory_csv
+        if not segment.gt_csv.is_file():
+            continue
+        estimate: Trajectory = read_trajectory(trajectory_path)
+        truth: Trajectory = read_trajectory(segment.gt_csv)
+        _assert_reproduces(ate(estimate, truth), segment.reference.expected_cpp_ate, segment.segment_id)
+        checked.append(segment.segment_id)
+    if not checked:
+        pytest.skip("no gt.csv sidecar is mounted on this host")
+    # The eight committed ones at least; the long pair joins when the bundle is present.
+    assert len(checked) >= 8
+
+
+@pytest.mark.slow
+def test_the_committed_trajectories_match_their_recorded_digest(manifest: ReferenceManifest) -> None:
+    """A fixture that was re-saved or line-ending-mangled would silently change the gate."""
+    for segment in manifest.segments:
+        if segment.reference.bundle_only:
+            continue
+        path: Path = manifest.package_root / segment.reference.trajectory_csv
+        assert hashlib.sha256(path.read_bytes()).hexdigest() == segment.reference.trajectory_sha256, segment.segment_id
+
+
+@pytest.mark.slow
+def test_the_committed_gt_fixture_matches_the_nas_sidecar(manifest: ReferenceManifest) -> None:
+    """The offline smoke gate must be reading the same bytes the NAS holds."""
+    for segment_id in SMOKE_SEGMENTS:
+        segment: ReferenceSegment = manifest.by_id(segment_id)
+        assert segment.reference.gt_csv_fixture is not None
+        if not segment.gt_csv.is_file():
+            pytest.skip(f"{segment.gt_csv} is not mounted on this host")
+        committed: Trajectory = read_trajectory(manifest.package_root / segment.reference.gt_csv_fixture)
+        on_nas: Trajectory = read_trajectory(segment.gt_csv)
+        np.testing.assert_array_equal(committed.t_ns, on_nas.t_ns)
+        np.testing.assert_array_equal(committed.position_m, on_nas.position_m)

--- a/packages/slam-rs/tests/test_dump_clip.py
+++ b/packages/slam-rs/tests/test_dump_clip.py
@@ -1,0 +1,36 @@
+"""What the PC11 dump producer refuses before it opens a segment.
+
+``tests/tools/dump_clip.py`` is a test-only producer — it writes the ``.npz``
+bundle :mod:`slam_rs.apis.bench_track` replays and the PGM directory the Rust
+lanes and the C++ oracle read — and a whole segment is gigabytes, so what is
+worth a test here is the selection it will not spend a feed on. It is reached as
+a namespace module under ``tests``, the same path pytest and pyrefly are given.
+"""
+
+from pathlib import Path
+
+import pytest
+from fixture_types import never
+from tools.dump_clip import Config, main
+
+from slam_rs.reference import SMOKE_SEGMENTS
+from tools import dump_clip
+
+
+def test_an_npz_dump_of_no_framesets_is_refused_before_the_feed_is_opened(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``--max-framesets 0 --npz`` wrote a partial directory and then raised out of NumPy.
+
+    Zero was accepted, the loop broke on its first frameset, and the non-NPZ
+    side files (``calib.json``, ``imu.csv``, ``timestamps.txt``, ``imu.json``,
+    ``frames.sha256``, ``clip.json``) were all written before ``np.stack`` on the
+    empty image list raised ``ValueError: need at least one array to stack`` — so
+    the tool left a clip directory that reads as a dump and holds no frameset
+    (S25 review). The refusal comes before the manifest, the catalog and the
+    output directory.
+    """
+
+    monkeypatch.setattr(dump_clip, "load_manifest", never("the manifest was read for a dump of no framesets"))
+    output: Path = tmp_path / "clip"
+    with pytest.raises(ValueError, match="--max-framesets 0.*--npz"):
+        main(Config(segment=SMOKE_SEGMENTS[1], output=output, max_framesets=0, npz=True))
+    assert not output.exists()

--- a/packages/slam-rs/tests/test_frameset_matching.py
+++ b/packages/slam-rs/tests/test_frameset_matching.py
@@ -1,0 +1,378 @@
+"""The frameset matcher, the two inertial clocks and the camera subset.
+
+Every case here is :mod:`slam_rs.catalog_feed`, on synthetic tables and without
+touching the NAS: which frames of which cameras are one frameset when the rig is
+not hardware-synced, how an accelerometer on its own clock reaches the
+gyroscope's, and which cameras of a six-camera rig are fed and in what order.
+RoboCap is why the code exists, so its numbers are the fixtures; what is under
+test is the feed. The rig's own calibration arithmetic and the two real-recording
+tests are in ``test_robocap_probe``.
+"""
+
+import numpy as np
+import pyarrow as pa
+import pytest
+from beartype.roar import BeartypeException
+from jaxtyping import Float64, Int64
+from numpy import ndarray
+
+from slam_rs.catalog_feed import (
+    _frame_nearest_anchor,
+    match_framesets,
+    pair_accel_onto_gyro,
+    select_cameras,
+)
+
+
+def camera_name_statics(names: list[str]) -> pa.Table:
+    """A statics table carrying just the ``name`` component of each camera node."""
+    return pa.table({f"/world/rig_00/cam_{position:02d}:name": [[name]] for position, name in enumerate(names)})
+
+# --- the accelerometer onto the gyroscope's clock ----------------------------
+
+
+def test_the_accelerometer_lands_on_the_gyroscopes_timestamps() -> None:
+    """Two clocks in, one out: every gyroscope time kept, the acceleration interpolated onto it."""
+    gyro_t_ns: Int64[ndarray, " 3"] = np.array([100, 200, 300], dtype=np.int64)
+    accel_t_ns: Int64[ndarray, " 3"] = np.array([50, 250, 450], dtype=np.int64)
+    accel: Float64[ndarray, "3 3"] = np.array([[0.0, 0.0, 0.0], [2.0, 4.0, 8.0], [4.0, 8.0, 16.0]])
+    paired = pair_accel_onto_gyro(gyro_t_ns, np.ones((3, 3)), accel_t_ns, accel)
+
+    assert paired.t_ns.tolist() == [100, 200, 300]
+    # 100 sits a quarter of the way from 50 to 250, 200 three quarters, and 300 a
+    # quarter of the way from 250 to 450.
+    assert paired.accel_m_s2[:, 0].tolist() == pytest.approx([0.5, 1.5, 2.5])
+    assert paired.accel_m_s2[:, 2].tolist() == pytest.approx([2.0, 6.0, 10.0])
+    assert paired.gyro_rad_s.shape == (3, 3)
+
+
+def test_a_gyroscope_sample_the_accelerometer_does_not_cover_is_dropped() -> None:
+    """`numpy.interp` clamps; a clamped endpoint is a measurement nobody took."""
+    gyro_t_ns: Int64[ndarray, " 5"] = np.array([10, 60, 110, 160, 210], dtype=np.int64)
+    accel_t_ns: Int64[ndarray, " 2"] = np.array([50, 150], dtype=np.int64)
+    paired = pair_accel_onto_gyro(gyro_t_ns, np.ones((5, 3)), accel_t_ns, np.array([[1.0, 1.0, 1.0], [3.0, 3.0, 3.0]]))
+
+    # The result is a subset of the gyroscope's own timestamps, so 10 and 210 are
+    # dropped and 150 — an accelerometer time — was never a candidate.
+    assert paired.t_ns.tolist() == [60, 110]
+    assert len(paired) == len(paired.gyro_rad_s) == len(paired.accel_m_s2)
+
+
+def test_the_accelerometers_span_is_closed_at_both_ends() -> None:
+    """basalt's endpoints, one nanosecond either side (`dataset_io_robocap.cpp:476-483`).
+
+    A gyroscope sample **on** the first accelerometer timestamp interpolates with
+    alpha 0 and one on the last with alpha 1, so both are measurements and both
+    are kept; one nanosecond outside has no accelerometer sample on both sides of
+    it and is dropped rather than clamped.
+    """
+    gyro_t_ns: Int64[ndarray, " 4"] = np.array([49, 50, 150, 151], dtype=np.int64)
+    accel: Float64[ndarray, "2 3"] = np.array([[1.0, 1.0, 1.0], [3.0, 3.0, 3.0]])
+    paired = pair_accel_onto_gyro(gyro_t_ns, np.ones((4, 3)), np.array([50, 150], dtype=np.int64), accel)
+
+    assert paired.t_ns.tolist() == [50, 150]
+    assert paired.accel_m_s2[:, 0].tolist() == pytest.approx([1.0, 3.0])
+
+
+def test_two_accelerometer_samples_on_one_timestamp_take_the_first() -> None:
+    """basalt deduplicates the raw channel before pairing (`dataset_io_robocap.cpp:472`).
+
+    Its `interval == 0` guard reads alpha 0 — the sample *before* — and the
+    deduplication is what makes that the only possible answer.
+    ``numpy.interp`` takes the second of the pair instead, and then interpolates
+    the following gyroscope sample from the wrong end of the gap.
+    """
+    paired = pair_accel_onto_gyro(
+        np.array([20, 30], dtype=np.int64),
+        np.ones((2, 3)),
+        np.array([20, 20, 40], dtype=np.int64),
+        np.array([[1.0, 1.0, 1.0], [9.0, 9.0, 9.0], [5.0, 5.0, 5.0]]),
+    )
+
+    assert paired.t_ns.tolist() == [20, 30]
+    assert paired.accel_m_s2[:, 0].tolist() == pytest.approx([1.0, 3.0])
+
+
+def test_two_channels_that_do_not_overlap_are_refused() -> None:
+    """basalt errors rather than deliver an empty stream (`dataset_io_robocap.cpp:496`).
+
+    The two channels have their own clocks, so a segment whose accelerometer
+    stops before its gyroscope starts pairs to nothing. Returning that silently
+    fed the estimator a rig with no inertial data at all.
+    """
+    with pytest.raises(ValueError, match=r"gyroscope spans 1000\.\.2000 ns and the accelerometer 10\.\.20 ns"):
+        pair_accel_onto_gyro(
+            np.array([1000, 2000], dtype=np.int64),
+            np.ones((2, 3)),
+            np.array([10, 20], dtype=np.int64),
+            np.ones((2, 3)),
+        )
+
+
+def test_one_accelerometer_sample_is_not_enough_to_interpolate() -> None:
+    """`raw_accel.size() < 2` is basalt's own bar (`dataset_io_robocap.cpp:473`)."""
+    with pytest.raises(ValueError, match="two accelerometer samples"):
+        pair_accel_onto_gyro(np.array([10], dtype=np.int64), np.ones((1, 3)), np.array([10], dtype=np.int64), np.ones((1, 3)))
+
+
+def test_pairing_an_empty_channel_says_which_one() -> None:
+    with pytest.raises(ValueError, match="0 gyro"):
+        pair_accel_onto_gyro(np.array([], dtype=np.int64), np.zeros((0, 3)), np.array([1], dtype=np.int64), np.ones((1, 3)))
+    with pytest.raises(ValueError, match="0 accel"):
+        pair_accel_onto_gyro(np.array([1], dtype=np.int64), np.ones((1, 3)), np.array([], dtype=np.int64), np.zeros((0, 3)))
+def test_the_pairing_boundary_is_typed() -> None:
+    """float32 acceleration is a different array; beartype refuses it rather than upcasting."""
+    with pytest.raises(BeartypeException):
+        pair_accel_onto_gyro(
+            np.array([1, 2], dtype=np.int64),
+            np.ones((2, 3)),
+            np.array([0, 3], dtype=np.int64),
+            np.ones((2, 3), dtype=np.float32),  # pyrefly: ignore[bad-argument-type]
+        )
+
+# --- which cameras of the rig are fed ---------------------------------------
+
+
+def test_the_named_cameras_come_back_in_the_callers_order() -> None:
+    """RoboCap's rig order is not the C++'s: cam_04, cam_00, cam_01, cam_05."""
+    statics: pa.Table = camera_name_statics(["left_front", "right_front", "left_eye", "right_eye", "left", "right"])
+    assert select_cameras(statics, 6, ("left", "left_front", "right_front", "right")) == (4, 0, 1, 5)
+    assert select_cameras(statics, 6, None) == (0, 1, 2, 3, 4, 5)
+
+
+def test_a_hyphenated_name_matches_the_underscored_one() -> None:
+    """The rig writes ``left-front`` where basalt's driver spells it ``left_front``.
+
+    Both sides are normalised, so a manifest that spells a camera the way the
+    recording itself does selects it rather than being refused.
+    """
+    statics: pa.Table = camera_name_statics(["left-front", "right-front"])
+    assert select_cameras(statics, 2, ("left_front",)) == (0,)
+    assert select_cameras(statics, 2, ("left-front",)) == (0,)
+    assert select_cameras(camera_name_statics(["left_front", "right_front"]), 2, ("left-front",)) == (0,)
+
+
+def test_a_camera_that_is_not_there_names_the_ones_that_are() -> None:
+    statics: pa.Table = camera_name_statics(["left_front", "right_front"])
+    with pytest.raises(ValueError, match=r"no camera named \['upside_down'\].*left_front.*right_front"):
+        select_cameras(statics, 2, ("left_front", "upside_down"))
+
+
+def test_two_cameras_answering_to_one_name_is_refused() -> None:
+    with pytest.raises(ValueError, match="cam_00 and cam_01 are both named 'left'"):
+        select_cameras(camera_name_statics(["left", "left"]), 2, ("left",))
+
+# --- the frameset matcher ----------------------------------------------------
+
+
+def test_the_matcher_reproduces_basalts_median_on_robocaps_first_frameset() -> None:
+    """Session 15's four cameras start 59 us apart and basalt calls that 70258640500 ns.
+
+    An even camera count takes the lower middle plus half the gap to the upper
+    one, which is neither the mean nor either middle value, and it is what the
+    NAS `slam` layer's own first row carries.
+    """
+    left: Int64[ndarray, " 2"] = np.array([70258648000, 70291970222], dtype=np.int64)
+    left_front: Int64[ndarray, " 2"] = np.array([70258633000, 70291955222], dtype=np.int64)
+    right_front: Int64[ndarray, " 2"] = np.array([70258662000, 70291984222], dtype=np.int64)
+    right: Int64[ndarray, " 2"] = np.array([70258603000, 70291936333], dtype=np.int64)
+    t_ns, frame_index = match_framesets([left, left_front, right_front, right], 1_000_000)
+
+    assert int(t_ns[0]) == 70258640500
+    assert frame_index[0].tolist() == [0, 0, 0, 0]
+    # Not the mean (70258636500), and not either middle value.
+    assert int(np.mean([70258603000, 70258633000, 70258648000, 70258662000])) == 70258636500
+
+
+def test_an_odd_camera_count_takes_the_middle_frame() -> None:
+    times = [np.array([100, 200], dtype=np.int64), np.array([120, 220], dtype=np.int64), np.array([140, 240], dtype=np.int64)]
+    t_ns, _ = match_framesets(times, 1_000)
+    assert t_ns.tolist() == [120, 220]
+
+
+def test_a_camera_that_misses_the_anchor_drops_the_frameset() -> None:
+    """The anchor's middle frame has no partner inside the tolerance, so it is not a frameset.
+
+    This is the mechanism that turns RoboCap's 1,594 / 1,588 / 1,596 / 1,592
+    frames into 1,588 framesets: a frameset needs all four.
+    """
+    anchor: Int64[ndarray, " 3"] = np.array([100, 200, 300], dtype=np.int64)
+    partner: Int64[ndarray, " 2"] = np.array([105, 305], dtype=np.int64)
+    t_ns, frame_index = match_framesets([anchor, partner], 50)
+
+    assert t_ns.tolist() == [102, 302]
+    assert frame_index.tolist() == [[0, 0], [2, 1]]
+
+
+def test_a_frame_belongs_to_one_frameset() -> None:
+    """basalt consumes the frame it took, so the next anchor cannot have it again.
+
+    Cursors move to ``selected + 1`` once every camera is inside the tolerance
+    (`dataset_io_robocap.cpp:439`). Leaving them on the selected frame fed the
+    estimator the same image twice under two frameset timestamps, which is a
+    measurement the rig never made.
+    """
+    anchors: Int64[ndarray, " 2"] = np.array([100, 180], dtype=np.int64)
+    partner: Int64[ndarray, " 1"] = np.array([140], dtype=np.int64)
+    t_ns, frame_index = match_framesets([anchors, partner], 50)
+
+    assert t_ns.tolist() == [120]
+    assert frame_index.tolist() == [[0, 0]]
+
+
+def test_a_camera_selected_for_an_incomplete_frameset_keeps_its_frame() -> None:
+    """A provisional selection is thrown away with the frameset it was for.
+
+    The C++ moves the cursors only after ``complete``
+    (`dataset_io_robocap.cpp:439`), so a camera picked for a frameset that then
+    fell keeps its frame. Anchor 100 takes camera 1's 150 (|150 - 100| = 50, the
+    inclusive edge) but camera 2's only frame is 200, which is 100 away, so the
+    frameset falls. Anchor 200 then takes camera 1's 150 (index 0, again the
+    inclusive edge) and camera 2's 200 (index 0): one frameset, whose three-camera
+    median of (200, 150, 200) is 200 — the matcher adds no offset of its own, the
+    caller applies ``cam_time_offset_ns``. Committing camera 1's selection after
+    anchor 100 would exhaust that camera and leave the rig with no frameset.
+    """
+    anchors: Int64[ndarray, " 2"] = np.array([100, 200], dtype=np.int64)
+    cameras: list[Int64[ndarray, " 1"]] = [np.array([150], dtype=np.int64), np.array([200], dtype=np.int64)]
+    t_ns, frame_index = match_framesets([anchors, *cameras], 50)
+
+    assert t_ns.tolist() == [200]
+    assert frame_index.tolist() == [[1, 0, 0]]
+
+
+def test_a_frame_the_anchor_is_too_early_for_waits_for_the_next_anchor() -> None:
+    """A camera ahead of the anchor keeps its frame; one behind it is consumed.
+
+    The C++ advances the cursor past the nearest frame only when that frame is
+    *earlier* than the anchor (`dataset_io_robocap.cpp:428`), because a late
+    camera's frame is still the right partner for the anchor after this one.
+    """
+    anchors: Int64[ndarray, " 2"] = np.array([100, 200], dtype=np.int64)
+    partner: Int64[ndarray, " 1"] = np.array([190], dtype=np.int64)
+    t_ns, frame_index = match_framesets([anchors, partner], 50)
+
+    assert t_ns.tolist() == [195]
+    assert frame_index.tolist() == [[1, 0]]
+
+
+def test_a_frame_no_later_anchor_can_reach_is_consumed_on_the_spot() -> None:
+    """The one matcher rule whose effect never reaches the output, tested where it lives.
+
+    `dataset_io_robocap.cpp:428` moves a camera's cursor past its nearest frame
+    when that frame is out of tolerance *and* earlier than the anchor. Anchors
+    only increase, so such a frame is farther from every later anchor still and
+    no frameset can ever take it. That also makes the rule invisible in
+    `match_framesets`'s output: leaving the cursor on the stale frame costs only
+    the nearest-frame walk, which re-reaches the same frame at the next anchor.
+    So it is pinned on the per-camera step instead, hand-computed:
+
+    * frames (0, 1000), cursor 0, anchor 100, tolerance 20 — the walk stays on 0
+      (|1000 - 100| = 900 is no closer than |0 - 100| = 100), 100 > 20 drops the
+      frameset, and 0 < 100, so the cursor moves to 1 and 0 is gone.
+    * frame (200) alone, same anchor — 100 > 20 drops it too, but 200 > 100, so
+      the cursor stays on 0 and 200 waits for the next anchor.
+    * frames (90, 110), same anchor — the walk ties onto 110, |110 - 100| = 10 is
+      inside the tolerance, and the cursor stays where it was: the caller commits
+      ``selected + 1`` only once the whole frameset stands.
+    * cursor 1 on a one-frame camera — exhausted, and it stays exhausted.
+    """
+    assert _frame_nearest_anchor(np.array([0, 1000], dtype=np.int64), 0, 100, 20) == (None, 1)
+    assert _frame_nearest_anchor(np.array([200], dtype=np.int64), 0, 100, 20) == (None, 0)
+    assert _frame_nearest_anchor(np.array([90, 110], dtype=np.int64), 0, 100, 20) == (1, 0)
+    assert _frame_nearest_anchor(np.array([0], dtype=np.int64), 1, 100, 20) == (None, 1)
+
+
+def test_the_tolerance_is_inclusive() -> None:
+    """`> kFramesetToleranceNs` drops it, so the tolerance itself still joins."""
+    anchor: Int64[ndarray, " 1"] = np.array([0], dtype=np.int64)
+    t_ns, _ = match_framesets([anchor, np.array([1_000_000], dtype=np.int64)], 1_000_000)
+    assert t_ns.tolist() == [500_000]
+    with pytest.raises(ValueError, match="no frameset has all 2 cameras"):
+        match_framesets([anchor, np.array([1_000_001], dtype=np.int64)], 1_000_000)
+
+
+def test_a_tie_takes_the_later_frame() -> None:
+    """The advance condition is ``<=``, so two frames equally close pick the later one."""
+    t_ns, frame_index = match_framesets([np.array([100], dtype=np.int64), np.array([90, 110], dtype=np.int64)], 50)
+    assert frame_index.tolist() == [[0, 1]]
+    assert t_ns.tolist() == [105]
+
+
+def test_interior_drops_are_allowed_one_in_a_thousand() -> None:
+    """A run that drops more interior framesets than basalt tolerates is not a run.
+
+    `dataset_io_robocap.cpp:458` allows ``max(1, ceil(interior * 0.001))``
+    incomplete framesets whose anchor lies inside every camera's own span; more
+    than that is a rig whose cameras are not the same recording.
+    """
+    anchors: Int64[ndarray, " 4"] = np.array([1000, 1100, 1200, 1300], dtype=np.int64)
+    # Four interior anchors allow one drop: this partner misses the third anchor.
+    t_ns, _ = match_framesets([anchors, np.array([990, 1110, 1310], dtype=np.int64)], 50)
+    assert t_ns.tolist() == [995, 1105, 1305]
+
+    # The same rig missing two of them is refused, and the error carries both counts.
+    with pytest.raises(ValueError, match="2 of 4 interior framesets are incomplete, more than the 1"):
+        match_framesets([anchors, np.array([990, 1310], dtype=np.int64)], 50)
+
+
+def test_the_drop_allowance_rounds_up_past_a_thousand_anchors() -> None:
+    """Past a thousand interior anchors the ceil, not the floor of one, sets the bar.
+
+    The allowance is ``max(1, ceil(interior * 0.001))``
+    (`dataset_io_robocap.cpp:458`), so 1,001 interior anchors allow
+    ceil(1.001) = 2 drops. The anchors here are 0, 100, ... 100,000 and the
+    partner is the same list minus two of its interior frames, which keeps its
+    first and last frame and therefore keeps all 1,001 anchors interior: 999
+    framesets stand, two interior anchors drop, and the run is accepted. Removing
+    a third makes 3 > 2 and the rig is refused. Truncation instead of a ceil, or
+    ``max(1, ...)`` alone, would allow one and refuse the accepted case.
+    """
+    anchors: Int64[ndarray, " 1001"] = np.arange(1001, dtype=np.int64) * 100
+    two_missing: Int64[ndarray, " 999"] = np.delete(anchors, [300, 600])
+    t_ns, _ = match_framesets([anchors, two_missing], 50)
+    assert t_ns.tolist() == two_missing.tolist()
+
+    three_missing: Int64[ndarray, " 998"] = np.delete(anchors, [300, 600, 900])
+    with pytest.raises(ValueError, match="3 of 1001 interior framesets are incomplete, more than the 2"):
+        match_framesets([anchors, three_missing], 50)
+
+
+def test_only_a_drop_inside_every_cameras_span_counts_against_the_run() -> None:
+    """An anchor no camera could partner is not the rig's fault, and is not counted.
+
+    Both counters are gated on ``overlap_start <= anchor <= overlap_end``
+    (`dataset_io_robocap.cpp:410` for the anchors, `:436` for the drops). The
+    anchors here are 0, 10, 20, 30, 40 and the one partner has 20 and 30, so the
+    overlap is [20, 30]: two interior anchors, both complete, and the misses at
+    0, 10 and 40 are exterior. Counting those would be 3 drops of 5 anchors
+    against an allowance of max(1, ceil(0.005)) = 1, and this rig — a partner
+    camera that simply started late and stopped early — would be refused.
+    """
+    anchors: Int64[ndarray, " 5"] = np.array([0, 10, 20, 30, 40], dtype=np.int64)
+    t_ns, frame_index = match_framesets([anchors, np.array([20, 30], dtype=np.int64)], 1)
+
+    assert t_ns.tolist() == [20, 30]
+    assert frame_index.tolist() == [[2, 0], [3, 1]]
+
+
+def test_frameset_timestamps_must_strictly_increase() -> None:
+    """Two anchors on one timestamp would file two framesets under one time."""
+    with pytest.raises(ValueError, match="frameset timestamps are not strictly increasing: 100 follows 100"):
+        match_framesets([np.array([100, 100], dtype=np.int64)], 1_000)
+
+
+def test_a_camera_with_no_frames_is_named() -> None:
+    """basalt refuses the rig rather than the frameset (`dataset_io_robocap.cpp:380`)."""
+    with pytest.raises(ValueError, match="camera 1 has no frames"):
+        match_framesets([np.array([100, 200], dtype=np.int64), np.array([], dtype=np.int64)], 50)
+
+
+def test_a_rig_no_frameset_survives_says_so() -> None:
+    with pytest.raises(ValueError, match="no frameset has all 2 cameras within 10 ns"):
+        match_framesets([np.array([0, 100], dtype=np.int64), np.array([500, 600], dtype=np.int64)], 10)
+
+
+def test_the_matcher_needs_a_camera() -> None:
+    with pytest.raises(ValueError, match="at least one camera"):
+        match_framesets([], 1_000)

--- a/packages/slam-rs/tests/test_frontend_boundary.py
+++ b/packages/slam-rs/tests/test_frontend_boundary.py
@@ -1,0 +1,535 @@
+"""Property tests for the optical-flow boundary, driven through ``slam_rs._core`` (D23).
+
+The rig, its frames and the frontend over it come from :mod:`conftest` as
+fixtures. The calibration is built from the feed's own ``CameraCalib``/
+``ImuCalib`` dataclasses, so these tests also pin the field-name contract
+``Calibration.from_catalog`` reads across the boundary: rename a field in
+:mod:`slam_rs.catalog_feed` and this file fails rather than the estimator.
+
+Everything here runs on small synthetic frames, so the whole file stays inside
+the default, seconds-long suite.
+"""
+
+import json
+import subprocess
+import sys
+from collections.abc import Callable
+from typing import TypeAlias, cast
+
+import numpy as np
+import pytest
+from fixture_types import CameraFactory, FrontendFactory, PipelineFactory, TextureFactory
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+from jaxtyping import Float32, Int64, UInt8
+from numpy import ndarray
+from numpy.typing import NDArray
+
+from slam_rs import _core
+from slam_rs.catalog_feed import CameraCalib, ImuCalib
+
+MAX_EXAMPLES: int = 25
+
+sizes = st.integers(min_value=1, max_value=32)
+camera_counts = st.integers(min_value=2, max_value=3)
+"""Camera counts both entry points accept: the estimator refuses a one-camera rig (``optical_flow.h:210``)."""
+wrong_sizes = st.integers(min_value=1, max_value=400)
+"""Frame sides on both sides of the synthetic rig's, so cropped and enlarged frames are both generated."""
+
+EntryPoint: TypeAlias = Callable[[int, list[UInt8[ndarray, "h w"]]], object]
+"""One frameset into a boundary call: ``(t_ns, images)``."""
+EntryFactory: TypeAlias = Callable[[int], EntryPoint]
+"""An entry point on a rig of the given camera count."""
+
+
+@pytest.fixture(scope="session", params=["Vio.track", "OpticalFlow.process"])
+def entry_point(request: pytest.FixtureRequest, frontend: FrontendFactory, pipeline: PipelineFactory) -> EntryFactory:
+    """Both array-taking entry points, so one property covers the two of them.
+
+    They share ``gray_array``'s rank, dtype and layout checks and the frontend's
+    own frame-size rule, so a rule proved on one of them says nothing about the
+    other unless both are driven. Every rig here has at least two cameras,
+    because that is what the estimator's epipolar filter requires.
+    """
+    if request.param == "Vio.track":
+        return lambda camera_count: pipeline(camera_count).track
+    return lambda camera_count: frontend(camera_count).process
+
+
+def test_the_calibration_comes_across_field_by_field(camera: CameraFactory, imu: ImuCalib) -> None:
+    calibrated: int = camera(0, 0.0).width
+    calibration: _core.Calibration = _core.Calibration.from_catalog([camera(0, 0.0), camera(1, 0.1)], imu)
+    assert calibration.camera_count == 2
+    assert calibration.resolution == [(calibrated, calibrated), (calibrated, calibrated)]
+    # basalt's own JSON is the round trip, so a reader can check what was pushed.
+    assert _core.Calibration.from_json(calibration.to_json()).resolution == calibration.resolution
+
+
+def test_an_extrinsic_that_is_not_a_rotation_is_rejected(camera: CameraFactory, imu: ImuCalib) -> None:
+    mirrored: CameraCalib = camera(0, 0.0)
+    mirrored.imu_T_cam[0, 0] = -1.0
+    with pytest.raises(ValueError, match="rotation"):
+        _core.Calibration.from_catalog([mirrored], imu)
+
+
+def test_a_config_asking_for_another_pattern_is_rejected(camera: CameraFactory, imu: ImuCalib) -> None:
+    config: _core.VioConfig = _core.VioConfig()
+    raw: str = config.to_json().replace('"config.optical_flow_pattern": 51', '"config.optical_flow_pattern": 24')
+    with pytest.raises(ValueError, match="pattern"):
+        _core.OpticalFlow(_core.Calibration.from_catalog([camera(0, 0.0)], imu), _core.VioConfig.from_json(raw))
+
+
+def test_the_image_safe_radius_survives_the_json_round_trip() -> None:
+    config: _core.VioConfig = _core.VioConfig()
+    config.optical_flow_image_safe_radius = 472.0
+    assert _core.VioConfig.from_json(config.to_json()).optical_flow_image_safe_radius == 472.0
+
+
+@settings(max_examples=MAX_EXAMPLES, deadline=None)
+@given(dtype=st.sampled_from([np.float32, np.float64, np.int16, np.uint16]), height=sizes, width=sizes)
+def test_images_of_the_wrong_dtype_are_rejected(entry_point: EntryFactory, dtype: type, height: int, width: int) -> None:
+    wrong: NDArray[np.uint8] = cast("NDArray[np.uint8]", np.zeros((height, width), dtype=dtype))
+    with pytest.raises(ValueError, match="2-D uint8"):
+        entry_point(2)(0, [wrong, wrong])
+
+
+@settings(max_examples=MAX_EXAMPLES, deadline=None)
+@given(ndim=st.sampled_from([1, 3, 4]), size=st.integers(min_value=1, max_value=4))
+def test_images_of_the_wrong_rank_are_rejected(entry_point: EntryFactory, ndim: int, size: int) -> None:
+    wrong: UInt8[ndarray, "..."] = np.zeros((size,) * ndim, dtype=np.uint8)
+    with pytest.raises(ValueError, match="2-D uint8"):
+        entry_point(2)(0, [wrong, wrong])
+
+
+@settings(max_examples=MAX_EXAMPLES, deadline=None)
+@given(height=st.integers(min_value=2, max_value=16), width=st.integers(min_value=2, max_value=16))
+def test_a_transposed_image_is_rejected(frontend: FrontendFactory, height: int, width: int) -> None:
+    """Fortran order passes ``as_slice`` but its bytes run down the columns."""
+    transposed: UInt8[ndarray, "w h"] = np.zeros((height, width), dtype=np.uint8).T
+    with pytest.raises(ValueError, match="C-contiguous"):
+        frontend(1).process(0, [transposed])
+
+
+@settings(max_examples=MAX_EXAMPLES, deadline=None)
+@given(count=camera_counts, given_count=st.integers(min_value=0, max_value=4))
+def test_the_wrong_number_of_images_is_rejected(entry_point: EntryFactory, texture: TextureFactory, count: int, given_count: int) -> None:
+    assume(count != given_count)
+    image: UInt8[ndarray, "h w"] = texture(0, 0)
+    with pytest.raises(ValueError, match=f"expected {count} images"):
+        entry_point(count)(0, [image] * given_count)
+
+
+@settings(max_examples=MAX_EXAMPLES, deadline=None)
+@given(first=st.integers(min_value=-(10**9), max_value=10**9), back=st.integers(min_value=0, max_value=10**6))
+def test_a_frameset_that_does_not_move_the_clock_forward_is_rejected(
+    frontend: FrontendFactory, texture: TextureFactory, first: int, back: int
+) -> None:
+    flow: _core.OpticalFlow = frontend(1)
+    image: UInt8[ndarray, "h w"] = texture(0, 0)
+    flow.process(first, [image])
+    with pytest.raises(ValueError, match="must increase"):
+        flow.process(first - back, [image])
+
+
+def test_a_refused_frameset_leaves_the_clock_alone(frontend: FrontendFactory, texture: TextureFactory) -> None:
+    flow: _core.OpticalFlow = frontend(1)
+    flow.process(1_000, [texture(0, 0)])
+    with pytest.raises(ValueError, match="expected 1 images"):
+        flow.process(2_000, [texture(0, 0), texture(0, 0)])
+    assert flow.t_ns == 1_000
+
+
+@settings(max_examples=10, deadline=None)
+@given(shift_x=st.integers(min_value=-3, max_value=3), shift_y=st.integers(min_value=-3, max_value=3))
+def test_a_shifted_texture_keeps_its_track_ids(frontend: FrontendFactory, texture: TextureFactory, shift_x: int, shift_y: int) -> None:
+    """Two frames of the same scene: the ids survive and the positions follow the shift."""
+    flow: _core.OpticalFlow = frontend(1)
+    first: _core.FlowFrame = flow.process(0, [texture(0, 0)])
+    second: _core.FlowFrame = flow.process(33_000_000, [texture(shift_x, shift_y)])
+
+    # 4x4 whole cells at one point per cell, so 16 is the ceiling.
+    assert first.num_tracks(0) >= 12, "the texture should offer a corner in most cells"
+    assert first.num_new(0) == first.num_tracks(0), "every keypoint of the first frameset is new"
+    assert second.num_tracks(0) > 0
+
+    before: Int64[ndarray, " n_first"] = first.ids(0)
+    after: Int64[ndarray, " n_second"] = second.ids(0)
+    assert np.array_equal(np.sort(before), before), "ids come back ascending"
+    kept: Int64[ndarray, " n_kept"] = np.intersect1d(before, after)
+    assert len(kept) >= 0.8 * len(before), f"only {len(kept)} of {len(before)} ids survived a ({shift_x}, {shift_y}) px shift"
+
+    moved: Float32[ndarray, "n_kept 2"] = second.positions(0)[np.isin(after, kept)] - first.positions(0)[np.isin(before, kept)]
+    assert np.allclose(np.median(moved, axis=0), [shift_x, shift_y], atol=0.5)
+
+
+def test_the_frame_reports_shapes_the_stub_promises(camera: CameraFactory, frontend: FrontendFactory, texture: TextureFactory) -> None:
+    cells: int = camera(0, 0.0).width // 50 + 1
+    flow: _core.OpticalFlow = frontend(2)
+    frame: _core.FlowFrame = flow.process(0, [texture(0, 0), texture(2, 0)])
+    assert frame.t_ns == 0
+    assert frame.camera_count == 2
+    for index in range(2):
+        count: int = frame.num_tracks(index)
+        assert frame.ids(index).shape == (count,)
+        assert frame.ids(index).dtype == np.int64
+        assert frame.positions(index).shape == (count, 2)
+        assert frame.positions(index).dtype == np.float32
+        assert frame.transforms(index).shape == (count, 2, 3)
+        # The occupancy grid is camera 0's for every camera, as basalt's is.
+        assert frame.occupancy(index).shape == (cells, cells)
+        assert frame.occupancy(index).dtype == np.int32
+    # The 2x3 warp starts at the identity with the keypoint's pixel in the last column.
+    assert np.allclose(frame.transforms(0)[:, :, :2], np.eye(2), atol=1e-6)
+    assert np.array_equal(frame.transforms(0)[:, :, 2], frame.positions(0))
+
+
+def test_a_camera_past_the_end_of_the_rig_is_an_index_error(frontend: FrontendFactory, texture: TextureFactory) -> None:
+    frame: _core.FlowFrame = frontend(1).process(0, [texture(0, 0)])
+    with pytest.raises(IndexError, match="past the end"):
+        frame.ids(1)
+
+
+HANG_GUARD_S: float = 60.0
+"""How long the subprocess probe below is given before it counts as a hang."""
+
+DETECTOR_PROBE: str = """
+import sys
+
+import numpy as np
+
+from slam_rs import _core
+
+flow = _core.OpticalFlow(_core.Calibration.from_json(sys.argv[1]), _core.VioConfig.from_json(sys.argv[2]))
+flow.process(0, [np.zeros((200, 200), dtype=np.uint8)])
+print("processed")
+"""
+"""Build a frontend from JSON text and detect on a blank frame, with no error handling.
+
+A blank frame is the worst case for the detector's threshold ladder: no cell ever
+fills its budget, so every rung is walked. This runs in a subprocess because the
+failure it guards against is a **hang** inside the released-GIL region, where a
+Python-level ``signal`` handler never gets to run — only an outside timeout can
+end it.
+"""
+
+
+def probe_detector(calibration_json: str, config_json: str) -> subprocess.CompletedProcess[str]:
+    """Run :data:`DETECTOR_PROBE` against one config, or fail the test on a hang.
+
+    Args:
+        calibration_json: The rig's calibration as basalt's JSON.
+        config_json: One of basalt's configs as text.
+
+    Returns:
+        The finished process, so the caller can assert on its output.
+    """
+    return subprocess.run(  # noqa: S603
+        [sys.executable, "-c", DETECTOR_PROBE, calibration_json, config_json],
+        capture_output=True,
+        text=True,
+        timeout=HANG_GUARD_S,
+        check=False,
+    )
+
+
+def config_with(key: str, value: int) -> str:
+    """basalt's default config as text, with one integer field replaced."""
+    document: dict = json.loads(_core.VioConfig().to_json())
+    assert key in document["value0"], f"{key} is not a config field: {sorted(document['value0'])}"
+    document["value0"][key] = value
+    return json.dumps(document)
+
+
+def test_the_shipped_config_detects_on_a_blank_frame_and_returns(camera: CameraFactory, imu: ImuCalib) -> None:
+    """The control for the probe below: this configuration reaches ``process`` and finishes."""
+    calibration: str = _core.Calibration.from_catalog([camera(0, 0.0)], imu).to_json()
+    finished: subprocess.CompletedProcess[str] = probe_detector(calibration, _core.VioConfig().to_json())
+    assert finished.returncode == 0, finished.stderr
+    assert "processed" in finished.stdout
+
+
+@pytest.mark.parametrize("min_threshold", [0, -1, -(2**31)])
+def test_a_detector_threshold_ladder_that_never_ends_is_refused(camera: CameraFactory, imu: ImuCalib, min_threshold: int) -> None:
+    """``min_threshold <= 0`` hangs the detector — and basalt's own — so it is refused.
+
+    ``keypoints.cpp:162,187`` halves the FAST threshold by integer division while
+    it is at or above ``min_threshold``: zero halves to zero for ever. The C++ has
+    the same non-terminating loop; the port refuses the config instead of running
+    it, and floors its own last rung as a second line.
+    """
+    calibration: str = _core.Calibration.from_catalog([camera(0, 0.0)], imu).to_json()
+    finished: subprocess.CompletedProcess[str] = probe_detector(
+        calibration, config_with("config.optical_flow_detection_min_threshold", min_threshold)
+    )
+    assert finished.returncode != 0, f"the frontend accepted min_threshold={min_threshold}: {finished.stdout}"
+    assert "ValueError" in finished.stderr
+    assert "optical_flow_detection_min_threshold" in finished.stderr
+
+
+def test_a_detector_threshold_ladder_that_never_runs_is_refused(camera: CameraFactory, imu: ImuCalib) -> None:
+    """A ladder starting below where it stops could never add a keypoint."""
+    document: dict = json.loads(_core.VioConfig().to_json())
+    document["value0"]["config.optical_flow_detection_min_threshold"] = 40
+    document["value0"]["config.optical_flow_detection_max_threshold"] = 5
+    with pytest.raises(ValueError, match="ladder starts below"):
+        _core.OpticalFlow(_core.Calibration.from_catalog([camera(0, 0.0)], imu), _core.VioConfig.from_json(json.dumps(document)))
+
+
+@pytest.mark.parametrize("max_keypoints", [2**20 + 1, 2**31, 2**63, 2**64 - 1])
+def test_a_keypoint_budget_nothing_could_allocate_is_a_value_error(camera: CameraFactory, imu: ImuCalib, max_keypoints: int) -> None:
+    """A budget is a memory request, and an impossible one used to be a Rust panic.
+
+    ``Vec::with_capacity(2**63)`` panics with ``capacity overflow``, which crosses
+    the boundary as ``pyo3_runtime.PanicException`` — a ``BaseException`` that no
+    ordinary ``except Exception`` catches. The ceiling makes it an answer.
+    """
+    with pytest.raises(ValueError, match="ceiling"):
+        _core.OpticalFlow(_core.Calibration.from_catalog([camera(0, 0.0)], imu), _core.VioConfig(), max_keypoints=max_keypoints)
+
+
+@pytest.mark.parametrize("threads", [2**20 + 1, 100_000, 2**63])
+def test_more_workers_than_the_ceiling_is_refused(camera: CameraFactory, imu: ImuCalib, threads: int) -> None:
+    """rayon spawns exactly what it is asked for, so an unbounded count wedges the machine."""
+    with pytest.raises(ValueError, match="ceiling"):
+        _core.OpticalFlow(_core.Calibration.from_catalog([camera(0, 0.0)], imu), _core.VioConfig(), threads=threads)
+
+
+@pytest.mark.parametrize("levels", [24, 1_000, 10**9])
+def test_a_pyramid_deeper_than_the_ceiling_is_refused(camera: CameraFactory, imu: ImuCalib, levels: int) -> None:
+    """``optical_flow_levels`` sizes every per-patch buffer; an absurd one aborted the process."""
+    with pytest.raises(ValueError, match="optical_flow_levels"):
+        _core.OpticalFlow(
+            _core.Calibration.from_catalog([camera(0, 0.0)], imu),
+            _core.VioConfig.from_json(config_with("config.optical_flow_levels", levels)),
+        )
+
+
+def test_a_calibration_whose_detection_grid_nothing_could_allocate_is_refused(camera: CameraFactory, imu: ImuCalib) -> None:
+    """The occupancy grid is derived from the calibration, so a resolution is a memory request too.
+
+    The re-review's finding: the grid nothing could allocate used to panic out of
+    the constructor with no image in sight (``detect::MAX_CELLS`` carries the
+    arithmetic). In process like the ceilings above, because nothing is allocated
+    on a refusal and a ``PanicException`` fails this ``pytest.raises`` anyway.
+    """
+    document: dict = json.loads(_core.Calibration.from_catalog([camera(0, 0.0)], imu).to_json())
+    document["value0"]["resolution"] = [[2**32 - 2, 2**32 - 2]]
+    with pytest.raises(ValueError, match="occupancy grid"):
+        _core.OpticalFlow(
+            _core.Calibration.from_json(json.dumps(document)),
+            _core.VioConfig.from_json(config_with("config.optical_flow_detection_grid_size", 1)),
+        )
+
+
+@settings(max_examples=MAX_EXAMPLES, deadline=None)
+@given(height=wrong_sizes, width=wrong_sizes)
+def test_an_image_that_is_not_the_calibrated_size_is_refused(camera: CameraFactory, frontend: FrontendFactory, height: int, width: int) -> None:
+    """The calibration is the geometry: a cropped or resized frame means other bearings.
+
+    The camera model projects with the calibrated intrinsics and the detection
+    grid is derived from the calibrated size, so a 64x64 frame tracked against a
+    200x200 calibration produces keypoints in pixels that do not exist.
+    """
+    calibrated: int = camera(0, 0.0).width
+    assume((height, width) != (calibrated, calibrated))
+    odd: UInt8[ndarray, "h w"] = np.zeros((height, width), dtype=np.uint8)
+    with pytest.raises(ValueError, match=f"the calibration is for {calibrated}x{calibrated} frames, got {width}x{height}"):
+        frontend(1).process(0, [odd])
+
+
+def test_the_wrong_camera_is_named_when_only_one_image_is_the_wrong_size(frontend: FrontendFactory, texture: TextureFactory) -> None:
+    flow: _core.OpticalFlow = frontend(2)
+    with pytest.raises(ValueError, match="camera 1"):
+        flow.process(0, [texture(0, 0), np.zeros((64, 64), dtype=np.uint8)])
+
+
+def test_a_frame_of_the_wrong_size_leaves_the_frontend_as_it_was(
+    camera: CameraFactory, frontend: FrontendFactory, texture: TextureFactory
+) -> None:
+    """The refusal is transactional: the frontend is as the last accepted frame left it."""
+    calibrated: int = camera(0, 0.0).width
+    flow: _core.OpticalFlow = frontend(1)
+    first: _core.FlowFrame = flow.process(1_000, [texture(0, 0)])
+    ids_before: int = flow.last_keypoint_id
+    with pytest.raises(ValueError, match="the calibration is for"):
+        flow.process(2_000, [np.zeros((calibrated + 8, calibrated), dtype=np.uint8)])
+    assert flow.t_ns == 1_000
+    assert flow.last_keypoint_id == ids_before
+
+    # And it still tracks against the frame it kept.
+    second: _core.FlowFrame = flow.process(3_000, [texture(1, 0)])
+    assert flow.t_ns == 3_000
+    kept: Int64[ndarray, " n_kept"] = np.intersect1d(first.ids(0), second.ids(0))
+    assert len(kept) > 0, "the kept frame was not tracked against"
+
+
+@settings(max_examples=10, deadline=None)
+@given(start=st.integers(min_value=-(10**12), max_value=-1))
+def test_identical_frames_at_negative_timestamps_keep_their_ids(frontend: FrontendFactory, texture: TextureFactory, start: int) -> None:
+    """basalt reads ``t_ns < 0`` as "no previous frame"; the port's clock is an Option.
+
+    Two identical framesets used to share **zero** ids at ``(-2, -1)`` and 14 of
+    16 at ``(0, 1)``: the negative timestamp made every frameset the first one.
+    """
+    negative: _core.OpticalFlow = frontend(1)
+    first: _core.FlowFrame = negative.process(start, [texture(0, 0)])
+    second: _core.FlowFrame = negative.process(start + 1, [texture(0, 0)])
+    shared: int = len(np.intersect1d(first.ids(0), second.ids(0)))
+
+    zeroed: _core.OpticalFlow = frontend(1)
+    third: _core.FlowFrame = zeroed.process(0, [texture(0, 0)])
+    fourth: _core.FlowFrame = zeroed.process(1, [texture(0, 0)])
+    at_zero: int = len(np.intersect1d(third.ids(0), fourth.ids(0)))
+
+    assert shared > 0, f"no id survived an identical frameset at t = {start}"
+    assert shared == at_zero, f"{shared} ids kept at t = {start} against {at_zero} at t = 0"
+    assert negative.t_ns == start + 1
+
+
+HOSTILE_INTS: tuple[int, ...] = (0, -1, 1, 2**31, 2**63 - 1, -(2**63), 2**63, 2**64, 10**40, -(10**40))
+"""Integers a caller can type: past both ends of ``i64``, past ``u64``, and beyond."""
+HOSTILE_OBJECTS: tuple[object, ...] = (None, "", "x", b"", [], {}, 0.5, float("nan"), object(), (1, 2))
+"""Objects that are not what any parameter here asks for."""
+EXPECTED_ERRORS: tuple[type[Exception], ...] = (ValueError, TypeError, IndexError, OverflowError)
+"""What a boundary may raise. A panic is a ``BaseException`` and is none of these."""
+
+
+def refuse(what: str, call: Callable[[], object], failures: list[str]) -> None:
+    """Call ``call`` and record anything that is not an ordinary refusal.
+
+    ``pyo3_runtime.PanicException`` only exists once a panic has been raised, so
+    it is recognised by class name rather than imported.
+
+    Args:
+        what: How the call is named in a failure.
+        call: The boundary call to make.
+        failures: Where an escaping panic is recorded.
+    """
+    try:
+        call()
+    except EXPECTED_ERRORS:
+        return
+    except BaseException as error:  # noqa: BLE001
+        failures.append(f"{what}: {type(error).__name__}({error})")
+
+
+def batch_imu(vio: _core.Vio, t_ns: object, gyro: object, accel: object) -> None:
+    """Push an IMU batch of whatever was handed in, past the stub's declared dtypes.
+
+    ``push_imu_batch`` declares ``int64[n]`` and ``float64[n, 3]``, and the audit's
+    business is what happens when it is given something else, so the three
+    arguments arrive as ``object`` and are cast here rather than at a dozen call
+    sites.
+
+    Args:
+        vio: The estimator to push into.
+        t_ns: Whatever is standing in for the timestamps.
+        gyro: Whatever is standing in for the gyroscope samples.
+        accel: Whatever is standing in for the accelerometer samples.
+    """
+    vio.push_imu_batch(
+        cast("NDArray[np.int64]", t_ns),
+        cast("NDArray[np.float64]", gyro),
+        cast("NDArray[np.float64]", accel),
+    )
+
+
+def test_no_hostile_argument_reaches_python_as_a_panic(
+    camera: CameraFactory, imu: ImuCalib, texture: TextureFactory, pipeline: PipelineFactory
+) -> None:
+    """Every public entry point, against every class of hostile argument (D32).
+
+    A panic inside the core reaches Python as ``PanicException``, which derives
+    from ``BaseException`` and so passes straight through an ``except Exception``
+    handler; ``max_keypoints`` did exactly that. This walks the surface rather
+    than the one argument that was reported.
+    """
+    failures: list[str] = []
+    calibration: _core.Calibration = _core.Calibration.from_catalog([camera(0, 0.0), camera(1, 0.1)], imu)
+    config: _core.VioConfig = _core.VioConfig()
+    good: list[UInt8[ndarray, "h w"]] = [texture(0, 0), texture(1, 0)]
+    flow: _core.OpticalFlow = _core.OpticalFlow(calibration, config)
+    frame: _core.FlowFrame = flow.process(0, good)
+    vio: _core.Vio = pipeline(2)
+
+    for value in HOSTILE_INTS:
+        refuse(f"push_imu({value})", lambda v=value: pipeline(2).push_imu(v, [0.0] * 3, [0.0] * 3), failures)
+        refuse(f"Vio(threads={value})", lambda v=value: _core.Vio(calibration, config, threads=v), failures)
+        refuse(f"Vio(max_keypoints={value})", lambda v=value: _core.Vio(calibration, config, max_keypoints=v), failures)
+        refuse(f"Vio.track(t_ns={value})", lambda v=value: pipeline(2).track(v, good), failures)
+        refuse(f"OpticalFlow(threads={value})", lambda v=value: _core.OpticalFlow(calibration, config, threads=v), failures)
+        refuse(f"OpticalFlow(max_keypoints={value})", lambda v=value: _core.OpticalFlow(calibration, config, max_keypoints=v), failures)
+        refuse(f"process(t_ns={value})", lambda v=value: _core.OpticalFlow(calibration, config).process(v, good), failures)
+        for accessor in ("ids", "positions", "transforms", "occupancy", "num_new", "num_tracks"):
+            refuse(f"frame.{accessor}({value})", lambda a=accessor, v=value: getattr(frame, a)(v), failures)
+
+    # Every value below violates the type its parameter declares — that is what
+    # is under test — so each is passed through the declared type. The casts are
+    # the violation, not an assumption about the value.
+    for thing in HOSTILE_OBJECTS:
+        text: str = cast("str", thing)
+        camera_like: CameraCalib = cast("CameraCalib", thing)
+        imu_like: ImuCalib = cast("ImuCalib", thing)
+        config_like: _core.VioConfig = cast("_core.VioConfig", thing)
+        calibration_like: _core.Calibration = cast("_core.Calibration", thing)
+        images_like: list[UInt8[ndarray, "h w"]] = cast("list[UInt8[ndarray, 'h w']]", thing)
+        frameset_like: list[UInt8[ndarray, "h w"]] = cast("list[UInt8[ndarray, 'h w']]", [thing, thing])
+        index_like: int = cast("int", thing)
+        refuse(f"Calibration.from_json({thing!r})", lambda o=text: _core.Calibration.from_json(o), failures)
+        refuse(f"VioConfig.from_json({thing!r})", lambda o=text: _core.VioConfig.from_json(o), failures)
+        refuse(f"Calibration.from_catalog([{thing!r}])", lambda c=camera_like, i=imu_like: _core.Calibration.from_catalog([c], i), failures)
+        refuse(f"Calibration.from_catalog(imu={thing!r})", lambda i=imu_like: _core.Calibration.from_catalog([camera(0, 0.0)], i), failures)
+        refuse(f"OpticalFlow(calibration={thing!r})", lambda c=calibration_like: _core.OpticalFlow(c, config), failures)
+        refuse(f"OpticalFlow(config={thing!r})", lambda o=config_like: _core.OpticalFlow(calibration, o), failures)
+        refuse(f"Vio(calibration={thing!r})", lambda c=calibration_like: _core.Vio(c, config), failures)
+        refuse(f"Vio(config={thing!r})", lambda o=config_like: _core.Vio(calibration, o), failures)
+        refuse(f"process(images={thing!r})", lambda o=images_like: flow.process(1, o), failures)
+        refuse(f"process([{thing!r}])", lambda o=frameset_like: flow.process(1, o), failures)
+        refuse(f"safe_radius = {thing!r}", lambda o=thing: setattr(config, "optical_flow_image_safe_radius", o), failures)
+        refuse(f"Vio.track({thing!r})", lambda o=images_like: vio.track(0, o), failures)
+        refuse(f"push_imu_batch({thing!r})", lambda o=thing: batch_imu(vio, o, o, o), failures)
+        refuse(f"frame.ids({thing!r})", lambda o=index_like: frame.ids(o), failures)
+
+    # Arrays of the wrong rank, dtype, layout or extent, the transposed one being
+    # a frame of exactly the calibrated size whose bytes run down the columns.
+    hostile_arrays: tuple[NDArray[np.uint8], ...] = (
+        np.zeros((0, 0), dtype=np.uint8),
+        np.zeros((1, 0), dtype=np.uint8),
+        cast("NDArray[np.uint8]", np.zeros((0,), dtype=np.uint8)),
+        cast("NDArray[np.uint8]", np.zeros((2, 2, 2), dtype=np.uint8)),
+        cast("NDArray[np.uint8]", np.zeros((3, 3), dtype=np.float64)),
+        cast("NDArray[np.uint8]", good[0].T),
+        np.asfortranarray(np.zeros((5, 5), dtype=np.uint8)),
+    )
+    for array in hostile_arrays:
+        refuse(f"process({array.shape} {array.dtype})", lambda a=array: flow.process(1, [a, a]), failures)
+        refuse(f"process(mixed {array.shape})", lambda a=array: flow.process(1, [good[0], a]), failures)
+        refuse(f"Vio.track({array.shape} {array.dtype})", lambda a=array: vio.track(0, [a, a]), failures)
+        refuse(f"Vio.track(mixed {array.shape})", lambda a=array: vio.track(0, [good[0], a]), failures)
+        refuse(f"push_imu_batch({array.shape} {array.dtype})", lambda a=array: batch_imu(vio, a, a, a), failures)
+
+    # Every numeric config field, one at a time, over the values that broke one.
+    # Both constructors: the estimator reads fields the frontend never looks at.
+    document: dict = json.loads(_core.VioConfig().to_json())
+    numeric: list[str] = [key for key, value in document["value0"].items() if isinstance(value, (int, float)) and not isinstance(value, bool)]
+    assert len(numeric) > 20, f"only {len(numeric)} numeric config fields were found"
+    for key in numeric:
+        for value in (0, -1, 1, 2**31 - 1, -(2**31), 10**12):
+            refuse(
+                f"OpticalFlow config {key}={value}",
+                lambda k=key, v=value: _core.OpticalFlow(calibration, _core.VioConfig.from_json(config_with(k, v))),
+                failures,
+            )
+            refuse(
+                f"Vio config {key}={value}",
+                lambda k=key, v=value: _core.Vio(calibration, _core.VioConfig.from_json(config_with(k, v))),
+                failures,
+            )
+
+    assert not failures, f"{len(failures)} calls did not refuse cleanly: {failures[:10]}"
+
+    # A refused frameset leaves a frontend that still works, after all of that.
+    assert flow.t_ns == 0
+    assert flow.process(2, good).num_tracks(0) > 0
+    # And an estimator that still tracks: nothing above moved its clock.
+    assert vio.track(1, good).status == _core.VioStatus.NeedMoreImu

--- a/packages/slam-rs/tests/test_frontend_log.py
+++ b/packages/slam-rs/tests/test_frontend_log.py
@@ -1,0 +1,358 @@
+"""What the frontend's Rerun layer promises: colours, dump association, and what ``log`` writes.
+
+The logging contract is checked against a recording, not against a mock. Each
+test initialises the global recording :class:`slam_rs.frontend_log.FrontendLogger`
+logs into (D03: the tools own no :class:`rerun.RecordingStream`), saves it to a
+temp file, and reads the chunks back with
+:class:`rerun.experimental.RrdReader` — the same rows a viewer would receive. So
+an entity path, a ``video_time`` value or a trail that never reached the file
+fails here.
+
+The frames are the synthetic 200x200 textures of :mod:`conftest` rather than the
+committed 960x960 fixtures: the fixtures are the Rust parity gate's, and four
+framesets of them through the frontend cost more than this whole Python suite.
+Reading the recording back is :mod:`conftest`'s :func:`read_rows`, which the
+estimator's logging suite drives too; the aliases below are declared here
+because ``tests`` is not on the typechecker's search path.
+"""
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import NamedTuple, TypeAlias
+
+import numpy as np
+import pytest
+import rerun as rr
+from fixture_types import FRAME_PERIOD_NS, FrontendFactory, Row, Rows, RowsReader, TextureFactory
+from jaxtyping import Float32, Int64, UInt8
+from numpy import ndarray
+
+from slam_rs import _core
+from slam_rs.apis.replay import SMOKE_SEGMENT
+from slam_rs.catalog_feed import TIMELINE, LocalSegment, SegmentFeed, open_segment
+from slam_rs.frontend_log import (
+    CPP_COLOR,
+    DEFAULT_DUMPS_DIR,
+    SOURCE_FILE,
+    STATS_ENTITY,
+    TRAIL_LENGTH,
+    FrontendLogger,
+    camera_entity,
+    dumps_source,
+    read_cpp_dumps,
+    track_colors,
+)
+from slam_rs.reference import ReferenceManifest, ReferenceSegment
+
+OTHER_SEGMENT: str = "msd-index__MIO_others__MIO07_mapping_easy"
+"""Another Index segment, whose ``video_time`` also starts at zero."""
+OVERLAY: Float32[ndarray, "n_keypoints 2"] = np.array([[10.0, 20.0], [30.0, 40.0]], dtype=np.float32)
+"""The C++ keypoints every written dump carries, on both cameras."""
+
+
+
+class ReplayResult(NamedTuple):
+    """What one logged run gives back."""
+
+    rows: Rows
+    """Every non-static row of the recording, by entity path."""
+    frames: list[_core.FlowFrame]
+    """What the frontend produced, in frameset order."""
+
+
+ReplayFactory: TypeAlias = Callable[[Path, int, str, Path | None], ReplayResult]
+"""One logged run: where the ``.rrd`` goes, how many framesets, the id the replayed recording carries, the dumps."""
+
+
+def write_dumps(directory: Path, segment_id: str, per_frameset: dict[int, list[Float32[ndarray, "n_keypoints 2"]]]) -> None:
+    """Write C++ dumps in ``dump_flow.cpp``'s shape, with the segment they came from.
+
+    Args:
+        directory: Where the ``frame_XXX.json`` and the source file go.
+        segment_id: Segment the dumps are to be attributed to.
+        per_frameset: Frameset timestamp to one ``[x, y]`` array per camera.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / SOURCE_FILE).write_text(json.dumps({"segment_id": segment_id}))
+    for index, (t_ns, cameras) in enumerate(sorted(per_frameset.items())):
+        dump: dict[str, object] = {
+            "frame": index,
+            "t_ns": t_ns,
+            "cameras": [
+                {
+                    "camera": camera,
+                    "keypoints": [
+                        {"id": slot, "x": float(point[0]), "y": float(point[1]), "linear": [1, 0, 0, 1], "response": 1}
+                        for slot, point in enumerate(points)
+                    ],
+                }
+                for camera, points in enumerate(cameras)
+            ],
+        }
+        (directory / f"frame_{index:03d}.json").write_text(json.dumps(dump))
+
+
+@pytest.fixture
+def replay(frontend: FrontendFactory, texture: TextureFactory, read_rows: RowsReader) -> ReplayFactory:
+    """Log ``framesets`` framesets of a drifting texture and read the recording back.
+
+    Args:
+        frontend: The two-camera frontend the framesets go through.
+        texture: The scene each frameset is a shifted copy of.
+        read_rows: Reads the recording back, from :mod:`conftest`.
+
+    Returns:
+        A function of the ``.rrd`` directory, the frameset count, the segment id
+        the replayed recording carries, and where its C++ dumps come from, giving
+        back the recording's rows and the frames that produced them.
+    """
+
+    def run(tmp_path: Path, framesets: int, segment_id: str, dumps_dir: Path | None) -> ReplayResult:
+        flow: _core.OpticalFlow = frontend(2)
+        logger: FrontendLogger = FrontendLogger(2, segment_id, dumps_dir)
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        output: Path = tmp_path / "frontend.rrd"
+        rr.init("slam-rs-frontend-log-test", recording_id=f"{segment_id}-{framesets}")
+        rr.save(output)
+        frames: list[_core.FlowFrame] = []
+        for step in range(framesets):
+            t_ns: int = step * FRAME_PERIOD_NS
+            rr.set_time(TIMELINE, duration=np.timedelta64(t_ns, "ns"))
+            frame: _core.FlowFrame = flow.process(t_ns, [texture(step, 0), texture(step, 1)])
+            logger.log(frame, elapsed_ms=1.5 * (step + 1))
+            frames.append(frame)
+        rr.disconnect()
+        return ReplayResult(rows=read_rows(output), frames=frames)
+
+    return run
+
+
+@pytest.fixture
+def smoke_dumps(tmp_path: Path) -> Path:
+    """Two framesets of two-camera C++ dumps, attributed to the smoke segment.
+
+    Returns:
+        The directory they were written to.
+    """
+    directory: Path = tmp_path / "dumps"
+    write_dumps(directory, SMOKE_SEGMENT, {0: [OVERLAY, OVERLAY], FRAME_PERIOD_NS: [OVERLAY, OVERLAY]})
+    return directory
+
+
+def test_a_track_keeps_its_colour_and_neighbours_do_not_share_one() -> None:
+    ids: Int64[ndarray, " n_tracks"] = np.arange(200, dtype=np.int64)
+    colors: UInt8[ndarray, "n_tracks 3"] = track_colors(ids)
+    assert colors.shape == (200, 3)
+    assert colors.dtype == np.uint8
+    # The colour is a pure function of the id, so a track that survives a frame
+    # keeps it however the array is ordered.
+    assert np.array_equal(track_colors(ids[::-1]), colors[::-1])
+    # Hue only: every colour is saturated, so none of them is grey on grey imagery.
+    assert np.all(colors.max(axis=1) == 255)
+    assert np.all(colors.min(axis=1) == 0)
+    # Neighbouring ids land far apart on the hue circle.
+    assert np.all(np.abs(colors[1:].astype(np.int64) - colors[:-1].astype(np.int64)).sum(axis=1) > 30)
+
+
+def test_no_track_is_ever_drawn_in_the_overlays_colour() -> None:
+    """The palette walks five of the six hue ramps: the sixth starts at magenta."""
+    colors: UInt8[ndarray, "n_tracks 3"] = track_colors(np.arange(5000, dtype=np.int64))
+    assert not np.any(np.all(colors == np.array(CPP_COLOR, dtype=np.uint8), axis=1))
+
+
+def test_an_empty_track_list_gives_an_empty_colour_list() -> None:
+    assert track_colors(np.zeros(0, dtype=np.int64)).shape == (0, 3)
+
+
+def test_the_committed_cpp_dumps_name_their_own_segment() -> None:
+    """The dumps carry the smoke segment's id and the feed's own ``video_time``."""
+    assert dumps_source(DEFAULT_DUMPS_DIR) == SMOKE_SEGMENT
+    dumps: dict[int, list[Float32[ndarray, "n_keypoints 2"]]] = read_cpp_dumps(2, DEFAULT_DUMPS_DIR)
+    assert len(dumps) == 8
+    assert 0 in dumps and 18507000 in dumps, sorted(dumps)
+    first: list[Float32[ndarray, "n_keypoints 2"]] = dumps[0]
+    assert len(first) == 2, "the smoke segment is a two-camera rig"
+    assert first[0].shape == (66, 2), "what dump_flow.cpp recorded for camera 0 of frameset 0"
+    assert first[0].dtype == np.float32
+    assert np.all((first[0] >= 0.0) & (first[0] < 960.0)), "keypoints lie inside the 960x960 frame"
+
+
+def test_a_directory_without_dumps_leaves_the_overlay_empty(tmp_path: Path) -> None:
+    for empty in (tmp_path, tmp_path / "does-not-exist"):
+        assert dumps_source(empty) == ""
+        assert read_cpp_dumps(2, empty) == {}
+
+
+def test_dumps_with_no_source_file_are_refused(tmp_path: Path) -> None:
+    """An unattributed dump could only be drawn on the wrong segment."""
+    write_dumps(tmp_path, SMOKE_SEGMENT, {0: [np.zeros((1, 2), dtype=np.float32)]})
+    (tmp_path / SOURCE_FILE).unlink()
+    with pytest.raises(ValueError, match=SOURCE_FILE):
+        dumps_source(tmp_path)
+
+
+def test_dumps_from_another_rig_are_refused(tmp_path: Path) -> None:
+    """A dump short of a camera would leave that camera's last overlay on screen."""
+    write_dumps(tmp_path, SMOKE_SEGMENT, {0: [np.zeros((1, 2), dtype=np.float32)]})
+    with pytest.raises(ValueError, match="1 cameras, the rig being replayed has 2"):
+        read_cpp_dumps(2, tmp_path)
+
+
+def test_a_dump_without_a_timestamp_is_refused(tmp_path: Path) -> None:
+    """``t_ns`` is the whole association within a segment, so its absence is not a default."""
+    write_dumps(tmp_path, SMOKE_SEGMENT, {0: [np.zeros((1, 2), dtype=np.float32)]})
+    path: Path = tmp_path / "frame_000.json"
+    dump: dict[str, object] = json.loads(path.read_text())
+    del dump["t_ns"]
+    path.write_text(json.dumps(dump))
+    with pytest.raises(ValueError, match="t_ns"):
+        read_cpp_dumps(1, tmp_path)
+
+
+def test_a_dump_directory_with_no_source_segment_is_refused(tmp_path: Path) -> None:
+    """An empty ``source.json`` names no segment, so nothing may be associated with it."""
+    write_dumps(tmp_path, SMOKE_SEGMENT, {0: [np.zeros((1, 2), dtype=np.float32)]})
+    (tmp_path / SOURCE_FILE).write_text("{}")
+    with pytest.raises(ValueError, match="segment_id"):
+        dumps_source(tmp_path)
+
+
+def test_dumps_of_another_recording_do_not_refuse_the_rig_on_screen(smoke_dumps: Path) -> None:
+    """A dump's camera count is a fact about the overlay, so it is checked only where one is drawn."""
+    assert FrontendLogger(4, OTHER_SEGMENT, smoke_dumps).cpp_dumps == {}
+    with pytest.raises(ValueError, match="2 cameras, the rig being replayed has 4"):
+        FrontendLogger(4, SMOKE_SEGMENT, smoke_dumps)
+
+
+def test_log_writes_the_dataset_tree_once_per_frameset(replay: ReplayFactory, tmp_path: Path) -> None:
+    """Every entity the blueprint shows gets one row per frameset, on ``video_time``."""
+    recorded: ReplayResult = replay(tmp_path, 3, OTHER_SEGMENT, tmp_path / "no-dumps")
+    expected_times: list[int] = [step * FRAME_PERIOD_NS for step in range(3)]
+    for camera in range(2):
+        for leaf in ("keypoints", "trails", "cells"):
+            entity: str = f"{camera_entity(camera)}/{leaf}"
+            assert entity in recorded.rows, sorted(recorded.rows)
+            assert [row.t_ns for row in recorded.rows[entity]] == expected_times
+        for counter in ("num_tracks", "num_new"):
+            entity = f"{STATS_ENTITY}/cam_{camera:02d}/{counter}"
+            assert [row.t_ns for row in recorded.rows[entity]] == expected_times
+    assert [row.t_ns for row in recorded.rows[f"{STATS_ENTITY}/frontend_ms"]] == expected_times
+    # The keypoints logged are the ones the frame carries, in the frame's order.
+    for step, frame in enumerate(recorded.frames):
+        logged: Float32[ndarray, "n_tracks 2"] = np.array(
+            recorded.rows[f"{camera_entity(0)}/keypoints"][step].values["Points2D:positions"], dtype=np.float32
+        )
+        assert np.allclose(logged, frame.positions(0))
+
+
+def test_the_counters_report_each_cameras_own_numbers(replay: ReplayFactory, tmp_path: Path) -> None:
+    recorded: ReplayResult = replay(tmp_path, 3, OTHER_SEGMENT, tmp_path / "no-dumps")
+    for camera in range(2):
+        tracks: list[Row] = recorded.rows[f"{STATS_ENTITY}/cam_{camera:02d}/num_tracks"]
+        fresh: list[Row] = recorded.rows[f"{STATS_ENTITY}/cam_{camera:02d}/num_new"]
+        assert [row.values["Scalars:scalars"] for row in tracks] == [[float(frame.num_tracks(camera))] for frame in recorded.frames]
+        assert [row.values["Scalars:scalars"] for row in fresh] == [[float(frame.num_new(camera))] for frame in recorded.frames]
+    assert [row.values["Scalars:scalars"] for row in recorded.rows[f"{STATS_ENTITY}/frontend_ms"]] == [[1.5], [3.0], [4.5]]
+
+
+def test_trails_follow_a_track_by_id_and_stop_at_the_trail_length(replay: ReplayFactory, tmp_path: Path) -> None:
+    """A strip is one id's history, so it survives the frame's order changing.
+
+    Asserted as invariants rather than as a second copy of ``_log_trails``: a
+    strip ends at that id's current position, it is the same id's previous strip
+    with this position appended, and it stops growing at :data:`TRAIL_LENGTH`.
+    Keying by slot would tie a strip to whatever id sits at that index, which
+    drifts as tracks die, and no invariant here would hold.
+    """
+    framesets: int = TRAIL_LENGTH + 4
+    recorded: ReplayResult = replay(tmp_path, framesets, OTHER_SEGMENT, tmp_path / "no-dumps")
+    survived: dict[int, int] = {}
+    previous: dict[int, tuple[tuple[float, float], ...]] = {}
+    for step, frame in enumerate(recorded.frames):
+        positions: Float32[ndarray, "n_tracks 2"] = frame.positions(0)
+        live: dict[int, tuple[float, float]] = {
+            identifier: (float(positions[slot, 0]), float(positions[slot, 1])) for slot, identifier in enumerate(frame.ids(0).tolist())
+        }
+        survived = {identifier: 1 + survived.get(identifier, 0) for identifier in live}
+        strips: list = recorded.rows[f"{camera_entity(0)}/trails"][step].values["LineStrips2D:strips"]
+        by_end: dict[tuple[float, float], tuple[tuple[float, float], ...]] = {
+            (strip[-1][0], strip[-1][1]): tuple((point[0], point[1]) for point in strip) for strip in strips
+        }
+        assert len(by_end) == len(strips), f"frameset {step}: two strips end at the same pixel"
+        current: dict[int, tuple[tuple[float, float], ...]] = {}
+        for identifier, position in live.items():
+            expected_length: int = min(survived[identifier], TRAIL_LENGTH)
+            if expected_length == 1:
+                # One position is a point, not a trail, so nothing is drawn yet.
+                assert position not in by_end, f"frameset {step}: a strip for a track born on it"
+                continue
+            strip: tuple[tuple[float, float], ...] | None = by_end.get(position)
+            assert strip is not None, f"frameset {step}: no strip ends at track {identifier}"
+            assert len(strip) == expected_length, f"frameset {step}: track {identifier} carries {len(strip)} points"
+            if identifier in previous:
+                grown: tuple[tuple[float, float], ...] = (*previous[identifier], position)
+                assert strip == grown[-TRAIL_LENGTH:], f"frameset {step}: track {identifier} is not its own history plus this position"
+            current[identifier] = strip
+        previous = current
+    # The run is long enough that the cap is actually reached.
+    last: list = recorded.rows[f"{camera_entity(0)}/trails"][-1].values["LineStrips2D:strips"]
+    assert max(len(strip) for strip in last) == TRAIL_LENGTH
+
+
+def test_the_overlay_is_drawn_on_the_recording_the_dumps_came_from(replay: ReplayFactory, smoke_dumps: Path, tmp_path: Path) -> None:
+    """Read back out of the file: the recording whose own id is the dumps' gets them."""
+    recorded: ReplayResult = replay(tmp_path / "smoke", 2, SMOKE_SEGMENT, smoke_dumps)
+    for camera in range(2):
+        entity: str = f"{camera_entity(camera)}/keypoints_cpp"
+        assert entity in recorded.rows, sorted(recorded.rows)
+        assert len(recorded.rows[entity]) == 2
+        for row in recorded.rows[entity]:
+            assert np.allclose(np.array(row.values["Points2D:positions"], dtype=np.float32), OVERLAY)
+            assert row.values["Points2D:colors"] == [(CPP_COLOR[0] << 24) | (CPP_COLOR[1] << 16) | (CPP_COLOR[2] << 8) | 0xFF]
+
+
+def test_no_other_recording_is_given_the_overlay(
+    replay: ReplayFactory, smoke_dumps: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The review's finding: MIO10's dumps used to land on MIO07's first frame."""
+    recorded: ReplayResult = replay(tmp_path / "other", 2, OTHER_SEGMENT, smoke_dumps)
+    assert not [entity for entity in recorded.rows if entity.endswith("keypoints_cpp")], sorted(recorded.rows)
+    # The frames themselves were still tracked and logged, and the run says why, once.
+    assert len(recorded.rows[f"{camera_entity(0)}/keypoints"]) == 2
+    assert capsys.readouterr().out == f"dumps are from {SMOKE_SEGMENT}, replaying {OTHER_SEGMENT}: no overlay\n"
+
+
+@pytest.mark.slow
+def test_the_overlay_follows_the_recording_and_not_the_filename(manifest: ReferenceManifest, tmp_path: Path) -> None:
+    """The re-review's collision: a file named like the dumps' segment, holding another recording.
+
+    ``--rrd`` used to switch the overlay off by the flag, so a path spelled like
+    a segment id drew MIO10's keypoints over MIO07's pixels. The feed reads the
+    id out of the recording, so what the file is called decides nothing.
+    """
+    smoke: ReferenceSegment = manifest.by_id(SMOKE_SEGMENT)
+    other: ReferenceSegment = manifest.by_id(OTHER_SEGMENT)
+    if not other.base_path.is_file():
+        pytest.skip(f"{other.base_path} is not mounted on this host")
+    spelled_like_the_dumps: Path = tmp_path / SMOKE_SEGMENT
+    spelled_like_the_dumps.symlink_to(other.base_path)
+
+    feed: SegmentFeed
+    with open_segment(LocalSegment(base_rrd=spelled_like_the_dumps), smoke.imu) as feed:
+        assert feed.segment_id == OTHER_SEGMENT
+        assert FrontendLogger(len(feed.cameras), feed.segment_id).cpp_dumps == {}
+
+
+def test_the_overlay_is_cleared_once_the_dumps_run_out_and_stays_cleared(replay: ReplayFactory, tmp_path: Path) -> None:
+    """Latest-at would leave the last overlay on screen for the rest of the segment."""
+    dumps_dir: Path = tmp_path / "dumps"
+    write_dumps(dumps_dir, SMOKE_SEGMENT, {0: [OVERLAY, OVERLAY]})
+    recorded: ReplayResult = replay(tmp_path, 4, SMOKE_SEGMENT, dumps_dir)
+    for camera in range(2):
+        logged: list[Row] = recorded.rows[f"{camera_entity(camera)}/keypoints_cpp"]
+        # One drawn row and exactly one clearing row: the clear is not repeated
+        # per frameset, and nothing is drawn after it.
+        assert [row.t_ns for row in logged] == [0, FRAME_PERIOD_NS]
+        assert len(logged[0].values["Points2D:positions"]) == len(OVERLAY)
+        assert logged[1].values["Points2D:positions"] == []

--- a/packages/slam-rs/tests/test_import.py
+++ b/packages/slam-rs/tests/test_import.py
@@ -1,0 +1,280 @@
+"""The compiled core imports, and the estimator's boundary behaves as the stub promises.
+
+The rig, its frames and the pipeline over it are :mod:`conftest` fixtures, which
+pytest injects: the factory aliases below are declared here rather than imported
+from it, because ``tests`` is not on the typechecker's search path and every
+module in this directory therefore stands alone. Everything runs on the 200x200
+synthetic rig, so the whole file stays inside the default, seconds-long suite;
+the reference segments are the V2 gate's business.
+"""
+
+from typing import cast
+
+import numpy as np
+import pytest
+from fixture_types import FRAME, FRAME_PERIOD_NS, IMU_PERIOD_NS, PipelineFactory, RigFactory, TextureFactory, gravity_batch
+from jaxtyping import Float64, Int64, UInt8
+from numpy import ndarray
+from numpy.typing import NDArray
+
+from slam_rs import _core
+
+
+def test_core_reports_a_version() -> None:
+    assert _core.__version__
+
+
+def test_a_frame_without_imu_needs_more_imu(pipeline: PipelineFactory, texture: TextureFactory) -> None:
+    """basalt blocks on its IMU queue here; Offline mode says so and returns (D17).
+
+    Nothing moves: the coverage test comes before the frontend, so the refused
+    frameset may be pushed again once its samples arrive and the result is the
+    one a run that had them all along would have produced.
+    """
+    vio: _core.Vio = pipeline(2)
+    assert vio.camera_count == 2
+    result: _core.VioResult = vio.track(1_000, [texture(0, 0), texture(1, 0)])
+    assert result.status == _core.VioStatus.NeedMoreImu
+    assert result.t_ns == 1_000
+    assert result.world_from_rig.shape == (7,)
+    assert result.velocity.shape == (3,)
+    np.testing.assert_allclose(result.world_from_rig, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0])
+    # Nothing measured, so there is no window and no statistics to snapshot; and
+    # the frontend never ran, so there are no keypoints either.
+    assert vio.snapshot() is None
+    assert vio.flow_frame() is None
+
+
+def test_a_rig_of_one_camera_is_refused(rig: RigFactory) -> None:
+    """``optical_flow.h:210``: the epipolar filter needs a second camera."""
+    with pytest.raises(ValueError, match="expected 2 cameras, got 1"):
+        _core.Vio(rig(1), _core.VioConfig())
+
+
+def test_a_config_the_port_does_not_implement_is_refused(rig: RigFactory) -> None:
+    """Offline mode cannot drop framesets without letting arrival order reach a decision."""
+    raw: str = _core.VioConfig().to_json().replace('"config.vio_enforce_realtime": false', '"config.vio_enforce_realtime": true')
+    with pytest.raises(ValueError, match="vio_enforce_realtime"):
+        _core.Vio(rig(2), _core.VioConfig.from_json(raw))
+
+
+def test_push_imu_rejects_a_non_monotonic_timestamp(pipeline: PipelineFactory) -> None:
+    vio: _core.Vio = pipeline(2)
+    vio.push_imu(1_000, [0.0, 0.0, 0.0], [0.0, 0.0, 9.81])
+    with pytest.raises(ValueError, match="does not follow"):
+        vio.push_imu(1_000, [0.0, 0.0, 0.0], [0.0, 0.0, 9.81])
+
+
+def test_a_frameset_retried_after_its_imu_tracks_as_if_it_had_it(pipeline: PipelineFactory, texture: TextureFactory) -> None:
+    """D17: no arrival order may reach the trajectory.
+
+    One pipeline gets every frameset's samples before the frameset. The other
+    gets only the samples up to the frame time — which do not cover it — is
+    refused, then gets the rest and tracks the same frameset again. The two
+    trajectories agree bit for bit, which is what makes holding a refused
+    frameset and retrying it the right thing for a feed to do.
+    """
+    frames: int = 8
+    covered: _core.Vio = pipeline(2)
+    retried: _core.Vio = pipeline(2)
+    for index in range(frames):
+        t_ns: int = index * FRAME_PERIOD_NS
+        images: list[UInt8[ndarray, "h w"]] = [texture(index, 0), texture(index + 1, 0)]
+        samples: Int64[ndarray, " n_samples"] = np.arange(t_ns, t_ns + FRAME_PERIOD_NS, IMU_PERIOD_NS, dtype=np.int64)
+        gyro, accel = gravity_batch(samples)
+        covered.push_imu_batch(samples, gyro, accel)
+        first: _core.VioResult = covered.track(t_ns, images)
+
+        short: Int64[ndarray, " n_short"] = samples[samples <= t_ns]
+        retried.push_imu_batch(short, *gravity_batch(short))
+        assert retried.track(t_ns, images).status == _core.VioStatus.NeedMoreImu
+        rest: Int64[ndarray, " n_rest"] = samples[samples > t_ns]
+        retried.push_imu_batch(rest, *gravity_batch(rest))
+        second: _core.VioResult = retried.track(t_ns, images)
+
+        assert first.status == second.status == _core.VioStatus.Tracking
+        np.testing.assert_array_equal(first.world_from_rig, second.world_from_rig)
+        np.testing.assert_array_equal(first.velocity, second.velocity)
+        np.testing.assert_array_equal(first.gyro_bias, second.gyro_bias)
+
+
+def test_a_refused_frameset_leaves_the_last_accepted_keypoints_alone(pipeline: PipelineFactory, texture: TextureFactory) -> None:
+    """``flow_frame`` still describes the last frameset the frontend actually ran on.
+
+    ``num_new`` is derived from the keypoint counter as it stood before that
+    frameset, so a refused one must not overwrite it: the keypoints would all
+    look old.
+    """
+    vio: _core.Vio = pipeline(2)
+    samples: Int64[ndarray, " n_samples"] = np.arange(0, FRAME_PERIOD_NS, IMU_PERIOD_NS, dtype=np.int64)
+    gyro, accel = gravity_batch(samples)
+    vio.push_imu_batch(samples, gyro, accel)
+    assert vio.track(0, [texture(0, 0), texture(1, 0)]).status == _core.VioStatus.Tracking
+    accepted: _core.FlowFrame | None = vio.flow_frame()
+    assert accepted is not None
+
+    assert vio.track(FRAME_PERIOD_NS, [texture(1, 0), texture(2, 0)]).status == _core.VioStatus.NeedMoreImu
+    refused: _core.FlowFrame | None = vio.flow_frame()
+    assert refused is not None
+    assert refused.t_ns == accepted.t_ns == 0
+    assert refused.num_new(0) == accepted.num_new(0) > 0
+
+
+def test_the_pipeline_tracks_a_shifted_scene_and_reports_its_window(pipeline: PipelineFactory, texture: TextureFactory) -> None:
+    """End to end on synthetic pixels: the estimator initialises, tracks and fills a window.
+
+    The scene translates by one pixel a frame, which is not a metric trajectory —
+    the numbers the port is measured against are the reference segments (the V2
+    gate). What this pins is that the whole path runs from Python and that every
+    array the Rerun rung reads comes back with the shapes the stub declares.
+    """
+    vio: _core.Vio = pipeline(2)
+    frames: int = 12
+    tracked: int = 0
+    for index in range(frames):
+        t_ns: int = index * FRAME_PERIOD_NS
+        # The samples of one frame period, pushed before the frameset they cover:
+        # the estimator needs one strictly past ``t_ns`` or it reports NeedMoreImu.
+        samples: Int64[ndarray, " n_samples"] = np.arange(t_ns, t_ns + FRAME_PERIOD_NS, IMU_PERIOD_NS, dtype=np.int64)
+        gyro, accel = gravity_batch(samples)
+        vio.push_imu_batch(samples, gyro, accel)
+        result: _core.VioResult = vio.track(t_ns, [texture(index, 0), texture(index + 1, 0)])
+        if result.status == _core.VioStatus.Tracking:
+            tracked += 1
+    assert tracked >= frames - 2, "only the framesets before the first covered one may fail to track"
+
+    snapshot: _core.VioSnapshot | None = vio.snapshot()
+    assert snapshot is not None
+    window: int = len(snapshot.window_t_ns)
+    assert window > 0
+    assert snapshot.t_ns == snapshot.window_t_ns.max()
+    assert snapshot.window_poses.shape == (window, 7)
+    # Every keyframe is a window frame; the reverse is not true.
+    assert set(snapshot.kf_ids.tolist()) <= set(snapshot.window_t_ns.tolist())
+    # The per-frame flags and the id list are the same fact, so a frame is a
+    # keyframe exactly where its timestamp is in the list.
+    assert snapshot.window_keyframe.shape == (window,)
+    assert snapshot.window_long_term.shape == (window,)
+    np.testing.assert_array_equal(snapshot.window_keyframe, np.isin(snapshot.window_t_ns, snapshot.kf_ids))
+    # A long-term keyframe is a keyframe.
+    assert not np.any(snapshot.window_long_term & ~snapshot.window_keyframe)
+
+    landmarks: int = len(snapshot.landmark_ids)
+    assert landmarks > 0, "a textured scene should triangulate something"
+    assert snapshot.landmark_positions.shape == (landmarks, 3)
+    assert snapshot.landmark_hosts.shape == (landmarks,)
+    assert set(snapshot.landmark_hosts.tolist()) <= set(snapshot.kf_ids.tolist()), "a landmark is hosted by a keyframe"
+    assert snapshot.num_observations >= landmarks
+
+    # The four LM scalars the Rerun rung logs, in the types the stub declares.
+    assert isinstance(snapshot.lm_iterations, int)
+    assert all(isinstance(value, float) for value in (snapshot.lm_lambda, snapshot.lm_error_before, snapshot.lm_error_after))
+    # The estimator's six stages and the frontend lane's four, in one map.
+    assert set(snapshot.timings_ms) == {
+        "back_substitution",
+        "error",
+        "linearize",
+        "marginalize",
+        "measure",
+        "solver",
+        "frontend_pyramid",
+        "frontend_detect",
+        "frontend_track",
+        "frontend_imu",
+    }
+    assert all(milliseconds >= 0.0 for milliseconds in snapshot.timings_ms.values())
+    # The three the frontend measures itself ran on every frameset this drive
+    # tracked; the preintegration only runs once the estimator has published a
+    # state, which it has by the last of them.
+    for stage in ("frontend_pyramid", "frontend_detect", "frontend_track", "frontend_imu"):
+        assert snapshot.timings_ms[stage] > 0.0, stage
+
+    frame: _core.FlowFrame | None = vio.flow_frame()
+    assert frame is not None
+    assert frame.t_ns == (frames - 1) * FRAME_PERIOD_NS
+    assert frame.num_tracks(0) > 0
+
+
+def test_wrong_dtype_and_rank_raise_value_error(pipeline: PipelineFactory) -> None:
+    vio: _core.Vio = pipeline(2)
+    # The casts feed the boundary exactly what it forbids: that is the point of
+    # the test, and the checker would otherwise reject the call statically.
+    float_image: NDArray[np.uint8] = cast("NDArray[np.uint8]", np.zeros((FRAME, FRAME), dtype=np.float32))
+    int32_times: NDArray[np.int64] = cast("NDArray[np.int64]", np.zeros(2, dtype=np.int32))
+    with pytest.raises(ValueError, match="2-D uint8"):
+        vio.track(0, [float_image, float_image])
+    with pytest.raises(ValueError, match="1-D int64"):
+        vio.push_imu_batch(int32_times, np.zeros((2, 3)), np.zeros((2, 3)))
+    with pytest.raises(ValueError, match=r"shape \(n, 3\)"):
+        vio.push_imu_batch(np.zeros(2, dtype=np.int64), np.zeros((2, 4)), np.zeros((2, 3)))
+
+
+def test_fortran_order_arrays_are_rejected(pipeline: PipelineFactory) -> None:
+    """Fortran bytes run down the columns; copying them as rows would transpose the data."""
+    vio: _core.Vio = pipeline(2)
+    fortran_image: UInt8[ndarray, "h w"] = np.asfortranarray(np.zeros((FRAME, FRAME), dtype=np.uint8))
+    with pytest.raises(ValueError, match="C-contiguous"):
+        vio.track(0, [fortran_image, fortran_image])
+
+    t_ns: NDArray[np.int64] = np.arange(2, dtype=np.int64)
+    fortran_gyro: NDArray[np.float64] = np.asfortranarray(np.arange(6, dtype=np.float64).reshape(2, 3))
+    contiguous: NDArray[np.float64] = np.zeros((2, 3), dtype=np.float64)
+    with pytest.raises(ValueError, match="C-contiguous"):
+        vio.push_imu_batch(t_ns, fortran_gyro, contiguous)
+    with pytest.raises(ValueError, match="C-contiguous"):
+        vio.push_imu_batch(t_ns, contiguous, fortran_gyro)
+    with pytest.raises(ValueError, match="C-contiguous"):
+        vio.push_imu_batch(np.arange(4, dtype=np.int64)[::2], contiguous, contiguous)
+
+
+def test_a_frameset_of_the_wrong_width_raises_value_error(pipeline: PipelineFactory, texture: TextureFactory) -> None:
+    vio: _core.Vio = pipeline(2)
+    with pytest.raises(ValueError, match="expected 2 images"):
+        vio.track(0, [texture(0, 0)])
+
+
+def test_a_frame_that_is_not_the_calibrated_size_is_refused(pipeline: PipelineFactory, texture: TextureFactory) -> None:
+    """The calibration is the geometry: a cropped frame means other bearings.
+
+    Every rule ``track`` has is decided before anything moves, so this one does
+    not need the inertial samples either; they are pushed because the refusal a
+    covered frameset gets is the one the retry below depends on.
+    """
+    vio: _core.Vio = pipeline(2)
+    samples: Int64[ndarray, " n_samples"] = np.arange(0, FRAME_PERIOD_NS, IMU_PERIOD_NS, dtype=np.int64)
+    gyro, accel = gravity_batch(samples)
+    vio.push_imu_batch(samples, gyro, accel)
+    with pytest.raises(ValueError, match=f"the calibration is for {FRAME}x{FRAME} frames"):
+        vio.track(0, [texture(0, 0), np.zeros((64, 64), dtype=np.uint8)])
+
+
+def test_a_refused_frameset_and_its_retry_are_the_clean_run_bit_for_bit(pipeline: PipelineFactory, texture: TextureFactory) -> None:
+    """The binding's promise, over a whole run: a refusal costs the trajectory nothing.
+
+    A cropped frameset is offered before every good one and then corrected. The
+    frontend undoes its own passes, but the refusal has to be decided before
+    ``track`` spends the frontend's own preintegration on the interval, which is
+    not undone: with that check behind it, the corrected retry parted from a
+    clean run by 6e-8 m in the pose by the seventh frameset. Twelve framesets, so
+    the probe lands both before the estimator has a state and after.
+    """
+    frames: int = 12
+    cropped: UInt8[ndarray, "h w"] = np.zeros((64, 64), dtype=np.uint8)
+    runs: list[list[Float64[ndarray, " 16"]]] = []
+    for probe in (False, True):
+        vio: _core.Vio = pipeline(2)
+        states: list[Float64[ndarray, " 16"]] = []
+        for index in range(frames):
+            t_ns: int = index * FRAME_PERIOD_NS
+            samples: Int64[ndarray, " n_samples"] = np.arange(t_ns, t_ns + FRAME_PERIOD_NS, IMU_PERIOD_NS, dtype=np.int64)
+            gyro, accel = gravity_batch(samples)
+            vio.push_imu_batch(samples, gyro, accel)
+            images: list[UInt8[ndarray, "h w"]] = [texture(index, 0), texture(index + 1, 0)]
+            if probe:
+                with pytest.raises(ValueError, match=f"the calibration is for {FRAME}x{FRAME} frames"):
+                    vio.track(t_ns, [images[0], cropped])
+            result: _core.VioResult = vio.track(t_ns, images)
+            states.append(np.concatenate([result.world_from_rig, result.velocity, result.gyro_bias, result.accel_bias]))
+        runs.append(states)
+    for index, (clean, probed) in enumerate(zip(runs[0], runs[1], strict=True)):
+        np.testing.assert_array_equal(probed, clean, err_msg=f"frameset {index}: the pose, velocity or a bias moved with a refusal before it")

--- a/packages/slam-rs/tests/test_replay_log.py
+++ b/packages/slam-rs/tests/test_replay_log.py
@@ -16,12 +16,15 @@ alone.
 from pathlib import Path
 
 import numpy as np
+import pytest
 import rerun as rr
 from fixture_types import IMU_PERIOD_NS, Rows, RowsReader
 from jaxtyping import Float64, Int64
 from numpy import ndarray
 
+from slam_rs.apis.replay import _cpp_trajectory
 from slam_rs.catalog_feed import IMU_ENTITY, TIMELINE, ImuStream
+from slam_rs.reference import SMOKE_SEGMENTS, ReferenceManifest
 from slam_rs.vio_log import log_imu
 
 SAMPLES: int = 33
@@ -70,3 +73,11 @@ def test_a_frameset_without_samples_logs_nothing(tmp_path: Path, read_rows: Rows
     log_imu(ImuStream(t_ns=np.zeros(0, dtype=np.int64), gyro_rad_s=np.zeros((0, 3)), accel_m_s2=np.zeros((0, 3))))
     rr.disconnect()
     assert read_rows(output) == {}
+
+
+def test_the_cpp_reference_is_skipped_when_the_recording_is_another_segment(manifest: ReferenceManifest, capsys: pytest.CaptureFixture[str]) -> None:
+    """``--rrd`` on a clip the manifest entry does not describe gets no C++ comparison, not a failed association."""
+    segment = manifest.by_id(SMOKE_SEGMENTS[1])
+    assert len(_cpp_trajectory(manifest, segment, 0, "some-other-segment")) == 0
+    assert "no C++ comparison" in capsys.readouterr().out
+    assert len(_cpp_trajectory(manifest, segment, 0, segment.segment_id)) > 0

--- a/packages/slam-rs/tests/test_replay_log.py
+++ b/packages/slam-rs/tests/test_replay_log.py
@@ -1,0 +1,72 @@
+"""What the replay tool's own input rung writes: the inertial samples.
+
+The estimator's rung is ``test_vio_log.py``'s and the frontend's is
+``test_frontend_log.py``'s; what neither covers is the input every stage logs
+whether or not it consumes it. The samples used to go in one row at a time —
+``set_time`` plus two ``log`` calls each, about 171 calls a frameset — and they
+now go in two columns. That is a rewrite of how the rows are written, so what is
+asserted here is that they are the same rows.
+
+The recording reader is a :mod:`conftest` fixture, which pytest injects; the
+alias below is declared here rather than imported from it, because ``tests`` is
+not on the typechecker's search path and every module in this directory stands
+alone.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import rerun as rr
+from fixture_types import IMU_PERIOD_NS, Rows, RowsReader
+from jaxtyping import Float64, Int64
+from numpy import ndarray
+
+from slam_rs.catalog_feed import IMU_ENTITY, TIMELINE, ImuStream
+from slam_rs.vio_log import log_imu
+
+SAMPLES: int = 33
+"""One 30 Hz frameset's worth of samples."""
+
+
+def stream() -> ImuStream:
+    """A frameset's samples, every component different so a transposition shows."""
+    t_ns: Int64[ndarray, " n_samples"] = np.arange(SAMPLES, dtype=np.int64) * IMU_PERIOD_NS
+    values: Float64[ndarray, "n_samples 3"] = np.arange(3 * SAMPLES, dtype=np.float64).reshape(SAMPLES, 3)
+    return ImuStream(t_ns=t_ns, gyro_rad_s=values, accel_m_s2=-values)
+
+
+def written(output: Path, read_rows: RowsReader, columnar: bool) -> Rows:
+    """Log one frameset's samples into a fresh recording, the new way or the old."""
+    imu: ImuStream = stream()
+    rr.init("slam-rs-replay-log-test", recording_id=f"replay-log-{output.stem}")
+    rr.save(output)
+    if columnar:
+        log_imu(imu)
+    else:
+        for sample in range(len(imu)):
+            rr.set_time(TIMELINE, duration=np.timedelta64(int(imu.t_ns[sample]), "ns"))
+            rr.log(f"{IMU_ENTITY}/gyro", rr.Scalars(imu.gyro_rad_s[sample]))
+            rr.log(f"{IMU_ENTITY}/accel", rr.Scalars(imu.accel_m_s2[sample]))
+    rr.disconnect()
+    return read_rows(output)
+
+
+def test_the_columns_write_the_rows_the_per_sample_loop_wrote(tmp_path: Path, read_rows: RowsReader) -> None:
+    """Same entities, same timestamps, same three components a row."""
+    columns: Rows = written(tmp_path / "columns.rrd", read_rows, columnar=True)
+    loop: Rows = written(tmp_path / "loop.rrd", read_rows, columnar=False)
+    assert set(columns) == {f"{IMU_ENTITY}/gyro", f"{IMU_ENTITY}/accel"} == set(loop)
+    for entity, rows in columns.items():
+        assert rows == loop[entity], entity
+        assert len(rows) == SAMPLES
+        assert all(len(row.values["Scalars:scalars"]) == 3 for row in rows)
+
+
+def test_a_frameset_without_samples_logs_nothing(tmp_path: Path, read_rows: RowsReader) -> None:
+    """An empty column is refused by the SDK, and there is nothing to draw anyway."""
+    output: Path = tmp_path / "empty.rrd"
+    rr.init("slam-rs-replay-log-test", recording_id="replay-log-empty")
+    rr.save(output)
+    log_imu(ImuStream(t_ns=np.zeros(0, dtype=np.int64), gyro_rad_s=np.zeros((0, 3)), accel_m_s2=np.zeros((0, 3))))
+    rr.disconnect()
+    assert read_rows(output) == {}

--- a/packages/slam-rs/tests/test_stub_matches.py
+++ b/packages/slam-rs/tests/test_stub_matches.py
@@ -236,3 +236,22 @@ def test_a_static_method_is_static_on_both_sides() -> None:
             is_static: bool = isinstance(vars(getattr(_core, class_name)).get(name), staticmethod)
             assert declared_static == is_static, f"{class_name}.{name}: stub static={declared_static}, runtime static={is_static}"
 
+
+def test_vio_status_behaves_as_the_stub_describes() -> None:
+    """The stub calls VioStatus a plain PyO3 class; hold it to exactly that contract."""
+    status: _core.VioStatus = _core.VioStatus.NeedMoreImu
+    assert int(status) == 0
+    assert int(_core.VioStatus.Tracking) == 1
+    assert status == _core.VioStatus.NeedMoreImu
+    assert status != _core.VioStatus.Tracking
+    assert repr(status) == "VioStatus.NeedMoreImu"
+    # Not an enum.Enum: no name/value, unhashable, not constructible.
+    assert not hasattr(status, "name")
+    assert not hasattr(status, "value")
+    with pytest.raises(TypeError):
+        hash(status)
+    # Routed through a Callable: the stub declares no constructor arguments, so a
+    # direct `VioStatus(1)` is a static error — which is exactly the promise here.
+    constructor: Callable[..., object] = _core.VioStatus
+    with pytest.raises(TypeError):
+        constructor(1)

--- a/packages/slam-rs/tests/test_tracking.py
+++ b/packages/slam-rs/tests/test_tracking.py
@@ -1,0 +1,132 @@
+"""The D17 hold, which the replay tool and the V2 gate both drive.
+
+The rule under test is that arrival order never reaches the trajectory: a
+frameset refused for want of inertial samples is held and tracked again once
+they arrive, before the frameset that brought them, and produces the pose a run
+that had the samples all along would have produced. ``_core`` proves that for
+one frameset (``test_import.py``); what is proved here is that
+:class:`slam_rs.tracking.Lockstep` — the one loop both drivers use — really does
+hold it, that the hold cannot grow, and that a run whose framesets were never
+covered still says so.
+
+The rig and the pipeline are :mod:`conftest` fixtures, which pytest injects; the
+factory aliases below are declared here rather than imported from another test
+module, because ``tests`` is not on the typechecker's search path and every
+module in this directory therefore stands alone.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import rerun as rr
+from fixture_types import FRAME_PERIOD_NS, IMU_PERIOD_NS, CameraFactory, PipelineFactory, TextureFactory, gravity_batch
+from jaxtyping import Float64, Int64, UInt8
+from numpy import ndarray
+
+from slam_rs.catalog_feed import Frameset, ImuStream
+from slam_rs.tracking import MAX_HELD_FRAMESETS, Lockstep
+from slam_rs.trajectory import empty_trajectory
+from slam_rs.vio_log import VioLogger, VioStage
+
+
+def frameset(step: int, texture: TextureFactory, sample_t_ns: Int64[ndarray, " n_samples"]) -> Frameset:
+    """One synthetic frameset of the two-camera rig, carrying the given samples.
+
+    Args:
+        step: Frameset index; the scene is shifted by it, and it sets the timestamp.
+        texture: The scene each frameset is a shifted copy of.
+        sample_t_ns: Inertial sample times to attach, which may cover the frame or not.
+
+    Returns:
+        The frameset, with gravity along +z on every sample and no ground truth.
+    """
+    images: list[UInt8[ndarray, "h w"]] = [texture(step, 0), texture(step + 1, 0)]
+    gyro_rad_s, accel_m_s2 = gravity_batch(sample_t_ns)
+    return Frameset(
+        t_ns=step * FRAME_PERIOD_NS,
+        images=images,
+        imu=ImuStream(t_ns=sample_t_ns, gyro_rad_s=gyro_rad_s, accel_m_s2=accel_m_s2),
+        ground_truth=None,
+    )
+
+
+def test_a_held_frameset_tracks_before_the_one_that_unblocked_it(pipeline: PipelineFactory, texture: TextureFactory) -> None:
+    """Time order is the trajectory, so the retry comes first and the poses are exact.
+
+    One lockstep gets each frameset's samples with the frameset. The other gets
+    only the samples up to its own frame time, which do not cover it, so the
+    frameset is held; the next frameset's batch runs past both frame times and
+    the held one tracks then. Both trajectories must be identical, pose by pose.
+    """
+    batches: list[Int64[ndarray, " n_samples"]] = [
+        np.arange(step * FRAME_PERIOD_NS, (step + 1) * FRAME_PERIOD_NS, IMU_PERIOD_NS, dtype=np.int64) for step in range(4)
+    ]
+    # The same samples in the same order, only split differently: the first
+    # frameset arrives with one sample at its own frame time, which does not
+    # cover it, and the rest of them come with the second frameset.
+    held_batches: list[Int64[ndarray, " n_samples"]] = [
+        batches[0][:1],
+        np.concatenate([batches[0][1:], batches[1]]),
+        batches[2],
+        batches[3],
+    ]
+    covered: Lockstep = Lockstep(vio=pipeline(2))
+    held: Lockstep = Lockstep(vio=pipeline(2))
+    covered_poses: list[Float64[ndarray, " 7"]] = []
+    held_poses: list[Float64[ndarray, " 7"]] = []
+    for step, (whole, split) in enumerate(zip(batches, held_batches, strict=True)):
+        covered_poses.extend(result.world_from_rig for _tracked, result in covered.push(frameset(step, texture, whole)))
+        held_poses.extend(result.world_from_rig for _tracked, result in held.push(frameset(step, texture, split)))
+
+    assert len(covered.elapsed_ms) == len(held.elapsed_ms) == 4
+    assert not covered.pending and not held.pending
+    assert covered.retries == 0
+    # One refusal, and the frameset it refused tracked again on the next push,
+    # before the frameset whose samples unblocked it.
+    assert held.retries == 1
+    for expected, actual in zip(covered_poses, held_poses, strict=True):
+        np.testing.assert_array_equal(expected, actual)
+
+
+def test_the_hold_never_grows_past_one_refused_frameset(pipeline: PipelineFactory, texture: TextureFactory) -> None:
+    """A feed that stops supplying samples fails at the frameset that broke the rule.
+
+    Without the bound the hold retains every remaining frameset — two decoded
+    960x960 frames each on a reference segment — and the error names a count
+    instead of the frameset.
+    """
+    lockstep: Lockstep = Lockstep(vio=pipeline(2))
+    nothing: Int64[ndarray, " 0"] = np.zeros(0, dtype=np.int64)
+    for step in range(MAX_HELD_FRAMESETS):
+        assert list(lockstep.push(frameset(step, texture, nothing))) == []
+    with pytest.raises(ValueError, match=f"frameset {MAX_HELD_FRAMESETS * FRAME_PERIOD_NS} takes the hold to 3 framesets"):
+        list(lockstep.push(frameset(MAX_HELD_FRAMESETS, texture, nothing)))
+
+
+def test_a_run_that_never_tracked_still_reports_what_it_held(
+    pipeline: PipelineFactory, camera: CameraFactory, texture: TextureFactory, tmp_path: Path
+) -> None:
+    """The run that most needs the diagnostic is the one that used to suppress it.
+
+    A replay whose framesets are never covered has no timings, so a summary
+    guarded on them printed nothing at all — and the held framesets are what the
+    reader needed to see.
+    """
+    rr.init("slam-rs-tracking-test", recording_id="never-tracked")
+    rr.save(tmp_path / "never-tracked.rrd")
+    stage: VioStage = VioStage(
+        lockstep=Lockstep(vio=pipeline(2)),
+        logger=VioLogger(
+            cameras=(camera(0, 0.0), camera(1, 0.1)),
+            ground_truth=empty_trajectory(),
+            cpp=empty_trajectory(),
+            frame_t_ns=np.zeros(1, dtype=np.int64),
+        ),
+    )
+    stage.run(frameset(0, texture, np.zeros(0, dtype=np.int64)))
+    rr.disconnect()
+
+    assert not stage.elapsed_ms
+    assert "nothing tracked" in stage.summary()
+    assert "NEVER COVERED BY THE IMU at [0]" in stage.summary()

--- a/packages/slam-rs/tests/test_v2_gate.py
+++ b/packages/slam-rs/tests/test_v2_gate.py
@@ -1,0 +1,466 @@
+"""The V2 milestone gate: the reference clips through the whole pipeline (D14, D35, D36, D58).
+
+Four clauses per clip, all on the absolute device clock every basalt CSV uses,
+and every error through :func:`slam_rs.trajectory.ate`, whose first argument is
+the estimate and therefore drives the association — each estimate pose takes the
+nearest reference pose within 5 ms, as the manifest's own C++ numbers were
+produced:
+
+* every frameset resolved: one refused for want of IMU is held and tracked again
+  once the samples arrive, and anything still held when the clip ends is a lost
+  frameset (D17);
+* against the basalt C++ trajectory fed the same decoded pixels, at most 2 cm —
+  but only on clips shorter than :data:`~slam_rs.reference.PATH_BOUND_MAX_CLIP_S`
+  seconds, because past that the C++ does not meet 2 cm against its own other
+  precision either (D60);
+* against the ``gt.csv`` sidecar, inside the C++'s own precision band on the same
+  footage — its ``f32`` and ``f64`` runs, one flag apart — or within
+  :data:`~slam_rs.reference.GT_BAND_RATIO` of the band's worst member, which is
+  the same rule written once because the ratio is above one (D60);
+* speed: the replay's own feed loop — decode plus ``track``, nothing logged, the
+  loop the C++ reference timed — within 1.2x the C++ single-thread wall for the
+  same footage (D58). A port several times slower is not a port of the thing,
+  so this clause is never left off.
+
+``no_divergence`` clips gate the frameset and speed clauses plus a finite,
+bounded trajectory (D36) — neither error tolerance: basalt itself sits at 43 cm
+and 78 cm there, and two legitimate decode paths of the same C++ estimator
+already differ by 18 to 32 cm, so a tolerance would measure noise.
+
+The lanes follow D59. The default is the **iteration set** — MIO10 whole plus
+the first ten seconds of one two-camera and one four-camera clip, about 1,650
+framesets — because finding out at the end of a ten-clip run that everything
+failed is the way not to iterate. ``SLAM_RS_V2_ALL=1`` runs all ten whole.
+Either way the clips run **shortest first** and each one's clauses are asserted
+as soon as it is measured, so the first clip that misses stops the run with its
+own row printed and is the one that gets fixed. ``SLAM_RS_V2_WINDOW_S=<seconds>``
+cuts every clip to its first N seconds, with the ``f32`` member of the C++'s own
+ground-truth band recomputed over exactly that span rather than taken from the
+manifest's whole-clip figure. Only that member is recomputed — the ``f64`` one
+stays the whole clip's — so a windowed row names the span each member covers.
+
+Whichever lane runs, it asserts **every** clip it names, both hold-outs included
+(C56): a clip whose artifacts are not on this host fails the lane instead of
+being stepped over, and only a host that holds none of them skips.
+
+The tolerances live in :mod:`slam_rs.reference`, not here: they are the
+milestone's verdict and S15 decides them from measurement.
+
+The gate drives :class:`slam_rs._core.Vio` through :func:`slam_rs.tracking.run_segment`
+rather than the replay tool: what is gated is the pipeline
+and the manifest, not the Rerun rung over them. Nothing here logs.
+
+The measuring tests are ``slow`` and skip cleanly on a host without the corpus;
+the two that check which clips the lane refuses to leave out are not — they
+decide against a relocated manifest of empty files and need no NAS.
+"""
+
+import os
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+import numpy as np
+import pytest
+from _pytest.outcomes import Skipped
+
+from slam_rs.reference import (
+    ATE_VS_CPP_CM,
+    GT_BAND_RATIO,
+    MIN_TRACKED_POSES,
+    PATH_BOUND_MAX_CLIP_S,
+    SMOKE_SEGMENTS,
+    SPEED_TOLERANCE,
+    CppAte,
+    ReferenceManifest,
+    ReferenceSegment,
+    band_cm_text,
+    d60_failures,
+    load_manifest,
+    pose_floor_text,
+)
+from slam_rs.reference_bundle import BundleFile
+from slam_rs.tracking import SegmentRun, run_segment
+from slam_rs.trajectory import (
+    MIN_ASSOCIATED_POSES,
+    AteResult,
+    Trajectory,
+    ate,
+    extent_m,
+    read_trajectory,
+    write_trajectory,
+)
+
+SMOKE_SEGMENT: str = SMOKE_SEGMENTS[1]
+"""The 7.6 s, 412-frameset clip the iteration set starts from."""
+ITERATION_SET: tuple[tuple[str, float | None], ...] = (
+    (SMOKE_SEGMENT, None),
+    ("msd-index__MIO_others__MIO07_mapping_easy", 10.0),
+    ("msd-g2__MGO_others__MGO07_mapping_easy", 10.0),
+)
+"""D59's iteration set: MIO10 whole, then ten seconds each of a two-camera and a four-camera clip."""
+ALL_SEGMENTS_VARIABLE: str = "SLAM_RS_V2_ALL"
+"""Set to ``1`` to gate all ten reference segments whole instead of the iteration set."""
+WINDOW_VARIABLE: str = "SLAM_RS_V2_WINDOW_S"
+"""Set to a number of seconds to cut every gated clip to its first N seconds."""
+
+
+@dataclass(slots=True, frozen=True)
+class GatedClip:
+    """One clip the gate measures: a reference segment, and how much of it."""
+
+    segment: ReferenceSegment
+    """The manifest entry, which carries the policy, the C++'s own error and its wall."""
+    window_s: float | None
+    """Seconds from the clip's start to replay; None replays the whole segment."""
+
+    @property
+    def name(self) -> str:
+        """What the row calls this clip."""
+        whole: str = "" if self.window_s is None else f" first {self.window_s:g} s"
+        held_out: str = ", hold-out" if self.segment.reference.hold_out else ""
+        return f"{self.segment.segment_id}{whole} [{self.segment.reference.gate_policy}{held_out}]"
+
+    @property
+    def expected_framesets(self) -> int:
+        """About how many framesets this clip replays, which is what orders the run."""
+        if self.window_s is None:
+            return self.segment.capture.num_frames
+        covered: float = min(1.0, self.window_s * 1e9 / self.segment.capture.duration_ns)
+        return max(1, round(covered * self.segment.capture.num_frames))
+
+
+def between(trajectory: Trajectory, first_ns: int, last_ns: int) -> Trajectory:
+    """The poses inside a closed time span, on the trajectory's own clock."""
+    keep: slice = slice(int(np.searchsorted(trajectory.t_ns, first_ns, side="left")), int(np.searchsorted(trajectory.t_ns, last_ns, side="right")))
+    return Trajectory(t_ns=trajectory.t_ns[keep], position_m=trajectory.position_m[keep], quaternion_wxyz=trajectory.quaternion_wxyz[keep])
+
+
+def gate_clips(manifest: ReferenceManifest) -> list[GatedClip]:
+    """The clips this run gates, shortest first (D59).
+
+    Args:
+        manifest: The frozen reference set.
+
+    Returns:
+        The iteration set, or all ten segments under
+        :data:`ALL_SEGMENTS_VARIABLE`, each cut to :data:`WINDOW_VARIABLE`
+        seconds when that is set, in increasing frameset count.
+    """
+    window_s: float | None = float(os.environ[WINDOW_VARIABLE]) if WINDOW_VARIABLE in os.environ else None
+    if os.environ.get(ALL_SEGMENTS_VARIABLE) == "1":
+        clips: list[GatedClip] = [GatedClip(segment=segment, window_s=window_s) for segment in manifest.segments]
+    else:
+        clips = [
+            GatedClip(segment=manifest.by_id(segment_id), window_s=window_s if window_s is not None else default_window_s)
+            for segment_id, default_window_s in ITERATION_SET
+        ]
+    return sorted(clips, key=lambda clip: clip.expected_framesets)
+
+
+@dataclass(slots=True, frozen=True)
+class References:
+    """One segment's two reference trajectories, both on the absolute device clock.
+
+    Why a segment *cannot* be gated is :func:`missing_reference`'s answer, given
+    before either trajectory is read.
+    """
+
+    cpp: Trajectory
+    """The basalt C++ trajectory, on the absolute device clock."""
+    truth: Trajectory
+    """The ``gt.csv`` sidecar, on the same clock."""
+
+
+def missing_reference(manifest: ReferenceManifest, segment: ReferenceSegment) -> str | None:
+    """Why this segment cannot be gated on this host, or None when it can be.
+
+    A reason is not a licence to leave the segment out: every clip the lane names
+    is measured and asserted, both hold-outs included (C56), so one absent
+    artifact fails the lane. Only a host that holds none of them — a checkout
+    without the NAS mount — skips, and says so.
+
+    Args:
+        manifest: The reference set the segment came from.
+        segment: The segment about to be gated.
+
+    Returns:
+        The first artifact that is not on this host, or None when all three are.
+    """
+    if not segment.base_path.is_file():
+        return f"{segment.base_path} is not mounted"
+    if not segment.gt_csv.is_file():
+        return f"{segment.gt_csv} is not mounted"
+    resolved: BundleFile = manifest.cpp_trajectory(segment)
+    return None if resolved.available else str(resolved.reason)
+
+
+def references(manifest: ReferenceManifest, segment: ReferenceSegment) -> References:
+    """One segment's C++ trajectory and ground-truth sidecar, on the absolute device clock.
+
+    Args:
+        manifest: The reference set the segment came from.
+        segment: A segment :func:`missing_reference` has passed.
+
+    Returns:
+        Both reference trajectories, read from this host.
+    """
+    return References(cpp=read_trajectory(manifest.cpp_trajectory(segment).path), truth=read_trajectory(segment.gt_csv))
+
+
+def cpp_gt_band_cm(clip: GatedClip, run: SegmentRun, available: References) -> tuple[float, float]:
+    """The C++'s own ground-truth error on this footage, in both of its precisions (D60).
+
+    The band is the same C++ code on the same pixels with one flag changed, and
+    it is what "as accurate as basalt" can mean at all: 0.00007 cm wide on
+    ``MIO10`` and 2.3 cm wide on the 410-second ``MIO14``.
+
+    A windowed run recomputes the ``f32`` member over exactly the span it
+    replayed, or a clip whose error grows late would be gated against a budget it
+    never had (D59). The ``f64`` member is the manifest's whole-clip figure,
+    **unscaled**: only the ``f32`` trajectory is a reference artifact, so there is
+    nothing to recompute a window from. That makes a windowed band as wide as the
+    whole clip's rather than tighter, which is why a window is an iteration lane
+    and the milestone is read off the whole clips.
+
+    Args:
+        clip: The clip, which says whether it was cut.
+        run: What the pipeline produced for it, which says what span it covers.
+        available: The two reference trajectories.
+
+    Returns:
+        The C++'s ``f32`` and ``f64`` ground-truth RMSE in centimetres.
+    """
+    expected: CppAte = clip.segment.reference.expected_cpp_ate
+    if clip.window_s is None:
+        return expected.rmse_cm, expected.rmse_cm_f64
+    span: Trajectory = between(available.cpp, int(run.estimate.t_ns[0]), int(run.estimate.t_ns[-1]))
+    return 100.0 * ate(span, available.truth).rmse_m, expected.rmse_cm_f64
+
+
+def band_text(clip: GatedClip, band: tuple[float, float]) -> str:
+    """The band as a row prints it, each member named for the span it covers.
+
+    A windowed clip's two members are of different spans — the ``f32``
+    recomputed over the window, the ``f64`` the manifest's whole-clip figure —
+    and two bare numbers read as one span's band, which is what the labels are
+    for: ``MGO07``'s windowed ``[f32 window 0.95, f64 whole 2.08]`` is not
+    2.08 cm of drift in ten seconds.
+
+    Args:
+        clip: The clip, which says whether it was cut.
+        band: The C++'s ``f32`` and ``f64`` ground-truth RMSE in centimetres.
+
+    Returns:
+        The labelled band, in centimetres.
+    """
+    if clip.window_s is None:
+        return band_cm_text(band)
+    return f"[f32 window {band[0]:.2f}, f64 whole {band[1]:.2f}]"
+
+
+def replayed_s(run: SegmentRun) -> float:
+    """Sensor seconds the run's own trajectory spans, whole clip or window."""
+    return float(run.estimate.t_ns[-1] - run.estimate.t_ns[0]) * 1e-9
+
+
+def cpp_wall_s(clip: GatedClip, run: SegmentRun) -> float:
+    """The C++ wall for the footage this run replayed, scaled by the frameset fraction.
+
+    Args:
+        clip: The clip, which carries the whole segment's C++ wall.
+        run: What the pipeline produced for it, which says how much of it ran.
+
+    Returns:
+        Seconds the C++ feed loop took over the same framesets.
+    """
+    return clip.segment.reference.expected_cpp_wall_s * run.framesets / clip.segment.capture.num_frames
+
+
+def clip_failures(clip: GatedClip, run: SegmentRun, available: References, against_cpp: AteResult, against_gt: AteResult) -> list[str]:
+    """Every V2 clause one clip fails, in the order they are stated.
+
+    Args:
+        clip: The clip, which carries the policy and the C++'s own numbers.
+        run: What the pipeline produced for it.
+        available: The two reference trajectories, for the divergence bound and
+            the C++'s own error over a windowed span.
+        against_cpp: The run's error against the basalt C++ trajectory.
+        against_gt: The run's error against the ground truth.
+
+    Returns:
+        One line per failed clause; empty when the clip passes.
+    """
+    band: tuple[float, float] = cpp_gt_band_cm(clip, run, available)
+    # The accuracy clauses are :func:`slam_rs.reference.d60_failures` — the gate
+    # and the fleet tool read one rule, or the two measure different milestones.
+    failures: list[str] = d60_failures(
+        gate_policy=clip.segment.reference.gate_policy,
+        framesets=run.framesets,
+        tracked=len(run.estimate),
+        lost=run.lost,
+        associated=against_cpp.n_associated,
+        replayed_s=replayed_s(run),
+        cpp_rmse_cm=against_cpp.rmse_m * 100.0,
+        gt_rmse_cm=against_gt.rmse_m * 100.0,
+        band=band,
+        extent_m=extent_m(run.estimate),
+        truth_extent_m=extent_m(available.truth),
+        poses_finite=bool(np.isfinite(run.estimate.position_m).all()),
+        band_text=band_text(clip, band),
+    )
+    # Speed is a clause of every policy: a run that does not diverge but takes
+    # three times as long has not matched the thing it is a port of (D58, D59).
+    cpp_s: float = cpp_wall_s(clip, run)
+    allowed_s: float = SPEED_TOLERANCE * cpp_s
+    if run.wall_s > allowed_s:
+        failures.append(
+            f"{run.wall_s:.2f} s against the C++'s {cpp_s:.2f} s, gate is {SPEED_TOLERANCE}x = {allowed_s:.2f} s ({run.wall_s / cpp_s:.2f}x)"
+        )
+    return failures
+
+
+@pytest.mark.slow
+def test_every_gated_clip_meets_the_v2_numbers(manifest: ReferenceManifest) -> None:
+    """The V2 milestone, clip by clip, shortest first, stopping at the first miss (D59).
+
+    Each clip prints its row as soon as it is measured and is asserted
+    immediately after, so a red run names the shortest clip that misses instead
+    of a table produced an hour later. A green run prints the whole table, which
+    is the milestone's own record.
+    """
+    clips: list[GatedClip] = gate_clips(manifest)
+    missing: dict[str, str] = {clip.name: reason for clip in clips if (reason := missing_reference(manifest, clip.segment)) is not None}
+    if len(missing) == len(clips):
+        pytest.skip("no clip of this lane is on this host: " + "; ".join(missing.values()))
+    # Anything short of the whole lane is a failure, not a quiet row: a run that
+    # skipped a segment has not gated the milestone the lane claims (C56).
+    assert not missing, "the lane asserts every clip it names, hold-outs included (C56); these are not on this host:\n" + "\n".join(
+        f"  {name}: {reason}" for name, reason in missing.items()
+    )
+    for clip in clips:
+        available: References = references(manifest, clip.segment)
+        run: SegmentRun = run_segment(manifest, clip.segment, window_s=clip.window_s)
+        if len(run.estimate) < MIN_TRACKED_POSES:
+            # The sentence is the shared verdict's own
+            # (:func:`slam_rs.reference.pose_floor_text`), so a dead run reads
+            # the same here and on a fleet row; the branch is because `ate` has
+            # no pose to align below the floor and raises instead of scoring.
+            pytest.fail(f"{clip.name}: {pose_floor_text(tracked=len(run.estimate), framesets=run.framesets)}")
+        against_cpp: AteResult = ate(run.estimate, available.cpp)
+        against_gt: AteResult = ate(run.estimate, available.truth)
+        expected_s: float = cpp_wall_s(clip, run)
+        band: tuple[float, float] = cpp_gt_band_cm(clip, run, available)
+        bound: str = (
+            f"bound {ATE_VS_CPP_CM:.0f} cm" if replayed_s(run) < PATH_BOUND_MAX_CLIP_S else f"no bound, {replayed_s(run):.0f} s clip"
+        )
+        print(
+            f"{clip.name}: {len(run.estimate)}/{run.framesets} tracked, "
+            f"vs C++ {against_cpp.rmse_m * 100:.2f} cm ({bound}), "
+            f"vs GT {against_gt.rmse_m * 100:.2f} cm (band {band_text(clip, band)}, "
+            f"allowed {GT_BAND_RATIO * max(band):.2f}), "
+            f"wall {run.wall_s:.2f} s, C++ {expected_s:.2f} s, ratio {run.wall_s / expected_s:.2f}"
+        )
+        failures: list[str] = clip_failures(clip, run, available, against_cpp, against_gt)
+        assert not failures, f"{clip.name}:\n" + "\n".join(failures)
+
+
+def relocated(root: Path, absent: frozenset[str] = frozenset()) -> ReferenceManifest:
+    """The reference set read from under ``root``, with the named segments' artifacts left out.
+
+    Empty files, because what is under test is which clips the lane refuses to
+    leave out — a decision it makes before it opens anything. That is also why
+    this needs no NAS: a host that holds the corpus and one that does not must
+    take the same decision.
+
+    The three artifacts move through :func:`slam_rs.reference.load_manifest`'s
+    own ``artifact_root``, which is the rule a fleet machine runs; only the C++
+    trajectory is moved here, because a reference bundle is not part of the
+    corpus a root points at.
+
+    Args:
+        root: Directory the artifacts are written into, one subdirectory each.
+        absent: Segment ids to leave without any artifact at all.
+
+    Returns:
+        The same manifest against the relocated corpus.
+    """
+    corpus: ReferenceManifest = load_manifest(artifact_root=root)
+    segments: list[ReferenceSegment] = []
+    for segment in corpus.segments:
+        directory: Path = root / segment.segment_id
+        directory.mkdir(parents=True, exist_ok=True)
+        for name in ("base.rrd", "gt.rrd", "gt.csv", "basalt_traj.csv"):
+            if segment.segment_id not in absent:
+                (directory / name).write_text("")
+        # Absolute, so the manifest's own package root drops out of the join,
+        # and committed, so the bundle is not consulted either.
+        segments.append(replace(segment, reference=replace(segment.reference, bundle_only=False, trajectory_csv=directory / "basalt_traj.csv")))
+    return replace(corpus, segments=tuple(segments))
+
+
+def test_a_clip_whose_reference_is_missing_fails_the_lane_rather_than_leaving_it_out(
+    manifest: ReferenceManifest, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """C56: the all-ten lane asserts all ten, so one absent artifact is a red run.
+
+    The bug this guards passed the lane on one to nine segments: a segment whose
+    trajectory was not on the host printed a line and was stepped over, and the
+    run reported success without it — including for a hold-out, which is the
+    whole point of having one.
+    """
+    monkeypatch.setenv(ALL_SEGMENTS_VARIABLE, "1")
+    corpus: ReferenceManifest = relocated(tmp_path, absent=frozenset({SMOKE_SEGMENT}))
+    assert len(gate_clips(corpus)) == len(manifest.segments)
+    try:
+        test_every_gated_clip_meets_the_v2_numbers(corpus)
+    except AssertionError as refusal:
+        assert SMOKE_SEGMENT in str(refusal), f"the refusal does not name the clip it could not measure: {refusal}"
+        assert "C56" in str(refusal)
+    except Skipped as skipped:
+        # A skip here is the bug in its other shape: a red run reported green.
+        pytest.fail(f"one absent artifact skipped the lane instead of failing it: {skipped}")
+    else:
+        pytest.fail(f"the lane passed without ever measuring {SMOKE_SEGMENT}")
+
+
+def test_a_host_that_holds_no_clip_of_the_lane_skips_it(
+    manifest: ReferenceManifest, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Total absence — a checkout without the NAS mount — is the one skip left, and it says so."""
+    monkeypatch.setenv(ALL_SEGMENTS_VARIABLE, "1")
+    corpus: ReferenceManifest = relocated(tmp_path, absent=frozenset(segment.segment_id for segment in manifest.segments))
+    with pytest.raises(Skipped, match="no clip of this lane is on this host"):
+        test_every_gated_clip_meets_the_v2_numbers(corpus)
+
+
+def test_a_windowed_row_names_which_band_member_covers_the_window(manifest: ReferenceManifest) -> None:
+    """The row labels both band members, because a windowed clip's two are of different spans (D60).
+
+    This needs no corpus: what is under test is how the row reads. Two bare
+    numbers would say the ``f64`` figure was measured over the window too, when
+    it is the whole clip's and only the ``f32`` one was recomputed.
+    """
+    segment: ReferenceSegment = manifest.by_id(SMOKE_SEGMENT)
+    assert band_text(GatedClip(segment=segment, window_s=10.0), (0.95, 2.08)) == "[f32 window 0.95, f64 whole 2.08]"
+    assert band_text(GatedClip(segment=segment, window_s=None), (1.43, 1.43)) == "[f32 1.43, f64 1.43]"
+
+
+@pytest.mark.slow
+def test_offline_mode_is_bit_reproducible(manifest: ReferenceManifest, tmp_path: Path) -> None:
+    """Two runs over the same input write byte-identical CSVs (D17).
+
+    Offline mode has no threads and no queues, so nothing about arrival order can
+    reach an estimator decision; this is the assertion that says so. A hundred
+    framesets of the smoke segment reach the first marginalizations, which is
+    where a scheduling dependency would first show.
+    """
+    segment: ReferenceSegment = manifest.by_id(SMOKE_SEGMENT)
+    if not segment.base_path.is_file():
+        pytest.skip(f"{segment.base_path} is not mounted on this host")
+    written: list[Path] = []
+    for run in range(2):
+        path: Path = tmp_path / f"run_{run}.csv"
+        write_trajectory(path, run_segment(manifest, segment, max_framesets=100).estimate)
+        written.append(path)
+    assert written[0].read_bytes() == written[1].read_bytes(), "two Offline-mode runs over the same input disagreed"
+    assert len(read_trajectory(written[0])) > MIN_ASSOCIATED_POSES

--- a/packages/slam-rs/tests/test_vio_log.py
+++ b/packages/slam-rs/tests/test_vio_log.py
@@ -1,0 +1,439 @@
+"""What the estimator's Rerun layer promises: the frustum geometry, and what ``log`` writes.
+
+The logging contract is checked against a recording, not against a mock: the test
+drives the whole pipeline over the synthetic rig, saves what
+:class:`slam_rs.vio_log.VioLogger` logged into the global recording (D03: the
+tools own no :class:`rerun.RecordingStream`) and reads the chunks back with
+:class:`rerun.experimental.RrdReader` — the same rows a viewer would receive. An
+entity path or a ``video_time`` value that never reached the file fails here.
+
+The reference trajectories are synthetic straight lines rather than a segment's:
+what is under test is that a reference is drawn up to the cursor and no further,
+which a straight line says as well as a real one and in milliseconds.
+
+The rig, the pipeline and the recording reader are :mod:`conftest` fixtures,
+which pytest injects; the aliases below are declared here rather than imported
+from it, because ``tests`` is not on the typechecker's search path and every
+module in this directory therefore stands alone.
+"""
+
+from pathlib import Path
+from typing import NamedTuple
+
+import numpy as np
+import pytest
+import rerun as rr
+import rerun.blueprint as rrb
+import rerun.experimental as rx
+from fixture_types import FRAME_PERIOD_NS, IMU_PERIOD_NS, CameraFactory, PipelineFactory, Row, Rows, RowsReader, TextureFactory, gravity_batch
+from jaxtyping import Float64, Int64
+from numpy import ndarray
+
+from slam_rs import _core, vio_log
+from slam_rs.catalog_feed import RIG_ENTITY, TIMELINE, CameraCalib
+from slam_rs.trajectory import AteResult, Trajectory, ate, empty_trajectory
+from slam_rs.vio_log import (
+    CPP_ENTITY,
+    GT_ENTITY,
+    IDENTITY,
+    IMAGE_PLANE_M,
+    RUN_ENTITY,
+    VIO_STATS_ENTITY,
+    VioLogger,
+    alignment_onto,
+    frustum_strip,
+    log_rig,
+    vio_blueprint,
+)
+
+FRAMESETS: int = 12
+"""Enough framesets for the estimator to initialise, optimise and fill a window."""
+
+
+class Logged(NamedTuple):
+    """What one logged run gives back."""
+
+    rows: Rows
+    """Every non-static row of the recording, by entity path."""
+    tracked: list[int]
+    """``video_time`` of every frameset that tracked, in order."""
+    logger: VioLogger
+    """The logger that produced them, for its accumulated estimate."""
+    recording: Path
+    """The ``.rrd`` itself, for the rows :func:`conftest.read_rows` drops: the static ones."""
+
+
+def straight_line(t_ns: Int64[ndarray, " n"]) -> Trajectory:
+    """A trajectory running along +x at 1 m/s, one pose per timestamp."""
+    seconds: Float64[ndarray, " n"] = t_ns.astype(np.float64) / 1e9
+    return Trajectory(
+        t_ns=t_ns,
+        position_m=np.column_stack([seconds, np.zeros_like(seconds), np.zeros_like(seconds)]),
+        quaternion_wxyz=np.tile(np.array([1.0, 0.0, 0.0, 0.0]), (len(t_ns), 1)),
+    )
+
+
+def drive(
+    vio: _core.Vio,
+    cameras: tuple[CameraCalib, ...],
+    references: Trajectory,
+    texture: TextureFactory,
+    output: Path,
+    read_rows: RowsReader,
+) -> Logged:
+    """Log ``FRAMESETS`` framesets of the synthetic rig and read the recording back.
+
+    Args:
+        vio: The pipeline the framesets go through.
+        cameras: The rig the logger draws.
+        references: Ground truth and C++ trajectory, the same line for both.
+        texture: The scene each frameset is a shifted copy of.
+        output: Where the ``.rrd`` is written.
+        read_rows: Reads the recording back, from :mod:`conftest`.
+
+    Returns:
+        The recording's rows, the framesets that tracked, and the logger.
+    """
+    rr.init("slam-rs-vio-log-test", recording_id=f"vio-log-{output.parent.name}")
+    rr.save(output)
+    frame_t_ns: Int64[ndarray, " n_frames"] = np.arange(0, FRAMESETS * FRAME_PERIOD_NS, FRAME_PERIOD_NS, dtype=np.int64)
+    logger: VioLogger = VioLogger(cameras=cameras, ground_truth=references, cpp=references, frame_t_ns=frame_t_ns)
+    tracked: list[int] = []
+    for step in range(FRAMESETS):
+        t_ns: int = step * FRAME_PERIOD_NS
+        samples: Int64[ndarray, " n_samples"] = np.arange(t_ns, t_ns + FRAME_PERIOD_NS, IMU_PERIOD_NS, dtype=np.int64)
+        vio.push_imu_batch(samples, *gravity_batch(samples))
+        rr.set_time(TIMELINE, duration=np.timedelta64(t_ns, "ns"))
+        # Camera 1 is the scene shifted one pixel along the baseline, so the
+        # stereo pass matches: a shift across it matches nothing and camera 1
+        # would carry no keypoint at all.
+        result: _core.VioResult = vio.track(t_ns, [texture(step, 0), texture(step + 1, 0)])
+        if result.status != _core.VioStatus.Tracking:
+            continue
+        snapshot: _core.VioSnapshot | None = vio.snapshot()
+        frame: _core.FlowFrame | None = vio.flow_frame()
+        assert snapshot is not None
+        assert frame is not None
+        logger.log(result, snapshot, frame, elapsed_ms=1.5)
+        tracked.append(t_ns)
+    # What a replay ends with, and the other half of the segment form: the rows
+    # above are one segment each, these are the whole paths, static.
+    logger.log_complete_paths()
+    rr.disconnect()
+    return Logged(rows=read_rows(output), tracked=tracked, logger=logger, recording=output)
+
+
+@pytest.fixture
+def logged(
+    pipeline: PipelineFactory, texture: TextureFactory, camera: CameraFactory, tmp_path: Path, read_rows: RowsReader
+) -> Logged:
+    """Drive the whole pipeline over the synthetic rig and read back what was logged."""
+    reference_t_ns: Int64[ndarray, " n"] = np.arange(0, FRAMESETS * FRAME_PERIOD_NS, FRAME_PERIOD_NS, dtype=np.int64)
+    return drive(pipeline(2), (camera(0, 0.0), camera(1, 0.1)), straight_line(reference_t_ns), texture, tmp_path / "vio.rrd", read_rows)
+
+
+def test_the_frustum_wireframe_sits_where_the_camera_does(camera: CameraFactory) -> None:
+    """Apex at the camera's origin in rig coordinates, corners a fixed depth in front."""
+    offset: float = 0.1
+    strip: Float64[ndarray, "10 3"] = frustum_strip(camera(1, offset), depth_m=0.5)
+    assert strip.shape == (10, 3)
+    # The rig transform of the synthetic camera is a pure x translation, so the
+    # apex — the only point at the camera origin — lands on it exactly.
+    apex: Float64[ndarray, "n 3"] = strip[np.array([5, 8])]
+    np.testing.assert_allclose(apex, np.tile([offset, 0.0, 0.0], (2, 1)), atol=1e-12)
+    corners: Float64[ndarray, "n 3"] = np.delete(strip, [5, 8], axis=0)
+    assert np.all(corners[:, 2] == 0.5), "every corner sits at the requested depth along +z"
+    # A closed rectangle: the strip returns to the corner it started from.
+    np.testing.assert_allclose(strip[0], strip[4])
+
+
+def test_a_deeper_frustum_is_the_same_shape_scaled(camera: CameraFactory) -> None:
+    """Depth is a scale on the rays, so the wireframe never changes direction."""
+    near: Float64[ndarray, "10 3"] = frustum_strip(camera(0, 0.0), depth_m=0.05)
+    far: Float64[ndarray, "10 3"] = frustum_strip(camera(0, 0.0), depth_m=0.5)
+    np.testing.assert_allclose(10.0 * near, far, atol=1e-12)
+
+
+def image_planes(recording: Path) -> dict[str, float]:
+    """Every ``Pinhole``'s image-plane distance in one recording, by entity path.
+
+    Read off the static chunks, which is why this is not :func:`conftest.read_rows`:
+    a rig's geometry is logged once and for all time, not at a cursor.
+    """
+    planes: dict[str, float] = {}
+    for chunk in rx.RrdReader(recording).stream().collect().stream():
+        batch = chunk.to_record_batch()
+        if "Pinhole:image_plane_distance" in batch.schema.names:
+            planes[chunk.entity_path] = batch.column("Pinhole:image_plane_distance").to_pylist()[0][0]
+    return planes
+
+
+def static_path_lengths(recording: Path) -> dict[str, int]:
+    """Every static line strip in one recording: how many points it has, by entity path.
+
+    Static like the rig geometry above and read the same way, because
+    :func:`conftest.read_rows` drops exactly the rows this asks about.
+    """
+    lengths: dict[str, int] = {}
+    for chunk in rx.RrdReader(recording).stream().collect().stream():
+        batch = chunk.to_record_batch()
+        if chunk.is_static and "LineStrips3D:strips" in batch.schema.names:
+            lengths[chunk.entity_path] = len(batch.column("LineStrips3D:strips").to_pylist()[0][0])
+    return lengths
+
+
+def test_every_rig_camera_pins_its_frustum_to_one_size(camera: CameraFactory, tmp_path: Path) -> None:
+    """Both drawn rigs name the image-plane distance, so a frustum keeps its size all replay.
+
+    Rerun's own default is a heuristic on the scene bounds, so the frusta grew as
+    the landmarks came in. Both call shapes are checked because both are drawn:
+    the estimated run's rig puts the ``Pinhole`` on the camera itself, and the
+    dataset's own rig — :func:`slam_rs.apis.replay._log_calibration` — puts it on
+    the ``pinhole`` child the images hang under.
+    """
+    output: Path = tmp_path / "rig.rrd"
+    rr.init("slam-rs-vio-log-test", recording_id=f"rig-{tmp_path.name}")
+    rr.save(output)
+    log_rig((camera(0, 0.0), camera(1, 0.1)), f"{RUN_ENTITY}/rig")
+    log_rig((camera(0, 0.0), camera(1, 0.1)), RIG_ENTITY, pinhole_child="/pinhole")
+    rr.disconnect()
+    # Float32 in the file, so approximately 0.1 is the most the component can say.
+    assert image_planes(output) == pytest.approx(
+        {
+            f"{prefix}/cam_{index:02d}{child}": IMAGE_PLANE_M
+            for prefix, child in ((f"{RUN_ENTITY}/rig", ""), (RIG_ENTITY, "/pinhole"))
+            for index in range(2)
+        }
+    )
+
+
+def test_every_tracked_frameset_writes_the_rung(logged: Logged) -> None:
+    """One row per tracked frameset on each of the rung's entities, at its own time.
+
+    The three ``trajectory`` entities are not here: they are drawn one segment at
+    a time and a line with no second pose yet writes nothing, which is what the
+    two path tests below pin.
+    """
+    assert len(logged.tracked) >= FRAMESETS - 2, "only the framesets before the first covered one may fail to track"
+    for entity in (
+        f"{RUN_ENTITY}/rig",
+        f"{RUN_ENTITY}/window",
+        f"{RUN_ENTITY}/marginalized",
+        f"{RUN_ENTITY}/landmarks",
+        f"{VIO_STATS_ENTITY}/num_landmarks",
+        f"{VIO_STATS_ENTITY}/lm_iterations",
+        f"{VIO_STATS_ENTITY}/lm_error_before",
+        f"{VIO_STATS_ENTITY}/lm_error_after",
+        f"{VIO_STATS_ENTITY}/stage_ms/measure",
+    ):
+        assert entity in logged.rows, f"{entity} never reached the recording"
+        assert [t_ns for t_ns, _ in logged.rows[entity]] == logged.tracked, entity
+    # The window this run marginalizes from the fifth frameset on, and a
+    # marginalized frame is drawn from the poses of the window it just left: a
+    # row that is always empty is the layer looking the removed frames up in the
+    # window they are already gone from.
+    faded: list[int] = [len(values["LineStrips3D:strips"]) for _, values in logged.rows[f"{RUN_ENTITY}/marginalized"]]
+    assert max(faded) > 0, "the marginalized layer never drew a frame the last marginalization removed"
+
+
+def test_the_estimated_path_gains_one_segment_a_frameset(logged: Logged) -> None:
+    """Each frameset writes the pair of poses it joined, not the path so far.
+
+    The whole path is what a viewer shows, and it is the view's visible time
+    range that assembles it (:func:`slam_rs.vio_log.vio_blueprint`); the rows
+    themselves are two points each, which is what makes the rung linear. The
+    first tracked frameset has one pose and no pair, so it writes no row.
+    """
+    rows: list[Row] = logged.rows[f"{RUN_ENTITY}/trajectory"]
+    assert [t_ns for t_ns, _ in rows] == logged.tracked[1:]
+    assert [len(values["LineStrips3D:strips"][0]) for _, values in rows] == [2] * len(rows)
+    assert len(logged.logger.estimated()) == len(logged.tracked)
+
+
+def test_a_reference_segment_ends_at_the_cursor_and_no_further(logged: Logged) -> None:
+    """A reference known in advance still stops where the estimate has got to."""
+    for entity in (f"{GT_ENTITY}/trajectory", f"{CPP_ENTITY}/trajectory"):
+        rows: list[Row] = logged.rows[entity]
+        # One reference pose every frame interval, from zero, so a cursor before
+        # the second one has no segment to draw.
+        assert [t_ns for t_ns, _ in rows] == [t_ns for t_ns in logged.tracked if t_ns >= FRAME_PERIOD_NS], entity
+        for t_ns, values in rows:
+            drawn: list = values["LineStrips3D:strips"][0]
+            assert len(drawn) == 2, entity
+            # The reference runs along +x at 1 m/s from zero, so the pose the
+            # segment ends on is the cursor's own time in seconds — never the
+            # one after it.
+            assert drawn[-1][0] == pytest.approx(t_ns / 1e9), entity
+
+
+def test_the_whole_paths_are_logged_once_at_the_end(logged: Logged) -> None:
+    """One static row per path, so a viewer opened at any cursor sees where each run went."""
+    strips: dict[str, int] = static_path_lengths(logged.recording)
+    assert sorted(strips) == sorted([f"{RUN_ENTITY}/path", f"{GT_ENTITY}/path", f"{CPP_ENTITY}/path"])
+    assert strips[f"{RUN_ENTITY}/path"] == len(logged.tracked)
+    assert strips[f"{GT_ENTITY}/path"] == strips[f"{CPP_ENTITY}/path"] == FRAMESETS
+
+
+def test_the_plotted_ate_is_the_estimate_driven_one(
+    pipeline: PipelineFactory,
+    texture: TextureFactory,
+    camera: CameraFactory,
+    tmp_path: Path,
+    read_rows: RowsReader,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The plotted ``ate_cm`` is the number the tool prints and the gate asserts.
+
+    A 1 kHz ground truth is what tells the two directions apart: driving the
+    association from the reference pairs about 33 truth poses to every frameset
+    and scores a different metric (5.32 cm against this run's 5.74 cm), which is
+    neither what :func:`slam_rs.apis.replay.main` prints nor what the V2 gate
+    asserts. One ATE a frameset, so a 12-frameset run reaches the association
+    floor and plots.
+    """
+    monkeypatch.setattr(vio_log, "ATE_EVERY", 1)
+    dense_t_ns: Int64[ndarray, " n"] = np.arange(0, FRAMESETS * FRAME_PERIOD_NS, IMU_PERIOD_NS, dtype=np.int64)
+    truth: Trajectory = straight_line(dense_t_ns)
+    logged: Logged = drive(pipeline(2), (camera(0, 0.0), camera(1, 0.1)), truth, texture, tmp_path / "dense.rrd", read_rows)
+    estimate: Trajectory = logged.logger.estimated()
+    estimate_driven: AteResult = ate(estimate, truth)
+    reference_driven: AteResult = ate(truth, estimate)
+    assert estimate_driven.n_associated == len(estimate), "every estimate pose takes the nearest truth pose"
+    assert reference_driven.n_associated > len(estimate), "the reference-driven association is the denser one"
+    plotted: float = logged.rows[f"{VIO_STATS_ENTITY}/ate_cm/gt"][-1][1]["Scalars:scalars"][0]
+    assert plotted == pytest.approx(100.0 * estimate_driven.rmse_m)
+    assert plotted != pytest.approx(100.0 * reference_driven.rmse_m)
+
+
+def test_an_alignment_recovers_a_known_rigid_offset() -> None:
+    """The transform a run carries is the one that takes it onto the ground truth."""
+    t_ns: Int64[ndarray, " n"] = np.arange(0, 40 * FRAME_PERIOD_NS, FRAME_PERIOD_NS, dtype=np.int64)
+    source: Trajectory = straight_line(t_ns)
+    turn: Float64[ndarray, "3 3"] = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    offset: Float64[ndarray, " 3"] = np.array([3.0, -2.0, 0.5])
+    target: Trajectory = Trajectory(
+        t_ns=t_ns,
+        position_m=source.position_m @ turn.T + offset,
+        quaternion_wxyz=source.quaternion_wxyz,
+    )
+    recovered = alignment_onto(source, target)
+    np.testing.assert_allclose(recovered.dst_R_src, turn, atol=1e-9)
+    np.testing.assert_allclose(recovered.dst_t_src, offset, atol=1e-9)
+    np.testing.assert_allclose(recovered.apply(source.position_m), target.position_m, atol=1e-9)
+
+
+def test_too_short_a_run_carries_no_alignment() -> None:
+    """Below the association floor the identity is honest: nothing has been measured yet."""
+    short: Trajectory = straight_line(np.arange(0, 3 * FRAME_PERIOD_NS, FRAME_PERIOD_NS, dtype=np.int64))
+    long: Trajectory = straight_line(np.arange(0, 40 * FRAME_PERIOD_NS, FRAME_PERIOD_NS, dtype=np.int64))
+    assert alignment_onto(short, long) is IDENTITY
+    assert alignment_onto(long, empty_trajectory()) is IDENTITY
+
+
+def test_the_cpp_reference_is_placed_once_at_the_first_tracked_frameset(logged: Logged) -> None:
+    """Both it and the ground truth are known up front, so its alignment never changes."""
+    rows: list[Row] = logged.rows[CPP_ENTITY]
+    assert [row.t_ns for row in rows] == logged.tracked[:1]
+    assert "Transform3D:translation" in rows[0].values
+
+
+def test_the_keypoints_land_on_the_camera_images(logged: Logged) -> None:
+    """The rung draws the estimator's own frontend output, on the frontend rung's paths."""
+    for index in range(2):
+        entity: str = f"/world/rig_00/cam_{index:02d}/pinhole/keypoints"
+        assert [t_ns for t_ns, _ in logged.rows[entity]] == logged.tracked
+        assert all(len(values["Points2D:positions"]) > 0 for _, values in logged.rows[entity])
+
+
+def test_a_run_without_references_still_logs_everything_else(pipeline: PipelineFactory, camera: CameraFactory) -> None:
+    """A segment with no ground truth and no C++ trajectory draws neither line, and no ATE."""
+    logger: VioLogger = VioLogger(
+        cameras=(camera(0, 0.0), camera(1, 0.1)),
+        ground_truth=empty_trajectory(),
+        cpp=empty_trajectory(),
+        frame_t_ns=np.arange(0, FRAMESETS * FRAME_PERIOD_NS, FRAME_PERIOD_NS, dtype=np.int64),
+    )
+    assert len(logger.estimated()) == 0
+    assert logger.window_strip.shape == (10, 3)
+
+
+def views_of(node: rrb.Container | rrb.View) -> list[rrb.View]:
+    """Every view under one blueprint node, in layout order."""
+    if isinstance(node, rrb.api.Container):
+        return [view for child in node.contents for view in views_of(child)]
+    return [node]
+
+
+def test_the_blueprint_covers_the_world_the_cameras_and_the_counters(camera: CameraFactory) -> None:
+    """One 3D view, one 2D view per camera, one time-series view per unit, panels collapsed."""
+    blueprint: rrb.Blueprint = vio_blueprint((camera(0, 0.0), camera(1, 0.1)))
+    views: list[rrb.View] = views_of(blueprint.root_container)
+    assert [str(view.origin) for view in views] == [
+        "/world",
+        "/world/rig_00/cam_00/pinhole",
+        "/world/rig_00/cam_01/pinhole",
+        *[VIO_STATS_ENTITY] * 8,
+    ]
+    assert [str(view.name) for view in views[3:]] == [
+        "counts",
+        "keyframes & LM steps",
+        "timing (ms)",
+        "solve stages (ms)",
+        "frontend stages (ms)",
+        "LM cost",
+        "LM damping",
+        "ATE (cm)",
+    ]
+    assert blueprint.collapse_panels
+
+
+def test_only_the_three_paths_reach_back_to_the_start_of_the_recording(camera: CameraFactory) -> None:
+    """The segments become a path because the view says so — and only for the paths.
+
+    Without the override Rerun's default for a 3D view is latest-at, and each
+    two-point strip would render alone. With it on the view instead of on these
+    three entities, every frameset's window frusta and landmarks would be drawn
+    at once as well.
+    """
+    world: rrb.View = views_of(vio_blueprint((camera(0, 0.0), camera(1, 0.1))).root_container)[0]
+    assert sorted(str(entity) for entity in world.visualizer_overrides) == [
+        f"{CPP_ENTITY}/trajectory",
+        f"{GT_ENTITY}/trajectory",
+        f"{RUN_ENTITY}/trajectory",
+    ]
+    reaching_back: rrb.VisibleTimeRanges = rrb.VisibleTimeRanges(
+        rrb.VisibleTimeRange(TIMELINE, start=rrb.TimeRangeBoundary.infinite(), end=rrb.TimeRangeBoundary.cursor_relative())
+    )
+    for override in world.visualizer_overrides.values():
+        assert isinstance(override, rrb.VisibleTimeRanges)
+        assert override.ranges is not None
+        assert reaching_back.ranges is not None
+        assert override.ranges.as_arrow_array() == reaching_back.ranges.as_arrow_array()
+
+
+def test_every_logged_counter_sits_in_exactly_one_time_series_view(logged: Logged, camera: CameraFactory) -> None:
+    """A scalar nobody put in a view is the bug this partition is checked to catch.
+
+    One view per unit only stays readable while every scalar is in one: a new
+    counter with no view of its own would otherwise fall back into whichever
+    axis Rerun's own ``$origin/**`` default reached it through, which is how the
+    LM cost came to flatten thirteen other series.
+
+    The ATE is added by hand because it is logged every
+    :data:`slam_rs.vio_log.ATE_EVERY` framesets and this drive is shorter than
+    that, so the recording carries no row of it to read back.
+    """
+    counters: set[str] = {entity for entity in logged.rows if entity.startswith(VIO_STATS_ENTITY)}
+    counters |= {f"{VIO_STATS_ENTITY}/ate_cm/gt", f"{VIO_STATS_ENTITY}/ate_cm/cpp"}
+    blueprint: rrb.Blueprint = vio_blueprint((camera(0, 0.0), camera(1, 0.1)))
+    plotted: list[str] = []
+    for view in views_of(blueprint.root_container):
+        if str(view.origin) != VIO_STATS_ENTITY:
+            continue
+        # ``contents`` is a query expression in general; the narrowing is what
+        # says these views name their entities one by one rather than globbing.
+        contents: object = view.contents
+        assert isinstance(contents, list), f"{view.name} does not list its entities"
+        plotted += [str(entity) for entity in contents]
+    assert sorted(plotted) == sorted(set(plotted)), "a counter is plotted in two views, so it is drawn against two axes"
+    assert set(plotted) == counters, "every logged counter is plotted exactly once, and nothing else is"

--- a/packages/slam-rs/tests/tools/dump_clip.py
+++ b/packages/slam-rs/tests/tools/dump_clip.py
@@ -1,0 +1,307 @@
+"""Dump a whole reference segment to disk so the Rust lanes can replay it offline.
+
+`crates/slam-rs/tests/full_clip.rs` needs three things the committed fixtures only
+carry for sixty framesets: every frameset's pixels, every inertial sample, and the
+calibration the C++ reference was actually handed. This writes all three into one
+directory:
+
+```
+<clip>/clip.json              segment, clock, frameset timestamps, camera shapes
+<clip>/calib.json             basalt-shaped calibration, from the catalog statics
+<clip>/imu.csv                t_ns,gx,gy,gz,ax,ay,az on the video_time clock
+<clip>/frames.sha256          the C++ reference's own format, absolute timestamps
+<clip>/frame_<NNN>_cam<C>.pgm tools/dump_flow.cpp's layout, gray8
+<clip>/timestamps.txt         the same layout's frameset clock, one per line
+<clip>/imu.json               the same samples as imu.csv, in the fork's shape
+<clip>/clip.npz               `--npz`: the same framesets as one array bundle
+<clip>/clip.npz.calib.pkl     `--npz`: the feed's own `CameraCalib`/`ImuCalib`
+```
+
+The last pair is what `slam_rs.apis.bench_track` replays: that harness times
+`Vio.track` with no decoder and no Rerun, so it needs the pixels as one array
+and the calibration as the dataclasses the feed built — this is the tool that
+writes them, and `--npz` holds every frame in memory, so a bench dump wants
+`--max-framesets`.
+
+The last two are what the fork's `basalt_vio_oracle <frames-dir> <calib.json>
+<config.json> <out.json> [n]` reads, so one dump feeds both the port's own lane
+and the C++ oracle that isolates the backend from the frontend.
+
+The pixels come off the frozen `cpu_gray8_dav1d_1thread` decode path, so
+`frames.sha256` is comparable line by line with the reference run's file — which
+is the check that both implementations are fed the same clip. `--calibration
+fixture` swaps in the fork's `data/msd/msd*_calib.json` doubles instead of the
+catalog's float32-stored values, which is how the port's sensitivity to that
+difference is measured.
+
+A whole segment is large: MIO07 is 4,095 framesets of 960x960 stereo, 7.5 GB.
+Nothing here is committed and the directory is meant to be deleted afterwards.
+"""
+
+import hashlib
+import json
+import pickle
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+import tyro
+from jaxtyping import Float64, Int64, UInt8
+from numpy import ndarray
+
+from slam_rs.catalog_feed import CameraCalib, Frameset, LocalSegment, SegmentFeed, open_segment
+from slam_rs.reference import ReferenceManifest, ReferenceSegment, flow_config, load_manifest
+
+FIXTURES: Path = Path(__file__).resolve().parents[2] / "crates/slam-rs/tests/fixtures"
+"""Where the fork's own MSD calibration files sit in this repository."""
+
+DEVICE_CALIBRATION: dict[str, str] = {"msd-index": "msdmi_calib.json", "msd-g2": "msdmg_calib.json"}
+"""Catalog dataset to the fork calibration file that carries the same rig in doubles."""
+
+
+@dataclass(slots=True)
+class Config:
+    """Dump one reference segment's pixels, inertial samples and calibration."""
+
+    segment: str
+    """Segment id from ``reference_segments.toml``."""
+    output: Path
+    """Directory the clip is written to; created if missing."""
+    calibration: Literal["catalog", "fixture"] = "catalog"
+    """``catalog`` writes the float32-stored values the C++ reference was pushed; ``fixture`` writes the fork file's doubles."""
+    max_framesets: int | None = None
+    """Stop after this many framesets; None dumps the whole segment."""
+    npz: bool = False
+    """Also write ``clip.npz`` and ``clip.npz.calib.pkl``, which is what ``bench_track`` replays."""
+    window_s: float = 60.0
+    """Longest time window fetched in one round trip."""
+
+
+def eigen_quaternion_xyzw(rotation: Float64[ndarray, "3 3"]) -> Float64[ndarray, " 4"]:
+    """Eigen's ``Quaterniond(Matrix3d)``, term for term.
+
+    ``vit_tracker.cpp:288`` builds the camera extrinsic this way from the 4x4 the
+    driver pushes, and the matrix it is given is not exactly orthonormal — the
+    catalog stores float32. Different conversions disagree in the last bits on
+    such a matrix, so this reproduces the one the reference actually ran rather
+    than calling a library.
+
+    Args:
+        rotation: Rotation block of ``imu_T_cam``.
+
+    Returns:
+        The quaternion as ``[qx, qy, qz, qw]``, unnormalised exactly as Eigen leaves it.
+    """
+    quaternion: Float64[ndarray, " 4"] = np.zeros(4, dtype=np.float64)
+    trace: float = float(rotation.trace())
+    if trace > 0.0:
+        root: float = float(np.sqrt(trace + 1.0))
+        quaternion[3] = 0.5 * root
+        root = 0.5 / root
+        quaternion[0] = (rotation[2, 1] - rotation[1, 2]) * root
+        quaternion[1] = (rotation[0, 2] - rotation[2, 0]) * root
+        quaternion[2] = (rotation[1, 0] - rotation[0, 1]) * root
+        return quaternion
+    i: int = 0
+    if rotation[1, 1] > rotation[0, 0]:
+        i = 1
+    if rotation[2, 2] > rotation[i, i]:
+        i = 2
+    j: int = (i + 1) % 3
+    k: int = (j + 1) % 3
+    root = float(np.sqrt(rotation[i, i] - rotation[j, j] - rotation[k, k] + 1.0))
+    quaternion[i] = 0.5 * root
+    root = 0.5 / root
+    quaternion[3] = (rotation[k, j] - rotation[j, k]) * root
+    quaternion[j] = (rotation[j, i] + rotation[i, j]) * root
+    quaternion[k] = (rotation[k, i] + rotation[i, k]) * root
+    return quaternion
+
+
+def catalog_calibration(feed: SegmentFeed, fork_file: dict[str, Any]) -> dict[str, Any]:
+    """A basalt calibration file holding the catalog's own geometry.
+
+    The intrinsics, resolutions and extrinsics are the values the C++ reference
+    was handed through the VIT C API; everything else — the noise model, the
+    update rate, the time offset — is not on the recording and stays as the fork
+    file has it.
+
+    Args:
+        feed: Open segment feed, whose cameras carry the catalog geometry.
+        fork_file: The fork's ``msd*_calib.json``, already unwrapped from ``value0``.
+
+    Returns:
+        The ``value0`` body of a basalt calibration file.
+    """
+    calibration: dict[str, Any] = dict(fork_file)
+    poses: list[dict[str, float]] = []
+    intrinsics: list[dict[str, Any]] = []
+    resolution: list[list[int]] = []
+    camera: CameraCalib
+    for camera in feed.cameras:
+        quaternion: Float64[ndarray, " 4"] = eigen_quaternion_xyzw(camera.imu_T_cam[:3, :3])
+        poses.append(
+            {
+                "px": float(camera.imu_T_cam[0, 3]),
+                "py": float(camera.imu_T_cam[1, 3]),
+                "pz": float(camera.imu_T_cam[2, 3]),
+                "qx": float(quaternion[0]),
+                "qy": float(quaternion[1]),
+                "qz": float(quaternion[2]),
+                "qw": float(quaternion[3]),
+            }
+        )
+        terms: dict[str, float] = {"fx": camera.fx, "fy": camera.fy, "cx": camera.cx, "cy": camera.cy}
+        if camera.model == "kb4":
+            terms |= dict(zip(["k1", "k2", "k3", "k4"], camera.distortion.tolist(), strict=True))
+            intrinsics.append({"camera_type": "kb4", "intrinsics": terms})
+        else:
+            terms |= dict(zip(["k1", "k2", "p1", "p2", "k3", "k4", "k5", "k6"], camera.distortion.tolist(), strict=True))
+            if camera.distortion_valid_radius is None:
+                raise ValueError(f"cam_{camera.index:02d} is radtan8 without a valid radius; basalt needs rpmax")
+            terms["rpmax"] = camera.distortion_valid_radius
+            intrinsics.append({"camera_type": "pinhole-radtan8", "intrinsics": terms})
+        resolution.append([camera.width, camera.height])
+    calibration["T_imu_cam"] = poses
+    calibration["intrinsics"] = intrinsics
+    calibration["resolution"] = resolution
+    return calibration
+
+
+def write_pgm(path: Path, image: UInt8[ndarray, "h w"]) -> None:
+    """Write one grayscale image in the binary PGM the Rust lanes read.
+
+    Args:
+        path: Destination file.
+        image: C-contiguous 8-bit raster.
+    """
+    header: bytes = f"P5\n{image.shape[1]} {image.shape[0]}\n255\n".encode("ascii")
+    path.write_bytes(header + image.tobytes())
+
+
+def write_oracle_inputs(output: Path, frame_t_ns: list[int], imu_lines: list[str]) -> None:
+    """Write the two files `basalt_vio_oracle` reads beside the PGMs.
+
+    The tool takes the frameset clock as one integer per line and the inertial
+    window as JSON. Both are the values already written to ``clip.json`` and
+    ``imu.csv``, in the shape ``tools/vio_oracle.cpp`` parses.
+
+    Args:
+        output: Clip directory.
+        frame_t_ns: Frameset timestamps, in order.
+        imu_lines: The data rows of ``imu.csv``, without the header.
+    """
+    (output / "timestamps.txt").write_text("".join(f"{t_ns}\n" for t_ns in frame_t_ns))
+    samples: list[str] = []
+    for line in imu_lines:
+        fields: list[str] = line.split(",")
+        samples.append(f'    {{"t_ns": {fields[0]}, "gyro": [{", ".join(fields[1:4])}], "accel": [{", ".join(fields[4:7])}]}}')
+    (output / "imu.json").write_text('{"imu": [\n' + ",\n".join(samples) + "\n]}\n")
+
+
+def main(config: Config) -> None:
+    """Dump the segment named by the config.
+
+    Args:
+        config: Parsed CLI options.
+
+    Raises:
+        ValueError: If ``--npz`` was asked for with no frameset to bundle, if the
+            segment is not in the manifest, or if its dataset has no fork
+            calibration.
+    """
+    # Before the manifest, the catalog and the output directory: zero framesets
+    # was accepted, every non-NPZ side file was written, and then `np.stack` on
+    # the empty image list raised out of NumPy — leaving a directory that reads
+    # as a clip and holds no frameset (S25 review).
+    if config.npz and config.max_framesets == 0:
+        raise ValueError("--max-framesets 0 with --npz has no frameset to bundle; the bench dump needs at least one")
+    manifest: ReferenceManifest = load_manifest()
+    segment: ReferenceSegment = manifest.by_id(config.segment)
+    if segment.dataset_name not in DEVICE_CALIBRATION:
+        raise ValueError(f"{segment.dataset_name} has no fork calibration file")
+    fork_file: dict[str, Any] = json.loads((FIXTURES / DEVICE_CALIBRATION[segment.dataset_name]).read_text())["value0"]
+
+    config.output.mkdir(parents=True, exist_ok=True)
+    bundle_images: list[UInt8[ndarray, "n_cameras h w"]] = []
+    bundle_imu_counts: list[int] = []
+    bundle_imu_t: list[Int64[ndarray, " n_samples"]] = []
+    bundle_imu_gyro: list[Float64[ndarray, "n_samples 3"]] = []
+    bundle_imu_accel: list[Float64[ndarray, "n_samples 3"]] = []
+    imu_lines: list[str] = ["#t_ns,gyro_x,gyro_y,gyro_z,accel_x,accel_y,accel_z"]
+    frame_lines: list[str] = ["# t_ns,cam_index,sha256 of the gray8 HxW pixels pushed to basalt"]
+    frame_t_ns: list[int] = []
+    dumped: int = 0
+
+    with open_segment(
+        LocalSegment(base_rrd=segment.base_path, gt_rrd=None),
+        segment.imu,
+        window_s=config.window_s,
+    ) as feed:
+        calibration: dict[str, Any] = catalog_calibration(feed, fork_file) if config.calibration == "catalog" else fork_file
+        (config.output / "calib.json").write_text(json.dumps({"value0": calibration}, indent=2) + "\n")
+        frameset: Frameset
+        for frameset in feed.framesets():
+            if config.max_framesets is not None and dumped >= config.max_framesets:
+                break
+            for index, image in enumerate(frameset.images):
+                write_pgm(config.output / f"frame_{dumped:03d}_cam{index}.pgm", image)
+            if config.npz:
+                bundle_images.append(np.stack(frameset.images))
+                bundle_imu_counts.append(len(frameset.imu))
+                bundle_imu_t.append(frameset.imu.t_ns)
+                bundle_imu_gyro.append(frameset.imu.gyro_rad_s)
+                bundle_imu_accel.append(frameset.imu.accel_m_s2)
+            absolute_ns: int = frameset.t_ns + feed.capture_start_time_ns
+            frame_lines.extend(f"{absolute_ns},{index},{digest}" for index, digest in enumerate(frameset.image_digests()))
+            for t_ns, gyro, accel in zip(frameset.imu.t_ns.tolist(), frameset.imu.gyro_rad_s.tolist(), frameset.imu.accel_m_s2.tolist(), strict=True):
+                imu_lines.append(f"{t_ns}," + ",".join(repr(value) for value in [*gyro, *accel]))
+            frame_t_ns.append(frameset.t_ns)
+            dumped += 1
+            if dumped % 200 == 0:
+                print(f"{dumped} framesets", flush=True)
+
+        clip: dict[str, Any] = {
+            "segment_id": feed.segment_id,
+            "dataset_name": segment.dataset_name,
+            "capture_start_time_ns": feed.capture_start_time_ns,
+            "calibration_source": config.calibration,
+            "num_cameras": len(feed.cameras),
+            "resolution_wh": [[camera.width, camera.height] for camera in feed.cameras],
+            "framesets": dumped,
+            "frame_t_ns": frame_t_ns,
+            "imu_samples": len(imu_lines) - 1,
+            "decode_path": segment.decode_path,
+        }
+    (config.output / "imu.csv").write_text("\n".join(imu_lines) + "\n")
+    write_oracle_inputs(config.output, frame_t_ns, imu_lines[1:])
+    (config.output / "frames.sha256").write_text("\n".join(frame_lines) + "\n")
+    (config.output / "clip.json").write_text(json.dumps(clip, indent=2) + "\n")
+    if config.npz:
+        bundle: Path = config.output / "clip.npz"
+        np.savez(
+            bundle,
+            images=np.stack(bundle_images),
+            t_ns=np.array(frame_t_ns, dtype=np.int64),
+            imu_counts=np.array(bundle_imu_counts, dtype=np.int64),
+            imu_t=np.concatenate(bundle_imu_t),
+            imu_g=np.concatenate(bundle_imu_gyro),
+            imu_a=np.concatenate(bundle_imu_accel),
+            safe_radius=np.int64(flow_config(manifest, segment).optical_flow_image_safe_radius),
+        )
+        # The dataclasses the feed built, because `bench_track` compares lanes on
+        # the calibration the reference ran and not on a second derivation of it.
+        # Pickle rather than JSON for the same reason: these two values are the
+        # feed's own, and a hand-written schema here would be a third account of
+        # what a calibration is. Producer and consumer therefore ship together.
+        with bundle.with_suffix(bundle.suffix + ".calib.pkl").open("wb") as handle:
+            pickle.dump({"cameras": feed.cameras, "imu": feed.imu}, handle)
+        print(f"clip.npz {np.stack(bundle_images).shape} + calib.pkl -> {bundle}")
+    digest: str = hashlib.sha256((config.output / "frames.sha256").read_bytes()).hexdigest()
+    print(f"{dumped} framesets, {clip['imu_samples']} inertial samples -> {config.output}")
+    print(f"frames.sha256 {digest}")
+
+
+if __name__ == "__main__":
+    main(tyro.cli(Config))

--- a/packages/slam-rs/tools/apps/replay.py
+++ b/packages/slam-rs/tools/apps/replay.py
@@ -1,0 +1,7 @@
+"""Thin CLI shim: replay a reference segment through the slam-rs core."""
+
+from slam_rs.apis import run
+from slam_rs.apis.replay import Config, main
+
+if __name__ == "__main__":
+    run(Config, main)


### PR DESCRIPTION
# slam-rs 7/9: the catalog feed, the Vio binding, the Rerun rungs and the replay tool

The Python half of the pipeline: a segment on the Rerun catalog becomes framesets and IMU
samples, `_core.Vio` consumes them in lockstep, and the whole thing is drawn in the viewer
and scored against two references. This is the PR where the port becomes runnable end to end.

## How to read it

1. `slam_rs/catalog_feed.py` — the feed: the calibration dataclasses, the frameset matcher,
   the segment-wide decode, the IMU pairing and the window bounds. `RigProfile` states the
   departures a rig needs rather than letting the feed guess them.
2. `crates/slam-rs-py/src/lib.rs`, `slam_rs/_core.pyi` — `Vio`, `VioResult`, `VioSnapshot`,
   `VioStatus`, and `Calibration.from_catalog`, which reads the feed's dataclasses field by
   field so the catalog-to-basalt rules are not written a second time in Python.
3. `slam_rs/tracking.py` — `Lockstep`: `NeedMoreImu` holds a frameset and retries it once its
   samples arrive, so a frameset is never silently dropped.
4. `slam_rs/frontend_log.py`, `slam_rs/vio_log.py` — the two Rerun rungs: keypoints, trails
   and occupancy for the frontend; the window, the landmarks, the three trajectories and the
   per-stage timings for the pipeline.
5. `slam_rs/apis/replay.py` + `tools/apps/replay.py` — the tool: `--stage input`, `frontend`
   or `vio` over one reference segment, with the C++ overlay and the ATE report.
6. `tests/conftest.py`, `tests/fixture_types.py` — the synthetic rig every Python suite runs
   on: 200x200 kb4 cameras, a blocky-noise scene that can be shifted by whole pixels.

Also in this PR: `wrap_mp4` moves from `simplecv/rerun_dataloader.py` to
`simplecv/catalog_video_codec.py`, so a CPU lane can mux samples without installing
torchcodec and torchvision to get the muxer.

## What proves it

* `test_frontend_boundary.py` and `test_boundary_properties.py` walk the whole FFI surface
  against hostile integers, objects and arrays: every refusal is a `ValueError`, `TypeError`,
  `OverflowError` or `IndexError`, never a Rust panic — which would cross PyO3 as a
  `PanicException` that `except Exception` does not catch.
* `test_catalog_feed.py` and `test_frameset_matching.py` pin the matcher, the decode path and
  the window arithmetic against basalt's own rules.
* `test_vio_log.py`, `test_frontend_log.py` and `test_replay_log.py` read a recording back
  and check the rungs row by row.
* `test_v2_gate.py` runs the D60 gate clauses over a replay.
* 205 Python tests pass, 1 skipped, 15 slow deselected; the Rust gates are unchanged.
* The tool itself: `replay.py --stage vio --rr-config.headless` on the MIO10 smoke segment
  tracks 412/412 framesets with 0 retries, 0.31 cm rmse against the basalt C++ trajectory
  and 1.50 cm against ground truth, and its CSV hashes to
  `e141b4fab68da9dc1985d50269a9052f43c787e2a6476a3a088f16665c75660a`.

## What it deliberately leaves out

The RoboCap rig profile and lane (8/9), the fleet and machine tools (8/9), the macOS
environment (8/9), and every `--gpu` path (9/9): `Vio` here has no `gpu` argument and
`_core` no `gpu_backend`.

## The commit to skip

None — this PR carries no data.
