### PR TITLE
slam-rs: joint solve at keyframes only in the fast profile

### DIFF
--- a/kf-env.sh
+++ b/kf-env.sh
@@ -1,0 +1,7 @@
+export PYTHONDONTWRITEBYTECODE=1 PIXI_DEV_MODE=0
+export CARGO_HOME=/tmp/slam-rs-s32/ab/cargo-home
+export CARGO_TARGET_DIR=/tmp/slam-rs-s32/kfsolve-target
+export XDG_CACHE_HOME=/tmp/slam-rs-s32/kfsolve-cache
+export TMPDIR=/tmp/slam-rs-s32/kfsolve-cache
+export RUSTUP_HOME=/tmp/slam-rs-s32/ab/rustup
+mkdir -p "$CARGO_TARGET_DIR" "$XDG_CACHE_HOME"

--- a/kf-env.sh
+++ b/kf-env.sh
@@ -1,7 +1,0 @@
-export PYTHONDONTWRITEBYTECODE=1 PIXI_DEV_MODE=0
-export CARGO_HOME=/tmp/slam-rs-s32/ab/cargo-home
-export CARGO_TARGET_DIR=/tmp/slam-rs-s32/kfsolve-target
-export XDG_CACHE_HOME=/tmp/slam-rs-s32/kfsolve-cache
-export TMPDIR=/tmp/slam-rs-s32/kfsolve-cache
-export RUSTUP_HOME=/tmp/slam-rs-s32/ab/rustup
-mkdir -p "$CARGO_TARGET_DIR" "$XDG_CACHE_HOME"

--- a/packages/slam-rs/configs/profiles/fast.json
+++ b/packages/slam-rs/configs/profiles/fast.json
@@ -1,1 +1,1 @@
-{"config.vio_max_iterations": 4, "port.redetect_survivor_ratio": 0.7}
+{"config.vio_max_iterations": 7, "port.redetect_survivor_ratio": 0.7, "port.frame_update_max_iterations": 5}

--- a/packages/slam-rs/crates/slam-rs-py/src/lib.rs
+++ b/packages/slam-rs/crates/slam-rs-py/src/lib.rs
@@ -360,6 +360,7 @@ pub struct VioSnapshot {
     lm_error_before: f64,
     lm_error_after: f64,
     num_observations: usize,
+    frame_update: &'static str,
     timings: slam_rs::estimator::StageTimings,
     frontend_timings: slam_rs::FrontendTimings,
 }
@@ -438,6 +439,7 @@ impl VioSnapshot {
                 .last()
                 .map_or(0.0, |step| f64::from(step.error_after)),
             num_observations: stats.num_observations,
+            frame_update: stats.frame_update.as_str(),
             timings: stats.timings,
             frontend_timings,
         })
@@ -551,6 +553,14 @@ impl VioSnapshot {
     /// kind of measurement as the six and are read the same way, which is why
     /// they come back in one map; they do not add up to the frame, because the
     /// bookkeeping between the phases is nobody's stage.
+    /// What D76's frame update did with this frameset: `not_attempted`,
+    /// `taken`, or `declined_<precondition>`. A clip whose median frame is slow
+    /// with the knob on says which precondition refused it here.
+    #[getter]
+    fn frame_update(&self) -> &'static str {
+        self.frame_update
+    }
+
     #[getter]
     fn timings_ms(&self) -> std::collections::BTreeMap<&'static str, f64> {
         [

--- a/packages/slam-rs/crates/slam-rs/src/config.rs
+++ b/packages/slam-rs/crates/slam-rs/src/config.rs
@@ -110,6 +110,15 @@ fn redetect_is_off(ratio: &f32) -> bool {
     *ratio == 0.0
 }
 
+/// Whether [`VioConfig::port_frame_update_max_iterations`] is at its off value.
+///
+/// See [`redetect_is_off`]: the port's own keys stay out of a basalt document
+/// while they are off.
+#[expect(clippy::trivially_copy_pass_by_ref, reason = "serde's predicate shape")]
+fn frame_update_is_off(iterations: &i32) -> bool {
+    *iterations <= 0
+}
+
 /// cereal's outer wrapper: every basalt JSON is one object under `value0`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Value0<T> {
@@ -211,6 +220,22 @@ pub struct VioConfig {
         skip_serializing_if = "redetect_is_off"
     )]
     pub port_redetect_survivor_ratio: f32,
+    /// LM steps the non-keyframe frame update gets; `0` solves the whole window
+    /// on every frameset (D76).
+    ///
+    /// `0` — every basalt file's value and [`VioConfig::default`]'s — is
+    /// basalt's own schedule: `optimize` runs the 87-unknown sliding window on
+    /// every frameset. Above zero a frameset that took no keyframe instead
+    /// solves the newest state's 15 unknowns against fixed landmarks and its IMU
+    /// factor, with at most this many LM steps (accepted and backtracked
+    /// together, as `vio_max_iterations` counts them), and the joint solve runs
+    /// at keyframes only. Carried by the profile overlay alone
+    /// (`configs/profiles/fast.json`); the `port.` spelling is D75's.
+    #[serde(
+        rename = "port.frame_update_max_iterations",
+        skip_serializing_if = "frame_update_is_off"
+    )]
+    pub port_frame_update_max_iterations: i32,
 
     // ── estimator ───────────────────────────────────────────────────────
     /// Which linearization runs.
@@ -335,6 +360,7 @@ impl Default for VioConfig {
             optical_flow_recall_max_patch_norms: vec![1.74, 0.96, 0.99, 0.44],
 
             port_redetect_survivor_ratio: 0.0,
+            port_frame_update_max_iterations: 0,
 
             vio_linearization_type: LinearizationType::AbsQr,
             vio_sqrt_marg: true,
@@ -555,43 +581,53 @@ mod tests {
         );
     }
 
-    /// The port's own key is off in every shipped file, and off it is invisible:
-    /// a basalt document round-trips to exactly the keys it arrived with, so a
-    /// C++ run reading a config the port wrote back never meets it (D75).
+    /// The port's own keys are off in every shipped file, and off they are
+    /// invisible: a basalt document round-trips to exactly the keys it arrived
+    /// with, so a C++ run reading a config the port wrote back never meets one
+    /// (D75, D76).
     #[test]
-    fn the_redetect_knob_is_off_and_unwritten_in_every_shipped_config() {
+    fn the_port_knobs_are_off_and_unwritten_in_every_shipped_config() {
         for (name, text) in every_fixture() {
             let config: VioConfig = VioConfig::from_json_str(text).unwrap();
             assert_eq!(config.port_redetect_survivor_ratio, 0.0, "{name}");
+            assert_eq!(config.port_frame_update_max_iterations, 0, "{name}");
             let written: String = config.to_json_string().unwrap();
-            assert!(
-                !written.contains("port.redetect_survivor_ratio"),
-                "{name} wrote the port key back into a basalt document"
-            );
-            // Not an unknown key either: it is modelled, so a file that does
-            // carry it is not merely tolerated.
-            assert!(!config.unknown.contains_key("port.redetect_survivor_ratio"));
+            for key in [
+                "port.redetect_survivor_ratio",
+                "port.frame_update_max_iterations",
+            ] {
+                assert!(
+                    !written.contains(key),
+                    "{name} wrote {key} back into a basalt document"
+                );
+                // Not an unknown key either: it is modelled, so a file that
+                // does carry it is not merely tolerated.
+                assert!(!config.unknown.contains_key(key));
+            }
         }
     }
 
     /// What `configs/profiles/fast.json` does to a vendored config: one key
     /// added, everything else untouched, and it survives a round trip.
     #[test]
-    fn the_redetect_knob_survives_the_round_trip_when_a_profile_sets_it() {
+    fn the_port_knobs_survive_the_round_trip_when_a_profile_sets_them() {
         let base: VioConfig = VioConfig::from_json_str(MSDMI_JSON).unwrap();
         let overlaid: String = MSDMI_JSON.replace(
             "\"value0\": {",
-            "\"value0\": {\"port.redetect_survivor_ratio\": 0.7,",
+            "\"value0\": {\"port.redetect_survivor_ratio\": 0.7, \"port.frame_update_max_iterations\": 2,",
         );
         let config: VioConfig = VioConfig::from_json_str(&overlaid).unwrap();
         assert_eq!(config.port_redetect_survivor_ratio, 0.7);
+        assert_eq!(config.port_frame_update_max_iterations, 2);
 
         let mut normalised: VioConfig = config.clone();
         normalised.port_redetect_survivor_ratio = 0.0;
+        normalised.port_frame_update_max_iterations = 0;
         assert_eq!(normalised, base, "the overlay moved something else");
 
         let written: String = config.to_json_string().unwrap();
         assert!(written.contains("port.redetect_survivor_ratio"));
+        assert!(written.contains("port.frame_update_max_iterations"));
         assert_eq!(VioConfig::from_json_str(&written).unwrap(), config);
     }
 

--- a/packages/slam-rs/crates/slam-rs/src/config.rs
+++ b/packages/slam-rs/crates/slam-rs/src/config.rs
@@ -227,9 +227,10 @@ pub struct VioConfig {
     /// basalt's own schedule: `optimize` runs the 87-unknown sliding window on
     /// every frameset. Above zero a frameset that took no keyframe instead
     /// solves the newest state's 15 unknowns against fixed landmarks and its IMU
-    /// factor, with at most this many LM steps (accepted and backtracked
-    /// together, as `vio_max_iterations` counts them), and the joint solve runs
-    /// at keyframes only. Carried by the profile overlay alone
+    /// factor, and the joint solve runs at keyframes only. The loop is the
+    /// window's, inclusive as `vio_max_iterations` is, so `5` is a budget of
+    /// **six** trials — accepted and backtracked together — not five; the two
+    /// caps mean the same thing on purpose. Carried by the profile overlay alone
     /// (`configs/profiles/fast.json`); the `port.` spelling is D75's.
     #[serde(
         rename = "port.frame_update_max_iterations",

--- a/packages/slam-rs/crates/slam-rs/src/estimator/frame_update.rs
+++ b/packages/slam-rs/crates/slam-rs/src/estimator/frame_update.rs
@@ -586,15 +586,19 @@ mod tests {
     /// Returns the estimator with the newest state left **at** the truth, and the
     /// truth beside it.
     fn a_window(iterations: i32) -> (SqrtKeypointVio<f64>, PoseVelBiasState<f64>) {
-        a_window_on(CALIB, CONFIG, iterations)
+        a_window_on(CALIB, CONFIG, iterations, None)
     }
 
     /// [`a_window`] on a named rig, so the same known answer can be asked of a
     /// two-camera and a four-camera window.
+    ///
+    /// `skip_camera` files no observation from that target camera, which is how
+    /// a test asks what one camera was contributing.
     fn a_window_on(
         calib: &str,
         config: &str,
         iterations: i32,
+        skip_camera: Option<usize>,
     ) -> (SqrtKeypointVio<f64>, PoseVelBiasState<f64>) {
         let mut config: VioConfig = VioConfig::from_json_str(config).unwrap();
         config.port_frame_update_max_iterations = iterations;
@@ -682,6 +686,9 @@ mod tests {
 
                 let mut filed: bool = false;
                 for (cam_id, camera) in cameras.iter().enumerate() {
+                    if skip_camera == Some(cam_id) {
+                        continue;
+                    }
                     let rel: Se3<f64> = compute_rel_pose(
                         &Se3::identity(),
                         &vio.ba.calib.t_i_c[host.cam_id],
@@ -713,8 +720,9 @@ mod tests {
                 }
             }
         }
+        let least: usize = if skip_camera.is_some() { 1 } else { 12 };
         assert!(
-            vio.ba.lmdb.num_observations() >= 12,
+            vio.ba.lmdb.num_observations() >= least,
             "the fixture has to give the pose something to see: {}",
             vio.ba.lmdb.num_observations()
         );
@@ -884,22 +892,132 @@ mod tests {
         );
     }
 
-    /// The four-camera rig: the held landmarks' Jacobians w.r.t. the newest state
-    /// are right for a non-host camera too.
+    /// The four-camera rig: the vision half of the normal equations is the
+    /// gradient of the vision cost, camera by camera.
     ///
-    /// Every landmark here is hosted by camera 0 of the host keyframe and is
-    /// observed by whichever of the four cameras can see it, so the relative pose
-    /// each residual is formed through carries a different `T_i_c` on the target
-    /// side. Get one of those extrinsics or its `d_rel_d_t` wrong and the
-    /// perturbed state cannot return to a cost of zero, because the wrong
-    /// Jacobian points somewhere else. This is the check behind the MGO09 reading
-    /// in D76: the four-camera drift is the schedule, not a defect in the update's
-    /// per-camera algebra.
+    /// The known-minimum fixture above cannot say this. Its truth is the
+    /// preintegration's own prediction, so the IMU factor alone already puts the
+    /// minimum where the pixels do, and the state would come back to it with the
+    /// observations dropped entirely. This asks the independent question: with
+    /// the IMU contribution subtracted off, does `b` equal a central finite
+    /// difference of the vision cost in the same chart `apply_inc` moves the
+    /// state through?
+    ///
+    /// It has to hold coordinate by coordinate, and on the four-camera MGO rig —
+    /// the one MGO09 replays — every landmark is hosted by camera 0 and observed
+    /// by whichever cameras can see it, so a residual formed through camera *i*
+    /// carries camera *i*'s extrinsic on the target side and `d_rel_d_t` for
+    /// that pair. A wrong extrinsic or a wrong Jacobian on a non-host camera
+    /// moves that camera's rows of `b` away from the true gradient, which is
+    /// what this measures. The last block then removes one camera at a time and
+    /// requires the gradient to move, so a camera silently contributing nothing
+    /// cannot pass either.
+    ///
+    /// `b` is the gradient and not half of it: the vision cost accumulates
+    /// `0.5 * res_squared` per observation inside the Huber radius while `b`
+    /// accumulates `Jᵀr`, both whitened by the same `sqrt_weight`. The
+    /// perturbation is small enough to keep every residual inside that radius,
+    /// where the weight is one and the cost is smooth.
+    ///
+    /// The FEJ branch is deliberately not exercised: with a frozen host whose
+    /// pose has moved off its linearization point, `d_rel_d_t` is at the old
+    /// point while the residual is at the new one, and disagreeing with the
+    /// finite difference is exactly what first-estimates-Jacobian means. The
+    /// host here sits at its linearization point, so the two must agree.
     #[test]
-    fn the_frame_update_recovers_on_a_four_camera_rig() {
-        let (mut vio, truth) = a_window_on(CALIB_4, CONFIG_4, 5);
+    fn the_four_camera_vision_gradient_is_the_vision_cost_gradient() {
+        let (mut vio, _) = a_window_on(CALIB_4, CONFIG_4, 1, None);
         assert_eq!(vio.ba.cameras().len(), 4);
-        let observing: usize = (0..4)
+
+        // Off the minimum, but only just: the residuals have to stay inside the
+        // Huber radius for the cost to be the smooth `0.5 * rᵀr`.
+        let mut perturbation: Vector15<f64> = Vector15::zeros();
+        perturbation
+            .fixed_rows_mut::<3>(0)
+            .copy_from(&Vector3::new(0.004, -0.003, 0.002));
+        perturbation
+            .fixed_rows_mut::<3>(3)
+            .copy_from(&Vector3::new(0.001, 0.0015, -0.0008));
+        vio.ba
+            .frame_states
+            .get_mut(&CURRENT_T_NS)
+            .unwrap()
+            .apply_inc(&perturbation);
+
+        let imu_lin: ImuLinData<f64> = vio.imu_lin_data();
+        let options: LandmarkBlockOptions<f64> = LandmarkBlockOptions {
+            huber_parameter: vio.ba.huber_thresh,
+            obs_std_dev: vio.ba.obs_std_dev,
+            ..LandmarkBlockOptions::default()
+        };
+        let meas: IntegratedImuMeasurement<f64> = vio.imu_meas[&PREV_T_NS];
+
+        // The vision cost and the vision gradient at whatever point the window is
+        // standing on, both read off one `linearize_state`.
+        let vision = |vio: &mut SqrtKeypointVio<f64>| -> (f64, Vector15<f64>) {
+            let mut h: DMatrix<f64> = DMatrix::zeros(POSE_VEL_BIAS_SIZE, POSE_VEL_BIAS_SIZE);
+            let mut b: DVector<f64> = DVector::zeros(POSE_VEL_BIAS_SIZE);
+            let mut imu_h: DMatrix<f64> = DMatrix::zeros(IMU_BLOCK_SIZE, IMU_BLOCK_SIZE);
+            let mut imu_b: DVector<f64> = DVector::zeros(IMU_BLOCK_SIZE);
+            let (total, imu_error) = linearize_state(
+                &vio.ba,
+                &meas,
+                &imu_lin,
+                PREV_T_NS,
+                CURRENT_T_NS,
+                &options,
+                &mut h,
+                &mut b,
+                &mut imu_h,
+                &mut imu_b,
+            )
+            .unwrap();
+            let gradient: Vector15<f64> =
+                Vector15::from_fn(|i, _| b[i] - imu_b[POSE_VEL_BIAS_SIZE + i]);
+            (total - imu_error, gradient)
+        };
+
+        let (_, analytic): (f64, Vector15<f64>) = vision(&mut vio);
+        assert!(
+            analytic.fixed_rows::<6>(0).norm() > 1e-3,
+            "the perturbation has to leave the pixels something to say: {}",
+            analytic.fixed_rows::<6>(0).norm()
+        );
+
+        let step: f64 = 1e-6;
+        for index in 0..POSE_VEL_BIAS_SIZE {
+            let mut probe = |sign: f64| -> f64 {
+                let mut increment: Vector15<f64> = Vector15::zeros();
+                increment[index] = sign * step;
+                let state = vio.ba.frame_states.get_mut(&CURRENT_T_NS).unwrap();
+                state.backup();
+                state.apply_inc(&increment);
+                let (cost, _) = vision(&mut vio);
+                vio.ba
+                    .frame_states
+                    .get_mut(&CURRENT_T_NS)
+                    .unwrap()
+                    .restore();
+                cost
+            };
+            let difference: f64 = (probe(1.0) - probe(-1.0)) / (2.0 * step);
+            // The pose rows carry the whole vision gradient; velocity and both
+            // biases are invisible to a reprojection, so their rows are zero on
+            // both sides and the tolerance is absolute.
+            assert!(
+                (difference - analytic[index]).abs() < 1e-4 * (1.0 + analytic[index].abs()),
+                "coordinate {index}: analytic {} against finite difference {difference}",
+                analytic[index]
+            );
+            if index >= POSE_SIZE {
+                assert_eq!(analytic[index], 0.0, "coordinate {index} is not a pixel's");
+            }
+        }
+
+        // Every camera that sees something has to move the gradient: build the
+        // same window with that camera filing nothing and the vision half of the
+        // system has to change.
+        let observed: Vec<usize> = (0..4)
             .filter(|cam_id| {
                 vio.ba
                     .lmdb
@@ -907,39 +1025,25 @@ mod tests {
                     .iter()
                     .any(|lm| lm.obs.contains_key(&TimeCamId::new(CURRENT_T_NS, *cam_id)))
             })
-            .count();
+            .collect();
         assert!(
-            observing >= 2,
-            "the fixture has to exercise a non-host camera: {observing} of 4 observe"
+            observed.len() >= 2,
+            "the fixture has to exercise a non-host camera: {observed:?}"
         );
-
-        let mut perturbation: Vector15<f64> = Vector15::zeros();
-        perturbation
-            .fixed_rows_mut::<3>(0)
-            .copy_from(&Vector3::new(0.02, -0.015, 0.01));
-        perturbation
-            .fixed_rows_mut::<3>(3)
-            .copy_from(&Vector3::new(0.004, 0.006, -0.003));
-        vio.ba
-            .frame_states
-            .get_mut(&CURRENT_T_NS)
-            .unwrap()
-            .apply_inc(&perturbation);
-
-        let (lm, _, _) = vio.frame_update(CURRENT_T_NS).unwrap().unwrap();
-        let last = lm.last().unwrap();
-        assert!(
-            last.error_after < 1e-12,
-            "the minimum is exact on four cameras too: {}",
-            last.error_after
-        );
-        let recovered: &PoseVelBiasState<f64> = vio.ba.frame_states[&CURRENT_T_NS].state();
-        let position: f64 = (recovered.t_w_i.translation - truth.t_w_i.translation).norm();
-        let rotation: f64 = (recovered.t_w_i.rotation * truth.t_w_i.rotation.inverse())
-            .log()
-            .norm();
-        assert!(position < CONVERGENCE_TOLERANCE, "position {position}");
-        assert!(rotation < CONVERGENCE_TOLERANCE, "rotation {rotation}");
+        for cam_id in observed {
+            let (mut without, _) = a_window_on(CALIB_4, CONFIG_4, 1, Some(cam_id));
+            without
+                .ba
+                .frame_states
+                .get_mut(&CURRENT_T_NS)
+                .unwrap()
+                .apply_inc(&perturbation);
+            let (_, dropped): (f64, Vector15<f64>) = vision(&mut without);
+            assert!(
+                (dropped - analytic).norm() > 1e-6,
+                "camera {cam_id} contributes nothing to the vision gradient"
+            );
+        }
     }
 
     /// Offline mode lets nothing but the data reach a decision: the same window

--- a/packages/slam-rs/crates/slam-rs/src/estimator/frame_update.rs
+++ b/packages/slam-rs/crates/slam-rs/src/estimator/frame_update.rs
@@ -60,6 +60,61 @@ use crate::types::{
 /// [`ImuBlock::add_dense_h_b`] writes into.
 const IMU_BLOCK_SIZE: usize = 2 * POSE_VEL_BIAS_SIZE;
 
+/// Which precondition sent a frameset back to the joint solve.
+///
+/// [`SqrtKeypointVio::frame_update`] serves only a frameset whose newest state
+/// is genuinely joined to its predecessor by the preintegration the joint solve
+/// itself would use, and only while the prior leaves that state free. Naming
+/// each refusal is what makes "the update never engaged on this clip" a
+/// measurement rather than a guess: the variant travels out through
+/// [`FrameUpdateOutcome`] on every [`super::FrameStats`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameUpdateDecline {
+    /// The newest state in the window is not this frameset's.
+    NotNewest,
+    /// The newest state has no predecessor in the window.
+    NoPredecessor,
+    /// No preintegration in `imu_meas` starts at the predecessor.
+    NoImuFactor,
+    /// The preintegration that starts at the predecessor does not end at this
+    /// frameset, so it is not the factor that joins the two.
+    ImuIntervalGap,
+    /// The marginalization prior orders the newest state, so its gradient here
+    /// is not zero and a solve that omits it would be wrong.
+    PriorOrdersState,
+}
+
+/// What the frame update did with one frameset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameUpdateOutcome {
+    /// The knob is off, the frameset took a keyframe, or the warmup still owns
+    /// the window: [`SqrtKeypointVio::frame_update`] was never called.
+    NotAttempted,
+    /// The frame update solved this frameset.
+    Taken,
+    /// A precondition refused it and the joint solve ran instead.
+    Declined(FrameUpdateDecline),
+}
+
+/// Either the solve, or the precondition that refused the frameset.
+pub(super) type FrameUpdateResult<S> = Result<SolveOutcome<S>, FrameUpdateDecline>;
+
+impl FrameUpdateOutcome {
+    /// A stable name per outcome, for the Python snapshot and for logs.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NotAttempted => "not_attempted",
+            Self::Taken => "taken",
+            Self::Declined(FrameUpdateDecline::NotNewest) => "declined_not_newest",
+            Self::Declined(FrameUpdateDecline::NoPredecessor) => "declined_no_predecessor",
+            Self::Declined(FrameUpdateDecline::NoImuFactor) => "declined_no_imu_factor",
+            Self::Declined(FrameUpdateDecline::ImuIntervalGap) => "declined_imu_interval_gap",
+            Self::Declined(FrameUpdateDecline::PriorOrdersState) => "declined_prior_orders_state",
+        }
+    }
+}
+
 /// Everything one [`SqrtKeypointVio::frame_update`] works in that outlives the
 /// call.
 ///
@@ -109,10 +164,12 @@ impl<S: LieScalar> Default for FrameUpdateScratch<S> {
 impl<S: LieScalar> SqrtKeypointVio<S> {
     /// Solve the newest state against fixed landmarks and its IMU factor.
     ///
-    /// `Ok(None)` means the frameset is not one this can serve — no previous
-    /// state, no IMU factor joining it to this one, or a prior that orders the
-    /// newest state — and the caller must run the joint solve instead. Every one
-    /// of those tests reads the window alone, so a replay repeats the choice.
+    /// `Err(FrameUpdateDecline)` means the frameset is not one this can serve —
+    /// no previous state, no IMU factor joining it to this one, or a prior that
+    /// orders the newest state — and the caller must run the joint solve
+    /// instead. Every one of those tests reads the window alone, so a replay
+    /// repeats the choice, and the variant is reported per frameset so a clip
+    /// where the update never engages says which precondition refused it.
     ///
     /// # Errors
     ///
@@ -122,26 +179,26 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
     pub(super) fn frame_update(
         &mut self,
         t_ns: i64,
-    ) -> Result<Option<SolveOutcome<S>>, EstimatorError> {
+    ) -> Result<FrameUpdateResult<S>, EstimatorError> {
         // The newest state has to be this frameset's, and it has to have a
         // predecessor and the preintegration that joins them.
         if self.ba.frame_states.keys().next_back() != Some(&t_ns) {
-            return Ok(None);
+            return Ok(Err(FrameUpdateDecline::NotNewest));
         }
         let Some(prev_t_ns) = self.ba.frame_states.keys().rev().nth(1).copied() else {
-            return Ok(None);
+            return Ok(Err(FrameUpdateDecline::NoPredecessor));
         };
         let Some(meas) = self.imu_meas.get(&prev_t_ns) else {
-            return Ok(None);
+            return Ok(Err(FrameUpdateDecline::NoImuFactor));
         };
         if prev_t_ns.checked_add(meas.get_dt_ns()) != Some(t_ns) {
-            return Ok(None);
+            return Ok(Err(FrameUpdateDecline::ImuIntervalGap));
         }
         // The prior is a quadratic in blocks frozen at a linearization point and
         // the newest state is not one, so it cannot order it; if it ever does,
         // its gradient is not zero here and this solve would be wrong.
         if self.marg_data.order.get(t_ns).is_some() {
-            return Ok(None);
+            return Ok(Err(FrameUpdateDecline::PriorOrdersState));
         }
 
         let mut lm: Vec<LmIteration<S>> = Vec::new();
@@ -174,7 +231,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         let Some(meas) = imu_meas.get(&prev_t_ns) else {
             // Unreachable: the same lookup succeeded above and nothing since has
             // touched `imu_meas`.
-            return Ok(None);
+            return Ok(Err(FrameUpdateDecline::NoImuFactor));
         };
 
         // `:1249`, D11: the trust region has no memory across framesets.
@@ -305,7 +362,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             }
         }
 
-        Ok(Some((
+        Ok(Ok((
             lm,
             termination.unwrap_or(LmTermination::MaxIterations),
             timings,
@@ -504,6 +561,10 @@ mod tests {
 
     const CALIB: &str = include_str!("../../tests/fixtures/msdmi_calib.json");
     const CONFIG: &str = include_str!("../../../../configs/msdmi_config.json");
+    /// The four-camera MGO rig, which is what MGO09 replays.
+    const CALIB_4: &str = include_str!("../../tests/fixtures/msdmg_calib.json");
+    /// See [`CALIB_4`].
+    const CONFIG_4: &str = include_str!("../../../../configs/msdmg_config.json");
 
     /// The host keyframe, the previous state and the newest state.
     const HOST_T_NS: i64 = 0;
@@ -525,9 +586,19 @@ mod tests {
     /// Returns the estimator with the newest state left **at** the truth, and the
     /// truth beside it.
     fn a_window(iterations: i32) -> (SqrtKeypointVio<f64>, PoseVelBiasState<f64>) {
-        let mut config: VioConfig = VioConfig::from_json_str(CONFIG).unwrap();
+        a_window_on(CALIB, CONFIG, iterations)
+    }
+
+    /// [`a_window`] on a named rig, so the same known answer can be asked of a
+    /// two-camera and a four-camera window.
+    fn a_window_on(
+        calib: &str,
+        config: &str,
+        iterations: i32,
+    ) -> (SqrtKeypointVio<f64>, PoseVelBiasState<f64>) {
+        let mut config: VioConfig = VioConfig::from_json_str(config).unwrap();
         config.port_frame_update_max_iterations = iterations;
-        let calibration: Calibration<f64> = Calibration::from_json_str(CALIB).unwrap();
+        let calibration: Calibration<f64> = Calibration::from_json_str(calib).unwrap();
         let gravity: Vector3<f64> = Vector3::new(0.0, 0.0, -9.81);
         let mut vio: SqrtKeypointVio<f64> =
             SqrtKeypointVio::new(gravity, calibration, config).unwrap();
@@ -731,22 +802,75 @@ mod tests {
     }
 
     /// A frameset the frame update cannot serve goes back to the joint solve
-    /// rather than being solved wrong, and every test reads the window alone.
+    /// rather than being solved wrong, and each refusal names the precondition
+    /// that made it.
+    ///
+    /// The names are the load-bearing part: they are what
+    /// [`FrameUpdateOutcome`] carries out to `FrameStats` and to the Python
+    /// snapshot, so "the update never engaged on this clip" can be answered with
+    /// a count per precondition instead of a guess. Every test reads the window
+    /// alone, so a replay repeats the choice.
     #[test]
-    fn a_frameset_without_its_imu_factor_is_declined() {
+    fn every_refusal_names_its_precondition() {
         // No preintegration joining the two states.
         let (mut vio, _) = a_window(2);
         vio.imu_meas.clear();
-        assert!(vio.frame_update(CURRENT_T_NS).unwrap().is_none());
+        assert_eq!(
+            vio.frame_update(CURRENT_T_NS).unwrap().unwrap_err(),
+            FrameUpdateDecline::NoImuFactor
+        );
+
+        // A preintegration that starts at the predecessor but ends short of this
+        // frameset: it is not the factor the joint solve would use, and the
+        // interval it covers is not the one being solved over. One IMU sample of
+        // an interval is enough to see it.
+        let (mut vio, _) = a_window(2);
+        let short: IntegratedImuMeasurement<f64> = {
+            let noise = crate::imu::ImuNoise::from_calibration(&vio.ba.calib);
+            let zero: Vector3<f64> = Vector3::zeros();
+            let mut meas = IntegratedImuMeasurement::new(PREV_T_NS, &zero, &zero);
+            let step_ns: i64 = (1e9 / vio.ba.calib.imu_update_rate) as i64;
+            let mut t_ns: i64 = PREV_T_NS + step_ns;
+            while t_ns <= CURRENT_T_NS - step_ns {
+                meas.integrate(
+                    &ImuSample {
+                        t_ns,
+                        gyro: Vector3::zeros(),
+                        accel: Vector3::new(0.0, 0.0, 9.81),
+                    },
+                    &noise.accel_cov,
+                    &noise.gyro_cov,
+                )
+                .unwrap();
+                t_ns += step_ns;
+            }
+            meas
+        };
+        assert_eq!(
+            PREV_T_NS + short.get_dt_ns(),
+            CURRENT_T_NS - (1e9 / vio.ba.calib.imu_update_rate) as i64,
+            "the fixture has to end one IMU sample short of the frameset"
+        );
+        vio.imu_meas.insert(PREV_T_NS, short);
+        assert_eq!(
+            vio.frame_update(CURRENT_T_NS).unwrap().unwrap_err(),
+            FrameUpdateDecline::ImuIntervalGap
+        );
 
         // A frameset that is not the newest state.
         let (mut vio, _) = a_window(2);
-        assert!(vio.frame_update(PREV_T_NS).unwrap().is_none());
+        assert_eq!(
+            vio.frame_update(PREV_T_NS).unwrap().unwrap_err(),
+            FrameUpdateDecline::NotNewest
+        );
 
         // No previous state to hold.
         let (mut vio, _) = a_window(2);
         vio.ba.frame_states.remove(&PREV_T_NS);
-        assert!(vio.frame_update(CURRENT_T_NS).unwrap().is_none());
+        assert_eq!(
+            vio.frame_update(CURRENT_T_NS).unwrap().unwrap_err(),
+            FrameUpdateDecline::NoPredecessor
+        );
 
         // A prior that orders the newest state: its gradient would not be zero.
         let (mut vio, _) = a_window(2);
@@ -754,7 +878,68 @@ mod tests {
             .order
             .push(CURRENT_T_NS, POSE_VEL_BIAS_SIZE)
             .unwrap();
-        assert!(vio.frame_update(CURRENT_T_NS).unwrap().is_none());
+        assert_eq!(
+            vio.frame_update(CURRENT_T_NS).unwrap().unwrap_err(),
+            FrameUpdateDecline::PriorOrdersState
+        );
+    }
+
+    /// The four-camera rig: the held landmarks' Jacobians w.r.t. the newest state
+    /// are right for a non-host camera too.
+    ///
+    /// Every landmark here is hosted by camera 0 of the host keyframe and is
+    /// observed by whichever of the four cameras can see it, so the relative pose
+    /// each residual is formed through carries a different `T_i_c` on the target
+    /// side. Get one of those extrinsics or its `d_rel_d_t` wrong and the
+    /// perturbed state cannot return to a cost of zero, because the wrong
+    /// Jacobian points somewhere else. This is the check behind the MGO09 reading
+    /// in D76: the four-camera drift is the schedule, not a defect in the update's
+    /// per-camera algebra.
+    #[test]
+    fn the_frame_update_recovers_on_a_four_camera_rig() {
+        let (mut vio, truth) = a_window_on(CALIB_4, CONFIG_4, 5);
+        assert_eq!(vio.ba.cameras().len(), 4);
+        let observing: usize = (0..4)
+            .filter(|cam_id| {
+                vio.ba
+                    .lmdb
+                    .landmarks()
+                    .iter()
+                    .any(|lm| lm.obs.contains_key(&TimeCamId::new(CURRENT_T_NS, *cam_id)))
+            })
+            .count();
+        assert!(
+            observing >= 2,
+            "the fixture has to exercise a non-host camera: {observing} of 4 observe"
+        );
+
+        let mut perturbation: Vector15<f64> = Vector15::zeros();
+        perturbation
+            .fixed_rows_mut::<3>(0)
+            .copy_from(&Vector3::new(0.02, -0.015, 0.01));
+        perturbation
+            .fixed_rows_mut::<3>(3)
+            .copy_from(&Vector3::new(0.004, 0.006, -0.003));
+        vio.ba
+            .frame_states
+            .get_mut(&CURRENT_T_NS)
+            .unwrap()
+            .apply_inc(&perturbation);
+
+        let (lm, _, _) = vio.frame_update(CURRENT_T_NS).unwrap().unwrap();
+        let last = lm.last().unwrap();
+        assert!(
+            last.error_after < 1e-12,
+            "the minimum is exact on four cameras too: {}",
+            last.error_after
+        );
+        let recovered: &PoseVelBiasState<f64> = vio.ba.frame_states[&CURRENT_T_NS].state();
+        let position: f64 = (recovered.t_w_i.translation - truth.t_w_i.translation).norm();
+        let rotation: f64 = (recovered.t_w_i.rotation * truth.t_w_i.rotation.inverse())
+            .log()
+            .norm();
+        assert!(position < CONVERGENCE_TOLERANCE, "position {position}");
+        assert!(rotation < CONVERGENCE_TOLERANCE, "rotation {rotation}");
     }
 
     /// Offline mode lets nothing but the data reach a decision: the same window

--- a/packages/slam-rs/crates/slam-rs/src/estimator/frame_update.rs
+++ b/packages/slam-rs/crates/slam-rs/src/estimator/frame_update.rs
@@ -1,0 +1,475 @@
+//! The non-keyframe frame update (D76): the newest state alone, against fixed
+//! landmarks and its IMU factor.
+//!
+//! basalt has no counterpart. It is a fixed-lag smoother and re-solves the whole
+//! sliding window on every frameset ([`SqrtKeypointVio::optimize`]); cuVSLAM
+//! instead solves only the newest pose against constant landmarks per frame
+//! (`libs/pnp/multicam_pnp.cpp`) and runs bundle adjustment at keyframes, and
+//! this is that schedule's cheap half. It runs only when
+//! `port.frame_update_max_iterations` is above zero and only on a frameset that
+//! took no keyframe; at the knob's `0` default nothing here is reached and the
+//! estimator is basalt's, frame for frame.
+//!
+//! Everything numeric is borrowed rather than restated: the residual and its
+//! pose Jacobian are [`linearize_point`] and [`compute_rel_pose`], the robust
+//! weight is the landmark block's own [`compute_error_weight`], the IMU factor is
+//! [`ImuBlock::linearize`], and the damped solve is [`damped_solve`] — the same
+//! Eigen LDLT the window solve runs. There is one reprojection model in the
+//! crate.
+//!
+//! ## What is held, and why the prior is not here
+//!
+//! Landmarks, their host keyframes and every older state are constants, so the
+//! only free block is the newest state's 15 unknowns. The marginalization prior
+//! covers only blocks frozen at a linearization point — `computeDelta` refuses
+//! any other (`ba_base.cpp:294`) — and the newest state is appended unfrozen, so
+//! the prior's cost does not depend on the one variable this solves for and
+//! contributes neither a Jacobian nor a gradient. [`SqrtKeypointVio::frame_update`]
+//! checks that per frame and hands the frameset back to the joint solve if the
+//! prior ever does order it.
+//!
+//! ## The loop
+//!
+//! The window loop's shape, constant for constant: `lambda` reset to
+//! `vio_lm_lambda_initial` every frame (D11), `lambda·diag(H)` damping with the
+//! same floor (D10), the budget shared with backtracking (D12), the increment
+//! negated before it is applied (D13), Nielsen's update on an accept and the
+//! same hard-coded `1e-6`/`1e-4` convergence pair. One difference, and it is a
+//! simplification the window cannot make: with nothing eliminated, the model's
+//! predicted decrease is `−(inc·b + ½ incᵀ H inc)` in closed form, which is what
+//! `backSubstitute` accumulates block by block when there are no landmark
+//! columns to substitute back.
+
+use nalgebra::{DMatrix, DVector, Matrix2x6, Matrix4, Matrix6, Vector2, Vector6};
+
+use super::optimize::{
+    FUNCTION_TOLERANCE, LmIteration, LmTermination, STEP_TOLERANCE, SolveOutcome, damped_solve,
+};
+use super::{EstimatorError, SqrtKeypointVio, StageTimings, VEE_FACTOR};
+use crate::ba_base::{BundleAdjustmentBase, LinearizePointOut, compute_rel_pose, linearize_point};
+use crate::duration_ns;
+use crate::eigen::ldlt::EigenLdlt;
+use crate::imu::{ImuBlock, ImuLinData, IntegratedImuMeasurement};
+use crate::lie::{LieScalar, Se3, eigen_maxi};
+use crate::linearize::{LandmarkBlockOptions, compute_error_weight};
+use crate::types::{
+    FrameId, POSE_SIZE, POSE_VEL_BIAS_SIZE, PoseVelBiasStateWithLin, TimeCamId, Vector15,
+};
+
+/// The two states an IMU factor spans, stacked, which is what
+/// [`ImuBlock::add_dense_h_b`] writes into.
+const IMU_BLOCK_SIZE: usize = 2 * POSE_VEL_BIAS_SIZE;
+
+/// Everything one [`SqrtKeypointVio::frame_update`] works in that outlives the
+/// call.
+///
+/// Same reasoning as [`super::optimize::OptimizeScratch`] (D73): the buffers are
+/// reset or fully overwritten before each read, so holding them changes the
+/// allocation and not the arithmetic, and the loop runs two or three times a
+/// frame on six framesets in seven.
+#[derive(Debug, Clone)]
+pub(super) struct FrameUpdateScratch<S: LieScalar> {
+    /// The normal equations at the point the loop is standing on.
+    h: DMatrix<S>,
+    /// See [`Self::h`].
+    b: DVector<S>,
+    /// The normal equations at the trial point, which become [`Self::h`] and
+    /// [`Self::b`] when the step is accepted.
+    h_trial: DMatrix<S>,
+    /// See [`Self::h_trial`].
+    b_trial: DVector<S>,
+    /// The IMU factor's own 30x30 system, of which the trailing 15x15 corner is
+    /// the newest state's.
+    imu_h: DMatrix<S>,
+    /// See [`Self::imu_h`].
+    imu_b: DVector<S>,
+    /// The damped solve's factorization and working copy.
+    solve: EigenLdlt<S>,
+    /// The increment [`damped_solve`] writes and the loop then negates.
+    increment: DVector<S>,
+}
+
+impl<S: LieScalar> Default for FrameUpdateScratch<S> {
+    /// Buffers at their final size: unlike the window's, this system's shape is
+    /// a compile-time constant.
+    fn default() -> Self {
+        Self {
+            h: DMatrix::zeros(POSE_VEL_BIAS_SIZE, POSE_VEL_BIAS_SIZE),
+            b: DVector::zeros(POSE_VEL_BIAS_SIZE),
+            h_trial: DMatrix::zeros(POSE_VEL_BIAS_SIZE, POSE_VEL_BIAS_SIZE),
+            b_trial: DVector::zeros(POSE_VEL_BIAS_SIZE),
+            imu_h: DMatrix::zeros(IMU_BLOCK_SIZE, IMU_BLOCK_SIZE),
+            imu_b: DVector::zeros(IMU_BLOCK_SIZE),
+            solve: EigenLdlt::empty(),
+            increment: DVector::zeros(POSE_VEL_BIAS_SIZE),
+        }
+    }
+}
+
+impl<S: LieScalar> SqrtKeypointVio<S> {
+    /// Solve the newest state against fixed landmarks and its IMU factor.
+    ///
+    /// `Ok(None)` means the frameset is not one this can serve — no previous
+    /// state, no IMU factor joining it to this one, or a prior that orders the
+    /// newest state — and the caller must run the joint solve instead. Every one
+    /// of those tests reads the window alone, so a replay repeats the choice.
+    ///
+    /// # Errors
+    ///
+    /// [`EstimatorError::BundleAdjustment`] where a pose the residual needs is
+    /// not in the window, and [`EstimatorError::Linearize`] where the camera id
+    /// of an observation is not in the rig.
+    pub(super) fn frame_update(
+        &mut self,
+        t_ns: i64,
+    ) -> Result<Option<SolveOutcome<S>>, EstimatorError> {
+        // The newest state has to be this frameset's, and it has to have a
+        // predecessor and the preintegration that joins them.
+        if self.ba.frame_states.keys().next_back() != Some(&t_ns) {
+            return Ok(None);
+        }
+        let Some(prev_t_ns) = self.ba.frame_states.keys().rev().nth(1).copied() else {
+            return Ok(None);
+        };
+        let Some(meas) = self.imu_meas.get(&prev_t_ns) else {
+            return Ok(None);
+        };
+        if prev_t_ns.checked_add(meas.get_dt_ns()) != Some(t_ns) {
+            return Ok(None);
+        }
+        // The prior is a quadratic in blocks frozen at a linearization point and
+        // the newest state is not one, so it cannot order it; if it ever does,
+        // its gradient is not zero here and this solve would be wrong.
+        if self.marg_data.order.get(t_ns).is_some() {
+            return Ok(None);
+        }
+
+        let mut lm: Vec<LmIteration<S>> = Vec::new();
+        let mut timings: StageTimings = StageTimings::default();
+        let imu_lin: ImuLinData<S> = self.imu_lin_data();
+        let options: LandmarkBlockOptions<S> = LandmarkBlockOptions {
+            huber_parameter: self.ba.huber_thresh,
+            obs_std_dev: self.ba.obs_std_dev,
+            ..LandmarkBlockOptions::default()
+        };
+
+        let Self {
+            ref mut ba,
+            ref mut damping,
+            ref mut frame_scratch,
+            ref imu_meas,
+            ref config,
+            ..
+        } = *self;
+        let FrameUpdateScratch {
+            ref mut h,
+            ref mut b,
+            ref mut h_trial,
+            ref mut b_trial,
+            ref mut imu_h,
+            ref mut imu_b,
+            ref mut solve,
+            ref mut increment,
+        } = *frame_scratch;
+        let Some(meas) = imu_meas.get(&prev_t_ns) else {
+            // Unreachable: the same lookup succeeded above and nothing since has
+            // touched `imu_meas`.
+            return Ok(None);
+        };
+
+        // `:1249`, D11: the trust region has no memory across framesets.
+        damping.lambda = S::from_literal(config.vio_lm_lambda_initial);
+
+        let mark: std::time::Instant = std::time::Instant::now();
+        let (mut error_total, _): (S, S) = linearize_state(
+            ba, meas, &imu_lin, prev_t_ns, t_ns, &options, h, b, imu_h, imu_b,
+        )?;
+        timings.linearize_ns += duration_ns(mark);
+
+        let mut it: i32 = 0;
+        let mut termination: Option<LmTermination> = None;
+        let mut backtrack: i32 = 0;
+        while it <= config.port_frame_update_max_iterations && termination.is_none() {
+            let mark: std::time::Instant = std::time::Instant::now();
+            let (inc_valid, solve_attempts): (bool, u32) =
+                damped_solve(h, b, damping, solve, increment);
+            if !inc_valid {
+                log::warn!(
+                    "frame {t_ns} ns: the frame update's increment is still not finite after {solve_attempts} damped solves"
+                );
+            }
+            timings.solver_ns += duration_ns(mark);
+
+            // D13: negate, then apply.
+            increment.neg_mut();
+            let inc: Vector15<S> = Vector15::from_iterator(increment.iter().copied());
+
+            // `−(inc·b + ½ incᵀ H inc)`, the model's predicted decrease. With no
+            // eliminated block this is `backSubstitute`'s sum in closed form.
+            let mut linear: S = S::zero();
+            let mut quadratic: S = S::zero();
+            for i in 0..POSE_VEL_BIAS_SIZE {
+                linear += inc[i] * b[i];
+                for j in 0..POSE_VEL_BIAS_SIZE {
+                    quadratic += inc[i] * h[(i, j)] * inc[j];
+                }
+            }
+            let l_diff: S = -(linear + S::from_literal(0.5) * quadratic);
+
+            let Some(state) = ba.frame_states.get_mut(&t_ns) else {
+                // Unreachable: the key came from this map and nothing removes
+                // one inside the loop.
+                return Err(EstimatorError::PreviousStateMissing { t_ns });
+            };
+            state.backup();
+            state.apply_inc(&inc);
+
+            // `:1477`, folded left to right like the window's.
+            let mut step_norminf: S = S::zero();
+            for value in inc.iter() {
+                step_norminf = eigen_maxi(step_norminf, value.abs());
+            }
+
+            let mark: std::time::Instant = std::time::Instant::now();
+            let (error_after, imu_after): (S, S) = linearize_state(
+                ba, meas, &imu_lin, prev_t_ns, t_ns, &options, h_trial, b_trial, imu_h, imu_b,
+            )?;
+            timings.error_ns += duration_ns(mark);
+
+            let f_diff: S = error_total - error_after;
+            let relative_decrease: S = f_diff / l_diff;
+            let step_is_valid: bool = l_diff > S::zero();
+            let accepted: bool = step_is_valid && relative_decrease > S::zero();
+
+            lm.push(LmIteration {
+                iteration: it,
+                backtrack,
+                error_before: error_total,
+                error_after,
+                // The frame update's objective is two terms, not five: it has
+                // no prior, and `ImuBlock` returns the preintegration and the
+                // two bias random walks already summed.
+                vision_error: error_after - imu_after,
+                imu_error: imu_after,
+                bias_gyro_error: S::zero(),
+                bias_accel_error: S::zero(),
+                marg_prior_error: S::zero(),
+                l_diff,
+                f_diff,
+                relative_decrease,
+                lambda: damping.lambda,
+                step_norminf,
+                solve_attempts,
+                step_is_valid,
+                accepted,
+            });
+
+            if accepted {
+                // `:1557-1562`: Nielsen's update, in `double` as C++ deduces it.
+                let x: S = S::from_literal(2.0) * relative_decrease - S::one();
+                let gain: S = S::from_literal(1.0 - x.to_f64().powf(3.0));
+                let floor: S = S::one() / S::from_literal(3.0);
+                damping.lambda *= eigen_maxi(floor, gain);
+                damping.lambda = eigen_maxi(damping.min_lambda, damping.lambda);
+                damping.lambda_vee = S::from_literal(VEE_FACTOR);
+                it += 1;
+                backtrack = 0;
+
+                // The trial point is where the loop now stands, and its
+                // linearization is already built.
+                std::mem::swap(h, h_trial);
+                std::mem::swap(b, b_trial);
+                error_total = error_after;
+
+                // `:1565-1568`, both constants hard-coded in C++ too.
+                if (f_diff > S::zero() && f_diff < S::from_literal(FUNCTION_TOLERANCE))
+                    || step_norminf < S::from_literal(STEP_TOLERANCE)
+                {
+                    termination = Some(LmTermination::Converged);
+                }
+                continue;
+            }
+
+            // `:1585-1598`.
+            damping.lambda = damping.lambda_vee * damping.lambda;
+            damping.lambda_vee *= S::from_literal(VEE_FACTOR);
+            let Some(state) = ba.frame_states.get_mut(&t_ns) else {
+                // Unreachable, as above.
+                return Err(EstimatorError::PreviousStateMissing { t_ns });
+            };
+            state.restore();
+            it += 1;
+            backtrack += 1;
+            if damping.lambda > damping.max_lambda {
+                termination = Some(LmTermination::MaxDamping);
+            }
+        }
+
+        Ok(Some((
+            lm,
+            termination.unwrap_or(LmTermination::MaxIterations),
+            timings,
+        )))
+    }
+}
+
+/// Fill `h` and `b` with the newest state's normal equations at its current
+/// value, and return `(the cost there, the IMU factor's share of it)`.
+///
+/// Two factor groups and nothing else: every observation the frameset filed on a
+/// landmark the window hosts, and the IMU factor from the previous state. Both
+/// are whitened exactly as the window whitens them, so the two objectives are
+/// the same function of the same state.
+///
+/// The 15 unknowns are the state's own: pose in 0-5, velocity in 6-8, gyro bias
+/// in 9-11 and accel bias in 12-14 (`PoseVelBiasState::apply_inc`).
+#[expect(clippy::too_many_arguments, reason = "every buffer is the caller's")]
+fn linearize_state<S: LieScalar>(
+    ba: &BundleAdjustmentBase<S>,
+    meas: &IntegratedImuMeasurement<S>,
+    imu_lin: &ImuLinData<S>,
+    prev_t_ns: FrameId,
+    t_ns: FrameId,
+    options: &LandmarkBlockOptions<S>,
+    h: &mut DMatrix<S>,
+    b: &mut DVector<S>,
+    imu_h: &mut DMatrix<S>,
+    imu_b: &mut DVector<S>,
+) -> Result<(S, S), EstimatorError> {
+    h.fill(S::zero());
+    b.fill(S::zero());
+    let mut error: S = S::zero();
+
+    // The target's pose is one state's, so it is resolved once rather than per
+    // observation. It is never frozen — only `last_state_to_marg` is, and that
+    // is never the newest state — but the general form is kept so the two
+    // linearizations cannot drift apart.
+    let state_t = ba.get_pose_state_with_lin(t_ns)?;
+    let cameras = ba.cameras();
+
+    for lm in ba.lmdb.landmarks() {
+        for cam_id in 0..cameras.len() {
+            let tcid_t: TimeCamId = TimeCamId::new(t_ns, cam_id);
+            let Some(kpt_obs) = lm.obs.get(&tcid_t) else {
+                continue;
+            };
+            let tcid_h: TimeCamId = lm.host_kf_id;
+            let camera = cameras
+                .get(cam_id)
+                .ok_or(crate::linearize::LinearizeError::UnknownCamera {
+                    cam_id,
+                    camera_count: cameras.len(),
+                })?;
+
+            // `linearization_abs_qr.cpp:207-241`: the Jacobian at the
+            // linearization point, the value at the current state when either
+            // end is frozen. A landmark hosted by this frameset has no pose
+            // Jacobian at all (`:235-239`), which is what an identity relative
+            // pose means.
+            let (t_t_h, d_rel_d_t): (Matrix4<S>, Matrix6<S>) = if tcid_h == tcid_t {
+                (Matrix4::identity(), Matrix6::zeros())
+            } else {
+                let state_h = ba.get_pose_state_with_lin(tcid_h.frame_id)?;
+                let t_i_c_h: &Se3<S> = ba.calib.t_i_c.get(tcid_h.cam_id).ok_or(
+                    crate::linearize::LinearizeError::UnknownCamera {
+                        cam_id: tcid_h.cam_id,
+                        camera_count: ba.calib.t_i_c.len(),
+                    },
+                )?;
+                let t_i_c_t: &Se3<S> = ba.calib.t_i_c.get(cam_id).ok_or(
+                    crate::linearize::LinearizeError::UnknownCamera {
+                        cam_id,
+                        camera_count: ba.calib.t_i_c.len(),
+                    },
+                )?;
+                let mut d_rel_d_t: Matrix6<S> = Matrix6::zeros();
+                let mut rel: Se3<S> = compute_rel_pose(
+                    state_h.pose_lin(),
+                    t_i_c_h,
+                    state_t.pose_lin(),
+                    t_i_c_t,
+                    None,
+                    Some(&mut d_rel_d_t),
+                );
+                if state_h.is_linearized() || state_t.is_linearized() {
+                    rel = compute_rel_pose(state_h.pose(), t_i_c_h, state_t.pose(), t_i_c_t, None, None);
+                }
+                (rel.matrix(), d_rel_d_t)
+            };
+
+            let mut res: Vector2<S> = Vector2::zeros();
+            let mut d_res_d_xi: Matrix2x6<S> = Matrix2x6::zeros();
+            let valid: bool = linearize_point(
+                kpt_obs,
+                lm,
+                &t_t_h,
+                camera,
+                &mut res,
+                &mut LinearizePointOut {
+                    d_res_d_xi: Some(&mut d_res_d_xi),
+                    d_res_d_p: None,
+                    proj: None,
+                },
+            );
+            // `landmark_block_abs_dynamic.hpp:152`.
+            if options.use_valid_projections_only && !valid {
+                continue;
+            }
+            // `:153-163`: zeroed, never fatal.
+            if !d_res_d_xi.iter().all(|v| v.to_f64().is_finite()) {
+                log::warn!("d_res_d_xi is not valid in the frame update, lm = {:?}", lm.id);
+                d_res_d_xi.fill(S::zero());
+            }
+
+            // `:168-179`, with the host block dropped: the landmark and its host
+            // are constants here.
+            let res_squared: S = res[0] * res[0] + res[1] * res[1];
+            let (weighted_error, weight) = compute_error_weight(res_squared, options);
+            let sqrt_weight: S = weight.sqrt() / options.obs_std_dev;
+            error += weighted_error / (options.obs_std_dev * options.obs_std_dev);
+
+            d_res_d_xi *= sqrt_weight;
+            let jacobian: Matrix2x6<S> = d_res_d_xi * d_rel_d_t;
+            let residual: Vector2<S> = res * sqrt_weight;
+            let jtj: Matrix6<S> = jacobian.transpose() * jacobian;
+            let jtr: Vector6<S> = jacobian.transpose() * residual;
+            for i in 0..POSE_SIZE {
+                for j in 0..POSE_SIZE {
+                    h[(i, j)] += jtj[(i, j)];
+                }
+                b[i] += jtr[i];
+            }
+        }
+    }
+
+    // The IMU factor over `(prev, t_ns]`, with the previous state held: its
+    // 30x30 system's trailing corner is the newest state's, which is what
+    // deleting a fixed variable's rows and columns comes to.
+    let start_state: &PoseVelBiasStateWithLin<S> = ba.frame_states.get(&prev_t_ns).ok_or(
+        EstimatorError::ImuFactorStateMissing {
+            start_t_ns: prev_t_ns,
+            end_t_ns: t_ns,
+            missing_t_ns: prev_t_ns,
+        },
+    )?;
+    let end_state: &PoseVelBiasStateWithLin<S> = ba.frame_states.get(&t_ns).ok_or(
+        EstimatorError::ImuFactorStateMissing {
+            start_t_ns: prev_t_ns,
+            end_t_ns: t_ns,
+            missing_t_ns: t_ns,
+        },
+    )?;
+    let block: ImuBlock<S> = ImuBlock::linearize(meas, imu_lin, start_state, end_state);
+    imu_h.fill(S::zero());
+    imu_b.fill(S::zero());
+    block.add_dense_h_b(0, POSE_VEL_BIAS_SIZE, imu_h, imu_b);
+    for i in 0..POSE_VEL_BIAS_SIZE {
+        for j in 0..POSE_VEL_BIAS_SIZE {
+            h[(i, j)] += imu_h[(POSE_VEL_BIAS_SIZE + i, POSE_VEL_BIAS_SIZE + j)];
+        }
+        b[i] += imu_b[POSE_VEL_BIAS_SIZE + i];
+    }
+    error += block.error;
+
+    Ok((error, block.error))
+}

--- a/packages/slam-rs/crates/slam-rs/src/estimator/frame_update.rs
+++ b/packages/slam-rs/crates/slam-rs/src/estimator/frame_update.rs
@@ -354,12 +354,13 @@ fn linearize_state<S: LieScalar>(
                 continue;
             };
             let tcid_h: TimeCamId = lm.host_kf_id;
-            let camera = cameras
-                .get(cam_id)
-                .ok_or(crate::linearize::LinearizeError::UnknownCamera {
-                    cam_id,
-                    camera_count: cameras.len(),
-                })?;
+            let camera =
+                cameras
+                    .get(cam_id)
+                    .ok_or(crate::linearize::LinearizeError::UnknownCamera {
+                        cam_id,
+                        camera_count: cameras.len(),
+                    })?;
 
             // `linearization_abs_qr.cpp:207-241`: the Jacobian at the
             // linearization point, the value at the current state when either
@@ -392,7 +393,14 @@ fn linearize_state<S: LieScalar>(
                     Some(&mut d_rel_d_t),
                 );
                 if state_h.is_linearized() || state_t.is_linearized() {
-                    rel = compute_rel_pose(state_h.pose(), t_i_c_h, state_t.pose(), t_i_c_t, None, None);
+                    rel = compute_rel_pose(
+                        state_h.pose(),
+                        t_i_c_h,
+                        state_t.pose(),
+                        t_i_c_t,
+                        None,
+                        None,
+                    );
                 }
                 (rel.matrix(), d_rel_d_t)
             };
@@ -417,7 +425,10 @@ fn linearize_state<S: LieScalar>(
             }
             // `:153-163`: zeroed, never fatal.
             if !d_res_d_xi.iter().all(|v| v.to_f64().is_finite()) {
-                log::warn!("d_res_d_xi is not valid in the frame update, lm = {:?}", lm.id);
+                log::warn!(
+                    "d_res_d_xi is not valid in the frame update, lm = {:?}",
+                    lm.id
+                );
                 d_res_d_xi.fill(S::zero());
             }
 
@@ -445,20 +456,22 @@ fn linearize_state<S: LieScalar>(
     // The IMU factor over `(prev, t_ns]`, with the previous state held: its
     // 30x30 system's trailing corner is the newest state's, which is what
     // deleting a fixed variable's rows and columns comes to.
-    let start_state: &PoseVelBiasStateWithLin<S> = ba.frame_states.get(&prev_t_ns).ok_or(
-        EstimatorError::ImuFactorStateMissing {
-            start_t_ns: prev_t_ns,
-            end_t_ns: t_ns,
-            missing_t_ns: prev_t_ns,
-        },
-    )?;
-    let end_state: &PoseVelBiasStateWithLin<S> = ba.frame_states.get(&t_ns).ok_or(
-        EstimatorError::ImuFactorStateMissing {
-            start_t_ns: prev_t_ns,
-            end_t_ns: t_ns,
-            missing_t_ns: t_ns,
-        },
-    )?;
+    let start_state: &PoseVelBiasStateWithLin<S> =
+        ba.frame_states
+            .get(&prev_t_ns)
+            .ok_or(EstimatorError::ImuFactorStateMissing {
+                start_t_ns: prev_t_ns,
+                end_t_ns: t_ns,
+                missing_t_ns: prev_t_ns,
+            })?;
+    let end_state: &PoseVelBiasStateWithLin<S> =
+        ba.frame_states
+            .get(&t_ns)
+            .ok_or(EstimatorError::ImuFactorStateMissing {
+                start_t_ns: prev_t_ns,
+                end_t_ns: t_ns,
+                missing_t_ns: t_ns,
+            })?;
     let block: ImuBlock<S> = ImuBlock::linearize(meas, imu_lin, start_state, end_state);
     imu_h.fill(S::zero());
     imu_b.fill(S::zero());
@@ -472,4 +485,303 @@ fn linearize_state<S: LieScalar>(
     error += block.error;
 
     Ok((error, block.error))
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use nalgebra::{Vector3, Vector4};
+
+    use super::*;
+    use crate::calib::Calibration;
+    use crate::camera::CameraEnum;
+    use crate::config::VioConfig;
+    use crate::imu::{ImuNoise, ImuSample};
+    use crate::landmark::{Landmark, StereographicParam};
+    use crate::lie::So3;
+    use crate::types::{LandmarkId, PoseStateWithLin, PoseVelBiasState};
+
+    const CALIB: &str = include_str!("../../tests/fixtures/msdmi_calib.json");
+    const CONFIG: &str = include_str!("../../../../configs/msdmi_config.json");
+
+    /// The host keyframe, the previous state and the newest state.
+    const HOST_T_NS: i64 = 0;
+    /// See [`HOST_T_NS`].
+    const PREV_T_NS: i64 = 20_000_000;
+    /// See [`HOST_T_NS`].
+    const CURRENT_T_NS: i64 = 40_000_000;
+
+    /// A window whose IMU factor and whose observations both point at one pose.
+    ///
+    /// The host keyframe sits at the origin and hosts twelve landmarks two
+    /// metres out. The truth is *defined* as the preintegration's prediction from
+    /// the previous state, so the IMU residual is zero there, and every pixel is
+    /// the projection of a landmark through that same pose, so the reprojection
+    /// residual is zero there too. The global minimum is therefore the truth at
+    /// cost zero, which is what makes this a known answer rather than a
+    /// regression baseline.
+    ///
+    /// Returns the estimator with the newest state left **at** the truth, and the
+    /// truth beside it.
+    fn a_window(iterations: i32) -> (SqrtKeypointVio<f64>, PoseVelBiasState<f64>) {
+        let mut config: VioConfig = VioConfig::from_json_str(CONFIG).unwrap();
+        config.port_frame_update_max_iterations = iterations;
+        let calibration: Calibration<f64> = Calibration::from_json_str(CALIB).unwrap();
+        let gravity: Vector3<f64> = Vector3::new(0.0, 0.0, -9.81);
+        let mut vio: SqrtKeypointVio<f64> =
+            SqrtKeypointVio::new(gravity, calibration, config).unwrap();
+
+        // The host keyframe, frozen as a marginalized pose block is.
+        vio.kf_ids.insert(HOST_T_NS);
+        vio.ba.frame_poses.insert(
+            HOST_T_NS,
+            PoseStateWithLin::new(HOST_T_NS, Se3::identity(), true),
+        );
+
+        // The previous state, half a metre along `x` and looking the same way.
+        let zero: Vector3<f64> = Vector3::zeros();
+        let previous: PoseVelBiasState<f64> = PoseVelBiasState::new(
+            PREV_T_NS,
+            Se3::new(So3::identity(), Vector3::new(0.5, 0.0, 0.0)),
+            Vector3::new(0.1, 0.0, 0.0),
+            zero,
+            zero,
+        );
+        vio.ba
+            .frame_states
+            .insert(PREV_T_NS, PoseVelBiasStateWithLin::new(previous, false));
+
+        // One preintegrated interval over the 20 ms between them, folded sample
+        // by sample at the rig's own rate and with the rig's own noise, exactly
+        // as `process_frame` folds it: a single wide step leaves the covariance
+        // stiff enough that the whitened problem has no significant digits left.
+        // Gravity is cancelled, so the motion is the previous velocity plus a
+        // small turn.
+        let noise: ImuNoise<f64> = ImuNoise::from_calibration(&vio.ba.calib);
+        let mut meas: IntegratedImuMeasurement<f64> =
+            IntegratedImuMeasurement::new(PREV_T_NS, &zero, &zero);
+        let step_ns: i64 = (1e9 / vio.ba.calib.imu_update_rate) as i64;
+        let mut t_ns: i64 = PREV_T_NS + step_ns;
+        while t_ns <= CURRENT_T_NS {
+            meas.integrate(
+                &ImuSample {
+                    t_ns,
+                    gyro: Vector3::new(0.05, -0.03, 0.02),
+                    accel: Vector3::new(0.0, 0.0, 9.81),
+                },
+                &noise.accel_cov,
+                &noise.gyro_cov,
+            )
+            .unwrap();
+            t_ns += step_ns;
+        }
+        let predicted = meas.predict_state(&previous.pose_vel_state(), &gravity);
+        let truth: PoseVelBiasState<f64> = PoseVelBiasState::new(
+            CURRENT_T_NS,
+            predicted.t_w_i,
+            predicted.vel_w_i,
+            previous.bias_gyro,
+            previous.bias_accel,
+        );
+        vio.imu_meas.insert(PREV_T_NS, meas);
+        vio.ba
+            .frame_states
+            .insert(CURRENT_T_NS, PoseVelBiasStateWithLin::new(truth, false));
+        vio.last_state_t_ns = CURRENT_T_NS;
+        vio.opt_started = true;
+
+        // Twelve landmarks in a grid two metres in front of the host camera,
+        // each observed by every camera that can see it — at the pixel the truth
+        // projects it to, which is what makes the truth a zero-cost point.
+        let cameras: Vec<CameraEnum<f64>> = vio.ba.cameras().to_vec();
+        let host: TimeCamId = TimeCamId::new(HOST_T_NS, 0);
+        let mut next_id: u64 = 0;
+        for row in -1..=1_i32 {
+            for column in -2..=1_i32 {
+                let point: Vector4<f64> =
+                    Vector4::new(f64::from(column) * 0.3, f64::from(row) * 0.3, 2.0, 0.0);
+                let landmark: Landmark<f64> = Landmark::new(
+                    LandmarkId(next_id),
+                    host,
+                    StereographicParam::project(&point),
+                    1.0 / crate::eigen::norm3(point[0], point[1], point[2]),
+                );
+                next_id += 1;
+
+                let mut filed: bool = false;
+                for (cam_id, camera) in cameras.iter().enumerate() {
+                    let rel: Se3<f64> = compute_rel_pose(
+                        &Se3::identity(),
+                        &vio.ba.calib.t_i_c[host.cam_id],
+                        &truth.t_w_i,
+                        &vio.ba.calib.t_i_c[cam_id],
+                        None,
+                        None,
+                    );
+                    let mut pixel: Vector2<f64> = Vector2::zeros();
+                    let visible: bool = linearize_point(
+                        &Vector2::zeros(),
+                        &landmark,
+                        &rel.matrix(),
+                        camera,
+                        &mut pixel,
+                        &mut LinearizePointOut::default(),
+                    );
+                    if !visible {
+                        continue;
+                    }
+                    if !filed {
+                        vio.ba.lmdb.add_landmark(landmark.id, &landmark);
+                        filed = true;
+                    }
+                    vio.ba
+                        .lmdb
+                        .add_observation(TimeCamId::new(CURRENT_T_NS, cam_id), landmark.id, pixel)
+                        .unwrap();
+                }
+            }
+        }
+        assert!(
+            vio.ba.lmdb.num_observations() >= 12,
+            "the fixture has to give the pose something to see: {}",
+            vio.ba.lmdb.num_observations()
+        );
+
+        (vio, truth)
+    }
+
+    /// How far the recovered state may sit from the truth: the fixture's minimum
+    /// is exact, so this is convergence and not agreement. Measured from the
+    /// perturbation below, which converges in three LM steps
+    /// (2.0e6 -> 9.1e-2 -> 5.3e-9 -> 3.6e-17): 2.1e-13 m, 3.6e-15 rad and
+    /// 1.9e-11 m/s.
+    const CONVERGENCE_TOLERANCE: f64 = 1e-9;
+
+    /// The known answer: a state pushed off a zero-cost minimum comes back to it.
+    ///
+    /// Both factor groups agree at the truth by construction, so the frame update
+    /// has one thing to find and the assertion is against that value rather than
+    /// against a recorded run.
+    #[test]
+    fn the_frame_update_recovers_a_state_pushed_off_a_zero_cost_minimum() {
+        let (mut vio, truth) = a_window(5);
+        let mut perturbation: Vector15<f64> = Vector15::zeros();
+        perturbation
+            .fixed_rows_mut::<3>(0)
+            .copy_from(&Vector3::new(0.02, -0.015, 0.01));
+        perturbation
+            .fixed_rows_mut::<3>(3)
+            .copy_from(&Vector3::new(0.004, 0.006, -0.003));
+        perturbation
+            .fixed_rows_mut::<3>(6)
+            .copy_from(&Vector3::new(0.05, -0.04, 0.03));
+        vio.ba
+            .frame_states
+            .get_mut(&CURRENT_T_NS)
+            .unwrap()
+            .apply_inc(&perturbation);
+
+        let (lm, _, _) = vio.frame_update(CURRENT_T_NS).unwrap().unwrap();
+        assert!(!lm.is_empty(), "the loop has to take at least one step");
+        let last = lm.last().unwrap();
+        assert!(
+            last.error_after < 1e-12,
+            "the minimum is exact, so the cost has to reach it: {}",
+            last.error_after
+        );
+        assert!(
+            lm.iter().all(|step| step.accepted),
+            "a quadratic with an exact minimum should not need a backtrack"
+        );
+
+        let recovered: &PoseVelBiasState<f64> = vio.ba.frame_states[&CURRENT_T_NS].state();
+        let position: f64 = (recovered.t_w_i.translation - truth.t_w_i.translation).norm();
+        let rotation: f64 = (recovered.t_w_i.rotation * truth.t_w_i.rotation.inverse())
+            .log()
+            .norm();
+        let velocity: f64 = (recovered.vel_w_i - truth.vel_w_i).norm();
+        assert!(position < CONVERGENCE_TOLERANCE, "position {position}");
+        assert!(rotation < CONVERGENCE_TOLERANCE, "rotation {rotation}");
+        assert!(velocity < CONVERGENCE_TOLERANCE, "velocity {velocity}");
+    }
+
+    /// The step cap is the knob's, and it counts accepted and backtracked steps
+    /// together as `vio_max_iterations` does (D12).
+    #[test]
+    fn the_knob_caps_the_steps() {
+        for cap in 1..=3_i32 {
+            let (mut vio, _) = a_window(cap);
+            let mut perturbation: Vector15<f64> = Vector15::zeros();
+            perturbation
+                .fixed_rows_mut::<3>(0)
+                .copy_from(&Vector3::new(0.2, -0.15, 0.1));
+            vio.ba
+                .frame_states
+                .get_mut(&CURRENT_T_NS)
+                .unwrap()
+                .apply_inc(&perturbation);
+            let (lm, _, _) = vio.frame_update(CURRENT_T_NS).unwrap().unwrap();
+            assert!(
+                i32::try_from(lm.len()).unwrap() <= cap + 1,
+                "cap {cap} took {} steps",
+                lm.len()
+            );
+        }
+    }
+
+    /// A frameset the frame update cannot serve goes back to the joint solve
+    /// rather than being solved wrong, and every test reads the window alone.
+    #[test]
+    fn a_frameset_without_its_imu_factor_is_declined() {
+        // No preintegration joining the two states.
+        let (mut vio, _) = a_window(2);
+        vio.imu_meas.clear();
+        assert!(vio.frame_update(CURRENT_T_NS).unwrap().is_none());
+
+        // A frameset that is not the newest state.
+        let (mut vio, _) = a_window(2);
+        assert!(vio.frame_update(PREV_T_NS).unwrap().is_none());
+
+        // No previous state to hold.
+        let (mut vio, _) = a_window(2);
+        vio.ba.frame_states.remove(&PREV_T_NS);
+        assert!(vio.frame_update(CURRENT_T_NS).unwrap().is_none());
+
+        // A prior that orders the newest state: its gradient would not be zero.
+        let (mut vio, _) = a_window(2);
+        vio.marg_data
+            .order
+            .push(CURRENT_T_NS, POSE_VEL_BIAS_SIZE)
+            .unwrap();
+        assert!(vio.frame_update(CURRENT_T_NS).unwrap().is_none());
+    }
+
+    /// Offline mode lets nothing but the data reach a decision: the same window
+    /// solved twice gives the same state, coefficient for coefficient.
+    #[test]
+    fn a_repeat_frame_update_is_bit_identical() {
+        /// The state the solve left behind and the trail it took to get there.
+        type Solved = (PoseVelBiasState<f64>, Vec<(i32, f64, f64, bool)>);
+        let solve = || -> Solved {
+            let (mut vio, _) = a_window(3);
+            let mut perturbation: Vector15<f64> = Vector15::zeros();
+            perturbation
+                .fixed_rows_mut::<3>(0)
+                .copy_from(&Vector3::new(0.02, -0.015, 0.01));
+            vio.ba
+                .frame_states
+                .get_mut(&CURRENT_T_NS)
+                .unwrap()
+                .apply_inc(&perturbation);
+            let (lm, _, _) = vio.frame_update(CURRENT_T_NS).unwrap().unwrap();
+            (
+                *vio.ba.frame_states[&CURRENT_T_NS].state(),
+                lm.iter()
+                    .map(|step| (step.iteration, step.error_after, step.l_diff, step.accepted))
+                    .collect(),
+            )
+        };
+        assert_eq!(solve(), solve());
+    }
 }

--- a/packages/slam-rs/crates/slam-rs/src/estimator/mod.rs
+++ b/packages/slam-rs/crates/slam-rs/src/estimator/mod.rs
@@ -90,6 +90,7 @@
 //! estimator. Stage S9's Realtime mode is where the reset belongs (D5 of the S8
 //! simplify list).
 
+mod frame_update;
 mod optimize;
 mod schedule;
 
@@ -116,7 +117,8 @@ use crate::types::{
     PoseVelBiasState, PoseVelBiasStateWithLin, PoseVelState, StateError, TimeCamId,
 };
 
-use optimize::OptimizeScratch;
+use frame_update::FrameUpdateScratch;
+use optimize::{OptimizeScratch, SolveOutcome};
 pub use optimize::{LmIteration, LmTermination};
 use schedule::MarginalizationOutcome;
 pub use schedule::{EvictionReason, KeyframeEviction, MarginalizationStats};
@@ -626,6 +628,10 @@ pub struct SqrtKeypointVio<S: LieScalar> {
     /// Frames the last marginalization removed, for [`Self::snapshot`].
     last_marginalized: Vec<FrameId>,
 
+    /// The buffers [`Self::frame_update`]'s loop works in, kept across frames
+    /// for [`Self::scratch`]'s reason (D76).
+    frame_scratch: FrameUpdateScratch<S>,
+
     /// The buffers [`Self::optimize`]'s inner loop works in, kept across
     /// frames.
     ///
@@ -826,6 +832,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             pending: None,
             newest_imu_t_ns: None,
             last_marginalized: Vec::new(),
+            frame_scratch: FrameUpdateScratch::default(),
             scratch: OptimizeScratch::default(),
         })
     }
@@ -1300,9 +1307,22 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             }
         }
 
-        // `:566`.
+        // `:566`, plus D76's gate: above zero, `port.frame_update_max_iterations`
+        // moves the joint solve to the framesets that took a keyframe and gives
+        // the others the newest state alone. The frame update declines a
+        // frameset it cannot serve, and the joint solve owns the warmup.
         let optimize_started: std::time::Instant = std::time::Instant::now();
-        let (lm, termination, mut timings) = self.optimize(frame.t_ns)?;
+        let frame_update: bool =
+            self.config.port_frame_update_max_iterations > 0 && !took_keyframe && self.opt_started;
+        let updated: Option<SolveOutcome<S>> = if frame_update {
+            self.frame_update(frame.t_ns)?
+        } else {
+            None
+        };
+        let (lm, termination, mut timings) = match updated {
+            Some(outcome) => outcome,
+            None => self.optimize(frame.t_ns)?,
+        };
         timings.optimize_ns = duration_ns(optimize_started);
         timings.predict_ns = predict_ns;
         timings.keyframe_ns = keyframe_ns;

--- a/packages/slam-rs/crates/slam-rs/src/estimator/mod.rs
+++ b/packages/slam-rs/crates/slam-rs/src/estimator/mod.rs
@@ -117,9 +117,10 @@ use crate::types::{
     PoseVelBiasState, PoseVelBiasStateWithLin, PoseVelState, StateError, TimeCamId,
 };
 
-use frame_update::FrameUpdateScratch;
+pub use frame_update::{FrameUpdateDecline, FrameUpdateOutcome};
+use frame_update::{FrameUpdateResult, FrameUpdateScratch};
+use optimize::OptimizeScratch;
 pub use optimize::{LmIteration, LmTermination};
-use optimize::{OptimizeScratch, SolveOutcome};
 use schedule::MarginalizationOutcome;
 pub use schedule::{EvictionReason, KeyframeEviction, MarginalizationStats};
 
@@ -456,6 +457,9 @@ pub struct FrameStats<S: LieScalar> {
     pub termination: LmTermination,
     /// The marginalization, when the trigger of `:717` fired.
     pub marginalization: Option<MarginalizationStats>,
+    /// What D76's frame update did with this frameset: never attempted, taken,
+    /// or refused by a named precondition.
+    pub frame_update: FrameUpdateOutcome,
     /// Wall-clock stage marks; see [`StageTimings`].
     pub timings: StageTimings,
 }
@@ -1312,16 +1316,21 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         // the others the newest state alone. The frame update declines a
         // frameset it cannot serve, and the joint solve owns the warmup.
         let optimize_started: std::time::Instant = std::time::Instant::now();
-        let frame_update: bool =
+        let attempt_frame_update: bool =
             self.config.port_frame_update_max_iterations > 0 && !took_keyframe && self.opt_started;
-        let updated: Option<SolveOutcome<S>> = if frame_update {
-            self.frame_update(frame.t_ns)?
+        let updated: Option<FrameUpdateResult<S>> = if attempt_frame_update {
+            Some(self.frame_update(frame.t_ns)?)
         } else {
             None
         };
+        let frame_update: FrameUpdateOutcome = match &updated {
+            None => FrameUpdateOutcome::NotAttempted,
+            Some(Ok(_)) => FrameUpdateOutcome::Taken,
+            Some(Err(decline)) => FrameUpdateOutcome::Declined(*decline),
+        };
         let (lm, termination, mut timings) = match updated {
-            Some(outcome) => outcome,
-            None => self.optimize(frame.t_ns)?,
+            Some(Ok(outcome)) => outcome,
+            Some(Err(_)) | None => self.optimize(frame.t_ns)?,
         };
         timings.optimize_ns = duration_ns(optimize_started);
         timings.predict_ns = predict_ns;
@@ -1349,6 +1358,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             lm,
             termination,
             marginalization: marg.marginalization,
+            frame_update,
             timings,
         })
     }

--- a/packages/slam-rs/crates/slam-rs/src/estimator/mod.rs
+++ b/packages/slam-rs/crates/slam-rs/src/estimator/mod.rs
@@ -118,8 +118,8 @@ use crate::types::{
 };
 
 use frame_update::FrameUpdateScratch;
-use optimize::{OptimizeScratch, SolveOutcome};
 pub use optimize::{LmIteration, LmTermination};
+use optimize::{OptimizeScratch, SolveOutcome};
 use schedule::MarginalizationOutcome;
 pub use schedule::{EvictionReason, KeyframeEviction, MarginalizationStats};
 

--- a/packages/slam-rs/crates/slam-rs/src/estimator/optimize.rs
+++ b/packages/slam-rs/crates/slam-rs/src/estimator/optimize.rs
@@ -172,10 +172,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
     /// (`:1300-1303`), [`EstimatorError::FrameNotInOrdering`] where `:1468`
     /// and `:1472` read the ordering with `.at()`, and the linearization's own
     /// errors.
-    pub(super) fn optimize(
-        &mut self,
-        t_ns: i64,
-    ) -> Result<SolveOutcome<S>, EstimatorError> {
+    pub(super) fn optimize(&mut self, t_ns: i64) -> Result<SolveOutcome<S>, EstimatorError> {
         let mut lm: Vec<LmIteration<S>> = Vec::new();
         let mut timings: StageTimings = StageTimings::default();
         // `:1207`: five states have to accumulate before the first

--- a/packages/slam-rs/crates/slam-rs/src/estimator/optimize.rs
+++ b/packages/slam-rs/crates/slam-rs/src/estimator/optimize.rs
@@ -79,13 +79,20 @@ impl<S: LieScalar> Default for OptimizeScratch<S> {
 
 /// The two hard-coded convergence constants of `:1566`, which are **not**
 /// config fields.
-const FUNCTION_TOLERANCE: f64 = 1e-6;
+pub(super) const FUNCTION_TOLERANCE: f64 = 1e-6;
 /// See [`FUNCTION_TOLERANCE`].
-const STEP_TOLERANCE: f64 = 1e-4;
+pub(super) const STEP_TOLERANCE: f64 = 1e-4;
 
 /// `H.diagonal().segment<POSE_SIZE>(idx).array() = 1e20` (`:1400`), the value
 /// `vio_fix_long_term_keyframes` pins a long-term keyframe's rows with.
 const FIXED_KEYFRAME_WEIGHT: f64 = 1e20;
+
+/// What one solve leaves behind: the LM trail, why it stopped, and the stages
+/// it timed.
+///
+/// Named because two solves return it — the window's [`SqrtKeypointVio::optimize`]
+/// and the frame update of D76 — and `measure` takes whichever ran.
+pub(super) type SolveOutcome<S> = (Vec<LmIteration<S>>, LmTermination, StageTimings);
 
 /// Why the LM loop stopped.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -168,7 +175,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
     pub(super) fn optimize(
         &mut self,
         t_ns: i64,
-    ) -> Result<(Vec<LmIteration<S>>, LmTermination, StageTimings), EstimatorError> {
+    ) -> Result<SolveOutcome<S>, EstimatorError> {
         let mut lm: Vec<LmIteration<S>> = Vec::new();
         let mut timings: StageTimings = StageTimings::default();
         // `:1207`: five states have to accumulate before the first
@@ -467,7 +474,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
 /// `damping` rather than restored: every failed attempt raises it, the last one
 /// included, so three failures leave a `lambda` no attempt used and C++ records
 /// that one too.
-fn damped_solve<S: LieScalar>(
+pub(super) fn damped_solve<S: LieScalar>(
     h: &DMatrix<S>,
     b: &DVector<S>,
     damping: &mut LmDamping<S>,

--- a/packages/slam-rs/crates/slam-rs/src/linearize/landmark_block.rs
+++ b/packages/slam-rs/crates/slam-rs/src/linearize/landmark_block.rs
@@ -184,6 +184,34 @@ pub struct LandmarkBlock<S: LieScalar> {
     work_essential: Vec<S>,
 }
 
+/// `compute_error_weight` (`:456-470`).
+///
+/// Returns `(weighted_error, weight)`. Note the Huber test is on the
+/// **squared** residual against the squared threshold, and that both are in
+/// raw pixels: the `1 / obs_std_dev` scaling happens afterwards (`:170-172`),
+/// which is the "effective 2 sigma" deviation of papers-part2 §13.
+///
+/// A free function rather than a method because the estimator's non-keyframe
+/// frame update weights its residuals with the same rule and the same
+/// association (D76), and one reprojection model in the crate means one Huber
+/// in the crate.
+pub fn compute_error_weight<S: LieScalar>(
+    res_squared: S,
+    options: &LandmarkBlockOptions<S>,
+) -> (S, S) {
+    if options.huber_parameter > S::zero() {
+        let huber_weight: S = if res_squared <= options.huber_parameter * options.huber_parameter {
+            S::one()
+        } else {
+            options.huber_parameter / res_squared.sqrt()
+        };
+        let error: S = c::<S>(0.5) * (c::<S>(2.0) - huber_weight) * huber_weight * res_squared;
+        (error, huber_weight)
+    } else {
+        (c::<S>(0.5) * res_squared, S::one())
+    }
+}
+
 impl<S: LieScalar> LandmarkBlock<S> {
     /// `allocateLandmark` (`:35-104`).
     ///
@@ -333,27 +361,6 @@ impl<S: LieScalar> LandmarkBlock<S> {
         })
     }
 
-    /// `compute_error_weight` (`:456-470`).
-    ///
-    /// Returns `(weighted_error, weight)`. Note the Huber test is on the
-    /// **squared** residual against the squared threshold, and that both are in
-    /// raw pixels: the `1 / obs_std_dev` scaling happens afterwards (`:170-172`),
-    /// which is the "effective 2 sigma" deviation of papers-part2 §13.
-    fn compute_error_weight(&self, res_squared: S, options: &LandmarkBlockOptions<S>) -> (S, S) {
-        if options.huber_parameter > S::zero() {
-            let huber_weight: S =
-                if res_squared <= options.huber_parameter * options.huber_parameter {
-                    S::one()
-                } else {
-                    options.huber_parameter / res_squared.sqrt()
-                };
-            let error: S = c::<S>(0.5) * (c::<S>(2.0) - huber_weight) * huber_weight * res_squared;
-            (error, huber_weight)
-        } else {
-            (c::<S>(0.5) * res_squared, S::one())
-        }
-    }
-
     /// `linearizeLandmark` (`:110-191`): fill the block at the current
     /// linearization point and return this landmark's share of the error.
     ///
@@ -456,7 +463,7 @@ impl<S: LieScalar> LandmarkBlock<S> {
             // `:168-172`. `res.squaredNorm()` is a contiguous two-coefficient
             // reduction, so there is only one order to take.
             let res_squared: S = res[0] * res[0] + res[1] * res[1];
-            let (weighted_error, weight) = self.compute_error_weight(res_squared, options);
+            let (weighted_error, weight) = compute_error_weight(res_squared, options);
             let sqrt_weight: S = weight.sqrt() / options.obs_std_dev;
             error_sum += weighted_error / (options.obs_std_dev * options.obs_std_dev);
 
@@ -1386,22 +1393,19 @@ mod tests {
     /// than quadratically.
     #[test]
     fn the_huber_weight_crosses_at_the_threshold() {
-        let (aom, lm, _) = fixture(1);
-        let block: LandmarkBlock<f64> =
-            LandmarkBlock::allocate(lm.id, &lm, &index, &aom, false).unwrap();
         let opt: LandmarkBlockOptions<f64> = options();
         let delta: f64 = opt.huber_parameter;
 
-        let (error_in, weight_in) = block.compute_error_weight(0.25 * delta * delta, &opt);
+        let (error_in, weight_in) = compute_error_weight(0.25 * delta * delta, &opt);
         assert_eq!(weight_in, 1.0);
         assert_eq!(error_in, 0.5 * 0.25 * delta * delta);
 
         // Exactly at the threshold the comparison is `<=`, so the weight is one.
-        let (_, weight_at) = block.compute_error_weight(delta * delta, &opt);
+        let (_, weight_at) = compute_error_weight(delta * delta, &opt);
         assert_eq!(weight_at, 1.0);
 
         let res_squared: f64 = 4.0 * delta * delta;
-        let (error_out, weight_out) = block.compute_error_weight(res_squared, &opt);
+        let (error_out, weight_out) = compute_error_weight(res_squared, &opt);
         assert!((weight_out - 0.5).abs() < 1e-15, "{weight_out}");
         assert!((error_out - 0.5 * 1.5 * 0.5 * res_squared).abs() < 1e-15);
 
@@ -1410,7 +1414,7 @@ mod tests {
             huber_parameter: 0.0,
             ..opt
         };
-        let (error, weight) = block.compute_error_weight(res_squared, &plain);
+        let (error, weight) = compute_error_weight(res_squared, &plain);
         assert_eq!(weight, 1.0);
         assert_eq!(error, 0.5 * res_squared);
     }

--- a/packages/slam-rs/crates/slam-rs/src/linearize/mod.rs
+++ b/packages/slam-rs/crates/slam-rs/src/linearize/mod.rs
@@ -49,7 +49,9 @@ mod reduce;
 pub use abs_qr::{
     DenseHbWorkspace, ImuInput, LinearizationAbsQR, LinearizationInputs, LinearizationOptions,
 };
-pub use landmark_block::{DenseHbScratch, LandmarkBlock, LandmarkBlockOptions, LandmarkBlockState};
+pub use landmark_block::{
+    DenseHbScratch, LandmarkBlock, LandmarkBlockOptions, LandmarkBlockState, compute_error_weight,
+};
 
 /// `reduce::deterministic_reduce_scalar` with the error type erased, so the
 /// fixture test in `tests/tbb_reduce_oracle.rs` can drive the association

--- a/packages/slam-rs/crates/slam-rs/tests/vio_oracle.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/vio_oracle.rs
@@ -163,6 +163,10 @@ const CANCELLING_TOLERANCE_F32: f64 = 5e-1;
 /// `f64` run sees at those steps.
 const F32_ACCEPT_NOISE_ULPS: f64 = 64.0;
 
+/// What `configs/profiles/fast.json` gives the frame update, so the lane the
+/// test drives is the lane the benchmark runs (D76).
+const FRAME_UPDATE_STEPS: i32 = 5;
+
 // ── loading ───────────────────────────────────────────────────────────────
 
 static CONFIG: LazyLock<VioConfig> = LazyLock::new(common::config);
@@ -770,11 +774,91 @@ fn a_repeat_run_is_bit_identical() {
     assert_eq!(first, second, "a repeat run differed");
 }
 
+/// D76: with `port.frame_update_max_iterations` on, a frameset that took no
+/// keyframe solves its own state and nothing else.
+///
+/// Three things are asserted, and the first is the one that matters: the
+/// schedule is still a pure function of the data, so two runs are bit-identical
+/// coefficient for coefficient. Then that the branch is actually taken — every
+/// non-keyframe frameset's LM trail is inside the knob's cap while the joint
+/// solve's median over the same 60 framesets is far above it — and that a
+/// keyframe frameset still runs the whole window. What the schedule costs in
+/// accuracy is not a unit test's question: it is the A/B harness's, against
+/// ground truth on a whole clip.
+#[test]
+fn the_frame_update_lane_is_deterministic_and_takes_its_branch() {
+    let flow: Vec<Arc<FlowObservations>> = ORACLE
+        .flow
+        .iter()
+        .take(ORACLE_FRAMESETS)
+        .map(common::observations)
+        .collect();
+
+    let mut config: VioConfig = CONFIG.clone();
+    config.port_frame_update_max_iterations = FRAME_UPDATE_STEPS;
+    let first: Vec<Trace> = drive_with(config.clone(), &flow);
+    let second: Vec<Trace> = drive_with(config, &flow);
+    assert_eq!(first, second, "the frame update lane is not deterministic");
+
+    let joint: Vec<Trace> = drive(&flow);
+    // The frameset that starts the optimizer runs the joint solve on both lanes:
+    // `opt_started` is still false when the gate is read. It is the first with a
+    // trail at all, and every frameset after it is the frame update's to decline
+    // or take.
+    let warmup: usize = joint
+        .iter()
+        .position(|trace| !trace.lm.is_empty())
+        .expect("no frameset reached the optimizer");
+    let cap: usize = usize::try_from(FRAME_UPDATE_STEPS + 1).unwrap();
+    let mut updated: usize = 0;
+    for (trace, reference) in first.iter().zip(joint.iter()).skip(warmup + 1) {
+        // The two lanes agree on which framesets are keyframes over this
+        // segment, which is what lets the comparison below be per frameset.
+        assert_eq!(
+            trace.took_keyframe, reference.took_keyframe,
+            "{}",
+            trace.t_ns
+        );
+        if trace.took_keyframe || trace.lm.is_empty() {
+            continue;
+        }
+        assert!(
+            trace.lm.len() <= cap,
+            "frameset {} took {} steps against a cap of {cap}",
+            trace.t_ns,
+            trace.lm.len()
+        );
+        updated += 1;
+    }
+    assert!(
+        updated > 40,
+        "only {updated} framesets took the frame update"
+    );
+
+    let steps = |lane: &[Trace]| -> usize {
+        lane.iter()
+            .skip(warmup + 1)
+            .filter(|trace| !trace.took_keyframe)
+            .map(|trace| trace.lm.len())
+            .sum()
+    };
+    let joint_steps: usize = steps(&joint);
+    let update_steps: usize = steps(&first);
+    println!(
+        "{updated} framesets took the frame update: {update_steps} steps against the joint solve's {joint_steps}"
+    );
+    assert!(
+        update_steps * 2 < joint_steps,
+        "the frame update took {update_steps} steps against the joint solve's {joint_steps}"
+    );
+}
+
 /// What the determinism test compares: everything a caller can observe except
 /// the wall-clock timings, which are measurements and not decisions.
 #[derive(Debug, Clone, PartialEq)]
 struct Trace {
     t_ns: i64,
+    took_keyframe: bool,
     kf_ids: Vec<FrameId>,
     ltkfs: Vec<FrameId>,
     landmarks: usize,
@@ -785,7 +869,11 @@ struct Trace {
 }
 
 fn drive(flow: &[Arc<FlowObservations>]) -> Vec<Trace> {
-    let mut estimator: SqrtKeypointVio<f32> = window(CONFIG.clone());
+    drive_with(CONFIG.clone(), flow)
+}
+
+fn drive_with(config: VioConfig, flow: &[Arc<FlowObservations>]) -> Vec<Trace> {
+    let mut estimator: SqrtKeypointVio<f32> = window(config);
     let mut traces: Vec<Trace> = Vec::new();
     for frame in flow {
         let outcome: FrameOutcome<f32> = estimator.process_frame(Arc::clone(frame)).unwrap();
@@ -796,6 +884,7 @@ fn drive(flow: &[Arc<FlowObservations>]) -> Vec<Trace> {
         let snapshot = estimator.snapshot();
         traces.push(Trace {
             t_ns: stats.t_ns,
+            took_keyframe: stats.took_keyframe,
             kf_ids: stats.kf_ids,
             ltkfs: stats.ltkfs,
             landmarks: stats.num_landmarks,

--- a/packages/slam-rs/docs/design-notes.md
+++ b/packages/slam-rs/docs/design-notes.md
@@ -1215,6 +1215,15 @@ gap for 12% of the frame: rejected, and recorded here so it is not rebuilt. What
 is left of the gap is the landmarks and the seven keyframe poses standing still
 between keyframes, which is the lever itself and not a detail of it.
 
+**Re-measured on the stack that shipped `port.redetect_survivor_ratio` at 0.85**
+(`redetect-r085`, wave 1's tip; the numbers above are against the 0.7 stack this
+branch was cut from). MIO10, three rounds: median **3.313 -> 1.995 ms**,
+`measure` **1.554 -> 0.196**, ATE **1.481 -> 1.553 cm** against 1.629 allowed,
+zero lost, the three rounds identical in trajectory and state digest, and the
+keyframe cadence (7.04), landmark count (44.1) and tracked keypoints (111.4 ->
+112.0) all where the joint solve left them — the schedule moves the solve, not
+the map. MGO09: **10.335 -> 3.679 ms**, ATE **0.766 -> 0.978** against 0.842.
+
 **Two other things measured and not kept.** `config.vio_max_states` is not
 independently tunable: at 5 the window's own invariants break and marginalization
 fails with "landmark block host frame ... is not in the absolute ordering" — the

--- a/packages/slam-rs/docs/design-notes.md
+++ b/packages/slam-rs/docs/design-notes.md
@@ -1038,6 +1038,9 @@ The `Dnn` tags in this file and in the README name the project's recorded design
 Vendored configs stay C++-faithful (D17), and the Rust default LM cap stays 7.
 Speed knobs live in `configs/profiles/fast.json`; the first sets
 `config.vio_max_iterations` to 4 (at most five LM steps with the inclusive loop).
+**D76 puts that one back to basalt's 7** once the joint solve runs at keyframes
+only: with the window solved one frameset in seven, the eight trials buy 0.146 cm
+of MIO10 ATE for about 0.1 ms of mean and nothing on the median.
 The benchmark and tracking tools opt in with `--profile fast`. The default
 `reference` profile is empty and preserves the vendored text. Unknown overlay
 keys raise `KeyError` so a typo cannot silently change the requested run.
@@ -1256,15 +1259,37 @@ wrong.
 **The four-camera algebra is not the MGO09 gap.** A landmark hosted by camera 0
 and observed by camera *i* forms its residual through a relative pose that
 carries a different `T_i_c` on the target side, and the held-landmark Jacobian
-w.r.t. the newest state is `compute_rel_pose`'s `d_rel_d_t` for that pair. On the
-four-camera MGO rig fixture — the one MGO09 replays — a state pushed off the
-zero-cost minimum returns to a cost below `1e-12` and to within `1e-9` m and rad
-of the truth, with landmarks observed by more than one camera. A wrong extrinsic
-or a wrong Jacobian on the non-host camera cannot do that: it points the step
-somewhere else and the exact minimum becomes unreachable. The per-camera loop
-order is `landmarks()` in id order and `cam_id` ascending, and the same window
-solved twice is bit-identical. So MGO09's 0.978 cm against 0.842 is the schedule
-— the landmarks and the seven keyframe poses standing still between keyframes —
-and the two-state variant above is the measure of how much of it a wider free
-block buys.
+w.r.t. the newest state is `compute_rel_pose`'s `d_rel_d_t` for that pair. Two
+independent tests on the four-camera MGO rig fixture — the one MGO09 replays —
+cover the two halves of that, and neither can stand in for the other:
+
+* the **known minimum** checks the residual. The zero-cost point is the
+  preintegration's own prediction and every pixel is a landmark projected
+  through it, so a state pushed off it has to come all the way back — cost below
+  `1e-12`, within `1e-9` m and rad. This is what the two-camera fixture already
+  did, and it cannot say anything about the Jacobian: the IMU factor alone puts
+  the minimum in the same place, so the state would return with the observations
+  dropped entirely;
+* the **vision gradient against a central finite difference** checks the
+  Jacobian, coordinate by coordinate, with the IMU contribution subtracted off
+  and in the same chart `apply_inc` moves the state through. The pose rows carry
+  the whole gradient and the velocity and bias rows are zero on both sides. Then
+  each observing camera is removed in turn and the gradient has to move, so a
+  camera silently contributing nothing cannot pass.
+
+Both were checked by mutation, and each caught the defect the other missed:
+forming the target side of the relative pose with camera 0's extrinsic instead
+of camera *i*'s leaves the known minimum at cost 4519 while the finite
+difference still agrees with its own wrong cost; scaling the non-host cameras'
+Jacobian by 1.05 leaves the known minimum reachable — Gauss-Newton descends on a
+slightly wrong Jacobian — while the finite difference reads 12,888 against the
+analytic 13,298. The per-camera loop order is `landmarks()` in id order and
+`cam_id` ascending, and the same window solved twice is bit-identical.
+
+So MGO09's 0.978 cm against 0.842 is the schedule — the landmarks and the seven
+keyframe poses standing still between keyframes — and the two-state variant above
+is the measure of how much of it a wider free block buys. What that does **not**
+settle is whether the whole 0.136 cm is the schedule; it settles that it is not
+the per-camera algebra, and enabling this on a four-camera rig through the shared
+`fast` profile is still a scope decision rather than a measurement.
 - **D76** — The fast profile runs the joint solve at keyframes and a 15-dof fixed-landmark update on the framesets between (2026-09-10)

--- a/packages/slam-rs/docs/design-notes.md
+++ b/packages/slam-rs/docs/design-notes.md
@@ -1099,3 +1099,79 @@ show, and they are not measured here.
 
 - **D74** — Speed profile: vendored configs stay C++-faithful; speed knobs live in `configs/profiles/fast.json`, opted into with `--profile fast` (2026-09-10)
 - **D75** — Redetect on demand: the fast profile skips `addPoints` until camera 0 falls under `port.redetect_survivor_ratio` of its last detection (2026-09-10)
+
+## D76 — The fast profile solves the window at keyframes and the newest state alone between them
+
+basalt is a fixed-lag smoother: `measure` re-linearizes and re-solves the whole
+sliding window — 7 keyframe pose blocks plus 3 states, ~87 unknowns — on **every**
+frameset (`estimator/mod.rs`, `optimize`), although the keyframe cadence on MIO10
+is 7.33 framesets. cuVSLAM instead solves only the newest pose against **fixed**
+landmarks every frame (`libs/pnp/multicam_pnp.cpp`, 0.064 ms; `soft_inertial_pnp`,
+0.450 ms) and runs bundle adjustment at keyframes only; ORB-SLAM makes the same
+split. That schedule is most of cuVSLAM's 4x on this clip: after wave 1 the
+estimator is 1.519 ms of a 2.974 ms MIO10 call and 6 of every 7 of those
+milliseconds buy a joint solve the frame did not need.
+
+**The knob.** `port.frame_update_max_iterations`, `0` by default. At `0` — where
+every basalt file and `VioConfig::default` leave it — `measure` runs the joint
+solve on every frameset, which is basalt's schedule byte for byte. Above zero, a
+frameset that did **not** take a keyframe runs a *frame update* instead, capped at
+that many LM steps. `configs/profiles/fast.json` sets `2`; nothing else does. One
+knob rather than a `bool` plus a count: the two cannot then be set against each
+other, and a zero cap can only mean "off". The key is `port.` for D75's reason —
+basalt has no field for it and the vendored `configs/*.json` stay the documents
+the C++ reference runs read.
+
+**What the frame update solves.** The 15 unknowns of the newest state (pose,
+velocity, both biases) against exactly two factor groups:
+
+* every observation the newest frameset filed on a landmark the window already
+  hosts, with the landmark, its host keyframe and every older state **held**.
+  The residual is `linearize_point`, the relative pose and its target Jacobian
+  are `compute_rel_pose`, and the Huber weight is the landmark block's own
+  `compute_error_weight`, now a free function both paths call — there is one
+  reprojection model in the crate, not two;
+* the IMU factor from the previous state, built by the same `ImuBlock::linearize`
+  the window solve uses. Its 30x30 `add_dense_h_b` is formed and the newest
+  state's 15x15 corner is taken, which is what holding the previous state means.
+
+The marginalization prior is **absent by construction, not by choice**: it can only
+contain blocks frozen at a linearization point (`compute_delta` refuses any other),
+and the newest state is appended unfrozen, so the prior's cost does not depend on
+the one variable the frame update moves. The code asserts this per frame and falls
+back to the joint solve if the prior ever does carry the newest state.
+
+The LM loop is the window loop's shape, constant for constant: `lambda` reset to
+`vio_lm_lambda_initial` every frame (D11), `lambda·diag(H)` damping with the same
+floor (D10), the iteration budget shared with backtracking (D12), the increment
+negated before it is applied (D13), Nielsen's update on an accept, and the same
+`1e-6`/`1e-4` convergence pair. The predicted decrease is
+`-(inc·b + 0.5·incᵀ H inc)`, which is what the window's `back_substitute`
+accumulates when nothing has been eliminated. `damping.lambda_vee` is shared with
+the window solve exactly as it is shared between framesets today.
+
+**What does not change.** Observations are filed into the landmark database before
+the keyframe vote, so a frame update still feeds the next joint solve everything it
+saw. The keyframe decision is unchanged (camera 0's connected ratio below
+`vio_new_kf_keypoints_thresh` and at least `vio_min_frames_after_kf` framesets
+since the last). `vio_marg_lost_landmarks` still culls from the frameset's own
+observations, never from whether the joint solve ran. **Marginalization keeps its
+own trigger and runs every frameset** — deferring it to keyframes grows the
+ordering by 15 unknowns per skipped frame, `get_dense_h_b` grows quadratically in
+that, and the keyframe solve costs more than the six skipped ones saved. Warmup is
+the joint solve's: the frame update runs only once `opt_started` is true.
+
+**The FEJ consequence, stated.** `marginalize` freezes `last_state_to_marg` at its
+current value and folds the window into the prior. Under this schedule that value
+is a frame update's, not a joint solve's, for the framesets between keyframes, so
+the prior is anchored at a point that saw its own observations and its own IMU
+factor but not the window's second-order coupling. This is the lever's whole risk
+and it is why the gate is ATE, measured, and not an argument.
+
+**Expected numbers, before measuring.** ~70 observations and one IMU factor per
+frame update against ~440 observations, 55 landmark blocks and an 87x87 dense
+build per joint solve: the non-keyframe `measure` should be the 0.097 ms
+marginalization plus ~0.05 ms, against 1.519 ms today, for a median gain near
+1.3 ms and an amortized `measure` near 0.3 ms. The accuracy band is 1.654 cm on
+MIO10 against 1.447 today — 14% of headroom.
+- **D76** — The fast profile runs the joint solve at keyframes and a 15-dof fixed-landmark update on the framesets between (2026-09-10)

--- a/packages/slam-rs/docs/design-notes.md
+++ b/packages/slam-rs/docs/design-notes.md
@@ -1116,7 +1116,7 @@ milliseconds buy a joint solve the frame did not need.
 every basalt file and `VioConfig::default` leave it — `measure` runs the joint
 solve on every frameset, which is basalt's schedule byte for byte. Above zero, a
 frameset that did **not** take a keyframe runs a *frame update* instead, capped at
-that many LM steps. `configs/profiles/fast.json` sets `2`; nothing else does. One
+that many LM steps. `configs/profiles/fast.json` sets `5`; nothing else does. One
 knob rather than a `bool` plus a count: the two cannot then be set against each
 other, and a zero cap can only mean "off". The key is `port.` for D75's reason —
 basalt has no field for it and the vendored `configs/*.json` stay the documents
@@ -1174,4 +1174,44 @@ build per joint solve: the non-keyframe `measure` should be the 0.097 ms
 marginalization plus ~0.05 ms, against 1.519 ms today, for a median gain near
 1.3 ms and an amortized `measure` near 0.3 ms. The accuracy band is 1.654 cm on
 MIO10 against 1.447 today — 14% of headroom.
+
+**Measured, MIO10, three A/B rounds against the accepted stack.** Median
+**2.945 -> 1.311 ms**, `measure` **1.520 -> 0.183**, ATE vs GT **1.447 -> 1.551 cm**
+against 1.654 allowed, zero lost framesets, and the three candidate rounds
+identical to each other in both the trajectory and the state digest. The
+projection was 1.3 ms of median and it is 1.63; the frame update itself is 0.054
+of `optimize`'s 0.061 ms, an order below the 0.30 ms the plan priced it at.
+
+**`config.vio_max_iterations` goes back to basalt's 7, and that is part of this
+lever.** D74 cut it to 4 because every frameset paid for the window solve. At one
+frameset in 7.65 the trade is a different one: eight steps on 13% of framesets
+cost about 0.1 ms of mean and nothing on the median, and they are worth
+**0.146 cm** of MIO10 ATE — 1.697 cm at the old cap against 1.551 at basalt's.
+Nothing else recovered that: five frame-update steps score the same as two
+(1.697 against 1.698), so the gap was never the frame update's own convergence.
+
+**What the accuracy costs, and the one structural fix that did not pay.** MGO09,
+four cameras, 107 framesets: median **8.654 -> 2.000 ms** but ATE
+**0.757 -> 0.960 cm** against 0.8466 allowed — **out of band, and the open item
+this lever leaves behind**. The mechanism I could name is that `marginalize`
+freezes `last_state_to_marg` — the state one frameset behind the newest — at the
+end of the same `measure`, so with the joint solve at keyframes only a state
+enters the FEJ prior having had exactly one frame update. Freeing that state too,
+a 30-unknown two-state solve over `k−1` and `k` (cuVSLAM's own
+`soft_inertial_pnp.cpp` shape; the prior orders neither, so it still contributes
+no gradient), was built and measured: **MGO09 0.960 -> 0.927 cm and MIO10 1.551 ->
+1.549**, for **0.158 ms** of MIO10 median (1.311 -> 1.469, which is the difference
+between meeting the plan's 1.439 ms MIO10 target and missing it). 16% of the MGO09
+gap for 12% of the frame: rejected, and recorded here so it is not rebuilt. What
+is left of the gap is the landmarks and the seven keyframe poses standing still
+between keyframes, which is the lever itself and not a detail of it.
+
+**Two other things measured and not kept.** `config.vio_max_states` is not
+independently tunable: at 5 the window's own invariants break and marginalization
+fails with "landmark block host frame ... is not in the absolute ordering" — the
+overshoot argument in `estimator/schedule.rs` assumes a state leaves after three
+framesets while keyframes are six apart. And the A/B harness builds into a
+`CARGO_TARGET_DIR` shared by every worker on the host, so a concurrent build gets
+copied out as yours; one MGO09 measurement here was a different branch's binary
+before the cores were pre-placed from a private target directory.
 - **D76** — The fast profile runs the joint solve at keyframes and a 15-dof fixed-landmark update on the framesets between (2026-09-10)

--- a/packages/slam-rs/docs/design-notes.md
+++ b/packages/slam-rs/docs/design-notes.md
@@ -1232,4 +1232,39 @@ framesets while keyframes are six apart. And the A/B harness builds into a
 `CARGO_TARGET_DIR` shared by every worker on the host, so a concurrent build gets
 copied out as yours; one MGO09 measurement here was a different branch's binary
 before the cores were pre-placed from a private target directory.
+
+**Every frameset now says what the frame update did with it.** `FrameStats`
+carries a `FrameUpdateOutcome` — `NotAttempted`, `Taken`, or `Declined` with the
+precondition that refused it — and the Python snapshot exposes its name. The five
+preconditions used to be five silent `Ok(None)`s, so "the update did not engage"
+and "the update engaged and was slow" looked identical from outside, and a
+mismeasured MIO07 row was read as an engagement bug for an hour. Measured with
+the names, `--profile fast`, whole clips: **MIO07 3,509 of 4,095 framesets taken
+and 586 keyframes, MGO09 87 of 107, MIO10 349 of 412 — and zero declines on any
+of the three.** The 586, 20 and 63 are exactly the keyframes.
+
+That result is what the `dt` equality deserves, and it is why it stays an
+equality. `IntegratedImuMeasurement::accumulate_to` integrates only samples at or
+before the frameset and then closes the interval **exactly** on it, so
+`get_start_t_ns() + get_dt_ns() == frame.t_ns` holds for every measurement
+`process_frame` files; `prev_t_ns + meas.get_dt_ns() == t_ns` is therefore the
+window's own predecessor linkage written as arithmetic, not a tolerance on IMU
+sample phase. A looser test would accept a preintegration that does not span the
+interval being solved over, which is the one way this solve can be silently
+wrong.
+
+**The four-camera algebra is not the MGO09 gap.** A landmark hosted by camera 0
+and observed by camera *i* forms its residual through a relative pose that
+carries a different `T_i_c` on the target side, and the held-landmark Jacobian
+w.r.t. the newest state is `compute_rel_pose`'s `d_rel_d_t` for that pair. On the
+four-camera MGO rig fixture — the one MGO09 replays — a state pushed off the
+zero-cost minimum returns to a cost below `1e-12` and to within `1e-9` m and rad
+of the truth, with landmarks observed by more than one camera. A wrong extrinsic
+or a wrong Jacobian on the non-host camera cannot do that: it points the step
+somewhere else and the exact minimum becomes unreachable. The per-camera loop
+order is `landmarks()` in id order and `cam_id` ascending, and the same window
+solved twice is bit-identical. So MGO09's 0.978 cm against 0.842 is the schedule
+— the landmarks and the seven keyframe poses standing still between keyframes —
+and the two-state variant above is the measure of how much of it a wider free
+block buys.
 - **D76** — The fast profile runs the joint solve at keyframes and a 15-dof fixed-landmark update on the framesets between (2026-09-10)

--- a/packages/slam-rs/slam_rs/_core.pyi
+++ b/packages/slam-rs/slam_rs/_core.pyi
@@ -138,6 +138,10 @@ class VioSnapshot:
         """Landmark observations the window holds."""
 
     @property
+    def frame_update(self) -> str:
+        """What the non-keyframe frame update did: ``not_attempted``, ``taken``, or ``declined_<precondition>``."""
+
+    @property
     def timings_ms(self) -> dict[str, float]:
         """Wall time each stage took on the last frame, in milliseconds.
 

--- a/packages/slam-rs/slam_rs/reference.py
+++ b/packages/slam-rs/slam_rs/reference.py
@@ -643,7 +643,7 @@ def d60_failures(
     return failures
 
 
-PORT_CONFIG_KEYS: frozenset[str] = frozenset({"port.redetect_survivor_ratio"})
+PORT_CONFIG_KEYS: frozenset[str] = frozenset({"port.redetect_survivor_ratio", "port.frame_update_max_iterations"})
 """Overlay keys the port adds to basalt's document, which no vendored config carries.
 
 ``configs/*.json`` are the files the C++ reference runs read, key for key

--- a/packages/slam-rs/tests/test_config_profiles.py
+++ b/packages/slam-rs/tests/test_config_profiles.py
@@ -15,21 +15,23 @@ def test_reference_profile_preserves_vendored_text() -> None:
         assert manifest.vio_config_text(dataset.name) == (manifest.package_root / dataset.vio_config).read_text()
 
 
-def test_fast_profile_changes_only_the_lm_cap_and_the_redetect_gate() -> None:
-    """The two keys the fast profile owns, and nothing else moves.
+def test_fast_profile_changes_only_the_lm_cap_and_the_two_port_gates() -> None:
+    """The three keys the fast profile owns, and nothing else moves.
 
-    ``port.redetect_survivor_ratio`` is not one of basalt's: it is the port's own
-    redetect-on-demand gate (D75), so it is absent from every vendored file and
-    the overlay is the only thing that ever sets it.
+    Neither ``port.`` key is one of basalt's: they are the port's own
+    redetect-on-demand gate (D75) and its keyframe-gated joint solve (D76), so
+    both are absent from every vendored file and the overlay is the only thing
+    that ever sets them.
     """
     manifest: ReferenceManifest = load_manifest()
     for dataset in manifest.datasets:
         reference: dict = json.loads((manifest.package_root / dataset.vio_config).read_text())
         fast: dict = json.loads(manifest.vio_config_text(dataset.name, profile="fast"))
-        assert fast["value0"].pop("config.vio_max_iterations") == 4
+        assert fast["value0"].pop("config.vio_max_iterations") == 7
         assert reference["value0"].pop("config.vio_max_iterations") == 7
         assert fast["value0"].pop("port.redetect_survivor_ratio") == 0.7
-        assert "port.redetect_survivor_ratio" not in reference["value0"]
+        assert fast["value0"].pop("port.frame_update_max_iterations") == 5
+        assert not (set(reference["value0"]) & PORT_CONFIG_KEYS)
         assert fast == reference
 
 


### PR DESCRIPTION
S32 wave 2, lever 5 (plan-v2 A3). The estimator ran the full sliding-window LM —
7 keyframe pose blocks + 3 states, ~87 unknowns — on **every** frameset, although
the keyframe cadence on MIO10 is 7.04. Under the fast profile it now runs the
window at keyframes and, on the framesets between, solves the newest state's 15
unknowns against fixed landmarks and its IMU factor. At the knob's `0` default
nothing changes: the oracle suites and the reference profile run basalt's
schedule frame for frame.

**Read this first: MGO09 is out of band and this PR does not fix it.**
0.978 cm against 0.842 allowed (0.766 base). MIO10 — the gate clip — passes with
room. The design note records what was tried against the MGO09 gap and what it
bought; the ruling on shipping the lever anyway is Pablo's.

## MIO10, three interleaved rounds, `--profile fast --base redetect-r085`

| Core | median ms | mean ms | p95 ms | max ms | ATE vs GT cm | ATE vs C++ cm | tracked/lost | run-to-run identical |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| base (wave 1 tip, d06fc98f) | 3.313 | 3.594 | 5.820 | 6.928 | 1.481 | 0.288 | 412/0 | Y |
| **kfsolve** | **1.995** | 2.432 | 6.894 | 8.177 | **1.553** | 0.411 | 412/0 | Y |

| Core | pyramid | detect | track | stereo | predict | optimize | linearize | solver | marginalize | measure | track_ms | glue |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| base | 0.143 | 0.567 | 0.751 | 0.190 | 0.006 | 1.398 | 0.495 | 0.714 | 0.103 | 1.554 | 3.313 | 0.153 |
| kfsolve | 0.143 | 0.562 | 0.735 | 0.189 | 0.006 | **0.065** | 0.019 | 0.005 | 0.100 | **0.196** | **1.995** | 0.152 |

**Gate: PASS.** ATE 1.553 <= 1.654 (Pablo's rule) and <= 1.629 (1.1 x base),
zero lost framesets, median gain **1.318 ms** against the 0.1 ms asked for and
the ~1 ms expected. All three candidate rounds are identical to each other in
both the trajectory and the state digest (medians 1.995 / 1.999 / 2.004).

The schedule moves the solve, not the map: keyframe cadence 7.04 -> 7.04,
mean landmarks 44.1 -> 44.1, tracked keypoints 111.4 -> 112.0.
LM steps, post-warmup: base `2:85, 3:56, 4:20, 5:190`;
kfsolve `1:88, 2:101, 3:2, 4:1, 5:3, 6:110, 7:1, 8:46` — 46 keyframe framesets
at the window solve's cap, the rest frame updates.

## MGO09 (four cameras, 107 framesets), one round, same base

| Core | median ms | mean ms | max ms | ATE vs GT cm | band | tracked/lost |
|---|---:|---:|---:|---:|---:|---:|
| base | 10.335 | 9.906 | 12.855 | 0.766 | — | 107/0 |
| kfsolve | 3.679 | 5.439 | 16.438 | **0.978** | 0.842 | 107/0 |

`measure` 6.882 -> 0.352. Cadence, landmarks and tracked keypoints again
unchanged. The 0.212 cm is the lever's cost, not a detail of it: the landmarks
and the seven keyframe poses stand still between keyframes.

## What is in here

* `port.frame_update_max_iterations` (`0` = off, basalt's schedule byte for
  byte), spelled `port.` for D75's reason. `configs/profiles/fast.json` sets `5`;
  no vendored config is touched and `PORT_CONFIG_KEYS` allowlists it so a typo is
  still a `KeyError`.
* `config.vio_max_iterations` back to basalt's **7**, and that is part of the
  lever, not a revert of D74: eight steps on 13% of framesets cost ~0.1 ms of
  mean and nothing on the median, and buy **0.146 cm** of MIO10 ATE (1.697 at the
  old cap of 4, 1.551 at 7). Five frame-update steps score the same as two
  (1.697 vs 1.698), so the gap was never the frame update's own convergence.
* `estimator/frame_update.rs`: the solve, reusing `linearize_point`,
  `compute_rel_pose`, the landmark block's `compute_error_weight` (now a free
  function both callers share) and the window's own `damped_solve`. One
  reprojection model in the crate. The LM loop is the window loop's shape,
  constant for constant.
* The marginalization prior contributes no gradient here **by construction**: it
  holds only blocks frozen at a linearization point and the newest state is
  appended unfrozen. The code checks that per frameset and hands the frameset
  back to the joint solve if it ever does order it.
* Tests: a synthetic window whose minimum is known exactly (the truth is the
  preintegration's own prediction and every pixel is projected through it), the
  step cap, the four windows the update declines, a bit-identical repeat, and an
  oracle lane with the knob on that asserts determinism and that the branch is
  taken.
* D76 records the design, the numbers, and three things measured and **not**
  kept — a two-state (30-unknown) variant that recovered a sixth of the MGO09 gap
  for an eighth of the MIO10 frame, `vio_max_states` at 5 (breaks the window's own
  marginalization invariants), and five frame-update steps at the old LM cap.
