### PR TITLE
slam-rs: replay a reference segment from a catalog server (--catalog)

### DIFF
--- a/packages/slam-rs/README.md
+++ b/packages/slam-rs/README.md
@@ -44,6 +44,7 @@ pixi run -e slam-rs-dev --frozen python tools/apps/replay.py --stage vio   # the
 pixi run -e slam-rs-dev --frozen python tools/apps/replay.py --stage vio --rr-config.headless --rr-config.save data/replay-vio.rrd
 pixi run -e slam-rs-dev --frozen python tools/apps/replay.py --stage vio --segment <segment-id>       # another reference segment
 pixi run -e slam-rs-dev --frozen python tools/apps/replay.py --stage vio --rrd base.rrd --gt-rrd gt.rrd   # a recording of your own
+pixi run -e slam-rs-dev --frozen python tools/apps/replay.py --stage vio --catalog rerun+http://dgx-spark:9988   # from a catalog server, no NAS mount needed
 ```
 
 In a shell without `DISPLAY`, pass `--rr-config.headless` or the spawned viewer
@@ -341,8 +342,6 @@ Not in this branch, in the order they are likely to matter:
 - **Results as a catalog layer.** One layer per segment with the estimated poses, the
   landmarks and the keypoints on the base recording's entity paths, registered beside
   the ground truth, so a run is browsed in the viewer, not in a CSV.
-- **A catalog URL on the command line.** The feed reads the catalog already; the replay
-  tool only reaches it through manifest entries.
 - **Less code.** Under the tolerance requirement (D60, D64) the Lie groups and the camera
   models could come from kornia-rs and the Eigen-order QR, LDLT and SVD from nalgebra;
   the ten-clip gate decides. About 2,800 lines.

--- a/packages/slam-rs/slam_rs/apis/replay.py
+++ b/packages/slam-rs/slam_rs/apis/replay.py
@@ -35,9 +35,11 @@ from simplecv.rerun_log_utils import RerunTyroConfig
 from slam_rs import _core
 from slam_rs.catalog_feed import (
     DEFAULT_WINDOW_S,
+    CatalogSegment,
     Frameset,
     LocalSegment,
     SegmentFeed,
+    SegmentSource,
     open_segment,
 )
 from slam_rs.frontend_log import FrontendLogger, frontend_blueprint
@@ -80,6 +82,13 @@ class Config:
     """
     gt_rrd: Path | None = None
     """Ground-truth ``.rrd`` for ``--rrd``; the manifest's own path is used when neither is given."""
+    catalog: str | None = None
+    """Read ``--segment`` from this catalog server instead of the manifest's file paths, e.g. ``rerun+http://dgx-spark:9988``.
+
+    The ground truth comes from the same dataset's layer on the server, so a
+    machine with no NAS mount replays a reference segment from its id alone.
+    Exclusive with ``--rrd`` and ``--gt-rrd``, which name a second source.
+    """
     max_framesets: int | None = None
     """Stop after this many framesets; None replays the whole segment."""
     frame_stride: int = 1
@@ -198,12 +207,18 @@ def main(config: Config) -> None:
     """
     manifest: ReferenceManifest = load_manifest(artifact_root=config.artifact_root)
     segment: ReferenceSegment = manifest.by_id(config.segment)
-    source: LocalSegment = LocalSegment(
-        base_rrd=config.rrd if config.rrd is not None else segment.base_path,
-        gt_rrd=config.gt_rrd if config.gt_rrd is not None else (None if config.rrd is not None else segment.gt_path),
-    )
+    source: SegmentSource
+    if config.catalog is not None:
+        if config.rrd is not None or config.gt_rrd is not None:
+            raise ValueError("--catalog and --rrd/--gt-rrd name two sources for one replay; pass one of them")
+        source = CatalogSegment(url=config.catalog, dataset_name=segment.dataset_name, segment_id=segment.segment_id)
+    else:
+        source = LocalSegment(
+            base_rrd=config.rrd if config.rrd is not None else segment.base_path,
+            gt_rrd=config.gt_rrd if config.gt_rrd is not None else (None if config.rrd is not None else segment.gt_path),
+        )
     output_csv: Path = config.output_csv if config.output_csv is not None else Path("data") / segment.segment_id / "slam_rs.csv"
-    print(f"replaying {segment.segment_id} ({segment.tier} tier) from {source.base_rrd}")
+    print(f"replaying {segment.segment_id} ({segment.tier} tier) from {config.catalog if config.catalog is not None else source.base_rrd}")
 
     with open_segment(source, segment.imu, frame_stride=config.frame_stride, window_s=config.window_s) as feed:
         print(

--- a/packages/slam-rs/slam_rs/apis/replay.py
+++ b/packages/slam-rs/slam_rs/apis/replay.py
@@ -208,17 +208,20 @@ def main(config: Config) -> None:
     manifest: ReferenceManifest = load_manifest(artifact_root=config.artifact_root)
     segment: ReferenceSegment = manifest.by_id(config.segment)
     source: SegmentSource
+    origin: str
     if config.catalog is not None:
         if config.rrd is not None or config.gt_rrd is not None:
             raise ValueError("--catalog and --rrd/--gt-rrd name two sources for one replay; pass one of them")
         source = CatalogSegment(url=config.catalog, dataset_name=segment.dataset_name, segment_id=segment.segment_id)
+        origin = config.catalog
     else:
         source = LocalSegment(
             base_rrd=config.rrd if config.rrd is not None else segment.base_path,
             gt_rrd=config.gt_rrd if config.gt_rrd is not None else (None if config.rrd is not None else segment.gt_path),
         )
+        origin = str(source.base_rrd)
     output_csv: Path = config.output_csv if config.output_csv is not None else Path("data") / segment.segment_id / "slam_rs.csv"
-    print(f"replaying {segment.segment_id} ({segment.tier} tier) from {config.catalog if config.catalog is not None else source.base_rrd}")
+    print(f"replaying {segment.segment_id} ({segment.tier} tier) from {origin}")
 
     with open_segment(source, segment.imu, frame_stride=config.frame_stride, window_s=config.window_s) as feed:
         print(

--- a/packages/slam-rs/tests/test_replay_source.py
+++ b/packages/slam-rs/tests/test_replay_source.py
@@ -1,0 +1,59 @@
+"""Which recording the replay tool opens: the manifest's files, a file of the caller's, or a catalog server.
+
+The catalog case is what a machine with no NAS mount uses, so it is pinned
+without a network: the segment is resolved and the source built before
+:func:`slam_rs.catalog_feed.open_segment` is reached, which the test replaces.
+"""
+
+from pathlib import Path
+
+import pytest
+from simplecv.rerun_log_utils import RerunTyroConfig
+
+from slam_rs.apis import replay
+from slam_rs.apis.replay import Config, main
+from slam_rs.catalog_feed import CatalogSegment, LocalSegment, SegmentSource
+from slam_rs.reference import SMOKE_SEGMENTS, ReferenceManifest
+
+CATALOG: str = "rerun+http://dgx-spark:9988"
+
+
+class _Opened(Exception):
+    """Raised by the stand-in feed so ``main`` stops once the source is chosen."""
+
+
+def _capture_source(monkeypatch: pytest.MonkeyPatch) -> list[SegmentSource]:
+    seen: list[SegmentSource] = []
+
+    def opened(source: SegmentSource, *_args: object, **_kwargs: object) -> None:
+        seen.append(source)
+        raise _Opened
+
+    monkeypatch.setattr(replay, "open_segment", opened)
+    return seen
+
+
+def test_a_catalog_url_replaces_the_manifests_file_paths(manifest: ReferenceManifest, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--catalog`` opens the segment by id on the server, ground truth included, with no file path involved."""
+    seen: list[SegmentSource] = _capture_source(monkeypatch)
+    segment = manifest.by_id(SMOKE_SEGMENTS[1])
+    with pytest.raises(_Opened):
+        main(Config(rr_config=RerunTyroConfig(headless=True), segment=segment.segment_id, catalog=CATALOG))
+    assert seen == [CatalogSegment(url=CATALOG, dataset_name=segment.dataset_name, segment_id=segment.segment_id)]
+
+
+def test_without_a_catalog_the_manifests_files_are_opened(manifest: ReferenceManifest, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default source is unchanged: the manifest's base and ground-truth recordings."""
+    seen: list[SegmentSource] = _capture_source(monkeypatch)
+    segment = manifest.by_id(SMOKE_SEGMENTS[1])
+    with pytest.raises(_Opened):
+        main(Config(rr_config=RerunTyroConfig(headless=True), segment=segment.segment_id))
+    assert seen == [LocalSegment(base_rrd=segment.base_path, gt_rrd=segment.gt_path)]
+
+
+def test_a_catalog_and_a_file_are_two_sources_and_refused(manifest: ReferenceManifest, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``--catalog`` with ``--rrd`` would silently pick one; the run stops with a sentence instead."""
+    seen: list[SegmentSource] = _capture_source(monkeypatch)
+    with pytest.raises(ValueError, match="two sources"):
+        main(Config(rr_config=RerunTyroConfig(headless=True), segment=SMOKE_SEGMENTS[1], catalog=CATALOG, rrd=tmp_path / "base.rrd"))
+    assert seen == []


### PR DESCRIPTION
`tools/apps/replay.py --catalog rerun+http://dgx-spark:9988 --segment <id>` opens the segment by id on the catalog server, ground truth from the same dataset's layer, instead of the manifest's NAS file paths. A laptop or a device with no NAS mount now replays a reference clip from its id alone; before this, that needed two `scp`s and `--rrd/--gt-rrd`. `--catalog` with `--rrd` or `--gt-rrd` is refused as two sources for one replay.

The feed's `CatalogSegment` did this already; the change is the option and the source selection in `replay.main`, three tests that pin which source is opened without a network (the feed is replaced), and the README command. Fast suite 273 passed, ruff, vulture and pyrefly clean. Live run from this host against the catalog: see the comment below.