### PR TITLE
slam-rs: select corners per grid cell on the GPU

### DIFF
--- a/packages/slam-rs/crates/slam-rs/src/frontend/detect.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/detect.rs
@@ -55,7 +55,11 @@
 //! parity gate seeds the tracker with the C++ keypoints for that reason.
 
 use kornia_image::{Image, ImageSize};
-use kornia_imgproc::features::{FastCorner, Rect as KorniaRect, fast_detect_rect_u8};
+use kornia_imgproc::features::{Rect as KorniaRect, fast_detect_rect_u8};
+
+/// kornia's FAST corner, re-exported because [`CornerScan::band`] hands it back:
+/// a backend outside this crate cannot implement the trait without naming it.
+pub use kornia_imgproc::features::FastCorner;
 
 use crate::image::ImageU16;
 
@@ -366,6 +370,27 @@ pub struct DetectorConfig {
 /// 1 and no further, rather than a wedged process (decision D32).
 pub const LOWEST_THRESHOLD_RUNG: i32 = 1;
 
+/// The thresholds [`detect_keypoints_with_cells`]'s ladder visits, in order.
+///
+/// `max_threshold`, then halved by integer division for as long as the value
+/// stays at or above the floor, which is `min_threshold` but never under
+/// [`LOWEST_THRESHOLD_RUNG`]. The shipped 40/5 configs give 40, 20, 10, 5; 40/6
+/// gives 40, 20, 10 and **not** 6, because the next halving is 5 and the ladder
+/// never visits the floor itself unless a halving happens to land on it. The
+/// sequence is empty when `max_threshold` is already under the floor.
+///
+/// One iterator rather than two expressions because both callers need it and
+/// they must not drift: the cell walk steps through it, and
+/// [`CornerScan::select_cells`] is handed its **last** value, which is the only
+/// rung that decides a one-point-per-cell winner. A device handed
+/// `min_threshold` instead would admit corners scoring between the two, which
+/// the walk never sees.
+pub fn threshold_rungs(config: &DetectorConfig) -> impl Iterator<Item = i32> {
+    let floor: i32 = config.min_threshold.max(LOWEST_THRESHOLD_RUNG);
+    std::iter::successors(Some(config.max_threshold), |threshold| Some(threshold / 2))
+        .take_while(move |threshold| *threshold >= floor)
+}
+
 /// One cell row's raw FAST candidates at one threshold, over the whole image width.
 ///
 /// `fast_detect_rect_u8` detects over **whole rows** and filters the result by
@@ -464,8 +489,9 @@ pub struct BandRequest {
 pub struct CellSelect {
     /// The detected image's own grid, as [`detect_keypoints_with_cells`] derives it.
     pub grid: CellGrid,
-    /// The rung the ladder stops at, which is the only one that decides the
-    /// winner (see [`CornerScan::select_cells`]).
+    /// The **last rung the ladder visits** ([`threshold_rungs`]), which is the
+    /// only one that decides the winner (see [`CornerScan::select_cells`]).
+    /// Not `min_threshold`: the halving ladder need never reach it.
     pub threshold: i32,
     /// `optical_flow_image_safe_radius`; `0` switches the gate off.
     pub safe_radius: f32,
@@ -560,14 +586,16 @@ pub trait CornerScan: std::fmt::Debug + Send + Sync {
     /// minimum and its fields are the corner the host walk would have chosen;
     /// [`NO_CELL_WINNER`] means the cell has none.
     ///
-    /// **Only the ladder's floor is passed, and that is exact rather than an
-    /// approximation.** A candidate at rung `t` is `kept > t`; suppression kills
+    /// **Only the ladder's last rung is passed, and that is exact rather than
+    /// an approximation.** A candidate at rung `t` is `kept > t`; suppression kills
     /// `p` only through a neighbour whose score is at least `p`'s, and such a
     /// neighbour is a candidate at every rung `p` is — so surviving suppression
     /// does not depend on the rung, and the ladder only admits survivors in
     /// descending score. With `num_points_cell == 1` the whole ladder is
-    /// therefore "the best survivor over the floor", which is what this asks
-    /// for. A caller with a larger budget per cell must use [`CornerScan::band`].
+    /// therefore "the best survivor over the last rung it visits", which is what
+    /// this asks for — and that rung is [`threshold_rungs`]'s last value, not
+    /// `min_threshold`, which the ladder can step straight past. A caller with a
+    /// larger budget per cell must use [`CornerScan::band`].
     ///
     /// The masks are the caller's: a backend applies `safe_radius` and the edge
     /// margin, and the caller drops the cells its masks cover.
@@ -911,11 +939,12 @@ fn cell_masks(
 /// index falls outside `occupancy` is skipped too, where the C++ reads out of
 /// range.
 ///
-/// The threshold ladder is `max_threshold`, then repeatedly halved by integer
-/// division until it drops below `min_threshold` — 40, 20, 10, 5 for the shipped
-/// configs (`:160-188`) — and it stops early as soon as the cell's budget is full.
-/// The last rung is never below [`LOWEST_THRESHOLD_RUNG`], which is what makes the
-/// ladder finite for every `min_threshold`; basalt's own is not.
+/// The threshold ladder is [`threshold_rungs`]: `max_threshold`, then repeatedly
+/// halved by integer division until it would drop below `min_threshold` — 40, 20,
+/// 10, 5 for the shipped configs (`:160-188`) — and it stops early as soon as the
+/// cell's budget is full. The last rung is never below [`LOWEST_THRESHOLD_RUNG`],
+/// which is what makes the ladder finite for every `min_threshold`; basalt's own
+/// is not.
 /// Within one threshold the surviving corners are ordered by descending response
 /// (`:166-167`) and taken until the budget is met, each having to clear the safe
 /// radius (`:178`), the masks (`:179`) and `EDGE_THRESHOLD` (`:180`).
@@ -962,9 +991,13 @@ pub fn detect_keypoints_with_cells(
         });
     }
 
-    // The rung the ladder below stops at: the config's own, but never under
-    // `LOWEST_THRESHOLD_RUNG`, or halving never gets past zero.
-    let lowest_rung: i32 = config.min_threshold.max(LOWEST_THRESHOLD_RUNG);
+    // The last rung the cell walk below visits, which is also what the device
+    // path is handed (`threshold_rungs`). A ladder with no rung at all detects
+    // nothing: the walk's own loop would not run once, so returning here is the
+    // answer it would give, without touching the frame.
+    let Some(last_rung) = threshold_rungs(config).last() else {
+        return Ok(());
+    };
 
     let width: usize = image.width();
     let height: usize = image.height();
@@ -1010,7 +1043,7 @@ pub fn detect_keypoints_with_cells(
     if device_shaped {
         let select: CellSelect = CellSelect {
             grid: *grid,
-            threshold: lowest_rung,
+            threshold: last_rung,
             safe_radius: config.safe_radius,
         };
         scanner.select_cells(camera, image, &select, winners)?;
@@ -1078,10 +1111,12 @@ pub fn detect_keypoints_with_cells(
             }
 
             let mut points_added: usize = 0;
-            let mut threshold: i32 = config.max_threshold;
-            // The ladder's position, which with `row` is the band cache's key.
-            let mut rung: usize = 0;
-            while points_added < config.num_points_cell && threshold >= lowest_rung {
+            // `rung` is the ladder's position, which with `row` is the band
+            // cache's key.
+            for (rung, threshold) in threshold_rungs(config).enumerate() {
+                if points_added >= config.num_points_cell {
+                    break;
+                }
                 // `cv::FAST` on the `PATCH_SIZE` sub-image detects at
                 // sub-coordinates `[3, PATCH_SIZE - 3)`; the same rectangle in
                 // whole-image coordinates is the cell shrunk by the ring radius.
@@ -1148,9 +1183,6 @@ pub fn detect_keypoints_with_cells(
                     out.responses.push(corner.response);
                     points_added += 1;
                 }
-
-                threshold /= 2;
-                rung += 1;
             }
 
             y += grid.cell;
@@ -1406,6 +1438,58 @@ mod tests {
                 "min_threshold {min_threshold} detected a different number of corners than the floor"
             );
         }
+    }
+
+    /// The rungs the ladder visits, and the last of them.
+    ///
+    /// The last rung is **not** `min_threshold`: halving lands on 5 from 40 and
+    /// steps straight past 6, and a different maximum moves every rung. That
+    /// last value is what a device path is handed, so the two must be one
+    /// computation ([`threshold_rungs`]).
+    #[test]
+    fn the_ladder_halves_the_maximum_and_need_never_reach_the_minimum() {
+        let rungs = |max_threshold: i32, min_threshold: i32| -> Vec<i32> {
+            threshold_rungs(&DetectorConfig {
+                max_threshold,
+                min_threshold,
+                ..config()
+            })
+            .collect()
+        };
+        assert_eq!(rungs(40, 5), vec![40, 20, 10, 5]);
+        assert_eq!(rungs(40, 6), vec![40, 20, 10]);
+        assert_eq!(rungs(32, 5), vec![32, 16, 8]);
+        // The floor holds at `LOWEST_THRESHOLD_RUNG` whatever the config asks
+        // for, which is what makes the ladder finite.
+        assert_eq!(rungs(8, i32::MIN), vec![8, 4, 2, 1]);
+        // A maximum already under the floor is a ladder with no rung at all.
+        assert!(rungs(4, 5).is_empty());
+    }
+
+    /// A ladder with no rung detects nothing rather than detecting at some rung
+    /// nobody asked for.
+    #[test]
+    fn a_maximum_under_the_minimum_detects_nothing() {
+        let image: ImageU16 = dotted_image(200, 200, 16);
+        let grid: CellGrid = CellGrid::new(200, 200, 50).unwrap();
+        let cells: Vec<i32> = vec![0; grid.rows * grid.columns];
+        let mut scratch: DetectorScratch = DetectorScratch::default();
+        let mut out: KeypointsData = KeypointsData::default();
+        let mut empty_ladder: DetectorConfig = config();
+        empty_ladder.max_threshold = config().min_threshold - 1;
+        detect_keypoints_with_cells(
+            &image,
+            0,
+            &grid,
+            &occupancy(&cells, &grid),
+            &empty_ladder,
+            &Masks::default(),
+            BUDGET,
+            &mut scratch,
+            &mut out,
+        )
+        .unwrap();
+        assert!(out.is_empty());
     }
 
     /// The floor changes nothing for a config whose ladder already ends.

--- a/packages/slam-rs/crates/slam-rs/src/frontend/detect.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/detect.rs
@@ -453,6 +453,44 @@ pub struct BandRequest {
     pub threshold: i32,
 }
 
+/// What a device backend needs to pick one corner per grid cell itself.
+///
+/// The other half of [`CornerScan`], and the reason it is a separate call
+/// rather than a flag on [`BandRequest`]: a backend that takes it does the whole
+/// of the inner loop — the candidate walk, the suppression, the ordering and the
+/// three filters — and hands back one answer per cell, so nothing about a band
+/// is meaningful afterwards.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CellSelect {
+    /// The detected image's own grid, as [`detect_keypoints_with_cells`] derives it.
+    pub grid: CellGrid,
+    /// The rung the ladder stops at, which is the only one that decides the
+    /// winner (see [`CornerScan::select_cells`]).
+    pub threshold: i32,
+    /// `optical_flow_image_safe_radius`; `0` switches the gate off.
+    pub safe_radius: f32,
+}
+
+/// The key a cell with no winner reports.
+///
+/// Unreachable as a real key: a winner scores at least `threshold + 1 >= 2`, so
+/// its score field is at most 253 where this is 255.
+pub const NO_CELL_WINNER: u32 = u32::MAX;
+
+/// Where a packed cell key keeps `255 - score`.
+pub(crate) const KEY_SCORE_SHIFT: u32 = 24;
+/// Where a packed cell key keeps the row.
+pub(crate) const KEY_ROW_SHIFT: u32 = 12;
+/// A packed cell key's column field, which is also its row field's width.
+const KEY_FIELD_MASK: u32 = 0xFFF;
+
+/// The frame size a packed cell key stops describing.
+///
+/// Twelve bits each for the row and the column, which every calibrated frame in
+/// the reference set is two orders of magnitude inside; a larger one takes the
+/// band path instead of losing a coordinate.
+pub const CELL_KEY_LIMIT: usize = 1 << KEY_ROW_SHIFT;
+
 /// The frontend's corner-candidate stage: one frame in, row bands of FAST
 /// candidates out.
 ///
@@ -506,6 +544,54 @@ pub trait CornerScan: std::fmt::Debug + Send + Sync {
     /// a scan is a programming error on both lanes, not an empty frame
     /// (decision D32). A device backend can also fail on the read.
     fn band(&mut self, request: BandRequest) -> Result<&[FastCorner], DetectError>;
+
+    /// Pick the winner of every grid cell where the pixels already are, filling
+    /// `out` with one packed key per cell and returning `true`.
+    ///
+    /// The default is `false`: a scanner with no device behind it has nothing to
+    /// gain from the shape, and [`detect_keypoints_with_cells`] then runs its own
+    /// walk. [`CpuCornerScan`] takes the default and stays the reference the GPU
+    /// lane is checked against.
+    ///
+    /// `out` is `cells_y * cells_x` keys, row-major over the grid the caller
+    /// walks — `(x_stop - x_start) / cell + 1` across and the same down, which
+    /// is one **less** than the occupancy matrix's shape. A key packs
+    /// `((255 - score) << 24) | (y << 12) | x`, so the winner is the key's
+    /// minimum and its fields are the corner the host walk would have chosen;
+    /// [`NO_CELL_WINNER`] means the cell has none.
+    ///
+    /// **Only the ladder's floor is passed, and that is exact rather than an
+    /// approximation.** A candidate at rung `t` is `kept > t`; suppression kills
+    /// `p` only through a neighbour whose score is at least `p`'s, and such a
+    /// neighbour is a candidate at every rung `p` is — so surviving suppression
+    /// does not depend on the rung, and the ladder only admits survivors in
+    /// descending score. With `num_points_cell == 1` the whole ladder is
+    /// therefore "the best survivor over the floor", which is what this asks
+    /// for. A caller with a larger budget per cell must use [`CornerScan::band`].
+    ///
+    /// The masks are the caller's: a backend applies `safe_radius` and the edge
+    /// margin, and the caller drops the cells its masks cover.
+    ///
+    /// A backend with no device path leaves `out` **empty**, which is also how
+    /// the caller decides: it takes the keys only when there are exactly as many
+    /// as the grid has cells, so a backend that fills the wrong number is
+    /// ignored rather than indexed.
+    ///
+    /// # Errors
+    ///
+    /// Whatever the backend's own scan can fail with; a backend that leaves
+    /// `out` empty must not have consumed the frame.
+    fn select_cells(
+        &mut self,
+        camera: usize,
+        image: &ImageU16,
+        select: &CellSelect,
+        out: &mut Vec<u32>,
+    ) -> Result<(), DetectError> {
+        let _ = (camera, image, select);
+        out.clear();
+        Ok(())
+    }
 }
 
 /// The CPU [`CornerScan`]: kornia's `fast_detect_rect_u8`, one sweep per
@@ -639,6 +725,11 @@ pub struct DetectorScratch {
     scores: Vec<f32>,
     /// Which of a cell's candidates survived suppression, in candidate order.
     keep: Vec<bool>,
+    /// Which cells this frame's masks cover whole, row-major over the grid the
+    /// cell loop walks. Only the device path reads it.
+    masked: Vec<bool>,
+    /// One packed winner key per cell, as a device backend filled it.
+    winners: Vec<u32>,
 }
 
 impl Default for DetectorScratch {
@@ -658,6 +749,8 @@ impl DetectorScratch {
             corners: Vec::new(),
             scores: Vec::new(),
             keep: Vec::new(),
+            masked: Vec::new(),
+            winners: Vec::new(),
         }
     }
 }
@@ -753,6 +846,61 @@ fn suppress_non_maxima(
     });
 }
 
+/// One cell of `grid` a rectangle's edge names, if it names one exactly.
+fn cell_index(edge: f32, start: usize, cell: f32) -> Option<usize> {
+    let offset: f32 = edge - start as f32;
+    if offset < 0.0 {
+        return None;
+    }
+    let index: f32 = offset / cell;
+    if index.fract() != 0.0 {
+        return None;
+    }
+    Some(index as usize)
+}
+
+/// Fold `masks` into one flag per cell, or refuse the whole camera.
+///
+/// The device path picks one corner per cell and cannot ask the masks about the
+/// runner-up, so it is only sound where a mask covers a cell **whole**: then the
+/// cell has no unmasked candidate at all and dropping its key is the same answer
+/// the host walk gives. That is what the frontend's masks are —
+/// `cam0OverlapCellsMasksForCam` pushes `cell` x `cell` rectangles at the cell
+/// origins — but only while the camera being detected shares camera 0's grid,
+/// which the mixed-geometry rigs the port supports deliberately do not. Rather
+/// than assume it, every rectangle is checked against this grid and a camera
+/// with one that straddles a cell boundary takes the band path.
+///
+/// `false` is that refusal. A rectangle past the last cell is not one: the cell
+/// loop never looks there, and the candidates of the last cell stop at its own
+/// right edge.
+fn cell_masks(
+    masks: &Masks,
+    grid: &CellGrid,
+    cells_x: usize,
+    cells_y: usize,
+    out: &mut Vec<bool>,
+) -> bool {
+    out.clear();
+    out.resize(cells_x * cells_y, false);
+    let cell: f32 = grid.cell as f32;
+    for rect in &masks.masks {
+        if rect.w != cell || rect.h != cell {
+            return false;
+        }
+        let (Some(column), Some(row)) = (
+            cell_index(rect.x, grid.x_start, cell),
+            cell_index(rect.y, grid.y_start, cell),
+        ) else {
+            return false;
+        };
+        if column < cells_x && row < cells_y {
+            out[row * cells_x + column] = true;
+        }
+    }
+    true
+}
+
 /// `detectKeypointsWithCells` (`keypoints.cpp:132-205`).
 ///
 /// `grid` is **the detected image's own** geometry, as the C++ derives it from
@@ -831,13 +979,83 @@ pub fn detect_keypoints_with_cells(
         corners: candidates,
         scores,
         keep,
+        masked,
+        winners,
     } = scratch;
-    scanner.scan(camera, image)?;
 
     // `float dist_to_center = {full_x - img_raw.w / 2, ...}.norm()` — an integer
     // halving of the size, then a float subtraction (`keypoints.cpp:176`).
     let centre_x: f32 = (width / 2) as f32;
     let centre_y: f32 = (height / 2) as f32;
+
+    // Cells the loop below walks: `x_stop` is the **last** cell's left edge, so
+    // this is one less each way than the occupancy matrix's shape.
+    let cells_x: usize = (grid.x_stop - grid.x_start) / grid.cell + 1;
+    let cells_y: usize = (grid.y_stop - grid.y_start) / grid.cell + 1;
+
+    // The device path: the scanner picks each cell's winner where the pixels
+    // already are, and what comes back is one packed key per cell instead of the
+    // candidate image. Four things have to hold — a budget of one point per cell,
+    // for which the threshold ladder carries no information
+    // ([`CornerScan::select_cells`]); a cell wide enough to hold a rectangle at
+    // all, which is also the only case the loop below detects in; a frame a
+    // packed key can name; and masks this grid's cells decompose
+    // ([`cell_masks`]). Anything else takes the band walk, which stays the
+    // reference.
+    let device_shaped: bool = config.num_points_cell == 1
+        && grid.cell > 2 * FAST_BORDER
+        && width < CELL_KEY_LIMIT
+        && height < CELL_KEY_LIMIT
+        && cell_masks(masks, grid, cells_x, cells_y, masked);
+    if device_shaped {
+        let select: CellSelect = CellSelect {
+            grid: *grid,
+            threshold: lowest_rung,
+            safe_radius: config.safe_radius,
+        };
+        scanner.select_cells(camera, image, &select, winners)?;
+        if winners.len() == cells_x * cells_y {
+            // `for (x = x_start; x <= x_stop; x += PATCH_SIZE) for (y = ...)`
+            // — x outer, y inner, which fixes the order corners are numbered in,
+            // and the cap is checked where the C++ checks it.
+            for column in 0..cells_x {
+                for row in 0..cells_y {
+                    if out.corners.len() >= max_corners {
+                        return Ok(());
+                    }
+                    if row >= occupancy.rows || column >= occupancy.columns {
+                        continue;
+                    }
+                    if occupancy.counts[row * occupancy.columns + column]
+                        >= config.num_points_cell as i32
+                    {
+                        continue;
+                    }
+                    // A wholly masked cell has no unmasked candidate, so the
+                    // host walk finds nothing in it either.
+                    if masked[row * cells_x + column] {
+                        continue;
+                    }
+                    let key: u32 = winners[row * cells_x + column];
+                    if key == NO_CELL_WINNER {
+                        continue;
+                    }
+                    let score: u32 = 255 - (key >> KEY_SCORE_SHIFT);
+                    out.corners.push([
+                        (key & KEY_FIELD_MASK) as f32,
+                        ((key >> KEY_ROW_SHIFT) & KEY_FIELD_MASK) as f32,
+                    ]);
+                    // The same arithmetic the band walk applies to the same
+                    // `u8`, so the response is the one `cv::FAST` reports.
+                    out.responses
+                        .push(opencv_corner_score(score as f32 / 255.0));
+                }
+            }
+            return Ok(());
+        }
+    }
+
+    scanner.scan(camera, image)?;
 
     // `for (x = x_start; x <= x_stop; x += PATCH_SIZE) for (y = y_start; ...)`
     // — x outer, y inner, which fixes the order corners are numbered in.

--- a/packages/slam-rs/crates/slam-rs/src/gpu/detect.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/detect.rs
@@ -8,8 +8,8 @@ use super::kernels::{self, MASK_BITS, RING_BIAS};
 use super::pyramid::{Level0, Level0Table};
 use super::{GpuError, guarded};
 use crate::frontend::detect::{
-    BandCache, BandRequest, CornerScan, DetectError, FAST_BORDER, FAST_RING_COLUMN, FAST_RING_ROW,
-    block_filter_end, opencv_corner_score,
+    BandCache, BandRequest, CellSelect, CornerScan, DetectError, FAST_BORDER, FAST_RING_COLUMN,
+    FAST_RING_ROW, block_filter_end, opencv_corner_score,
 };
 use crate::image::ImageU16;
 
@@ -24,6 +24,18 @@ struct ScanBuffers {
     /// Pixels these were sized for.
     pixels: usize,
     /// Mask words these were sized for.
+    mask_len: usize,
+}
+
+/// What one frame's two shared kernels leave on the device.
+struct ScanHandles {
+    /// The candidate image: the score where the local-maximum filter kept it.
+    kept: cubecl::server::Handle,
+    /// Its column bitmask, which only the band path goes on to fill.
+    mask: cubecl::server::Handle,
+    /// Pixels in the frame.
+    pixels: usize,
+    /// Words in the bitmask.
     mask_len: usize,
 }
 
@@ -80,6 +92,10 @@ pub struct GpuCornerScan<R: Runtime> {
     /// is the test that says so. Three `client.empty` calls per camera per
     /// frameset were the largest source of pool churn in the lane.
     buffers: Vec<Option<ScanBuffers>>,
+    /// The per-cell winner keys of the selection path, per camera, with the cell
+    /// count they were sized for: allocated once per camera grid, like
+    /// [`GpuCornerScan::buffers`] and for the same reason.
+    keys: Vec<Option<(cubecl::server::Handle, usize)>>,
     /// Times the three device buffers have been allocated, which a rig of one
     /// geometry keeps at one.
     buffer_allocations: usize,
@@ -132,6 +148,7 @@ impl<R: Runtime> GpuCornerScan<R> {
                     uploads: 0,
                     packed: Vec::new(),
                     buffers: Vec::new(),
+                    keys: Vec::new(),
                     buffer_allocations: 0,
                     kept: None,
                     mask: None,
@@ -201,6 +218,77 @@ impl<R: Runtime> GpuCornerScan<R> {
         // whole-frame narrowing pass on the host.
         super::upload_frame(&self.client, image, &mut self.packed)
     }
+
+    /// Level 0 in, the candidate image out: the two kernels both entry points
+    /// run, this camera's buffers sized and reused.
+    ///
+    /// The previous frame's readback is dropped **first**, and the geometry is
+    /// recorded before anything can fail, so a scan that dies further on leaves
+    /// a scanner that refuses a band rather than one that answers with the last
+    /// frame's corners under this frame's width (decision D32).
+    fn candidates(&mut self, camera: usize, image: &ImageU16) -> ScanHandles {
+        self.bands.clear();
+        self.kept = None;
+        self.mask = None;
+        self.width = image.width();
+        self.height = image.height();
+        let pixels: usize = self.width * self.height;
+        self.words = self.width.div_ceil(MASK_BITS);
+        let mask_len: usize = self.words * self.height;
+
+        let (handle, handle_len): (cubecl::server::Handle, usize) = self.frame(camera, image);
+        if self.buffers.len() <= camera {
+            self.buffers.resize_with(camera + 1, || None);
+        }
+        let slot: &mut Option<ScanBuffers> = &mut self.buffers[camera];
+        let fits: bool = slot
+            .as_ref()
+            .is_some_and(|buffers| buffers.pixels == pixels && buffers.mask_len == mask_len);
+        let buffers: &ScanBuffers = match slot {
+            Some(existing) if fits => existing,
+            slot => {
+                self.buffer_allocations += 1;
+                slot.insert(ScanBuffers {
+                    score: self.client.empty(pixels),
+                    kept: self.client.empty(pixels),
+                    mask: self.client.empty(mask_len * size_of::<u32>()),
+                    pixels,
+                    mask_len,
+                })
+            }
+        };
+        let (score, kept, mask) = (
+            buffers.score.clone(),
+            buffers.kept.clone(),
+            buffers.mask.clone(),
+        );
+        kernels::launch_fast_score::<R>(
+            &self.client,
+            (&handle, handle_len),
+            (&self.ring, 32),
+            (&score, pixels),
+            self.width,
+            self.height,
+            FAST_BORDER,
+        );
+        let (filtered_end, use_filter): (usize, bool) = block_filter_end(self.width);
+        kernels::launch_fast_localmax::<R>(
+            &self.client,
+            (&score, pixels),
+            (&kept, pixels),
+            self.width,
+            self.height,
+            FAST_BORDER,
+            filtered_end,
+            use_filter,
+        );
+        ScanHandles {
+            kept,
+            mask,
+            pixels,
+            mask_len,
+        }
+    }
 }
 
 /// One row's candidates over `threshold`, appended in column order.
@@ -250,74 +338,11 @@ impl<R: Runtime> CornerScan for GpuCornerScan<R> {
                 what: "corner scan",
             },
             || {
-                // Nothing of the previous frame survives this call, and it is
-                // dropped **first**: the two buffers below are replaced only
-                // where the scan succeeds, so a scan that fails after this line
-                // would otherwise leave the last frame's corners readable — and
-                // readable under the new frame's width, which for a rig whose
-                // cameras differ in size indexes them out of range. A band after
-                // a failed scan is the same refusal as a band before the first
-                // one (decision D32).
-                self.bands.clear();
-                self.kept = None;
-                self.mask = None;
-                self.width = image.width();
-                self.height = image.height();
-                let pixels: usize = self.width * self.height;
-                self.words = self.width.div_ceil(MASK_BITS);
-                let mask_len: usize = self.words * self.height;
-
-                let (handle, handle_len): (cubecl::server::Handle, usize) =
-                    self.frame(camera, image);
-                if self.buffers.len() <= camera {
-                    self.buffers.resize_with(camera + 1, || None);
-                }
-                let slot: &mut Option<ScanBuffers> = &mut self.buffers[camera];
-                let fits: bool = slot.as_ref().is_some_and(|buffers| {
-                    buffers.pixels == pixels && buffers.mask_len == mask_len
-                });
-                let buffers: &ScanBuffers = match slot {
-                    Some(existing) if fits => existing,
-                    slot => {
-                        self.buffer_allocations += 1;
-                        slot.insert(ScanBuffers {
-                            score: self.client.empty(pixels),
-                            kept: self.client.empty(pixels),
-                            mask: self.client.empty(mask_len * size_of::<u32>()),
-                            pixels,
-                            mask_len,
-                        })
-                    }
-                };
-                let (score, kept, mask) = (
-                    buffers.score.clone(),
-                    buffers.kept.clone(),
-                    buffers.mask.clone(),
-                );
-                kernels::launch_fast_score::<R>(
-                    &self.client,
-                    (&handle, handle_len),
-                    (&self.ring, 32),
-                    (&score, pixels),
-                    self.width,
-                    self.height,
-                    FAST_BORDER,
-                );
-                let (filtered_end, use_filter): (usize, bool) = block_filter_end(self.width);
-                kernels::launch_fast_localmax::<R>(
-                    &self.client,
-                    (&score, pixels),
-                    (&kept, pixels),
-                    self.width,
-                    self.height,
-                    FAST_BORDER,
-                    filtered_end,
-                    use_filter,
-                );
+                let handles: ScanHandles = self.candidates(camera, image);
                 kernels::launch_fast_mask::<R>(
                     &self.client,
-                    (&kept, pixels),
-                    (&mask, mask_len),
+                    (&handles.kept, handles.pixels),
+                    (&handles.mask, handles.mask_len),
                     self.width,
                     self.height,
                     self.words,
@@ -332,10 +357,12 @@ impl<R: Runtime> CornerScan for GpuCornerScan<R> {
                 // fallible form of it: `client.read` is `read_sync(..).expect("TODO")`,
                 // and a panic here would unwind out of the frontend with the GIL
                 // detached (decision D32).
-                let reads: Vec<cubecl::bytes::Bytes> =
-                    cubecl::reader::read_sync(self.client.read_async(vec![kept, mask])).map_err(
-                        |error| super::read_failed("the candidate image and its bitmask", &error),
-                    )?;
+                let reads: Vec<cubecl::bytes::Bytes> = cubecl::reader::read_sync(
+                    self.client.read_async(vec![handles.kept, handles.mask]),
+                )
+                .map_err(|error| {
+                    super::read_failed("the candidate image and its bitmask", &error)
+                })?;
                 // One buffer per handle, in the order they were asked for; anything else
                 // is the runtime breaking its own contract rather than short data.
                 let Ok([kept_bytes, mask_bytes]) = <[cubecl::bytes::Bytes; 2]>::try_from(reads)
@@ -348,11 +375,11 @@ impl<R: Runtime> CornerScan for GpuCornerScan<R> {
                 // Checked one buffer at a time, so a short read says which one was
                 // short: summing the two lengths made that unsayable.
                 for (what, actual, expected) in [
-                    ("the candidate image", kept_bytes.len(), pixels),
+                    ("the candidate image", kept_bytes.len(), handles.pixels),
                     (
                         "the candidate bitmask",
                         mask_bytes.len(),
-                        mask_len * size_of::<u32>(),
+                        handles.mask_len * size_of::<u32>(),
                     ),
                 ] {
                     if actual != expected {
@@ -369,6 +396,109 @@ impl<R: Runtime> CornerScan for GpuCornerScan<R> {
                 // wants to read from anyway.
                 self.kept = Some(kept_bytes);
                 self.mask = Some(mask_bytes);
+                Ok(())
+            },
+        )
+    }
+
+    /// One packed key per grid cell, and no candidate image at all.
+    ///
+    /// This is where the 2.07 MB the band path downloads per two-camera frameset
+    /// goes away: the selection kernel walks each cell's own window, suppresses
+    /// non-maxima against the same zero rim `suppress_non_maxima` sees, applies
+    /// `safe_radius` and the edge margin, and reduces the survivors under the
+    /// host's own total order. What comes back is 361 x 4 B on the 960x960 index
+    /// rig. The band path stays for the shapes the trait's contract excludes and
+    /// for [`CpuCornerScan`](crate::frontend::detect::CpuCornerScan), which is
+    /// the reference the equality tests measure this against.
+    ///
+    /// `out` is left empty — and the frame untouched — when the grid needs more
+    /// cubes in one dispatch dimension than a WebGPU implementation must allow.
+    fn select_cells(
+        &mut self,
+        camera: usize,
+        image: &ImageU16,
+        select: &CellSelect,
+        out: &mut Vec<u32>,
+    ) -> Result<(), DetectError> {
+        out.clear();
+        let grid: &crate::frontend::detect::CellGrid = &select.grid;
+        let cells_x: usize = (grid.x_stop - grid.x_start) / grid.cell + 1;
+        let cells_y: usize = (grid.y_stop - grid.y_start) / grid.cell + 1;
+        let cells: usize = cells_x * cells_y;
+        let ceiling: usize = kernels::MAX_CUBES_PER_DIM as usize;
+        if cells_x > ceiling || cells_y > ceiling {
+            return Ok(());
+        }
+        guarded(
+            GpuError::DeviceLost {
+                what: "corner cell selection",
+            },
+            || {
+                let (width, height): (usize, usize) = (image.width(), image.height());
+                let handles: ScanHandles = self.candidates(camera, image);
+
+                if self.keys.len() <= camera {
+                    self.keys.resize_with(camera + 1, || None);
+                }
+                let slot: &mut Option<(cubecl::server::Handle, usize)> = &mut self.keys[camera];
+                let fits: bool = slot.as_ref().is_some_and(|(_, sized)| *sized == cells);
+                let (best, best_len): (cubecl::server::Handle, usize) = match slot {
+                    Some(existing) if fits => existing.clone(),
+                    slot => {
+                        self.buffer_allocations += 1;
+                        slot.insert((self.client.empty(cells * size_of::<u32>()), cells))
+                            .clone()
+                    }
+                };
+
+                kernels::launch_fast_cell_select::<R>(
+                    &self.client,
+                    (&handles.kept, handles.pixels),
+                    (&best, best_len),
+                    kernels::CellSelectGeometry {
+                        width,
+                        height,
+                        cell: grid.cell,
+                        x_start: grid.x_start,
+                        y_start: grid.y_start,
+                        cells_x,
+                        cells_y,
+                        // The score is a `u8`, so a rung at or over 255 admits
+                        // nothing and one under zero is every candidate.
+                        threshold: select.threshold.clamp(0, 255) as u32,
+                        safe_radius: select.safe_radius,
+                        // `img_raw.w / 2` is an integer halving (`keypoints.cpp:176`).
+                        centre_x: (width / 2) as f32,
+                        centre_y: (height / 2) as f32,
+                    },
+                );
+
+                #[cfg(test)]
+                super::fire_if_armed(super::CORNER_SCAN_READ);
+
+                let reads: Vec<cubecl::bytes::Bytes> =
+                    cubecl::reader::read_sync(self.client.read_async(vec![best]))
+                        .map_err(|error| super::read_failed("the cell winner keys", &error))?;
+                let Ok([keys]) = <[cubecl::bytes::Bytes; 1]>::try_from(reads) else {
+                    return Err(super::GpuError::DeviceReadFailed {
+                        what: "the cell winner buffer",
+                    }
+                    .into());
+                };
+                let expected: usize = cells * size_of::<u32>();
+                if keys.len() != expected {
+                    return Err(super::GpuError::ShortRead {
+                        what: "the cell winner keys",
+                        actual: keys.len(),
+                        expected,
+                    }
+                    .into());
+                }
+                // Copied rather than held, unlike the candidate image: 1.4 kB
+                // into a buffer the detector owns and reuses, against a
+                // `Bytes` the next frame would replace anyway.
+                out.extend_from_slice(u32::from_bytes(&keys));
                 Ok(())
             },
         )

--- a/packages/slam-rs/crates/slam-rs/src/gpu/kernels.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/kernels.rs
@@ -2024,7 +2024,8 @@ pub(super) struct CellSelectGeometry {
     pub cells_x: usize,
     /// Cells the grid walks down.
     pub cells_y: usize,
-    /// The ladder's floor, already clamped into the score's own `u8` range.
+    /// The last rung the host ladder visits, already clamped into the score's
+    /// own `u8` range.
     pub threshold: u32,
     /// `optical_flow_image_safe_radius`; `0` switches the gate off.
     pub safe_radius: f32,

--- a/packages/slam-rs/crates/slam-rs/src/gpu/kernels.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/kernels.rs
@@ -1117,7 +1117,7 @@ fn tile_2d(width: usize, height: usize) -> (CubeCount, CubeDim) {
 /// wgpu reports its adapter's own `max_compute_workgroups_per_dimension` and on
 /// every adapter measured that is exactly this floor, so the portable lane
 /// treats it as the limit rather than as a minimum.
-const MAX_CUBES_PER_DIM: u32 = 65_535;
+pub(super) const MAX_CUBES_PER_DIM: u32 = 65_535;
 
 /// The dispatch every per-element bookkeeping kernel uses: one unit per element,
 /// found through [`ABSOLUTE_POS`].
@@ -1682,6 +1682,387 @@ pub(super) fn launch_fast_mask<R: Runtime>(
             width,
             height,
             words,
+        );
+    }
+}
+
+// ── per-cell corner selection ────────────────────────────────────────────────
+
+/// Cube width on the per-cell selection kernel.
+///
+/// 32x8 units, the same 256-unit tile the image kernels use: a cell's candidate
+/// window is at most `cell - 6` wide, so a 32-wide row of units walks it in one
+/// or two coalesced steps and the shared reduction stays at WebGPU's 256-unit
+/// floor.
+const SELECT_DIM_X: usize = 32;
+/// Cube height on the per-cell selection kernel.
+const SELECT_DIM_Y: usize = 8;
+/// Units per cube, and the length of the shared reduction array.
+const SELECT_SLOTS: usize = SELECT_DIM_X * SELECT_DIM_Y;
+/// Halvings a 256-slot tree reduction takes.
+const SELECT_STEPS: usize = 8;
+
+/// The FAST ring radius, off the CPU detector's own constant.
+const SELECT_MARGIN: usize = crate::frontend::detect::FAST_BORDER;
+/// `EDGE_THRESHOLD`, likewise: the kernel applies the same gate the host loop
+/// applied to the corner it chose.
+const SELECT_EDGE: f32 = crate::frontend::detect::EDGE_THRESHOLD;
+
+// The packed cell key's layout is the host detector's, aliased rather than
+// re-declared for the same reason `FILTER_LANES` is: the kernel writes the keys
+// and `detect_keypoints_with_cells` takes them apart, and a shift that drifted
+// by one would move every corner without failing to compile.
+/// Where the packed key keeps `255 - score`.
+const KEY_SCORE_SHIFT: u32 = crate::frontend::detect::KEY_SCORE_SHIFT;
+/// Where the packed key keeps the row.
+const KEY_ROW_SHIFT: u32 = crate::frontend::detect::KEY_ROW_SHIFT;
+/// `NO_CELL_WINNER`, which the kernel spells as a literal below because the
+/// `#[cube]` macro keeps a *named* integer constant comptime and the local it
+/// initialises is then assigned from the runtime reduction. This is what pins
+/// the literal to the constant.
+const _: () = assert!(crate::frontend::detect::NO_CELL_WINNER == 4_294_967_295);
+
+/// One in-window candidate's score, or zero.
+///
+/// The zero is load-bearing rather than a convenience: the host's
+/// `suppress_non_maxima` compares a candidate against a `side x side` scratch
+/// grid that is **zero wherever this cell wrote nothing**, so a neighbour
+/// outside the cell's own column and row window scores `0.0` there even where
+/// `kept` holds a real corner. Reproducing that means testing the window before
+/// the load, which is also what keeps the load in range: the caller only ever
+/// asks about a pixel one step outside the window.
+#[cube]
+#[allow(clippy::too_many_arguments)]
+fn cell_candidate(
+    kept: &Array<u8>,
+    width: usize,
+    x: usize,
+    y: usize,
+    first_x: usize,
+    last_x: usize,
+    first_y: usize,
+    last_y: usize,
+    threshold: u32,
+) -> u32 {
+    let mut value: u32 = 0u32;
+    if x >= first_x && x < last_x && y >= first_y && y < last_y {
+        let score = u32::cast_from(kept[y * width + x]);
+        if score > threshold {
+            value = score;
+        }
+    }
+    value
+}
+
+/// `detectKeypointsWithCells`' inner loop, one cube per grid cell.
+///
+/// The host used to download the candidate image and its bitmask — 2.07 MB per
+/// two-camera frameset on MIO10 — walk one row band per cell row, suppress
+/// non-maxima per cell and sort the survivors. All of that is this kernel, and
+/// what comes back is one packed key per cell.
+///
+/// **Why one key is the whole answer.** Every shipped config sets
+/// `optical_flow_detection_num_points_cell = 1`, and the threshold ladder cannot
+/// change which corner that one point is: a candidate at rung `t` is
+/// `kept > t`, suppression kills `p` only through a neighbour `q` with
+/// `score_q >= score_p`, and such a `q` is itself a candidate at every rung `p`
+/// is. So suppression survival does not depend on the rung, and the ladder
+/// simply admits survivors in descending score. The cell's outcome is the first
+/// survivor in the host's own total order — score descending, then row, then
+/// column ascending, which is the order the band walk produces and
+/// `sort_by` is stable in — that clears `safe_radius`, the masks and
+/// `EDGE_THRESHOLD`.
+///
+/// That total order is what the packed key
+/// `((255 - score) << 24) | (y << 12) | x` reduces under integer **minimum**:
+/// exact, associative and commutative, so the shared tree below agrees with the
+/// host walk bit for bit and a subgroup fast path would agree with both. It
+/// holds while the frame is under 4,096 pixels on a side, which the caller
+/// checks.
+///
+/// The masks are not here: they arrive as whole cells (`flow.rs`'s overlap
+/// rectangles are the cell rectangles), so a masked cell is wholly masked and
+/// the host drops its key instead of the kernel testing 361 rectangles per
+/// pixel.
+#[cube(launch, launch_unchecked)]
+#[allow(clippy::too_many_arguments)]
+fn fast_cell_select_kernel(
+    kept: &Array<u8>,
+    best: &mut Array<u32>,
+    width: usize,
+    height: usize,
+    cell: usize,
+    x_start: usize,
+    y_start: usize,
+    cells_x: usize,
+    cells_y: usize,
+    threshold: u32,
+    safe_radius: f32,
+    centre_x: f32,
+    centre_y: f32,
+) {
+    let column = usize::cast_from(CUBE_POS_X);
+    let row = usize::cast_from(CUBE_POS_Y);
+    let unit = usize::cast_from(UNIT_POS_Y) * SELECT_DIM_X + usize::cast_from(UNIT_POS_X);
+
+    // Cube-uniform, so every unit leaves together and no barrier below is
+    // reached by only part of the cube. The launch sizes the grid exactly, so
+    // this is the guard against a future launcher rather than a live branch.
+    if column >= cells_x || row >= cells_y {
+        terminate!();
+    }
+
+    // The band `detect_keypoints_with_cells` asks for is `[y + 3, y + cell - 3)`
+    // clamped to `height - 3`, and the columns a cell keeps out of it are
+    // `[x + 3, min(x + cell - 3, width - 3))`.
+    let first_x = x_start + column * cell + SELECT_MARGIN;
+    let first_y = y_start + row * cell + SELECT_MARGIN;
+    let mut last_x = x_start + column * cell + cell - SELECT_MARGIN;
+    if last_x > width - SELECT_MARGIN {
+        last_x = width - SELECT_MARGIN;
+    }
+    let mut last_y = y_start + row * cell + cell - SELECT_MARGIN;
+    if last_y > height - SELECT_MARGIN {
+        last_y = height - SELECT_MARGIN;
+    }
+
+    // `border <= x && x < w - border - 1` (`image.h:687-689`), hoisted.
+    let edge_x = f32::cast_from(width) - SELECT_EDGE - 1.0f32;
+    let edge_y = f32::cast_from(height) - SELECT_EDGE - 1.0f32;
+
+    // `NO_CELL_WINNER`; see the assertion beside `KEY_ROW_SHIFT`.
+    let mut key: u32 = 4_294_967_295u32;
+    let mut y = first_y + usize::cast_from(UNIT_POS_Y);
+    while y < last_y {
+        let mut x = first_x + usize::cast_from(UNIT_POS_X);
+        while x < last_x {
+            let score = cell_candidate(
+                kept, width, x, y, first_x, last_x, first_y, last_y, threshold,
+            );
+            if score > 0u32 {
+                // OpenCV's rule: strictly greater than all eight neighbours, a
+                // neighbour that is not a candidate scoring zero. Both sides
+                // strict, so a plateau of equal scores yields nothing.
+                let mut rival: u32 = 0u32;
+                rival = max(
+                    rival,
+                    cell_candidate(
+                        kept,
+                        width,
+                        x - 1usize,
+                        y - 1usize,
+                        first_x,
+                        last_x,
+                        first_y,
+                        last_y,
+                        threshold,
+                    ),
+                );
+                rival = max(
+                    rival,
+                    cell_candidate(
+                        kept,
+                        width,
+                        x,
+                        y - 1usize,
+                        first_x,
+                        last_x,
+                        first_y,
+                        last_y,
+                        threshold,
+                    ),
+                );
+                rival = max(
+                    rival,
+                    cell_candidate(
+                        kept,
+                        width,
+                        x + 1usize,
+                        y - 1usize,
+                        first_x,
+                        last_x,
+                        first_y,
+                        last_y,
+                        threshold,
+                    ),
+                );
+                rival = max(
+                    rival,
+                    cell_candidate(
+                        kept,
+                        width,
+                        x - 1usize,
+                        y,
+                        first_x,
+                        last_x,
+                        first_y,
+                        last_y,
+                        threshold,
+                    ),
+                );
+                rival = max(
+                    rival,
+                    cell_candidate(
+                        kept,
+                        width,
+                        x + 1usize,
+                        y,
+                        first_x,
+                        last_x,
+                        first_y,
+                        last_y,
+                        threshold,
+                    ),
+                );
+                rival = max(
+                    rival,
+                    cell_candidate(
+                        kept,
+                        width,
+                        x - 1usize,
+                        y + 1usize,
+                        first_x,
+                        last_x,
+                        first_y,
+                        last_y,
+                        threshold,
+                    ),
+                );
+                rival = max(
+                    rival,
+                    cell_candidate(
+                        kept,
+                        width,
+                        x,
+                        y + 1usize,
+                        first_x,
+                        last_x,
+                        first_y,
+                        last_y,
+                        threshold,
+                    ),
+                );
+                rival = max(
+                    rival,
+                    cell_candidate(
+                        kept,
+                        width,
+                        x + 1usize,
+                        y + 1usize,
+                        first_x,
+                        last_x,
+                        first_y,
+                        last_y,
+                        threshold,
+                    ),
+                );
+                if score > rival {
+                    let fx = f32::cast_from(x);
+                    let fy = f32::cast_from(y);
+                    let dx = fx - centre_x;
+                    let dy = fy - centre_y;
+                    // `Eigen::Vector2f{...}.norm()`, not `hypot`
+                    // (`keypoints.cpp:176`).
+                    let distance = f32::sqrt(dx * dx + dy * dy);
+                    let mut inside = true;
+                    if safe_radius != 0.0f32 && distance >= safe_radius {
+                        inside = false;
+                    }
+                    if fx < SELECT_EDGE || fx >= edge_x || fy < SELECT_EDGE || fy >= edge_y {
+                        inside = false;
+                    }
+                    if inside {
+                        let candidate = ((255u32 - score) << KEY_SCORE_SHIFT)
+                            | (u32::cast_from(y) << KEY_ROW_SHIFT)
+                            | u32::cast_from(x);
+                        key = min(key, candidate);
+                    }
+                }
+            }
+            x += SELECT_DIM_X;
+        }
+        y += SELECT_DIM_Y;
+    }
+
+    // Integer minimum is associative and commutative, so this tree is the same
+    // answer as the ascending serial reduction the float kernels are obliged to
+    // use — and every barrier is cube-uniform.
+    let mut reduce = SharedMemory::<u32>::new(SELECT_SLOTS);
+    reduce[unit] = key;
+    sync_cube();
+    #[unroll]
+    for step in 0..SELECT_STEPS {
+        // Comptime, and it has to be: a `let mut` seeded from a constant is a
+        // const variable inside `#[cube]` and `stride /= 2` on one panics the
+        // expansion on cubecl's own thread — which reaches the caller as a
+        // buffer of zeros, not as an error.
+        let stride = SELECT_SLOTS >> (step + 1usize);
+        if unit < stride {
+            reduce[unit] = min(reduce[unit], reduce[unit + stride]);
+        }
+        sync_cube();
+    }
+    if unit == 0usize {
+        best[row * cells_x + column] = reduce[0usize];
+    }
+}
+
+/// The detection grid one [`launch_fast_cell_select`] covers.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct CellSelectGeometry {
+    /// Frame width in pixels.
+    pub width: usize,
+    /// Frame height in pixels.
+    pub height: usize,
+    /// `PATCH_SIZE`.
+    pub cell: usize,
+    /// The grid's first cell's left edge.
+    pub x_start: usize,
+    /// The grid's first cell's top edge.
+    pub y_start: usize,
+    /// Cells the grid walks across, which is `w / cell`.
+    pub cells_x: usize,
+    /// Cells the grid walks down.
+    pub cells_y: usize,
+    /// The ladder's floor, already clamped into the score's own `u8` range.
+    pub threshold: u32,
+    /// `optical_flow_image_safe_radius`; `0` switches the gate off.
+    pub safe_radius: f32,
+    /// `(width / 2) as f32`, an integer halving.
+    pub centre_x: f32,
+    /// `(height / 2) as f32`.
+    pub centre_y: f32,
+}
+
+/// One packed winner key per grid cell, from the candidate image.
+pub(super) fn launch_fast_cell_select<R: Runtime>(
+    client: &ComputeClient<R>,
+    kept: Buffer<'_>,
+    best: Buffer<'_>,
+    geometry: CellSelectGeometry,
+) {
+    unsafe {
+        fast_cell_select_kernel::launch_unchecked::<R>(
+            client,
+            CubeCount::Static(geometry.cells_x as u32, geometry.cells_y as u32, 1),
+            CubeDim {
+                x: SELECT_DIM_X as u32,
+                y: SELECT_DIM_Y as u32,
+                z: 1,
+            },
+            ArrayArg::from_raw_parts(kept.0.clone(), kept.1),
+            ArrayArg::from_raw_parts(best.0.clone(), best.1),
+            geometry.width,
+            geometry.height,
+            geometry.cell,
+            geometry.x_start,
+            geometry.y_start,
+            geometry.cells_x,
+            geometry.cells_y,
+            geometry.threshold,
+            geometry.safe_radius,
+            geometry.centre_x,
+            geometry.centre_y,
         );
     }
 }

--- a/packages/slam-rs/crates/slam-rs/tests/gpu_detect.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/gpu_detect.rs
@@ -1,0 +1,303 @@
+//! The GPU detector against the host band walk, cell for cell.
+//!
+//! A binary of its own rather than three more tests in `gpu_kernels.rs`, and for
+//! a measurable reason: `the_whole_gpu_path_holds_the_pool_flat` asserts that
+//! CubeCL's pool is **exactly** flat frame after frame, and every test in one
+//! binary shares one client and one pool. These drive two 960x960 scanners at a
+//! time, which made that assertion fail about one run in three. Cargo runs test
+//! binaries one after another, so the separation is what makes both
+//! deterministic.
+//!
+//! What is checked here is the exactness argument behind
+//! [`slam_rs::frontend::detect::CornerScan::select_cells`]: the whole of
+//! `detectKeypointsWithCells` runs twice over the same frame — once through
+//! `CpuCornerScan`, which walks the threshold ladder band by band, and once
+//! through `GpuCornerScan`, which picks one winner per cell on the device — and
+//! the two results have to be equal corner for corner, response for response, in
+//! the same cell scan order. Ties are included rather than excused: the packed
+//! key's row and column fields break them the way the row-major band walk and a
+//! stable sort do.
+//!
+//! These run only under `--features gpu-wgpu` and need a working CubeCL runtime.
+#![cfg(feature = "gpu-core")]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use slam_rs::frontend::detect::{
+    CellGrid, CornerScan, CpuCornerScan, DetectorConfig, DetectorScratch, KeypointsData, Masks,
+    Occupancy, Rect, detect_keypoints_with_cells,
+};
+use slam_rs::gpu::{GpuCornerScan, gpu_client};
+use slam_rs::image::ImageU16;
+
+mod common;
+
+use common::cornered_image;
+
+/// The msd-index detector, which is `num_points_cell = 1` and the 40/20/10/5
+/// ladder every shipped config runs.
+fn detector_config(safe_radius: f32) -> DetectorConfig {
+    DetectorConfig {
+        num_points_cell: 1,
+        min_threshold: 5,
+        max_threshold: 40,
+        safe_radius,
+    }
+}
+
+/// One camera's detection, from a scanner of the caller's choosing.
+fn detect_with(
+    scanner: Box<dyn CornerScan>,
+    image: &ImageU16,
+    grid: &CellGrid,
+    counts: &[i32],
+    config: &DetectorConfig,
+    masks: &Masks,
+    budget: usize,
+) -> KeypointsData {
+    let mut scratch: DetectorScratch = DetectorScratch::with_scanner(scanner);
+    let mut out: KeypointsData = KeypointsData::default();
+    detect_keypoints_with_cells(
+        image,
+        0,
+        grid,
+        &Occupancy {
+            counts,
+            rows: grid.rows,
+            columns: grid.columns,
+        },
+        config,
+        masks,
+        budget,
+        &mut scratch,
+        &mut out,
+    )
+    .unwrap();
+    out
+}
+
+/// The GPU's per-cell winners are the ones the host band walk chooses.
+///
+/// The whole of `detectKeypointsWithCells` runs twice over the same frame — once
+/// through `CpuCornerScan`, which takes the trait's default and walks bands, and
+/// once through `GpuCornerScan`, which picks each cell's winner on the device —
+/// and the two `KeypointsData` must be equal, corner for corner and response for
+/// response, in the same cell scan order.
+///
+/// That equality is the exactness argument, not the A/B run: the ladder carries
+/// no information at `num_points_cell = 1`, suppression is threshold-independent,
+/// and the packed key orders candidates the way the host's stable sort does. Ties
+/// are included rather than excused — the key's row and column fields break them
+/// the way the row-major band walk does.
+fn detection_agrees(
+    image: &ImageU16,
+    grid: &CellGrid,
+    counts: &[i32],
+    config: &DetectorConfig,
+    masks: &Masks,
+    budget: usize,
+    label: &str,
+) -> usize {
+    let want: KeypointsData = detect_with(
+        Box::new(CpuCornerScan::default()),
+        image,
+        grid,
+        counts,
+        config,
+        masks,
+        budget,
+    );
+    let got: KeypointsData = detect_with(
+        Box::new(GpuCornerScan::new(gpu_client().unwrap()).unwrap()),
+        image,
+        grid,
+        counts,
+        config,
+        masks,
+        budget,
+    );
+    assert_eq!(
+        got.corners.len(),
+        want.corners.len(),
+        "{label}: {} corners against {}",
+        got.corners.len(),
+        want.corners.len()
+    );
+    for (index, (got, want)) in got.corners.iter().zip(want.corners.iter()).enumerate() {
+        assert_eq!(got, want, "{label}: corner {index}");
+    }
+    assert_eq!(got.responses, want.responses, "{label}: responses");
+    want.corners.len()
+}
+
+/// The three framesets of MIO10 the flow fixtures carry, as the detector sees
+/// them: 960x960, the geometry the msd-index rig runs.
+fn mio10_frame(frame: usize, camera: usize) -> ImageU16 {
+    let pgm: common::Pgm = common::read_pgm(&common::fixtures().join("flow/frames"), frame, camera);
+    let mut image: ImageU16 = ImageU16::zeros(pgm.width, pgm.height).unwrap();
+    for y in 0..pgm.height {
+        for x in 0..pgm.width {
+            image.set(x, y, u16::from(pgm.pixels[y * pgm.width + x]) << 8);
+        }
+    }
+    image
+}
+
+/// Every cell of a real MIO10 frameset, both cameras, empty and half full.
+#[test]
+fn the_gpu_cell_selection_matches_the_host_walk_on_a_real_frameset() {
+    let config: DetectorConfig = detector_config(472.0);
+    for camera in 0..2 {
+        let image: ImageU16 = mio10_frame(0, camera);
+        let grid: CellGrid = CellGrid::new(image.width(), image.height(), 50).unwrap();
+        let cells: usize = grid.rows * grid.columns;
+
+        // Nothing tracked yet: every cell of the grid is detected in.
+        let empty: Vec<i32> = vec![0; cells];
+        let found: usize = detection_agrees(
+            &image,
+            &grid,
+            &empty,
+            &config,
+            &Masks::default(),
+            4096,
+            &format!("cam{camera} empty"),
+        );
+        assert!(
+            found > 30,
+            "cam{camera} found only {found} corners, which would make the equality vacuous"
+        );
+
+        // Half the cells already hold a feature, which is the steady state: the
+        // skip has to land on the same cells on both lanes.
+        let mut busy: Vec<i32> = vec![0; cells];
+        for (index, count) in busy.iter_mut().enumerate() {
+            *count = i32::from(index % 3 == 0);
+        }
+        detection_agrees(
+            &image,
+            &grid,
+            &busy,
+            &config,
+            &Masks::default(),
+            4096,
+            &format!("cam{camera} occupied"),
+        );
+    }
+}
+
+/// The gates the kernel took over, one at a time, and the budget the host keeps.
+#[test]
+fn the_gpu_cell_selection_applies_the_same_gates() {
+    let image: ImageU16 = mio10_frame(1, 0);
+    let grid: CellGrid = CellGrid::new(image.width(), image.height(), 50).unwrap();
+    let counts: Vec<i32> = vec![0; grid.rows * grid.columns];
+
+    // `safe_radius = 0` switches the distance gate off entirely, and 200 makes
+    // it bite on a 960x960 frame where 472 leaves most of the grid alone.
+    for radius in [0.0f32, 200.0, 472.0] {
+        detection_agrees(
+            &image,
+            &grid,
+            &counts,
+            &detector_config(radius),
+            &Masks::default(),
+            4096,
+            &format!("safe radius {radius}"),
+        );
+    }
+
+    // `cam0OverlapCellsMasksForCam`'s own shape: `cell` x `cell` rectangles at
+    // the cell origins. Every third one, so masked and clear cells interleave.
+    let mut masks: Masks = Masks::default();
+    let mut index: usize = 0;
+    let mut y: usize = grid.y_start;
+    while y <= grid.y_stop {
+        let mut x: usize = grid.x_start;
+        while x <= grid.x_stop {
+            if index % 3 == 0 {
+                masks.masks.push(Rect {
+                    x: x as f32,
+                    y: y as f32,
+                    w: grid.cell as f32,
+                    h: grid.cell as f32,
+                });
+            }
+            index += 1;
+            x += grid.cell;
+        }
+        y += grid.cell;
+    }
+    detection_agrees(
+        &image,
+        &grid,
+        &counts,
+        &detector_config(472.0),
+        &masks,
+        4096,
+        "cell-aligned masks",
+    );
+
+    // A rectangle that straddles a cell boundary is the mixed-geometry rig's
+    // shape: the device path has to refuse it and the band walk has to answer,
+    // which is the same answer either way.
+    let mut straddling: Masks = Masks::default();
+    straddling.masks.push(Rect {
+        x: (grid.x_start + 17) as f32,
+        y: (grid.y_start + 21) as f32,
+        w: grid.cell as f32,
+        h: grid.cell as f32,
+    });
+    detection_agrees(
+        &image,
+        &grid,
+        &counts,
+        &detector_config(472.0),
+        &straddling,
+        4096,
+        "a mask across a cell boundary",
+    );
+
+    // The port's own cap, checked where the C++ checks its cell budget: the
+    // truncation must fall in the same place in the same scan order.
+    for budget in [1usize, 7, 40] {
+        detection_agrees(
+            &image,
+            &grid,
+            &counts,
+            &detector_config(472.0),
+            &Masks::default(),
+            budget,
+            &format!("budget {budget}"),
+        );
+    }
+}
+
+/// A frame whose width is not a whole number of cells, and one shorter than it
+/// is wide.
+///
+/// The right and bottom clamps are the two the cell window carries and the two
+/// a square 960x960 frame never exercises: `min(x + cell - 3, width - 3)` bites
+/// only where the last cell runs past the image, and kornia's in-block filter is
+/// on at 960 and off at 512, which changes the candidate set the selection reads.
+#[test]
+fn the_gpu_cell_selection_matches_the_host_walk_on_clamped_grids() {
+    for (width, height, cell) in [
+        (960usize, 240usize, 50usize),
+        (512, 192, 32),
+        (517, 193, 50),
+    ] {
+        let image: ImageU16 = cornered_image(width, height);
+        let grid: CellGrid = CellGrid::new(width, height, cell).unwrap();
+        let counts: Vec<i32> = vec![0; grid.rows * grid.columns];
+        let found: usize = detection_agrees(
+            &image,
+            &grid,
+            &counts,
+            &detector_config(0.0),
+            &Masks::default(),
+            4096,
+            &format!("{width}x{height} cell {cell}"),
+        );
+        assert!(found > 0, "{width}x{height} found nothing to compare");
+    }
+}

--- a/packages/slam-rs/crates/slam-rs/tests/gpu_detect.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/gpu_detect.rs
@@ -22,9 +22,13 @@
 #![cfg(feature = "gpu-core")]
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use slam_rs::frontend::detect::{
-    CellGrid, CornerScan, CpuCornerScan, DetectorConfig, DetectorScratch, KeypointsData, Masks,
-    Occupancy, Rect, detect_keypoints_with_cells,
+    BandRequest, CELL_KEY_LIMIT, CellGrid, CellSelect, CornerScan, CpuCornerScan, DetectError,
+    DetectorConfig, DetectorScratch, FAST_BORDER, FastCorner, KeypointsData, Masks, Occupancy,
+    Rect, detect_keypoints_with_cells, threshold_rungs,
 };
 use slam_rs::gpu::{GpuCornerScan, gpu_client};
 use slam_rs::image::ImageU16;
@@ -42,6 +46,50 @@ fn detector_config(safe_radius: f32) -> DetectorConfig {
         max_threshold: 40,
         safe_radius,
     }
+}
+
+/// A scanner that records which of the detector's two paths it was asked for.
+///
+/// Equality on its own cannot tell them apart: a device path that quietly never
+/// engaged agrees with the host walk perfectly, and every check here would pass
+/// while measuring nothing. So each one says which path it meant.
+#[derive(Debug)]
+struct CountingScan {
+    inner: Box<dyn CornerScan>,
+    bands: Arc<AtomicUsize>,
+    selections: Arc<AtomicUsize>,
+}
+
+impl CornerScan for CountingScan {
+    fn scan(&mut self, camera: usize, image: &ImageU16) -> Result<(), DetectError> {
+        self.inner.scan(camera, image)
+    }
+
+    fn band(&mut self, request: BandRequest) -> Result<&[FastCorner], DetectError> {
+        self.bands.fetch_add(1, Ordering::Relaxed);
+        self.inner.band(request)
+    }
+
+    fn select_cells(
+        &mut self,
+        camera: usize,
+        image: &ImageU16,
+        select: &CellSelect,
+        out: &mut Vec<u32>,
+    ) -> Result<(), DetectError> {
+        self.selections.fetch_add(1, Ordering::Relaxed);
+        self.inner.select_cells(camera, image, select, out)
+    }
+}
+
+/// What one equality check saw.
+struct Agreement {
+    /// Corners both lanes produced, cell scan order for cell scan order.
+    corners: usize,
+    /// Band sweeps the GPU scanner was asked for: nonzero means the walk ran.
+    bands: usize,
+    /// Cell selections it was asked for: nonzero means the device path ran.
+    selections: usize,
 }
 
 /// One camera's detection, from a scanner of the caller's choosing.
@@ -96,7 +144,7 @@ fn detection_agrees(
     masks: &Masks,
     budget: usize,
     label: &str,
-) -> usize {
+) -> Agreement {
     let want: KeypointsData = detect_with(
         Box::new(CpuCornerScan::default()),
         image,
@@ -106,8 +154,14 @@ fn detection_agrees(
         masks,
         budget,
     );
+    let bands: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    let selections: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
     let got: KeypointsData = detect_with(
-        Box::new(GpuCornerScan::new(gpu_client().unwrap()).unwrap()),
+        Box::new(CountingScan {
+            inner: Box::new(GpuCornerScan::new(gpu_client().unwrap()).unwrap()),
+            bands: Arc::clone(&bands),
+            selections: Arc::clone(&selections),
+        }),
         image,
         grid,
         counts,
@@ -126,7 +180,11 @@ fn detection_agrees(
         assert_eq!(got, want, "{label}: corner {index}");
     }
     assert_eq!(got.responses, want.responses, "{label}: responses");
-    want.corners.len()
+    Agreement {
+        corners: want.corners.len(),
+        bands: bands.load(Ordering::Relaxed),
+        selections: selections.load(Ordering::Relaxed),
+    }
 }
 
 /// The three framesets of MIO10 the flow fixtures carry, as the detector sees
@@ -153,7 +211,7 @@ fn the_gpu_cell_selection_matches_the_host_walk_on_a_real_frameset() {
 
         // Nothing tracked yet: every cell of the grid is detected in.
         let empty: Vec<i32> = vec![0; cells];
-        let found: usize = detection_agrees(
+        let agreed: Agreement = detection_agrees(
             &image,
             &grid,
             &empty,
@@ -163,8 +221,15 @@ fn the_gpu_cell_selection_matches_the_host_walk_on_a_real_frameset() {
             &format!("cam{camera} empty"),
         );
         assert!(
-            found > 30,
-            "cam{camera} found only {found} corners, which would make the equality vacuous"
+            agreed.corners > 30,
+            "cam{camera} found only {} corners, which would make the equality vacuous",
+            agreed.corners
+        );
+        assert!(
+            agreed.selections > 0 && agreed.bands == 0,
+            "cam{camera} did not take the device path: {} selections, {} bands",
+            agreed.selections,
+            agreed.bands
         );
 
         // Half the cells already hold a feature, which is the steady state: the
@@ -247,7 +312,7 @@ fn the_gpu_cell_selection_applies_the_same_gates() {
         w: grid.cell as f32,
         h: grid.cell as f32,
     });
-    detection_agrees(
+    let refused: Agreement = detection_agrees(
         &image,
         &grid,
         &counts,
@@ -256,6 +321,11 @@ fn the_gpu_cell_selection_applies_the_same_gates() {
         4096,
         "a mask across a cell boundary",
     );
+    assert_eq!(
+        refused.selections, 0,
+        "a straddling mask has to send the whole camera down the band walk"
+    );
+    assert!(refused.bands > 0, "and the band walk has to have run");
 
     // The port's own cap, checked where the C++ checks its cell budget: the
     // truncation must fall in the same place in the same scan order.
@@ -275,12 +345,14 @@ fn the_gpu_cell_selection_applies_the_same_gates() {
 /// A frame whose width is not a whole number of cells, and one shorter than it
 /// is wide.
 ///
-/// The right and bottom clamps are the two the cell window carries and the two
-/// a square 960x960 frame never exercises: `min(x + cell - 3, width - 3)` bites
-/// only where the last cell runs past the image, and kornia's in-block filter is
-/// on at 960 and off at 512, which changes the candidate set the selection reads.
+/// Not the clamps — [`CellGrid::new`] floors and centres, so every grid it
+/// derives ends inside its image and the kernel's two strict clamps never run.
+/// What these three do exercise is the other half of the geometry: kornia's
+/// in-block local-maximum filter is on at 960 and off at 512, and a width that
+/// is not a whole number of cells moves the grid's own start, both of which
+/// change the candidate set the selection reads.
 #[test]
-fn the_gpu_cell_selection_matches_the_host_walk_on_clamped_grids() {
+fn the_gpu_cell_selection_matches_the_host_walk_on_uneven_frames() {
     for (width, height, cell) in [
         (960usize, 240usize, 50usize),
         (512, 192, 32),
@@ -288,8 +360,11 @@ fn the_gpu_cell_selection_matches_the_host_walk_on_clamped_grids() {
     ] {
         let image: ImageU16 = cornered_image(width, height);
         let grid: CellGrid = CellGrid::new(width, height, cell).unwrap();
+        // The precondition the clamp test below needs and this one does not
+        // have: `CellGrid::new` cannot produce a cell that runs past the image.
+        assert!(grid.x_stop + cell <= width && grid.y_stop + cell <= height);
         let counts: Vec<i32> = vec![0; grid.rows * grid.columns];
-        let found: usize = detection_agrees(
+        let agreed: Agreement = detection_agrees(
             &image,
             &grid,
             &counts,
@@ -298,6 +373,259 @@ fn the_gpu_cell_selection_matches_the_host_walk_on_clamped_grids() {
             4096,
             &format!("{width}x{height} cell {cell}"),
         );
-        assert!(found > 0, "{width}x{height} found nothing to compare");
+        assert!(
+            agreed.corners > 0,
+            "{width}x{height} found nothing to compare"
+        );
+        assert!(agreed.selections > 0, "{width}x{height} took the band walk");
+    }
+}
+
+/// A grid the detector's **caller** supplies, rather than one `CellGrid::new`
+/// derives from an image.
+///
+/// The occupancy matrix `detect_with` sizes from `rows` and `columns` has to
+/// cover every cell the walk visits, or the cells fall out of it instead of
+/// being detected in.
+fn caller_grid(
+    x_start: usize,
+    x_stop: usize,
+    y_start: usize,
+    y_stop: usize,
+    cell: usize,
+) -> CellGrid {
+    CellGrid {
+        cell,
+        x_start,
+        x_stop,
+        y_start,
+        y_stop,
+        columns: (x_stop - x_start) / cell + 1,
+        rows: (y_stop - y_start) / cell + 1,
+    }
+}
+
+/// Grids whose last cell runs past the image, which is where the clamps bite.
+///
+/// The frontend derives its grid with `CellGrid::new`, whose last cell always
+/// ends inside the frame, so `min(x + cell - 3, width - 3)` and the same down
+/// the side are dead there. The detector takes the grid from its caller, and
+/// these are the two shapes that reach them: a last column and a last row that
+/// overhang while still holding pixels inside `EDGE_THRESHOLD`, and a last
+/// column whose whole window is empty, which the device has to report as the
+/// no-winner sentinel and the host as nothing at all.
+///
+/// What the equality proves is that the device stays inside the image and sees
+/// the same zero rim; the clamped columns themselves are past
+/// `width - EDGE_THRESHOLD - 1`, so no corner can come out of them on either
+/// lane whatever the clamp does.
+#[test]
+fn the_gpu_cell_selection_matches_the_host_walk_on_overhanging_cells() {
+    let (width, height, cell): (usize, usize, usize) = (200, 150, 50);
+    let image: ImageU16 = cornered_image(width, height);
+
+    // Cells at x = 20, 70, 120, 170 and y = 10, 60, 110: the last column ends at
+    // 220 and the last row at 160, both past the frame.
+    let overhanging: CellGrid = caller_grid(20, 170, 10, 110, cell);
+    assert!(
+        overhanging.x_stop + cell > width,
+        "the last column has to run past the right edge"
+    );
+    assert!(
+        overhanging.y_stop + cell > height,
+        "the last row has to run past the bottom edge"
+    );
+    assert!(
+        overhanging.x_stop + FAST_BORDER < width - FAST_BORDER,
+        "and its window still has to hold candidates"
+    );
+
+    // Cells at x = 47, 97, 147, 197: the last column's window is [200, 197),
+    // which is empty, and the cell has to come back as the sentinel.
+    let empty_window: CellGrid = caller_grid(47, 197, 0, 100, cell);
+    assert!(
+        empty_window.x_stop + FAST_BORDER >= width - FAST_BORDER,
+        "the last column's candidate window has to be empty"
+    );
+
+    for (grid, label) in [
+        (overhanging, "an overhanging last column and row"),
+        (empty_window, "an empty last candidate window"),
+    ] {
+        let counts: Vec<i32> = vec![0; grid.rows * grid.columns];
+        let agreed: Agreement = detection_agrees(
+            &image,
+            &grid,
+            &counts,
+            &detector_config(0.0),
+            &Masks::default(),
+            4096,
+            label,
+        );
+        assert!(agreed.corners > 0, "{label} found nothing to compare");
+        assert!(agreed.selections > 0, "{label} took the band walk");
+    }
+}
+
+/// The ladder's last rung is what the device is handed, not `min_threshold`.
+///
+/// `40/6` visits 40, 20, 10 and stops, because the next halving is 5 and the
+/// floor is 6; `32/5` visits 32, 16, 8. A device handed the configured minimum
+/// would admit a cell's best survivor scoring between the two — a corner the
+/// host walk never sees. The `admitted` run below is exactly that ladder, and
+/// asserting it finds strictly more corners is what stops this from passing
+/// vacuously.
+#[test]
+fn the_gpu_cell_selection_stops_at_the_last_rung_the_walk_visits() {
+    let image: ImageU16 = mio10_frame(0, 0);
+    let grid: CellGrid = CellGrid::new(image.width(), image.height(), 50).unwrap();
+    let counts: Vec<i32> = vec![0; grid.rows * grid.columns];
+
+    for (max_threshold, min_threshold, last_rung) in [(40i32, 6i32, 10i32), (32, 5, 8)] {
+        let config: DetectorConfig = DetectorConfig {
+            max_threshold,
+            min_threshold,
+            ..detector_config(472.0)
+        };
+        assert_eq!(threshold_rungs(&config).last(), Some(last_rung));
+
+        // The ladder that stops at the configured minimum instead: one rung, at
+        // `min_threshold`. This is what a device given the wrong bound detects.
+        let at_the_minimum: DetectorConfig = DetectorConfig {
+            max_threshold: min_threshold,
+            ..config
+        };
+        assert_eq!(threshold_rungs(&at_the_minimum).last(), Some(min_threshold));
+        let admitted: usize = detect_with(
+            Box::new(CpuCornerScan::default()),
+            &image,
+            &grid,
+            &counts,
+            &at_the_minimum,
+            &Masks::default(),
+            4096,
+        )
+        .corners
+        .len();
+
+        let label: String = format!("ladder {max_threshold}/{min_threshold}");
+        let agreed: Agreement = detection_agrees(
+            &image,
+            &grid,
+            &counts,
+            &config,
+            &Masks::default(),
+            4096,
+            &label,
+        );
+        assert!(agreed.selections > 0, "{label} took the band walk");
+        assert!(
+            admitted > agreed.corners,
+            "{label}: a rung at {min_threshold} admits {admitted} corners against the last \
+             rung's {}, so the two bounds are not separable on this frame",
+            agreed.corners
+        );
+    }
+}
+
+/// A frame a packed key cannot name takes the band walk.
+///
+/// The key keeps twelve bits each for the row and the column, so
+/// [`CELL_KEY_LIMIT`] pixels on a side is where the device path has to give up
+/// rather than lose a coordinate. The guard is on the frame, not on the grid, so
+/// a wide short frame is enough to reach it.
+#[test]
+fn a_frame_at_the_key_limit_takes_the_band_walk() {
+    let (width, height, cell): (usize, usize, usize) = (CELL_KEY_LIMIT, 96, 32);
+    let image: ImageU16 = cornered_image(width, height);
+    let grid: CellGrid = CellGrid::new(width, height, cell).unwrap();
+    let counts: Vec<i32> = vec![0; grid.rows * grid.columns];
+    let agreed: Agreement = detection_agrees(
+        &image,
+        &grid,
+        &counts,
+        &detector_config(0.0),
+        &Masks::default(),
+        4096,
+        "a frame at the key limit",
+    );
+    assert_eq!(
+        agreed.selections, 0,
+        "{width} pixels wide is past what a packed key can name"
+    );
+    assert!(agreed.bands > 0, "so the band walk has to have run");
+    assert!(agreed.corners > 0, "and it has to have found something");
+}
+
+/// More than one point per cell takes the band walk.
+///
+/// The exactness argument is a one-point-per-cell argument: with a larger budget
+/// the ladder decides how many corners a cell contributes and one key cannot say.
+#[test]
+fn a_budget_over_one_point_per_cell_takes_the_band_walk() {
+    let image: ImageU16 = mio10_frame(1, 0);
+    let grid: CellGrid = CellGrid::new(image.width(), image.height(), 50).unwrap();
+    let counts: Vec<i32> = vec![0; grid.rows * grid.columns];
+    let config: DetectorConfig = DetectorConfig {
+        num_points_cell: 2,
+        ..detector_config(472.0)
+    };
+    let agreed: Agreement = detection_agrees(
+        &image,
+        &grid,
+        &counts,
+        &config,
+        &Masks::default(),
+        4096,
+        "two points per cell",
+    );
+    assert_eq!(agreed.selections, 0, "two points per cell is the band walk");
+    assert!(agreed.bands > 0, "so the band walk has to have run");
+    assert!(agreed.corners > 0, "and it has to have found something");
+}
+
+/// One scanner, four camera slots.
+///
+/// The device path keeps a key buffer per camera beside the three the band path
+/// keeps, and the frontend calls the detector with the frameset's own camera
+/// index — so a rig with four cameras reaches slot 3. The scratch is reused
+/// across the four calls, which is what the frontend does and what makes the
+/// per-camera buffers a thing that can be got wrong.
+#[test]
+fn the_gpu_cell_selection_holds_for_every_camera_slot() {
+    let config: DetectorConfig = detector_config(472.0);
+    let mut host: DetectorScratch = DetectorScratch::default();
+    let mut device: DetectorScratch =
+        DetectorScratch::with_scanner(Box::new(GpuCornerScan::new(gpu_client().unwrap()).unwrap()));
+
+    for camera in 0..4 {
+        // Two frames alternating, so consecutive slots hold different pixels.
+        let image: ImageU16 = mio10_frame(camera % 2, camera % 2);
+        let grid: CellGrid = CellGrid::new(image.width(), image.height(), 50).unwrap();
+        let counts: Vec<i32> = vec![0; grid.rows * grid.columns];
+        let occupancy: Occupancy<'_> = Occupancy {
+            counts: &counts,
+            rows: grid.rows,
+            columns: grid.columns,
+        };
+        let mut want: KeypointsData = KeypointsData::default();
+        let mut got: KeypointsData = KeypointsData::default();
+        for (scratch, out) in [(&mut host, &mut want), (&mut device, &mut got)] {
+            detect_keypoints_with_cells(
+                &image,
+                camera,
+                &grid,
+                &occupancy,
+                &config,
+                &Masks::default(),
+                4096,
+                scratch,
+                out,
+            )
+            .unwrap();
+        }
+        assert!(!want.corners.is_empty(), "camera {camera} found nothing");
+        assert_eq!(got.corners, want.corners, "camera {camera}: corners");
+        assert_eq!(got.responses, want.responses, "camera {camera}: responses");
     }
 }

--- a/packages/slam-rs/docs/design-notes.md
+++ b/packages/slam-rs/docs/design-notes.md
@@ -900,7 +900,30 @@ the one to try next.
 through the band walk and through the device selection — and the two
 `KeypointsData` are equal corner for corner and response for response, on both
 cameras, empty and half-occupied, at three safe radii, under cell-aligned masks
-and one that straddles a boundary, at three budgets, and on three clamped grids.
+and one that straddles a boundary, at three budgets, over four camera slots
+through one reused scanner, and on three frames whose width is not a whole
+number of cells. Two ladders that step past their own minimum — 40/6 and 32/5 —
+are in it because equality there is what the last-rung fix buys: the same frame
+detected at a rung of 6 yields 62 corners against the real ladder's 54, so a
+device handed `min_threshold` is separable from one handed the last rung, and
+the test asserts that gap before asserting the equality.
+
+The GPU scanner is wrapped in a counting one, because equality alone cannot tell
+the two paths apart — a device path that quietly never engaged agrees with the
+host walk perfectly — so every case says which path it meant. That is what makes
+the three fallbacks assertions rather than assumptions: a straddling mask, a
+`num_points_cell` of 2 and a frame `CELL_KEY_LIMIT` pixels wide each have to
+report zero selections and a nonzero band count.
+
+The clamps are their own case. `CellGrid::new` floors and centres, so no grid it
+derives has a cell that runs past the image and neither strict clamp in the
+kernel would ever run; the detector takes its grid from the caller, so the test
+supplies two — a last column and row that overhang, and a last column whose
+candidate window is empty and must come back as the sentinel. The clamped columns
+lie past `width - EDGE_THRESHOLD - 1`, so no corner can come out of them on
+either lane: what the equality proves there is that the device stays inside the
+image and sees the same zero rim, not that the answer changes.
+
 It is a separate test binary because `the_whole_gpu_path_holds_the_pool_flat`
 asserts an exactly flat CubeCL pool and every test in one binary shares one
 client.

--- a/packages/slam-rs/docs/design-notes.md
+++ b/packages/slam-rs/docs/design-notes.md
@@ -834,14 +834,20 @@ selection on the host: a row band per cell row and rung, a column filter, OpenCV
 non-maximum suppression per cell, a sort and three gates. The three FAST kernels
 were 0.04 ms of that; the stage was **1.45 ms**.
 
-Only the floor of the threshold ladder decides the winner, and that is exact
-rather than an approximation. A candidate at rung `t` is `kept > t`;
+Only the **last rung the ladder visits** decides the winner, and that is exact
+rather than an approximation. That rung is `max_threshold` halved until the next
+halving would fall under `max(min_threshold, 1)`, which for the shipped 40/5
+configs is 5 but for 40/6 is 10 — not the configured minimum, which a halving
+ladder need never reach. `threshold_rungs` is the one place it is computed, and
+the cell walk steps through the same iterator, so the two cannot drift; handing
+the device `min_threshold` instead would let it admit a corner scoring between
+the two that the walk never sees. A candidate at rung `t` is `kept > t`;
 `suppress_non_maxima` kills a pixel only through an in-window neighbour scoring at
 least as much, and such a neighbour is itself a candidate at every rung the pixel
 is. Suppression therefore does not depend on the rung, and the ladder only admits
 survivors in descending score. With `optical_flow_detection_num_points_cell = 1`,
-which every shipped config sets, the cell's outcome is the best survivor over the
-floor that clears `safe_radius`, the masks and `EDGE_THRESHOLD`.
+which every shipped config sets, the cell's outcome is the best survivor over
+that last rung which clears `safe_radius`, the masks and `EDGE_THRESHOLD`.
 
 `fast_cell_select_kernel` is one cube per cell over that cell's own window, with
 the same zero rim the host scratch grid gives a neighbour outside the window, and

--- a/packages/slam-rs/docs/design-notes.md
+++ b/packages/slam-rs/docs/design-notes.md
@@ -821,6 +821,92 @@ precision-band entry in the ten-clip manifest. These checks establish the local
 MIO14 correction and short-clip regression behavior, not a fresh all-device or
 ten-clip gate. The GPU stays opt-in and the default build stays CPU-only.
 
+## D72 — the detector picks each grid cell's corner on the device
+
+Decision, 2026-09-09: on the GPU lane, pick one corner per detection grid cell in
+a CubeCL kernel and download one packed key per cell, instead of downloading the
+candidate image and its bitmask and walking them on the host. Keep the band walk
+as the reference and as the fallback. The CPU lane is unchanged.
+
+The band path downloaded 0.92 MB of candidate image plus 0.115 MB of bitmask per
+camera — **2.07 MB per two-camera frameset** on MIO10 — and then did all of the
+selection on the host: a row band per cell row and rung, a column filter, OpenCV's
+non-maximum suppression per cell, a sort and three gates. The three FAST kernels
+were 0.04 ms of that; the stage was **1.45 ms**.
+
+Only the floor of the threshold ladder decides the winner, and that is exact
+rather than an approximation. A candidate at rung `t` is `kept > t`;
+`suppress_non_maxima` kills a pixel only through an in-window neighbour scoring at
+least as much, and such a neighbour is itself a candidate at every rung the pixel
+is. Suppression therefore does not depend on the rung, and the ladder only admits
+survivors in descending score. With `optical_flow_detection_num_points_cell = 1`,
+which every shipped config sets, the cell's outcome is the best survivor over the
+floor that clears `safe_radius`, the masks and `EDGE_THRESHOLD`.
+
+`fast_cell_select_kernel` is one cube per cell over that cell's own window, with
+the same zero rim the host scratch grid gives a neighbour outside the window, and
+a shared tree reduction over the packed key
+`((255 - score) << 24) | (y << 12) | x`. Integer minimum is associative,
+commutative and exact, so the tree is the host's own total order — score
+descending, then row, then column, which is what the row-major band walk and a
+stable sort produce — and a subgroup fast path would agree with it bit for bit.
+Readback is 361 x 4 B per camera against 1,036,800.
+
+The masks stay on the host and are exact there: `cam0OverlapCellsMasksForCam`
+pushes `cell` x `cell` rectangles at the cell origins and a cell's candidates lie
+strictly inside it, so a cell is wholly masked or wholly clear. The guard is at
+the camera level — a rectangle that does not name one cell of *this* camera's
+grid, which the mixed-geometry rigs the port supports deliberately produce, sends
+the whole camera down the band path. So do `num_points_cell != 1`, a cell no wider
+than the FAST ring and a frame 4,096 pixels or more on a side.
+
+MIO10, three interleaved rounds against main + timers (44cbdb0f) on one core:
+
+| Core | frontend_detect ms | track median ms | ATE vs GT cm | tracked/lost | identical |
+|---|---:|---:|---:|---:|---|
+| base | 1.466 | 5.151 | 1.504 | 412/0 | — |
+| this | 0.589 | 4.372 | 1.504 | 412/0 | byte and state |
+
+MGO09, four 640x480 cameras, one round: `frontend_detect` 2.233 ms against
+2.241, unchanged; `track_ms` 16.904 against 13.165; ATE vs GT 0.770 against a
+0.847 band; 107/0 tracked; byte and state identical. **The stage does not move
+on that rig**, and that says where the rest of the time is: the kernels are
+microseconds and the readback is now 432 B per camera, so what 2.24 ms buys is
+four device round trips. One trip per camera is the floor this shape has.
+
+A hoisted variant that launched every camera and read them all in **one**
+download was written, measured and dropped. It is right in isolation — 0.502 ms
+against 0.822 for two 960x960 cameras through the scanner alone, and 0.74-0.84
+against 1.01-1.04 per frameset through the whole frontend in one process — and
+it is wrong under the gate, twice: `frontend_detect` 1.418 and 1.422 ms against
+this shape's 0.589, with `track_ms` −8.4% and −8.8% against −15.1%. A counter on
+the scanner rules out the obvious explanation: through the real frontend the
+batch answered every selection and none fell back. What moves with it is the
+estimator — `measure` 2.070 against the base's 2.431 in the same interleaved
+run, which no detector change can cause — so the harness is attributing
+something the stage timers cannot separate. The finding is recorded rather than
+shipped: on a four-camera rig the trip count is still the lever, and a variant
+that keeps the single download but leaves the wait where this shape leaves it is
+the one to try next.
+
+`tests/gpu_detect.rs` is the exactness gate rather than the A/B run: the whole of
+`detectKeypointsWithCells` runs twice over the committed 960x960 MIO10 frames —
+through the band walk and through the device selection — and the two
+`KeypointsData` are equal corner for corner and response for response, on both
+cameras, empty and half-occupied, at three safe radii, under cell-aligned masks
+and one that straddles a boundary, at three budgets, and on three clamped grids.
+It is a separate test binary because `the_whole_gpu_path_holds_the_pool_flat`
+asserts an exactly flat CubeCL pool and every test in one binary shares one
+client.
+
+Two CubeCL traps cost a debugging pass each. A **named** integer constant stays
+comptime inside `#[cube]`: seeding a `let mut` from one makes a const variable,
+and `stride /= 2` on it panics the expansion on cubecl's own worker thread — the
+launch reports success and the buffer comes back as zeros, which is the failure
+mode D32 exists for. The sentinel key is spelled as a literal with a
+`const _: () = assert!(..)` pinning it to the host's constant, and the reduction
+stride is comptime per unrolled step.
+
 ## Decision references
 
 The `Dnn` tags in this file and in the README name the project's recorded design decisions. What each one decided, in one line:
@@ -842,3 +928,4 @@ The `Dnn` tags in this file and in the README name the project's recorded design
 - **D68** — The three unreachable blocks go: squared-form marginalization, nullspace diagnostics, the D34 damping stack
 - **D70** — One GPU runtime: the CUDA lane is removed; wgpu is the GPU lane (2026-09-09)
 - **D71** — Exponent-bit finite classification and bounded small-angle trig; the MIO14 replay passes its unchanged accuracy limit (2026-09-09)
+- **D72** — The GPU detector picks one corner per grid cell on the device; the candidate image never comes back (2026-09-09)

--- a/pixi.toml
+++ b/pixi.toml
@@ -2485,14 +2485,19 @@ cmd = "cargo clippy -p slam-rs --features gpu-wgpu --all-targets -- -D warnings"
 cwd = "packages/slam-rs"
 description = "Lint the portable wgpu lane, tests included, with warnings denied"
 
-# `--list | grep -c` first, and it is not decoration: this suite is
+# `--list | grep -c` first, and it is not decoration: both suites are
 # `#![cfg(feature = "gpu-core")]` and the task selects `gpu-wgpu`, so a feature
-# rename that stops the two matching compiles the file away and `cargo test`
+# rename that stops the two matching compiles the files away and `cargo test`
 # reports "ok. 0 passed" — a green gate that ran nothing. It happened once,
 # splitting out `gpu-core`, and the count is what caught it. `grep -c`
 # exits non-zero on no matches, so an empty binary fails before it runs.
+#
+# `gpu_detect` is a second binary rather than more tests in `gpu_kernels`
+# because `the_whole_gpu_path_holds_the_pool_flat` asserts an exactly flat
+# CubeCL pool and every test in one binary shares one client; cargo runs
+# binaries one after another, which is what keeps both deterministic.
 [feature.slam-rs.tasks.slam-rs-wgpu-test]
-cmd = "cargo test -p slam-rs --features gpu-wgpu --test gpu_kernels -- --list | grep -c ': test' && cargo test -p slam-rs --features gpu-wgpu --test gpu_kernels"
+cmd = "cargo test -p slam-rs --features gpu-wgpu --test gpu_kernels -- --list | grep -c ': test' && cargo test -p slam-rs --features gpu-wgpu --test gpu_detect -- --list | grep -c ': test' && cargo test -p slam-rs --features gpu-wgpu --test gpu_kernels --test gpu_detect"
 cwd = "packages/slam-rs"
 description = "Run the per-kernel tolerance suite through wgpu on this host's Vulkan adapter"
 


### PR DESCRIPTION
Detection on the GPU lane downloaded the candidate image and its column bitmask —
0.92 MB + 0.115 MB per camera, **2.07 MB per two-camera frameset** on MIO10 — and
then did all of the selection on the host: a row band per cell row and rung, a
column filter, OpenCV's non-maximum suppression per cell, a sort and three gates.
The three FAST kernels were 0.04 ms of a 1.45 ms stage.

This moves the selection to the device. One cube per grid cell picks that cell's
winner and the readback is one packed key per cell — 361 x 4 B per camera instead
of 1,036,800.

### Why one key is the whole answer

The threshold ladder cannot change which corner it is. A candidate at rung `t` is
`kept > t`; `suppress_non_maxima` kills a pixel only through an in-window
neighbour scoring at least as much, and such a neighbour is itself a candidate at
every rung the pixel is. Suppression therefore does not depend on the rung, and
the ladder only admits survivors in descending score. With
`optical_flow_detection_num_points_cell = 1`, which every shipped config sets,
the cell's outcome is the best survivor over the floor that clears `safe_radius`,
the masks and `EDGE_THRESHOLD`.

The packed key `((255 - score) << 24) | (y << 12) | x` reduces under integer
**minimum** to exactly the host's total order — score descending, then row, then
column, which is what the row-major band walk and a stable sort produce. Integer
minimum is associative, commutative and exact, so the shared tree agrees with the
host bit for bit and a subgroup fast path would agree with both.

The masks stay on the host and are exact there: `cam0OverlapCellsMasksForCam`
pushes `cell` x `cell` rectangles at the cell origins and a cell's candidates lie
strictly inside it, so a cell is wholly masked or wholly clear. The guard is at
the camera level — a rectangle that does not name one cell of *this* camera's
grid sends the whole camera down the band walk, which is what the mixed-geometry
rigs the port supports deliberately produce. So do `num_points_cell != 1`, a cell
no wider than the FAST ring, and a frame 4,096 pixels or more on a side.
`CpuCornerScan` takes the trait's default and is untouched.

### Harness

`/tmp/slam-rs-s32/ab/ab.sh`, one core, interleaved rounds against
`slam-rs/stage-timers` (44cbdb0f). Core measured: `809e978b`, whose tree differs
from this branch's head only by test-file formatting and `docs/design-notes.md` —
neither is compiled into the core.

**MIO10, 3 rounds**

| Core | median ms | mean ms | p95 ms | max ms | ATE vs GT cm | ATE vs C++ cm | tracked/lost | byte-identical | state-identical |
|---|---:|---:|---:|---:|---:|---:|---:|---|---|
| base | 5.151 | 5.688 | 9.670 | 11.236 | 1.504 | 0.311 | 412/0 | Y | Y |
| this | 4.372 | 4.835 | 8.744 | 10.349 | 1.504 | 0.311 | 412/0 | Y | Y |

| Core | pyramid | **detect** | track | stereo | optimize | linearize | solver | marginalize | measure | track_ms | glue |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| base | 0.173 | **1.466** | 0.756 | 0.212 | 2.243 | 0.746 | 1.196 | 0.148 | 2.465 | 5.151 | 0.152 |
| this | 0.172 | **0.589** | 0.741 | 0.188 | 2.269 | 0.753 | 1.172 | 0.148 | 2.462 | 4.372 | 0.152 |

`ACCURACY PASS; IDENTICAL yes; delta -0.778 ms (-15.11%) vs base.`
Gate: ATE 1.504 cm against a 1.654 cm band, zero lost framesets, median gain
0.778 ms against a 0.100 ms bar. **PASS.**

**MGO09, four 640x480 cameras, 1 round**

| Core | median ms | ATE vs GT cm | tracked/lost | byte-identical | state-identical |
|---|---:|---:|---:|---|---|
| base | 16.904 | 0.770 | 107/0 | Y | Y |
| this | 13.165 | 0.770 | 107/0 | Y | Y |

`frontend_detect` there is 2.233 against 2.241 — **unchanged**. On a small
four-camera rig the readback was never the cost; four device round trips is what
2.24 ms is. The `track_ms` and estimator movement in that single 107-frameset
round is run noise, not this change: the trajectories are byte-identical.

A hoisted variant that launched every camera and read them all in one download
was written, measured and dropped — right in isolation (0.502 ms against 0.822
for two 960x960 cameras through the scanner; 0.74-0.84 against 1.01-1.04 per
frameset through the whole frontend in one process) and wrong under the gate,
twice (`frontend_detect` 1.418 and 1.422 ms, `track_ms` -8.4% and -8.8%). A
counter through the real frontend rules out the obvious cause — the batch
answered every selection. D72 records it so it is not rebuilt blind.

### Tests

`tests/gpu_detect.rs` is the exactness gate rather than the A/B run: the whole of
`detectKeypointsWithCells` runs twice over the same frame — through the band walk
and through the device selection — and the two `KeypointsData` must be equal
corner for corner and response for response, on the committed 960x960 MIO10
frames, both cameras, empty and half-occupied, at three safe radii, under
cell-aligned masks and one that straddles a boundary, at three budgets, and on
three clamped grids where the last cell runs past the image. It is a second test
binary because `the_whole_gpu_path_holds_the_pool_flat` asserts an exactly flat
CubeCL pool and every test in one binary shares one client; two 960x960 scanners
beside it failed that about one run in three.

`cargo test --workspace` green; `slam-rs-wgpu-test` 20 + 3 green; `pytest` 256
passed, 1 skipped; both Clippy lanes clean at `-D warnings`.

No `.rrd` is produced by this change and none is needed.
