### PR TITLE
slam-rs: GPU seam plumbing (trimmed readback, copy-free widening, grouped uploads)

### DIFF
--- a/packages/slam-rs/crates/slam-rs-py/src/lib.rs
+++ b/packages/slam-rs/crates/slam-rs-py/src/lib.rs
@@ -104,8 +104,8 @@ impl VioResult {
 ///
 /// Offline mode: the frontend and the backend run to completion in the calling
 /// thread, so every `track` result is final and a repeat run over the same input
-/// is bit-identical. The GIL is released around the whole call, so a decoder
-/// thread keeps running while the frameset is tracked.
+/// is bit-identical. The GIL is released around frontend and estimator compute,
+/// so a decoder thread keeps running while the frameset is tracked.
 #[pyclass(module = "slam_rs._core")]
 pub struct Vio {
     inner: slam_rs::Vio<f32>,
@@ -228,9 +228,10 @@ impl Vio {
 
     /// Process one frameset: `images` holds one `uint8[h, w]` array per camera.
     ///
-    /// The pixels are copied out of numpy while the GIL is held — one copy — and
-    /// the whole pipeline then runs without it. A frameset the core refuses
-    /// leaves the estimator exactly as the last accepted one did.
+    /// On the GPU lane, pixels widen directly into reused core storage while
+    /// the GIL is held. Computation then runs without a NumPy borrow. The CPU
+    /// lane copies the bytes before detaching. A refused frameset leaves the
+    /// estimator exactly as the last accepted one did.
     ///
     /// On a GPU lane a device that dies mid-run is a `ValueError` here as well:
     /// CubeCL panics on a lost device rather than returning an error, and every
@@ -242,6 +243,38 @@ impl Vio {
         t_ns: i64,
         images: Vec<Bound<'_, PyAny>>,
     ) -> PyResult<VioResult> {
+        if self.inner.backend() == slam_rs::Backend::Gpu {
+            let arrays: Vec<PyReadonlyArray2<'_, u8>> = images
+                .iter()
+                .enumerate()
+                .map(|(index, image)| {
+                    let array = gray_array(image, index)?;
+                    gray_pixels(&array, index)?;
+                    Ok(array)
+                })
+                .collect::<PyResult<_>>()?;
+            let views: Vec<ImageView<'_>> = arrays
+                .iter()
+                .enumerate()
+                .map(|(index, array)| {
+                    let (data, width, height) = gray_pixels(array, index)?;
+                    Ok(ImageView {
+                        width,
+                        height,
+                        stride: width,
+                        data,
+                    })
+                })
+                .collect::<PyResult<_>>()?;
+            let prepared = self
+                .inner
+                .prepare_track(t_ns, &views)
+                .map_err(value_error)?;
+            drop(views);
+            drop(arrays);
+            let inner = py.detach(|| prepared.finish()).map_err(value_error)?;
+            return Ok(VioResult { inner });
+        }
         let mut frames: Vec<GrayImage> = Vec::with_capacity(images.len());
         for (index, image) in images.iter().enumerate() {
             frames.push(gray_image(image, index)?);
@@ -599,10 +632,8 @@ where
 
 /// Borrow one `uint8[h, w]` array out of Python: rank and dtype checked.
 ///
-/// The two consumers differ only in what they do with the bytes — [`Vio::track`]
-/// copies them into a `Vec`, [`OpticalFlow::process`] widens them straight into a
-/// reused [`ImageU16`] — so the checks live here and neither repeats them. The
-/// layout is [`gray_pixels`]' half of the same pair.
+/// Consumers either copy the bytes or widen them into reused [`ImageU16`]
+/// storage. The layout is [`gray_pixels`]' half of the same pair.
 fn gray_array<'py>(
     object: &Bound<'py, PyAny>,
     index: usize,

--- a/packages/slam-rs/crates/slam-rs/src/frontend/flow.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/flow.rs
@@ -1203,8 +1203,17 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
                     None => self.staging.push(fresh),
                 }
             }
-            self.pyramid_builder
-                .build(index, image, &mut self.staging[index])?;
+            if !B::PREPARE_IMAGES {
+                self.pyramid_builder
+                    .build(index, image, &mut self.staging[index])?;
+            }
+        }
+        if B::PREPARE_IMAGES {
+            self.pyramid_builder.prepare_images(images)?;
+            for (index, image) in images.iter().enumerate() {
+                self.pyramid_builder
+                    .build(index, image, &mut self.staging[index])?;
+            }
         }
         Ok(())
     }
@@ -1289,8 +1298,9 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
             &self.staging[cam1]
         };
         let mark: std::time::Instant = std::time::Instant::now();
-        self.patches.build(source_pyramid, &self.positions, None)?;
-        self.tracker.track(
+        self.patches
+            .prepare(source_pyramid, &self.positions, None)?;
+        self.tracker.track_prepared(
             source_pyramid,
             &self.staging[cam2],
             &self.patches,

--- a/packages/slam-rs/crates/slam-rs/src/frontend/tracker.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/tracker.rs
@@ -661,6 +661,17 @@ pub(crate) fn check_patch_inputs(
 /// GPU wants as one kernel, and the tracker consumes the result.
 #[allow(clippy::len_without_is_empty)]
 pub trait SourcePatches {
+    /// Prepare source storage before tracker inputs are uploaded. A synchronous
+    /// backend builds immediately; a device tracker may defer the patch kernel.
+    fn prepare(
+        &mut self,
+        pyramid: &Self::Pyramid,
+        positions: &PointsSoA,
+        selected: Option<&[bool]>,
+    ) -> Result<(), TrackerError> {
+        self.build(pyramid, positions, selected)
+    }
+
     /// The pyramid representation these patches are sampled from.
     type Pyramid: Pyramid;
 
@@ -987,6 +998,20 @@ impl FlowResult {
 /// concrete pyramid or patch storage, so the CPU implementation here and a later
 /// CubeCL one can be swapped without touching the driver (§12.1).
 pub trait PatchTracker {
+    /// Track source patches prepared by [`SourcePatches::prepare`].
+    /// Device implementations can upload all inputs before launching the source
+    /// patch kernel; synchronous implementations keep their ordinary path.
+    fn track_prepared(
+        &mut self,
+        prev: &Self::Pyramid,
+        next: &Self::Pyramid,
+        patches: &Self::Patches,
+        transforms_in: &FlowTransforms,
+        out: &mut FlowResult,
+    ) -> Result<(), TrackerError> {
+        self.track(prev, next, patches, transforms_in, out)
+    }
+
     /// The sampling pattern this tracker was built for.
     type Pattern: Pattern;
 

--- a/packages/slam-rs/crates/slam-rs/src/gpu/patches.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/patches.rs
@@ -362,6 +362,24 @@ impl<P: Pattern, R: Runtime> SourcePatches for GpuPatches<P, R> {
         positions: &PointsSoA,
         selected: Option<&[bool]>,
     ) -> Result<(), TrackerError> {
+        self.prepare(pyramid, positions, selected)?;
+        guarded(
+            GpuError::DeviceLost {
+                what: "patch build",
+            },
+            || {
+                self.launch_build(pyramid, self.bases());
+                Ok(())
+            },
+        )
+    }
+
+    fn prepare(
+        &mut self,
+        pyramid: &GpuPyramid<R>,
+        positions: &PointsSoA,
+        selected: Option<&[bool]>,
+    ) -> Result<(), TrackerError> {
         guarded(
             GpuError::DeviceLost {
                 what: "patch build",
@@ -373,8 +391,6 @@ impl<P: Pattern, R: Runtime> SourcePatches for GpuPatches<P, R> {
                 }
                 // `accept` has set `len`, which is what the runs are now strided by.
                 self.upload_positions(positions, selected);
-                let bases: PositionBases = self.bases();
-                self.launch_build(pyramid, bases);
                 Ok(())
             },
         )

--- a/packages/slam-rs/crates/slam-rs/src/gpu/pyramid.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/pyramid.rs
@@ -230,6 +230,7 @@ pub struct GpuPyramidBuilder<R: Runtime> {
     pattern: Vec<[f32; 2]>,
     staging: Vec<u16>,
     level0: Level0Table,
+    prepared: Vec<Option<Level0>>,
 }
 
 impl<R: Runtime> GpuPyramidBuilder<R> {
@@ -240,6 +241,7 @@ impl<R: Runtime> GpuPyramidBuilder<R> {
             pattern: pattern.to_vec(),
             staging: Vec::new(),
             level0: Level0Table::default(),
+            prepared: Vec::new(),
         }
     }
 
@@ -258,6 +260,27 @@ impl<R: Runtime> GpuPyramidBuilder<R> {
 
 impl<R: Runtime> crate::pyramid::PyramidBuilder for GpuPyramidBuilder<R> {
     type Pyramid = GpuPyramid<R>;
+    const PREPARE_IMAGES: bool = true;
+
+    fn prepare_images(&mut self, images: &[ImageU16]) -> Result<(), PyramidError> {
+        guarded(
+            GpuError::DeviceLost {
+                what: "frameset uploads",
+            },
+            || {
+                self.prepared.resize_with(images.len(), || None);
+                for (slot, image) in self.prepared.iter_mut().zip(images) {
+                    let (handle, _) = super::upload_frame(&self.client, image, &mut self.staging);
+                    *slot = Some(Level0 {
+                        handle,
+                        width: image.width(),
+                        height: image.height(),
+                    });
+                }
+                Ok(())
+            },
+        )
+    }
 
     fn allocate(
         &self,
@@ -321,7 +344,14 @@ impl<R: Runtime> crate::pyramid::PyramidBuilder for GpuPyramidBuilder<R> {
                 // replaced every frame. `upload_frame` is what puts the frame
                 // there, and its doc is where the copy count lives.
                 let (upload, pixels): (cubecl::server::Handle, usize) =
-                    super::upload_frame(&out.client, img, &mut self.staging);
+                    match self.prepared.get_mut(camera).and_then(Option::take) {
+                        Some(frame)
+                            if frame.width == img.width() && frame.height == img.height() =>
+                        {
+                            (frame.handle, frame.width * frame.height)
+                        }
+                        _ => super::upload_frame(&out.client, img, &mut self.staging),
+                    };
                 kernels::launch_copy_level0::<R>(
                     &out.client,
                     (&upload, pixels),

--- a/packages/slam-rs/crates/slam-rs/src/gpu/track.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/track.rs
@@ -115,7 +115,6 @@ impl<P: Pattern, R: Runtime> PatchTracker for GpuPatchTracker<P, R> {
         )
     }
 
-    /// `trackPoints` (`frame_to_frame_optical_flow.h:294-375`) on the device.
     fn track(
         &mut self,
         prev: &GpuPyramid<R>,
@@ -123,6 +122,32 @@ impl<P: Pattern, R: Runtime> PatchTracker for GpuPatchTracker<P, R> {
         patches: &GpuPatches<P, R>,
         transforms_in: &FlowTransforms,
         out: &mut FlowResult,
+    ) -> Result<(), TrackerError> {
+        self.track_inner(prev, next, patches, transforms_in, out, false)
+    }
+
+    fn track_prepared(
+        &mut self,
+        prev: &GpuPyramid<R>,
+        next: &GpuPyramid<R>,
+        patches: &GpuPatches<P, R>,
+        transforms_in: &FlowTransforms,
+        out: &mut FlowResult,
+    ) -> Result<(), TrackerError> {
+        self.track_inner(prev, next, patches, transforms_in, out, true)
+    }
+}
+
+impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
+    /// `trackPoints` (`frame_to_frame_optical_flow.h:294-375`) on the device.
+    fn track_inner(
+        &mut self,
+        prev: &GpuPyramid<R>,
+        next: &GpuPyramid<R>,
+        patches: &GpuPatches<P, R>,
+        transforms_in: &FlowTransforms,
+        out: &mut FlowResult,
+        build_source: bool,
     ) -> Result<(), TrackerError> {
         // The one call per frameset that waits on the device, and the one the
         // frontend makes with the GIL released: a lost device panics inside
@@ -184,6 +209,14 @@ impl<P: Pattern, R: Runtime> PatchTracker for GpuPatchTracker<P, R> {
             let shape = patches.shape();
             let forward_view = (&forward, TRANSFORM_RUNS * count);
 
+            self.backward_patches
+                .accept(count, None, next.num_levels())?;
+            self.backward_patches
+                .upload_offsets(&self.offset_x[..count], &self.offset_y[..count]);
+            if build_source {
+                patches.launch_build(prev, patches.bases());
+            }
+
             // ── forward: `trackPoint(pyr_1, pyr_2, transform_1, transform_2)` (`:349`).
             kernels::launch_klt::<R>(
                 &self.client,
@@ -197,10 +230,6 @@ impl<P: Pattern, R: Runtime> PatchTracker for GpuPatchTracker<P, R> {
             );
 
             // ── the backward source patches, from `next` at the forward result.
-            self.backward_patches
-                .accept(count, None, next.num_levels())?;
-            self.backward_patches
-                .upload_offsets(&self.offset_x[..count], &self.offset_y[..count]);
             kernels::launch_prepare_backward::<R>(
                 &self.client,
                 forward_view,

--- a/packages/slam-rs/crates/slam-rs/src/gpu/track.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/track.rs
@@ -249,16 +249,17 @@ impl<P: Pattern, R: Runtime> PatchTracker for GpuPatchTracker<P, R> {
             );
 
             // ── the one wait of the call.
+            let expected: usize = TRANSFORM_RUNS * count * size_of::<f32>();
+            let result = self
+                .result
+                .clone()
+                .offset_end(self.result.size_in_used() - expected as u64);
             let bytes = self
                 .client
-                .read_one(self.result.clone())
+                .read_one(result)
                 .map_err(|error| super::read_failed("the tracker result", &error))?;
-            // `<`, where every sibling download checks `!=`: `self.result` is
-            // allocated at `capacity` and read whole, while `expected` is sized by
-            // `count`, so a full frame returns more bytes than this call reads
-            // (28,672 against 700 on the tracker's own tolerance test). What an
-            // incomplete runtime does — return fewer — is what this refuses.
-            let expected: usize = TRANSFORM_RUNS * count * size_of::<f32>();
+            // The kernel packs by count; the unused capacity tail stays on the
+            // device. Keep the short-read refusal before decoding any values.
             if bytes.len() < expected {
                 return Err(TrackerError::LengthMismatch {
                     first_name: "result bytes expected",

--- a/packages/slam-rs/crates/slam-rs/src/lib.rs
+++ b/packages/slam-rs/crates/slam-rs/src/lib.rs
@@ -502,6 +502,30 @@ pub struct Vio<S: lie::LieScalar = f32> {
     frontend_timings: FrontendTimings,
 }
 
+/// A validated frameset whose pixels are owned by the pipeline.
+///
+/// The mutable borrow prevents another call from replacing those pixels before
+/// computation finishes. No source image borrow is retained.
+pub struct PreparedTrack<'a, S: lie::LieScalar> {
+    vio: &'a mut Vio<S>,
+    t_ns: i64,
+    prediction: Option<frontend::flow::PosePrediction>,
+}
+
+impl<S: lie::LieScalar> PreparedTrack<'_, S> {
+    /// Finish tracking, or return the unchanged IMU-coverage refusal.
+    ///
+    /// # Errors
+    ///
+    /// The frontend or estimator errors returned by [`Vio::track`].
+    pub fn finish(self) -> Result<VioResult, VioError> {
+        match self.prediction {
+            Some(prediction) => self.vio.finish_track(self.t_ns, &prediction),
+            None => Ok(self.vio.result(VioStatus::NeedMoreImu, self.t_ns)),
+        }
+    }
+}
+
 impl<S: lie::LieScalar> Vio<S> {
     /// Build the pipeline from basalt's own config and calibration (D18).
     ///
@@ -635,6 +659,22 @@ impl<S: lie::LieScalar> Vio<S> {
     /// size the calibration gives its cameras, does not follow the last accepted
     /// frameset, or when the estimator refuses it.
     pub fn track(&mut self, t_ns: i64, images: &[ImageView<'_>]) -> Result<VioResult, VioError> {
+        self.prepare_track(t_ns, images)?.finish()
+    }
+
+    /// Validate and widen borrowed pixels before releasing their owner.
+    ///
+    /// Checks, IMU prediction and widening run in the same order as [`Self::track`].
+    /// The returned value borrows only this pipeline, not `images`.
+    ///
+    /// # Errors
+    ///
+    /// The input and IMU prediction errors returned by [`Self::track`].
+    pub fn prepare_track(
+        &mut self,
+        t_ns: i64,
+        images: &[ImageView<'_>],
+    ) -> Result<PreparedTrack<'_, S>, VioError> {
         // Every refusal is decided here, before **any** mutation, and the
         // coverage test is one of them. Everything below moves the pipeline
         // forward irreversibly — the frontend's own preintegrator eats its
@@ -652,7 +692,11 @@ impl<S: lie::LieScalar> Vio<S> {
         self.frontend
             .check_frameset(t_ns, images.iter().map(|image| (image.width, image.height)))?;
         if !self.estimator.imu_covers_frame(t_ns) {
-            return Ok(self.result(VioStatus::NeedMoreImu, t_ns));
+            return Ok(PreparedTrack {
+                vio: self,
+                t_ns,
+                prediction: None,
+            });
         }
 
         // `frame_to_frame_optical_flow.h:138-152`: the prediction the KLT is
@@ -682,8 +726,20 @@ impl<S: lie::LieScalar> Vio<S> {
         for (frame, view) in self.frames.iter_mut().zip(images.iter()) {
             frame.fill_from_u8_strided(view.data, view.width, view.height, view.stride)?;
         }
+        Ok(PreparedTrack {
+            vio: self,
+            t_ns,
+            prediction: Some(prediction),
+        })
+    }
+
+    fn finish_track(
+        &mut self,
+        t_ns: i64,
+        prediction: &frontend::flow::PosePrediction,
+    ) -> Result<VioResult, VioError> {
         self.frontend
-            .process_frame(t_ns, &self.frames, &prediction, &self.masks)?;
+            .process_frame(t_ns, &self.frames, prediction, &self.masks)?;
         let flow: frontend::flow::FlowTimings = self.frontend.timings();
         self.frontend_timings.pyramid_ns = flow.pyramid_ns;
         self.frontend_timings.detect_ns = flow.detect_ns;

--- a/packages/slam-rs/crates/slam-rs/src/pyramid.rs
+++ b/packages/slam-rs/crates/slam-rs/src/pyramid.rs
@@ -76,6 +76,14 @@ pub(crate) const MIN_SIDE: usize = 3;
 /// signature. The output is a `&mut` parameter, never a return value, so the
 /// caller owns the allocation and the per-frame path never allocates.
 pub trait PyramidBuilder {
+    /// Whether images are uploaded together before any pyramid dispatch.
+    const PREPARE_IMAGES: bool = false;
+
+    /// Prepare this frameset's uploads after all pyramid allocations.
+    fn prepare_images(&mut self, _images: &[ImageU16]) -> Result<(), PyramidError> {
+        Ok(())
+    }
+
     /// The pyramid representation this builder fills.
     ///
     /// Bounded by [`Pyramid`], so generic code can read geometry and copy


### PR DESCRIPTION
## What

Three plumbing commits on the GPU seam. No kernel arithmetic changes; every trajectory is byte-identical to the base.

1. **Trim the tracker readback to the used prefix.** 84,000 bytes per call became `28 * n` (about 1.5 KB on the benchmark clips).
2. **Widen frames straight from the borrowed NumPy array.** One image-sized host copy per camera per frame removed; no borrow survives the detached compute; validation, IMU refusal and rollback order unchanged.
3. **Group uploads ahead of their dispatches.** Camera images before the pyramid dispatches, patch positions and transforms before each tracker group, so cubecl-wgpu's pre-write flush does not split the encoder mid-group. Vulkan queue submits per frameset: 18 → 7 (2 cameras), 40 → 11 (4 cameras).

## Before / after (RTX 5090, wgpu lane, three interleaved rounds, base core vs this branch, best median of the `track` call)

| clip | base | this branch |
|---|---|---|
| MIO10, 2 cameras 960x960 | 5.074 ms | 4.935 ms (-2.7 %) |
| MGO10, 4 cameras 480x640 | 8.111 ms | 7.703 ms (-5.0 %) |

Below the base in every round; all trajectories `cmp`-identical to the base and to the previous reference runs.

## What was tried and dropped

Merging the independent result waits (5 → 2 per frame) was byte-identical but 12 % slower on the 4-camera clip: sharing one readback means scanning every camera for corners before the occupancy is known, and the speculative work outweighed the saved waits. The remaining seam items (CubeCL's double host copy in `create_from_slice`, writing into resident buffers, importing foreign device memory) are runtime-side and are listed in the design notes as follow-ups.
