### PR TITLE
slam-rs: hand the cell selection's download to the stage that was going to wait

### DIFF
--- a/packages/slam-rs/crates/slam-rs/src/frontend/detect.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/detect.rs
@@ -621,30 +621,46 @@ pub trait CornerScan: std::fmt::Debug + Send + Sync {
         Ok(())
     }
 
-    /// Answer every camera of a frameset's [`CornerScan::select_cells`] in one
-    /// device round trip, before the frameset asks for any of them.
+    /// Launch the [`CornerScan::select_cells`] of every camera `selects` names,
+    /// and download none of them.
     ///
     /// `selects[camera]` is [`cell_select`]'s answer for that camera, `None`
-    /// where the shape cannot take the device path at all. What this saves is a
-    /// wait, not arithmetic: the selection kernels read the frame and nothing
-    /// else, so every camera's can be launched together and downloaded once,
-    /// where the per-camera call synchronises once per camera. A backend that
-    /// takes it must answer the matching [`CornerScan::select_cells`] with the
-    /// same keys it downloaded here, and one that does nothing leaves every
-    /// `select_cells` to answer for itself.
+    /// where the shape cannot take the device path — or where the caller does
+    /// not want that camera's selection yet. What this saves is a wait, not
+    /// arithmetic: the selection kernels read the frame and nothing else, so
+    /// they can be launched before the frameset has decided anything at all,
+    /// and the answer picked up by [`CornerScan::take_cells`] behind whatever
+    /// download comes next. A backend that takes it must answer the matching
+    /// [`CornerScan::select_cells`] with the same keys, and one that does
+    /// nothing leaves every `select_cells` to answer for itself.
     ///
-    /// Called once per detecting frameset. Whatever it prepared is spent by the
-    /// `select_cells` calls that follow and must not outlive them.
+    /// Called once or twice per frameset, and it **clears** what a previous
+    /// call left: whatever a `submit_cells` prepares is spent by the
+    /// `select_cells` calls of its own frameset and must not outlive them.
     ///
     /// # Errors
     ///
     /// Whatever the backend's own scan can fail with.
-    fn prepare_cells(
+    fn submit_cells(
         &mut self,
         images: &[ImageU16],
         selects: &[Option<CellSelect>],
     ) -> Result<(), DetectError> {
         let _ = (images, selects);
+        Ok(())
+    }
+
+    /// Take what [`CornerScan::submit_cells`] launched, downloading it here only
+    /// if nothing else already has.
+    ///
+    /// Called once after every `submit_cells`, and after the download the
+    /// caller expected to carry it. A no-op for a backend whose `submit_cells`
+    /// is one.
+    ///
+    /// # Errors
+    ///
+    /// Whatever the backend's own download can fail with.
+    fn take_cells(&mut self) -> Result<(), DetectError> {
         Ok(())
     }
 }
@@ -655,7 +671,7 @@ pub trait CornerScan: std::fmt::Debug + Send + Sync {
 /// Mask-independent on purpose: `cell_masks` decides the rest of the gate and is
 /// not known until the frameset has masked the camera, while the kernels this
 /// describes read the frame and nothing else. So this is what
-/// [`CornerScan::prepare_cells`] can be handed before the frameset has run, and
+/// [`CornerScan::submit_cells`] can be handed before the frameset has run, and
 /// [`detect_keypoints_with_cells`] applies the mask half itself.
 #[must_use]
 pub fn cell_select(
@@ -842,18 +858,27 @@ impl DetectorScratch {
         }
     }
 
-    /// [`CornerScan::prepare_cells`] on the scanner this holds, which is the
+    /// [`CornerScan::submit_cells`] on the scanner this holds, which is the
     /// only way to it from outside this module.
     ///
     /// # Errors
     ///
     /// Whatever the scanner's own preparation can fail with.
-    pub fn prepare_cells(
+    pub fn submit_cells(
         &mut self,
         images: &[ImageU16],
         selects: &[Option<CellSelect>],
     ) -> Result<(), DetectError> {
-        self.scanner.prepare_cells(images, selects)
+        self.scanner.submit_cells(images, selects)
+    }
+
+    /// [`CornerScan::take_cells`] on the scanner this holds.
+    ///
+    /// # Errors
+    ///
+    /// Whatever the scanner's own download can fail with.
+    pub fn take_cells(&mut self) -> Result<(), DetectError> {
+        self.scanner.take_cells()
     }
 }
 

--- a/packages/slam-rs/crates/slam-rs/src/frontend/flow.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/flow.rs
@@ -556,9 +556,15 @@ pub struct FrameToFrameOpticalFlow<
     tracked: FlowTransforms,
     detector: DetectorScratch,
     /// The device cell selection each camera can take, or `None` where its shape
-    /// cannot ([`cell_select`]); rebuilt per detecting frameset so the whole rig
-    /// can be prepared in one device round trip.
+    /// cannot ([`cell_select`]); rebuilt at the top of every frameset, before
+    /// anything about it has been decided.
     cell_selects: Vec<Option<CellSelect>>,
+    /// [`FrameToFrameOpticalFlow::cell_selects`] narrowed to the cameras one
+    /// phase launches: camera 0 before the temporal tracks, the rest behind the
+    /// cross-camera matches, so each set rides a download that was happening
+    /// anyway (D78). A field rather than a local because it is rebuilt twice a
+    /// frameset and this module allocates once.
+    cell_selects_now: Vec<Option<CellSelect>>,
     detected: KeypointsData,
     /// The keypoints `addPointsForCamera(0)` produced, to be matched onward.
     new_cam0: Keypoints,
@@ -896,6 +902,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
             tracked: FlowTransforms::default(),
             detector: DetectorScratch::with_scanner(scanner),
             cell_selects: vec![None; num_cams],
+            cell_selects_now: vec![None; num_cams],
             detected: KeypointsData::default(),
             new_cam0: Keypoints::default(),
             to_remove: Vec::new(),
@@ -1175,6 +1182,42 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         }
 
         let num_cams: usize = self.cameras.len();
+
+        // Camera 0's cell winners, launched here and downloaded by the temporal
+        // tracks below (D78). The selection kernels read the frame alone — the
+        // occupancy counts and the masks stay on the host and are applied to
+        // the downloaded keys — so there is nothing about this frameset they
+        // need to know, including whether it detects at all. That last part is
+        // the speculation: on a frameset that skips `add_points` these kernels
+        // are wasted GPU time, and what they buy on one that detects is a whole
+        // synchronising read, 0.12 ms of host time on this lane. Camera 0 alone
+        // because it is the only camera the match needs before it launches; the
+        // others go behind the matches, where another download is waiting.
+        let config: DetectorConfig = self.detector_config();
+        let Self {
+            cell_selects,
+            detection_grids,
+            ..
+        } = self;
+        for ((slot, image), grid) in cell_selects
+            .iter_mut()
+            .zip(images)
+            .zip(detection_grids.iter())
+        {
+            *slot = cell_select(image, grid, &config);
+        }
+        let mark: std::time::Instant = std::time::Instant::now();
+        self.cell_selects_now.clear();
+        self.cell_selects_now.resize(images.len(), None);
+        if let (Some(slot), Some(select)) = (
+            self.cell_selects_now.first_mut(),
+            self.cell_selects.first().copied(),
+        ) {
+            *slot = select;
+        }
+        self.detector.submit_cells(images, &self.cell_selects_now)?;
+        self.timings.detect_ns += duration_ns(mark);
+
         if self.t_ns.is_none() {
             for keypoints in &mut self.frame.cameras {
                 keypoints.clear();
@@ -1208,6 +1251,14 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
                 self.update_cell_counts(camera);
             }
         }
+
+        // Camera 0's keys, out of the download the tracks just made. On the
+        // first frameset of a run there was no track to carry them and this
+        // reads them itself, which is the read the detector used to make on
+        // every frameset.
+        let mark: std::time::Instant = std::time::Instant::now();
+        self.detector.take_cells()?;
+        self.timings.detect_ns += duration_ns(mark);
 
         if self.should_detect() {
             self.add_points(images)?;
@@ -1599,21 +1650,10 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
     /// `addPoints` (`:637-666`): detect on camera 0, match onward, then detect
     /// again on the cameras that do not overlap camera 0.
     fn add_points(&mut self, images: &[ImageU16]) -> Result<(), FrontendError> {
-        // Every camera's cell winners in one device round trip, before the first
-        // of them is asked for. The selection kernels read the frame alone — the
-        // occupancy counts and the masks stay on the host and are applied to the
-        // keys afterwards — so a camera's can be launched before this frameset
-        // has decided anything about it, and what that saves is one wait per
-        // camera (D77). A backend without a device path prepares nothing and
-        // every `detect_keypoints_with_cells` answers for itself.
-        let config: DetectorConfig = self.detector_config();
-        for (camera, image) in images.iter().enumerate() {
-            self.cell_selects[camera] = cell_select(image, &self.detection_grids[camera], &config);
-        }
-        let mark: std::time::Instant = std::time::Instant::now();
-        self.detector.prepare_cells(images, &self.cell_selects)?;
-        self.timings.detect_ns += duration_ns(mark);
-
+        // Camera 0's cell winners are already on the host: `run_passes`
+        // launched them before the temporal tracks and the tracks' own download
+        // brought them back (D78). A backend without a device path prepared
+        // nothing and every `detect_keypoints_with_cells` answers for itself.
         self.add_points_for_camera(0, images)?;
 
         // `for (i = 1; i < getNumCams(); i++) trackPoints(pyr0, pyri, kpts0, ...)`
@@ -1633,6 +1673,24 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
             let t_c0_ci: Se3<f32> = self.calib.t_i_c[0].inverse() * self.calib.t_i_c[camera];
             self.submit_track_points(lane, 0, camera, &t_c0_ci, false)?;
         }
+        self.timings.stereo_ns += duration_ns(mark);
+
+        // The other cameras' selections, launched behind the matches so the
+        // match download carries them too. Only the non-overlap pass below
+        // reads them, so a config without it launches nothing here.
+        let tail: bool = self.cameras.len() > 1 && self.config.optical_flow_detection_nonoverlap;
+        if tail {
+            let mark: std::time::Instant = std::time::Instant::now();
+            self.cell_selects_now.clear();
+            self.cell_selects_now.resize(images.len(), None);
+            for camera in 1..self.cell_selects_now.len().min(self.cell_selects.len()) {
+                self.cell_selects_now[camera] = self.cell_selects[camera];
+            }
+            self.detector.submit_cells(images, &self.cell_selects_now)?;
+            self.timings.detect_ns += duration_ns(mark);
+        }
+
+        let mark: std::time::Instant = std::time::Instant::now();
         if self.cameras.len() > 1 {
             self.tracker.collect(&mut self.results)?;
         }
@@ -1640,8 +1698,11 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
             self.finish_track_points(camera - 1, camera);
             self.add_keypoints(camera);
         }
-
         self.timings.stereo_ns += duration_ns(mark);
+
+        let mark: std::time::Instant = std::time::Instant::now();
+        self.detector.take_cells()?;
+        self.timings.detect_ns += duration_ns(mark);
 
         // `if (!config.optical_flow_detection_nonoverlap) continue;` (`:657-664`).
         if self.config.optical_flow_detection_nonoverlap {

--- a/packages/slam-rs/crates/slam-rs/src/gpu/detect.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/detect.rs
@@ -96,15 +96,26 @@ pub struct GpuCornerScan<R: Runtime> {
     /// count they were sized for: allocated once per camera grid, like
     /// [`GpuCornerScan::buffers`] and for the same reason.
     keys: Vec<Option<(cubecl::server::Handle, usize)>>,
-    /// What [`CornerScan::prepare_cells`] downloaded for each camera, and the
+    /// What [`CornerScan::submit_cells`] launched for each camera, and the
     /// selection it answers. `select_cells` spends the entry rather than
     /// reading it twice, so nothing here can outlive the frameset that filled
-    /// it: the next `prepare_cells` clears every slot first.
+    /// it: the next `submit_cells` clears every slot first.
     prepared: Vec<Option<CellSelect>>,
     /// The keys of [`GpuCornerScan::prepared`], in buffers the scanner keeps so
     /// a frameset's preparation reaches the host allocator only while a grid is
     /// growing.
     prepared_keys: Vec<Vec<u32>>,
+    /// The key buffers [`CornerScan::submit_cells`] launched into and
+    /// [`CornerScan::take_cells`] has still to decode: the camera, its buffer
+    /// and the cells it was sized for, in launch order.
+    ///
+    /// Kept here as well as staged on [`GpuCornerScan::reads`] so a
+    /// `take_cells` that finds no download waiting can make its own.
+    submitted: Vec<(usize, cubecl::server::Handle, usize)>,
+    /// Where the launched key buffers are offered to the next download —
+    /// the tracker's temporal read, on the lane [`super::gpu_backends`] builds
+    /// (D78). Unshared by default, which makes `take_cells` read for itself.
+    reads: super::ReadRelay,
     /// Times the three device buffers have been allocated, which a rig of one
     /// geometry keeps at one.
     buffer_allocations: usize,
@@ -160,6 +171,8 @@ impl<R: Runtime> GpuCornerScan<R> {
                     keys: Vec::new(),
                     prepared: Vec::new(),
                     prepared_keys: Vec::new(),
+                    submitted: Vec::new(),
+                    reads: super::ReadRelay::default(),
                     buffer_allocations: 0,
                     kept: None,
                     mask: None,
@@ -181,6 +194,17 @@ impl<R: Runtime> GpuCornerScan<R> {
     /// frameset and two.
     pub fn share_level0(&mut self, table: Level0Table) {
         self.level0 = table;
+    }
+
+    /// Offer this scanner's cell-key downloads to `relay`, which the tracker on
+    /// the same client drains inside its own read.
+    ///
+    /// Wired by [`super::gpu_backends`] for the same reason
+    /// [`GpuCornerScan::share_level0`] is: the two stages are on one client and
+    /// one frameset, so the difference between sharing this and not is one
+    /// synchronising read a frameset — 0.12 ms of host time on this lane (D78).
+    pub fn share_reads(&mut self, relay: super::ReadRelay) {
+        self.reads = relay;
     }
 
     /// Frames this scanner uploaded itself. Zero once
@@ -552,10 +576,14 @@ impl<R: Runtime> CornerScan for GpuCornerScan<R> {
         )
     }
 
-    /// Every camera's selection launched together, then one download for all of
-    /// them: on this lane the wait is what a frameset pays for, not the 1.4 kB
-    /// each camera brings back (D77).
-    fn prepare_cells(
+    /// The named cameras' selections launched together and downloaded by
+    /// nobody: the handles go on the relay, and whichever stage reads next
+    /// carries them (D78).
+    ///
+    /// On this lane the wait is what a frameset pays for, not the 1.4 kB each
+    /// camera brings back, so this stage's whole job is to be launched early
+    /// enough that another stage's read can absorb it.
+    fn submit_cells(
         &mut self,
         images: &[ImageU16],
         selects: &[Option<CellSelect>],
@@ -563,54 +591,88 @@ impl<R: Runtime> CornerScan for GpuCornerScan<R> {
         self.prepared.clear();
         self.prepared.resize(images.len(), None);
         self.prepared_keys.resize_with(images.len(), Vec::new);
+        self.submitted.clear();
         guarded(
             GpuError::DeviceLost {
                 what: "corner cell selection",
             },
             || {
-                let mut launched: Vec<(usize, cubecl::server::Handle, usize)> = Vec::new();
                 for (camera, image) in images.iter().enumerate() {
                     let Some(select) = selects.get(camera).copied().flatten() else {
                         continue;
                     };
                     if let Some((best, cells)) = self.launch_selection(camera, image, &select) {
                         self.prepared[camera] = Some(select);
-                        launched.push((camera, best, cells));
+                        self.submitted.push((camera, best, cells));
                         // Three launches, and the frame upload when the
                         // pyramid did not publish one.
                         super::queued(&self.client, 4)?;
                     }
                 }
-                if launched.is_empty() {
-                    return Ok(());
-                }
+                self.reads.stage(
+                    self.submitted
+                        .iter()
+                        .map(|(_, best, _)| best.clone())
+                        .collect(),
+                );
+                Ok(())
+            },
+        )
+    }
 
-                #[cfg(test)]
-                super::fire_if_armed(super::CORNER_SCAN_READ);
+    /// The keys of [`CornerScan::submit_cells`], out of the download that
+    /// carried them — or out of one made here when none did, which is the first
+    /// frameset of a run and any lane with no relay wired.
+    fn take_cells(&mut self) -> Result<(), DetectError> {
+        if self.submitted.is_empty() {
+            return Ok(());
+        }
+        let outcome: Result<(), DetectError> = guarded(
+            GpuError::DeviceLost {
+                what: "corner cell selection",
+            },
+            || {
+                // `take_delivered` also drops anything still staged, so the read
+                // below cannot be made twice over the same handles.
+                let reads: Vec<cubecl::bytes::Bytes> = match self.reads.take_delivered() {
+                    Some(bytes) => bytes,
+                    None => {
+                        #[cfg(test)]
+                        super::fire_if_armed(super::CORNER_SCAN_READ);
 
-                let handles: Vec<cubecl::server::Handle> =
-                    launched.iter().map(|(_, best, _)| best.clone()).collect();
-                let reads: Vec<cubecl::bytes::Bytes> = {
-                    let read = super::seam::READ_DETECT
-                        .measure(|| cubecl::reader::read_sync(self.client.read_async(handles)));
-                    super::drained();
-                    read.map_err(|error| super::read_failed("the cell winner keys", &error))?
+                        let handles: Vec<cubecl::server::Handle> = self
+                            .submitted
+                            .iter()
+                            .map(|(_, best, _)| best.clone())
+                            .collect();
+                        let read = super::seam::READ_DETECT
+                            .measure(|| cubecl::reader::read_sync(self.client.read_async(handles)));
+                        super::drained();
+                        read.map_err(|error| super::read_failed("the cell winner keys", &error))?
+                    }
                 };
-                if reads.len() != launched.len() {
-                    self.prepared.iter_mut().for_each(|slot| *slot = None);
+                if reads.len() != self.submitted.len() {
                     return Err(super::GpuError::DeviceReadFailed {
                         what: "the cell winner buffers",
                     }
                     .into());
                 }
-                for ((camera, _, cells), keys) in launched.iter().zip(reads.iter()) {
+                for ((camera, _, cells), keys) in self.submitted.iter().zip(reads.iter()) {
                     let keys: &[u32] = checked_keys(keys, *cells)?;
                     self.prepared_keys[*camera].clear();
                     self.prepared_keys[*camera].extend_from_slice(keys);
                 }
                 Ok(())
             },
-        )
+        );
+        // A download that did not arrive leaves no prepared entry behind: every
+        // `select_cells` of this frameset falls back to the band walk rather
+        // than reading the keys of the last one.
+        if outcome.is_err() {
+            self.prepared.iter_mut().for_each(|slot| *slot = None);
+        }
+        self.submitted.clear();
+        outcome
     }
 
     fn band(&mut self, request: BandRequest) -> Result<&[FastCorner], DetectError> {

--- a/packages/slam-rs/crates/slam-rs/src/gpu/mod.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/mod.rs
@@ -353,7 +353,7 @@ pub fn gpu_backends<P: crate::frontend::patterns::Pattern>(
             // worse than a refusal.
             let client = gpu_client()?;
             probe_storage(&client)?;
-            let tracker: LanePatchTracker<P> = GpuPatchTracker::new(
+            let mut tracker: LanePatchTracker<P> = GpuPatchTracker::new(
                 client.clone(),
                 capacity,
                 num_levels,
@@ -368,9 +368,108 @@ pub fn gpu_backends<P: crate::frontend::patterns::Pattern>(
             // reads it. This is the one line that makes it one upload per camera
             // per frameset instead of two (see [`Level0`]).
             scanner.share_level0(builder.level0_table());
+            // And the same again for the download: the scanner's cell keys ride
+            // the tracker's temporal read instead of paying for one of their own
+            // (see [`ReadRelay`]).
+            let relay: ReadRelay = ReadRelay::default();
+            scanner.share_reads(relay.clone());
+            tracker.share_reads(relay);
             Ok((builder, tracker, Box::new(scanner)))
         },
     )
+}
+
+/// Buffers one stage has launched, offered to whichever stage downloads next,
+/// and the bytes that download left behind.
+///
+/// A read on this lane costs about 0.12 ms of host time before it moves a byte
+/// (D77), so two buffers that no arithmetic connects are still worth **one**
+/// read between them. The corner scanner's cell keys and the tracker's temporal
+/// results are exactly that pair: the selection kernels read the frame alone,
+/// so they can be launched before the frameset has decided anything, and the
+/// tracker's `collect` was going to synchronise anyway. The scanner stages its
+/// handles here, `collect` appends them to its own download, and the scanner
+/// takes the tail (D78).
+///
+/// Shared explicitly by [`gpu_backends`] rather than kept in a process-wide
+/// static like [`QUEUED`]: an over-count there drains early, which is only
+/// conservative, where a crossed relay would hand one frontend another's
+/// pixels. A stage that finds nothing here downloads for itself, which is what
+/// the first frameset of a run — no temporal pass, so no `collect` — does.
+///
+/// A `Mutex` for the reason [`Level0Table`] is one: [`crate::frontend::detect::CornerScan`]
+/// is `Send + Sync`, and this is taken twice a frameset by two stages on the
+/// frontend's own thread, never contended. A poisoned lock is not an error
+/// here — every method degrades to "nothing was staged", and the stager then
+/// reads for itself.
+#[cfg(feature = "gpu-core")]
+#[derive(Debug, Clone, Default)]
+pub struct ReadRelay(std::sync::Arc<std::sync::Mutex<RelayInner>>);
+
+/// [`ReadRelay`]'s contents: at most one frameset's worth, in one direction.
+#[cfg(feature = "gpu-core")]
+#[derive(Debug, Default)]
+struct RelayInner {
+    /// Launched and waiting for someone to download.
+    staged: Vec<cubecl::server::Handle>,
+    /// What a download left for the stage that staged it.
+    delivered: Option<Vec<cubecl::bytes::Bytes>>,
+}
+
+#[cfg(feature = "gpu-core")]
+impl ReadRelay {
+    /// Offer `handles` to the next download, replacing anything unclaimed:
+    /// there is one producer and one frameset in flight.
+    pub(super) fn stage(&self, handles: Vec<cubecl::server::Handle>) {
+        if let Ok(mut inner) = self.0.lock() {
+            inner.staged = handles;
+            inner.delivered = None;
+        }
+    }
+
+    /// Take what was staged, to append to a download this stage is making.
+    pub(super) fn take_staged(&self) -> Vec<cubecl::server::Handle> {
+        self.0
+            .lock()
+            .map(|mut inner| std::mem::take(&mut inner.staged))
+            .unwrap_or_default()
+    }
+
+    /// Leave a download's tail for the stage that staged it.
+    pub(super) fn deliver(&self, bytes: Vec<cubecl::bytes::Bytes>) {
+        if let Ok(mut inner) = self.0.lock() {
+            inner.delivered = Some(bytes);
+        }
+    }
+
+    /// Handles launched and not yet downloaded by anyone.
+    ///
+    /// Public because it is the only deterministic way to see the mechanism
+    /// work: the values alone cannot tell a carried download from one the
+    /// stager made itself, and the seam counters are process-wide statics that
+    /// a second test thread moves under the assertion.
+    #[must_use]
+    pub fn waiting(&self) -> usize {
+        self.0.lock().map(|inner| inner.staged.len()).unwrap_or(0)
+    }
+
+    /// Buffers a download left here and the stager has not taken yet.
+    #[must_use]
+    pub fn carried(&self) -> usize {
+        self.0
+            .lock()
+            .map(|inner| inner.delivered.as_ref().map_or(0, Vec::len))
+            .unwrap_or(0)
+    }
+
+    /// Take the bytes a download left, or `None` when none did — a stage that
+    /// gets `None` still holds its own handles and reads them itself.
+    pub(super) fn take_delivered(&self) -> Option<Vec<cubecl::bytes::Bytes>> {
+        self.0.lock().ok().and_then(|mut inner| {
+            inner.staged.clear();
+            inner.delivered.take()
+        })
+    }
 }
 
 /// Tasks CubeCL 0.10's client-to-server channel holds before a producer spins

--- a/packages/slam-rs/crates/slam-rs/src/gpu/seam.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/seam.rs
@@ -5,7 +5,9 @@
 //! question these answer is where the rest goes: how many launches, uploads and
 //! synchronising reads a frameset makes, and how long the host sits in each.
 //! The answer that shaped D77 was **five reads, 1.51 ms**, against 0.15 ms in
-//! every upload and nothing measurable in the launches.
+//! every upload and nothing measurable in the launches; D78 took the count to
+//! two by letting one stage's download carry another's buffers, so the reads
+//! here are counted by whoever *issued* them, not by whose data they hold.
 //!
 //! Relaxed atomics and one `Instant` pair per upload or read: about 0.6 µs a
 //! frameset against the 1600 it measures. `tests/gpu_seam_bench.rs` is the rig
@@ -66,9 +68,13 @@ impl Meter {
 pub static LAUNCH: Meter = Meter::new();
 /// `create_from_slice`: a logical allocation and a host-to-device write.
 pub static UPLOAD: Meter = Meter::new();
-/// The tracker batch's one download.
+/// The tracker batch's one download, which since D78 also carries whatever the
+/// corner scanner staged on the [`super::ReadRelay`] — so on the device lane
+/// this is where a frameset's cell keys are counted too.
 pub static READ_TRACK: Meter = Meter::new();
-/// The corner scanner's cell-key download.
+/// A download the corner scanner made itself: the band path's candidate image,
+/// and the cell keys of a frameset no tracker read carried — the first frameset
+/// of a run, and a scanner with no relay wired.
 pub static READ_DETECT: Meter = Meter::new();
 
 /// Count one launch.

--- a/packages/slam-rs/crates/slam-rs/src/gpu/track.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/track.rs
@@ -65,6 +65,10 @@ pub struct GpuPatchTracker<P: Pattern, R: Runtime> {
     offset_x: Vec<f32>,
     /// The `y` half of the same offset.
     offset_y: Vec<f32>,
+    /// Buffers another stage on this client launched and left for whichever
+    /// download comes next; [`PatchTracker::collect`] appends them to its own,
+    /// which is the corner scanner's cell keys arriving for free (D78).
+    reads: super::ReadRelay,
 }
 
 impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
@@ -112,10 +116,21 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
                     staging: vec![0.0; TRANSFORM_RUNS * capacity],
                     offset_x: vec![0.0; capacity],
                     offset_y: vec![0.0; capacity],
+                    reads: super::ReadRelay::default(),
                     client,
                 })
             },
         )
+    }
+
+    /// Drain `relay` inside this tracker's own download.
+    ///
+    /// Wired by [`super::gpu_backends`]: the corner scanner stages its cell-key
+    /// buffers there, and a read on this lane costs 0.12 ms of host time before
+    /// it moves a byte, so carrying them is free where a second read is not
+    /// (D78).
+    pub fn share_reads(&mut self, relay: super::ReadRelay) {
+        self.reads = relay;
     }
 }
 
@@ -362,7 +377,7 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
         }
         // A pass that offered nothing launched nothing, so it has no buffer to
         // read; the download is over the lanes that do.
-        let reads: Vec<cubecl::server::Handle> = self
+        let mut reads: Vec<cubecl::server::Handle> = self
             .pending
             .iter()
             .enumerate()
@@ -373,7 +388,15 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
                 handle.clone().offset_end(handle.size_in_used() - expected)
             })
             .collect();
-        let bytes: Vec<cubecl::bytes::Bytes> = if reads.is_empty() {
+        // Whatever another stage staged rides along on the tail, and the tail is
+        // handed back to it: one synchronisation for the frameset's two answers
+        // instead of one each (D78). Taken **before** the empty-read shortcut,
+        // so a frameset whose every lane offered nothing still carries them.
+        let lanes: usize = reads.len();
+        let relayed: Vec<cubecl::server::Handle> = self.reads.take_staged();
+        let carried: usize = relayed.len();
+        reads.extend(relayed);
+        let mut bytes: Vec<cubecl::bytes::Bytes> = if reads.is_empty() {
             Vec::new()
         } else {
             {
@@ -383,6 +406,10 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
                 read.map_err(|error| super::read_failed("the tracker result", &error))?
             }
         };
+        if carried != 0 && bytes.len() >= lanes {
+            let tail: Vec<cubecl::bytes::Bytes> = bytes.split_off(lanes);
+            self.reads.deliver(tail);
+        }
 
         let mut read: usize = 0;
         for (lane, count) in self.pending.iter().enumerate() {

--- a/packages/slam-rs/crates/slam-rs/tests/gpu_detect.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/gpu_detect.rs
@@ -30,7 +30,9 @@ use slam_rs::frontend::detect::{
     DetectorConfig, DetectorScratch, FAST_BORDER, FastCorner, KeypointsData, Masks, Occupancy,
     Rect, detect_keypoints_with_cells, threshold_rungs,
 };
-use slam_rs::gpu::{GpuCornerScan, gpu_client};
+use slam_rs::frontend::patterns::Pattern51;
+use slam_rs::frontend::tracker::PatchTracker;
+use slam_rs::gpu::{GpuCornerScan, GpuPatchTracker, ReadRelay, gpu_client};
 use slam_rs::image::ImageU16;
 
 mod common;
@@ -84,12 +86,17 @@ impl CornerScan for CountingScan {
     /// Forwarded, not defaulted: the trait's default prepares nothing, so a
     /// decorator that forgot this would silently take the device lane off the
     /// batched path and every equality below would still pass.
-    fn prepare_cells(
+    fn submit_cells(
         &mut self,
         images: &[ImageU16],
         selects: &[Option<CellSelect>],
     ) -> Result<(), DetectError> {
-        self.inner.prepare_cells(images, selects)
+        self.inner.submit_cells(images, selects)
+    }
+
+    /// Forwarded for the reason above: this is the half that downloads.
+    fn take_cells(&mut self) -> Result<(), DetectError> {
+        self.inner.take_cells()
     }
 }
 
@@ -643,8 +650,9 @@ fn the_gpu_cell_selection_holds_for_every_camera_slot() {
 
 /// The batched preparation answers exactly what the per-camera call does.
 ///
-/// [`CornerScan::prepare_cells`] launches every camera's selection at once and
-/// downloads them together, which is a scheduling change and must be nothing
+/// [`CornerScan::submit_cells`] launches every camera's selection at once and
+/// [`CornerScan::take_cells`] downloads them together, which is a scheduling
+/// change and must be nothing
 /// else: the keys it hands each camera have to be the ones that camera's own
 /// `select_cells` would have read. Two different MIO10 frames in the two camera
 /// slots, so a batch that crossed its cameras over would be caught.
@@ -678,7 +686,8 @@ fn the_batched_preparation_answers_what_the_per_camera_call_does() {
         alone.push(keys);
     }
 
-    scanner.prepare_cells(&images, &selects).unwrap();
+    scanner.submit_cells(&images, &selects).unwrap();
+    scanner.take_cells().unwrap();
     for (camera, image) in images.iter().enumerate() {
         let mut keys: Vec<u32> = Vec::new();
         scanner
@@ -689,10 +698,69 @@ fn the_batched_preparation_answers_what_the_per_camera_call_does() {
     assert_ne!(alone[0], alone[1], "the two cameras hold the same frame");
 }
 
+/// The scanner's keys come home inside the tracker's download.
+///
+/// The relay is the whole of D78: `submit_cells` launches and downloads
+/// nothing, and the next stage to synchronise is what brings the keys back —
+/// here a `collect` with no tracking pass in flight at all, which is the
+/// weakest form of the claim and so the sharpest test of it. A relay that
+/// dropped them would be invisible from the values alone, because `take_cells`
+/// reads for itself when nothing was delivered; so what is asserted is that the
+/// scanner made no read of its own, and that the keys are still the ones its
+/// own download would have given.
+#[test]
+fn the_tracker_download_carries_the_scanner_keys() {
+    let config: DetectorConfig = detector_config(472.0);
+    let images: [ImageU16; 2] = [mio10_frame(0, 0), mio10_frame(1, 1)];
+    let grid: CellGrid = CellGrid::new(images[0].width(), images[0].height(), 50).unwrap();
+    let selects: Vec<Option<CellSelect>> = images
+        .iter()
+        .map(|image| slam_rs::frontend::detect::cell_select(image, &grid, &config))
+        .collect();
+
+    // What the scanner answers when it downloads for itself: no relay wired.
+    let mut alone: GpuCornerScan<_> = GpuCornerScan::new(gpu_client().unwrap()).unwrap();
+    alone.submit_cells(&images, &selects).unwrap();
+    alone.take_cells().unwrap();
+    let mut want: Vec<Vec<u32>> = Vec::new();
+    for (camera, image) in images.iter().enumerate() {
+        let mut keys: Vec<u32> = Vec::new();
+        alone
+            .select_cells(camera, image, &selects[camera].unwrap(), &mut keys)
+            .unwrap();
+        assert!(!keys.is_empty(), "camera {camera} took the device path");
+        want.push(keys);
+    }
+
+    // And the same two cameras with the tracker's `collect` in between.
+    let relay: ReadRelay = ReadRelay::default();
+    let mut scanner: GpuCornerScan<_> = GpuCornerScan::new(gpu_client().unwrap()).unwrap();
+    let mut tracker: GpuPatchTracker<Pattern51, _> =
+        GpuPatchTracker::new(gpu_client().unwrap(), 512, 4, 5, 4.0, 2).unwrap();
+    scanner.share_reads(relay.clone());
+    tracker.share_reads(relay.clone());
+
+    scanner.submit_cells(&images, &selects).unwrap();
+    assert_eq!(relay.waiting(), 2, "both cameras are launched and unread");
+    assert_eq!(relay.carried(), 0, "nothing has downloaded them yet");
+    tracker.collect(&mut []).unwrap();
+    assert_eq!(relay.waiting(), 0, "the collect took the staged handles");
+    assert_eq!(relay.carried(), 2, "and left both cameras' keys behind");
+    scanner.take_cells().unwrap();
+    assert_eq!(relay.carried(), 0, "which the scanner then took");
+    for (camera, image) in images.iter().enumerate() {
+        let mut keys: Vec<u32> = Vec::new();
+        scanner
+            .select_cells(camera, image, &selects[camera].unwrap(), &mut keys)
+            .unwrap();
+        assert_eq!(keys, want[camera], "camera {camera} through the relay");
+    }
+}
+
 /// A prepared selection is spent by the call that reads it, and a camera the
 /// batch skipped still answers for itself.
 ///
-/// The keys are cached on the scanner between `prepare_cells` and the
+/// The keys are cached on the scanner between `take_cells` and the
 /// `select_cells` that takes them, so the thing that must not happen is a
 /// leftover answering a later frameset. Reading twice, and preparing a rig where
 /// only one camera is offered, are the two ways that could happen.
@@ -709,8 +777,9 @@ fn a_prepared_selection_is_spent_once() {
     let mut scanner: GpuCornerScan<_> = GpuCornerScan::new(gpu_client().unwrap()).unwrap();
     // Only camera 0 is offered, so camera 1 has nothing prepared for it.
     scanner
-        .prepare_cells(&images, &[Some(select), None])
+        .submit_cells(&images, &[Some(select), None])
         .unwrap();
+    scanner.take_cells().unwrap();
 
     let mut first: Vec<u32> = Vec::new();
     scanner

--- a/packages/slam-rs/crates/slam-rs/tests/gpu_seam_bench.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/gpu_seam_bench.rs
@@ -47,7 +47,17 @@ fn the_gpu_frontend_reports_its_host_seam() {
         return;
     };
 
-    let config = common::config();
+    let mut config = common::config();
+    // The vendored config detects on every frameset. `SLAM_RS_SEAM_REDETECT`
+    // puts the fast profile's gate on instead (D75), which is the mix that
+    // decides whether speculating a selection pays: a frameset that detects
+    // saves a read and one that skips wastes the FAST kernels.
+    if let Some(ratio) = std::env::var("SLAM_RS_SEAM_REDETECT")
+        .ok()
+        .and_then(|value| value.parse::<f32>().ok())
+    {
+        config.port_redetect_survivor_ratio = ratio;
+    }
     // `SLAM_RS_SEAM_CAMERAS` widens the two-camera fixture rig by repeating its
     // cameras, which is how a four-camera rig's batch shape is reachable from
     // the committed 960x960 frames.
@@ -103,6 +113,9 @@ fn the_gpu_frontend_reports_its_host_seam() {
     let mut stereo: Vec<u64> = Vec::with_capacity(count);
     let mut whole: Vec<u64> = Vec::with_capacity(count);
     let mut keypoints: usize = 0;
+    // Framesets that ran `addPoints`, which is the only thing the speculated
+    // selection is for: the id space only grows where a corner was registered.
+    let mut detected: usize = 0;
     // The marginal cost of one more synchronising read, measured where the
     // frontend pays it: `SLAM_RS_SEAM_EXTRA=<k>` adds k four-byte reads to every
     // frameset, on the same client the frontend uses.
@@ -120,6 +133,7 @@ fn the_gpu_frontend_reports_its_host_seam() {
             slam_rs::gpu::seam::reset();
         }
         let images: &[ImageU16] = &frames[order[index % order.len()]];
+        let ids_before: u64 = flow.last_keypoint_id();
         let mark: std::time::Instant = std::time::Instant::now();
         let frame = flow
             .process_frame(
@@ -135,6 +149,9 @@ fn the_gpu_frontend_reports_its_host_seam() {
         let elapsed: u64 = mark.elapsed().as_nanos() as u64;
         keypoints = frame.cameras[0].len();
         if index >= warmup {
+            if flow.last_keypoint_id() != ids_before {
+                detected += 1;
+            }
             let timings = flow.timings();
             pyramid.push(timings.pyramid_ns);
             detect.push(timings.detect_ns);
@@ -145,7 +162,8 @@ fn the_gpu_frontend_reports_its_host_seam() {
     }
 
     println!(
-        "MIO10 {count} framesets, {cameras} cameras, {keypoints} keypoints on camera 0\n\
+        "MIO10 {count} framesets, {cameras} cameras, {keypoints} keypoints on camera 0, \
+         {detected} detected\n\
          medians ms: whole {:.3} = pyramid {:.3} + detect {:.3} + track {:.3} + stereo {:.3}\n\
          {}",
         median(&mut whole),

--- a/packages/slam-rs/docs/design-notes.md
+++ b/packages/slam-rs/docs/design-notes.md
@@ -1371,3 +1371,83 @@ is the cell selection's, which needs `should_detect` decided before the temporal
 tracks come back — a speculation that is free on a detecting frameset and costs
 the FAST kernels on one that skips.
 - **D77** — The GPU frontend waits once per phase instead of once per camera, and bounds the runtime queue so a four-camera rig does not spin (2026-09-10)
+
+## D78 — One stage's download carries another's buffers: the cell selection rides the temporal tracks
+
+D77 left the frontend at three synchronising reads a detecting frameset and named
+the next one to remove: the cell selection's, which came after the temporal
+tracks only because `should_detect` is decided from them. It is gone, and the
+mechanism is general — a `ReadRelay` (`gpu/mod.rs`) that one stage stages
+launched handles on and the next stage to synchronise appends to its own
+`read_async`, handing the tail back. `gpu_backends` shares one between the
+corner scanner and the tracker, the same wiring and for the same reason as the
+level-0 table: both stages are on one client and one frameset, so the difference
+between sharing and not is a whole read.
+
+**Camera 0's selection is launched at the top of the frameset**, before the
+temporal tracks and before anything about the frameset is known, and its keys
+come back inside `PatchTracker::collect`. That is a speculation: on MIO10's fast
+profile **79 % of framesets detect** (`added_points > 0`, 277 of 352
+post-warmup), so four times in five the keys are free and the fifth time the
+FAST kernels are wasted GPU work — no extra read either way, because a frameset
+that skips `add_points` never asks for them. The **other** cameras' selections
+only feed the non-overlap pass, so they are launched behind the cross-camera
+matches and ride *that* download; nothing is left for a read of its own.
+`CornerScan::prepare_cells` splits into `submit_cells` (launch, stage) and
+`take_cells` (take the tail, or download it here when nothing carried it — the
+first frameset of a run, which has no temporal pass).
+
+No arithmetic moves. The occupancy gate and the masks stay on the host and are
+still applied to the downloaded keys, `cell_select` is still the mask-independent
+half (D77), and the mixed-geometry and `num_points_cell != 1` fallbacks still
+take the band walk. Trajectories are byte- and state-identical to D77's on both
+clips.
+
+### The two orders that were tried and lost
+
+Both measured in the in-process rig (`tests/gpu_seam_bench.rs`, now with
+`SLAM_RS_SEAM_REDETECT=<ratio>` so the fast profile's gate is reachable), 400
+framesets, whole-frameset median in ms:
+
+| shape | 2 cam, every frameset detects | 2 cam, 18 % detect | 4 cam, every | 4 cam, 18 % |
+|---|---:|---:|---:|---:|
+| D77 | 1.258 | 0.887 | 2.735 | 1.653 |
+| **camera 0 up front, the rest behind the matches** | **1.205** | 0.971 | **2.455** | **1.582** |
+| every camera up front | 1.337 | 1.012 | 2.399 | 1.745 |
+| camera 0 up front, the rest *ahead* of the matches | 1.240 | 0.919 | 2.500 | 1.664 |
+
+Launching every camera up front loses because it puts 26 tasks in the
+two-camera phase and 52 in the four-camera one, so D77's queue ceiling flushes
+where the chosen shape does not. Launching the tail ahead of the matches rather
+than behind them loses by less and consistently, on all four cells.
+
+### What a read is worth, revised
+
+D77 measured 0.115 ms for one *added* empty read and this lever recovers about
+half of that per read removed: 0.053 ms in the rig, 0.10 ms on the clip. The
+difference is that a removed read does not take its GPU wait with it — the
+surviving read inherits it. So the seam's remaining cost is not "reads × 0.115":
+it is two fixed read costs plus the device work they wait on, and the clip's
+own detect stage went 0.214 → 0.008 ms while stereo went 0.193 → 0.298, which is
+that inheritance in the stage table.
+
+### Measured
+
+Fast profile, `--base wave3` (`c1f1a73a`), three interleaved rounds on MIO10 and
+one on MGO09.
+
+| clip | base median | after | delta | ATE vs GT | lost | identical |
+|---|---:|---:|---:|---:|---:|---|
+| MIO10 | 1.530 ms | **1.429** | −0.102 (−6.7 %) | 1.553 cm both | 0/0 | byte + state |
+| MGO09 | 2.282 ms | **2.197** | −0.086 (−3.8 %) | 0.978 cm both | 0/0 | byte + state |
+
+MIO10 clears the 1.439 ms speed target on every round (1.429, 1.432, 1.447).
+Reads per frameset 3 → **2** while detecting, 1 → 1 while not.
+
+The next thing in the seam is the **uploads**, not the reads: eleven a
+two-camera frameset for 0.174 ms, which is 0.016 ms each whether it carries
+1.84 MB of frame or a few hundred floats, so the cost is per call and nine of
+the eleven are the tracker's three-per-pass. Merging a pass's positions,
+forward transforms and backward offsets into one buffer with three regions —
+the kernels already take base offsets — would take eleven to five.
+- **D78** — One GPU stage's download carries another's buffers: camera 0's cell selection is launched at the top of the frameset and read back by the temporal tracks (2026-09-10)


### PR DESCRIPTION
Stacked on `slam-rs/s32-wave1` (`c1f1a73a`, everything through lever 6). S32 wave 2, lever 7.

D77 left the GPU frontend at three synchronising reads a detecting frameset and named the next one to remove: the cell selection's, which came after the temporal tracks only because `should_detect` is decided from them.

## What changed

A `ReadRelay` (`gpu/mod.rs`): one stage stages its launched handles there and the next stage to synchronise appends them to its own `read_async`, handing the tail back. `gpu_backends` shares one between the corner scanner and the tracker — the same wiring, and for the same reason, as the level-0 table.

* **Camera 0's selection is launched at the top of the frameset**, before the temporal tracks, and its keys come back inside `PatchTracker::collect`. That is a speculation: 79 % of MIO10 fast-profile framesets detect (277 of 352 post-warmup), so four times in five the keys are free and the fifth time the FAST kernels are wasted GPU work. No read is added either way.
* The **other** cameras' selections only feed the non-overlap pass, so they are launched behind the cross-camera matches and ride *that* download.
* `CornerScan::prepare_cells` splits into `submit_cells` (launch, stage) and `take_cells` (take the tail, or download it here when nothing carried it — the first frameset of a run has no temporal pass).

No arithmetic moves: the occupancy gate and the masks stay on the host and are still applied to the downloaded keys, and the mixed-geometry and `num_points_cell != 1` fallbacks still take the band walk.

| file | change |
|---|---|
| `gpu/mod.rs` | `ReadRelay` + `RelayInner`; `gpu_backends` shares one between scanner and tracker |
| `gpu/detect.rs` | `submit_cells` / `take_cells` replace `prepare_cells`; `submitted`, `reads`, `share_reads` |
| `gpu/track.rs` | `share_reads`; `collect_inner` appends the relay's handles and delivers the tail |
| `frontend/detect.rs` | the trait split, and `DetectorScratch`'s two pass-throughs |
| `frontend/flow.rs` | `run_passes` builds every camera's `cell_select` and submits camera 0's before the temporal tracks; `take_cells` after them; `add_points` submits the tail behind the matches |
| `gpu/seam.rs` | the read meters now say which stage *issued* a read, not whose data it holds |
| `tests/gpu_detect.rs` | `the_tracker_download_carries_the_scanner_keys` |
| `tests/gpu_seam_bench.rs` | `SLAM_RS_SEAM_REDETECT=<ratio>`, and it reports how many framesets detected |
| `docs/design-notes.md` | D78 and its index line |

## Harness

`ab.sh /tmp/slam-rs-s32-handoff2 handoff-2 --profile fast --base wave3`. Base `wave3` = `c1f1a73a`, core `a49aee94c990`; candidate core `d8692430db50`.

### MIO10, fast profile, 3 interleaved rounds

```
| Core | profile | median ms | mean ms | p95 ms | max ms | ATE vs GT cm | ATE vs C++ cm | tracked/lost | byte-identical to base | state-identical | cores used |
|---|---|---:|---:|---:|---:|---:|---:|---:|---|---|---:|
| base | fast | 1.530 | 2.022 | 6.792 | 8.144 | 1.553 | 0.411 | 412/0 | Y | Y | 0.909 |
| handoff-2 | fast | 1.429 | 1.948 | 6.693 | 9.109 | 1.553 | 0.411 | 412/0 | Y | Y | 0.912 |
| cuVSLAM Inertial (frozen) | n/a | 1.199 | 2.677 | 2.887 | 228.788 | 3.998 | n/a | 412/0 | n/a | n/a | 1.000 |

| Core | frontend_pyramid | frontend_detect | frontend_track | frontend_stereo | predict | keyframe | optimize | linearize | solver | marginalize | measure | track_ms | glue |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| base | 0.142 | 0.214 | 0.553 | 0.193 | 0.006 | 0.000 | 0.065 | 0.019 | 0.005 | 0.101 | 0.199 | 1.530 | 0.140 |
| handoff-2 | 0.142 | 0.008 | 0.582 | 0.298 | 0.006 | 0.000 | 0.065 | 0.020 | 0.005 | 0.101 | 0.200 | 1.429 | 0.139 |

Speed target: 1.439 ms; accuracy band: 1.708 cm (1.1 x base 1.553).
SPEED PASS; ACCURACY PASS; IDENTICAL yes; delta -0.102 ms (-6.65%) vs base.
Round medians (ms): base 1.552, 1.530, 1.540; handoff-2 1.429, 1.432, 1.447
Raw: /tmp/slam-rs-s32/ab/results/handoff-2/MIO10/20260910T044734.657520Z
```

### MGO09, fast profile, 1 round (four cameras)

```
| Core | profile | median ms | mean ms | p95 ms | max ms | ATE vs GT cm | ATE vs C++ cm | tracked/lost | byte-identical to base | state-identical | cores used |
|---|---|---:|---:|---:|---:|---:|---:|---:|---|---|---:|
| base | fast | 2.282 | 4.115 | 14.685 | 15.731 | 0.978 | 0.492 | 107/0 | Y | Y | 0.891 |
| handoff-2-mgo09 | fast | 2.197 | 4.061 | 14.159 | 16.203 | 0.978 | 0.492 | 107/0 | Y | Y | 0.884 |

| Core | frontend_pyramid | frontend_detect | frontend_track | frontend_stereo | predict | keyframe | optimize | linearize | solver | marginalize | measure | track_ms | glue |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| base | 0.108 | 0.326 | 0.812 | 0.454 | 0.010 | 0.000 | 0.188 | 0.033 | 0.008 | 0.143 | 0.353 | 2.282 | 0.130 |
| handoff-2-mgo09 | 0.109 | 0.290 | 0.647 | 0.567 | 0.010 | 0.000 | 0.193 | 0.034 | 0.008 | 0.142 | 0.376 | 2.197 | 0.132 |

SPEED N/A; ACCURACY PASS; IDENTICAL yes; delta -0.086 ms (-3.76%) vs base.
Raw: /tmp/slam-rs-s32/ab/results/handoff-2-mgo09/MGO09/20260910T044812.814630Z
```

## Seam counters, per frameset

In-process rig, 400 framesets, two cameras. `ratio` is `port.redetect_survivor_ratio`: 0 detects on every frameset, 0.85 on 18 % of the rig's synthetic cycle.

| | reads | read ms | uploads | upload ms | launches | whole ms |
|---|---:|---:|---:|---:|---:|---:|
| base, every frameset detects | 3.00 | 0.726 | 11.00 | 0.176 | 32.00 | 1.258 |
| **after**, every frameset detects | **2.00** | **0.669** | 11.00 | 0.174 | 32.00 | **1.205** |
| base, 18 % detect | 1.36 | 0.380 | 8.54 | 0.177 | 22.16 | 0.887 |
| **after**, 18 % detect | **1.18** | 0.416 | 8.54 | 0.219 | 24.62 | 0.971 |

Four cameras, every frameset detects: reads 3.00 → 2.00, whole 2.735 → 2.455 ms; at 18 % detect, 1.653 → 1.582 ms. The 2.46 extra launches at 18 % detect are the speculation's price — 82 % of framesets times the three FAST kernels camera 0 did not need.

## Gate verdict

**PASS.** MIO10: ATE 1.553 cm against the 1.654 cm band, zero lost framesets, median gain 0.102 ms against the 0.1 ms bar, and every round below the stack's 1.439 ms speed target. Trajectories are byte- **and** state-identical to `wave3` on both clips, so MIO07 was not run.

## Tests

`cargo test --workspace --release` green. `cargo test -p slam-rs --release --features gpu-wgpu --test gpu_kernels --test gpu_detect`: 21 + 11 passed. `pytest -q`: 261 passed, 1 skipped, 18 deselected. `cargo clippy --workspace --release --all-targets --features slam-rs/gpu-wgpu -- -D warnings` clean; `cargo fmt --check` clean for every file this branch touches (the `estimator/mod.rs` deviation comes from the base branch).

## Refused, with the reason

The brief asked for the *match's* read to go instead — the cell keys compacted into the patch-position list on the device so the selection and the cross-camera match enqueue back to back. That cannot be done here: the match also needs its **guesses**, and a guess is `project_between_cams` — `unproject` on camera 0's model and `project` on camera *i*'s, KB4 on every MSD rig, an iterative Newton solve over `tan`/`atan2`/`sqrt`. WGSL's transcendental accuracy is implementation-defined and differs between Vulkan and Metal, so a device port of it cannot be bit-faithful, which is what the whole lane rests on. Two reads is the floor for a detecting frameset while the guesses are host arithmetic.

No `.rrd` is produced by this change and none is needed.
