### PR TITLE
Fix GPU queue reservations for larger rigs and deeper pyramids

### DIFF
--- a/packages/slam-rs/crates/slam-rs/src/gpu/detect.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/detect.rs
@@ -152,7 +152,7 @@ impl<R: Runtime> GpuCornerScan<R> {
                     }
                 }
                 Ok(Self {
-                    ring: client.create_from_slice(u32::as_bytes(&ring)),
+                    ring: super::seam::upload(&client, u32::as_bytes(&ring)),
                     level0: Level0Table::default(),
                     uploads: 0,
                     packed: Vec::new(),
@@ -262,7 +262,7 @@ impl<R: Runtime> GpuCornerScan<R> {
             Some(existing) if fits => existing.clone(),
             slot => {
                 self.buffer_allocations += 1;
-                slot.insert((self.client.empty(cells * size_of::<u32>()), cells))
+                slot.insert((super::empty(&self.client, cells * size_of::<u32>()), cells))
                     .clone()
             }
         };
@@ -321,9 +321,9 @@ impl<R: Runtime> GpuCornerScan<R> {
             slot => {
                 self.buffer_allocations += 1;
                 slot.insert(ScanBuffers {
-                    score: self.client.empty(pixels),
-                    kept: self.client.empty(pixels),
-                    mask: self.client.empty(mask_len * size_of::<u32>()),
+                    score: super::empty(&self.client, pixels),
+                    kept: super::empty(&self.client, pixels),
+                    mask: super::empty(&self.client, mask_len * size_of::<u32>()),
                     pixels,
                     mask_len,
                 })
@@ -448,7 +448,7 @@ impl<R: Runtime> CornerScan for GpuCornerScan<R> {
                         let read = cubecl::reader::read_sync(
                             self.client.read_async(vec![handles.kept, handles.mask]),
                         );
-                        super::drained();
+                        super::drained(&self.client);
                         read
                     })
                     .map_err(|error| {
@@ -534,7 +534,7 @@ impl<R: Runtime> CornerScan for GpuCornerScan<R> {
                 let reads: Vec<cubecl::bytes::Bytes> = {
                     let read = super::seam::READ_DETECT
                         .measure(|| cubecl::reader::read_sync(self.client.read_async(vec![best])));
-                    super::drained();
+                    super::drained(&self.client);
                     read.map_err(|error| super::read_failed("the cell winner keys", &error))?
                 };
                 let Ok([keys]) = <[cubecl::bytes::Bytes; 1]>::try_from(reads) else {
@@ -576,9 +576,6 @@ impl<R: Runtime> CornerScan for GpuCornerScan<R> {
                     if let Some((best, cells)) = self.launch_selection(camera, image, &select) {
                         self.prepared[camera] = Some(select);
                         launched.push((camera, best, cells));
-                        // Three launches, and the frame upload when the
-                        // pyramid did not publish one.
-                        super::queued(&self.client, 4)?;
                     }
                 }
                 if launched.is_empty() {
@@ -593,7 +590,7 @@ impl<R: Runtime> CornerScan for GpuCornerScan<R> {
                 let reads: Vec<cubecl::bytes::Bytes> = {
                     let read = super::seam::READ_DETECT
                         .measure(|| cubecl::reader::read_sync(self.client.read_async(handles)));
-                    super::drained();
+                    super::drained(&self.client);
                     read.map_err(|error| super::read_failed("the cell winner keys", &error))?
                 };
                 if reads.len() != launched.len() {

--- a/packages/slam-rs/crates/slam-rs/src/gpu/kernels.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/kernels.rs
@@ -1156,7 +1156,7 @@ pub(super) fn launch_subsample<R: Runtime>(
     target: super::pyramid::Level,
 ) {
     let (cubes, units) = tile_2d(target.width, target.height);
-    super::seam::launch();
+    super::seam::launch(client);
     unsafe {
         subsample_kernel::launch_unchecked::<R>(
             client,
@@ -1214,7 +1214,7 @@ pub(super) fn launch_patch_build<R: Runtime>(
     shape: PatchShape,
     bases: PositionBases,
 ) {
-    super::seam::launch();
+    super::seam::launch(client);
     unsafe {
         patch_build_kernel::launch_unchecked::<R>(
             client,
@@ -1257,7 +1257,7 @@ pub(super) fn launch_klt<R: Runtime>(
     max_iterations: usize,
     check_guess_bounds: bool,
 ) {
-    super::seam::launch();
+    super::seam::launch(client);
     unsafe {
         klt_kernel::launch_unchecked::<R>(
             client,
@@ -1321,7 +1321,7 @@ pub(super) fn launch_probe<N: Numeric, R: Runtime>(
     count: usize,
 ) {
     let (cubes, units) = linear_1d(count);
-    super::seam::launch();
+    super::seam::launch(client);
     unsafe {
         probe_kernel::launch::<N, R>(
             client,
@@ -1347,7 +1347,7 @@ pub(super) fn launch_copy_level0<R: Runtime>(
     count: usize,
 ) {
     let (cubes, units) = linear_1d(count);
-    super::seam::launch();
+    super::seam::launch(client);
     unsafe {
         probe_kernel::launch_unchecked::<u16, R>(
             client,
@@ -1371,7 +1371,7 @@ pub(super) fn launch_prepare_backward<R: Runtime>(
     bases: PositionBases,
 ) {
     let (cubes, units) = linear_1d(count);
-    super::seam::launch();
+    super::seam::launch(client);
     unsafe {
         prepare_backward_kernel::launch_unchecked::<R>(
             client,
@@ -1400,7 +1400,7 @@ pub(super) fn launch_finish<R: Runtime>(
     max_recovered_dist2: f32,
 ) {
     let (cubes, units) = linear_1d(count);
-    super::seam::launch();
+    super::seam::launch(client);
     unsafe {
         finish_kernel::launch_unchecked::<R>(
             client,
@@ -1590,7 +1590,7 @@ pub(super) fn launch_fast_score<R: Runtime>(
     margin: usize,
 ) {
     let (cubes, units) = tile_2d(width, height);
-    super::seam::launch();
+    super::seam::launch(client);
     unsafe {
         fast_score_kernel::launch_unchecked::<R>(
             client,
@@ -1619,7 +1619,7 @@ pub(super) fn launch_fast_localmax<R: Runtime>(
     use_filter: bool,
 ) {
     let (cubes, units) = tile_2d(width, height);
-    super::seam::launch();
+    super::seam::launch(client);
     unsafe {
         fast_localmax_kernel::launch_unchecked::<R>(
             client,
@@ -1681,7 +1681,7 @@ pub(super) fn launch_fast_mask<R: Runtime>(
     words: usize,
 ) {
     let (cubes, units) = tile_2d(words, height);
-    super::seam::launch();
+    super::seam::launch(client);
     unsafe {
         fast_mask_kernel::launch_unchecked::<R>(
             client,
@@ -2052,7 +2052,7 @@ pub(super) fn launch_fast_cell_select<R: Runtime>(
     best: Buffer<'_>,
     geometry: CellSelectGeometry,
 ) {
-    super::seam::launch();
+    super::seam::launch(client);
     unsafe {
         fast_cell_select_kernel::launch_unchecked::<R>(
             client,

--- a/packages/slam-rs/crates/slam-rs/src/gpu/mod.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/mod.rs
@@ -373,71 +373,87 @@ pub fn gpu_backends<P: crate::frontend::patterns::Pattern>(
     )
 }
 
-/// Tasks CubeCL 0.10's client-to-server channel holds before a producer spins
-/// (`cubecl-common`'s `CHANNEL_MAX_TASK`).
+/// CubeCL 0.10.0's private `custom_channel::CHANNEL_MAX_TASK` is 32.
+/// Recheck this value when upgrading CubeCL; it is not exported by the runtime.
 #[cfg(feature = "gpu-core")]
-const CHANNEL_TASKS: usize = 32;
+pub const CHANNEL_TASKS: usize = 32;
 
-/// The most tasks one stage enqueues between two reports: a tracking pass's
-/// three uploads and six launches.
 #[cfg(feature = "gpu-core")]
-const STAGE_TASKS: usize = 9;
-
-/// Tasks handed to the runtime's server since the channel was last known empty.
-///
-/// One counter for the process, which is what the channel is: CubeCL caches one
-/// client per device, and this pipeline is single-threaded. A second frontend on
-/// another thread would make this over-count, which drains early — the safe
-/// direction.
-#[cfg(feature = "gpu-core")]
-static QUEUED: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
-
-/// Record that a stage enqueued `tasks`, handing the queue to the runtime's
-/// server thread when another stage would not fit in it.
-///
-/// CubeCL 0.10's client-to-server channel is [`CHANNEL_TASKS`] deep, and a
-/// producer that fills it does not block: it spins for 524,288 iterations, then
-/// yields 4,096 times, then sleeps in 75 microsecond steps
-/// (`cubecl-common`'s `SPIN_BUDGET_CLIENT`). That is tuned for a producer and a
-/// server on different cores. This pipeline is pinned to one — the benchmark and
-/// the fleet both run it with a single-CPU affinity — so the spin is the
-/// server's own core and the queue cannot drain until the producer gives it up.
-///
-/// It only became reachable when the frontend stopped waiting per camera. A
-/// two-camera frameset enqueues 28 tasks between its downloads and stays under
-/// the cliff; a four-camera frameset enqueues 56, and fell off it hard enough to
-/// spend 2.9 ms a frameset spinning inside one launch. Reporting here keeps the
-/// queue under the ceiling at any camera count, at about one flush a frameset on
-/// a stereo rig and three on a four-camera one.
-///
-/// The flush is not extra work: it is the encoding and submission the next
-/// download would have paid for, moved earlier.
-///
-/// # Errors
-///
-/// [`GpuError::DeviceReadFailed`] when the runtime refuses the flush, which on
-/// this path means the device is gone.
-#[cfg(feature = "gpu-core")]
-pub(super) fn queued<R: cubecl::prelude::Runtime>(
-    client: &cubecl::prelude::ComputeClient<R>,
-    tasks: usize,
-) -> Result<(), GpuError> {
-    use std::sync::atomic::Ordering;
-
-    let total: usize = QUEUED.fetch_add(tasks, Ordering::Relaxed) + tasks;
-    if total + STAGE_TASKS < CHANNEL_TASKS {
-        return Ok(());
-    }
-    QUEUED.store(0, Ordering::Relaxed);
-    client
-        .flush()
-        .map_err(|error| read_failed("the queued launches", &error))
+thread_local! {
+    // One producer per device is required. Separate producer threads must not
+    // submit to the same device through this helper. This is a performance
+    // budget for the single-threaded frontend, not a concurrency guarantee.
+    static QUEUED: std::cell::RefCell<Vec<((std::any::TypeId, usize), usize)>> = const {
+        std::cell::RefCell::new(Vec::new())
+    };
 }
 
-/// The channel is empty: a download has waited for everything that was in it.
+/// Reserve a stage BEFORE it submits. Each upload, allocation and kernel is a
+/// one-task stage, so even a pyramid larger than the budget is split safely.
+/// Leave one channel slot for the blocking flush or download itself.
+///
+/// CubeCL clones share `utilities.properties` (0.10.0 `client.rs`), so its
+/// address identifies their device's queue. A stale address can only retain an
+/// old count and cause an early flush. Runtime type separates backend types.
+/// Each device must have one producer thread; a read resets only that device.
 #[cfg(feature = "gpu-core")]
-pub(super) fn drained() {
-    QUEUED.store(0, std::sync::atomic::Ordering::Relaxed);
+pub(super) fn reserve<R: cubecl::prelude::Runtime>(
+    client: &cubecl::prelude::ComputeClient<R>,
+    tasks: usize,
+) {
+    assert!(
+        tasks < CHANNEL_TASKS,
+        "split stages larger than the queue budget"
+    );
+    let key = (
+        std::any::TypeId::of::<R>(),
+        std::ptr::from_ref(client.properties()) as usize,
+    );
+    QUEUED.with(|queues| {
+        let mut queues = queues.borrow_mut();
+        let index = queues
+            .iter()
+            .position(|(id, _)| *id == key)
+            .unwrap_or_else(|| {
+                queues.push((key, 0));
+                queues.len() - 1
+            });
+        let count = &mut queues[index].1;
+        if *count + tasks >= CHANNEL_TASKS {
+            // Same failure contract as CubeCL's uploads and launches: guarded()
+            // at the public stage boundary converts this to a typed GPU error.
+            client
+                .flush()
+                .unwrap_or_else(|error| panic!("GPU queue flush failed: {error}"));
+            *count = 0;
+        }
+        *count += tasks;
+        seam::queue_reserved(*count);
+    });
+}
+
+/// A blocking read has consumed this producer's outstanding tasks on this device.
+#[cfg(feature = "gpu-core")]
+pub(super) fn drained<R: cubecl::prelude::Runtime>(client: &cubecl::prelude::ComputeClient<R>) {
+    let key = (
+        std::any::TypeId::of::<R>(),
+        std::ptr::from_ref(client.properties()) as usize,
+    );
+    QUEUED.with(|queues| {
+        if let Some((_, count)) = queues.borrow_mut().iter_mut().find(|(id, _)| *id == key) {
+            *count = 0;
+        }
+    });
+}
+
+/// Allocation also submits one initialize-memory task in CubeCL 0.10.0.
+#[cfg(feature = "gpu-core")]
+pub(super) fn empty<R: cubecl::prelude::Runtime>(
+    client: &cubecl::prelude::ComputeClient<R>,
+    bytes: usize,
+) -> cubecl::server::Handle {
+    reserve(client, 1);
+    client.empty(bytes)
 }
 
 /// A failed device read as a typed error, with the runtime's own reason logged.
@@ -571,8 +587,7 @@ pub(super) fn upload_frame<R: cubecl::prelude::Runtime>(
     let pixels: usize = width * height;
     if image.stride() == width {
         return (
-            seam::UPLOAD
-                .measure(|| client.create_from_slice(u16::as_bytes(&image.data()[..pixels]))),
+            seam::upload(client, u16::as_bytes(&image.data()[..pixels])),
             pixels,
         );
     }
@@ -581,10 +596,7 @@ pub(super) fn upload_frame<R: cubecl::prelude::Runtime>(
     for y in 0..height {
         scratch.extend_from_slice(image.row(y));
     }
-    (
-        seam::UPLOAD.measure(|| client.create_from_slice(u16::as_bytes(scratch))),
-        pixels,
-    )
+    (seam::upload(client, u16::as_bytes(scratch)), pixels)
 }
 
 /// So the check is the one thing that cannot lie: write a known pattern, copy
@@ -618,12 +630,13 @@ pub fn probe_storage<R: cubecl::prelude::Runtime>(
         let count: usize = pattern.len();
         let width: usize = size_of::<N>() * 8;
         let expected: usize = size_of_val(pattern);
-        let source: cubecl::server::Handle = client.create_from_slice(N::as_bytes(pattern));
-        let target: cubecl::server::Handle = client.empty(expected);
+        let source: cubecl::server::Handle = seam::upload(client, N::as_bytes(pattern));
+        let target: cubecl::server::Handle = empty(client, expected);
         kernels::launch_probe::<N, R>(client, (&source, count), (&target, count), count);
         let bytes = client
             .read_one(target)
             .map_err(|error| read_failed("the storage probe", &error))?;
+        drained(client);
         if bytes.len() != expected {
             return Err(GpuError::ShortRead {
                 what: "the storage probe",

--- a/packages/slam-rs/crates/slam-rs/src/gpu/patches.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/patches.rs
@@ -150,8 +150,8 @@ impl<P: Pattern, R: Runtime> GpuPatches<P, R> {
                 Ok(Self {
                     layout,
                     len: 0,
-                    store: client.empty(elements * size_of::<f32>()),
-                    positions: client.empty(POSITION_RUNS * capacity * size_of::<f32>()),
+                    store: super::empty(&client, elements * size_of::<f32>()),
+                    positions: super::empty(&client, POSITION_RUNS * capacity * size_of::<f32>()),
                     host,
                     staging: vec![0.0; POSITION_RUNS * capacity],
                     pattern: std::marker::PhantomData,
@@ -252,10 +252,10 @@ impl<P: Pattern, R: Runtime> GpuPatches<P, R> {
     /// Replace the device positions buffer with this call's runs of the staging
     /// buffer, which is as long as the capacity but only filled to `len`.
     fn upload_staging(&mut self) {
-        self.positions = super::seam::UPLOAD.measure(|| {
-            self.client
-                .create_from_slice(f32::as_bytes(&self.staging[..POSITION_RUNS * self.len]))
-        });
+        self.positions = super::seam::upload(
+            &self.client,
+            f32::as_bytes(&self.staging[..POSITION_RUNS * self.len]),
+        );
     }
 
     /// Sample every filled patch at every level of `pyramid`, without waiting.
@@ -333,6 +333,7 @@ impl<P: Pattern, R: Runtime> GpuPatches<P, R> {
                     .client
                     .read_one(self.store.clone())
                     .map_err(|error| super::read_failed("the patch store", &error))?;
+                super::drained(&self.client);
                 let expected: usize = self.layout.elements() * size_of::<f32>();
                 if bytes.len() != expected {
                     return Err(TrackerError::LengthMismatch {

--- a/packages/slam-rs/crates/slam-rs/src/gpu/pyramid.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/pyramid.rs
@@ -182,11 +182,11 @@ impl<R: Runtime> GpuPyramid<R> {
 
         Ok(Self {
             levels,
-            even: client.empty(lengths[0] * size_of::<u16>()),
+            even: super::empty(&client, lengths[0] * size_of::<u16>()),
             even_len: lengths[0],
-            odd: client.empty(lengths[1] * size_of::<u16>()),
+            odd: super::empty(&client, lengths[1] * size_of::<u16>()),
             odd_len: lengths[1],
-            meta: client.create_from_slice(u32::as_bytes(&meta)),
+            meta: super::seam::upload(&client, u32::as_bytes(&meta)),
             meta_len: meta.len(),
             client,
         })
@@ -270,6 +270,7 @@ impl<R: Runtime> crate::pyramid::PyramidBuilder for GpuPyramidBuilder<R> {
             || {
                 self.prepared.resize_with(images.len(), || None);
                 for (slot, image) in self.prepared.iter_mut().zip(images) {
+                    // upload_frame reserves its task here, before any camera builds.
                     let (handle, _) = super::upload_frame(&self.client, image, &mut self.staging);
                     *slot = Some(Level0 {
                         handle,
@@ -378,6 +379,7 @@ impl<R: Runtime> crate::pyramid::PyramidBuilder for GpuPyramidBuilder<R> {
                     );
                 }
 
+                // Each launch reserves one task; deeper pyramids split at the queue ceiling.
                 for level in 1..out.levels.len() {
                     let source: Level = out.levels[level - 1];
                     let target: Level = out.levels[level];
@@ -389,8 +391,6 @@ impl<R: Runtime> crate::pyramid::PyramidBuilder for GpuPyramidBuilder<R> {
                         target,
                     );
                 }
-                // One upload, the level-0 copy and a subsample per level above it.
-                super::queued(&out.client, 1 + out.levels.len())?;
                 Ok(())
             },
         )
@@ -433,6 +433,7 @@ impl<R: Runtime> Pyramid for GpuPyramid<R> {
                     .client
                     .read_one(handle.clone())
                     .map_err(|error| super::read_failed("a pyramid level", &error))?;
+                super::drained(&self.client);
                 let expected: usize = length * size_of::<u16>();
                 if bytes.len() != expected {
                     return Err(PyramidError::ShortDeviceRead {

--- a/packages/slam-rs/crates/slam-rs/src/gpu/seam.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/seam.rs
@@ -72,7 +72,8 @@ pub static READ_TRACK: Meter = Meter::new();
 pub static READ_DETECT: Meter = Meter::new();
 
 /// Count one launch.
-pub fn launch() {
+pub fn launch<R: cubecl::prelude::Runtime>(client: &cubecl::prelude::ComputeClient<R>) {
+    super::reserve(client, 1);
     LAUNCH.count();
 }
 
@@ -104,4 +105,31 @@ pub fn line(framesets: u64) -> String {
         detect_reads as f64 / scale,
         detect_ns as f64 / scale / 1e6,
     )
+}
+
+thread_local! {
+    static PEAK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+pub(super) fn queue_reserved(tasks: usize) {
+    PEAK.with(|peak| peak.set(peak.get().max(tasks)));
+}
+
+/// Largest reserved task count on any device on this producer thread.
+pub fn queue_peak() -> usize {
+    PEAK.with(|peak| peak.get())
+}
+
+/// Start a new queue measurement; does not change outstanding reservations.
+pub fn reset_queue_peak() {
+    PEAK.with(|peak| peak.set(0));
+}
+
+/// Reserve and measure the one task that uploads a host slice.
+pub(super) fn upload<R: cubecl::prelude::Runtime>(
+    client: &cubecl::prelude::ComputeClient<R>,
+    bytes: &[u8],
+) -> cubecl::server::Handle {
+    super::reserve(client, 1);
+    UPLOAD.measure(|| client.create_from_slice(bytes))
 }

--- a/packages/slam-rs/crates/slam-rs/src/gpu/track.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/track.rs
@@ -98,7 +98,7 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
                 // the first frameset, which a lane allocated on first use would
                 // break (`the_whole_gpu_path_holds_the_pool_flat`).
                 let results: Vec<cubecl::server::Handle> = (0..lanes.max(1))
-                    .map(|_| client.empty(transform_bytes))
+                    .map(|_| super::empty(&client, transform_bytes))
                     .collect();
                 Ok(Self {
                     capacity,
@@ -106,7 +106,7 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
                     max_iterations,
                     max_recovered_dist2,
                     backward_patches,
-                    backward: client.empty(transform_bytes),
+                    backward: super::empty(&client, transform_bytes),
                     results,
                     pending: Vec::with_capacity(lanes.max(1)),
                     staging: vec![0.0; TRANSFORM_RUNS * capacity],
@@ -250,10 +250,10 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
             // returns before touching it). Measured: this form costs about 0.05 ms
             // of the lane's 5.9 and an `Option` field about 0.14, both inside this
             // host's drift and above its 0.02 ms pair-to-pair floor.
-            let forward: cubecl::server::Handle = super::seam::UPLOAD.measure(|| {
-                self.client
-                    .create_from_slice(f32::as_bytes(&self.staging[..TRANSFORM_RUNS * count]))
-            });
+            let forward: cubecl::server::Handle = super::seam::upload(
+                &self.client,
+                f32::as_bytes(&self.staging[..TRANSFORM_RUNS * count]),
+            );
 
             // `off = source position - guess` (`:339`), which the backward guess
             // adds back (`:357`). Both terms are on the host already, so the offset
@@ -339,9 +339,6 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
                 patches.bases(),
                 self.max_recovered_dist2,
             );
-            // The caller's positions upload, this call's two uploads and its
-            // six launches.
-            super::queued(&self.client, 9)?;
             Ok(())
         })
     }
@@ -379,7 +376,7 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
             {
                 let read = super::seam::READ_TRACK
                     .measure(|| cubecl::reader::read_sync(self.client.read_async(reads)));
-                super::drained();
+                super::drained(&self.client);
                 read.map_err(|error| super::read_failed("the tracker result", &error))?
             }
         };

--- a/packages/slam-rs/crates/slam-rs/tests/gpu_detect.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/gpu_detect.rs
@@ -718,9 +718,15 @@ fn a_prepared_selection_is_spent_once() {
         .unwrap();
     let mut again: Vec<u32> = Vec::new();
     scanner
-        .select_cells(0, &images[0], &select, &mut again)
+        .select_cells(0, &images[1], &select, &mut again)
         .unwrap();
-    assert_eq!(again, first, "the second read went back to the device");
+    let mut independent = GpuCornerScan::new(gpu_client().unwrap()).unwrap();
+    let mut expected = Vec::new();
+    independent
+        .select_cells(0, &images[1], &select, &mut expected)
+        .unwrap();
+    assert_ne!(expected, first, "the second image must have different keys");
+    assert_eq!(again, expected, "the second read must scan the new image");
 
     let mut second: Vec<u32> = Vec::new();
     scanner

--- a/packages/slam-rs/crates/slam-rs/tests/gpu_kernels.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/gpu_kernels.rs
@@ -1408,3 +1408,30 @@ fn a_batch_of_two_passes_answers_what_two_calls_do() {
         "the two lanes tracked the same set, so crossing them would not show"
     );
 }
+
+/// All uploads precede all builds, as in the frontend staging phase.
+#[test]
+fn prepared_pyramids_stay_below_the_runtime_channel_depth() {
+    for levels in [5, 8] {
+        // `allocate` takes the number of halvings: these are six and nine levels.
+        let client = gpu_client().unwrap();
+        let mut builder = GpuPyramidBuilder::new(client.clone(), &[[0.0, 0.0]]);
+        let images: Vec<_> = (0..8).map(|_| textured_image(960, 960, 0.0, 0.0)).collect();
+        let mut pyramids: Vec<_> = (0..8)
+            .map(|_| builder.allocate(960, 960, levels).unwrap())
+            .collect();
+        client.flush().unwrap();
+        slam_rs::gpu::seam::reset_queue_peak();
+        builder.prepare_images(&images).unwrap();
+        for (camera, (image, pyramid)) in images.iter().zip(&mut pyramids).enumerate() {
+            builder.build(camera, image, pyramid).unwrap();
+        }
+        let peak = slam_rs::gpu::seam::queue_peak();
+        assert!(
+            peak < slam_rs::gpu::CHANNEL_TASKS,
+            "eight cameras / {} levels queued {peak} tasks; leave room for the flush",
+            levels + 1
+        );
+        client.flush().unwrap();
+    }
+}

--- a/packages/slam-rs/docs/design-notes.md
+++ b/packages/slam-rs/docs/design-notes.md
@@ -1294,7 +1294,7 @@ the per-camera algebra, and enabling this on a four-camera rig through the share
 `fast` profile is still a scope decision rather than a measurement.
 - **D76** — The fast profile runs the joint solve at keyframes and a 15-dof fixed-landmark update on the framesets between (2026-09-10)
 
-## D77 — The GPU frontend waits once per phase, and reports what it queued
+## D77 — The GPU frontend waits once per phase, and reserves its queue budget
 
 The device timestamps say every kernel of a two-camera MIO10 frameset is 0.44 ms
 of GPU time while the frontend spends 1.63 ms of host time. Counters at the seam
@@ -1345,11 +1345,19 @@ four-camera frameset enqueues 56 and spent **2.9 ms a frameset spinning**.
 Flushing after every camera fixed it and cost 0.10 ms a frameset on the stereo
 lane, because the flush waits for the server and on one core that handoff is real
 even when the work is not. What the channel needs is a ceiling, not a rhythm: the
-stages report what they enqueued (`gpu::queued`) and the seam flushes when
-another stage's nine tasks would not fit, with a download resetting the count
-because it has waited for everything in it. About one flush a frameset on a
-stereo rig, three on a four-camera one, and the queue never passes thirty-one at
-any camera count.
+seam reserves one task before each upload, allocation, or kernel launch.
+Pyramid preparation counts uploads when it submits them; builds consume those
+images without charging the upload again. Splitting builds into single-launch
+stages makes the count follow the actual geometry, with no fixed stage bound.
+A flush runs before a reservation would exceed 31 tasks, leaving the last slot
+of CubeCL 0.10.0's private `CHANNEL_MAX_TASK = 32` for the flush or read itself.
+
+The budget is per device on a producer thread, identified by the shared client
+properties address and runtime type. Each device must have one producer; this
+is not a multi-producer guarantee. A read resets only that device's count.
+The regression covers eight cameras with six and nine pyramid levels. Under
+this producer constraint, accounted frontend submissions stay at most 31
+between blocking calls, including on deeper pyramids and larger rigs.
 
 ### Measured
 


### PR DESCRIPTION
Eight-camera rigs could fill CubeCL's 32-task channel because pyramid uploads were charged after the launches and a fixed nine-task stage estimate did not bound deeper pyramids. Reserve before every upload, allocation, and kernel launch, leaving one slot for a blocking flush/read. Prepared images charge their uploads when prepared; builds charge only their launches. Splitting submissions into one-task stages covers every accepted pyramid geometry without a fixed level bound.

Queue counts now belong to each device on its producer thread. Reads reset only that device. The helper explicitly requires one producer per device and makes no multi-producer guarantee. CubeCL 0.10.0 keeps `CHANNEL_MAX_TASK` private, so the copied constant names its source and upgrade requirement. D77 states the corrected bound.

The eight-camera regression covers six and nine pyramid levels; it failed before the fix at 32 tasks. The spent-once detector test uses a different same-size image and an independent scanner. A temporary non-consuming lookup failed that test; the consuming code was restored. No kernel arithmetic, camera ordering, or phase batching changed.

Validation: `cargo test --workspace --release` (458 passed); GPU `gpu_kernels` (22 passed) and `gpu_detect` (10 passed), serialized under the GPU lock; workspace release clippy with GPU features and `-D warnings` clean; touched-file rustfmt and diff checks clean. Direct Cargo gates used `/tmp/slam-rs-s32/seam2-target`.

Before/after against saved `wave3` (`c1f1a73a`), fast profile, one tracker thread:

| Clip | Rounds | wave3 median ms | fix median ms | ATE vs GT cm, both | Lost, both | Byte/state identical |
|---|---:|---:|---:|---:|---:|---|
| MIO10 | 3 | 1.535 | 1.516 | 1.553 | 0 | Yes/Yes |
| MGO09 | 1 | 2.328 | 2.276 | 0.978 | 0 | Yes/Yes |

```
ab.sh /tmp/slam-rs-s32-seam2 seam-fix --clip MIO10 --rounds 3 --profile fast --base wave3
ab.sh /tmp/slam-rs-s32-seam2 seam-fix --clip MGO09 --rounds 1 --profile fast --base wave3
```

The fix-round gate passes: identical trajectories/state and no time cost against wave3. MIO10 round medians: wave3 1.562/1.535/1.538 ms; fix 1.538/1.536/1.516 ms. The harness's older absolute speed target prints `SPEED FAIL` (1.439 ms); the fix-round brief requires the same median within noise against wave3, not a new speedup. Both accuracy gates pass. No `.rrd` was produced.

Follow-up to already-merged #249. The requested target `slam-rs/stage-timers` predates the original stack; this PR therefore includes that ancestry. The new fix is commit `b298eb20`; measurements compare exactly against the merged seam commit.
