### PR TITLE
slam-rs: reuse estimator scratch across frames

### DIFF
--- a/packages/slam-rs/crates/slam-rs/src/eigen/ldlt.rs
+++ b/packages/slam-rs/crates/slam-rs/src/eigen/ldlt.rs
@@ -44,25 +44,84 @@ const TRIANGULAR_PANEL_WIDTH: usize = 8;
 pub(crate) struct EigenLdlt<S: LieScalar> {
     mat: DMatrix<S>,
     transpositions: Vec<usize>,
+    /// Eigen's own `m_temporary` (`LDLT.h:496`), held so a reused
+    /// factorization allocates nothing.
+    temp: Vec<S>,
+    /// The trailing update's accumulators, one per row below the pivot.
+    accumulator: Vec<S>,
 }
 
 impl<S: LieScalar> EigenLdlt<S> {
+    /// An unfactorized `0x0`, for a caller that reuses one factorization.
+    ///
+    /// Every buffer is sized by [`Self::working_copy`], so this allocates
+    /// nothing.
+    pub(crate) fn empty() -> Self {
+        Self {
+            mat: DMatrix::zeros(0, 0),
+            transpositions: Vec::new(),
+            temp: Vec::new(),
+            accumulator: Vec::new(),
+        }
+    }
+
+    /// The working copy, `size x size` and with **undefined contents**, for a
+    /// caller that fills it and then calls [`Self::factor`].
+    ///
+    /// This and `factor` are `new` split in two, so the Levenberg-Marquardt
+    /// step can write the damped matrix straight into the buffer the
+    /// factorization consumes: `sqrt_keypoint_vio.cpp:1415-1420` copies `H`,
+    /// adds `lambda * diag(H)` and factorizes, up to three times per inner
+    /// step, and Eigen's factorization is in place.
+    pub(crate) fn working_copy(&mut self, size: usize) -> &mut DMatrix<S> {
+        if self.mat.nrows() != size || self.mat.ncols() != size {
+            self.mat = DMatrix::zeros(size, size);
+        }
+        &mut self.mat
+    }
+
     /// `internal::ldlt_inplace<Lower>::unblocked` (`LDLT.h:280-382`).
     ///
     /// Only the lower triangle of `a` is read, as `LDLT<MatrixType, Lower>`
     /// reads. `a` is consumed because Eigen's is an in-place factorization and
     /// `marg_helper.cpp:202` hands it a `Ref` into `marg_H`, which is dead
     /// afterwards.
-    pub(crate) fn new(mut mat: DMatrix<S>) -> Self {
+    ///
+    /// The shipped Levenberg-Marquardt path does not use it: it reuses one
+    /// factorization through [`Self::working_copy`] and [`Self::factor`], which
+    /// are this constructor split in two. This spelling is what the tests
+    /// below and the ported reference drive.
+    #[cfg(test)]
+    pub(crate) fn new(mat: DMatrix<S>) -> Self {
+        let mut this: Self = Self {
+            mat,
+            transpositions: Vec::new(),
+            temp: Vec::new(),
+            accumulator: Vec::new(),
+        };
+        this.factor();
+        this
+    }
+
+    /// The sweep itself, over whatever [`Self::working_copy`] left in place.
+    pub(crate) fn factor(&mut self) {
+        let Self {
+            ref mut mat,
+            ref mut transpositions,
+            ref mut temp,
+            ref mut accumulator,
+        } = *self;
         let size: usize = mat.nrows().min(mat.ncols());
-        let mut transpositions: Vec<usize> = vec![0; size];
+        transpositions.clear();
+        transpositions.resize(size, 0);
         // Eigen passes one `temp` workspace through the whole sweep
         // (`m_temporary.resize(size)` at `:496`, then `temp.head(k)` at
         // `:336-338`); step `k` reads and writes its first `k` entries, so
         // hoisting it here changes no read and no write.
-        let mut temp: Vec<S> = vec![S::zero(); size];
-        // The trailing update's accumulators, one per row below the pivot.
-        let mut accumulator: Vec<S> = vec![S::zero(); size];
+        temp.clear();
+        temp.resize(size, S::zero());
+        accumulator.clear();
+        accumulator.resize(size, S::zero());
 
         for k in 0..size {
             // "Find largest diagonal element" (`:305-307`). `maxCoeff` reports
@@ -154,10 +213,7 @@ impl<S: LieScalar> EigenLdlt<S> {
                 for (j, entry) in transpositions.iter_mut().enumerate() {
                     *entry = j;
                 }
-                return Self {
-                    mat,
-                    transpositions,
-                };
+                return;
             }
 
             // `:359-360`. Eigen divides; it does not multiply by a reciprocal.
@@ -166,11 +222,6 @@ impl<S: LieScalar> EigenLdlt<S> {
                     mat[(i, k)] /= real_akk;
                 }
             }
-        }
-
-        Self {
-            mat,
-            transpositions,
         }
     }
 
@@ -327,11 +378,29 @@ impl<S: LieScalar> EigenLdlt<S> {
     /// factorizes the damped `H` and solves against the `b` that came out of
     /// the same `get_dense_H_b` (`sqrt_keypoint_vio.cpp:1393`, `:1419`), so the
     /// two agree by construction.
+    ///
+    /// Allocates its result; the shipped path calls [`Self::solve_vec_into`]
+    /// over a vector it keeps.
+    #[cfg(test)]
     pub(crate) fn solve_vec(&self, rhs: &DVector<S>) -> DVector<S> {
+        let mut dst: DVector<S> = DVector::zeros(rhs.nrows());
+        self.solve_vec_into(rhs, &mut dst);
+        dst
+    }
+
+    /// [`Self::solve_vec`] into a vector the caller keeps.
+    ///
+    /// `dst` is resized when it has to be and overwritten from `rhs` either
+    /// way, so its previous contents decide nothing.
+    pub(crate) fn solve_vec_into(&self, rhs: &DVector<S>, dst: &mut DVector<S>) {
         debug_assert_eq!(rhs.nrows(), self.transpositions.len());
-        let mut dst: DVector<S> = rhs.clone();
-        self.apply_transpositions_left_vec(&mut dst);
-        self.solve_unit_lower_in_place(&mut dst);
+        if dst.nrows() == rhs.nrows() {
+            dst.copy_from(rhs);
+        } else {
+            *dst = rhs.clone();
+        }
+        self.apply_transpositions_left_vec(dst);
+        self.solve_unit_lower_in_place(dst);
 
         let tolerance: S = S::min_positive();
         for i in 0..self.transpositions.len() {
@@ -343,9 +412,8 @@ impl<S: LieScalar> EigenLdlt<S> {
             }
         }
 
-        self.solve_unit_upper_in_place(&mut dst);
-        self.apply_transpositions_transpose_left_vec(&mut dst);
-        dst
+        self.solve_unit_upper_in_place(dst);
+        self.apply_transpositions_transpose_left_vec(dst);
     }
 }
 

--- a/packages/slam-rs/crates/slam-rs/src/eigen/ldlt.rs
+++ b/packages/slam-rs/crates/slam-rs/src/eigen/ldlt.rs
@@ -61,6 +61,8 @@ impl<S: LieScalar> EigenLdlt<S> {
         // `:336-338`); step `k` reads and writes its first `k` entries, so
         // hoisting it here changes no read and no write.
         let mut temp: Vec<S> = vec![S::zero(); size];
+        // The trailing update's accumulators, one per row below the pivot.
+        let mut accumulator: Vec<S> = vec![S::zero(); size];
 
         for k in 0..size {
             // "Find largest diagonal element" (`:305-307`). `maxCoeff` reports
@@ -112,12 +114,31 @@ impl<S: LieScalar> EigenLdlt<S> {
                 }
                 mat[(k, k)] -= diagonal; // `:337`
                 if rs > 0 {
-                    for i in (k + 1)..size {
-                        let mut sum: S = S::zero();
-                        for (j, entry) in temp.iter().enumerate() {
-                            sum += mat[(i, j)] * *entry;
+                    // `:338`, one accumulator per trailing row instead of one
+                    // fold per row.
+                    //
+                    // Eigen's expression is `A(k+1.., 0..k) * temp`, a
+                    // matrix-vector product whose every output coefficient sums
+                    // over `j`. Row `i`'s additions still happen in ascending
+                    // `j` — `j` is the outer loop, so each `acc[i]` is touched
+                    // once per `j`, in order — so no sum is reassociated; what
+                    // changes is that the coefficients are read down a column
+                    // of the column-major factor, contiguously, rather than
+                    // across a row at a stride of `nrows`.
+                    let column_stride: usize = mat.nrows();
+                    let acc: &mut [S] = &mut accumulator[..rs];
+                    acc.fill(S::zero());
+                    let data: &[S] = mat.as_slice();
+                    for (j, entry) in temp.iter().enumerate() {
+                        let factor: S = *entry;
+                        let base: usize = j * column_stride + k + 1;
+                        let trailing: &[S] = &data[base..base + rs];
+                        for (slot, value) in acc.iter_mut().zip(trailing.iter()) {
+                            *slot += *value * factor;
                         }
-                        mat[(i, k)] -= sum; // `:338`
+                    }
+                    for (i, sum) in acc.iter().enumerate() {
+                        mat[(k + 1 + i, k)] -= *sum;
                     }
                 }
             }

--- a/packages/slam-rs/crates/slam-rs/src/eigen/qr.rs
+++ b/packages/slam-rs/crates/slam-rs/src/eigen/qr.rs
@@ -297,14 +297,29 @@ pub(crate) fn apply_householder_on_the_left_block<S: LieScalar>(
         return;
     }
 
+    // `bottom` is `rows - 1` consecutive coefficients of each column, and a
+    // `DMatrix` is column-major, so it is one contiguous run per column. Both
+    // loops below walk it that way — through the slice rather than through
+    // `storage[(i, j)]`, which recomputes `j * nrows + i` and bounds-checks it
+    // per coefficient.
+    let nrows: usize = storage.nrows();
+    let tail: usize = rows - 1;
+    let essential: &[S] = &essential[..tail.min(essential.len())];
+
     // `tmp.noalias() = essential.adjoint() * bottom` (`:113`): one dot product
-    // per column, over the `rows - 1` rows below the first.
-    for (j, slot) in work.iter_mut().enumerate().take(cols) {
-        let mut acc: S = S::zero();
-        for (i, e) in essential.iter().enumerate().take(rows - 1) {
-            acc += *e * storage[(row_start + 1 + i, col_start + j)];
+    // per column, over the `rows - 1` rows below the first. The fold stays
+    // sequential and stays in this order — it is the one reduction here.
+    {
+        let data: &[S] = storage.as_slice();
+        for (j, slot) in work.iter_mut().enumerate().take(cols) {
+            let base: usize = (col_start + j) * nrows + row_start + 1;
+            let bottom: &[S] = &data[base..base + tail];
+            let mut acc: S = S::zero();
+            for (e, value) in essential.iter().zip(bottom.iter()) {
+                acc += *e * *value;
+            }
+            *slot = acc;
         }
-        *slot = acc;
     }
 
     // `tmp += this->row(0)` (`:114`).
@@ -320,10 +335,22 @@ pub(crate) fn apply_householder_on_the_left_block<S: LieScalar>(
     // `bottom.noalias() -= tau * essential * tmp` (`:116`): the outer product,
     // with the scalar folded into the left factor as C++'s left-associative
     // `*` does.
-    for (i, e) in essential.iter().enumerate().take(rows - 1) {
-        let scale: S = tau * *e;
-        for j in 0..cols {
-            storage[(row_start + 1 + i, col_start + j)] -= scale * work[j];
+    //
+    // Column outer, row inner. The product is elementwise — every coefficient
+    // is one `-= (tau * e_i) * tmp_j` and no coefficient is summed twice — so
+    // the loop order is free, and this one is the unit-stride one: `i` inner
+    // walks a column's contiguous run, where `j` inner strided by `nrows` and
+    // read a fresh cache line per coefficient. `tau * *e` is recomputed per
+    // column rather than hoisted into a scratch vector; it is the same product
+    // of the same two values, so the coefficient is unchanged.
+    {
+        let data: &mut [S] = storage.as_mut_slice();
+        for (j, &value) in work.iter().enumerate().take(cols) {
+            let base: usize = (col_start + j) * nrows + row_start + 1;
+            let bottom: &mut [S] = &mut data[base..base + tail];
+            for (target, e) in bottom.iter_mut().zip(essential.iter()) {
+                *target -= (tau * *e) * value;
+            }
         }
     }
 }

--- a/packages/slam-rs/crates/slam-rs/src/estimator/mod.rs
+++ b/packages/slam-rs/crates/slam-rs/src/estimator/mod.rs
@@ -116,6 +116,7 @@ use crate::types::{
     PoseVelBiasState, PoseVelBiasStateWithLin, PoseVelState, StateError, TimeCamId,
 };
 
+use optimize::OptimizeScratch;
 pub use optimize::{LmIteration, LmTermination};
 use schedule::MarginalizationOutcome;
 pub use schedule::{EvictionReason, KeyframeEviction, MarginalizationStats};
@@ -624,6 +625,16 @@ pub struct SqrtKeypointVio<S: LieScalar> {
     newest_imu_t_ns: Option<i64>,
     /// Frames the last marginalization removed, for [`Self::snapshot`].
     last_marginalized: Vec<FrameId>,
+
+    /// The buffers [`Self::optimize`]'s inner loop works in, kept across
+    /// frames.
+    ///
+    /// Not state: every one of them is reset or overwritten before it is read,
+    /// so an estimator that dropped and rebuilt them each frame would compute
+    /// the same numbers. They are held because the loop runs seven times on the
+    /// median MIO10 frame and each pass wanted a fresh `87x87` reduced system, a
+    /// damped copy of it and the reduction's subtree partials.
+    scratch: OptimizeScratch<S>,
 }
 
 /// Every live scalar the estimator's own arithmetic needs, checked before any
@@ -815,6 +826,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             pending: None,
             newest_imu_t_ns: None,
             last_marginalized: Vec::new(),
+            scratch: OptimizeScratch::default(),
         })
     }
 

--- a/packages/slam-rs/crates/slam-rs/src/estimator/optimize.rs
+++ b/packages/slam-rs/crates/slam-rs/src/estimator/optimize.rs
@@ -35,7 +35,9 @@ use crate::duration_ns;
 use crate::eigen::ldlt::EigenLdlt;
 use crate::imu::{ImuLinData, IntegratedImuMeasurement, Matrix9};
 use crate::lie::{LieScalar, eigen_maxi};
-use crate::linearize::{ImuInput, LinearizationAbsQR, LinearizationInputs, LinearizationOptions};
+use crate::linearize::{
+    DenseHbWorkspace, ImuInput, LinearizationAbsQR, LinearizationInputs, LinearizationOptions,
+};
 use crate::types::{
     AbsOrderMap, FrameId, POSE_SIZE, POSE_VEL_BIAS_SIZE, PoseVelBiasState, PoseVelBiasStateWithLin,
     Vector9, Vector15,
@@ -43,6 +45,31 @@ use crate::types::{
 
 /// `max_num_iter` for the damped solve (`:1408`).
 const MAX_SOLVE_ATTEMPTS: u32 = 3;
+
+/// Everything one `optimize` call works in that outlives the call.
+///
+/// The estimator holds one and hands it to the loop, so the buffers survive
+/// from frame to frame; they are reset or fully overwritten before each read,
+/// which is what makes holding them a change of allocation and not of
+/// arithmetic. Kept as a struct rather than as loose fields so
+/// [`super::SqrtKeypointVio`] has one thing to name and the destructuring at
+/// the top of [`SqrtKeypointVio::optimize`] stays one line.
+#[derive(Debug, Clone)]
+pub(super) struct OptimizeScratch<S: LieScalar> {
+    /// The dense reduction's accumulator, subtree partials and leaf transpose.
+    pub(super) dense: DenseHbWorkspace<S>,
+}
+
+impl<S: LieScalar> Default for OptimizeScratch<S> {
+    /// Empty buffers, sized on the first call. Written out rather than derived:
+    /// `#[derive(Default)]` would demand `S: Default`, which `LieScalar` does
+    /// not.
+    fn default() -> Self {
+        Self {
+            dense: DenseHbWorkspace::default(),
+        }
+    }
+}
 
 /// The two hard-coded convergence constants of `:1566`, which are **not**
 /// config fields.
@@ -152,12 +179,14 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         let Self {
             ref mut ba,
             ref mut damping,
+            ref mut scratch,
             ref marg_data,
             ref imu_meas,
             ref ltkfs,
             ref config,
             ..
         } = *self;
+        let OptimizeScratch { ref mut dense } = *scratch;
 
         // `:1221-1242`: poses first, then states, both in ascending timestamp
         // order, and each entry checked against the prior's. C++ reads the prior
@@ -242,7 +271,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             while it <= config.vio_max_iterations && termination.is_none() {
                 let mark: std::time::Instant = std::time::Instant::now();
                 // `:1393`.
-                let (mut h, mut b) = lqr.get_dense_h_b(ba, &inputs)?;
+                let (h, b) = lqr.get_dense_h_b_into(ba, &inputs, dense)?;
                 // The reduced system is the ordering's: every `(idx, size)` in
                 // `aom` is a block of it, and every frame of the two maps has
                 // an entry, because `aom` was built from those maps above and

--- a/packages/slam-rs/crates/slam-rs/src/estimator/optimize.rs
+++ b/packages/slam-rs/crates/slam-rs/src/estimator/optimize.rs
@@ -58,6 +58,10 @@ const MAX_SOLVE_ATTEMPTS: u32 = 3;
 pub(super) struct OptimizeScratch<S: LieScalar> {
     /// The dense reduction's accumulator, subtree partials and leaf transpose.
     pub(super) dense: DenseHbWorkspace<S>,
+    /// The damped solve's factorization, its working copy and the increment.
+    pub(super) solve: EigenLdlt<S>,
+    /// The increment [`damped_solve`] writes and the loop then negates.
+    pub(super) increment: DVector<S>,
 }
 
 impl<S: LieScalar> Default for OptimizeScratch<S> {
@@ -67,6 +71,8 @@ impl<S: LieScalar> Default for OptimizeScratch<S> {
     fn default() -> Self {
         Self {
             dense: DenseHbWorkspace::default(),
+            solve: EigenLdlt::empty(),
+            increment: DVector::zeros(0),
         }
     }
 }
@@ -186,7 +192,11 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             ref config,
             ..
         } = *self;
-        let OptimizeScratch { ref mut dense } = *scratch;
+        let OptimizeScratch {
+            ref mut dense,
+            ref mut solve,
+            ref mut increment,
+        } = *scratch;
 
         // `:1221-1242`: poses first, then states, both in ascending timestamp
         // order, and each entry checked against the prior's. C++ reads the prior
@@ -303,8 +313,8 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
                 }
 
                 // `:1408-1430`.
-                let (mut inc, inc_valid, solve_attempts): (DVector<S>, bool, u32) =
-                    damped_solve(&h, &b, damping);
+                let (inc_valid, solve_attempts): (bool, u32) =
+                    damped_solve(h, b, damping, solve, increment);
                 // `:1432`: C++ warns and carries on with the non-finite increment.
                 if !inc_valid {
                     log::warn!(
@@ -318,8 +328,9 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
 
                 // `:1447-1454`, D13: negate, then back-substitute.
                 let mark: std::time::Instant = std::time::Instant::now();
-                inc = -inc;
-                let l_diff: S = lqr.back_substitute(ba, &inputs, &inc)?;
+                increment.neg_mut();
+                let inc: &DVector<S> = increment;
+                let l_diff: S = lqr.back_substitute(ba, &inputs, inc)?;
                 timings.back_substitution_ns += duration_ns(mark);
 
                 // `:1466-1474`.
@@ -460,7 +471,9 @@ fn damped_solve<S: LieScalar>(
     h: &DMatrix<S>,
     b: &DVector<S>,
     damping: &mut LmDamping<S>,
-) -> (DVector<S>, bool, u32) {
+    ldlt: &mut EigenLdlt<S>,
+    inc: &mut DVector<S>,
+) -> (bool, u32) {
     let size: usize = h.nrows();
     let mut solve_attempts: u32 = 0;
     // `MAX_SOLVE_ATTEMPTS` is three, so the first solve always happens and the
@@ -468,21 +481,28 @@ fn damped_solve<S: LieScalar>(
     loop {
         // `:1415-1417`. `cwiseMax` is `numext::maxi`, so a NaN on the left
         // survives where `f32::max` would drop it.
-        let mut h_copy: DMatrix<S> = h.clone();
+        //
+        // Eigen factorizes in place over a copy of `H`; the copy is the
+        // factorization's own working buffer, written here rather than cloned,
+        // so a frame's three attempts share one `87x87` allocation instead of
+        // taking a fresh one each.
+        let copy: &mut DMatrix<S> = ldlt.working_copy(size);
+        copy.copy_from(h);
         for i in 0..size {
             let damped: S = eigen_maxi(h[(i, i)] * damping.lambda, damping.min_lambda);
-            h_copy[(i, i)] += damped;
+            copy[(i, i)] += damped;
         }
         // `:1419-1420`.
-        let inc: DVector<S> = EigenLdlt::new(h_copy).solve_vec(b);
+        ldlt.factor();
+        ldlt.solve_vec_into(b, inc);
         solve_attempts += 1;
         if inc.iter().all(|v| v.is_finite()) {
-            return (inc, true, solve_attempts);
+            return (true, solve_attempts);
         }
         damping.lambda = damping.lambda_vee * damping.lambda;
         damping.lambda_vee *= S::from_literal(VEE_FACTOR);
         if solve_attempts >= MAX_SOLVE_ATTEMPTS {
-            return (inc, false, solve_attempts);
+            return (false, solve_attempts);
         }
     }
 }
@@ -619,7 +639,9 @@ mod tests {
         let h: DMatrix<f64> = DMatrix::identity(3, 3);
         let b: DVector<f64> = DVector::from_element(3, 1.0);
         let mut lm: LmDamping<f64> = damping(1e-4, 1e-32);
-        let (inc, valid, attempts) = damped_solve(&h, &b, &mut lm);
+        let mut ldlt: EigenLdlt<f64> = EigenLdlt::empty();
+        let mut inc: DVector<f64> = DVector::zeros(0);
+        let (valid, attempts) = damped_solve(&h, &b, &mut lm, &mut ldlt, &mut inc);
         assert!(valid);
         assert_eq!(attempts, 1);
         assert!(inc.iter().all(|v| v.is_finite()));
@@ -640,7 +662,9 @@ mod tests {
         let b: DVector<f64> = DVector::from_vec(vec![1.0, f64::NAN, 1.0]);
         let mut lm: LmDamping<f64> = damping(1e-4, 1e-32);
 
-        let (inc, valid, attempts) = damped_solve(&h, &b, &mut lm);
+        let mut ldlt: EigenLdlt<f64> = EigenLdlt::empty();
+        let mut inc: DVector<f64> = DVector::zeros(0);
+        let (valid, attempts) = damped_solve(&h, &b, &mut lm, &mut ldlt, &mut inc);
         assert!(!valid, "a NaN right-hand side has to fail: {inc:?}");
         assert_eq!(attempts, MAX_SOLVE_ATTEMPTS);
         assert_eq!(lm.lambda, 1e-4 * 64.0);
@@ -664,7 +688,9 @@ mod tests {
             lambda_vee: VEE_FACTOR as f32,
         };
 
-        let (inc, valid, attempts) = damped_solve(&h, &b, &mut lm);
+        let mut ldlt: EigenLdlt<f32> = EigenLdlt::empty();
+        let mut inc: DVector<f32> = DVector::zeros(0);
+        let (valid, attempts) = damped_solve(&h, &b, &mut lm, &mut ldlt, &mut inc);
         assert!(valid);
         assert_eq!(attempts, 2);
         assert!(inc[0].is_finite());

--- a/packages/slam-rs/crates/slam-rs/src/linearize/abs_qr.rs
+++ b/packages/slam-rs/crates/slam-rs/src/linearize/abs_qr.rs
@@ -141,6 +141,7 @@ pub struct LinearizationAbsQR<S: LieScalar> {
 /// a skipped write would have changed exists. A block whose own columns are not
 /// the identity to skip — [`LandmarkBlock::active_writeback_is_exact`] — is
 /// added at full width instead.
+#[derive(Debug, Clone)]
 struct DensePartial<S: LieScalar> {
     /// The partial `H`, full size, zero outside `columns` x `columns`.
     h: DMatrix<S>,
@@ -160,6 +161,27 @@ impl<S: LieScalar> DensePartial<S> {
             b: DVector::zeros(n),
             written: vec![false; n],
             columns: Vec::with_capacity(n),
+        }
+    }
+
+    /// Back to the identity for an `n`-column ordering, reusing the buffers.
+    ///
+    /// [`Reducible::reset`] is the cheaper reset and is what the reduction's own
+    /// subtree buffers take; this one zeroes the whole square, because the
+    /// accumulator the reduction hands back is written by three more parties —
+    /// the IMU blocks, the marginalization prior and the caller that pins a
+    /// fixed keyframe's rows — none of which record the columns they touched.
+    /// The window's landmarks cover nearly every column of the ordering
+    /// anyway, so on the frame that matters the two resets zero the same
+    /// square; what this saves is the allocation, not the memset.
+    fn reset_sized(&mut self, n: usize) {
+        if self.b.nrows() == n {
+            self.h.fill(S::zero());
+            self.b.fill(S::zero());
+            self.columns.clear();
+            self.written.fill(false);
+        } else {
+            *self = Self::zeros(n);
         }
     }
 
@@ -242,6 +264,55 @@ impl<S: LieScalar> Reducible for DensePartial<S> {
             self.b[j] += right.b[j];
         }
         self.mark(right.columns.iter().copied());
+    }
+}
+
+/// The buffers [`LinearizationAbsQR::get_dense_h_b_into`] reduces in, held
+/// across calls and across frames.
+///
+/// One call over `n` landmark blocks needs the accumulator it returns plus
+/// `ceil(log2 n)` subtree partials, each a full `opt_size` square, and the
+/// linearizer's own leaf scratch: seven `87x87` `f32` matrices on the median
+/// MIO10 frame. The Levenberg-Marquardt loop calls it **once per inner step** —
+/// seven times on that frame — and every one of those buffers is either zeroed
+/// on entry ([`DensePartial::reset_sized`]) or reset by the reduction before a
+/// leaf writes it ([`Reducible::reset`], which restores exactly `+0.0` over the
+/// columns that were written), so a buffer that persists is the same
+/// arithmetic on the same values.
+///
+/// The window changes size, so the buffers are keyed on `opt_size` and dropped
+/// when it moves; that happens when a keyframe enters or leaves, not per frame.
+#[derive(Debug, Clone)]
+pub struct DenseHbWorkspace<S: LieScalar> {
+    /// What the reduction accumulates into and the caller reads.
+    accumulator: DensePartial<S>,
+    /// One subtree partial per recursion depth, as `deterministic_reduce` wants
+    /// them.
+    depths: Vec<Option<DensePartial<S>>>,
+    /// The per-block transpose buffer of [`LandmarkBlock::add_dense_h_b`].
+    leaf: DenseHbScratch<S>,
+}
+
+impl<S: LieScalar> Default for DenseHbWorkspace<S> {
+    fn default() -> Self {
+        Self {
+            accumulator: DensePartial::zeros(0),
+            depths: Vec::new(),
+            leaf: DenseHbScratch::default(),
+        }
+    }
+}
+
+impl<S: LieScalar> DenseHbWorkspace<S> {
+    /// Every buffer at the identity for an `n`-column ordering.
+    fn prepare(&mut self, n: usize) {
+        if self.accumulator.b.nrows() != n {
+            // A subtree partial is only ever built by `identity_like` off the
+            // accumulator, so dropping them here is what keeps the two agreeing
+            // on the ordering's width.
+            self.depths.clear();
+        }
+        self.accumulator.reset_sized(n);
     }
 }
 
@@ -555,32 +626,54 @@ impl<S: LieScalar> LinearizationAbsQR<S> {
         estimator: &BundleAdjustmentBase<S>,
         inputs: &LinearizationInputs<'_, S>,
     ) -> Result<(DMatrix<S>, DVector<S>), LinearizeError> {
+        let mut workspace: DenseHbWorkspace<S> = DenseHbWorkspace::default();
+        let (h, b) = self.get_dense_h_b_into(estimator, inputs, &mut workspace)?;
+        Ok((h.clone(), b.clone()))
+    }
+
+    /// [`Self::get_dense_h_b`] into buffers the caller keeps.
+    ///
+    /// The reduced system is the workspace's own accumulator, handed back by
+    /// reference: the Levenberg-Marquardt loop builds one per inner step and
+    /// throws it away, so nothing wants an owned copy. The caller may write
+    /// into both — `sqrt_keypoint_vio.cpp:1395-1406` pins a fixed keyframe's
+    /// rows in place — because the next call zeroes the whole square rather
+    /// than only the columns the reduction recorded.
+    pub fn get_dense_h_b_into<'w>(
+        &self,
+        estimator: &BundleAdjustmentBase<S>,
+        inputs: &LinearizationInputs<'_, S>,
+        workspace: &'w mut DenseHbWorkspace<S>,
+    ) -> Result<(&'w mut DMatrix<S>, &'w mut DVector<S>), LinearizeError> {
         let opt_size: usize = self.aom.total_size();
-        let mut accumulator: DensePartial<S> = DensePartial::zeros(opt_size);
-        let mut scratch: Vec<Option<DensePartial<S>>> = Vec::new();
+        workspace.prepare(opt_size);
+        let DenseHbWorkspace {
+            accumulator,
+            depths,
+            leaf,
+        } = workspace;
         let blocks: &[LandmarkBlock<S>] = &self.landmark_blocks;
-        let mut leaf_scratch: DenseHbScratch<S> = DenseHbScratch::default();
         deterministic_reduce::<DensePartial<S>, LinearizeError>(
             blocks.len(),
-            &mut accumulator,
-            &mut scratch,
+            accumulator,
+            depths,
             &mut |i: usize, acc: &mut DensePartial<S>| {
                 let block: &LandmarkBlock<S> =
                     blocks.get(i).ok_or(LinearizeError::LayoutOverflow)?;
-                acc.accumulate(block, &mut leaf_scratch)
+                acc.accumulate(block, leaf)
             },
         )?;
-        let DensePartial { mut h, mut b, .. } = accumulator;
+        let DensePartial { h, b, .. } = accumulator;
 
         // `add_dense_H_b_imu` (`:640-653`).
         for (block, meta) in self.imu_blocks.iter().zip(self.imu_meta.iter()) {
-            block.add_dense_h_b(meta.start_idx, meta.end_idx, &mut h, &mut b);
+            block.add_dense_h_b(meta.start_idx, meta.end_idx, h, b);
         }
 
         // `add_dense_H_b_marg_prior` (`:600-631`). `:595-598`'s pose-damping
         // diagonal is not here: nothing sets it (D68).
         if let Some(marg) = inputs.marg {
-            estimator.linearize_marg_prior(marg, &self.aom, &mut h, &mut b)?;
+            estimator.linearize_marg_prior(marg, &self.aom, h, b)?;
         }
 
         Ok((h, b))

--- a/packages/slam-rs/crates/slam-rs/src/linearize/abs_qr.rs
+++ b/packages/slam-rs/crates/slam-rs/src/linearize/abs_qr.rs
@@ -151,6 +151,20 @@ struct DensePartial<S: LieScalar> {
     written: Vec<bool>,
     /// The same set ascending, which is the order `h`'s column-major storage wants.
     columns: Vec<usize>,
+    /// The same set again as `(start, length)` runs of consecutive columns.
+    ///
+    /// [`Reducible::reset`] and [`Reducible::join`] between them are the whole
+    /// cost of the reduction's interior — 54 joins and 54 resets over 55
+    /// landmark blocks — and both touch `columns` x `columns` of a column-major
+    /// square. Walking `columns` reaches every coefficient through a `usize`
+    /// out of a `Vec`, which LLVM has to treat as a gather, plus a bounds check
+    /// per coefficient. The set is almost never scattered: a landmark's own
+    /// columns are two runs of six, and a subtree's union saturates towards the
+    /// contiguous `0..opt_size`. Holding the runs turns both operations into
+    /// slice work on `h`'s own storage. It is the same set, so the same
+    /// coefficients are touched, and both operations are elementwise, so no sum
+    /// is reassociated.
+    runs: Vec<(usize, usize)>,
 }
 
 impl<S: LieScalar> DensePartial<S> {
@@ -161,6 +175,7 @@ impl<S: LieScalar> DensePartial<S> {
             b: DVector::zeros(n),
             written: vec![false; n],
             columns: Vec::with_capacity(n),
+            runs: Vec::new(),
         }
     }
 
@@ -179,6 +194,7 @@ impl<S: LieScalar> DensePartial<S> {
             self.h.fill(S::zero());
             self.b.fill(S::zero());
             self.columns.clear();
+            self.runs.clear();
             self.written.fill(false);
         } else {
             *self = Self::zeros(n);
@@ -201,8 +217,18 @@ impl<S: LieScalar> DensePartial<S> {
         }
         if added {
             self.columns.clear();
-            self.columns
-                .extend((0..self.written.len()).filter(|&i| self.written[i]));
+            self.runs.clear();
+            for column in 0..self.written.len() {
+                if !self.written[column] {
+                    continue;
+                }
+                self.columns.push(column);
+                match self.runs.last_mut() {
+                    // Consecutive with the run being built, so extend it.
+                    Some((start, length)) if *start + *length == column => *length += 1,
+                    _ => self.runs.push((column, 1)),
+                }
+            }
         }
     }
 
@@ -245,23 +271,61 @@ impl<S: LieScalar> Reducible for DensePartial<S> {
 
     /// Back to the identity, zeroing only what was written.
     fn reset(&mut self) {
-        for &j in &self.columns {
-            for &i in &self.columns {
-                self.h[(i, j)] = S::zero();
+        let stride: usize = self.h.nrows();
+        {
+            let h: &mut [S] = self.h.as_mut_slice();
+            for &(first_col, cols) in &self.runs {
+                for column in first_col..(first_col + cols) {
+                    let base: usize = column * stride;
+                    for &(first_row, rows) in &self.runs {
+                        h[(base + first_row)..(base + first_row + rows)].fill(S::zero());
+                    }
+                }
             }
-            self.b[j] = S::zero();
+        }
+        {
+            let b: &mut [S] = self.b.as_mut_slice();
+            for &(first, length) in &self.runs {
+                b[first..(first + length)].fill(S::zero());
+            }
         }
         self.columns.clear();
+        self.runs.clear();
         self.written.fill(false);
     }
 
     /// `H_ += b.H_; b_ += b.b_` (`:532-535`), over the right side's columns.
     fn join(&mut self, right: &Self) {
-        for &j in &right.columns {
-            for &i in &right.columns {
-                self.h[(i, j)] += right.h[(i, j)];
+        debug_assert_eq!(self.h.nrows(), right.h.nrows());
+        let stride: usize = self.h.nrows();
+        {
+            let destination: &mut [S] = self.h.as_mut_slice();
+            let source: &[S] = right.h.as_slice();
+            for &(first_col, cols) in &right.runs {
+                for column in first_col..(first_col + cols) {
+                    let base: usize = column * stride;
+                    for &(first_row, rows) in &right.runs {
+                        let lo: usize = base + first_row;
+                        let target: &mut [S] = &mut destination[lo..(lo + rows)];
+                        for (slot, value) in target.iter_mut().zip(source[lo..(lo + rows)].iter()) {
+                            *slot += *value;
+                        }
+                    }
+                }
             }
-            self.b[j] += right.b[j];
+        }
+        {
+            let destination: &mut [S] = self.b.as_mut_slice();
+            let source: &[S] = right.b.as_slice();
+            for &(first, length) in &right.runs {
+                let target: &mut [S] = &mut destination[first..(first + length)];
+                for (slot, value) in target
+                    .iter_mut()
+                    .zip(source[first..(first + length)].iter())
+                {
+                    *slot += *value;
+                }
+            }
         }
         self.mark(right.columns.iter().copied());
     }

--- a/packages/slam-rs/crates/slam-rs/src/linearize/landmark_block.rs
+++ b/packages/slam-rs/crates/slam-rs/src/linearize/landmark_block.rs
@@ -49,7 +49,18 @@ impl<S: LieScalar> Default for LandmarkBlockOptions<S> {
     }
 }
 
-/// The buffers [`LandmarkBlock::add_dense_h_b`] works in, reused across blocks.
+/// How many coefficients of one row of `H` are accumulated at a time.
+///
+/// The accumulator is a fixed-size array rather than a slice of the scratch
+/// buffer for two reasons, and both decide whether the loop vectorises: its
+/// length is a constant, so the body unrolls with no runtime trip count and no
+/// scalar tail, and it is a local, so the compiler can see that writing it
+/// cannot change the row it is reading. Written against `Q2Jp` — two pose
+/// blocks of six columns plus the residual on the median frame — eight is one
+/// SSE pair and holds a whole pose block plus its neighbour.
+const LANES: usize = 8;
+
+/// The buffer [`LandmarkBlock::add_dense_h_b`] works in, reused across blocks.
 ///
 /// `H += Q2Jp^T Q2Jp` is a dot product per coefficient down two columns of
 /// `storage`, and an `f32` sum cannot be reassociated, so the reduction over
@@ -60,18 +71,14 @@ impl<S: LieScalar> Default for LandmarkBlockOptions<S> {
 #[derive(Debug, Clone)]
 pub struct DenseHbScratch<S: LieScalar> {
     /// The `Q2` rows of `storage` over the written columns then the residual,
-    /// row-major so one row is contiguous.
+    /// row-major so one row is contiguous, and padded to a whole number of
+    /// [`LANES`] with `+0.0`.
     rows: Vec<S>,
-    /// One row of `H` plus its `b`, one coefficient per written column.
-    acc: Vec<S>,
 }
 
 impl<S: LieScalar> Default for DenseHbScratch<S> {
     fn default() -> Self {
-        Self {
-            rows: Vec::new(),
-            acc: Vec::new(),
-        }
+        Self { rows: Vec::new() }
     }
 }
 
@@ -859,34 +866,51 @@ impl<S: LieScalar> LandmarkBlock<S> {
         let rows: usize = self.num_q2rows();
         let live: usize = columns.len();
         // `[ the columns | the residual ]`, one contiguous row per `Q2` row;
-        // see [`DenseHbScratch`] for why the transpose is worth its copy.
+        // see [`DenseHbScratch`] for why the transpose is worth its copy. The
+        // row is padded to a whole number of [`LANES`] so every chunk below is
+        // a full one; the padding is `+0.0`, contributes `factor * 0.0` to a
+        // coefficient nothing reads, and is never written back.
         let width: usize = live + 1;
+        let stride: usize = width.div_ceil(LANES) * LANES;
         scratch.rows.clear();
-        scratch.rows.resize(rows * width, S::zero());
+        scratch.rows.resize(rows * stride, S::zero());
         for (slot, &column) in columns.iter().enumerate() {
             for r in 0..rows {
-                scratch.rows[r * width + slot] = self.storage[(3 + r, column)];
+                scratch.rows[r * stride + slot] = self.storage[(3 + r, column)];
             }
         }
         for r in 0..rows {
-            scratch.rows[r * width + live] = self.storage[(3 + r, self.res_idx)];
+            scratch.rows[r * stride + live] = self.storage[(3 + r, self.res_idx)];
         }
 
-        scratch.acc.clear();
-        scratch.acc.resize(width, S::zero());
+        let transposed: &[S] = &scratch.rows;
         for (slot, &i) in columns.iter().enumerate() {
-            scratch.acc.fill(S::zero());
-            for r in 0..rows {
-                let row: &[S] = &scratch.rows[r * width..(r + 1) * width];
-                let factor: S = row[slot];
-                for (acc, &value) in scratch.acc.iter_mut().zip(row.iter()) {
-                    *acc += factor * value;
+            for lo in (0..stride).step_by(LANES) {
+                // One row of `H` over `LANES` of its columns. Every coefficient
+                // still sums over the `Q2` rows in ascending row order — `r` is
+                // the loop below and each lane is touched once per row — so
+                // this is the same sum as one accumulator per column was, in
+                // the same order, over `LANES` columns at a time.
+                let mut partial: [S; LANES] = [S::zero(); LANES];
+                for r in 0..rows {
+                    let row: &[S] = &transposed[(r * stride)..((r + 1) * stride)];
+                    let factor: S = row[slot];
+                    let source: &[S] = &row[lo..(lo + LANES)];
+                    for (accumulator, &value) in partial.iter_mut().zip(source.iter()) {
+                        *accumulator += factor * value;
+                    }
+                }
+                let end: usize = (lo + LANES).min(width);
+                for (offset, &value) in partial.iter().enumerate().take(end - lo) {
+                    let j: usize = lo + offset;
+                    if j < live {
+                        h[(i, columns[j])] += value;
+                    } else {
+                        // `j == live`: the residual column.
+                        b[i] += value;
+                    }
                 }
             }
-            for (&j, &acc) in columns.iter().zip(scratch.acc.iter()) {
-                h[(i, j)] += acc;
-            }
-            b[i] += scratch.acc[live];
         }
     }
 

--- a/packages/slam-rs/crates/slam-rs/src/linearize/landmark_block.rs
+++ b/packages/slam-rs/crates/slam-rs/src/linearize/landmark_block.rs
@@ -57,7 +57,7 @@ impl<S: LieScalar> Default for LandmarkBlockOptions<S> {
 /// of one per coefficient turns the inner loop into `acc[j] += t * row[j]`,
 /// which each accumulator still walks in row order — the same additions in the
 /// same order — and which vectorises, where the dot product does not.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DenseHbScratch<S: LieScalar> {
     /// The `Q2` rows of `storage` over the written columns then the residual,
     /// row-major so one row is contiguous.

--- a/packages/slam-rs/crates/slam-rs/src/linearize/mod.rs
+++ b/packages/slam-rs/crates/slam-rs/src/linearize/mod.rs
@@ -46,7 +46,9 @@ mod abs_qr;
 mod landmark_block;
 mod reduce;
 
-pub use abs_qr::{ImuInput, LinearizationAbsQR, LinearizationInputs, LinearizationOptions};
+pub use abs_qr::{
+    DenseHbWorkspace, ImuInput, LinearizationAbsQR, LinearizationInputs, LinearizationOptions,
+};
 pub use landmark_block::{DenseHbScratch, LandmarkBlock, LandmarkBlockOptions, LandmarkBlockState};
 
 /// `reduce::deterministic_reduce_scalar` with the error type erased, so the

--- a/packages/slam-rs/crates/slam-rs/tests/frame_allocations.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/frame_allocations.rs
@@ -703,7 +703,7 @@ fn the_estimators_per_frame_cost_does_not_grow_with_the_lm_step_count() {
     assert!(
         slope <= CALLS_PER_STEP,
         "the estimator reaches the allocator {slope:.1} times per LM step, over the \
-         {CALLS_PER_STEP} the per-step path is allowed: a buffer the loop used to \
-         allocate per step is being allocated again"
+         {CALLS_PER_STEP} the per-step path is allowed: the inner LM step allocates \
+         noticeably more than it did (this is a bulk gate; one small buffer can hide under it)"
     );
 }

--- a/packages/slam-rs/crates/slam-rs/tests/frame_allocations.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/frame_allocations.rs
@@ -1,4 +1,8 @@
-//! What the frontend's per-frame path asks of the allocator, counted.
+//! What the per-frame paths ask of the allocator, counted.
+//!
+//! The frontend's first, then the estimator's: same counting allocator, same
+//! thread-scoped gate, and in both cases a claim that had to be measured
+//! rather than asserted in a comment.
 //!
 //! `cubecl-portability.md` §12.2 asks for no allocation on the per-frame path,
 //! because a GPU kernel cannot grow a buffer and because an allocator call
@@ -461,5 +465,245 @@ fn a_restored_frame_costs_no_more_than_a_successful_one() {
     assert_eq!(
         counts[2], 0,
         "a warm restore cost {counts:?} allocator calls"
+    );
+}
+
+// ── the estimator's per-frame path ────────────────────────────────────────
+
+/// Framesets the oracle fixture covers; the estimator walks all of them.
+const ESTIMATOR_FRAMESETS: usize = 60;
+
+/// Framesets before the first measurement.
+///
+/// `opt_started` flips at frameset 4, the second keyframe arrives at 7 and the
+/// prior reaches its 22x27 shape at 9, so by 20 the window is at its steady
+/// shape and every scratch buffer has reached its high-water mark.
+const ESTIMATOR_WARMUP: usize = 20;
+
+/// One estimator over the oracle fixture's calibration and config, with the
+/// whole inertial window pushed in advance — `vio_oracle::window`, which the
+/// integration tests cannot share because each has its own binary.
+fn estimator_window() -> slam_rs::estimator::SqrtKeypointVio<f32> {
+    let mut estimator: slam_rs::estimator::SqrtKeypointVio<f32> =
+        slam_rs::estimator::SqrtKeypointVio::with_default_gravity(
+            common::calibration().cast(),
+            common::config(),
+        )
+        .unwrap();
+    for row in common::IMU.iter() {
+        estimator.push_imu(slam_rs::imu::ImuSample {
+            t_ns: row.t_ns,
+            gyro: nalgebra::Vector3::from(row.gyro),
+            accel: nalgebra::Vector3::from(row.accel),
+        });
+    }
+    estimator
+}
+
+/// The dense reduction over a workspace that persists: zero, after the first.
+///
+/// This is the estimator's hottest allocation site made visible on its own.
+/// `get_dense_h_b` runs **once per inner Levenberg-Marquardt step** — two to
+/// eight times per frameset on this window, seven on the median MIO10 frame —
+/// and it used to take a fresh accumulator, a fresh subtree partial per
+/// recursion depth and a fresh leaf transpose every time: on a 55-landmark
+/// window seven `opt_size`-square matrices, or 38 allocations and their frees,
+/// per step. They are one `DenseHbWorkspace` now, and the assertion is that
+/// the second call over the same workspace reaches the allocator zero times.
+///
+/// The problem below is synthetic and small — three frames, twelve landmarks,
+/// each seen in every frame — because the count being asserted is zero and
+/// zero does not depend on the window's size. What it does need is a window
+/// whose reduction actually recurses, so the subtree partials at every depth
+/// are allocated on the first call and reused on the second.
+#[test]
+fn the_dense_reduction_allocates_nothing_after_its_first_call() {
+    let mut calibration: slam_rs::calib::Calibration<f32> = common::calibration().cast::<f32>();
+    calibration.t_i_c.truncate(2);
+    calibration.intrinsics.truncate(2);
+    let mut estimator: slam_rs::ba_base::BundleAdjustmentBase<f32> =
+        slam_rs::ba_base::BundleAdjustmentBase::new(calibration, 1.0, 1.0).unwrap();
+
+    let frames: [i64; 3] = [0, 1, 2];
+    let mut aom: slam_rs::types::AbsOrderMap = slam_rs::types::AbsOrderMap::new();
+    for (index, &t_ns) in frames.iter().enumerate() {
+        let pose: slam_rs::lie::Se3<f32> = slam_rs::lie::Se3::new(
+            slam_rs::lie::So3::identity(),
+            nalgebra::Vector3::new(0.01 * index as f32, 0.0, 0.0),
+        );
+        estimator.frame_poses.insert(
+            t_ns,
+            slam_rs::types::PoseStateWithLin::new(t_ns, pose, false),
+        );
+        aom.push(t_ns, slam_rs::types::POSE_SIZE).unwrap();
+    }
+
+    let host: slam_rs::types::TimeCamId = slam_rs::types::TimeCamId::new(frames[0], 0);
+    for index in 0..12u64 {
+        let id: slam_rs::types::LandmarkId = slam_rs::types::LandmarkId(index);
+        let direction: nalgebra::Vector2<f32> =
+            nalgebra::Vector2::new(0.01 * index as f32 - 0.05, -0.02);
+        let landmark: slam_rs::landmark::Landmark<f32> =
+            slam_rs::landmark::Landmark::new(id, host, direction, 0.25);
+        estimator.lmdb.add_landmark(id, &landmark);
+        for &t_ns in &frames {
+            estimator
+                .lmdb
+                .add_observation(
+                    slam_rs::types::TimeCamId::new(t_ns, 0),
+                    id,
+                    nalgebra::Vector2::new(500.0 + index as f32, 510.0),
+                )
+                .unwrap();
+        }
+    }
+
+    let inputs: slam_rs::linearize::LinearizationInputs<'_, f32> = Default::default();
+    let mut lqr: slam_rs::linearize::LinearizationAbsQR<f32> =
+        slam_rs::linearize::LinearizationAbsQR::new(
+            &estimator,
+            &aom,
+            slam_rs::linearize::LinearizationOptions::default(),
+            &inputs,
+        )
+        .unwrap();
+    lqr.linearize_problem(&estimator, &inputs).unwrap();
+    lqr.perform_qr().unwrap();
+
+    let mut workspace: slam_rs::linearize::DenseHbWorkspace<f32> = Default::default();
+    // The first call is allowed to allocate, and does: this is where every
+    // buffer reaches its size.
+    let (_, first) = measure(|| {
+        let _ = lqr
+            .get_dense_h_b_into(&estimator, &inputs, &mut workspace)
+            .unwrap();
+    });
+    for repeat in 0..3 {
+        let (_, again) = measure(|| {
+            let _ = lqr
+                .get_dense_h_b_into(&estimator, &inputs, &mut workspace)
+                .unwrap();
+        });
+        assert_eq!(
+            again.total(),
+            0,
+            "call {} over a warm workspace cost {again:?} (the first cost {first:?})",
+            repeat + 2,
+        );
+    }
+    println!("dense reduction: first call {first:?}, then zero");
+}
+
+/// What one steady-state frameset costs the estimator, and how that cost grows
+/// with the number of Levenberg-Marquardt steps it takes.
+///
+/// A frameset is **not** allocation-free and is not claimed to be: the landmark
+/// database is `BTreeMap`-shaped and every new observation can split a node,
+/// the LM trail is a `Vec<LmIteration>` inside a boxed `FrameStats`, and the
+/// marginalization builds its own square-root system — which on this window is
+/// every steady-state frameset, all forty of them marginalize. Measured here:
+/// 805 to 1,389 allocator calls, and the bound below is that with room.
+///
+/// The second assertion is the one that measures **this** change. The inner LM
+/// loop runs two to eight times per frameset (seven on the median MIO10 frame)
+/// and each pass used to take a fresh set of buffers:
+///
+/// | per inner step | allocations |
+/// |---|---:|
+/// | the dense reduction's accumulator (`DMatrix`, `DVector`, two `Vec`s) | 4 |
+/// | one subtree partial per recursion depth, `ceil(log2 55) = 6` | 24 |
+/// | the depth vector itself, grown to six | ~3 |
+/// | the leaf transpose buffers | 2 |
+/// | `h.clone()` per damping attempt | 1 |
+/// | `EigenLdlt`'s transpositions, `temp` and accumulator | 3 |
+/// | the right-hand side clone inside the solve | 1 |
+///
+/// All of them are now buffers the estimator owns and resets. Measured on this
+/// fixture, with the layout commits in and the pooling out (`9a248147`) and
+/// then with the pooling in: **126.8 allocator calls per LM step and 1,531 per
+/// frameset, down to 59.5 and 1,133**. What is left per step is
+/// `compute_delta` and the prior's `H · delta`, once each, and the IMU blocks.
+///
+/// The gate is a slope as well as a total, because the total is dominated by
+/// the per-frame database work: a per-step buffer coming back moves the slope
+/// long before it is visible in a mean.
+#[test]
+fn the_estimators_per_frame_cost_does_not_grow_with_the_lm_step_count() {
+    /// Measured on this fixture: 805 to 1,389 allocator calls per frameset.
+    const BOUND: usize = 1_600;
+    /// Measured slope: 59.5 allocator calls per LM step, against 126.8 before
+    /// the buffers were pooled, so this sits well inside the gap.
+    const CALLS_PER_STEP: f64 = 85.0;
+
+    let flow: Vec<std::sync::Arc<slam_rs::estimator::FlowObservations>> = common::ORACLE
+        .flow
+        .iter()
+        .take(ESTIMATOR_FRAMESETS)
+        .map(common::observations)
+        .collect();
+    let mut estimator = estimator_window();
+    for frame in flow.iter().take(ESTIMATOR_WARMUP) {
+        estimator
+            .process_frame(std::sync::Arc::clone(frame))
+            .unwrap();
+    }
+
+    let mut measured: Vec<(f64, f64)> = Vec::new();
+    for frame in flow.iter().skip(ESTIMATOR_WARMUP) {
+        let (outcome, counted) = measure(|| {
+            estimator
+                .process_frame(std::sync::Arc::clone(frame))
+                .unwrap()
+        });
+        let slam_rs::estimator::FrameOutcome::Measured(stats) = outcome else {
+            panic!("the fixture's inertial window is complete, so every frameset measures");
+        };
+        println!(
+            "frameset {}: {} LM steps, marginalized {}, {counted:?}",
+            stats.t_ns,
+            stats.lm.len(),
+            stats.marginalization.is_some(),
+        );
+        assert!(
+            counted.total() <= BOUND,
+            "a steady-state frameset with {} LM steps reached the allocator {counted:?} times, \
+             over the structural bound of {BOUND}",
+            stats.lm.len(),
+        );
+        measured.push((stats.lm.len() as f64, counted.total() as f64));
+    }
+
+    // Least squares on (LM steps, allocator calls). The fixture has to spread
+    // the step count or the slope is not identified: without that spread the
+    // total bound above would hold for a per-step allocation too.
+    let steps: Vec<f64> = measured.iter().map(|(x, _)| *x).collect();
+    let low: f64 = steps.iter().copied().fold(f64::INFINITY, f64::min);
+    let high: f64 = steps.iter().copied().fold(0.0, f64::max);
+    assert!(
+        high >= low + 4.0,
+        "the measured framesets took {low} to {high} LM steps, too narrow to \
+         tell a per-step allocation from a per-frame one"
+    );
+    let count: f64 = measured.len() as f64;
+    let mean_x: f64 = steps.iter().sum::<f64>() / count;
+    let mean_y: f64 = measured.iter().map(|(_, y)| *y).sum::<f64>() / count;
+    let covariance: f64 = measured
+        .iter()
+        .map(|(x, y)| (x - mean_x) * (y - mean_y))
+        .sum::<f64>();
+    let variance: f64 = steps
+        .iter()
+        .map(|x| (x - mean_x) * (x - mean_x))
+        .sum::<f64>();
+    let slope: f64 = covariance / variance;
+    println!(
+        "{count} framesets, {low}-{high} LM steps: {slope:.1} allocator calls per step, \
+         {mean_y:.0} mean per frameset"
+    );
+    assert!(
+        slope <= CALLS_PER_STEP,
+        "the estimator reaches the allocator {slope:.1} times per LM step, over the \
+         {CALLS_PER_STEP} the per-step path is allowed: a buffer the loop used to \
+         allocate per step is being allocated again"
     );
 }

--- a/packages/slam-rs/docs/design-notes.md
+++ b/packages/slam-rs/docs/design-notes.md
@@ -890,7 +890,7 @@ layout the port already models in `ColumnRedux::Strided`. It touches every
 reader of `storage` and is not a local change.
 
 **Gate.** MIO10, three interleaved rounds against `44cbdb0f`: median
-5.081 → 4.645 ms, `measure` 2.443 → 2.049, ATE vs ground truth 1.504 cm
+5.140 → 4.733 ms, `measure` 2.451 → 2.108, ATE vs ground truth 1.504 cm
 unchanged, zero lost framesets, and every candidate trajectory and state digest
 byte-identical to the baseline's. `tests/frame_allocations.rs` gates the
 allocation half: zero allocator calls on a warm dense reduction, and a

--- a/packages/slam-rs/docs/design-notes.md
+++ b/packages/slam-rs/docs/design-notes.md
@@ -821,6 +821,81 @@ precision-band entry in the ten-clip manifest. These checks establish the local
 MIO14 correction and short-clip regression behavior, not a fresh all-device or
 ten-clip gate. The GPU stays opt-in and the default build stays CPU-only.
 
+## D73 — the estimator's per-frame scratch is the estimator's, and its hot loops walk columns
+
+Decision, 2026-09-10: hold the Levenberg-Marquardt loop's buffers on
+`SqrtKeypointVio` instead of allocating them per inner step, and write the three
+hot inner loops of the backend so that the coefficient they walk is the
+contiguous one. No arithmetic changes: every sum keeps its order, every product
+keeps its operand order, and the MIO10 trajectory stays byte-identical to the
+CPU lane's.
+
+**What the estimator was spending.** On MIO10 the `measure` stage was 2.443 ms of
+a 5.117 ms call (optimize 2.236, of which linearize 0.741 and solver 1.182,
+marginalize 0.147) on a window of 7 keyframes and 3 states — 87 pose parameters,
+~55 landmark blocks, seven inner LM steps on the median frame. That is a few
+MFLOP. Three things ate it, in this order:
+
+1. **Row-major loops over column-major storage.** `nalgebra`'s `DMatrix` is
+   column-major, and three loops indexed it with the column innermost:
+   `apply_householder_on_the_left_block`'s rank-1 update (`eigen/qr.rs`), the
+   `O(n³)` trailing update of Eigen's LDLT sweep (`eigen/ldlt.rs:338`), and both
+   of them at a stride of `nrows`. Interchanging them is free where the
+   operation is elementwise (the Householder update) and needs one accumulator
+   per output row where it is a reduction (the LDLT), which keeps each
+   coefficient's additions in their original order because the reduced index
+   becomes the outer loop. Worth 0.152 ms and 0.164 ms on MIO10, the two largest
+   single gains of the pass.
+2. **A hot loop the vectoriser refused.** `LandmarkBlock::add_dense_h_b_over`
+   was 31% of `optimize`'s self time and compiled to scalar `mulss`/`addss`: its
+   accumulator was a slice of runtime length, reached through the same
+   `&mut DenseHbScratch` as the row it multiplies, so the compiler had neither a
+   trip count nor a disjointness proof. A fixed `[S; 8]` local accumulator over
+   a row buffer padded to whole lanes gives it both. Worth 0.115 ms.
+3. **Per-step allocation.** `get_dense_h_b` took a fresh `opt_size`-square
+   accumulator, a fresh subtree partial per recursion depth and a fresh leaf
+   transpose on every call; `damped_solve` cloned the reduced system per damping
+   attempt and `EigenLdlt::new` allocated two more workspaces with it. Measured
+   with a counting allocator: **126.8 allocator calls per LM step**, 1,531 per
+   frameset. They are now a `DenseHbWorkspace`, an `EigenLdlt` and an increment
+   the estimator owns and resets, at 59.5 and 1,133.
+
+**Why pooling is not arithmetic.** The reduction resets every subtree buffer
+before a leaf writes it, and that reset restores exactly `+0.0` over the
+columns that were written; the accumulator it hands back is zeroed whole rather
+than by recorded column, because the IMU blocks, the prior and the
+fixed-keyframe pinning all write into it without recording anything. Eigen's
+LDLT is an in-place factorization, so the damped copy is the buffer the sweep
+consumes — writing it in place is what Eigen does, not a shortcut.
+
+**What did not pay, measured.** Pooling the landmark blocks across frames —
+~275 allocations and 182 kB of zeroing a frame — **regressed** MIO10 by
+0.074 ms and was dropped; a window whose landmark set shifts hands each pooled
+block to a different landmark, whose row count often differs, so the storage is
+replaced anyway and the shape test and the `Vec` rebuilds are what is left. The
+same reasoning retires the marginalization's permutation copy: `marginalize` is
+0.103 ms a frame after the Householder fix, no marginalization symbol appears in
+the top twenty of the native profile, and its copy is ~7 µs.
+
+**What is left, and where it is.** After the pass, `optimize` is 1.92 ms and its
+self time is `add_dense_h_b_over` 23%, `apply_householder_on_the_left_block`
+19%, the damped solve 17%, `linearize_problem` 12% and the dense reduction's
+joins and resets 8.5%. The Householder is the next lever and it needs the change
+this pass would not make: `LandmarkBlock::storage` is column-major here where
+basalt's is `Eigen::RowMajor`, so the reflection's long dimension — 92 columns —
+is the strided one and vectorising over its 3-to-5-row short dimension is most
+of what it can do. Making the block row-major would give both the dot product
+and the outer product a 92-long contiguous inner loop, and it would match the
+layout the port already models in `ColumnRedux::Strided`. It touches every
+reader of `storage` and is not a local change.
+
+**Gate.** MIO10, three interleaved rounds against `44cbdb0f`: median
+5.081 → 4.645 ms, `measure` 2.443 → 2.049, ATE vs ground truth 1.504 cm
+unchanged, zero lost framesets, and every candidate trajectory and state digest
+byte-identical to the baseline's. `tests/frame_allocations.rs` gates the
+allocation half: zero allocator calls on a warm dense reduction, and a
+slope-and-total bound per frameset that the pre-pooling code fails.
+
 ## Decision references
 
 The `Dnn` tags in this file and in the README name the project's recorded design decisions. What each one decided, in one line:
@@ -842,3 +917,4 @@ The `Dnn` tags in this file and in the README name the project's recorded design
 - **D68** — The three unreachable blocks go: squared-form marginalization, nullspace diagnostics, the D34 damping stack
 - **D70** — One GPU runtime: the CUDA lane is removed; wgpu is the GPU lane (2026-09-09)
 - **D71** — Exponent-bit finite classification and bounded small-angle trig; the MIO14 replay passes its unchanged accuracy limit (2026-09-09)
+- **D73** — The estimator's LM buffers live on the estimator and its hot loops walk columns; no arithmetic changes (2026-09-10)


### PR DESCRIPTION
Stacked on `slam-rs/stage-timers` (44cbdb0f = main + the stage timers).

The estimator was 2.45 ms of a 5.14 ms MIO10 call for a few MFLOP of arithmetic on
an 87-parameter window. This is the allocation and layout pass: no sum is
reassociated, no product changes operand order, the LM iteration count, window,
damping constants and the deterministic reduction tree are untouched, and the
trajectories stay **byte-identical** to the baseline's with matching state digests.

Six changes, each A/B'd on its own (deltas measured against the previous label):

| commit | mechanism | MIO10 delta |
|---|---|---:|
| Walk the Householder update down columns | the rank-1 update had the column innermost, a stride of `nrows`; the loop nest is interchanged and both loops go through the column's slice | **−0.152** |
| Accumulate the LDLT trailing update down columns | `LDLT.h:338`, the sweep's O(n³) term, read `mat[(i, j)]` with `j` innermost; one accumulator per trailing row makes it contiguous with the additions in their original order | **−0.164** |
| Reuse the dense reduction's buffers | `get_dense_h_b` took 7 `87×87` matrices per call and runs once per inner LM step; they become a `DenseHbWorkspace` the estimator owns | −0.009 |
| Reset and join the dense partials over column runs | `reset`/`join` indexed through a `Vec<usize>`, which LLVM compiles as a gather; the written set is kept as runs too | −0.004 |
| Accumulate the dense writeback in whole lanes | `add_dense_h_b_over` was 31% of `optimize` self time and compiled fully scalar; a fixed `[S; 8]` local over a lane-padded row buffer gives the vectoriser a trip count and a disjointness proof | **−0.115** |
| Damp and factorize in the factorization's own buffer | `h.clone()` per damping attempt plus three `EigenLdlt` workspaces and a right-hand-side clone; Eigen factorizes in place, so the damped copy is the buffer the sweep consumes | −0.023 |

Plus `tests/frame_allocations.rs` and design note D73.

## Gate — MIO10, three interleaved rounds against `base` (44cbdb0f)

| Core | median ms | mean ms | p95 ms | max ms | ATE vs GT cm | ATE vs C++ cm | tracked/lost | byte-identical | state-identical |
|---|---:|---:|---:|---:|---:|---:|---:|---|---|
| base | 5.140 | 5.691 | 9.697 | 11.244 | 1.504 | 0.311 | 412/0 | Y | Y |
| est-final2 | 4.733 | 5.100 | 8.334 | 9.569 | 1.504 | 0.311 | 412/0 | Y | Y |

| Core | pyramid | detect | track | stereo | predict | keyframe | optimize | linearize | solver | marginalize | measure | track_ms |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| base | 0.172 | 1.452 | 0.754 | 0.211 | 0.006 | 0.000 | 2.233 | 0.748 | 1.191 | 0.148 | 2.451 | 5.140 |
| est-final2 | 0.144 | 1.405 | 0.757 | 0.211 | 0.006 | 0.000 | 1.981 | 0.641 | 0.972 | 0.109 | 2.108 | 4.733 |

`ACCURACY PASS; IDENTICAL yes; delta -0.407 ms (-7.92%)`. Round medians: base
5.140/5.181/5.169, candidate 4.746/4.747/4.733. The LM histogram is unchanged
(1:1, 2:67, 3:57, 4:27, 5:10, 6:10, 7:29, 8:151). Gate asked for ≥0.1 ms with
ATE ≤ 1.654 cm and zero lost framesets; the estimator's own target was
2.45 → ~2.1 ms and `measure` lands at 2.108.

## The allocation gate

`tests/frame_allocations.rs` grows two tests beside the frontend's:

- `the_dense_reduction_allocates_nothing_after_its_first_call` — the second,
  third and fourth `get_dense_h_b_into` over one workspace reach the allocator
  **zero** times (the first costs 27).
- `the_estimators_per_frame_cost_does_not_grow_with_the_lm_step_count` — fits
  allocator calls against the LM step count each frameset reports. Measured with
  the layout commits in and the pooling out: **126.8 calls per LM step, 1,531 per
  frameset**; now **59.5 and 1,133**. Gates at 85 and 1,600, which the old code
  fails.

## Tried and dropped, with numbers

- **Pooling the landmark blocks across frames** (~275 allocations and 182 kB of
  zeroing a frame): **regressed MIO10 by 0.074 ms**, reverted. A window whose
  landmark set shifts hands each pooled block to a different landmark whose row
  count often differs, so the storage is replaced anyway.
- **The marginalization permutation copy**: not attempted. `marginalize` is
  0.109 ms a frame after the Householder fix, no marginalization symbol appears
  in the top twenty of the native profile, and the copy is ~7 µs — under the
  0.03 ms drop rule by construction.

## Verification

`cargo test -p slam-rs --release` after every commit: 440 tests, 0 failures,
including all four oracle suites (`linearize_oracle`, `marg_oracle`,
`lmdb_oracle`, `tbb_reduce_oracle`) plus `vio_oracle`, `vio_parity` and
`linearize_reference`. `cargo clippy --workspace --all-targets -- -D warnings`
clean. Python: 256 passed, 1 skipped, 18 deselected.

`cargo fmt --all --check` reports one diff, at `estimator/mod.rs:1287`
(`keyframe_ns`), which is pre-existing on this PR's base and is left alone.
