### PR TITLE
slam-rs: NVDEC decode option for evaluation

### DIFF
--- a/packages/slam-rs/docs/design-notes.md
+++ b/packages/slam-rs/docs/design-notes.md
@@ -1468,3 +1468,44 @@ the eleven are the tracker's three-per-pass. Merging a pass's positions,
 forward transforms and backward offsets into one buffer with three regions —
 the kernels already take base offsets — would take eleven to five.
 - **D78** — One GPU stage's download carries another's buffers: camera 0's cell selection is launched at the top of the frameset and read back by the temporal tracks (2026-09-10)
+
+## D79 — An opt-in NVDEC feed keeps the reference pixels
+
+Evaluation can select `decoder="nvdec"`; the default remains `dav1d` and the
+`cpu_gray8_dav1d_1thread` reference contract does not change. Packet reads,
+in-memory MP4 wrapping, timestamps, frameset assembly and stride behavior are
+shared. Each camera has one decoder, advanced sequentially. Every encoded frame
+is decoded, including frames that the yield stride omits.
+
+PyAV 18.1.0's `av1_cuvid` with CUDA hardware acceleration downloads an NV12
+surface. Software fallback is disabled. The feed requires NV12 and passes it
+through the same gray8 reformat and padded-row copy as dav1d. This preserves
+limited-to-full expansion without an RGB conversion. The generic native `av1`
+context rejected packets on this host; selecting `av1_cuvid` works. No new
+package or dependency pin was needed. This option is AV1-only and fails explicitly
+if hardware decoding is unavailable.
+
+The full NAS clips MIO10 (412 × 2 cameras), MGO09 (107 × 4), and Odyssey MOO09
+(147 × 2) produced identical `frames.sha256` files, line for line: 1,546 camera
+frames, zero differing pixels. Portrait MGO09 stays `(640, 480)`. A GPU-marked
+integration test checks the first 20 MIO10 framesets through the feed and the
+benchmark loader. The checked-in fixture has hashes and trajectories, not
+encoded video, so the test reads the NAS clip.
+
+One CPU core (3), one decoder thread, decode-only wall time over prefetched MP4
+bytes, including initialization, YUV download and gray8 conversion:
+
+| Clip | dav1d ms/frameset | NVDEC ms/frameset | dav1d / NVDEC |
+|---|---:|---:|---:|
+| MIO10 | 3.400 | 3.082 | 1.103× |
+| MGO09 | 3.713 | 14.063 | 0.264× |
+| MOO09 | 1.723 | 5.124 | 0.336× |
+
+Identity is proven; a general speedup is not. The scratch catalog runner defaults
+to dav1d because NVDEC loses on the smaller rigs. Replay and fleet checking pass
+the decoder to the feed. `bench_track` accepts an RRD and decodes once before its
+tracker-only rounds; NPZ input is already decoded and rejects an NVDEC request.
+Long catalog recordings use the separate streaming runner, not this in-memory
+microbenchmark loader.
+
+- **D79** — Evaluation can opt into raw-luma NVDEC with byte-identical gray8 output; dav1d stays the default (2026-09-10)

--- a/packages/slam-rs/pyproject.toml
+++ b/packages/slam-rs/pyproject.toml
@@ -24,7 +24,7 @@ build-backend = "hatchling.build"
 packages = ["slam_rs"]
 
 [tool.pytest.ini_options]
-markers = ["slow: reads a reference .rrd from the NAS or queries the catalog (deselected by default; run with -m slow)"]
+markers = ["nvdec: requires an NVIDIA AV1 decode device and the GPU lock", "slow: reads a reference .rrd from the NAS or queries the catalog (deselected by default; run with -m slow)"]
 addopts = "-m 'not slow'"
 # `DatasetEntry.manifest()` is deprecated but is the only surface that reports a
 # layer's size and schema digest, which the reference manifest pins.

--- a/packages/slam-rs/slam_rs/apis/bench_track.py
+++ b/packages/slam-rs/slam_rs/apis/bench_track.py
@@ -6,9 +6,9 @@ the evidence behind a row can be re-run rather than re-derived.
 
 **The protocol**, which is the part that matters more than the code:
 
-* **No decoder and no Rerun.** The framesets are replayed out of an ``.npz``
-  dumped once by ``tests/tools/dump_clip.py --npz``, so the number is the
-  estimator's and not AV1's.
+* **No decoder inside timing and no Viewer.** Framesets are loaded from an
+  ``.npz`` dumped by ``tests/tools/dump_clip.py --npz``, or decoded once from
+  an MSD ``.rrd`` before the rounds. The number is the estimator's, not AV1's.
 * **One pinned core** (``--pin-core``). The lane runs single-threaded by
   contract (D31), and on this host an unpinned run drifts by more than the
   differences being measured. The GPU lane's CubeCL worker thread shares that
@@ -47,6 +47,7 @@ import statistics
 import threading
 import time
 from dataclasses import dataclass
+from itertools import islice
 from pathlib import Path
 from typing import Literal, TypeAlias, get_args
 
@@ -55,8 +56,8 @@ from jaxtyping import Float64, Int64, UInt8
 from numpy import ndarray
 
 from slam_rs import _core
-from slam_rs.catalog_feed import CameraCalib, Frameset, ImuCalib, ImuStream
-from slam_rs.reference import profiled_config_text
+from slam_rs.catalog_feed import CameraCalib, Decoder, Frameset, ImuCalib, ImuStream, LocalSegment, open_segment
+from slam_rs.reference import load_manifest, profiled_config_text
 from slam_rs.tracking import Lockstep
 
 Lane: TypeAlias = Literal["cpu", "gpu"]
@@ -155,9 +156,11 @@ class Config:
     """Options for the slam-rs track benchmark."""
 
     dump: Path
-    """The ``.npz`` of decoded framesets to replay; a sibling ``.calib.pkl`` carries the calibration."""
+    """An MSD ``.rrd`` to decode once, or an ``.npz`` with sibling ``.calib.pkl`` calibration."""
     config: Path
     """The basalt VIO config JSON the reference run used."""
+    decoder: Decoder = "dav1d"
+    """Decoder for RRD input. NPZ input already contains decoded pixels."""
     profile: Literal["reference", "fast"] = "reference"
     """Config overlay applied before tracking."""
     lanes: tuple[Lane, ...] = ("cpu", "gpu")
@@ -212,16 +215,38 @@ def best_median_ms(rounds: list[LaneRound]) -> float:
     return min(entry.median_ms for entry in rounds)
 
 
-def load_framesets(dump: Path, limit: int | None) -> Framesets:
+def load_framesets(dump: Path, limit: int | None, decoder: Decoder = "dav1d", safe_radius: float = 0.0) -> Framesets:
     """Read a dumped segment and its calibration.
 
     Args:
         dump: The ``.npz`` written for a reference segment.
         limit: Replay only the first this many framesets, or all of them.
+        decoder: Decoder used for an RRD input; NPZ input has no decode step.
+        safe_radius: Tracker safe radius recorded for an RRD input.
 
     Returns:
         The framesets, with the IMU counts turned into offsets.
     """
+    if dump.suffix == ".rrd":
+        dataset_name: str = dump.stem.split("__")[0]
+        parameters = next(segment.imu for segment in load_manifest().segments if segment.dataset_name == dataset_name)
+        with open_segment(LocalSegment(dump), parameters, decoder=decoder) as feed:
+            decoded: list[Frameset] = list(islice(feed.framesets(feed.stop_ns_after(limit)), limit))
+            if not decoded:
+                raise ValueError("RRD input yielded no framesets")
+            return Framesets(
+                images=np.stack([frame.images for frame in decoded]),
+                t_ns=np.asarray([frame.t_ns for frame in decoded], dtype=np.int64),
+                imu_offsets=np.concatenate([[0], np.cumsum([len(frame.imu) for frame in decoded])]),
+                imu_t=np.concatenate([frame.imu.t_ns for frame in decoded]),
+                imu_gyro=np.concatenate([frame.imu.gyro_rad_s for frame in decoded]),
+                imu_accel=np.concatenate([frame.imu.accel_m_s2 for frame in decoded]),
+                safe_radius=safe_radius,
+                cameras=feed.cameras,
+                imu=feed.imu,
+            )
+    if decoder != "dav1d":
+        raise ValueError("--decoder nvdec requires an RRD input; NPZ pixels are already decoded")
     data = np.load(dump)
     # Our own dump, written beside the npz by the same tool that decoded it.
     with dump.with_suffix(dump.suffix + ".calib.pkl").open("rb") as handle:
@@ -319,8 +344,8 @@ def main(config: Config) -> None:
         raise ValueError(f"--lanes named no backend to measure; the lanes are {', '.join(get_args(Lane))}")
     if config.pin_core is not None:
         os.sched_setaffinity(0, {config.pin_core})
-    framesets: Framesets = load_framesets(config.dump, config.limit)
     vio_config = _core.VioConfig.from_json(profiled_config_text(config.config, config.profile))
+    framesets: Framesets = load_framesets(config.dump, config.limit, config.decoder, float(vio_config.optical_flow_image_safe_radius))
     if vio_config.optical_flow_image_safe_radius != framesets.safe_radius:
         raise ValueError(
             f"the dump was decoded at safe radius {framesets.safe_radius} and "

--- a/packages/slam-rs/slam_rs/apis/fleet_check.py
+++ b/packages/slam-rs/slam_rs/apis/fleet_check.py
@@ -174,7 +174,7 @@ def check_scoring_inputs(manifest: ReferenceManifest, segment: ReferenceSegment)
     return reference.path, segment.gt_csv
 
 
-def measure(manifest: ReferenceManifest, segment: ReferenceSegment, gpu: bool = False, profile: Literal["reference", "fast"] = "reference") -> ClipResult:
+def measure(manifest: ReferenceManifest, segment: ReferenceSegment, gpu: bool = False, profile: Literal["reference", "fast"] = "reference", decoder: Literal["dav1d", "nvdec"] = "dav1d") -> ClipResult:
     """Run one clip through the estimator and score it against both references.
 
     Args:
@@ -204,7 +204,7 @@ def measure(manifest: ReferenceManifest, segment: ReferenceSegment, gpu: bool = 
     # costs nothing either.
     cpp: Trajectory = read_trajectory(cpp_csv)
     truth: Trajectory = read_trajectory(gt_csv)
-    run: SegmentRun = run_segment(manifest, segment, gpu=gpu, profile=profile)
+    run: SegmentRun = run_segment(manifest, segment, gpu=gpu, profile=profile, decoder=decoder)
     tracked: int = len(run.estimate)
     # A run below the floor is not scored at all: `ate` has no pose to align and
     # raises, and a machine that tracked nothing is precisely the machine this
@@ -325,6 +325,8 @@ def this_lane(gpu: bool) -> Lane:
 class Config:
     """Run the reference smoke clips on this machine and report the D60 verdict."""
 
+    decoder: Literal["dav1d", "nvdec"] = "dav1d"
+    """Opt-in evaluation decoder; dav1d preserves the reference default."""
     profile: Literal["reference", "fast"] = "reference"
     """Config overlay applied before tracking."""
 
@@ -384,7 +386,7 @@ def main(config: Config) -> None:
     config.output_json.parent.mkdir(parents=True, exist_ok=True)
     results: list[ClipResult] = []
     for segment in segments:
-        results.append(measure(manifest, segment, config.gpu, profile=config.profile))
+        results.append(measure(manifest, segment, config.gpu, profile=config.profile, decoder=config.decoder))
         print(results[-1].row(machine))
         payload: dict[str, object] = {
             "machine": asdict(machine),

--- a/packages/slam-rs/slam_rs/apis/replay.py
+++ b/packages/slam-rs/slam_rs/apis/replay.py
@@ -88,6 +88,8 @@ class Config:
     """Longest time window fetched from the catalog in one round trip."""
     output_csv: Path | None = None
     """Where the estimated trajectory is written; defaults to ``data/<segment>/slam_rs.csv``."""
+    decoder: Literal["dav1d", "nvdec"] = "dav1d"
+    """Opt-in evaluation decoder; dav1d preserves the reference default."""
     profile: Literal["reference", "fast"] = "reference"
     """Config overlay applied before tracking."""
     gpu: bool = False
@@ -205,7 +207,7 @@ def main(config: Config) -> None:
     output_csv: Path = config.output_csv if config.output_csv is not None else Path("data") / segment.segment_id / "slam_rs.csv"
     print(f"replaying {segment.segment_id} ({segment.tier} tier) from {source.base_rrd}")
 
-    with open_segment(source, segment.imu, frame_stride=config.frame_stride, window_s=config.window_s) as feed:
+    with open_segment(source, segment.imu, frame_stride=config.frame_stride, window_s=config.window_s, decoder=config.decoder) as feed:
         print(
             f"{len(feed.cameras)} cameras, {len(feed.frame_t_ns)} framesets, ground truth "
             f"{'attached' if feed.has_ground_truth else 'absent'}, clock offset {feed.capture_start_time_ns} ns"

--- a/packages/slam-rs/slam_rs/catalog_feed.py
+++ b/packages/slam-rs/slam_rs/catalog_feed.py
@@ -12,6 +12,9 @@ Three decisions are frozen here because each one silently changes the numbers:
   expansion) is what recovers the original grayscale; the raw Y plane is off by
   up to 17 LSB. dav1d also pads rows, so the decoded plane's ``line_size``
   exceeds the frame width and the copy honours it.
+  Evaluation may opt into ``nvdec``: PyAV's ``av1_cuvid`` downloads the NV12
+  surface before the same gray8 conversion. No RGB intermediate is permitted;
+  dav1d remains the default and the reference contract.
 * **Round trips.** Video, IMU and ground truth for one time window arrive in one
   query each, and long segments are cut into windows on ``video_time`` whose
   edges land on frames that are keyframes in *every* camera, so a window decodes
@@ -50,6 +53,7 @@ import av
 import numpy as np
 import pyarrow as pa
 import rerun as rr
+from av.codec.hwaccel import HWAccel
 from datafusion import col, lit
 from jaxtyping import Bool, Float64, Int64, UInt8
 from numpy import ndarray
@@ -69,6 +73,9 @@ CHILD_FROM_PARENT: int = 2
 """``rr.TransformRelation.ChildFromParent``; the only relation the extrinsic inversion is valid for."""
 DEFAULT_WINDOW_S: float = 60.0
 """Time window a long segment is cut into: a 7.6 s two-camera segment is 8.5 MB, so a 2,000 s one is not one query."""
+
+Decoder: TypeAlias = Literal["dav1d", "nvdec"]
+"""Evaluation decoder; dav1d remains the frozen default."""
 
 CameraModelName: TypeAlias = Literal["kb4", "radtan8"]
 """Projection models V0 supports, named as basalt names them."""
@@ -518,7 +525,7 @@ def read_camera_statics(statics: pa.Table, entity: str) -> CameraStatics:
     )
 
 
-def decode_gray(mp4_bytes: bytes, downscale: int = 1) -> Iterator[UInt8[ndarray, "h w"]]:
+def decode_gray(mp4_bytes: bytes, downscale: int = 1, decoder: Decoder = "dav1d") -> Iterator[UInt8[ndarray, "h w"]]:
     """Decode an in-memory MP4 to C-contiguous ``gray8`` frames, one decoder thread.
 
     ``reformat(format="gray8")`` performs the limited-to-full range expansion the
@@ -542,6 +549,7 @@ def decode_gray(mp4_bytes: bytes, downscale: int = 1) -> Iterator[UInt8[ndarray,
     Args:
         mp4_bytes: MP4 produced by :func:`wrap_mp4`.
         downscale: Integer factor to shrink each frame by.
+        decoder: Opt-in NVDEC for AV1 evaluation, or the frozen dav1d path.
 
     Yields:
         One grayscale image per frame, in decode order.
@@ -556,7 +564,29 @@ def decode_gray(mp4_bytes: bytes, downscale: int = 1) -> Iterator[UInt8[ndarray,
         stream = container.streams.video[0]
         stream.thread_count = 1
         stream.thread_type = "NONE"
-        for frame in container.decode(stream):
+        if decoder == "nvdec":
+            if stream.codec_context.codec.name not in ("libdav1d", "av1"):
+                raise ValueError("nvdec evaluation requires an AV1 stream")
+            # Select CUVID explicitly: the default libdav1d has no HWConfig.
+            # PyAV downloads the reconstructed YUV surface, without an RGB
+            # conversion. Both paths then use exactly the same swscale call.
+            hardware = av.CodecContext.create("av1_cuvid", "r", hwaccel=HWAccel("cuda", allow_software_fallback=False))
+            assert isinstance(hardware, av.video.codeccontext.VideoCodecContext)
+            hardware.extradata = stream.codec_context.extradata
+            hardware.width = stream.codec_context.width
+            hardware.height = stream.codec_context.height
+            hardware.thread_count = 1
+            hardware.thread_type = "NONE"
+            if not hardware.is_hwaccel:
+                raise RuntimeError("AV1 NVDEC is unavailable; software fallback is disabled")
+            frames = (frame for packet in container.demux(stream) for frame in hardware.decode(packet))
+        elif decoder == "dav1d":
+            frames = container.decode(stream)
+        else:
+            raise ValueError(f"unknown decoder {decoder!r}")
+        for frame in frames:
+            if decoder == "nvdec" and frame.format.name != "nv12":
+                raise ValueError(f"NVDEC requires an 8-bit NV12 surface, got {frame.format.name}")
             gray = (
                 frame.reformat(format="gray8")
                 if downscale == 1
@@ -643,6 +673,9 @@ class SegmentFeed:
     """Frameset timing, the per-camera frames behind it, and the codec."""
     window_ns: int
     """Longest time window fetched in one round trip."""
+
+    decoder: Decoder = "dav1d"
+    """Opt-in evaluation decoder; each camera is advanced sequentially."""
 
     @property
     def has_ground_truth(self) -> bool:
@@ -753,7 +786,7 @@ class SegmentFeed:
             decoders: list[Iterator[UInt8[ndarray, "h w"]]] = []
             for position in range(len(self.cameras)):
                 samples, keyframes = self._fetch_samples(position, start, stop)
-                decoders.append(decode_gray(wrap_mp4(samples, keyframes, fps=self.index.fps, codec=self.index.codec), self.profile.downscale))
+                decoders.append(decode_gray(wrap_mp4(samples, keyframes, fps=self.index.fps, codec=self.index.codec), self.profile.downscale, self.decoder))
             # One frame per camera resident, and one decode cursor per camera: a
             # camera that contributes no frame to this frameset still has its own
             # frames decoded in order, because dropping one breaks the next.
@@ -1304,6 +1337,7 @@ def _build_feed(
     profile: RigProfile,
     frame_stride: int,
     window_s: float,
+    decoder: Decoder = "dav1d",
 ) -> SegmentFeed:
     """Read calibration, IMU, ground truth and frameset timing for one segment."""
     if frame_stride < 1:
@@ -1348,6 +1382,7 @@ def _build_feed(
         gt_dataset=gt_dataset,
         index=index,
         window_ns=int(window_s * 1e9),
+        decoder=decoder,
     )
 
 
@@ -1358,6 +1393,7 @@ def open_segment(
     profile: RigProfile = MSD_RIG,
     frame_stride: int = 1,
     window_s: float = DEFAULT_WINDOW_S,
+    decoder: Decoder = "dav1d",
 ) -> Iterator[SegmentFeed]:
     """Open one segment for reading, from local ``.rrd`` files or from a catalog server.
 
@@ -1372,6 +1408,7 @@ def open_segment(
         profile: How this rig has to be read; the default is what MSD is.
         frame_stride: Yield every n-th frameset; every frame is still decoded.
         window_s: Longest time window fetched in one round trip.
+        decoder: Evaluation decoder; the frozen dav1d path remains the default.
 
     Yields:
         The open feed.
@@ -1390,10 +1427,10 @@ def open_segment(
             segment_ids: list[str] = list(base.segment_ids())
             if len(segment_ids) != 1:
                 raise ValueError(f"{source.base_rrd} holds {len(segment_ids)} segments; the feed reads one")
-            yield _build_feed(base, ground_truth, segment_ids[0], parameters, profile, frame_stride, window_s)
+            yield _build_feed(base, ground_truth, segment_ids[0], parameters, profile, frame_stride, window_s, decoder)
     else:
         dataset: DatasetEntry = CatalogClient(source.url).get_dataset(source.dataset_name)
-        yield _build_feed(dataset, dataset, source.segment_id, parameters, profile, frame_stride, window_s)
+        yield _build_feed(dataset, dataset, source.segment_id, parameters, profile, frame_stride, window_s, decoder)
 
 
 def read_rig_trajectory(rrd: Path) -> Trajectory:

--- a/packages/slam-rs/slam_rs/tracking.py
+++ b/packages/slam-rs/slam_rs/tracking.py
@@ -190,6 +190,7 @@ def run_segment(
     max_framesets: int | None = None,
     gpu: bool = False,
     profile: Literal["reference", "fast"] = "reference",
+    decoder: Literal["dav1d", "nvdec"] = "dav1d",
 ) -> SegmentRun:
     """Drive one MSD reference clip through :class:`slam_rs._core.Vio`.
 
@@ -209,7 +210,7 @@ def run_segment(
     """
     source: LocalSegment = LocalSegment(base_rrd=segment.base_path, gt_rrd=segment.gt_path)
     feed: SegmentFeed
-    with open_segment(source, segment.imu) as feed:
+    with open_segment(source, segment.imu, decoder=decoder) as feed:
         lockstep: Lockstep = Lockstep(vio=_core.Vio(_core.Calibration.from_catalog(feed.cameras, feed.imu), flow_config(manifest, segment, profile=profile), gpu=gpu))
         return _drive(feed, lockstep, None if window_s is None else int(window_s * 1e9), max_framesets)
 

--- a/packages/slam-rs/tests/test_fleet_check.py
+++ b/packages/slam-rs/tests/test_fleet_check.py
@@ -343,7 +343,7 @@ def test_the_first_clips_evidence_survives_a_directory_that_is_not_there_yet(mon
     clip's row has to be on disk already — and it is not, if the last line of the
     run is what discovers that ``out/`` does not exist.
     """
-    monkeypatch.setattr(fleet_check, "measure", lambda _manifest, _segment, _gpu, *, profile: PASSING)
+    monkeypatch.setattr(fleet_check, "measure", lambda _manifest, _segment, _gpu, *, profile, decoder: PASSING)
     output: Path = tmp_path / "out" / "fleet_check.json"
     main(Config(segments=(SMOKE_SEGMENTS[1],), output_json=output))
     written: dict = json.loads(output.read_text())
@@ -359,7 +359,7 @@ def test_the_lane_is_on_the_json_and_the_clip_columns_are_not(monkeypatch: pytes
     beside ``machine``.
     """
     monkeypatch.setattr(_core, "gpu_backend", "wgpu")
-    monkeypatch.setattr(fleet_check, "measure", lambda _manifest, _segment, _gpu, *, profile: PASSING)
+    monkeypatch.setattr(fleet_check, "measure", lambda _manifest, _segment, _gpu, *, profile, decoder: PASSING)
     output: Path = tmp_path / "fleet_check.json"
     main(Config(segments=(SMOKE_SEGMENTS[1],), output_json=output, gpu=True))
     written: dict = json.loads(output.read_text())
@@ -423,14 +423,15 @@ def test_the_gpu_flag_reaches_the_estimator_and_nothing_else_does(monkeypatch: p
     """
     seen: list[bool] = []
 
-    def record(_manifest: ReferenceManifest, _segment: ReferenceSegment, *, gpu: bool, profile: str) -> SegmentRun:
+    def record(_manifest: ReferenceManifest, _segment: ReferenceSegment, *, gpu: bool, profile: str, decoder: str) -> SegmentRun:
         assert profile == "reference"
+        assert decoder == ("nvdec" if gpu else "dav1d")
         seen.append(gpu)
         return SegmentRun(estimate=empty_trajectory(), framesets=412, lost=412, wall_s=1.0)
 
     monkeypatch.setattr(fleet_check, "run_segment", record)
     manifest: ReferenceManifest = fleet_check.load_manifest(MANIFEST_PATH)
     segment: ReferenceSegment = manifest.by_id(SMOKE_SEGMENTS[1])
-    measure(manifest, segment, True)
+    measure(manifest, segment, True, decoder="nvdec")
     measure(manifest, segment)
     assert seen == [True, False]

--- a/packages/slam-rs/tests/test_nvdec_feed.py
+++ b/packages/slam-rs/tests/test_nvdec_feed.py
@@ -1,0 +1,39 @@
+"""Opt-in NVDEC must preserve the frozen feed's timestamps and image bytes."""
+
+import hashlib
+import subprocess
+from itertools import islice
+from pathlib import Path
+from shutil import which
+
+import pytest
+
+from slam_rs.apis.bench_track import Framesets, load_framesets
+from slam_rs.catalog_feed import LocalSegment, open_segment
+from slam_rs.reference import SMOKE_SEGMENTS, ImuParameters, load_manifest
+
+
+@pytest.mark.slow
+@pytest.mark.nvdec
+def test_nvdec_matches_first_twenty_mio10_framesets() -> None:
+    """Compare the public feed on the smallest available MIO10 NAS recording."""
+    if which("nvidia-smi") is None:
+        pytest.skip("No NVIDIA driver tools are installed")
+    probe: subprocess.CompletedProcess[str] = subprocess.run(
+        ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"], capture_output=True, text=True, check=False
+    )
+    if probe.returncode != 0 or not probe.stdout.strip():
+        pytest.skip("No NVIDIA device is visible")
+    path: Path = Path("/mnt/nas/datasets/msd-rrd/base") / f"{SMOKE_SEGMENTS[1]}.rrd"
+    if not path.exists():
+        pytest.skip("MIO10 NAS clip is not mounted")
+    parameters: ImuParameters = next(segment for segment in load_manifest().segments if segment.segment_id == SMOKE_SEGMENTS[1]).imu
+    digests: list[list[tuple[int, tuple[str, ...]]]] = []
+    for decoder in ("dav1d", "nvdec"):
+        with open_segment(LocalSegment(path), parameters, decoder=decoder) as feed:
+            digests.append([(frame.t_ns, frame.image_digests()) for frame in islice(feed.framesets(stop_ns=feed.stop_ns_after(20)), 20)])
+    assert len(digests[0]) == 20
+    assert digests[0] == digests[1]
+    benchmark: Framesets = load_framesets(path, 20, decoder="nvdec")
+    assert benchmark.t_ns.tolist() == [stamp for stamp, _ in digests[0]]
+    assert [tuple(hashlib.sha256(image).hexdigest() for image in frame) for frame in benchmark.images] == [hashes for _, hashes in digests[0]]


### PR DESCRIPTION
Adds an opt-in AV1 NVDEC feed for evaluation through PyAV `av1_cuvid`. It downloads NV12 and uses the existing gray8 expansion and padded-row copy. Software fallback and RGB intermediates are disallowed; dav1d remains the default. Replay and fleet checking pass the option through; bench_track can decode RRD input once before tracker-only rounds. Thin tool shims are unchanged. D79 records the contract and measurements.

Full-feed `frames.sha256` comparisons passed line for line on MIO10 (412 framesets × 2 cameras), MGO09 (107 × 4, portrait), and Odyssey MOO09 (147 × 2): 1,546 camera frames, zero pixel differences.

| Clip | dav1d ms/frameset | NVDEC ms/frameset | Speedup |
|---|---:|---:|---:|
| MIO10 | 3.400 | 3.082 | 1.103× |
| MGO09 | 3.713 | 14.063 | 0.264× |
| MOO09 | 1.723 | 5.124 | 0.336× |

Measured decode-only on CPU core 3 under the GPU flock, with prefetched MP4 bytes, one decoder thread, including initialization/download/gray8 conversion. This proves identity, not a general speedup. No dependency changes were required (PyAV 18.1.0).

Validation: Python suite 261 passed, 1 skipped; lint, typecheck and deadcode pass. The separately selected NVDEC integration test passed (1 passed in 1.88 s); it checks 20 MIO10 framesets through the feed and benchmark loader. Scratch catalog tooling and its nine-run wave3 dry run stay outside the repository. The full run was not launched. No RRD is a deliverable.
