### PR TITLE
slam-rs: one wait per phase on the GPU frontend

### DIFF
--- a/packages/slam-rs/crates/slam-rs/src/frontend/detect.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/detect.rs
@@ -620,6 +620,66 @@ pub trait CornerScan: std::fmt::Debug + Send + Sync {
         out.clear();
         Ok(())
     }
+
+    /// Answer every camera of a frameset's [`CornerScan::select_cells`] in one
+    /// device round trip, before the frameset asks for any of them.
+    ///
+    /// `selects[camera]` is [`cell_select`]'s answer for that camera, `None`
+    /// where the shape cannot take the device path at all. What this saves is a
+    /// wait, not arithmetic: the selection kernels read the frame and nothing
+    /// else, so every camera's can be launched together and downloaded once,
+    /// where the per-camera call synchronises once per camera. A backend that
+    /// takes it must answer the matching [`CornerScan::select_cells`] with the
+    /// same keys it downloaded here, and one that does nothing leaves every
+    /// `select_cells` to answer for itself.
+    ///
+    /// Called once per detecting frameset. Whatever it prepared is spent by the
+    /// `select_cells` calls that follow and must not outlive them.
+    ///
+    /// # Errors
+    ///
+    /// Whatever the backend's own scan can fail with.
+    fn prepare_cells(
+        &mut self,
+        images: &[ImageU16],
+        selects: &[Option<CellSelect>],
+    ) -> Result<(), DetectError> {
+        let _ = (images, selects);
+        Ok(())
+    }
+}
+
+/// The device selection [`detect_keypoints_with_cells`] would ask `camera` for,
+/// or `None` when nothing about the shape can take the device path.
+///
+/// Mask-independent on purpose: `cell_masks` decides the rest of the gate and is
+/// not known until the frameset has masked the camera, while the kernels this
+/// describes read the frame and nothing else. So this is what
+/// [`CornerScan::prepare_cells`] can be handed before the frameset has run, and
+/// [`detect_keypoints_with_cells`] applies the mask half itself.
+#[must_use]
+pub fn cell_select(
+    image: &ImageU16,
+    grid: &CellGrid,
+    config: &DetectorConfig,
+) -> Option<CellSelect> {
+    let (width, height): (usize, usize) = (image.width(), image.height());
+    let takes_device: bool = config.num_points_cell == 1
+        && grid.cell > 2 * FAST_BORDER
+        && width >= grid.cell
+        && height >= grid.cell
+        && width < CELL_KEY_LIMIT
+        && height < CELL_KEY_LIMIT;
+    if !takes_device {
+        return None;
+    }
+    Some(CellSelect {
+        grid: *grid,
+        // The **last** rung the cell walk visits, which is the only one that
+        // decides a one-point-per-cell winner.
+        threshold: threshold_rungs(config).last()?,
+        safe_radius: config.safe_radius,
+    })
 }
 
 /// The CPU [`CornerScan`]: kornia's `fast_detect_rect_u8`, one sweep per
@@ -780,6 +840,20 @@ impl DetectorScratch {
             masked: Vec::new(),
             winners: Vec::new(),
         }
+    }
+
+    /// [`CornerScan::prepare_cells`] on the scanner this holds, which is the
+    /// only way to it from outside this module.
+    ///
+    /// # Errors
+    ///
+    /// Whatever the scanner's own preparation can fail with.
+    pub fn prepare_cells(
+        &mut self,
+        images: &[ImageU16],
+        selects: &[Option<CellSelect>],
+    ) -> Result<(), DetectError> {
+        self.scanner.prepare_cells(images, selects)
     }
 }
 
@@ -995,9 +1069,9 @@ pub fn detect_keypoints_with_cells(
     // path is handed (`threshold_rungs`). A ladder with no rung at all detects
     // nothing: the walk's own loop would not run once, so returning here is the
     // answer it would give, without touching the frame.
-    let Some(last_rung) = threshold_rungs(config).last() else {
+    if threshold_rungs(config).last().is_none() {
         return Ok(());
-    };
+    }
 
     let width: usize = image.width();
     let height: usize = image.height();
@@ -1035,17 +1109,9 @@ pub fn detect_keypoints_with_cells(
     // packed key can name; and masks this grid's cells decompose
     // ([`cell_masks`]). Anything else takes the band walk, which stays the
     // reference.
-    let device_shaped: bool = config.num_points_cell == 1
-        && grid.cell > 2 * FAST_BORDER
-        && width < CELL_KEY_LIMIT
-        && height < CELL_KEY_LIMIT
-        && cell_masks(masks, grid, cells_x, cells_y, masked);
-    if device_shaped {
-        let select: CellSelect = CellSelect {
-            grid: *grid,
-            threshold: last_rung,
-            safe_radius: config.safe_radius,
-        };
+    let shaped: Option<CellSelect> = cell_select(image, grid, config)
+        .filter(|_| cell_masks(masks, grid, cells_x, cells_y, masked));
+    if let Some(select) = shaped {
         scanner.select_cells(camera, image, &select, winners)?;
         if winners.len() == cells_x * cells_y {
             // `for (x = x_start; x <= x_stop; x += PATCH_SIZE) for (y = ...)`

--- a/packages/slam-rs/crates/slam-rs/src/frontend/flow.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/flow.rs
@@ -65,8 +65,8 @@ use crate::camera::{CameraError, RigCamera};
 use crate::config::{MatchingGuessType, VioConfig};
 use crate::duration_ns;
 use crate::frontend::detect::{
-    CellGrid, CornerScan, CpuCornerScan, DetectError, DetectorConfig, DetectorScratch,
-    KeypointsData, LOWEST_THRESHOLD_RUNG, MAX_CELLS, Masks, Occupancy, Rect,
+    CellGrid, CellSelect, CornerScan, CpuCornerScan, DetectError, DetectorConfig, DetectorScratch,
+    KeypointsData, LOWEST_THRESHOLD_RUNG, MAX_CELLS, Masks, Occupancy, Rect, cell_select,
     detect_keypoints_with_cells,
 };
 use crate::frontend::parallel::{MAX_THREADS, WorkPool};
@@ -530,24 +530,35 @@ pub struct FrameToFrameOpticalFlow<
     staging: Vec<B::Pyramid>,
     tracker: T,
     patches: T::Patches,
-    /// The source keypoint ids of the call in flight, in map order (`:299`, `:306`).
-    ids: Vec<KeypointId>,
-    /// The source warps, in the same order (`:300`, `:307`).
+    /// The source keypoint ids of each lane of the batch in flight, in map order
+    /// (`:299`, `:306`).
+    ///
+    /// Per lane rather than per call because a batch's passes are all launched
+    /// before any of them is read, and mapping a tracked slot back to its
+    /// keypoint needs this after the download.
+    ids: Vec<Vec<KeypointId>>,
+    /// The source warps of the pass being submitted, in the same order (`:300`,
+    /// `:307`). One buffer for the batch: it is consumed before the next pass
+    /// overwrites it.
     source: FlowTransforms,
-    /// Which entries of `ids` survived the `masks1` test and were offered to the
-    /// tracker; the tracker's index space is this vector's.
-    offered: Vec<usize>,
+    /// Which entries of `ids[lane]` survived the `masks1` test and were offered
+    /// to the tracker; the lane's index space is this vector's.
+    offered: Vec<Vec<usize>>,
     /// The source positions the forward patches are built at.
     positions: PointsSoA,
     /// `transform_2` once the depth guess has been applied (`:342`).
     guesses: FlowTransforms,
-    /// The tracker's dense output.
-    result: FlowResult,
+    /// The tracker's dense output, one per lane of the batch in flight.
+    results: Vec<FlowResult>,
     /// The ids that survived, in ascending source order, with their warps.
     tracked_ids: Vec<KeypointId>,
     /// The warps of [`FrameToFrameOpticalFlow::tracked_ids`].
     tracked: FlowTransforms,
     detector: DetectorScratch,
+    /// The device cell selection each camera can take, or `None` where its shape
+    /// cannot ([`cell_select`]); rebuilt per detecting frameset so the whole rig
+    /// can be prepared in one device round trip.
+    cell_selects: Vec<Option<CellSelect>>,
     detected: KeypointsData,
     /// The keypoints `addPointsForCamera(0)` produced, to be matched onward.
     new_cam0: Keypoints,
@@ -875,15 +886,16 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
             snapshot: FrameState::default(),
             timings: FlowTimings::default(),
             pyramid_builder: builder,
-            ids: Vec::new(),
+            ids: vec![Vec::new(); num_cams],
             source: FlowTransforms::default(),
-            offered: Vec::new(),
+            offered: vec![Vec::new(); num_cams],
             positions: PointsSoA::default(),
             guesses: FlowTransforms::default(),
-            result: FlowResult::default(),
+            results: vec![FlowResult::default(); num_cams],
             tracked_ids: Vec::new(),
             tracked: FlowTransforms::default(),
             detector: DetectorScratch::with_scanner(scanner),
+            cell_selects: vec![None; num_cams],
             detected: KeypointsData::default(),
             new_cam0: Keypoints::default(),
             to_remove: Vec::new(),
@@ -1131,6 +1143,9 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
                 self.last_keypoint_id_before_frame = snapshot.last_keypoint_id;
             }
             Err(_) => {
+                // A frameset refused between the launches and the download
+                // leaves a batch in flight; the next one starts empty.
+                self.tracker.discard();
                 self.frame.cameras.clone_from(&snapshot.cameras);
                 self.cells.clone_from(&snapshot.cells);
                 self.last_keypoint_id = snapshot.last_keypoint_id;
@@ -1169,14 +1184,24 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
             }
         } else {
             // `for (i) trackPoints(old_pyramid[i], pyramid[i], ..., T_c1_c2, i, i)`
-            // (`:261-271`).
+            // (`:261-271`), as one batch: every camera's pass is launched, then
+            // one download answers all of them. A camera's pass reads only its
+            // own two pyramids and writes only its own lane, so batching moves
+            // no arithmetic — it removes the per-camera wait, which on the GPU
+            // lane is the frameset's dominant host cost (D77).
             let t_i1: Se3<f32> = prediction.t_w_i_previous;
             let t_i2: Se3<f32> = prediction.t_w_i_current;
+            let mark: std::time::Instant = std::time::Instant::now();
             for camera in 0..num_cams {
                 let t_c1: Se3<f32> = t_i1 * self.calib.t_i_c[camera];
                 let t_c2: Se3<f32> = t_i2 * self.calib.t_i_c[camera];
                 let t_c1_c2: Se3<f32> = t_c1.inverse() * t_c2;
-                self.track_camera(camera, &t_c1_c2)?;
+                self.submit_camera(camera, &t_c1_c2)?;
+            }
+            self.tracker.collect(&mut self.results)?;
+            self.timings.track_ns += duration_ns(mark);
+            for camera in 0..num_cams {
+                self.finish_camera(camera);
             }
             // `for (i) updateCellCounts(i)` (`:277`).
             for camera in 0..num_cams {
@@ -1232,39 +1257,47 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         Ok(())
     }
 
-    /// One camera's frame-to-frame track: `trackPoints(..., cam, cam)` (`:267-270`).
-    fn track_camera(&mut self, camera: usize, t_c1_c2: &Se3<f32>) -> Result<(), FrontendError> {
+    /// One camera's frame-to-frame track launched into its own lane:
+    /// `trackPoints(..., cam, cam)` (`:267-270`) up to the download.
+    fn submit_camera(&mut self, camera: usize, t_c1_c2: &Se3<f32>) -> Result<(), FrontendError> {
         // Source and destination are the same slot (`:299-308`, `:371`), so the
         // ids and warps are copied out first — and the slot is only cleared once
         // the track has succeeded, so a refused frame does not lose the camera's
         // keypoints.
-        self.ids.clear();
+        self.ids[camera].clear();
         self.source.clear();
-        self.ids.extend_from_slice(&self.frame.cameras[camera].ids);
-        for index in 0..self.frame.cameras[camera].len() {
-            self.source
-                .push(&self.frame.cameras[camera].transforms.get(index));
+        let source: &Keypoints = &self.frame.cameras[camera];
+        self.ids[camera].extend_from_slice(&source.ids);
+        for index in 0..source.len() {
+            self.source.push(&source.transforms.get(index));
         }
 
-        self.run_track_points(camera, camera, t_c1_c2, true)?;
+        self.submit_track_points(camera, camera, camera, t_c1_c2, true)
+    }
 
+    /// The tail of `trackPoints` for one camera, once its lane has arrived.
+    fn finish_camera(&mut self, camera: usize) {
+        self.finish_track_points(camera, camera);
         self.frame.cameras[camera].clear();
         for (slot, id) in self.tracked_ids.iter().enumerate() {
             // `keypoint_map_2.insert(result.begin(), result.end())` (`:372`); the
             // cell counts are rebuilt afterwards by `updateCellCounts`.
             self.frame.cameras[camera].set(*id, &self.tracked.get(slot), NO_RESPONSE);
         }
-        Ok(())
     }
 
-    /// The body of `trackPoints` (`:294-375`) minus the map bookkeeping.
+    /// The launching half of `trackPoints` (`:294-375`): the mask test, the
+    /// guesses, the patch build and the tracker's own kernels, into `lane`.
     ///
-    /// Reads `ids` and `source`, writes `tracked_ids` and `tracked`. The caller
-    /// decides what to do with the survivors, because `trackPoints` serves two
-    /// purposes: carrying a camera's own keypoints forward in time, and matching
-    /// camera 0's new keypoints into camera *i*.
-    fn run_track_points(
+    /// Reads `ids[lane]` and `source`, writes `offered[lane]` and eventually
+    /// `results[lane]`. Split from [`FrameToFrameOpticalFlow::finish_track_points`]
+    /// because `trackPoints` serves two purposes — carrying a camera's own
+    /// keypoints forward in time, and matching camera 0's new keypoints into
+    /// camera *i* — and both run every camera of the frameset before reading any
+    /// of them.
+    fn submit_track_points(
         &mut self,
+        lane: usize,
         cam1: usize,
         cam2: usize,
         t_c1_c2: &Se3<f32>,
@@ -1275,11 +1308,9 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
             || self.config.optical_flow_matching_guess_type != MatchingGuessType::SamePixel;
         let depth: f32 = self.depth_guess;
 
-        self.offered.clear();
+        self.offered[lane].clear();
         self.positions.clear();
         self.guesses.clear();
-        self.tracked_ids.clear();
-        self.tracked.clear();
 
         for index in 0..self.source.len() {
             let transform_1: AffineCompact2f = self.source.get(index);
@@ -1295,7 +1326,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
             } else {
                 t1
             };
-            self.offered.push(index);
+            self.offered[lane].push(index);
             self.positions.push(t1);
             self.guesses.push(&AffineCompact2f {
                 linear: transform_1.linear,
@@ -1311,31 +1342,34 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         } else {
             &self.staging[cam1]
         };
-        let mark: std::time::Instant = std::time::Instant::now();
         self.patches
             .prepare(source_pyramid, &self.positions, None)?;
-        self.tracker.track_prepared(
+        self.tracker.submit_prepared(
             source_pyramid,
             &self.staging[cam2],
             &self.patches,
             &self.guesses,
-            &mut self.result,
+            &mut self.results[lane],
         )?;
-        if tracking {
-            self.timings.track_ns += duration_ns(mark);
-        }
+        Ok(())
+    }
 
-        for slot in self.result.tracked() {
+    /// The reading half of `trackPoints`: `masks2` over one collected lane,
+    /// leaving the survivors in `tracked_ids` and `tracked`.
+    fn finish_track_points(&mut self, lane: usize, cam2: usize) {
+        self.tracked_ids.clear();
+        self.tracked.clear();
+        for slot in self.results[lane].tracked() {
             let slot: usize = *slot as usize;
-            let transform: AffineCompact2f = self.result.transform(slot);
+            let transform: AffineCompact2f = self.results[lane].transform(slot);
             // `if (masks2.inBounds(t2.x(), t2.y())) continue;` (`:352`).
             if self.masks[cam2].in_bounds(transform.translation.x, transform.translation.y) {
                 continue;
             }
-            self.tracked_ids.push(self.ids[self.offered[slot]]);
+            self.tracked_ids
+                .push(self.ids[lane][self.offered[lane][slot]]);
             self.tracked.push(&transform);
         }
-        Ok(())
     }
 
     /// `updateCellCounts` (`:707-716`): rebuild one camera's occupancy from scratch.
@@ -1377,17 +1411,22 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
     /// Detection is capped at the camera's remaining budget
     /// ([`FrontendOptions::max_keypoints`]), so the frame it produces is always
     /// one the tracker can carry next time.
+    /// `detectKeypointsWithCells`' own configuration, from this frontend's.
+    fn detector_config(&self) -> DetectorConfig {
+        DetectorConfig {
+            num_points_cell: self.config.optical_flow_detection_num_points_cell as usize,
+            min_threshold: self.config.optical_flow_detection_min_threshold,
+            max_threshold: self.config.optical_flow_detection_max_threshold,
+            safe_radius: self.config.optical_flow_image_safe_radius,
+        }
+    }
+
     fn add_points_for_camera(
         &mut self,
         camera: usize,
         images: &[ImageU16],
     ) -> Result<(), FrontendError> {
-        let config: DetectorConfig = DetectorConfig {
-            num_points_cell: self.config.optical_flow_detection_num_points_cell as usize,
-            min_threshold: self.config.optical_flow_detection_min_threshold,
-            max_threshold: self.config.optical_flow_detection_max_threshold,
-            safe_radius: self.config.optical_flow_image_safe_radius,
-        };
+        let config: DetectorConfig = self.detector_config();
         let budget: usize = self
             .options
             .max_keypoints
@@ -1560,20 +1599,45 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
     /// `addPoints` (`:637-666`): detect on camera 0, match onward, then detect
     /// again on the cameras that do not overlap camera 0.
     fn add_points(&mut self, images: &[ImageU16]) -> Result<(), FrontendError> {
+        // Every camera's cell winners in one device round trip, before the first
+        // of them is asked for. The selection kernels read the frame alone — the
+        // occupancy counts and the masks stay on the host and are applied to the
+        // keys afterwards — so a camera's can be launched before this frameset
+        // has decided anything about it, and what that saves is one wait per
+        // camera (D77). A backend without a device path prepares nothing and
+        // every `detect_keypoints_with_cells` answers for itself.
+        let config: DetectorConfig = self.detector_config();
+        for (camera, image) in images.iter().enumerate() {
+            self.cell_selects[camera] = cell_select(image, &self.detection_grids[camera], &config);
+        }
+        let mark: std::time::Instant = std::time::Instant::now();
+        self.detector.prepare_cells(images, &self.cell_selects)?;
+        self.timings.detect_ns += duration_ns(mark);
+
         self.add_points_for_camera(0, images)?;
 
         // `for (i = 1; i < getNumCams(); i++) trackPoints(pyr0, pyri, kpts0, ...)`
         // (`:643-654`). With one camera there is nothing to match into (trap 17).
+        // One batch again: camera *i*'s match reads camera 0's new keypoints and
+        // writes camera *i* alone, so the whole rig is launched before any of it
+        // is downloaded.
         let mark: std::time::Instant = std::time::Instant::now();
         for camera in 1..self.cameras.len() {
-            self.ids.clear();
+            let lane: usize = camera - 1;
+            self.ids[lane].clear();
             self.source.clear();
-            self.ids.extend_from_slice(&self.new_cam0.ids);
+            self.ids[lane].extend_from_slice(&self.new_cam0.ids);
             for index in 0..self.new_cam0.len() {
                 self.source.push(&self.new_cam0.transforms.get(index));
             }
             let t_c0_ci: Se3<f32> = self.calib.t_i_c[0].inverse() * self.calib.t_i_c[camera];
-            self.run_track_points(0, camera, &t_c0_ci, false)?;
+            self.submit_track_points(lane, 0, camera, &t_c0_ci, false)?;
+        }
+        if self.cameras.len() > 1 {
+            self.tracker.collect(&mut self.results)?;
+        }
+        for camera in 1..self.cameras.len() {
+            self.finish_track_points(camera - 1, camera);
             self.add_keypoints(camera);
         }
 

--- a/packages/slam-rs/crates/slam-rs/src/frontend/tracker.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/tracker.rs
@@ -150,6 +150,14 @@ pub enum TrackerError {
     #[cfg(feature = "gpu-core")]
     #[error(transparent)]
     Gpu(#[from] crate::gpu::GpuError),
+    /// More passes were put in flight at once than the tracker has result slots.
+    #[error("{submitted} tracking passes in flight against {lanes} result slots")]
+    TooManyPasses {
+        /// Passes submitted since the last collect, this one included.
+        submitted: usize,
+        /// Slots the tracker was built for, which is the rig's camera count.
+        lanes: usize,
+    },
     /// A tracker was asked for more pyramid levels than [`MAX_LEVELS`].
     #[error("a patch buffer over {num_levels} pyramid levels is over the ceiling of {ceiling}")]
     TooManyLevels {
@@ -1011,6 +1019,51 @@ pub trait PatchTracker {
     ) -> Result<(), TrackerError> {
         self.track(prev, next, patches, transforms_in, out)
     }
+
+    /// Start a pass whose result lands in `out` when [`PatchTracker::collect`]
+    /// runs.
+    ///
+    /// A device backend can hold several passes in flight and wait once for all
+    /// of them, which is what this is for: on the GPU lane a synchronising read
+    /// costs about 0.12 ms of host time whatever it carries, so the frameset's
+    /// cost is set by how many reads it makes and not by how much they move.
+    /// `out` is **not** filled until `collect`.
+    ///
+    /// The default runs the whole pass here and leaves `collect` nothing to do,
+    /// which is what a synchronous tracker wants.
+    ///
+    /// # Errors
+    ///
+    /// As [`PatchTracker::track`], plus [`TrackerError::TooManyPasses`] when
+    /// more passes are in flight than the tracker has slots.
+    fn submit_prepared(
+        &mut self,
+        prev: &Self::Pyramid,
+        next: &Self::Pyramid,
+        patches: &Self::Patches,
+        transforms_in: &FlowTransforms,
+        out: &mut FlowResult,
+    ) -> Result<(), TrackerError> {
+        self.track_prepared(prev, next, patches, transforms_in, out)
+    }
+
+    /// Finish every pass submitted since the last call, filling the first of
+    /// `outs` in submission order.
+    ///
+    /// # Errors
+    ///
+    /// [`TrackerError`] when a device read fails, or when `outs` is shorter
+    /// than the number of passes submitted.
+    fn collect(&mut self, outs: &mut [FlowResult]) -> Result<(), TrackerError> {
+        let _ = outs;
+        Ok(())
+    }
+
+    /// Drop whatever [`PatchTracker::submit_prepared`] has in flight.
+    ///
+    /// The frontend calls this when a frameset is refused between the submits
+    /// and the collect, so the next frameset starts an empty batch.
+    fn discard(&mut self) {}
 
     /// The sampling pattern this tracker was built for.
     type Pattern: Pattern;

--- a/packages/slam-rs/crates/slam-rs/src/gpu/detect.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/detect.rs
@@ -96,6 +96,15 @@ pub struct GpuCornerScan<R: Runtime> {
     /// count they were sized for: allocated once per camera grid, like
     /// [`GpuCornerScan::buffers`] and for the same reason.
     keys: Vec<Option<(cubecl::server::Handle, usize)>>,
+    /// What [`CornerScan::prepare_cells`] downloaded for each camera, and the
+    /// selection it answers. `select_cells` spends the entry rather than
+    /// reading it twice, so nothing here can outlive the frameset that filled
+    /// it: the next `prepare_cells` clears every slot first.
+    prepared: Vec<Option<CellSelect>>,
+    /// The keys of [`GpuCornerScan::prepared`], in buffers the scanner keeps so
+    /// a frameset's preparation reaches the host allocator only while a grid is
+    /// growing.
+    prepared_keys: Vec<Vec<u32>>,
     /// Times the three device buffers have been allocated, which a rig of one
     /// geometry keeps at one.
     buffer_allocations: usize,
@@ -149,6 +158,8 @@ impl<R: Runtime> GpuCornerScan<R> {
                     packed: Vec::new(),
                     buffers: Vec::new(),
                     keys: Vec::new(),
+                    prepared: Vec::new(),
+                    prepared_keys: Vec::new(),
                     buffer_allocations: 0,
                     kept: None,
                     mask: None,
@@ -217,6 +228,67 @@ impl<R: Runtime> GpuCornerScan<R> {
         // on the device: the extra 0.9 MB over the bus costs less than a
         // whole-frame narrowing pass on the host.
         super::upload_frame(&self.client, image, &mut self.packed)
+    }
+
+    /// This camera's candidate kernels and its cell selection, launched into the
+    /// camera's own key buffer; the handle and the cell count to read back.
+    ///
+    /// `None` when the grid needs more cubes in one dispatch dimension than a
+    /// WebGPU implementation must allow, which is the caller's signal to leave
+    /// the frame alone and let the band walk answer.
+    fn launch_selection(
+        &mut self,
+        camera: usize,
+        image: &ImageU16,
+        select: &CellSelect,
+    ) -> Option<(cubecl::server::Handle, usize)> {
+        let grid: &crate::frontend::detect::CellGrid = &select.grid;
+        let cells_x: usize = (grid.x_stop - grid.x_start) / grid.cell + 1;
+        let cells_y: usize = (grid.y_stop - grid.y_start) / grid.cell + 1;
+        let ceiling: usize = kernels::MAX_CUBES_PER_DIM as usize;
+        if cells_x > ceiling || cells_y > ceiling {
+            return None;
+        }
+        let cells: usize = cells_x * cells_y;
+        let (width, height): (usize, usize) = (image.width(), image.height());
+        let handles: ScanHandles = self.candidates(camera, image);
+
+        if self.keys.len() <= camera {
+            self.keys.resize_with(camera + 1, || None);
+        }
+        let slot: &mut Option<(cubecl::server::Handle, usize)> = &mut self.keys[camera];
+        let fits: bool = slot.as_ref().is_some_and(|(_, sized)| *sized == cells);
+        let (best, best_len): (cubecl::server::Handle, usize) = match slot {
+            Some(existing) if fits => existing.clone(),
+            slot => {
+                self.buffer_allocations += 1;
+                slot.insert((self.client.empty(cells * size_of::<u32>()), cells))
+                    .clone()
+            }
+        };
+
+        kernels::launch_fast_cell_select::<R>(
+            &self.client,
+            (&handles.kept, handles.pixels),
+            (&best, best_len),
+            kernels::CellSelectGeometry {
+                width,
+                height,
+                cell: grid.cell,
+                x_start: grid.x_start,
+                y_start: grid.y_start,
+                cells_x,
+                cells_y,
+                // The score is a `u8`, so a rung at or over 255 admits nothing
+                // and one under zero is every candidate.
+                threshold: select.threshold.clamp(0, 255) as u32,
+                safe_radius: select.safe_radius,
+                // `img_raw.w / 2` is an integer halving (`keypoints.cpp:176`).
+                centre_x: (width / 2) as f32,
+                centre_y: (height / 2) as f32,
+            },
+        );
+        Some((best, cells))
     }
 
     /// Level 0 in, the candidate image out: the two kernels both entry points
@@ -291,6 +363,20 @@ impl<R: Runtime> GpuCornerScan<R> {
     }
 }
 
+/// A downloaded key buffer as `u32`, refused when it is not the grid's length.
+fn checked_keys(keys: &cubecl::bytes::Bytes, cells: usize) -> Result<&[u32], DetectError> {
+    let expected: usize = cells * size_of::<u32>();
+    if keys.len() != expected {
+        return Err(super::GpuError::ShortRead {
+            what: "the cell winner keys",
+            actual: keys.len(),
+            expected,
+        }
+        .into());
+    }
+    Ok(u32::from_bytes(keys))
+}
+
 /// One row's candidates over `threshold`, appended in column order.
 ///
 /// The bitmask says where to look: one word per thirty-two columns, and
@@ -357,12 +443,15 @@ impl<R: Runtime> CornerScan for GpuCornerScan<R> {
                 // fallible form of it: `client.read` is `read_sync(..).expect("TODO")`,
                 // and a panic here would unwind out of the frontend with the GIL
                 // detached (decision D32).
-                let reads: Vec<cubecl::bytes::Bytes> = cubecl::reader::read_sync(
-                    self.client.read_async(vec![handles.kept, handles.mask]),
-                )
-                .map_err(|error| {
-                    super::read_failed("the candidate image and its bitmask", &error)
-                })?;
+                let reads: Vec<cubecl::bytes::Bytes> = super::seam::READ_DETECT
+                    .measure(|| {
+                        cubecl::reader::read_sync(
+                            self.client.read_async(vec![handles.kept, handles.mask]),
+                        )
+                    })
+                    .map_err(|error| {
+                        super::read_failed("the candidate image and its bitmask", &error)
+                    })?;
                 // One buffer per handle, in the order they were asked for; anything else
                 // is the runtime breaking its own contract rather than short data.
                 let Ok([kept_bytes, mask_bytes]) = <[cubecl::bytes::Bytes; 2]>::try_from(reads)
@@ -422,12 +511,10 @@ impl<R: Runtime> CornerScan for GpuCornerScan<R> {
         out: &mut Vec<u32>,
     ) -> Result<(), DetectError> {
         out.clear();
-        let grid: &crate::frontend::detect::CellGrid = &select.grid;
-        let cells_x: usize = (grid.x_stop - grid.x_start) / grid.cell + 1;
-        let cells_y: usize = (grid.y_stop - grid.y_start) / grid.cell + 1;
-        let cells: usize = cells_x * cells_y;
-        let ceiling: usize = kernels::MAX_CUBES_PER_DIM as usize;
-        if cells_x > ceiling || cells_y > ceiling {
+        // Spent, not read twice: an entry left behind would answer a later
+        // frameset with this one's corners.
+        if self.prepared.get_mut(camera).and_then(Option::take) == Some(*select) {
+            out.extend_from_slice(&self.prepared_keys[camera]);
             return Ok(());
         }
         guarded(
@@ -435,70 +522,81 @@ impl<R: Runtime> CornerScan for GpuCornerScan<R> {
                 what: "corner cell selection",
             },
             || {
-                let (width, height): (usize, usize) = (image.width(), image.height());
-                let handles: ScanHandles = self.candidates(camera, image);
-
-                if self.keys.len() <= camera {
-                    self.keys.resize_with(camera + 1, || None);
-                }
-                let slot: &mut Option<(cubecl::server::Handle, usize)> = &mut self.keys[camera];
-                let fits: bool = slot.as_ref().is_some_and(|(_, sized)| *sized == cells);
-                let (best, best_len): (cubecl::server::Handle, usize) = match slot {
-                    Some(existing) if fits => existing.clone(),
-                    slot => {
-                        self.buffer_allocations += 1;
-                        slot.insert((self.client.empty(cells * size_of::<u32>()), cells))
-                            .clone()
-                    }
+                let Some((best, cells)) = self.launch_selection(camera, image, select) else {
+                    return Ok(());
                 };
-
-                kernels::launch_fast_cell_select::<R>(
-                    &self.client,
-                    (&handles.kept, handles.pixels),
-                    (&best, best_len),
-                    kernels::CellSelectGeometry {
-                        width,
-                        height,
-                        cell: grid.cell,
-                        x_start: grid.x_start,
-                        y_start: grid.y_start,
-                        cells_x,
-                        cells_y,
-                        // The score is a `u8`, so a rung at or over 255 admits
-                        // nothing and one under zero is every candidate.
-                        threshold: select.threshold.clamp(0, 255) as u32,
-                        safe_radius: select.safe_radius,
-                        // `img_raw.w / 2` is an integer halving (`keypoints.cpp:176`).
-                        centre_x: (width / 2) as f32,
-                        centre_y: (height / 2) as f32,
-                    },
-                );
 
                 #[cfg(test)]
                 super::fire_if_armed(super::CORNER_SCAN_READ);
 
-                let reads: Vec<cubecl::bytes::Bytes> =
-                    cubecl::reader::read_sync(self.client.read_async(vec![best]))
-                        .map_err(|error| super::read_failed("the cell winner keys", &error))?;
+                let reads: Vec<cubecl::bytes::Bytes> = super::seam::READ_DETECT
+                    .measure(|| cubecl::reader::read_sync(self.client.read_async(vec![best])))
+                    .map_err(|error| super::read_failed("the cell winner keys", &error))?;
                 let Ok([keys]) = <[cubecl::bytes::Bytes; 1]>::try_from(reads) else {
                     return Err(super::GpuError::DeviceReadFailed {
                         what: "the cell winner buffer",
                     }
                     .into());
                 };
-                let expected: usize = cells * size_of::<u32>();
-                if keys.len() != expected {
-                    return Err(super::GpuError::ShortRead {
-                        what: "the cell winner keys",
-                        actual: keys.len(),
-                        expected,
-                    }
-                    .into());
-                }
                 // Copied rather than held, unlike the candidate image: 1.4 kB
                 // into a buffer the detector owns and reuses, against a
                 // `Bytes` the next frame would replace anyway.
-                out.extend_from_slice(u32::from_bytes(&keys));
+                out.extend_from_slice(checked_keys(&keys, cells)?);
+                Ok(())
+            },
+        )
+    }
+
+    /// Every camera's selection launched together, then one download for all of
+    /// them: on this lane the wait is what a frameset pays for, not the 1.4 kB
+    /// each camera brings back (D77).
+    fn prepare_cells(
+        &mut self,
+        images: &[ImageU16],
+        selects: &[Option<CellSelect>],
+    ) -> Result<(), DetectError> {
+        self.prepared.clear();
+        self.prepared.resize(images.len(), None);
+        self.prepared_keys.resize_with(images.len(), Vec::new);
+        guarded(
+            GpuError::DeviceLost {
+                what: "corner cell selection",
+            },
+            || {
+                let mut launched: Vec<(usize, cubecl::server::Handle, usize)> = Vec::new();
+                for (camera, image) in images.iter().enumerate() {
+                    let Some(select) = selects.get(camera).copied().flatten() else {
+                        continue;
+                    };
+                    if let Some((best, cells)) = self.launch_selection(camera, image, &select) {
+                        self.prepared[camera] = Some(select);
+                        launched.push((camera, best, cells));
+                    }
+                }
+                if launched.is_empty() {
+                    return Ok(());
+                }
+
+                #[cfg(test)]
+                super::fire_if_armed(super::CORNER_SCAN_READ);
+
+                let handles: Vec<cubecl::server::Handle> =
+                    launched.iter().map(|(_, best, _)| best.clone()).collect();
+                let reads: Vec<cubecl::bytes::Bytes> = super::seam::READ_DETECT
+                    .measure(|| cubecl::reader::read_sync(self.client.read_async(handles)))
+                    .map_err(|error| super::read_failed("the cell winner keys", &error))?;
+                if reads.len() != launched.len() {
+                    self.prepared.iter_mut().for_each(|slot| *slot = None);
+                    return Err(super::GpuError::DeviceReadFailed {
+                        what: "the cell winner buffers",
+                    }
+                    .into());
+                }
+                for ((camera, _, cells), keys) in launched.iter().zip(reads.iter()) {
+                    let keys: &[u32] = checked_keys(keys, *cells)?;
+                    self.prepared_keys[*camera].clear();
+                    self.prepared_keys[*camera].extend_from_slice(keys);
+                }
                 Ok(())
             },
         )

--- a/packages/slam-rs/crates/slam-rs/src/gpu/detect.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/detect.rs
@@ -445,9 +445,11 @@ impl<R: Runtime> CornerScan for GpuCornerScan<R> {
                 // detached (decision D32).
                 let reads: Vec<cubecl::bytes::Bytes> = super::seam::READ_DETECT
                     .measure(|| {
-                        cubecl::reader::read_sync(
+                        let read = cubecl::reader::read_sync(
                             self.client.read_async(vec![handles.kept, handles.mask]),
-                        )
+                        );
+                        super::drained();
+                        read
                     })
                     .map_err(|error| {
                         super::read_failed("the candidate image and its bitmask", &error)
@@ -529,9 +531,12 @@ impl<R: Runtime> CornerScan for GpuCornerScan<R> {
                 #[cfg(test)]
                 super::fire_if_armed(super::CORNER_SCAN_READ);
 
-                let reads: Vec<cubecl::bytes::Bytes> = super::seam::READ_DETECT
-                    .measure(|| cubecl::reader::read_sync(self.client.read_async(vec![best])))
-                    .map_err(|error| super::read_failed("the cell winner keys", &error))?;
+                let reads: Vec<cubecl::bytes::Bytes> = {
+                    let read = super::seam::READ_DETECT
+                        .measure(|| cubecl::reader::read_sync(self.client.read_async(vec![best])));
+                    super::drained();
+                    read.map_err(|error| super::read_failed("the cell winner keys", &error))?
+                };
                 let Ok([keys]) = <[cubecl::bytes::Bytes; 1]>::try_from(reads) else {
                     return Err(super::GpuError::DeviceReadFailed {
                         what: "the cell winner buffer",
@@ -571,6 +576,9 @@ impl<R: Runtime> CornerScan for GpuCornerScan<R> {
                     if let Some((best, cells)) = self.launch_selection(camera, image, &select) {
                         self.prepared[camera] = Some(select);
                         launched.push((camera, best, cells));
+                        // Three launches, and the frame upload when the
+                        // pyramid did not publish one.
+                        super::queued(&self.client, 4)?;
                     }
                 }
                 if launched.is_empty() {
@@ -582,9 +590,12 @@ impl<R: Runtime> CornerScan for GpuCornerScan<R> {
 
                 let handles: Vec<cubecl::server::Handle> =
                     launched.iter().map(|(_, best, _)| best.clone()).collect();
-                let reads: Vec<cubecl::bytes::Bytes> = super::seam::READ_DETECT
-                    .measure(|| cubecl::reader::read_sync(self.client.read_async(handles)))
-                    .map_err(|error| super::read_failed("the cell winner keys", &error))?;
+                let reads: Vec<cubecl::bytes::Bytes> = {
+                    let read = super::seam::READ_DETECT
+                        .measure(|| cubecl::reader::read_sync(self.client.read_async(handles)));
+                    super::drained();
+                    read.map_err(|error| super::read_failed("the cell winner keys", &error))?
+                };
                 if reads.len() != launched.len() {
                     self.prepared.iter_mut().for_each(|slot| *slot = None);
                     return Err(super::GpuError::DeviceReadFailed {

--- a/packages/slam-rs/crates/slam-rs/src/gpu/kernels.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/kernels.rs
@@ -1156,6 +1156,7 @@ pub(super) fn launch_subsample<R: Runtime>(
     target: super::pyramid::Level,
 ) {
     let (cubes, units) = tile_2d(target.width, target.height);
+    super::seam::launch();
     unsafe {
         subsample_kernel::launch_unchecked::<R>(
             client,
@@ -1213,6 +1214,7 @@ pub(super) fn launch_patch_build<R: Runtime>(
     shape: PatchShape,
     bases: PositionBases,
 ) {
+    super::seam::launch();
     unsafe {
         patch_build_kernel::launch_unchecked::<R>(
             client,
@@ -1255,6 +1257,7 @@ pub(super) fn launch_klt<R: Runtime>(
     max_iterations: usize,
     check_guess_bounds: bool,
 ) {
+    super::seam::launch();
     unsafe {
         klt_kernel::launch_unchecked::<R>(
             client,
@@ -1318,6 +1321,7 @@ pub(super) fn launch_probe<N: Numeric, R: Runtime>(
     count: usize,
 ) {
     let (cubes, units) = linear_1d(count);
+    super::seam::launch();
     unsafe {
         probe_kernel::launch::<N, R>(
             client,
@@ -1343,6 +1347,7 @@ pub(super) fn launch_copy_level0<R: Runtime>(
     count: usize,
 ) {
     let (cubes, units) = linear_1d(count);
+    super::seam::launch();
     unsafe {
         probe_kernel::launch_unchecked::<u16, R>(
             client,
@@ -1366,6 +1371,7 @@ pub(super) fn launch_prepare_backward<R: Runtime>(
     bases: PositionBases,
 ) {
     let (cubes, units) = linear_1d(count);
+    super::seam::launch();
     unsafe {
         prepare_backward_kernel::launch_unchecked::<R>(
             client,
@@ -1394,6 +1400,7 @@ pub(super) fn launch_finish<R: Runtime>(
     max_recovered_dist2: f32,
 ) {
     let (cubes, units) = linear_1d(count);
+    super::seam::launch();
     unsafe {
         finish_kernel::launch_unchecked::<R>(
             client,
@@ -1583,6 +1590,7 @@ pub(super) fn launch_fast_score<R: Runtime>(
     margin: usize,
 ) {
     let (cubes, units) = tile_2d(width, height);
+    super::seam::launch();
     unsafe {
         fast_score_kernel::launch_unchecked::<R>(
             client,
@@ -1611,6 +1619,7 @@ pub(super) fn launch_fast_localmax<R: Runtime>(
     use_filter: bool,
 ) {
     let (cubes, units) = tile_2d(width, height);
+    super::seam::launch();
     unsafe {
         fast_localmax_kernel::launch_unchecked::<R>(
             client,
@@ -1672,6 +1681,7 @@ pub(super) fn launch_fast_mask<R: Runtime>(
     words: usize,
 ) {
     let (cubes, units) = tile_2d(words, height);
+    super::seam::launch();
     unsafe {
         fast_mask_kernel::launch_unchecked::<R>(
             client,
@@ -2042,6 +2052,7 @@ pub(super) fn launch_fast_cell_select<R: Runtime>(
     best: Buffer<'_>,
     geometry: CellSelectGeometry,
 ) {
+    super::seam::launch();
     unsafe {
         fast_cell_select_kernel::launch_unchecked::<R>(
             client,

--- a/packages/slam-rs/crates/slam-rs/src/gpu/mod.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/mod.rs
@@ -68,6 +68,7 @@ mod finite;
 mod kernels;
 mod patches;
 mod pyramid;
+pub mod seam;
 mod track;
 mod trig;
 
@@ -498,7 +499,8 @@ pub(super) fn upload_frame<R: cubecl::prelude::Runtime>(
     let pixels: usize = width * height;
     if image.stride() == width {
         return (
-            client.create_from_slice(u16::as_bytes(&image.data()[..pixels])),
+            seam::UPLOAD
+                .measure(|| client.create_from_slice(u16::as_bytes(&image.data()[..pixels]))),
             pixels,
         );
     }
@@ -507,7 +509,10 @@ pub(super) fn upload_frame<R: cubecl::prelude::Runtime>(
     for y in 0..height {
         scratch.extend_from_slice(image.row(y));
     }
-    (client.create_from_slice(u16::as_bytes(scratch)), pixels)
+    (
+        seam::UPLOAD.measure(|| client.create_from_slice(u16::as_bytes(scratch))),
+        pixels,
+    )
 }
 
 /// So the check is the one thing that cannot lie: write a known pattern, copy

--- a/packages/slam-rs/crates/slam-rs/src/gpu/mod.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/mod.rs
@@ -373,6 +373,73 @@ pub fn gpu_backends<P: crate::frontend::patterns::Pattern>(
     )
 }
 
+/// Tasks CubeCL 0.10's client-to-server channel holds before a producer spins
+/// (`cubecl-common`'s `CHANNEL_MAX_TASK`).
+#[cfg(feature = "gpu-core")]
+const CHANNEL_TASKS: usize = 32;
+
+/// The most tasks one stage enqueues between two reports: a tracking pass's
+/// three uploads and six launches.
+#[cfg(feature = "gpu-core")]
+const STAGE_TASKS: usize = 9;
+
+/// Tasks handed to the runtime's server since the channel was last known empty.
+///
+/// One counter for the process, which is what the channel is: CubeCL caches one
+/// client per device, and this pipeline is single-threaded. A second frontend on
+/// another thread would make this over-count, which drains early — the safe
+/// direction.
+#[cfg(feature = "gpu-core")]
+static QUEUED: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// Record that a stage enqueued `tasks`, handing the queue to the runtime's
+/// server thread when another stage would not fit in it.
+///
+/// CubeCL 0.10's client-to-server channel is [`CHANNEL_TASKS`] deep, and a
+/// producer that fills it does not block: it spins for 524,288 iterations, then
+/// yields 4,096 times, then sleeps in 75 microsecond steps
+/// (`cubecl-common`'s `SPIN_BUDGET_CLIENT`). That is tuned for a producer and a
+/// server on different cores. This pipeline is pinned to one — the benchmark and
+/// the fleet both run it with a single-CPU affinity — so the spin is the
+/// server's own core and the queue cannot drain until the producer gives it up.
+///
+/// It only became reachable when the frontend stopped waiting per camera. A
+/// two-camera frameset enqueues 28 tasks between its downloads and stays under
+/// the cliff; a four-camera frameset enqueues 56, and fell off it hard enough to
+/// spend 2.9 ms a frameset spinning inside one launch. Reporting here keeps the
+/// queue under the ceiling at any camera count, at about one flush a frameset on
+/// a stereo rig and three on a four-camera one.
+///
+/// The flush is not extra work: it is the encoding and submission the next
+/// download would have paid for, moved earlier.
+///
+/// # Errors
+///
+/// [`GpuError::DeviceReadFailed`] when the runtime refuses the flush, which on
+/// this path means the device is gone.
+#[cfg(feature = "gpu-core")]
+pub(super) fn queued<R: cubecl::prelude::Runtime>(
+    client: &cubecl::prelude::ComputeClient<R>,
+    tasks: usize,
+) -> Result<(), GpuError> {
+    use std::sync::atomic::Ordering;
+
+    let total: usize = QUEUED.fetch_add(tasks, Ordering::Relaxed) + tasks;
+    if total + STAGE_TASKS < CHANNEL_TASKS {
+        return Ok(());
+    }
+    QUEUED.store(0, Ordering::Relaxed);
+    client
+        .flush()
+        .map_err(|error| read_failed("the queued launches", &error))
+}
+
+/// The channel is empty: a download has waited for everything that was in it.
+#[cfg(feature = "gpu-core")]
+pub(super) fn drained() {
+    QUEUED.store(0, std::sync::atomic::Ordering::Relaxed);
+}
+
 /// A failed device read as a typed error, with the runtime's own reason logged.
 ///
 /// [`GpuError`] is `Copy`, so it cannot carry the `ServerError`'s reason and

--- a/packages/slam-rs/crates/slam-rs/src/gpu/mod.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/mod.rs
@@ -312,9 +312,12 @@ pub type LaneBackends<P> = (
 /// one shared client.
 ///
 /// One client for both stages is what keeps a pyramid and the patches it feeds
-/// on the same device queue, so the frontend synchronises once per
-/// [`crate::frontend::tracker::PatchTracker::track`] call rather than once per
-/// stage.
+/// on the same device queue, so the frontend synchronises once per tracking
+/// **batch** rather than once per stage or once per camera.
+///
+/// `cameras` is the rig's camera count, which is how many tracking passes the
+/// tracker must be able to hold in flight at once
+/// ([`crate::frontend::tracker::PatchTracker::submit_prepared`]).
 ///
 /// # Errors
 ///
@@ -330,6 +333,7 @@ pub fn gpu_backends<P: crate::frontend::patterns::Pattern>(
     num_levels: usize,
     max_iterations: usize,
     max_recovered_dist2: f32,
+    cameras: usize,
 ) -> Result<LaneBackends<P>, crate::frontend::tracker::TrackerError> {
     // The guard is around the whole of it, not around the client alone: from
     // here to the returned backends every line allocates, launches or reads on
@@ -355,6 +359,7 @@ pub fn gpu_backends<P: crate::frontend::patterns::Pattern>(
                 num_levels,
                 max_iterations,
                 max_recovered_dist2,
+                cameras,
             )?;
             let builder: LanePyramidBuilder = GpuPyramidBuilder::new(client.clone(), P::OFFSETS);
             let mut scanner: GpuCornerScan<GpuRuntime> = GpuCornerScan::new(client)?;
@@ -712,7 +717,7 @@ mod tests {
     fn a_panic_after_the_client_is_built_is_a_typed_error() {
         arm_fault_at(GUARDED_REGION);
         let outer: crate::frontend::tracker::TrackerError =
-            gpu_backends::<crate::frontend::patterns::Pattern51>(64, 3, 5, 4.0).unwrap_err();
+            gpu_backends::<crate::frontend::patterns::Pattern51>(64, 3, 5, 4.0, 2).unwrap_err();
         assert!(
             matches!(
                 outer,
@@ -723,7 +728,7 @@ mod tests {
 
         arm_fault_at(STORAGE_PROBE);
         let probe: crate::frontend::tracker::TrackerError =
-            gpu_backends::<crate::frontend::patterns::Pattern51>(64, 3, 5, 4.0).unwrap_err();
+            gpu_backends::<crate::frontend::patterns::Pattern51>(64, 3, 5, 4.0, 2).unwrap_err();
         assert!(
             matches!(
                 probe,
@@ -736,7 +741,7 @@ mod tests {
 
         // And the same call with nothing armed builds the three backends, so
         // what the lines above measure is the guards.
-        gpu_backends::<crate::frontend::patterns::Pattern51>(64, 3, 5, 4.0).unwrap();
+        gpu_backends::<crate::frontend::patterns::Pattern51>(64, 3, 5, 4.0, 2).unwrap();
     }
 
     /// A panic in an exported constructor is a typed error, not an unwind.
@@ -779,7 +784,7 @@ mod tests {
 
         arm_fault_at(GUARDED_REGION);
         let tracker: TrackerError =
-            GpuPatchTracker::<Pattern51, GpuRuntime>::new(client.clone(), 64, 4, 5, 4.0)
+            GpuPatchTracker::<Pattern51, GpuRuntime>::new(client.clone(), 64, 4, 5, 4.0, 2)
                 .unwrap_err();
         assert!(
             matches!(
@@ -793,7 +798,7 @@ mod tests {
 
         GpuCornerScan::<GpuRuntime>::new(client.clone()).unwrap();
         GpuPatches::<Pattern51, GpuRuntime>::new(client.clone(), 64, 4).unwrap();
-        GpuPatchTracker::<Pattern51, GpuRuntime>::new(client, 64, 4, 5, 4.0).unwrap();
+        GpuPatchTracker::<Pattern51, GpuRuntime>::new(client, 64, 4, 5, 4.0, 2).unwrap();
     }
 
     /// A panic in the public storage probe is a typed error, not an unwind.

--- a/packages/slam-rs/crates/slam-rs/src/gpu/patches.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/patches.rs
@@ -252,9 +252,10 @@ impl<P: Pattern, R: Runtime> GpuPatches<P, R> {
     /// Replace the device positions buffer with this call's runs of the staging
     /// buffer, which is as long as the capacity but only filled to `len`.
     fn upload_staging(&mut self) {
-        self.positions = self
-            .client
-            .create_from_slice(f32::as_bytes(&self.staging[..POSITION_RUNS * self.len]));
+        self.positions = super::seam::UPLOAD.measure(|| {
+            self.client
+                .create_from_slice(f32::as_bytes(&self.staging[..POSITION_RUNS * self.len]))
+        });
     }
 
     /// Sample every filled patch at every level of `pyramid`, without waiting.

--- a/packages/slam-rs/crates/slam-rs/src/gpu/pyramid.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/pyramid.rs
@@ -389,6 +389,8 @@ impl<R: Runtime> crate::pyramid::PyramidBuilder for GpuPyramidBuilder<R> {
                         target,
                     );
                 }
+                // One upload, the level-0 copy and a subsample per level above it.
+                super::queued(&out.client, 1 + out.levels.len())?;
                 Ok(())
             },
         )

--- a/packages/slam-rs/crates/slam-rs/src/gpu/seam.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/seam.rs
@@ -1,0 +1,107 @@
+//! Host-side counters for the per-frameset GPU seam.
+//!
+//! The device timestamps say every kernel of a two-camera MIO10 frameset is
+//! 0.44 ms of GPU time while the frontend spends 1.63 ms of host time, so the
+//! question these answer is where the rest goes: how many launches, uploads and
+//! synchronising reads a frameset makes, and how long the host sits in each.
+//! The answer that shaped D77 was **five reads, 1.51 ms**, against 0.15 ms in
+//! every upload and nothing measurable in the launches.
+//!
+//! Relaxed atomics and one `Instant` pair per upload or read: about 0.6 µs a
+//! frameset against the 1600 it measures. `tests/gpu_seam_bench.rs` is the rig
+//! that prints them.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+/// How many times an operation ran, and the host time inside it.
+#[derive(Debug)]
+pub struct Meter {
+    calls: AtomicU64,
+    nanos: AtomicU64,
+}
+
+impl Meter {
+    /// A meter at zero.
+    const fn new() -> Self {
+        Self {
+            calls: AtomicU64::new(0),
+            nanos: AtomicU64::new(0),
+        }
+    }
+
+    /// Run `body`, adding one call and the host time it took.
+    pub fn measure<T>(&self, body: impl FnOnce() -> T) -> T {
+        let mark: Instant = Instant::now();
+        let out: T = body();
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        self.nanos
+            .fetch_add(mark.elapsed().as_nanos() as u64, Ordering::Relaxed);
+        out
+    }
+
+    /// Count one call whose host time is not worth an `Instant` pair.
+    pub fn count(&self) {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Calls and their total host nanoseconds.
+    #[must_use]
+    pub fn read(&self) -> (u64, u64) {
+        (
+            self.calls.load(Ordering::Relaxed),
+            self.nanos.load(Ordering::Relaxed),
+        )
+    }
+
+    /// Back to zero, so a caller can bracket a measured run.
+    fn reset(&self) {
+        self.calls.store(0, Ordering::Relaxed);
+        self.nanos.store(0, Ordering::Relaxed);
+    }
+}
+
+/// Kernel launches. Counted only: the enqueue is inside its stage's own timer
+/// and measured under a millisecond for all thirty-two of a frameset together.
+pub static LAUNCH: Meter = Meter::new();
+/// `create_from_slice`: a logical allocation and a host-to-device write.
+pub static UPLOAD: Meter = Meter::new();
+/// The tracker batch's one download.
+pub static READ_TRACK: Meter = Meter::new();
+/// The corner scanner's cell-key download.
+pub static READ_DETECT: Meter = Meter::new();
+
+/// Count one launch.
+pub fn launch() {
+    LAUNCH.count();
+}
+
+/// Every counter back to zero.
+pub fn reset() {
+    for meter in [&LAUNCH, &UPLOAD, &READ_TRACK, &READ_DETECT] {
+        meter.reset();
+    }
+}
+
+/// The whole seam over `framesets`, per frameset, on one line.
+#[must_use]
+pub fn line(framesets: u64) -> String {
+    let scale: f64 = framesets.max(1) as f64;
+    let (launches, _) = LAUNCH.read();
+    let (uploads, upload_ns) = UPLOAD.read();
+    let (track_reads, track_ns) = READ_TRACK.read();
+    let (detect_reads, detect_ns) = READ_DETECT.read();
+    format!(
+        "per frameset: {:.2} launches, {:.2} uploads ({:.3} ms), {:.2} reads ({:.3} ms) \
+         = {:.2} tracker ({:.3} ms) + {:.2} detector ({:.3} ms)",
+        launches as f64 / scale,
+        uploads as f64 / scale,
+        upload_ns as f64 / scale / 1e6,
+        (track_reads + detect_reads) as f64 / scale,
+        (track_ns + detect_ns) as f64 / scale / 1e6,
+        track_reads as f64 / scale,
+        track_ns as f64 / scale / 1e6,
+        detect_reads as f64 / scale,
+        detect_ns as f64 / scale / 1e6,
+    )
+}

--- a/packages/slam-rs/crates/slam-rs/src/gpu/track.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/track.rs
@@ -339,6 +339,9 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
                 patches.bases(),
                 self.max_recovered_dist2,
             );
+            // The caller's positions upload, this call's two uploads and its
+            // six launches.
+            super::queued(&self.client, 9)?;
             Ok(())
         })
     }
@@ -373,9 +376,12 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
         let bytes: Vec<cubecl::bytes::Bytes> = if reads.is_empty() {
             Vec::new()
         } else {
-            super::seam::READ_TRACK
-                .measure(|| cubecl::reader::read_sync(self.client.read_async(reads)))
-                .map_err(|error| super::read_failed("the tracker result", &error))?
+            {
+                let read = super::seam::READ_TRACK
+                    .measure(|| cubecl::reader::read_sync(self.client.read_async(reads)));
+                super::drained();
+                read.map_err(|error| super::read_failed("the tracker result", &error))?
+            }
         };
 
         let mut read: usize = 0;

--- a/packages/slam-rs/crates/slam-rs/src/gpu/track.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/track.rs
@@ -20,12 +20,25 @@ const TRANSFORM_RUNS: usize = 7;
 /// The CPU tracker's counterpart, with the two passes and the check between them
 /// on the device.
 ///
-/// One [`PatchTracker::track`] call is five launches and one wait: the forward
-/// sweep, the backward pass's inputs, the backward patch build, the backward
-/// sweep, and the recovered-distance test that combines them. Nothing crosses
-/// back to the host in between — the backward pass reads the forward result
-/// where it lies — so the only download is the packed result, seven `f32` per
-/// keypoint.
+/// One [`PatchTracker::submit_prepared`] call is five launches and no wait: the
+/// forward sweep, the backward pass's inputs, the backward patch build, the
+/// backward sweep, and the recovered-distance test that combines them. Nothing
+/// crosses back to the host in between — the backward pass reads the forward
+/// result where it lies — so the only download is the packed result, seven `f32`
+/// per keypoint, and [`PatchTracker::collect`] takes every submitted pass's
+/// result in **one** download.
+///
+/// That split is the whole point of the type. A synchronising read on this lane
+/// costs about 0.12 ms of host time before it has moved a byte — a staging
+/// reservation, a submit, a `map_async`, and two thread handoffs to the runtime's
+/// polling thread — so a frameset's host cost is set by how many reads it makes.
+/// A two-camera frameset made five and spent 1.51 ms of its 1.64 in them.
+///
+/// The passes of one batch share every intermediate buffer, and may: the device
+/// stream is ordered, so pass *k*'s `finish` has read the patch stores and the
+/// backward transforms before pass *k+1*'s kernels write them. The **result**
+/// is the one buffer that must survive until the download, so there is one per
+/// lane and a lane is a camera.
 ///
 /// The buffers a call needs are allocated once at construction and reused; the
 /// one exception is the forward pass's inputs, which arrive from the host and so
@@ -40,8 +53,12 @@ pub struct GpuPatchTracker<P: Pattern, R: Runtime> {
     backward_patches: GpuPatches<P, R>,
     /// The backward pass's inputs, then its results in place.
     backward: cubecl::server::Handle,
-    /// The combined result the host downloads.
-    result: cubecl::server::Handle,
+    /// One combined result per lane; a batch writes `results[lane]` and
+    /// [`PatchTracker::collect`] downloads every one of them at once.
+    results: Vec<cubecl::server::Handle>,
+    /// The keypoint counts of the passes submitted since the last collect, in
+    /// submission order, which is also their lane order.
+    pending: Vec<usize>,
     /// The staging buffer the transform inputs are uploaded from.
     staging: Vec<f32>,
     /// `source position - guess` per patch, the offset the backward guess adds.
@@ -51,7 +68,8 @@ pub struct GpuPatchTracker<P: Pattern, R: Runtime> {
 }
 
 impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
-    /// A tracker sized for `capacity` keypoints over `num_levels` levels.
+    /// A tracker sized for `capacity` keypoints over `num_levels` levels, able
+    /// to hold `lanes` passes in flight — the rig's camera count.
     ///
     /// # Errors
     ///
@@ -66,6 +84,7 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
         num_levels: usize,
         max_iterations: usize,
         max_recovered_dist2: f32,
+        lanes: usize,
     ) -> Result<Self, TrackerError> {
         guarded(
             GpuError::DeviceLost {
@@ -75,6 +94,12 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
                 let backward_patches: GpuPatches<P, R> =
                     GpuPatches::new(client.clone(), capacity, num_levels)?;
                 let transform_bytes: usize = TRANSFORM_RUNS * capacity * size_of::<f32>();
+                // Allocated here and never again: the pool has to be flat from
+                // the first frameset, which a lane allocated on first use would
+                // break (`the_whole_gpu_path_holds_the_pool_flat`).
+                let results: Vec<cubecl::server::Handle> = (0..lanes.max(1))
+                    .map(|_| client.empty(transform_bytes))
+                    .collect();
                 Ok(Self {
                     capacity,
                     num_levels,
@@ -82,7 +107,8 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
                     max_recovered_dist2,
                     backward_patches,
                     backward: client.empty(transform_bytes),
-                    result: client.empty(transform_bytes),
+                    results,
+                    pending: Vec::with_capacity(lanes.max(1)),
                     staging: vec![0.0; TRANSFORM_RUNS * capacity],
                     offset_x: vec![0.0; capacity],
                     offset_y: vec![0.0; capacity],
@@ -123,7 +149,8 @@ impl<P: Pattern, R: Runtime> PatchTracker for GpuPatchTracker<P, R> {
         transforms_in: &FlowTransforms,
         out: &mut FlowResult,
     ) -> Result<(), TrackerError> {
-        self.track_inner(prev, next, patches, transforms_in, out, false)
+        self.submit_inner(prev, next, patches, transforms_in, false)?;
+        self.collect(std::slice::from_mut(out))
     }
 
     fn track_prepared(
@@ -134,25 +161,55 @@ impl<P: Pattern, R: Runtime> PatchTracker for GpuPatchTracker<P, R> {
         transforms_in: &FlowTransforms,
         out: &mut FlowResult,
     ) -> Result<(), TrackerError> {
-        self.track_inner(prev, next, patches, transforms_in, out, true)
+        self.submit_prepared(prev, next, patches, transforms_in, out)?;
+        self.collect(std::slice::from_mut(out))
     }
-}
 
-impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
-    /// `trackPoints` (`frame_to_frame_optical_flow.h:294-375`) on the device.
-    fn track_inner(
+    fn submit_prepared(
         &mut self,
         prev: &GpuPyramid<R>,
         next: &GpuPyramid<R>,
         patches: &GpuPatches<P, R>,
         transforms_in: &FlowTransforms,
-        out: &mut FlowResult,
-        build_source: bool,
+        _out: &mut FlowResult,
     ) -> Result<(), TrackerError> {
+        self.submit_inner(prev, next, patches, transforms_in, true)
+    }
+
+    /// Every submitted pass's result in one download, decoded in order.
+    fn collect(&mut self, outs: &mut [FlowResult]) -> Result<(), TrackerError> {
         // The one call per frameset that waits on the device, and the one the
         // frontend makes with the GIL released: a lost device panics inside
         // CubeCL's own client, and the guard is what turns that into this
         // method's error rather than a `PanicException` in Python (decision D32).
+        let outcome: Result<(), TrackerError> =
+            guarded(GpuError::DeviceLost { what: "tracker" }, || {
+                self.collect_inner(outs)
+            });
+        self.pending.clear();
+        outcome
+    }
+
+    fn discard(&mut self) {
+        self.pending.clear();
+    }
+}
+
+impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
+    /// `trackPoints` (`frame_to_frame_optical_flow.h:294-375`) on the device,
+    /// launched into the next free lane and left there.
+    fn submit_inner(
+        &mut self,
+        prev: &GpuPyramid<R>,
+        next: &GpuPyramid<R>,
+        patches: &GpuPatches<P, R>,
+        transforms_in: &FlowTransforms,
+        build_source: bool,
+    ) -> Result<(), TrackerError> {
+        // Launches only, but they still reach the device, and a lost one panics
+        // inside CubeCL's own client: the guard is what turns that into this
+        // method's error rather than a `PanicException` through the released GIL
+        // (decision D32).
         guarded(GpuError::DeviceLost { what: "tracker" }, || {
             let count: usize = transforms_in.len();
             check_track_inputs(
@@ -164,10 +221,15 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
                 self.capacity,
                 self.num_levels,
             )?;
-
-            out.reset(count);
+            let lane: usize = self.pending.len();
+            if lane >= self.results.len() {
+                return Err(TrackerError::TooManyPasses {
+                    submitted: lane + 1,
+                    lanes: self.results.len(),
+                });
+            }
+            self.pending.push(count);
             if count == 0 {
-                out.finish(0);
                 return Ok(());
             }
 
@@ -188,9 +250,10 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
             // returns before touching it). Measured: this form costs about 0.05 ms
             // of the lane's 5.9 and an `Option` field about 0.14, both inside this
             // host's drift and above its 0.02 ms pair-to-pair floor.
-            let forward: cubecl::server::Handle = self
-                .client
-                .create_from_slice(f32::as_bytes(&self.staging[..TRANSFORM_RUNS * count]));
+            let forward: cubecl::server::Handle = super::seam::UPLOAD.measure(|| {
+                self.client
+                    .create_from_slice(f32::as_bytes(&self.staging[..TRANSFORM_RUNS * count]))
+            });
 
             // `off = source position - guess` (`:339`), which the backward guess
             // adds back (`:357`). Both terms are on the host already, so the offset
@@ -271,34 +334,79 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
                 forward_view,
                 backward_view,
                 patches.position_buffer(),
-                (&self.result, TRANSFORM_RUNS * count),
+                (&self.results[lane], TRANSFORM_RUNS * count),
                 count,
                 patches.bases(),
                 self.max_recovered_dist2,
             );
+            Ok(())
+        })
+    }
 
-            // ── the one wait of the call.
+    /// The batch's one wait: every submitted lane's packed result downloaded
+    /// together, then decoded into `outs` in submission order.
+    fn collect_inner(&mut self, outs: &mut [FlowResult]) -> Result<(), TrackerError> {
+        if self.pending.len() > outs.len() {
+            return Err(TrackerError::LengthMismatch {
+                first_name: "submitted passes",
+                first: self.pending.len(),
+                second_name: "results offered",
+                second: outs.len(),
+            });
+        }
+        for (lane, count) in self.pending.iter().enumerate() {
+            outs[lane].reset(*count);
+        }
+        // A pass that offered nothing launched nothing, so it has no buffer to
+        // read; the download is over the lanes that do.
+        let reads: Vec<cubecl::server::Handle> = self
+            .pending
+            .iter()
+            .enumerate()
+            .filter(|(_, count)| **count != 0)
+            .map(|(lane, count)| {
+                let expected: u64 = (TRANSFORM_RUNS * count * size_of::<f32>()) as u64;
+                let handle: &cubecl::server::Handle = &self.results[lane];
+                handle.clone().offset_end(handle.size_in_used() - expected)
+            })
+            .collect();
+        let bytes: Vec<cubecl::bytes::Bytes> = if reads.is_empty() {
+            Vec::new()
+        } else {
+            super::seam::READ_TRACK
+                .measure(|| cubecl::reader::read_sync(self.client.read_async(reads)))
+                .map_err(|error| super::read_failed("the tracker result", &error))?
+        };
+
+        let mut read: usize = 0;
+        for (lane, count) in self.pending.iter().enumerate() {
+            let count: usize = *count;
+            if count == 0 {
+                outs[lane].finish(0);
+                continue;
+            }
             let expected: usize = TRANSFORM_RUNS * count * size_of::<f32>();
-            let result = self
-                .result
-                .clone()
-                .offset_end(self.result.size_in_used() - expected as u64);
-            let bytes = self
-                .client
-                .read_one(result)
-                .map_err(|error| super::read_failed("the tracker result", &error))?;
+            // One buffer per non-empty lane, in the order they were asked for;
+            // anything else is the runtime breaking its own contract.
+            let Some(buffer) = bytes.get(read) else {
+                return Err(super::GpuError::DeviceReadFailed {
+                    what: "a tracker lane's result",
+                }
+                .into());
+            };
+            read += 1;
             // The kernel packs by count; the unused capacity tail stays on the
             // device. Keep the short-read refusal before decoding any values.
-            if bytes.len() < expected {
+            if buffer.len() < expected {
                 return Err(TrackerError::LengthMismatch {
                     first_name: "result bytes expected",
                     first: expected,
                     second_name: "returned",
-                    second: bytes.len(),
+                    second: buffer.len(),
                 });
             }
-            let values: &[f32] = f32::from_bytes(&bytes);
-            let (valid, transforms) = out.parts_mut();
+            let values: &[f32] = f32::from_bytes(buffer);
+            let (valid, transforms) = outs[lane].parts_mut();
             let [m00, m01, m10, m11, tx, ty] = transforms.coefficients_mut();
             for index in 0..count {
                 m00[index] = values[index];
@@ -309,9 +417,9 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
                 ty[index] = values[5 * count + index];
                 valid[index] = values[6 * count + index] != 0.0;
             }
-            out.finish(count);
-            Ok(())
-        })
+            outs[lane].finish(count);
+        }
+        Ok(())
     }
 }
 
@@ -322,6 +430,7 @@ impl<P: Pattern, R: Runtime> std::fmt::Debug for GpuPatchTracker<P, R> {
             .field("num_levels", &self.num_levels)
             .field("max_iterations", &self.max_iterations)
             .field("max_recovered_dist2", &self.max_recovered_dist2)
+            .field("lanes", &self.results.len())
             .finish()
     }
 }

--- a/packages/slam-rs/crates/slam-rs/src/lib.rs
+++ b/packages/slam-rs/crates/slam-rs/src/lib.rs
@@ -428,6 +428,7 @@ fn build_frontend(
                 num_levels,
                 config.optical_flow_max_iterations as usize,
                 config.optical_flow_max_recovered_dist2,
+                calibration.intrinsics.len(),
             )
             .map_err(frontend::flow::FrontendError::from)?;
             Ok(FrontendLane::Gpu(

--- a/packages/slam-rs/crates/slam-rs/tests/gpu_detect.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/gpu_detect.rs
@@ -80,6 +80,17 @@ impl CornerScan for CountingScan {
         self.selections.fetch_add(1, Ordering::Relaxed);
         self.inner.select_cells(camera, image, select, out)
     }
+
+    /// Forwarded, not defaulted: the trait's default prepares nothing, so a
+    /// decorator that forgot this would silently take the device lane off the
+    /// batched path and every equality below would still pass.
+    fn prepare_cells(
+        &mut self,
+        images: &[ImageU16],
+        selects: &[Option<CellSelect>],
+    ) -> Result<(), DetectError> {
+        self.inner.prepare_cells(images, selects)
+    }
 }
 
 /// What one equality check saw.
@@ -628,4 +639,93 @@ fn the_gpu_cell_selection_holds_for_every_camera_slot() {
         assert_eq!(got.corners, want.corners, "camera {camera}: corners");
         assert_eq!(got.responses, want.responses, "camera {camera}: responses");
     }
+}
+
+/// The batched preparation answers exactly what the per-camera call does.
+///
+/// [`CornerScan::prepare_cells`] launches every camera's selection at once and
+/// downloads them together, which is a scheduling change and must be nothing
+/// else: the keys it hands each camera have to be the ones that camera's own
+/// `select_cells` would have read. Two different MIO10 frames in the two camera
+/// slots, so a batch that crossed its cameras over would be caught.
+#[test]
+fn the_batched_preparation_answers_what_the_per_camera_call_does() {
+    let config: DetectorConfig = detector_config(472.0);
+    let images: [ImageU16; 2] = [mio10_frame(0, 0), mio10_frame(1, 1)];
+    let grid: CellGrid = CellGrid::new(images[0].width(), images[0].height(), 50).unwrap();
+    let selects: Vec<Option<CellSelect>> = images
+        .iter()
+        .map(|image| slam_rs::frontend::detect::cell_select(image, &grid, &config))
+        .collect();
+    assert!(
+        selects.iter().all(Option::is_some),
+        "the rig is device shaped"
+    );
+
+    // The selection's grid is the cells the walk visits, one less each way than
+    // the occupancy matrix: `x_stop` is the last cell's left edge.
+    let cells: usize = ((grid.x_stop - grid.x_start) / grid.cell + 1)
+        * ((grid.y_stop - grid.y_start) / grid.cell + 1);
+
+    let mut scanner: GpuCornerScan<_> = GpuCornerScan::new(gpu_client().unwrap()).unwrap();
+    let mut alone: Vec<Vec<u32>> = Vec::new();
+    for (camera, image) in images.iter().enumerate() {
+        let mut keys: Vec<u32> = Vec::new();
+        scanner
+            .select_cells(camera, image, &selects[camera].unwrap(), &mut keys)
+            .unwrap();
+        assert_eq!(keys.len(), cells, "camera {camera}");
+        alone.push(keys);
+    }
+
+    scanner.prepare_cells(&images, &selects).unwrap();
+    for (camera, image) in images.iter().enumerate() {
+        let mut keys: Vec<u32> = Vec::new();
+        scanner
+            .select_cells(camera, image, &selects[camera].unwrap(), &mut keys)
+            .unwrap();
+        assert_eq!(keys, alone[camera], "camera {camera} out of the batch");
+    }
+    assert_ne!(alone[0], alone[1], "the two cameras hold the same frame");
+}
+
+/// A prepared selection is spent by the call that reads it, and a camera the
+/// batch skipped still answers for itself.
+///
+/// The keys are cached on the scanner between `prepare_cells` and the
+/// `select_cells` that takes them, so the thing that must not happen is a
+/// leftover answering a later frameset. Reading twice, and preparing a rig where
+/// only one camera is offered, are the two ways that could happen.
+#[test]
+fn a_prepared_selection_is_spent_once() {
+    let config: DetectorConfig = detector_config(472.0);
+    let images: [ImageU16; 2] = [mio10_frame(0, 0), mio10_frame(1, 1)];
+    let grid: CellGrid = CellGrid::new(images[0].width(), images[0].height(), 50).unwrap();
+    let select: CellSelect =
+        slam_rs::frontend::detect::cell_select(&images[0], &grid, &config).unwrap();
+    let cells: usize = ((grid.x_stop - grid.x_start) / grid.cell + 1)
+        * ((grid.y_stop - grid.y_start) / grid.cell + 1);
+
+    let mut scanner: GpuCornerScan<_> = GpuCornerScan::new(gpu_client().unwrap()).unwrap();
+    // Only camera 0 is offered, so camera 1 has nothing prepared for it.
+    scanner
+        .prepare_cells(&images, &[Some(select), None])
+        .unwrap();
+
+    let mut first: Vec<u32> = Vec::new();
+    scanner
+        .select_cells(0, &images[0], &select, &mut first)
+        .unwrap();
+    let mut again: Vec<u32> = Vec::new();
+    scanner
+        .select_cells(0, &images[0], &select, &mut again)
+        .unwrap();
+    assert_eq!(again, first, "the second read went back to the device");
+
+    let mut second: Vec<u32> = Vec::new();
+    scanner
+        .select_cells(1, &images[1], &select, &mut second)
+        .unwrap();
+    assert_eq!(second.len(), cells);
+    assert_ne!(second, first, "camera 1 answered with camera 0's frame");
 }

--- a/packages/slam-rs/crates/slam-rs/tests/gpu_kernels.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/gpu_kernels.rs
@@ -458,6 +458,7 @@ fn track_both_lanes(
         LEVELS + 1,
         MAX_ITERATIONS,
         MAX_RECOVERED_DIST2,
+        1,
     )
     .unwrap();
     let mut gpu_patches: GpuPatches<Pattern51, _> = gpu_tracker.make_patches().unwrap();
@@ -927,6 +928,7 @@ fn the_whole_gpu_path_holds_the_pool_flat() {
         LEVELS + 1,
         MAX_ITERATIONS,
         MAX_RECOVERED_DIST2,
+        1,
     )
     .unwrap();
     let mut patches: GpuPatches<Pattern51, _> = tracker.make_patches().unwrap();
@@ -1310,4 +1312,99 @@ fn small_angle_trig_stays_within_two_ulps_of_the_cpu() {
         }
     }
     println!("small-angle sin/cos maximum ULP errors: {worst:?}");
+}
+
+/// Two passes in flight over **one** patch set answer what two separate calls do.
+///
+/// This is the claim the batched tracker rests on: a batch's passes share every
+/// intermediate buffer — the source and backward patch stores, the backward
+/// transforms — and may, because the device stream is ordered, so pass 0's
+/// `finish` has read them before pass 1's kernels write them. Only the packed
+/// result is per lane. If that ordering did not hold, the second `prepare` would
+/// corrupt the first pass and lane 0 would come back wrong; the reference here
+/// is the same two passes run one at a time, which is what the frontend did
+/// before D77.
+#[test]
+fn a_batch_of_two_passes_answers_what_two_calls_do() {
+    const SIZE: usize = 512;
+    let first: ImageU16 = textured_image(SIZE, SIZE, 0.0, 0.0);
+    let second: ImageU16 = textured_image(SIZE, SIZE, 2.75, -1.5);
+    let lane0: PointsSoA = grid_positions(SIZE);
+    // A different pass, so a batch that answered both lanes from one of them
+    // would be caught: half the patches, a quarter-pixel off the grid.
+    let mut lane1: PointsSoA = PointsSoA::default();
+    for index in (0..lane0.len()).step_by(2) {
+        let point = lane0.get(index);
+        lane1.push(Vector2::new(point.x + 0.25, point.y - 0.25));
+    }
+    let guesses: [FlowTransforms; 2] = [guesses_at(&lane0), guesses_at(&lane1)];
+    let points: [&PointsSoA; 2] = [&lane0, &lane1];
+
+    let client = gpu_client().unwrap();
+    let mut builder = GpuPyramidBuilder::new(client.clone(), Pattern51::OFFSETS);
+    let mut prev = builder.allocate(SIZE, SIZE, LEVELS).unwrap();
+    let mut next = builder.allocate(SIZE, SIZE, LEVELS).unwrap();
+    builder.build(0, &first, &mut prev).unwrap();
+    builder.build(0, &second, &mut next).unwrap();
+
+    let mut tracker: GpuPatchTracker<Pattern51, _> = GpuPatchTracker::new(
+        client.clone(),
+        MAX_KEYPOINTS,
+        LEVELS + 1,
+        MAX_ITERATIONS,
+        MAX_RECOVERED_DIST2,
+        2,
+    )
+    .unwrap();
+    let mut patches: GpuPatches<Pattern51, _> = tracker.make_patches().unwrap();
+
+    // ── one at a time, which is the reference
+    let mut alone: Vec<FlowResult> = Vec::new();
+    for lane in 0..2 {
+        let mut out: FlowResult = FlowResult::with_capacity(MAX_KEYPOINTS);
+        patches.prepare(&prev, points[lane], None).unwrap();
+        tracker
+            .track_prepared(&prev, &next, &patches, &guesses[lane], &mut out)
+            .unwrap();
+        alone.push(out);
+    }
+
+    // ── both launched, then one download
+    let mut batched: Vec<FlowResult> = (0..2)
+        .map(|_| FlowResult::with_capacity(MAX_KEYPOINTS))
+        .collect();
+    for lane in 0..2 {
+        patches.prepare(&prev, points[lane], None).unwrap();
+        tracker
+            .submit_prepared(&prev, &next, &patches, &guesses[lane], &mut batched[lane])
+            .unwrap();
+    }
+    tracker.collect(&mut batched).unwrap();
+
+    for lane in 0..2 {
+        assert_eq!(
+            batched[lane].tracked(),
+            alone[lane].tracked(),
+            "lane {lane} kept a different set out of the batch"
+        );
+        for index in 0..points[lane].len() {
+            assert_eq!(
+                batched[lane].is_valid(index),
+                alone[lane].is_valid(index),
+                "lane {lane}: patch {index} survived out of the batch and not alone"
+            );
+            if alone[lane].is_valid(index) {
+                assert_eq!(
+                    batched[lane].transform(index).translation,
+                    alone[lane].transform(index).translation,
+                    "lane {lane}: patch {index} moved"
+                );
+            }
+        }
+    }
+    assert_ne!(
+        alone[0].tracked().len(),
+        alone[1].tracked().len(),
+        "the two lanes tracked the same set, so crossing them would not show"
+    );
 }

--- a/packages/slam-rs/crates/slam-rs/tests/gpu_seam_bench.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/gpu_seam_bench.rs
@@ -48,14 +48,32 @@ fn the_gpu_frontend_reports_its_host_seam() {
     };
 
     let config = common::config();
-    let calibration = common::calibration();
+    // `SLAM_RS_SEAM_CAMERAS` widens the two-camera fixture rig by repeating its
+    // cameras, which is how a four-camera rig's batch shape is reachable from
+    // the committed 960x960 frames.
+    let cameras: usize = std::env::var("SLAM_RS_SEAM_CAMERAS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(2);
+    let mut calibration = common::calibration();
+    while calibration.intrinsics.len() < cameras {
+        let source: usize = calibration.intrinsics.len() % 2;
+        calibration.intrinsics.push(calibration.intrinsics[source]);
+        calibration.resolution.push(calibration.resolution[source]);
+        let mut pose = calibration.t_i_c[source];
+        pose.translation.x += 0.05 * (calibration.t_i_c.len() as f64);
+        calibration.t_i_c.push(pose);
+    }
+    calibration.intrinsics.truncate(cameras);
+    calibration.resolution.truncate(cameras);
+    calibration.t_i_c.truncate(cameras);
     let options: FrontendOptions = FrontendOptions::default();
     let (builder, tracker, scanner) = slam_rs::gpu::gpu_backends::<Pattern51>(
         options.max_keypoints,
         config.optical_flow_levels as usize + 1,
         config.optical_flow_max_iterations as usize,
         config.optical_flow_max_recovered_dist2,
-        2,
+        cameras,
     )
     .unwrap();
     let mut flow = FrameToFrameOpticalFlow::with_backends(
@@ -70,8 +88,12 @@ fn the_gpu_frontend_reports_its_host_seam() {
 
     // The three committed framesets, walked forward and back so consecutive
     // framesets are a real small motion rather than a jump.
-    let frames: Vec<[ImageU16; 2]> = (0..3)
-        .map(|frame| [mio10_frame(frame, 0), mio10_frame(frame, 1)])
+    let frames: Vec<Vec<ImageU16>> = (0..3)
+        .map(|frame| {
+            (0..cameras)
+                .map(|camera| mio10_frame(frame, camera % 2))
+                .collect()
+        })
         .collect();
     let order: [usize; 4] = [0, 1, 2, 1];
 
@@ -97,7 +119,7 @@ fn the_gpu_frontend_reports_its_host_seam() {
         if index == warmup {
             slam_rs::gpu::seam::reset();
         }
-        let images: &[ImageU16; 2] = &frames[order[index % order.len()]];
+        let images: &[ImageU16] = &frames[order[index % order.len()]];
         let mark: std::time::Instant = std::time::Instant::now();
         let frame = flow
             .process_frame(
@@ -123,7 +145,7 @@ fn the_gpu_frontend_reports_its_host_seam() {
     }
 
     println!(
-        "MIO10 {count} framesets, {keypoints} keypoints on camera 0\n\
+        "MIO10 {count} framesets, {cameras} cameras, {keypoints} keypoints on camera 0\n\
          medians ms: whole {:.3} = pyramid {:.3} + detect {:.3} + track {:.3} + stereo {:.3}\n\
          {}",
         median(&mut whole),

--- a/packages/slam-rs/crates/slam-rs/tests/gpu_seam_bench.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/gpu_seam_bench.rs
@@ -1,0 +1,136 @@
+//! Where the GPU frontend's host time goes, over real MIO10 framesets.
+//!
+//! Not an assertion: a measurement rig. `SLAM_RS_SEAM_BENCH=<framesets>` runs
+//! the whole frontend on the device and prints the four stage timers beside the
+//! seam counters, so a change to the launch/wait shape can be read in one
+//! process without the A/B harness. Without the variable it prints why and
+//! passes.
+//!
+//! ```bash
+//! SLAM_RS_SEAM_BENCH=300 cargo test --release --features gpu-wgpu \
+//!   --test gpu_seam_bench -- --nocapture
+//! ```
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![cfg(feature = "gpu-wgpu")]
+
+use slam_rs::frontend::flow::{FrameToFrameOpticalFlow, FrontendOptions, PosePrediction};
+use slam_rs::frontend::patterns::Pattern51;
+use slam_rs::image::ImageU16;
+
+mod common;
+
+/// One committed MIO10 frame as the frontend takes it: 960x960, `u8 << 8`.
+fn mio10_frame(frame: usize, camera: usize) -> ImageU16 {
+    let pgm: common::Pgm = common::read_pgm(&common::fixtures().join("flow/frames"), frame, camera);
+    let mut image: ImageU16 = ImageU16::zeros(pgm.width, pgm.height).unwrap();
+    for y in 0..pgm.height {
+        for x in 0..pgm.width {
+            image.set(x, y, u16::from(pgm.pixels[y * pgm.width + x]) << 8);
+        }
+    }
+    image
+}
+
+/// The median of a copy of `values`, which is what a stage timer is reported as.
+fn median(values: &mut [u64]) -> f64 {
+    values.sort_unstable();
+    values[values.len() / 2] as f64 / 1e6
+}
+
+#[test]
+fn the_gpu_frontend_reports_its_host_seam() {
+    let Some(count) = std::env::var("SLAM_RS_SEAM_BENCH")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+    else {
+        println!("skipped: set SLAM_RS_SEAM_BENCH=<framesets> to measure the seam");
+        return;
+    };
+
+    let config = common::config();
+    let calibration = common::calibration();
+    let options: FrontendOptions = FrontendOptions::default();
+    let (builder, tracker, scanner) = slam_rs::gpu::gpu_backends::<Pattern51>(
+        options.max_keypoints,
+        config.optical_flow_levels as usize + 1,
+        config.optical_flow_max_iterations as usize,
+        config.optical_flow_max_recovered_dist2,
+        2,
+    )
+    .unwrap();
+    let mut flow = FrameToFrameOpticalFlow::with_backends(
+        config,
+        &calibration,
+        options,
+        builder,
+        tracker,
+        scanner,
+    )
+    .unwrap();
+
+    // The three committed framesets, walked forward and back so consecutive
+    // framesets are a real small motion rather than a jump.
+    let frames: Vec<[ImageU16; 2]> = (0..3)
+        .map(|frame| [mio10_frame(frame, 0), mio10_frame(frame, 1)])
+        .collect();
+    let order: [usize; 4] = [0, 1, 2, 1];
+
+    let mut pyramid: Vec<u64> = Vec::with_capacity(count);
+    let mut detect: Vec<u64> = Vec::with_capacity(count);
+    let mut track: Vec<u64> = Vec::with_capacity(count);
+    let mut stereo: Vec<u64> = Vec::with_capacity(count);
+    let mut whole: Vec<u64> = Vec::with_capacity(count);
+    let mut keypoints: usize = 0;
+    // The marginal cost of one more synchronising read, measured where the
+    // frontend pays it: `SLAM_RS_SEAM_EXTRA=<k>` adds k four-byte reads to every
+    // frameset, on the same client the frontend uses.
+    let extra: usize = std::env::var("SLAM_RS_SEAM_EXTRA")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(0);
+    let client = slam_rs::gpu::gpu_client().unwrap();
+    let probe = client.empty(16);
+
+    // A tenth of the run is warm-up: the first frameset allocates every buffer.
+    let warmup: usize = (count / 10).max(2);
+    for index in 0..count + warmup {
+        if index == warmup {
+            slam_rs::gpu::seam::reset();
+        }
+        let images: &[ImageU16; 2] = &frames[order[index % order.len()]];
+        let mark: std::time::Instant = std::time::Instant::now();
+        let frame = flow
+            .process_frame(
+                index as i64 * 50_000_000,
+                images,
+                &PosePrediction::default(),
+                &[],
+            )
+            .unwrap();
+        for _ in 0..extra {
+            client.read_one(probe.clone()).unwrap();
+        }
+        let elapsed: u64 = mark.elapsed().as_nanos() as u64;
+        keypoints = frame.cameras[0].len();
+        if index >= warmup {
+            let timings = flow.timings();
+            pyramid.push(timings.pyramid_ns);
+            detect.push(timings.detect_ns);
+            track.push(timings.track_ns);
+            stereo.push(timings.stereo_ns);
+            whole.push(elapsed);
+        }
+    }
+
+    println!(
+        "MIO10 {count} framesets, {keypoints} keypoints on camera 0\n\
+         medians ms: whole {:.3} = pyramid {:.3} + detect {:.3} + track {:.3} + stereo {:.3}\n\
+         {}",
+        median(&mut whole),
+        median(&mut pyramid),
+        median(&mut detect),
+        median(&mut track),
+        median(&mut stereo),
+        slam_rs::gpu::seam::line(count as u64),
+    );
+}

--- a/packages/slam-rs/docs/design-notes.md
+++ b/packages/slam-rs/docs/design-notes.md
@@ -1293,3 +1293,81 @@ settle is whether the whole 0.136 cm is the schedule; it settles that it is not
 the per-camera algebra, and enabling this on a four-camera rig through the shared
 `fast` profile is still a scope decision rather than a measurement.
 - **D76** — The fast profile runs the joint solve at keyframes and a 15-dof fixed-landmark update on the framesets between (2026-09-10)
+
+## D77 — The GPU frontend waits once per phase, and reports what it queued
+
+The device timestamps say every kernel of a two-camera MIO10 frameset is 0.44 ms
+of GPU time while the frontend spends 1.63 ms of host time. Counters at the seam
+(`gpu/seam.rs`, `tests/gpu_seam_bench.rs`) say where the rest of it was: **five
+synchronising reads, 1.51 ms**, against 0.15 ms in all eleven uploads and nothing
+measurable in the thirty-two launches.
+
+A read on this lane costs about **0.12 ms of host time before it has moved a
+byte** — measured by adding empty four-byte reads to a frameset, which cost
+0.115 ms each — because `read_async` reserves a staging buffer, submits, calls
+`map_async`, and then hands off twice to the runtime's polling thread. So a
+frameset's host cost is set by *how many reads it makes*, not by how much they
+carry, and `CUBECL_WGPU_MAX_TASKS` moves none of it (32 is already the best of
+1/2/4/8/16/32/64).
+
+Three of the five were removable because the passes they separated do not depend
+on each other:
+
+* the temporal tracks read only their own camera's two pyramids;
+* the cross-camera matches read camera 0's new keypoints and write camera *i*;
+* the cell selection reads the frame — the occupancy counts and the masks stay on
+  the host and are applied to the downloaded keys afterwards.
+
+So each phase launches the whole rig and downloads it once.
+`PatchTracker::submit_prepared` and `collect` split the tracker's five launches
+from its download, `CornerScan::prepare_cells` answers every camera's selection
+at once, and `cell_select` is the mask-independent half of the device gate that
+lets the frontend ask for a camera's selection before the frameset has masked it.
+A batch's passes share every intermediate buffer — the source and backward patch
+stores, the backward transforms — and may, because the device stream is ordered:
+pass *k*'s `finish` has read them before pass *k+1*'s kernels write them. Only
+the packed result is per lane, which is why `gpu_backends` takes a camera count.
+`a_batch_of_two_passes_answers_what_two_calls_do` is the test that would catch
+that ordering claim being wrong.
+
+### The spin the batch uncovered
+
+Batching made the **four-camera** lane 32 % slower, all of it inside the first
+launch of the second pass. CubeCL 0.10's client-to-server channel is 32 tasks
+deep (`CHANNEL_MAX_TASK`), and a producer that fills it does not block: it spins
+524,288 times, yields 4,096 times, then sleeps in 75 µs steps
+(`SPIN_BUDGET_CLIENT`). That is tuned for a producer and a server on different
+cores; this pipeline is pinned to one, so the spin is the server's own core and
+the queue cannot drain until the producer gives it up. A two-camera frameset
+enqueues 28 tasks between its downloads and stayed under the cliff by four; a
+four-camera frameset enqueues 56 and spent **2.9 ms a frameset spinning**.
+
+Flushing after every camera fixed it and cost 0.10 ms a frameset on the stereo
+lane, because the flush waits for the server and on one core that handoff is real
+even when the work is not. What the channel needs is a ceiling, not a rhythm: the
+stages report what they enqueued (`gpu::queued`) and the seam flushes when
+another stage's nine tasks would not fit, with a download resetting the count
+because it has waited for everything in it. About one flush a frameset on a
+stereo rig, three on a four-camera one, and the queue never passes thirty-one at
+any camera count.
+
+### Measured
+
+Fast profile, `--base wave2` (`60c01a33`), three interleaved rounds on MIO10 and
+one on MGO09. Trajectories are **byte-identical** to the base on both.
+
+| clip | base median | after | delta | ATE vs GT | lost |
+|---|---:|---:|---:|---:|---:|
+| MIO10 | 2.007 ms | **1.533** | −0.473 (−23.6 %) | 1.553 cm both | 0/0 |
+| MGO09 | 3.803 ms | **2.260** | −1.543 (−40.6 %) | 0.978 cm both | 0/0 |
+
+MIO10 stage medians: pyramid 0.143 → 0.142, detect 0.562 → 0.217, temporal track
+0.743 → 0.558, stereo 0.191 → 0.194. Reads per frameset 5 → 3 while detecting,
+2 → 1 while not.
+
+What is left in the frontend is still mostly the three reads: the in-process rig
+puts 0.73 of the two-camera frameset's 1.11 ms in them. The next read to remove
+is the cell selection's, which needs `should_detect` decided before the temporal
+tracks come back — a speculation that is free on a detecting frameset and costs
+the FAST kernels on one that skips.
+- **D77** — The GPU frontend waits once per phase instead of once per camera, and bounds the runtime queue so a four-camera rig does not spin (2026-09-10)


### PR DESCRIPTION
## What this is

S32 wave 2, lever 6: the GPU frontend's host path. Device timestamps say every
kernel of a two-camera MIO10 frameset is 0.44 ms of GPU time while the frontend
spends 1.63 ms of host time. This finds the rest of it and removes most of it.
No arithmetic changes: the trajectories are **byte-identical** to the base on
both clips.

## Where the time was

New counters at the seam (`gpu/seam.rs`) plus an in-process rig
(`tests/gpu_seam_bench.rs`, `SLAM_RS_SEAM_BENCH=<n>`) over the committed MIO10
frames, which reproduces the harness frontend to 0.01 ms:

```
before: whole 1.643 = pyramid 0.146 + detect 0.558 + track 0.711 + stereo 0.188
        per frameset: 32.00 launches, 11.00 uploads (0.147 ms), 5.00 reads (1.510 ms)
```

**Five reads, 1.51 ms of the 1.64.** A read costs about 0.12 ms of host time
before it has moved a byte — measured by adding empty four-byte reads to a
frameset: 1.643 / 1.753 / 1.870 / 2.102 ms for 0 / 1 / 2 / 4 of them, so
0.115 ms each. `CUBECL_WGPU_MAX_TASKS` moves none of it (32 is the best of
1/2/4/8/16/32/64).

## What changed

Three of the five reads separated passes that do not depend on each other, so
each phase now launches the whole rig and downloads it once.

| file | change |
|---|---|
| `frontend/tracker.rs` | `PatchTracker::submit_prepared` / `collect` / `discard`; the default runs the pass and leaves `collect` nothing to do, so `CpuPatchTracker` is untouched |
| `gpu/track.rs` | `submit_inner` launches into a lane, `collect_inner` downloads every lane at once; one result buffer per lane |
| `frontend/flow.rs` | the temporal tracks and the cross-camera matches are each one batch: submit every camera, collect once, then finish each |
| `frontend/detect.rs` | `CornerScan::prepare_cells`, and `cell_select` — the mask-independent half of the device gate — so a camera's selection can be asked for before the frameset has masked it |
| `gpu/detect.rs` | `launch_selection` extracted; `prepare_cells` launches every camera and reads them together; `select_cells` spends a prepared entry |
| `gpu/mod.rs` | `gpu::queued` / `gpu::drained`, the ceiling on the runtime's task queue (below); `gpu_backends` takes the rig's camera count |
| `docs/design-notes.md` | D77 |

A batch's passes share every intermediate buffer — the source and backward patch
stores, the backward transforms — and may, because the device stream is ordered:
pass *k*'s `finish` has read them before pass *k+1*'s kernels write them. Only
the packed result is per lane.

## The spin the batch uncovered

Batching made the **four-camera** lane 32 % slower, all of it inside the first
launch of the second pass. CubeCL 0.10's client-to-server channel is 32 tasks
deep, and a producer that fills it does not block: it spins 524,288 times, yields
4,096 times, then sleeps in 75 µs steps. That is tuned for a producer and a
server on different cores; this pipeline is pinned to one, so the spin is the
server's own core. A two-camera frameset enqueues 28 tasks between its downloads
and stayed under the cliff by four; a four-camera frameset enqueues 56 and spent
2.9 ms a frameset spinning. Flushing after every camera fixed it and cost 0.10 ms
on the stereo lane, so instead the stages report what they enqueued and the seam
flushes when another stage's nine tasks would not fit — about one flush a
frameset on a stereo rig, three on a four-camera one, and the queue never passes
thirty-one at any camera count.

## Harness

`ab.sh /tmp/slam-rs-s32-seam2 seam-3 --clip <clip> --profile fast --base wave2`,
base `wave2` = `60c01a33`. Candidate core `e6e64126adeb`.

### MIO10, 3 interleaved rounds

```
| Core | profile | median ms | mean ms | p95 ms | max ms | ATE vs GT cm | ATE vs C++ cm | tracked/lost | byte-identical to base | state-identical | cores used |
|---|---|---:|---:|---:|---:|---:|---:|---:|---|---|---:|
| base | fast | 2.007 | 2.445 | 6.945 | 8.297 | 1.553 | 0.411 | 412/0 | Y | Y | 0.835 |
| seam-3 | fast | 1.533 | 2.033 | 6.725 | 7.989 | 1.553 | 0.411 | 412/0 | Y | Y | 0.909 |
| cuVSLAM Inertial (frozen) | n/a | 1.199 | 2.677 | 2.887 | 228.788 | 3.998 | n/a | 412/0 | n/a | n/a | 1.000 |

| Core | frontend_pyramid | frontend_detect | frontend_track | frontend_stereo | predict | keyframe | optimize | linearize | solver | marginalize | measure | track_ms | glue |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| base | 0.143 | 0.562 | 0.743 | 0.191 | 0.006 | 0.000 | 0.067 | 0.020 | 0.005 | 0.106 | 0.203 | 2.007 | 0.148 |
| seam-3 | 0.142 | 0.217 | 0.558 | 0.194 | 0.006 | 0.000 | 0.066 | 0.019 | 0.005 | 0.101 | 0.197 | 1.533 | 0.141 |

Speed target: 1.439 ms; accuracy band: 1.708 cm (1.1 x base 1.553).
SPEED FAIL; ACCURACY PASS; IDENTICAL yes; delta -0.473 ms (-23.59%) vs base.
Round medians (ms): base 2.007, 2.015, 2.024; seam-3 1.533, 1.575, 1.562
```

### MGO09, four 640x480 cameras, 1 round

```
| Core | profile | median ms | mean ms | p95 ms | max ms | ATE vs GT cm | ATE vs C++ cm | tracked/lost | byte-identical to base | state-identical | cores used |
|---|---|---:|---:|---:|---:|---:|---:|---:|---|---|---:|
| base | fast | 3.803 | 5.539 | 14.902 | 17.014 | 0.978 | 0.492 | 107/0 | Y | Y | 0.816 |
| seam-3-mgo09 | fast | 2.260 | 4.178 | 14.616 | 15.781 | 0.978 | 0.492 | 107/0 | Y | Y | 0.885 |

| Core | frontend_pyramid | frontend_detect | frontend_track | frontend_stereo | predict | keyframe | optimize | linearize | solver | marginalize | measure | track_ms | glue |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| base | 0.108 | 0.755 | 1.399 | 0.859 | 0.010 | 0.000 | 0.186 | 0.033 | 0.008 | 0.145 | 0.374 | 3.803 | 0.148 |
| seam-3-mgo09 | 0.108 | 0.318 | 0.817 | 0.455 | 0.010 | 0.000 | 0.190 | 0.033 | 0.008 | 0.142 | 0.354 | 2.260 | 0.131 |

SPEED N/A; ACCURACY PASS; IDENTICAL yes; delta -1.543 ms (-40.57%) vs base.
```

Gate: ATE 1.553 cm against a 1.654 cm band, zero lost framesets, and −0.473 ms
against a −0.1 ms bar — pass, and past the lever's own −0.4 ms target. MIO07 was
not run because the change is byte-identical to the base on both clips.

## Tests

- `cargo test --workspace --release`: green.
- `cargo test -p slam-rs --release --features gpu-wgpu --test gpu_kernels --test gpu_detect`:
  21 + 10 passed. New: `a_batch_of_two_passes_answers_what_two_calls_do` (two
  lanes over one shared patch set answer what two separate calls do, which is the
  stream-ordering claim), `the_batched_preparation_answers_what_the_per_camera_call_does`,
  `a_prepared_selection_is_spent_once`.
- `pytest -q` in `packages/slam-rs`: 261 passed, 1 skipped, 18 deselected.
- `cargo clippy --workspace --release --all-targets --features slam-rs/gpu-wgpu -- -D warnings`:
  clean. `cargo fmt --check` clean for every file this branch touches; the
  pre-existing deviation in `estimator/mod.rs` is left alone.

No `.rrd` is produced by this work and none is needed.
