### PR TITLE
slam-rs: --catalog replays any segment of a known dataset

### DIFF
--- a/packages/slam-rs/README.md
+++ b/packages/slam-rs/README.md
@@ -44,7 +44,7 @@ pixi run -e slam-rs-dev --frozen python tools/apps/replay.py --stage vio   # the
 pixi run -e slam-rs-dev --frozen python tools/apps/replay.py --stage vio --rr-config.headless --rr-config.save data/replay-vio.rrd
 pixi run -e slam-rs-dev --frozen python tools/apps/replay.py --stage vio --segment <segment-id>       # another reference segment
 pixi run -e slam-rs-dev --frozen python tools/apps/replay.py --stage vio --rrd base.rrd --gt-rrd gt.rrd   # a recording of your own
-pixi run -e slam-rs-dev --frozen python tools/apps/replay.py --stage vio --catalog rerun+http://dgx-spark:9988   # from a catalog server, no NAS mount needed
+pixi run -e slam-rs-dev --frozen python tools/apps/replay.py --stage vio --catalog rerun+http://dgx-spark:9988 --segment <any-segment-id>   # from a catalog server: any segment of a known dataset, no NAS mount
 ```
 
 In a shell without `DISPLAY`, pass `--rr-config.headless` or the spawned viewer

--- a/packages/slam-rs/slam_rs/apis/replay.py
+++ b/packages/slam-rs/slam_rs/apis/replay.py
@@ -43,7 +43,7 @@ from slam_rs.catalog_feed import (
     open_segment,
 )
 from slam_rs.frontend_log import FrontendLogger, frontend_blueprint
-from slam_rs.reference import SMOKE_SEGMENTS, ReferenceManifest, ReferenceSegment, load_manifest, resolved_flow_config
+from slam_rs.reference import SMOKE_SEGMENTS, ImuParameters, ReferenceManifest, ReferenceSegment, load_manifest, resolved_flow_config
 from slam_rs.reference_bundle import BundleFile
 from slam_rs.tracking import Lockstep
 from slam_rs.trajectory import Trajectory, ate, coverage, empty_trajectory, read_trajectory, shift_clock, write_trajectory
@@ -85,9 +85,12 @@ class Config:
     catalog: str | None = None
     """Read ``--segment`` from this catalog server instead of the manifest's file paths, e.g. ``rerun+http://dgx-spark:9988``.
 
-    The ground truth comes from the same dataset's layer on the server, so a
-    machine with no NAS mount replays a reference segment from its id alone.
-    Exclusive with ``--rrd`` and ``--gt-rrd``, which name a second source.
+    Any segment of a dataset the manifest knows replays this way, not only the
+    reference set: the IMU noise model and the basalt config are the dataset's,
+    and the server carries the rig calibration and the ground-truth layer. A
+    segment outside the reference set has no C++ run to compare with, so it is
+    scored against ground truth only. Exclusive with ``--rrd`` and ``--gt-rrd``,
+    which name a second source.
     """
     max_framesets: int | None = None
     """Stop after this many framesets; None replays the whole segment."""
@@ -206,33 +209,50 @@ def main(config: Config) -> None:
         config: Parsed CLI options.
     """
     manifest: ReferenceManifest = load_manifest(artifact_root=config.artifact_root)
-    segment: ReferenceSegment = manifest.by_id(config.segment)
+    listed: ReferenceSegment | None = next((s for s in manifest.segments if s.segment_id == config.segment), None)
+    dataset_name: str = listed.dataset_name if listed is not None else config.segment.split("__")[0]
+    # A segment outside the reference set takes its dataset's parameters: the IMU
+    # noise model and the basalt config are per device, and the catalog carries the
+    # rig and the ground truth itself. What it cannot have is a C++ run to compare with.
+    vio_config: _core.VioConfig
+    imu: ImuParameters
+    if listed is not None:
+        vio_config, _config_text = resolved_flow_config(manifest, listed, profile=config.profile)
+        imu = listed.imu
+    else:
+        vio_config = _core.VioConfig.from_json(manifest.vio_config_text(dataset_name, profile=config.profile))  # refuses an unknown dataset
+        imu = next(s.imu for s in manifest.segments if s.dataset_name == dataset_name)
     source: SegmentSource
     origin: str
     if config.catalog is not None:
         if config.rrd is not None or config.gt_rrd is not None:
             raise ValueError("--catalog and --rrd/--gt-rrd name two sources for one replay; pass one of them")
-        source = CatalogSegment(url=config.catalog, dataset_name=segment.dataset_name, segment_id=segment.segment_id)
+        source = CatalogSegment(url=config.catalog, dataset_name=dataset_name, segment_id=config.segment)
         origin = config.catalog
-    else:
+    elif listed is not None:
         source = LocalSegment(
-            base_rrd=config.rrd if config.rrd is not None else segment.base_path,
-            gt_rrd=config.gt_rrd if config.gt_rrd is not None else (None if config.rrd is not None else segment.gt_path),
+            base_rrd=config.rrd if config.rrd is not None else listed.base_path,
+            gt_rrd=config.gt_rrd if config.gt_rrd is not None else (None if config.rrd is not None else listed.gt_path),
         )
         origin = str(source.base_rrd)
-    output_csv: Path = config.output_csv if config.output_csv is not None else Path("data") / segment.segment_id / "slam_rs.csv"
-    print(f"replaying {segment.segment_id} ({segment.tier} tier) from {origin}")
+    else:
+        raise ValueError(
+            f"{config.segment!r} is not in the reference set, the only segments the manifest has files for; "
+            f"have {[s.segment_id for s in manifest.segments]}. With --catalog any segment of a known dataset replays from the server."
+        )
+    output_csv: Path = config.output_csv if config.output_csv is not None else Path("data") / config.segment / "slam_rs.csv"
+    print(
+        f"replaying {config.segment} ({f'{listed.tier} tier' if listed is not None else 'not in the reference set: ground truth only'}) from {origin}"
+    )
 
-    with open_segment(source, segment.imu, frame_stride=config.frame_stride, window_s=config.window_s) as feed:
+    with open_segment(source, imu, frame_stride=config.frame_stride, window_s=config.window_s) as feed:
         print(
             f"{len(feed.cameras)} cameras, {len(feed.frame_t_ns)} framesets, ground truth "
             f"{'attached' if feed.has_ground_truth else 'absent'}, clock offset {feed.capture_start_time_ns} ns"
         )
         log_calibration(feed.cameras)
         stage: FrontendStage | VioStage | None = None
-        vio_config: _core.VioConfig
         if config.stage == "frontend":
-            vio_config, _config_text = resolved_flow_config(manifest, segment, profile=config.profile)
             stage = FrontendStage(
                 flow=_core.OpticalFlow(_core.Calibration.from_catalog(feed.cameras, feed.imu), vio_config),
                 logger=FrontendLogger(len(feed.cameras), feed.segment_id),
@@ -245,14 +265,13 @@ def main(config: Config) -> None:
             # with no driver, no device or no adapter — and the shim
             # (:func:`slam_rs.apis.run`) is what turns it into one sentence and a
             # non-zero exit rather than a traceback through the feed.
-            vio_config, _config_text = resolved_flow_config(manifest, segment, profile=config.profile)
             vio: _core.Vio = _core.Vio(_core.Calibration.from_catalog(feed.cameras, feed.imu), vio_config, gpu=config.gpu)
             stage = VioStage(
                 lockstep=Lockstep(vio=vio),
                 logger=VioLogger(
                     cameras=feed.cameras,
                     ground_truth=truth,
-                    cpp=_cpp_trajectory(manifest, segment, feed.capture_start_time_ns, feed.segment_id),
+                    cpp=_cpp_trajectory(manifest, listed, feed.capture_start_time_ns, feed.segment_id) if listed is not None else empty_trajectory(),
                     frame_t_ns=feed.frame_t_ns,
                 ),
             )

--- a/packages/slam-rs/tests/test_replay_source.py
+++ b/packages/slam-rs/tests/test_replay_source.py
@@ -13,20 +13,24 @@ from simplecv.rerun_log_utils import RerunTyroConfig
 from slam_rs.apis import replay
 from slam_rs.apis.replay import Config, main
 from slam_rs.catalog_feed import CatalogSegment, LocalSegment, SegmentSource
-from slam_rs.reference import SMOKE_SEGMENTS, ReferenceManifest
+from slam_rs.reference import SMOKE_SEGMENTS, ImuParameters, ReferenceManifest
 
 CATALOG: str = "rerun+http://dgx-spark:9988"
+UNLISTED: str = "msd-g2__MGO_others__MGO11_short_3_backandforth"
+"""A catalog segment of a known dataset that the reference set does not list."""
 
 
 class _Opened(Exception):
     """Raised by the stand-in feed so ``main`` stops once the source is chosen."""
 
 
-def _capture_source(monkeypatch: pytest.MonkeyPatch) -> list[SegmentSource]:
+def _capture_source(monkeypatch: pytest.MonkeyPatch, parameters: list[ImuParameters] | None = None) -> list[SegmentSource]:
     seen: list[SegmentSource] = []
 
-    def opened(source: SegmentSource, *_args: object, **_kwargs: object) -> None:
+    def opened(source: SegmentSource, imu: ImuParameters, *_args: object, **_kwargs: object) -> None:
         seen.append(source)
+        if parameters is not None:
+            parameters.append(imu)
         raise _Opened
 
     monkeypatch.setattr(replay, "open_segment", opened)
@@ -56,4 +60,30 @@ def test_a_catalog_and_a_file_are_two_sources_and_refused(manifest: ReferenceMan
     seen: list[SegmentSource] = _capture_source(monkeypatch)
     with pytest.raises(ValueError, match="two sources"):
         main(Config(rr_config=RerunTyroConfig(headless=True), segment=SMOKE_SEGMENTS[1], catalog=CATALOG, rrd=tmp_path / "base.rrd"))
+    assert seen == []
+
+
+def test_an_unlisted_catalog_segment_takes_its_datasets_parameters(manifest: ReferenceManifest, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Any segment of a known dataset replays from the catalog with that dataset's IMU model; no manifest entry is needed."""
+    parameters: list[ImuParameters] = []
+    seen: list[SegmentSource] = _capture_source(monkeypatch, parameters)
+    with pytest.raises(_Opened):
+        main(Config(rr_config=RerunTyroConfig(headless=True), segment=UNLISTED, catalog=CATALOG))
+    assert seen == [CatalogSegment(url=CATALOG, dataset_name="msd-g2", segment_id=UNLISTED)]
+    assert parameters == [next(s.imu for s in manifest.segments if s.dataset_name == "msd-g2")]
+
+
+def test_an_unlisted_segment_without_a_catalog_is_refused_with_the_way_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The manifest has files only for the reference set; the refusal names --catalog."""
+    seen: list[SegmentSource] = _capture_source(monkeypatch)
+    with pytest.raises(ValueError, match="not in the reference set.*--catalog"):
+        main(Config(rr_config=RerunTyroConfig(headless=True), segment=UNLISTED))
+    assert seen == []
+
+
+def test_a_catalog_segment_of_an_unknown_dataset_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A dataset the manifest has no config or IMU model for cannot be replayed, catalog or not."""
+    seen: list[SegmentSource] = _capture_source(monkeypatch)
+    with pytest.raises(ValueError, match="'msd-nowhere' is not in the reference set"):
+        main(Config(rr_config=RerunTyroConfig(headless=True), segment="msd-nowhere__X__Y", catalog=CATALOG))
     assert seen == []


### PR DESCRIPTION
Follow-up to #257, which merged before this commit reached the branch. `--catalog` now accepts any segment id of a dataset the manifest knows (msd-index, msd-g2), not only the ten reference segments: the dataset's IMU model and basalt config come from the manifest's dataset block, the rig and the ground truth from the catalog, and a segment outside the reference set is scored against ground truth only. A file-based replay of an unlisted id refuses and names `--catalog`; an unknown dataset is refused by the manifest.

Live from pablo-dl-server: `msd-g2__MGO_others__MGO11_short_3_backandforth`, 4 cameras, 539 framesets in 9.3 s, ATE 2.30 cm against ground truth (the S32 catalog run's number). Three new tests pin the source and IMU selection without a network; fast suite 276 passed, ruff, vulture and pyrefly clean.