### PR TITLE
slam-rs: redetect on demand in the fast profile

### DIFF
--- a/packages/slam-rs/configs/profiles/fast.json
+++ b/packages/slam-rs/configs/profiles/fast.json
@@ -1,1 +1,1 @@
-{"config.vio_max_iterations": 4}
+{"config.vio_max_iterations": 4, "port.redetect_survivor_ratio": 0.5}

--- a/packages/slam-rs/configs/profiles/fast.json
+++ b/packages/slam-rs/configs/profiles/fast.json
@@ -1,1 +1,1 @@
-{"config.vio_max_iterations": 4, "port.redetect_survivor_ratio": 0.5}
+{"config.vio_max_iterations": 4, "port.redetect_survivor_ratio": 0.7}

--- a/packages/slam-rs/crates/slam-rs/src/config.rs
+++ b/packages/slam-rs/crates/slam-rs/src/config.rs
@@ -581,10 +581,10 @@ mod tests {
         let base: VioConfig = VioConfig::from_json_str(MSDMI_JSON).unwrap();
         let overlaid: String = MSDMI_JSON.replace(
             "\"value0\": {",
-            "\"value0\": {\"port.redetect_survivor_ratio\": 0.5,",
+            "\"value0\": {\"port.redetect_survivor_ratio\": 0.7,",
         );
         let config: VioConfig = VioConfig::from_json_str(&overlaid).unwrap();
-        assert_eq!(config.port_redetect_survivor_ratio, 0.5);
+        assert_eq!(config.port_redetect_survivor_ratio, 0.7);
 
         let mut normalised: VioConfig = config.clone();
         normalised.port_redetect_survivor_ratio = 0.0;

--- a/packages/slam-rs/crates/slam-rs/src/config.rs
+++ b/packages/slam-rs/crates/slam-rs/src/config.rs
@@ -100,6 +100,16 @@ pub enum ConfigError {
     Parse(#[from] serde_json::Error),
 }
 
+/// Whether [`VioConfig::port_redetect_survivor_ratio`] is at its off value.
+///
+/// The port's own key is skipped when it is off, so a basalt document still
+/// round-trips to exactly the keys it arrived with and a C++ run reading a
+/// config the port wrote back never meets a key cereal has no field for.
+#[expect(clippy::trivially_copy_pass_by_ref, reason = "serde's predicate shape")]
+fn redetect_is_off(ratio: &f32) -> bool {
+    *ratio == 0.0
+}
+
 /// cereal's outer wrapper: every basalt JSON is one object under `value0`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Value0<T> {
@@ -181,6 +191,26 @@ pub struct VioConfig {
     /// Per-level residual cap for accepting a recall.
     #[serde(rename = "config.optical_flow_recall_max_patch_norms")]
     pub optical_flow_recall_max_patch_norms: Vec<f32>,
+
+    // ── the port's own knobs ────────────────────────────────────────────
+    /// Survivor fraction below which a frameset detects; `0` detects always (D75).
+    ///
+    /// The one key here that basalt has no counterpart for, which is why it is
+    /// spelled `port.` instead of `config.`: the vendored `configs/*.json` are
+    /// the files the C++ reference runs read, so nothing writes a key into them
+    /// that the C++ never saw, and this one is carried by a profile overlay
+    /// alone (`configs/profiles/fast.json`). `0.0` — the value every basalt file
+    /// leaves it at, and [`VioConfig::default`]'s — is basalt's own behaviour:
+    /// `addPoints` on every frameset. Above zero the frameset detects only once
+    /// camera 0 holds fewer than this fraction of the keypoints the last
+    /// detecting frameset left it with, which is cuVSLAM's rule. Anything not
+    /// finite and above zero reads as `0`, so a garbled value detects rather
+    /// than silently stopping.
+    #[serde(
+        rename = "port.redetect_survivor_ratio",
+        skip_serializing_if = "redetect_is_off"
+    )]
+    pub port_redetect_survivor_ratio: f32,
 
     // ── estimator ───────────────────────────────────────────────────────
     /// Which linearization runs.
@@ -303,6 +333,8 @@ impl Default for VioConfig {
             optical_flow_recall_update_patch_viewpoint: false,
             optical_flow_recall_max_patch_dist: 3.0,
             optical_flow_recall_max_patch_norms: vec![1.74, 0.96, 0.99, 0.44],
+
+            port_redetect_survivor_ratio: 0.0,
 
             vio_linearization_type: LinearizationType::AbsQr,
             vio_sqrt_marg: true,
@@ -521,6 +553,46 @@ mod tests {
             reread.unknown.get("config.mapper_ransac_threshold"),
             Some(value)
         );
+    }
+
+    /// The port's own key is off in every shipped file, and off it is invisible:
+    /// a basalt document round-trips to exactly the keys it arrived with, so a
+    /// C++ run reading a config the port wrote back never meets it (D75).
+    #[test]
+    fn the_redetect_knob_is_off_and_unwritten_in_every_shipped_config() {
+        for (name, text) in every_fixture() {
+            let config: VioConfig = VioConfig::from_json_str(text).unwrap();
+            assert_eq!(config.port_redetect_survivor_ratio, 0.0, "{name}");
+            let written: String = config.to_json_string().unwrap();
+            assert!(
+                !written.contains("port.redetect_survivor_ratio"),
+                "{name} wrote the port key back into a basalt document"
+            );
+            // Not an unknown key either: it is modelled, so a file that does
+            // carry it is not merely tolerated.
+            assert!(!config.unknown.contains_key("port.redetect_survivor_ratio"));
+        }
+    }
+
+    /// What `configs/profiles/fast.json` does to a vendored config: one key
+    /// added, everything else untouched, and it survives a round trip.
+    #[test]
+    fn the_redetect_knob_survives_the_round_trip_when_a_profile_sets_it() {
+        let base: VioConfig = VioConfig::from_json_str(MSDMI_JSON).unwrap();
+        let overlaid: String = MSDMI_JSON.replace(
+            "\"value0\": {",
+            "\"value0\": {\"port.redetect_survivor_ratio\": 0.5,",
+        );
+        let config: VioConfig = VioConfig::from_json_str(&overlaid).unwrap();
+        assert_eq!(config.port_redetect_survivor_ratio, 0.5);
+
+        let mut normalised: VioConfig = config.clone();
+        normalised.port_redetect_survivor_ratio = 0.0;
+        assert_eq!(normalised, base, "the overlay moved something else");
+
+        let written: String = config.to_json_string().unwrap();
+        assert!(written.contains("port.redetect_survivor_ratio"));
+        assert_eq!(VioConfig::from_json_str(&written).unwrap(), config);
     }
 
     /// A key nobody has ever heard of is warned about, not rejected.

--- a/packages/slam-rs/crates/slam-rs/src/frontend/flow.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/flow.rs
@@ -498,6 +498,10 @@ pub struct FrameToFrameOpticalFlow<
     cells: Vec<Vec<i32>>,
     /// `last_keypoint_id` (`optical_flow.h:174`), the global landmark id space.
     last_keypoint_id: u64,
+    /// Camera 0's keypoint count as the last **detecting** frameset left it,
+    /// which is what `port.redetect_survivor_ratio` measures survivors against
+    /// (D75). Zero until one frameset has detected.
+    last_detect_count: usize,
     /// `last_keypoint_id` as it stood before the last **committed** frameset,
     /// which is what makes "how many of these keypoints are new" answerable
     /// after the fact rather than only inside the call that produced them.
@@ -592,6 +596,7 @@ struct FrameState {
     cameras: Vec<Keypoints>,
     cells: Vec<Vec<i32>>,
     last_keypoint_id: u64,
+    last_detect_count: usize,
 }
 
 impl<P: Pattern> FrameToFrameOpticalFlow<P, CpuPyramidBuilder, CpuPatchTracker<P>> {
@@ -888,6 +893,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
             },
             last_keypoint_id: 0,
             last_keypoint_id_before_frame: 0,
+            last_detect_count: 0,
             t_ns: None,
             frame_counter: 0,
             config,
@@ -1108,6 +1114,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         snapshot.cameras.clone_from(&self.frame.cameras);
         snapshot.cells.clone_from(&self.cells);
         snapshot.last_keypoint_id = self.last_keypoint_id;
+        snapshot.last_detect_count = self.last_detect_count;
 
         let outcome: Result<(), FrontendError> = self.run_passes(images, prediction, masks);
 
@@ -1127,6 +1134,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
                 self.frame.cameras.clone_from(&snapshot.cameras);
                 self.cells.clone_from(&snapshot.cells);
                 self.last_keypoint_id = snapshot.last_keypoint_id;
+                self.last_detect_count = snapshot.last_detect_count;
             }
         }
         self.snapshot = snapshot;
@@ -1176,7 +1184,10 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
             }
         }
 
-        self.add_points(images)?;
+        if self.should_detect() {
+            self.add_points(images)?;
+            self.last_detect_count = self.frame.cameras[0].len();
+        }
         let mark: std::time::Instant = std::time::Instant::now();
         self.filter_points();
         self.timings.stereo_ns += duration_ns(mark);
@@ -1505,6 +1516,45 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
             }
             y += cell;
         }
+    }
+
+    /// Whether this frameset runs [`FrameToFrameOpticalFlow::add_points`] at
+    /// all (D75).
+    ///
+    /// basalt detects on every frameset, and `port.redetect_survivor_ratio` at
+    /// its `0` default keeps that exactly — this returns `true` before anything
+    /// else is read. Above zero the frameset detects only once camera 0 has
+    /// fallen below that fraction of the count the last detecting frameset left
+    /// it with, which is cuVSLAM's `SelectKeyframe` rule (survivors under 41 %
+    /// of the last detection) rather than a fixed target count, so it needs no
+    /// per-rig tuning.
+    ///
+    /// **The whole frameset is gated, on camera 0 alone.** `add_points` is one
+    /// unit — camera 0's detection, the cross-camera match that carries its new
+    /// keypoints into cameras 1..n, and the non-overlap detection on those same
+    /// cameras — so gating it per camera would leave a rig half detected, with
+    /// camera 0's new ids never matched onward. Camera 0 is also the only camera
+    /// the keyframe vote reads (`estimator/mod.rs`, D21), so its survivor count
+    /// is the state this decision is about.
+    ///
+    /// Pure in the frameset's own state: this frame's camera-0 count, the count
+    /// the last detecting frameset ended with, and a config field. No timer, no
+    /// frame index, nothing the estimator fed back, so a replay repeats it.
+    fn should_detect(&self) -> bool {
+        let ratio: f32 = self.config.port_redetect_survivor_ratio;
+        // A ratio that is not a positive number is the knob switched off, NaN
+        // included: `x < NaN` is false, which would stop detection for good.
+        if !ratio.is_finite() || ratio <= 0.0 {
+            return true;
+        }
+        // Nothing has been detected yet, so there is no survivor fraction to
+        // take: the first frameset of a run, and the first after one that was
+        // refused before it detected.
+        if self.last_detect_count == 0 {
+            return true;
+        }
+        let survivors: f32 = self.frame.cameras[0].len() as f32;
+        survivors < ratio * self.last_detect_count as f32
     }
 
     /// `addPoints` (`:637-666`): detect on camera 0, match onward, then detect

--- a/packages/slam-rs/crates/slam-rs/tests/flow_frontend.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/flow_frontend.rs
@@ -123,6 +123,107 @@ fn the_keypoint_watermark_describes_the_committed_frame() {
     assert_eq!(flow.last_keypoint_id_before_frame(), after_first);
 }
 
+/// A frontend on the synthetic rig with the redetect gate set.
+fn gated_frontend(cameras: usize, ratio: f32) -> FrameToFrameOpticalFlow<Pattern51> {
+    let gated: VioConfig = VioConfig {
+        port_redetect_survivor_ratio: ratio,
+        ..config()
+    };
+    FrameToFrameOpticalFlow::new(gated, &rig(cameras), FrontendOptions::default()).unwrap()
+}
+
+/// The gate's default is basalt's schedule (D75): `addPoints` on every
+/// frameset, so every frameset hands out ids.
+///
+/// This is the control the two tests below are read against — without it, a
+/// gated run that detects rarely could not be told from a rig that has nothing
+/// left to detect.
+#[test]
+fn the_default_config_detects_on_every_frameset() {
+    assert_eq!(VioConfig::default().port_redetect_survivor_ratio, 0.0);
+    let mut flow: FrameToFrameOpticalFlow<Pattern51> = frontend(2, FrontendOptions::default());
+    let mut watermark: u64 = 0;
+    for shift in 0..6 {
+        let images: [ImageU16; 2] = [dotted_image(shift), dotted_image(shift)];
+        flow.process_frame(i64::from(shift), &images, &PosePrediction::default(), &[])
+            .unwrap();
+        assert!(
+            flow.last_keypoint_id() > watermark,
+            "frameset {shift} detected nothing"
+        );
+        watermark = flow.last_keypoint_id();
+    }
+}
+
+/// A ratio nothing can fall below detects once and then never again, which is
+/// what says the gate is really the only thing deciding.
+#[test]
+fn a_survivor_ratio_nothing_reaches_detects_only_on_the_first_frameset() {
+    let mut flow: FrameToFrameOpticalFlow<Pattern51> = gated_frontend(2, 1e-6);
+    let images: [ImageU16; 2] = [dotted_image(0), dotted_image(0)];
+    flow.process_frame(0, &images, &PosePrediction::default(), &[])
+        .unwrap();
+    let after_first: u64 = flow.last_keypoint_id();
+    assert!(after_first > 0, "the first frameset must detect");
+
+    for shift in 1..6 {
+        let moved: [ImageU16; 2] = [dotted_image(shift), dotted_image(shift)];
+        flow.process_frame(i64::from(shift), &moved, &PosePrediction::default(), &[])
+            .unwrap();
+        assert_eq!(
+            flow.last_keypoint_id(),
+            after_first,
+            "frameset {shift} detected while gated"
+        );
+    }
+}
+
+/// The gate is one decision for the whole rig, never a camera at a time: a
+/// skipped frameset leaves camera 1 with no new ids either, because the
+/// cross-camera match and the non-overlap pass are both inside `addPoints`.
+#[test]
+fn a_skipped_frameset_leaves_no_camera_detected() {
+    let mut flow: FrameToFrameOpticalFlow<Pattern51> = gated_frontend(3, 1e-6);
+    let images: [ImageU16; 3] = [dotted_image(0), dotted_image(0), dotted_image(0)];
+    flow.process_frame(0, &images, &PosePrediction::default(), &[])
+        .unwrap();
+    let mut known: Vec<Vec<KeypointId>> = flow
+        .frame()
+        .cameras
+        .iter()
+        .map(|camera| camera.ids.clone())
+        .collect();
+    assert!(known.iter().all(|ids| !ids.is_empty()));
+
+    for shift in 1..4 {
+        let moved: [ImageU16; 3] = [
+            dotted_image(shift),
+            dotted_image(shift),
+            dotted_image(shift),
+        ];
+        flow.process_frame(i64::from(shift), &moved, &PosePrediction::default(), &[])
+            .unwrap();
+        for (camera, ids) in flow.frame().cameras.iter().enumerate() {
+            let fresh: Vec<KeypointId> = ids
+                .ids
+                .iter()
+                .filter(|id| !known[camera].contains(id))
+                .copied()
+                .collect();
+            assert!(
+                fresh.is_empty(),
+                "camera {camera} gained {fresh:?} on a skipped frameset"
+            );
+        }
+        known = flow
+            .frame()
+            .cameras
+            .iter()
+            .map(|camera| camera.ids.clone())
+            .collect();
+    }
+}
+
 /// `updateCellCounts` / `addKeypoint` / `removeKeypoint` (`:707-749`) keep
 /// `cells` equal to the number of keypoints in each grid cell — except where
 /// `addKeypoints` deliberately double-counts, which cannot happen on camera 0.

--- a/packages/slam-rs/docs/design-notes.md
+++ b/packages/slam-rs/docs/design-notes.md
@@ -1042,4 +1042,60 @@ The benchmark and tracking tools opt in with `--profile fast`. The default
 `reference` profile is empty and preserves the vendored text. Unknown overlay
 keys raise `KeyError` so a typo cannot silently change the requested run.
 - **D73** — The estimator's LM buffers live on the estimator and its hot loops walk columns; no arithmetic changes (2026-09-10)
+
+## D75 — Redetect on demand: the fast profile detects when camera 0 has lost tracks
+
+basalt calls `addPoints` on every frameset and tops up every empty grid cell
+(`frame_to_frame_optical_flow.h:637-666`, `frontend/flow.rs`). cuVSLAM instead
+detects only once its survivors fall under a fraction of what the last detection
+left it, and so pays detection about every fourth frame. On MIO10 that is the
+one stage where the two are furthest apart.
+
+**The knob.** `port.redetect_survivor_ratio`, `0.0` by default. At `0` — where
+every basalt file and `VioConfig::default` leave it — the frameset always
+detects, which is basalt's schedule byte for byte. Above zero the frameset
+detects only when camera 0 holds fewer than that fraction of the keypoints the
+last **detecting** frameset ended with. `configs/profiles/fast.json` sets `0.7`;
+nothing else does.
+
+**Why the key is `port.` and not `config.`.** basalt has no field for it, and the
+vendored `configs/*.json` are the documents the C++ reference runs read, key for
+key (`tests/test_cpp_reference.py::test_the_vendored_configs_are_the_ones_the_cpp_runs_used`).
+So no port-only key is written into them: the profile overlay inserts it,
+`slam_rs.reference.PORT_CONFIG_KEYS` allowlists it so a typo is still a
+`KeyError`, and `VioConfig` skips serializing it while it is off — a basalt
+document still round-trips to exactly the keys it arrived with.
+
+**One decision for the whole rig, taken on camera 0.** `add_points` is a unit:
+camera 0's detection, the cross-camera match that carries its new ids into
+cameras 1..n, and the non-overlap pass on those cameras. Gating it per camera
+would leave a rig half detected, with camera 0's new ids never matched onward.
+Camera 0 is also the only camera the keyframe vote reads (D21). The test is a
+pure function of the frameset's own state — this frame's camera-0 count, the
+count the last detecting frameset ended with, a config field — so a replay
+repeats it, and `FrameState` carries the baseline so a refused frameset does not
+move it.
+
+**The keyframe coupling, measured.** The vote is
+`connected[0] / (connected[0] + unconnected[0]) < 0.7` and the unconnected
+observations are the freshly detected keypoints, so gating detection could have
+starved the vote. It does not at `0.7`: MIO10's post-warmup cadence goes 7.04 ->
+7.33 frames per keyframe and MGO09's stays at 6.71, both inside the 5-9 band the
+later scheduling work is priced against.
+
+**Why 0.7 and not 0.5.** Both clear the gate. `0.5` is faster — MIO10 median
+2.337 ms against `0.7`'s 2.980, from a 3.549 ms stack — but it detects only
+every 6.6 framesets on MIO10 and every 23.5 on MGO09, which halves what the
+estimator sees: on MIO10 the mean landmark count goes 46.0 -> 25.7 and tracked
+keypoints 119.1 -> 58.4, and MGO09's keyframe cadence goes to 9.40. `0.7` detects every 2.9
+framesets on MIO10 and every 5.2 on MGO09, keeps 38.5 landmarks and 84.3 tracked
+keypoints, and is the only setting where **both** measured clips score better
+than the stack does: MIO10 1.447 cm against 1.525, MGO09 0.757 cm against 0.766.
+It gives 0.582 ms of the 0.3 ms this lever was asked for, and leaves the cadence
+the next lever is sized against where it was. The `0.5` numbers are recorded so
+the trade is re-openable once the wider clip set has been run — the clips with
+fast-dying tracks (MIO11, MIO07, MGO13) are where a halved landmark count would
+show, and they are not measured here.
+
 - **D74** — Speed profile: vendored configs stay C++-faithful; speed knobs live in `configs/profiles/fast.json`, opted into with `--profile fast` (2026-09-10)
+- **D75** — Redetect on demand: the fast profile skips `addPoints` until camera 0 falls under `port.redetect_survivor_ratio` of its last detection (2026-09-10)

--- a/packages/slam-rs/slam_rs/reference.py
+++ b/packages/slam-rs/slam_rs/reference.py
@@ -643,6 +643,19 @@ def d60_failures(
     return failures
 
 
+PORT_CONFIG_KEYS: frozenset[str] = frozenset({"port.redetect_survivor_ratio"})
+"""Overlay keys the port adds to basalt's document, which no vendored config carries.
+
+``configs/*.json`` are the files the C++ reference runs read, key for key
+(``tests/test_cpp_reference.py``), so a knob basalt has no field for is never
+written into them: it is spelled ``port.`` instead of ``config.``, an overlay
+inserts it, and :class:`slam_rs._core.VioConfig` models it with a default that
+reproduces basalt's behaviour for every path that does not. Listing them here
+keeps :func:`profiled_config_text`'s typo check: a key that is neither in the
+base document nor in this set is still a ``KeyError``.
+"""
+
+
 def profiled_config_text(path: Path, profile: str = "reference", profiles: Path = MANIFEST_PATH.parent / "configs/profiles") -> str:
     """Read a config and apply a named overlay; empty overlays preserve its text.
 
@@ -655,7 +668,8 @@ def profiled_config_text(path: Path, profile: str = "reference", profiles: Path 
         Config JSON with the overlay applied.
 
     Raises:
-        KeyError: If an overlay key is absent from the base value0 namespace.
+        KeyError: If an overlay key is neither in the base value0 namespace nor
+            one of :data:`PORT_CONFIG_KEYS`.
     """
     text: str = path.read_text()
     overlay: dict = json.loads((profiles / f"{profile}.json").read_text())
@@ -664,7 +678,7 @@ def profiled_config_text(path: Path, profile: str = "reference", profiles: Path 
     document: dict = json.loads(text)
     values: dict = document["value0"]
     for key in overlay:
-        if key not in values:
+        if key not in values and key not in PORT_CONFIG_KEYS:
             raise KeyError(key)
     values.update(overlay)
     return json.dumps(document)

--- a/packages/slam-rs/tests/test_config_profiles.py
+++ b/packages/slam-rs/tests/test_config_profiles.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from slam_rs.reference import DatasetProperties, ReferenceManifest, load_manifest
+from slam_rs.reference import PORT_CONFIG_KEYS, DatasetProperties, ReferenceManifest, load_manifest
 
 
 def test_reference_profile_preserves_vendored_text() -> None:
@@ -15,14 +15,50 @@ def test_reference_profile_preserves_vendored_text() -> None:
         assert manifest.vio_config_text(dataset.name) == (manifest.package_root / dataset.vio_config).read_text()
 
 
-def test_fast_profile_changes_only_lm_cap() -> None:
+def test_fast_profile_changes_only_the_lm_cap_and_the_redetect_gate() -> None:
+    """The two keys the fast profile owns, and nothing else moves.
+
+    ``port.redetect_survivor_ratio`` is not one of basalt's: it is the port's own
+    redetect-on-demand gate (D75), so it is absent from every vendored file and
+    the overlay is the only thing that ever sets it.
+    """
     manifest: ReferenceManifest = load_manifest()
     for dataset in manifest.datasets:
         reference: dict = json.loads((manifest.package_root / dataset.vio_config).read_text())
         fast: dict = json.loads(manifest.vio_config_text(dataset.name, profile="fast"))
         assert fast["value0"].pop("config.vio_max_iterations") == 4
         assert reference["value0"].pop("config.vio_max_iterations") == 7
+        assert fast["value0"].pop("port.redetect_survivor_ratio") == 0.5
+        assert "port.redetect_survivor_ratio" not in reference["value0"]
         assert fast == reference
+
+
+def test_no_vendored_config_carries_a_port_key() -> None:
+    """The vendored files stay the documents the C++ runs read, key for key.
+
+    ``tests/test_cpp_reference.py`` compares them against every run manifest, so
+    a port-only knob is inserted by the overlay and defaulted by
+    :class:`slam_rs._core.VioConfig` instead of being written into them.
+    """
+    manifest: ReferenceManifest = load_manifest()
+    for dataset in manifest.datasets:
+        values: dict = json.loads((manifest.package_root / dataset.vio_config).read_text())["value0"]
+        assert not (set(values) & PORT_CONFIG_KEYS), dataset.name
+        assert all(key.startswith("config.") for key in values), dataset.name
+
+
+def test_an_invented_port_key_is_rejected(tmp_path: Path) -> None:
+    """The ``port.`` namespace is an allowlist, not an escape hatch for typos."""
+    manifest: ReferenceManifest = load_manifest()
+    dataset: DatasetProperties = manifest.datasets[0]
+    config_path: Path = tmp_path / dataset.vio_config
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text((manifest.package_root / dataset.vio_config).read_text())
+    profiles: Path = tmp_path / "configs/profiles"
+    profiles.mkdir()
+    (profiles / "fast.json").write_text('{"port.redetect_survivor_ration": 0.5}')
+    with pytest.raises(KeyError, match="port.redetect_survivor_ration"):
+        replace(manifest, package_root=tmp_path).vio_config_text(dataset.name, profile="fast")
 
 
 def test_unknown_overlay_key_is_rejected(tmp_path: Path) -> None:

--- a/packages/slam-rs/tests/test_config_profiles.py
+++ b/packages/slam-rs/tests/test_config_profiles.py
@@ -28,7 +28,7 @@ def test_fast_profile_changes_only_the_lm_cap_and_the_redetect_gate() -> None:
         fast: dict = json.loads(manifest.vio_config_text(dataset.name, profile="fast"))
         assert fast["value0"].pop("config.vio_max_iterations") == 4
         assert reference["value0"].pop("config.vio_max_iterations") == 7
-        assert fast["value0"].pop("port.redetect_survivor_ratio") == 0.5
+        assert fast["value0"].pop("port.redetect_survivor_ratio") == 0.7
         assert "port.redetect_survivor_ratio" not in reference["value0"]
         assert fast == reference
 


### PR DESCRIPTION
## What

`add_points` ran on every frameset (basalt's schedule). cuVSLAM detects only
once its survivors fall under a fraction of what the last detection left it, and
so pays detection about every fourth frame. This adds that rule as
`port.redetect_survivor_ratio` and turns it on in the fast profile alone.

- `crates/slam-rs/src/frontend/flow.rs` — `should_detect()` gates `run_passes`'
  call to `add_points`; `last_detect_count` is camera 0's count as the last
  detecting frameset left it, snapshotted in `FrameState` so a refused frameset
  does not move it.
- `crates/slam-rs/src/config.rs` — the `port.redetect_survivor_ratio` field,
  `0.0` (= basalt: detect every frameset) by default, skipped on serialization
  while it is off.
- `slam_rs/reference.py` — `PORT_CONFIG_KEYS`; the overlay may insert a
  port-only key that no vendored config carries, and any other unknown key is
  still a `KeyError`.
- `configs/profiles/fast.json` — `"port.redetect_survivor_ratio": 0.7`.
- `docs/design-notes.md` — D75 and its index line.

**No vendored config changed.** basalt has no field for this knob, so it is
spelled `port.` rather than `config.` and the vendored `configs/*.json` stay the
documents the C++ reference runs read, key for key —
`test_the_vendored_configs_are_the_ones_the_cpp_runs_used` is untouched and
green.

**The gate is one decision for the whole rig, taken on camera 0.** `add_points`
is camera 0's detection, the cross-camera match that carries its new ids into
cameras 1..n, and the non-overlap pass on those cameras, so gating part of it
would leave a rig half detected. MGO09 (4 cameras) exercises that path.

## MIO10, 3 rounds, fast profile, `--base wave1`

| Core | profile | median ms | mean ms | p95 ms | max ms | ATE vs GT cm | ATE vs C++ cm | tracked/lost | byte-identical to base | state-identical | cores used |
|---|---|---:|---:|---:|---:|---:|---:|---:|---|---|---:|
| base (wave1) | fast | 3.526 | 3.885 | 6.039 | 7.396 | 1.525 | 0.311 | 412/0 | Y | Y | 0.877 |
| redetect | fast | 2.974 | 3.172 | 4.988 | 5.894 | **1.447** | 0.651 | 412/0 | N | N | 0.906 |

| Core | pyramid | detect | track | stereo | predict | keyframe | optimize | linearize | solver | marginalize | measure | track_ms | glue |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| base (wave1) | 0.143 | 0.574 | 0.751 | 0.193 | 0.006 | 0.000 | 1.514 | 0.535 | 0.753 | 0.106 | 1.683 | 3.526 | 0.150 |
| redetect | 0.144 | **0.000** | 0.755 | **0.001** | 0.006 | 0.000 | 1.394 | 0.479 | 0.721 | 0.097 | 1.519 | 2.974 | 0.133 |

Round medians: base 3.526, 3.562, 3.581; redetect 2.989, 2.974, 3.023.
Delta **-0.551 ms (-15.63 %)**. The median frame now detects nothing, so both
`detect` and the `add_points` half of `stereo` fall off it.

## MGO09, 1 round, fast profile, `--base wave1`

| Core | profile | median ms | mean ms | p95 ms | max ms | ATE vs GT cm | ATE vs C++ cm | tracked/lost |
|---|---|---:|---:|---:|---:|---:|---:|---:|
| base (wave1) | fast | 10.357 | 10.083 | 12.410 | 13.043 | 0.766 | 0.317 | 107/0 |
| redetect | fast | 8.536 | 8.280 | 11.054 | 11.710 | **0.757** | 0.317 | 107/0 |

Delta -1.821 ms (-17.58 %).

## Keyframe cadence, landmarks, tracked keypoints (post-warmup, round 1)

| clip / core | frames | keyframes | frames per keyframe | detect every N framesets | mean landmarks | mean tracked kpts | mean observations |
|---|---:|---:|---:|---:|---:|---:|---:|
| MIO10 base (wave1) | 352 | 50 | 7.04 | 1.00 | 46.0 | 119.1 | 321.2 |
| MIO10 redetect | 352 | 48 | **7.33** | 2.91 | 38.5 | 84.3 | 288.2 |
| MGO09 base (wave1) | 47 | 7 | 6.71 | 1.00 | 106.2 | 306.3 | 879.6 |
| MGO09 redetect | 47 | 7 | **6.71** | 5.22 | 101.9 | 231.6 | 848.9 |

The cadence stays inside the 5-9 band on both clips, so the vote the later
scheduling work is priced against has not moved.

## Gate

| clause | limit | MIO10 | verdict |
|---|---|---|---|
| ATE vs GT | <= 1.654 cm | 1.447 cm | PASS |
| lost framesets | 0 | 0 (412 tracked) | PASS |
| median gain vs wave1 | >= 0.1 ms | 0.551 ms | PASS |
| run-to-run identical within the label | required | trajectory md5 and state digest identical over 3 rounds | PASS |
| MGO09 band | <= 0.8466 cm | 0.757 cm | PASS |

Trajectories are **not** byte-identical to the stack, as expected for a
trajectory-changing lever.

## Why 0.7 and not 0.5

`0.5` was measured first and also clears the gate — MIO10 median 2.337 ms
(-1.212), ATE 1.516 cm; MGO09 0.777 cm — but it detects only every 6.6
framesets on MIO10 and every 23.5 on MGO09, taking mean landmarks to 25.7 and
tracked keypoints to 58.4 on MIO10 and MGO09's keyframe cadence to 9.40. `0.7`
gives 0.582 ms against the 0.3 ms this lever was asked for and is the only
setting where **both** measured clips score better than the stack. D75 records
the `0.5` numbers so the trade is re-openable once the wider clip set has run.

## Tests

`cargo test --workspace --release`: 447 passed, 0 failed.
`cargo clippy --workspace --all-targets -- -D warnings`: clean.
`ruff check .`: clean.
Python suite: 261 passed, 1 skipped, 18 deselected (with `PYTHONPATH` set to
this worktree — the shared bench env's editable `.pth` otherwise wins).
`cargo fmt --all --check` reports only the pre-existing `estimator/mod.rs:1287`
diff, left alone.

New tests: `the_default_config_detects_on_every_frameset`,
`a_survivor_ratio_nothing_reaches_detects_only_on_the_first_frameset`,
`a_skipped_frameset_leaves_no_camera_detected`,
`the_redetect_knob_is_off_and_unwritten_in_every_shipped_config`,
`the_redetect_knob_survives_the_round_trip_when_a_profile_sets_it`,
`test_no_vendored_config_carries_a_port_key`,
`test_an_invented_port_key_is_rejected`.

## Caveats

- Only MIO10 and MGO09 are measured. MIO11, MIO07, MGO07, MGO10 and MGO11 are
  unrun; the clips with fast-dying tracks are where a lower steady-state
  landmark count would show.
- MIO10's ATE vs the C++ trajectory moves 0.311 -> 0.651 cm. Still well inside
  the 2 cm path bound, but it is a real move away from basalt's own path.
- No `.rrd` was produced by this work.
