### PR TITLE
slam-rs: docs and comments describe the crate on its own terms

### DIFF
--- a/packages/slam-rs/README.md
+++ b/packages/slam-rs/README.md
@@ -4,8 +4,8 @@
   <img src="media/slam-rs-github.gif" alt="slam-rs replaying a Monado SLAM Dataset clip in Rerun: the estimated trajectory against ground truth, the landmarks, the rig, and the tracked keypoints on the camera frames" width="800" />
 </p>
 
-Visual-inertial odometry with a Rust core. The estimator is a port of the
-basalt VIO fork: pure Rust, N-camera from the start, with a CPU frontend and a
+Visual-inertial odometry with a Rust core and support for multiple cameras,
+a CPU frontend and a
 portable GPU frontend through CubeCL and wgpu. Python owns the plumbing —
 catalog feed, decode, evaluation and Rerun logging — and talks to the core
 through a PyO3 extension module, so the whole pipeline runs from Python:
@@ -17,7 +17,7 @@ Each lane/profile is compared with its measured baseline in
 `reference_segments.toml`. MIO10 GPU fast scores about 1.55 cm on the RTX 5090.
 The same code runs on `linux-64`, `linux-aarch64`, and macOS `osx-arm64`.
 
-Design notes — the module-by-module account of the port, the full Python API,
+Design notes — the module-by-module account of the estimator, the full Python API,
 the reference set, the gates and every recorded decision:
 [docs/design-notes.md](docs/design-notes.md).
 
@@ -77,19 +77,18 @@ default in every tracking tool.
 {"config.vio_max_iterations": 7, "port.redetect_survivor_ratio": 0.85, "port.frame_update_max_iterations": 5}
 ```
 
-A key spelled `port.` is a knob basalt has no field for; absent, it reproduces
-basalt's behaviour. A key that is neither a basalt field nor a listed port key
-is a `KeyError`, so a typo cannot silently change a run. The fast profile changes
+Keys under `port.` select additional scheduling options. Their zero defaults
+retain per-frame detection and joint optimization. Unknown configuration or
+overlay keys raise `KeyError`, so a typo cannot silently change a run. The fast profile changes
 two things about the schedule and nothing about the arithmetic:
 
-- **Detection on demand.** basalt tops up every empty grid cell on every
-  frameset. The fast profile detects only when camera 0 holds fewer than 85 % of
+- **Detection on demand.** The reference profile detects every frameset. The fast profile detects only when camera 0 holds fewer than 85 % of
   the keypoints the last detecting frameset ended with, which is cuVSLAM's
   schedule.
-- **The window is solved at keyframes.** basalt re-solves the whole sliding
-  window on every frameset. The fast profile does so at keyframes only; between
+- **The window is solved at keyframes.** The reference profile solves the
+  whole sliding window every frameset. The fast profile does so at keyframes only; between
   them it solves the newest pose, velocity and biases against the held landmarks
-  and the IMU factor, five steps at most, and falls back to the joint solve when
+  and the IMU factor, up to six trials with the inclusive iteration cap, and falls back to the joint solve when
   that update declines. `VioSnapshot.frame_update` says which one ran.
 
 The gate compares each clip with the baseline for the selected lane and
@@ -163,10 +162,10 @@ frame = flow.process(t_ns, [left, right])
 frame.ids(0), frame.positions(0), frame.transforms(0), frame.occupancy(0)
 ```
 
-One `track` call is basalt's whole pipeline for one frameset in the calling
+One `track` call runs the whole pipeline for one frameset in the calling
 thread (Offline mode, D17), so every result is final and a repeat run over the
-same input is bit-identical. `VioStatus` has two states: `NeedMoreImu` where
-basalt would block on its IMU queue, `Tracking` otherwise; `replay.py` holds
+same input is bit-identical. `VioStatus` has two states: `NeedMoreImu` until
+IMU coverage extends past the frameset, `Tracking` otherwise; `replay.py` holds
 such a frameset and pushes it again once its samples arrive.
 
 Design notes — the accessors field by field, every refusal and its ceiling, and
@@ -193,24 +192,24 @@ Design notes — the accessors field by field, every refusal and its ceiling, an
 
 | Module | What it is |
 |---|---|
-| `lie` | `So3`/`Se3` over any `f32`/`f64` scalar: Sophus's `exp`/`log`, the adjoint, basalt's four SO(3) Jacobians and the decoupled SE(3) pair. |
+| `lie` | `So3`/`Se3` over any `f32`/`f64` scalar: SO(3) operations through kornia-algebra, the adjoint, four SO(3) Jacobians and the decoupled SE(3) pair. |
 | `types` | `TimeCamId`, `KeypointId`/`LandmarkId`, `AbsOrderMap`, the three pose states and the two fixed-linearization wrappers. |
-| `config` | basalt's `VioConfig`, read straight from `configs/*_config.json`, plus the `port.*` overlay keys the profiles set. |
-| `calib` | basalt's `Calibration`: extrinsics, the six shipped camera models, the 9- and 12-parameter IMU bias calibrations. |
-| `camera` | `pinhole`, `kb4` and `pinhole-radtan8` with basalt's 4-D homogeneous `project`/`unproject` and their analytic Jacobians. |
-| `image` | `ImageU16`: an owned flat 16-bit frame with an explicit row stride, and `interp`/`interp_grad`/`in_bounds` from `image.h`. |
-| `pyramid` | The `PyramidBuilder` stage seam, `PyramidU16`, and `CpuPyramidBuilder`, whose `subsample` is bit-exact with `image_pyr.h`. |
+| `config` | `VioConfig`, read straight from `configs/*_config.json`, plus the `port.*` overlay keys the profiles set. |
+| `calib` | `Calibration`: extrinsics, the six shipped camera models, the 9- and 12-parameter IMU bias calibrations. |
+| `camera` | `pinhole`, `kb4` and `pinhole-radtan8` with 4-D homogeneous `project`/`unproject` and their analytic Jacobians. |
+| `image` | `ImageU16`: an owned flat 16-bit frame with an explicit row stride, and bilinear sampling, central-difference gradients and interpolation bounds. |
+| `pyramid` | The `PyramidBuilder` stage seam, `PyramidU16`, and `CpuPyramidBuilder`, with a separable integer Gaussian filter and one final rounding. |
 | `landmark` | `StereographicParam`, the three-parameter `Landmark`, and `LandmarkDatabase` with a reproducible iteration order (D31). |
 | `ba_base` | `BundleAdjustmentBase`: the window state maps, Huber-weighted `compute_error`, the reprojection residual and its three Jacobians, DLT `triangulate`. |
-| `imu` | Preintegration: basalt's midpoint propagation, the covariance and bias-Jacobian recurrences, the 9-vector residual, gravity initialisation. |
+| `imu` | Preintegration: midpoint propagation, the covariance and bias-Jacobian recurrences, the 9-vector residual, gravity initialisation. |
 | `frontend` | The optical-flow frontend: `patterns`, `se2`, `ldlt`, `patch`, `tracker`, `detect`, `flow` (`FrameToFrameOpticalFlow`, with detection on demand) and `parallel`. |
 | `gpu` | The CubeCL frontend behind `gpu-wgpu`: the kernels, the per-cell corner selection, the patch and track stages, the `ReadRelay` that lets one stage's download carry another's buffers, and the seam counters. |
 | `linearize` | The square-root linearization: `LandmarkBlock` and `LinearizationAbsQR`, which produce `H`, `b`, `Q2Jp`, `Q2r` and `l_diff`. |
 | `marg` | Square-root marginalization: `MargHelper`'s rank-revealing flat Householder QR and `marginalizeHelperSqrtToSqrt`. |
-| `eigen` | The Eigen ports in one place — `qr`, `ldlt`, `svd`, `blas` — each reproducing Eigen's **operation order** rather than only its result (D44). |
+| `qr` | In-place nalgebra reflections and Givens rotations, using column-major storage and reusable scratch. |
 | `estimator` | The Offline sliding-window driver: `process_frame`, `schedule` (the keyframe vote and the keep/marginalize sets), the Levenberg-Marquardt `optimize` over reused scratch, and `frame_update`, the fast profile's between-keyframes solve. |
 
-Design notes — what each module reproduces, quoted against the C++ it comes from
+Design notes — each module's role and numerical contracts
 ([Core modules](docs/design-notes.md#core-modules)), and the four stages where an ulp or a rank
 decision is load-bearing: [the frontend](docs/design-notes.md#the-frontend-and-the-one-thing-that-is-not-bit-parity),
 [the landmark stage](docs/design-notes.md#the-landmark-stage-and-where-an-ulp-is-load-bearing),
@@ -337,11 +336,11 @@ Not in this branch, in the order they are likely to matter:
 - **The Python seam.** 0.14 ms a frameset between the feed and `Vio.track`,
   fixed across clips: a tenth of a fast `MIO10` call.
 - **More datasets.** Camera-only datasets (Assembly101, HO-Cap, the WildCap sets)
-  need basalt's vision-only estimator ported beside the VIO. Aria recordings need
+  need a vision-only estimator alongside the VIO. Aria recordings need
   the fisheye624 camera model.
 - **Results as a catalog layer.** One layer per segment with the estimated poses, the
   landmarks and the keypoints on the base recording's entity paths, registered beside
   the ground truth, so a run is browsed in the viewer, not in a CSV.
 - **Less code.** With ground-truth accuracy checks the Lie groups and the camera
-  models could come from kornia-rs and the Eigen-order QR, LDLT and SVD from nalgebra;
-  the ten-clip gate decides. About 2,800 lines.
+  models could move further into kornia-rs. S34 already uses nalgebra for QR,
+  the damped solve and SVD; the ground-truth gate checks further replacements.

--- a/packages/slam-rs/configs/README
+++ b/packages/slam-rs/configs/README
@@ -1,4 +1,4 @@
-Dataset VIO configurations and RoboCap calibration.
+slam-rs JSON inputs: dataset VIO configurations and RoboCap calibration.
 
 Each dataset in ../reference_segments.toml selects one configuration. The
 reference profile leaves it unchanged. The default fast profile applies the

--- a/packages/slam-rs/crates/slam-rs-py/src/lib.rs
+++ b/packages/slam-rs/crates/slam-rs-py/src/lib.rs
@@ -113,30 +113,11 @@ pub struct Vio {
 
 #[pymethods]
 impl Vio {
-    /// Build the pipeline from basalt's own calibration and config.
-    ///
-    /// The two objects are the ones [`OpticalFlow`] takes: basalt's files arrive
-    /// through [`Calibration::from_json`] and [`VioConfig::from_json`], and the
-    /// catalog's own dataclasses through [`Calibration::from_catalog`]. The
-    /// estimator runs in single precision, which is the precision every
-    /// reference run was produced at (`use-double` false).
-    /// `gpu` runs the frontend's pyramid, patch build and KLT tracker through
-    /// CubeCL on this host's GPU instead of the CPU port (decision D21). The
-    /// default is the CPU, which is what every accuracy reference was produced
-    /// on; a build without the `gpu-wgpu` cargo feature refuses `gpu=True` rather
-    /// than ignoring it, and so does a build that has the feature on a host
-    /// with no usable GPU — a missing driver library, a driver that will not
-    /// initialise, no visible device, no adapter — each a `ValueError` naming
-    /// what is absent rather than the `PanicException` CubeCL's own unwrapped
-    /// bring-up produces (decision D32). A failure no probe anticipates is
-    /// caught rather than raised, so it is a `ValueError` too — with the
-    /// runtime's own panic message left on stderr, which is the only account of
-    /// a case the probe did not know to ask about.
-    ///
-    /// `threads` is **inert on the GPU lane**: it reaches
-    /// `FrontendOptions::threads`, which only `CpuPatchTracker::new` reads, and
-    /// the GPU tracker holds no work pool. It is accepted rather than refused
-    /// together with `gpu=True` so the same call site can select either lane.
+    /// Build an f32 pipeline from calibration and configuration.
+    /// Inputs can come from JSON or catalog dataclasses. CPU is the default; `gpu`
+    /// selects CubeCL frontend stages. Missing feature support or unusable runtime
+    /// returns `ValueError`, including caught runtime initialization panics (D32).
+    /// `threads` controls only the CPU pool and is accepted but inert with `gpu=True`.
     #[new]
     #[pyo3(signature = (calibration, config, *, threads = 1, max_keypoints = None, gpu = false))]
     fn new(
@@ -713,11 +694,7 @@ fn float64_triples(object: &Bound<'_, PyAny>, name: &str) -> PyResult<Vec<[f64; 
         .collect())
 }
 
-/// basalt's `VioConfig`, as `data/**/*_config.json` carries it.
-///
-/// A fresh instance is `VioConfig::VioConfig()`, the same defaults the C++
-/// constructor sets; `VioConfig::from_json` then overwrites whatever keys a
-/// file names, leaving the rest alone, as cereal does.
+/// VIO configuration read from JSON. Omitted keys retain constructor defaults.
 #[pyclass(module = "slam_rs._core", skip_from_py_object)]
 #[derive(Debug, Clone)]
 pub struct VioConfig {
@@ -726,7 +703,7 @@ pub struct VioConfig {
 
 #[pymethods]
 impl VioConfig {
-    /// basalt's own defaults (`src/utils/vio_config.cpp:47-128`).
+    /// Default VIO configuration.
     #[new]
     fn new() -> Self {
         Self {
@@ -734,7 +711,7 @@ impl VioConfig {
         }
     }
 
-    /// Read one of basalt's config files; keys it omits keep their default.
+    /// Read configuration JSON, retaining defaults for omitted keys.
     #[staticmethod]
     fn from_json(text: &str) -> PyResult<Self> {
         Ok(Self {
@@ -742,7 +719,7 @@ impl VioConfig {
         })
     }
 
-    /// Write the config back in basalt's shape, `value0` wrapper and all.
+    /// Write configuration JSON with the `value0` wrapper.
     fn to_json(&self) -> PyResult<String> {
         self.inner.to_json_string().map_err(value_error)
     }
@@ -774,14 +751,9 @@ impl VioConfig {
     }
 }
 
-/// basalt's camera-IMU calibration: extrinsics, intrinsics and the noise model.
-///
-/// Either read from one of basalt's calibration files, or built from what the
-/// catalog feed reports. The second path takes
-/// `slam_rs.catalog_feed.CameraCalib` and `ImuCalib` field by field, so the
-/// catalog-to-basalt rules — the rotation-matrix check, the model names, the
-/// isotropic noise densities — stay in the Rust that is tested against basalt's
-/// own JSON rather than being written a second time in Python.
+/// Camera-IMU calibration: extrinsics, intrinsics and noise model.
+/// Read JSON or copy catalog dataclass fields into the same Rust implementation.
+/// Rotation validation, model names and isotropic noise conversion stay in one place.
 #[pyclass(module = "slam_rs._core", skip_from_py_object)]
 #[derive(Debug, Clone)]
 pub struct Calibration {
@@ -790,7 +762,7 @@ pub struct Calibration {
 
 #[pymethods]
 impl Calibration {
-    /// Read one of basalt's calibration files.
+    /// Read calibration JSON.
     #[staticmethod]
     fn from_json(text: &str) -> PyResult<Self> {
         Ok(Self {
@@ -798,11 +770,8 @@ impl Calibration {
         })
     }
 
-    /// Build the calibration from the feed's dataclasses.
-    ///
-    /// `cameras` are `CameraCalib` in rig order and `imu` is an `ImuCalib`; only
-    /// the fields basalt models are read, so `ImuCalib.imu_T_body` is ignored —
-    /// the rig reference frame *is* the IMU on every recording the feed reads.
+    /// Build calibration from cameras in rig order and IMU fields.
+    /// `imu_T_body` is ignored because the recording rig frame is the IMU frame.
     #[staticmethod]
     fn from_catalog(cameras: Vec<Bound<'_, PyAny>>, imu: &Bound<'_, PyAny>) -> PyResult<Self> {
         let mut parts: Vec<CoreCameraParts<f64>> = Vec::with_capacity(cameras.len());
@@ -815,7 +784,7 @@ impl Calibration {
         })
     }
 
-    /// Write the calibration back in basalt's shape, `value0` wrapper and all.
+    /// Write calibration JSON with the `value0` wrapper.
     fn to_json(&self) -> PyResult<String> {
         self.inner.to_json_string().map_err(value_error)
     }
@@ -901,10 +870,7 @@ impl FlowFrame {
         self.grid.cell
     }
 
-    /// `(x_start, y_start)`: the top-left corner of cell `(0, 0)` in pixels.
-    ///
-    /// basalt centres the grid on the frame, so the leftover `width % cell` is
-    /// split between the two edges (`keypoints.cpp:140-144`).
+    /// Top-left grid origin; split leftover pixels between the two image edges.
     #[getter]
     fn cell_origin(&self) -> (usize, usize) {
         (self.grid.x_start, self.grid.y_start)
@@ -946,10 +912,7 @@ impl FlowFrame {
             .reshape((keypoints.ids.len(), 2, 3))
     }
 
-    /// One camera's occupancy counts: `int32[rows, columns]`.
-    ///
-    /// The grid is camera 0's, as basalt's is (`frame_to_frame_optical_flow.h:119`),
-    /// whatever the camera's own resolution is.
+    /// Occupancy counts with camera 0's grid shape, regardless of this camera's resolution.
     fn occupancy<'py>(
         &self,
         py: Python<'py>,
@@ -978,11 +941,8 @@ impl FlowFrame {
     }
 }
 
-/// basalt's `FrameToFrameOpticalFlow`, driven one frameset at a time.
-///
-/// Pattern 51 only: every shipped config sets `optical_flow_pattern = 51`, and a
-/// config asking for another one is refused rather than silently tracked with
-/// the wrong pattern.
+/// Frame-to-frame optical flow, driven one frameset at a time.
+/// Only Pattern51 is supported; other configured patterns are refused.
 #[pyclass(module = "slam_rs._core")]
 pub struct OpticalFlow {
     inner: FrontendLane,
@@ -992,10 +952,7 @@ pub struct OpticalFlow {
 
 #[pymethods]
 impl OpticalFlow {
-    /// Build a frontend for one rig.
-    ///
-    /// One of basalt's own files arrives through [`Calibration::from_json`] and
-    /// [`VioConfig::from_json`], so this takes the two classes only.
+    /// Build a frontend from calibration and configuration objects loaded through their JSON APIs.
     #[new]
     #[pyo3(signature = (calibration, config, *, threads = 1, max_keypoints = None))]
     fn new(
@@ -1189,10 +1146,7 @@ fn camera_parts(object: &Bound<'_, PyAny>, index: usize) -> PyResult<CoreCameraP
     })
 }
 
-/// One `slam_rs.catalog_feed.ImuCalib`, read attribute by attribute.
-///
-/// `imu_T_body` is not read: basalt's calibration has no such field, because the
-/// rig reference frame *is* the IMU on every recording the feed reads.
+/// Read catalog IMU fields. `imu_T_body` is unused because the rig frame is the IMU frame.
 fn imu_parts(object: &Bound<'_, PyAny>) -> PyResult<CoreImuParts<f64>> {
     let what: &str = "imu";
     Ok(CoreImuParts {

--- a/packages/slam-rs/crates/slam-rs/src/ba_base.rs
+++ b/packages/slam-rs/crates/slam-rs/src/ba_base.rs
@@ -1,36 +1,19 @@
-//! The bundle-adjustment base: sliding-window state, the reprojection residual
-//! and DLT triangulation.
+//! The bundle-adjustment base: sliding-window state, reprojection residuals and DLT triangulation.
 //!
-//! Ported from `include/basalt/vi_estimator/ba_base.h`,
-//! `src/vi_estimator/ba_base.cpp` and `include/basalt/utils/ba_utils.h`.
-//! Everything the square-root linearizer needs before it starts building
-//! landmark blocks lives here: the two state maps, the landmark database, the
-//! per-observation residual with its three Jacobians, the relative pose that is
-//! hoisted per (host, target) pair, the error the Levenberg-Marquardt loop
-//! accepts or rejects on, and `backup`/`restore`.
+//! This module owns the state maps, landmark database, per-observation residuals,
+//! relative poses, objective cost and backup/restore operations.
 //!
-//! Three conventions are load-bearing, and each one is a documented deviation of
-//! basalt's code from its own papers (papers-part2 §13):
+//! Three conventions determine the estimator's updates:
+//! * The residual is `pi(...) - z`, opposite to Paper 1 Eq. (8). The solver
+//!   negates its increment before back-substitution. Changing either sign alone
+//!   reverses the update.
+//! * Huber weighting uses raw pixel residuals before division by `obs_std_dev^2`.
+//!   A 1 px threshold with a 0.5 px deviation is therefore a 2-sigma threshold.
+//! * Pose increments are decoupled and left-multiplied; the pose Jacobians
+//!   differentiate that increment.
 //!
-//! * **The residual sign is flipped.** Paper 1 Eq. (8) is `r = z - pi(...)`;
-//!   `ba_utils.h:117` computes `res -= kpt_obs`, i.e. `pi(...) - z`. `J^T J` does
-//!   not care, `J^T r` does, and basalt compensates by negating the increment at
-//!   `sqrt_keypoint_vio.cpp:1450` (`inc = -inc`). The port keeps **both** halves:
-//!   [`linearize_point`] returns basalt's sign, and the increment is negated
-//!   where basalt negates it (a later stage). Fixing one without the other
-//!   inverts the whole optimisation.
-//! * **Huber is applied to the raw pixel residual, `1/sigma` afterwards.**
-//!   `ba_base.cpp:179-182` compares `res.norm()` against `huber_thresh` in
-//!   pixels and only then divides by `obs_std_dev^2`. With the shipped
-//!   `vio_obs_huber_thresh = 1.0` px and `vio_obs_std_dev = 0.5` px, the
-//!   effective threshold is **2 sigma**, not 1.
-//! * **The pose increment is the decoupled, left-multiplied one**
-//!   (`imu_types.h:96-99`), which is what `d_res_d_xi` is taken with respect to.
-//!
-//! Parallelism: none in this stage. `compute_error` is written as a fixed-order
-//! fold over per-host-frame partial results, so the `threads` config field can
-//! later turn the middle line into a `par_chunks` over the same `Vec` with the
-//! same sequential merge and produce the same floating-point sum (decision D31).
+//! Error accumulation uses a fixed-order fold over host-frame partial results
+//! (decision D31). This keeps the floating-point sum deterministic.
 
 use std::collections::BTreeMap;
 
@@ -50,21 +33,18 @@ use crate::types::{
 
 /// What the bundle-adjustment base refuses to do.
 ///
-/// Each variant replaces a place where C++ aborts, asserts or indexes out of
-/// range. The estimator runs inside a released GIL where a panic aborts the
-/// process, so none of these may be a panic (decision D32, trap 15).
+/// Data errors must return typed errors: a panic while the estimator runs with
+/// the GIL released can abort the process (decision D32, trap 15).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum BaError {
     /// `getPoseStateWithLin` found the timestamp in neither map and called
-    /// `std::abort()` (`ba_base.h:131-142`).
+    /// `std::abort()`.
     #[error("no pose or state for frame {t_ns} ns")]
     UnknownFrame {
         /// The timestamp that was looked up.
         t_ns: FrameId,
     },
-    /// An image named a camera the calibration does not have; C++ indexes
-    /// `calib.T_i_c[cam_id]` and `calib.intrinsics[cam_id]` unchecked
-    /// (`ba_base.cpp:154-155`, `:188`).
+    /// An image names a camera absent from the calibration.
     #[error("camera {cam_id} is not in the calibration ({camera_count} cameras)")]
     UnknownCamera {
         /// The camera index that was asked for.
@@ -72,13 +52,10 @@ pub enum BaError {
         /// Cameras the calibration carries.
         camera_count: usize,
     },
-    /// The adjacency named a landmark the database does not hold, or a landmark
-    /// has no observation in a target the adjacency lists it under; C++ throws
-    /// from `at` (`ba_base.cpp:165-166`).
+    /// The adjacency names a missing landmark or an observation absent from its target.
     #[error("landmark {0:?} is missing from the database or from that target")]
     InconsistentLandmark(LandmarkId),
-    /// `computeDelta` met a block that is neither a pose nor a full state
-    /// (`ba_base.cpp:300`, `BASALT_ASSERT(false)`).
+    /// The delta computation met a block that is neither a pose nor a full state.
     #[error("frame {frame_id}: block size {size} is neither {POSE_SIZE} nor {POSE_VEL_BIAS_SIZE}")]
     UnexpectedBlockSize {
         /// The frame the ordering names.
@@ -86,15 +63,14 @@ pub enum BaError {
         /// The size it was given.
         size: usize,
     },
-    /// `computeDelta` met a block whose linearization point is not frozen
-    /// (`ba_base.cpp:294`, `:297`). Its delta would be meaningless.
+    /// The block is not frozen at its linearization point, so its delta is undefined.
     #[error("frame {frame_id} is in the marginalization ordering but is not linearized")]
     NotLinearized {
         /// The frame the ordering names.
         frame_id: FrameId,
     },
     /// The marginalization prior's matrix does not match its own ordering, or
-    /// the destination system is too small (`ba_base.cpp:379`, `:444` assert).
+    /// the destination system is too small (assert).
     #[error("marginalization prior has {cols} columns, expected {total_size}")]
     MargPriorSize {
         /// The prior's column count.
@@ -102,8 +78,7 @@ pub enum BaError {
         /// What its ordering says it should be.
         total_size: usize,
     },
-    /// The prior's ordering disagrees with the window's, which C++ asserts
-    /// block by block (`ba_base.cpp:383-388`).
+    /// The prior's ordering disagrees with the window's block ordering.
     #[error("frame {frame_id} has a different offset in the prior than in the window")]
     MargOrderMismatch {
         /// The frame that disagrees.
@@ -119,13 +94,10 @@ pub enum BaError {
 
 // ─── the relative pose, hoisted per (host, target) pair ────────────────────
 
-/// `computeRelPose` (`ba_utils.h:41-78`): the transform that takes a point in
-/// the host camera frame to the target camera frame, with its two 6x6 Jacobians.
+/// The host-camera to target-camera transform and its two 6x6 Jacobians.
 ///
-/// The composition is basalt's **decoupled** one (`:49-50`): the rotation is a
-/// plain product, but the translation is `R_t^-1 (t_h - t_t)` rather than
-/// anything `SE3::inverse` would produce. That is what makes the Jacobians below
-/// match the left-multiplied increment of `imu_types.h:96-99`.
+/// The composition is decoupled: rotation is a product, while translation is
+/// `R_t^-1 (t_h - t_t)`. Its Jacobians use the decoupled, left-multiplied increment.
 pub fn compute_rel_pose<S: LieScalar>(
     t_w_i_h: &Se3<S>,
     t_i_c_h: &Se3<S>,
@@ -136,7 +108,7 @@ pub fn compute_rel_pose<S: LieScalar>(
 ) -> Se3<S> {
     let tmp2: Se3<S> = t_i_c_t.inverse();
 
-    // `T_t_i_h_i` (`ba_utils.h:48-50`).
+    // `T_t_i_h_i`.
     let t_t_i_h_i: Se3<S> = Se3::new(
         t_w_i_t.rotation.inverse() * t_w_i_h.rotation,
         t_w_i_t.rotation.inverse() * (t_w_i_h.translation - t_w_i_t.translation),
@@ -147,7 +119,6 @@ pub fn compute_rel_pose<S: LieScalar>(
 
     if let Some(out) = d_rel_d_h {
         // `RR = blkdiag(R, R)` with `R = T_w_i_h.so3().inverse().matrix()`
-        // (`ba_utils.h:56-63`).
         let r: Matrix3<S> = t_w_i_h.rotation.inverse().matrix();
         let mut rr: Matrix6<S> = Matrix6::zeros();
         rr.fixed_view_mut::<3, 3>(0, 0).copy_from(&r);
@@ -156,7 +127,7 @@ pub fn compute_rel_pose<S: LieScalar>(
     }
 
     if let Some(out) = d_rel_d_t {
-        // `-T_i_c_t.inverse().Adj() * RR` (`ba_utils.h:67-74`).
+        // `-T_i_c_t.inverse().Adj() * RR`.
         let r: Matrix3<S> = t_w_i_t.rotation.inverse().matrix();
         let mut rr: Matrix6<S> = Matrix6::zeros();
         rr.fixed_view_mut::<3, 3>(0, 0).copy_from(&r);
@@ -169,12 +140,10 @@ pub fn compute_rel_pose<S: LieScalar>(
 
 // ─── the reprojection residual ─────────────────────────────────────────────
 
-/// Everything [`linearize_point`] can be asked to fill in besides the residual.
+/// Optional outputs of [`linearize_point`] besides the residual.
 ///
-/// C++ passes four raw pointers, three of them defaulted to null
-/// (`ba_utils.h:80-85`). One struct of options keeps the call sites honest and
-/// costs nothing: every field is a borrowed fixed-size matrix, so the residual
-/// path allocates nothing.
+/// Borrowed fixed-size matrices let callers request only the outputs they need
+/// without allocation.
 #[derive(Debug)]
 pub struct LinearizePointOut<'a, S: LieScalar> {
     /// `d_res_d_xi` (2x6): the residual against the relative-pose increment.
@@ -186,8 +155,7 @@ pub struct LinearizePointOut<'a, S: LieScalar> {
 }
 
 impl<S: LieScalar> Default for LinearizePointOut<'_, S> {
-    /// All four C++ pointers null: the residual only
-    /// (`ba_utils.h:83-85` default arguments).
+    /// Request only the residual.
     fn default() -> Self {
         Self {
             d_res_d_xi: None,
@@ -197,16 +165,12 @@ impl<S: LieScalar> Default for LinearizePointOut<'_, S> {
     }
 }
 
-/// `linearizePoint` (`ba_utils.h:80-138`): one observation's residual and, on
-/// request, its Jacobians.
+/// One observation's residual and optional Jacobians.
 ///
-/// The residual is `pi(T_t_h * q) - z` (`:94-117`) with `q` the homogeneous
-/// landmark `[unproject(direction), inv_dist]`. **The sign is basalt's, i.e.
-/// flipped relative to Paper 1 Eq. (8)** — see the module docs.
-///
-/// Returns `false` when the camera rejects the point or the pixel is not finite
-/// (`:97-98`), in which case `res` holds whatever the camera model wrote and the
-/// caller must ignore it, exactly as C++ does.
+/// The residual is `pi(T_t_h * q) - z`, where `q` is the homogeneous landmark
+/// `[unproject(direction), inv_dist]`. See the module docs for the sign convention.
+/// Returns `false` if the camera rejects the point or the pixel is non-finite.
+/// In that case the caller must ignore `res`, which may still have been written.
 pub fn linearize_point<S: LieScalar>(
     kpt_obs: &Vector2<S>,
     kpt_pos: &Landmark<S>,
@@ -216,7 +180,7 @@ pub fn linearize_point<S: LieScalar>(
     out: &mut LinearizePointOut<'_, S>,
 ) -> bool {
     // `StereographicParam::unproject(direction, &Jup)` then the inverse distance
-    // into the homogeneous slot (`ba_utils.h:89-92`).
+    // into the homogeneous slot.
     let mut jup: Matrix4x2<S> = Matrix4x2::zeros();
     let mut p_h_3d: Vector4<S> =
         StereographicParam::unproject_with_jacobian(&kpt_pos.direction, &mut jup);
@@ -226,7 +190,7 @@ pub fn linearize_point<S: LieScalar>(
 
     let mut jp: Matrix2x4<S> = Matrix2x4::zeros();
     let mut valid: bool = cam.project_with_jacobian(&p_t_3d, res, &mut jp);
-    // `valid &= res.array().isFinite().all()` (`ba_utils.h:98`).
+    // `valid &= res.array().isFinite().all()`.
     valid &= res[0].to_f64().is_finite() && res[1].to_f64().is_finite();
 
     if !valid {
@@ -234,18 +198,17 @@ pub fn linearize_point<S: LieScalar>(
     }
 
     if let Some(proj) = out.proj.as_deref_mut() {
-        // `proj.head<2>() = res` and the inverse depth in the target frame
-        // (`ba_utils.h:113-116`), before the observation is subtracted.
+        // Store the projection and inverse depth before subtracting the observation.
         proj[0] = res[0];
         proj[1] = res[1];
         proj[2] = p_t_3d[3] / p_t_3d.fixed_rows::<3>(0).norm();
     }
 
-    // `res -= kpt_obs` (`ba_utils.h:117`) — the flipped sign.
+    // `res -= kpt_obs` — the flipped sign.
     *res -= kpt_obs;
 
     if let Some(d_res_d_xi) = out.d_res_d_xi.as_deref_mut() {
-        // `d_point_d_xi` (4x6, `ba_utils.h:120-123`). The inverse-distance
+        // `d_point_d_xi` (4x6). The inverse-distance
         // scaling on the translation columns is what the homogeneous `q` costs.
         let mut d_point_d_xi: nalgebra::Matrix4x6<S> = nalgebra::Matrix4x6::zeros();
         let mut ident: Matrix3<S> = Matrix3::identity();
@@ -254,12 +217,12 @@ pub fn linearize_point<S: LieScalar>(
         d_point_d_xi
             .fixed_view_mut::<3, 3>(0, 3)
             .copy_from(&(-So3::hat(&Vector3::new(p_t_3d[0], p_t_3d[1], p_t_3d[2]))));
-        // `row(3).setZero()` (`:123`) — already zero from the constructor.
+        // `row(3).setZero()` — already zero from the constructor.
         *d_res_d_xi = jp * d_point_d_xi;
     }
 
     if let Some(d_res_d_p) = out.d_res_d_p.as_deref_mut() {
-        // `Jpp` (4x3, `ba_utils.h:129-132`).
+        // `Jpp` (4x3).
         let mut jpp: Matrix4x3<S> = Matrix4x3::zeros();
         let top: nalgebra::Matrix3x4<S> = t_t_h.fixed_view::<3, 4>(0, 0).into_owned();
         jpp.fixed_view_mut::<3, 2>(0, 0).copy_from(&(top * jup));
@@ -280,21 +243,16 @@ pub fn linearize_point<S: LieScalar>(
 /// matrix that reaches it is degenerate, and `None` is the honest answer.
 const SVD_MAX_ITERATIONS: usize = 64;
 
-/// `triangulate(f0, f1, T_0_1)` (`ba_base.h:89-116`): the DLT, returning a
-/// homogeneous `[unit direction (3), inverse distance]` in frame 0.
+/// DLT triangulation, returning `[unit direction (3), inverse distance]` in frame 0.
 ///
-/// `f0` and `f1` are the two bearing vectors, `T_0_1` the transform from frame 1
-/// to frame 0. The 4x4 `A` is built from the two projection matrices exactly as
-/// `:103-107`, the null space comes from the last column of `V`, and the sign is
-/// flipped when the result points away from `f0` (`:113`).
+/// `f0` and `f1` are bearing vectors; `T_0_1` maps frame 1 to frame 0.
+/// The 4x4 system is built from the two projection matrices. Its null vector is
+/// the last column of `V`, with sign chosen to point towards `f0`.
 ///
-/// The caller accepts finite results with `0 < inv_dist < 3`, so the point
-/// must be farther than 1/3 m. Exactly parallel bearings carry no finite depth
-/// and are refused before decomposition.
-///
-/// Compute the DLT null vector with nalgebra SVD in f64, including for f32
-/// inputs, to reduce cancellation error. Return None for invalid inputs,
-/// non-convergence, or a homogeneous vector with no spatial direction.
+/// The caller accepts finite results with `0 < inv_dist < 3`, so points must be
+/// farther than 1/3 m. Exactly parallel bearings are refused before decomposition.
+/// The SVD runs in f64 even for f32 inputs to reduce cancellation. Invalid inputs,
+/// non-convergence and vectors without a spatial direction return `None`.
 pub fn triangulate<S: LieScalar>(
     f0: &Vector3<S>,
     f1: &Vector3<S>,
@@ -306,7 +264,7 @@ pub fn triangulate<S: LieScalar>(
     if f0.cross(&f1_in_0).iter().all(|value| *value == S::zero()) {
         return None;
     }
-    // `P1.setIdentity()`, `P2 = T_0_1.inverse().matrix3x4()` (`ba_base.h:98-100`).
+    // `P1.setIdentity()`, `P2 = T_0_1.inverse().matrix3x4()`.
     let p1: nalgebra::Matrix3x4<S> = {
         let mut m: nalgebra::Matrix3x4<S> = nalgebra::Matrix3x4::zeros();
         m.fixed_view_mut::<3, 3>(0, 0)
@@ -366,7 +324,7 @@ pub fn triangulate<S: LieScalar>(
         world_point[i] /= norm;
     }
 
-    // `if (f0.dot(worldPoint.head<3>()) < 0) worldPoint *= -1` (`ba_base.h:113`).
+    // `if (f0.dot(worldPoint.head<3>()) < 0) worldPoint *= -1`.
     let dot: S = f0[0] * world_point[0] + f0[1] * world_point[1] + f0[2] * world_point[2];
     if dot < S::zero() {
         world_point = -world_point;
@@ -376,8 +334,7 @@ pub fn triangulate<S: LieScalar>(
 
 // ─── the Huber-weighted cost of one observation ───────────────────────────
 
-/// The weight and the cost `computeError` adds for one observation
-/// (`ba_base.cpp:179-182`), with a fixed row order.
+/// The robust weight and cost of one observation, accumulated in fixed order.
 ///
 /// ```text
 /// huber_weight = e < huber_thresh ? 1 : huber_thresh / e
@@ -385,19 +342,11 @@ pub fn triangulate<S: LieScalar>(
 /// cost         = 0.5 * (2 - huber_weight) * obs_weight * res^T * res
 /// ```
 ///
-/// `e` is `res.norm()` in **raw pixels**: the Huber comparison happens before
-/// the `1/sigma` scaling (papers-part2 §13 D14), so the shipped 1.0 px threshold
-/// against a 0.5 px sigma is an effective 2 sigma.
-///
-/// The last line is not `weight * (rx^2 + ry^2)`. C++'s `*` is left-associative,
-/// so the scalar factor multiplies `res.transpose()` — a **row expression whose
-/// two coefficients are each scaled** — and only then does the 1x2 by 2x1 product
-/// contract it against the unscaled column. Reassociating it to scale the dot
-/// product instead moves the last bits: at `res = [10.125, 9.625]` with
-/// `huber_thresh = 1` and `obs_std_dev = 0.5` in `f32`, C++ returns
-/// `53.879341125488281` and the reassociated form `53.879337310791016`. This is
-/// the cost the Levenberg-Marquardt accept test compares against its predicted
-/// decrease, so the difference is not cosmetic.
+/// `e` is the norm in raw pixels. Huber weighting precedes noise scaling, so
+/// 1 px at a 0.5 px deviation is a 2-sigma threshold.
+/// The scalar factor multiplies each row coefficient before contraction with
+/// the unscaled residual. Reassociating to scale the dot product changes rounding
+/// and can change the LM acceptance test near its threshold.
 #[inline]
 pub fn huber_cost<S: LieScalar>(res: &Vector2<S>, e: S, huber_thresh: S, obs_std_dev: S) -> (S, S) {
     let huber_weight: S = if e < huber_thresh {
@@ -415,7 +364,7 @@ pub fn huber_cost<S: LieScalar>(res: &Vector2<S>, e: S, huber_thresh: S, obs_std
 
 // ─── the sliding-window state ──────────────────────────────────────────────
 
-/// `BundleAdjustmentBase<Scalar>` (`ba_base.h:42-155`): the window the estimator
+/// `BundleAdjustmentBase<Scalar>` : the window the estimator
 /// optimises over.
 ///
 /// `frame_poses` holds keyframes as 6-dof pose blocks, `frame_states` the
@@ -424,26 +373,22 @@ pub fn huber_cost<S: LieScalar>(res: &Vector2<S>, e: S, huber_thresh: S, obs_std
 /// maps; [`Self::get_pose_state_with_lin`] hides which.
 #[derive(Debug, Clone)]
 pub struct BundleAdjustmentBase<S: LieScalar> {
-    /// Full states, newest frames (`ba_base.h:144`).
+    /// Full states, newest frames.
     pub frame_states: BTreeMap<FrameId, PoseVelBiasStateWithLin<S>>,
-    /// Pose-only blocks, keyframes (`ba_base.h:145`).
+    /// Pose-only blocks, keyframes.
     pub frame_poses: BTreeMap<FrameId, PoseStateWithLin<S>>,
-    /// The landmark database (`ba_base.h:148`).
+    /// The landmark database.
     pub lmdb: LandmarkDatabase<S>,
     /// `vio_obs_std_dev`, the pixel noise the residual is whitened by
-    /// (`ba_base.h:150`).
     pub obs_std_dev: S,
-    /// `vio_obs_huber_thresh`, in **raw pixels** (`ba_base.h:151`).
+    /// `vio_obs_huber_thresh`, in **raw pixels**.
     pub huber_thresh: S,
-    /// The rig calibration (`ba_base.h:153`).
+    /// The rig calibration.
     pub calib: Calibration<S>,
-    /// The projection models, resolved once from `calib.intrinsics`.
+    /// Projection models resolved once when the window is built.
     ///
-    /// C++ carries a `std::variant` per camera and `std::visit`s it at every
-    /// call site (`ba_base.cpp:162-188`); the port resolves the parsed
-    /// [`crate::calib::CameraModel`] into a [`CameraEnum`] when the window is
-    /// built, so a model this stage cannot project with is an error at
-    /// construction rather than inside the residual loop.
+    /// Resolving [`crate::calib::CameraModel`] into [`CameraEnum`] rejects unsupported
+    /// models at construction, before the residual loop.
     cameras: Vec<CameraEnum<S>>,
 }
 
@@ -471,14 +416,9 @@ impl<S: LieScalar> BundleAdjustmentBase<S> {
         &self.cameras
     }
 
-    /// The pose block for a timestamp, `getPoseStateWithLin`
-    /// (`ba_base.h:131-142`).
-    ///
-    /// `frame_poses` is searched first; a hit in `frame_states` is **promoted**
-    /// to a pose block, carrying the first six entries of its delta and its
-    /// `linearized` flag (`imu_types.h:205-212`). C++ prints to `cerr` and
-    /// `std::abort()`s when neither map has it; the port returns
-    /// [`BaError::UnknownFrame`].
+    /// Look up a pose block by timestamp, searching `frame_poses` first.
+    /// A full state is promoted to a pose block with its first six delta entries and
+    /// `linearized` flag. A timestamp in neither map returns [`BaError::UnknownFrame`].
     pub fn get_pose_state_with_lin(&self, t_ns: FrameId) -> Result<PoseStateWithLin<S>, BaError> {
         if let Some(pose) = self.frame_poses.get(&t_ns) {
             return Ok(*pose);
@@ -510,7 +450,7 @@ impl<S: LieScalar> BundleAdjustmentBase<S> {
         Ok((t_i_c, cam))
     }
 
-    /// `T_t_h` for one (host, target) pair (`ba_base.cpp:148-160`).
+    /// `T_t_h` for one (host, target) pair.
     ///
     /// The identity when host and target are the same image, which is why a
     /// landmark hosted and observed in the same frame costs nothing.
@@ -527,44 +467,24 @@ impl<S: LieScalar> BundleAdjustmentBase<S> {
         Ok(rel.matrix())
     }
 
-    /// The Huber-weighted reprojection error over the whole window, and how many
-    /// observations contributed, `computeError` (`ba_base.cpp:132-204`).
+    /// The window's Huber-weighted reprojection cost and contributing observation count.
     ///
-    /// Per observation (`:172-185`), with `e = |res|` in **raw pixels**:
+    /// With `e = |res|` in raw pixels, `huber_weight = min(1, huber_thresh / e)`
+    /// (with weight 1 at zero), `obs_weight = huber_weight / obs_std_dev^2`, and
+    /// `error += 0.5 * (2 - huber_weight) * obs_weight * res^T res`.
+    /// Huber weighting precedes noise scaling: 1 px at 0.5 px deviation is 2 sigma.
     ///
-    /// ```text
-    /// huber_weight = e < huber_thresh ? 1 : huber_thresh / e
-    /// obs_weight   = huber_weight / obs_std_dev^2
-    /// error       += 0.5 * (2 - huber_weight) * obs_weight * res^T res
-    /// ```
-    ///
-    /// The Huber comparison happens **before** the `1/sigma` scaling
-    /// (papers-part2 §13 D14), so the shipped 1.0 px threshold with a 0.5 px
-    /// sigma is an effective 2 sigma.
-    ///
-    /// With `outliers` given, every observation whose `e` exceeds
-    /// `outlier_threshold` is recorded as `(target, e)`, and an observation the
-    /// camera rejected as `(target, -1)`; both become `-2` when host and target
-    /// are the same image, which is `filterOutliers`' signal to delete the whole
-    /// landmark (`:176`, `:184`, `:268`).
-    ///
-    /// The returned count is the number of observations that produced a residual
-    /// at all. C++ does not return it; the port does, because the caller
-    /// otherwise cannot tell an error of zero from an empty window.
-    ///
-    /// Sequential in this stage. The body is a fold over `host_frames` in index
-    /// order, so a `par_chunks` with a fixed-order merge is a drop-in that does
-    /// not change the sum (decision D31). **That is the only reason
-    /// `host_frame_error` is a separate function** — one host frame's
-    /// partial sum is what a parallel task would own. It is not inlined here so
-    /// the shape stays the C++'s (`ba_base.cpp:141-193` is a TBB lambda), and
-    /// D65 freezes the parallel path out of this stage.
+    /// If `outliers` is supplied, residuals above the threshold record `(target, e)`;
+    /// rejected projections record `(target, -1)`. Both use `-2` when host and target
+    /// are the same image, signalling deletion of the whole landmark.
+    /// The count distinguishes zero error from a window with no valid observations.
+    /// Host-frame partial sums merge sequentially in index order (D31, D65).
     pub fn compute_error(
         &self,
         mut outliers: Option<&mut BTreeMap<LandmarkId, Vec<(TimeCamId, S)>>>,
         outlier_threshold: S,
     ) -> Result<(S, usize), BaError> {
-        // `host_frames` (`ba_base.cpp:136-137`), sorted here rather than in
+        // `host_frames`, sorted here rather than in
         // `unordered_map` order — see the `landmark` module docs.
         let host_frames: Vec<TimeCamId> = self.lmdb.host_kfs();
 
@@ -584,7 +504,7 @@ impl<S: LieScalar> BundleAdjustmentBase<S> {
     }
 
     /// One host frame's contribution to [`Self::compute_error`]: the body of the
-    /// TBB lambda (`ba_base.cpp:141-193`), with its own accumulator so the
+    /// TBB lambda, with its own accumulator so the
     /// fold above sees a fixed number of partial sums.
     fn host_frame_error(
         &self,
@@ -600,7 +520,7 @@ impl<S: LieScalar> BundleAdjustmentBase<S> {
         for (&tcid_t, ids) in targets {
             let t_t_h: Matrix4<S> = self.rel_pose_matrix(tcid_h, tcid_t)?;
             let (_, cam) = self.camera_of(tcid_t)?;
-            // `tcid_h != tcid_t ? e : -2` (`ba_base.cpp:176`, `:184`).
+            // `tcid_h != tcid_t ? e : -2`.
             let same_image: bool = tcid_h == tcid_t;
             for &kpt_id in ids {
                 let kpt_pos: &Landmark<S> = self
@@ -642,14 +562,10 @@ impl<S: LieScalar> BundleAdjustmentBase<S> {
         Ok((local_error, num_points))
     }
 
-    /// Where every landmark projects in the newest frame, `computeProjections`
-    /// (`ba_base.cpp:329-372`), one list per camera.
-    ///
-    /// Each entry is `[u, v, inverse depth in the target camera, landmark id]`:
-    /// the residual is evaluated against a **zero** observation (`:363`), so the
-    /// first two components are the projection itself, and the fourth slot is
-    /// overwritten with the id (`:365`). This is the visualisation payload, not
-    /// an optimisation quantity.
+    /// Project every landmark into the newest frame, returning one list per camera.
+    /// Each entry is `[u, v, inverse depth, landmark id]`. A zero observation leaves
+    /// the projection in the first two components; the id replaces the fourth.
+    /// This payload is for visualization, not optimization.
     pub fn compute_projections(
         &self,
         last_state_t_ns: FrameId,
@@ -695,11 +611,8 @@ impl<S: LieScalar> BundleAdjustmentBase<S> {
         Ok(data)
     }
 
-    /// The stacked deltas of the frames in a marginalization ordering,
-    /// `computeDelta` (`ba_base.cpp:288-303`).
-    ///
-    /// Every block must be frozen at its linearization point, or its delta means
-    /// nothing; C++ asserts (`:294`, `:297`), the port returns
+    /// Stack deltas in the marginalization ordering.
+    /// Every block must be frozen at its linearization point or this returns
     /// [`BaError::NotLinearized`].
     pub fn compute_delta(&self, marg_order: &AbsOrderMap) -> Result<DVector<S>, BaError> {
         // Validate every block **before** allocating. `AbsOrderMap::push` accepts
@@ -744,27 +657,15 @@ impl<S: LieScalar> BundleAdjustmentBase<S> {
         Ok(delta)
     }
 
-    /// The marginalization prior's contribution to `H` and `b`, and its current
-    /// cost, `linearizeMargPrior` (`ba_base.cpp:374-439`).
+    /// The marginalization prior's contribution to `H`, `b` and the current cost.
     ///
-    /// The prior is a quadratic in the drift since its own linearization point,
-    /// `P(x) = 0.5 ‖J (delta + x) + r‖²` (`:390-408`), so linearizing it at
-    /// `x = 0` gives Jacobian `J` and residual `J delta + r` — that
-    /// re-anchoring is trap 8, and its mirror is
-    /// `linearization_abs_qr.cpp:592`. The returned error **drops the constant
-    /// `0.5 rᵀr` term** (`:416-419`) and can therefore be negative; it is only
-    /// ever compared against itself across an increment.
-    ///
-    /// C++ asserts that the prior's ordering is a prefix of the window's, block
-    /// for block (`:379-388`); the port returns
-    /// [`crate::linearize::LinearizeError::MargOrderMismatch`] through the
-    /// caller.
-    /// The prior's own shape: `H` as wide as its ordering and `b` as long as
-    /// `H` is tall.
-    ///
-    /// C++ asserts only the width (`ba_base.cpp:379`, `:444`) and indexes the
-    /// rest; a prior with an empty `b` reaches `mld.b[k]` past its end, which
-    /// may not be a panic here (decision D32).
+    /// For `P(x) = 0.5 ‖J (delta + x) + r‖²`, linearization at zero has Jacobian `J`
+    /// and residual `J delta + r`. The returned cost omits `0.5 rᵀr`, so it can be
+    /// negative and must only be compared across increments of this same prior.
+    /// The prior ordering must be a block-for-block prefix of the window ordering;
+    /// a mismatch returns [`crate::linearize::LinearizeError::MargOrderMismatch`].
+    /// The matrix width and residual length must also agree with the prior ordering.
+    /// Shape checks prevent out-of-bounds reads (D32).
     fn check_marg_prior_shape(mld: &MargLinData<S>) -> Result<(), BaError> {
         let marg_size: usize = mld.order.total_size();
         if mld.h.ncols() != marg_size {
@@ -783,11 +684,10 @@ impl<S: LieScalar> BundleAdjustmentBase<S> {
     }
 
     /// The prior's ordering must be the window's prefix, block for block
-    /// (`ba_base.cpp:383-388`).
     ///
     /// Public because the square-root export needs it too: it writes the prior
     /// into the first columns of the stacked system
-    /// (`linearization_abs_qr.cpp:587-589`) without checking anything, which
+    ///  without checking anything, which
     /// would attach one frame's columns to another.
     pub fn check_marg_prior_order(
         &self,
@@ -814,7 +714,7 @@ impl<S: LieScalar> BundleAdjustmentBase<S> {
         abs_b: &mut DVector<S>,
     ) -> Result<S, BaError> {
         let marg_size: usize = mld.order.total_size();
-        // `:379`, and the shapes C++ indexes without asserting.
+        // Validate the prior's matrix and residual shapes before indexing.
         self.check_marg_prior_order(mld, aom)?;
         if abs_h.nrows() < marg_size || abs_h.ncols() < marg_size || abs_b.nrows() < marg_size {
             return Err(BaError::MargPriorSize {
@@ -825,8 +725,7 @@ impl<S: LieScalar> BundleAdjustmentBase<S> {
 
         let delta: DVector<S> = self.compute_delta(&mld.order)?;
 
-        // `:427-431`. C++ takes the squared arm at `:433-437` when the prior
-        // is not a square root; the port has no such prior (D68).
+        // Only square-root priors are supported (D68).
         let rows: usize = mld.h.nrows();
         // `H_delta = mld.H * delta`, reused by both `b` and the error.
         let mut h_delta: DVector<S> = DVector::zeros(rows);
@@ -851,16 +750,15 @@ impl<S: LieScalar> BundleAdjustmentBase<S> {
             }
             abs_b[i] += acc;
         }
-        // `delta^T H^T (0.5 H delta + b)` (`:431`).
+        // `delta^T H^T (0.5 H delta + b)`.
         Ok(prior_error(&h_delta, &h_delta, &mld.b, rows))
     }
 
     /// The prior's cost at the current state, `computeMargPriorError`
-    /// (`ba_base.cpp:441-465`).
     ///
     /// The same expression as [`Self::linearize_marg_prior`]'s error, without
     /// touching `H` or `b`; the constant `0.5 rᵀr` is dropped for the same
-    /// reason (`:452-455`), so this can be negative.
+    /// reason, so this can be negative.
     pub fn compute_marg_prior_error(&self, mld: &MargLinData<S>) -> Result<S, BaError> {
         let marg_size: usize = mld.order.total_size();
         Self::check_marg_prior_shape(mld)?;
@@ -874,21 +772,12 @@ impl<S: LieScalar> BundleAdjustmentBase<S> {
             }
             h_delta[i] = acc;
         }
-        // `:461`; `:463` is the squared arm, which the port has no prior for
-        // (D68).
         Ok(prior_error(&h_delta, &h_delta, &mld.b, rows))
     }
 
-    /// The prior's share of the model cost change,
-    /// `computeMargPriorModelCostChange` (`ba_base.cpp:467-528`).
-    ///
-    /// `l_diff = -(J inc)ᵀ (J delta + r + 0.5 (J inc))` (`:519-522`).
-    ///
-    /// C++ takes a `marg_scaling` vector and multiplies `H` by it where it
-    /// meets `inc` but **not** where it meets `delta` (the asymmetry `:503-507`
-    /// spells out, because `delta` was never scaled). The port takes no such
-    /// vector: only the Jacobian scaling could produce one and nothing scales
-    /// (D68).
+    /// The prior's contribution to the predicted cost change:
+    /// `l_diff = -(J inc)ᵀ (J delta + r + 0.5 (J inc))`.
+    /// No scaling vector is needed because Jacobian scaling is absent (D68).
     pub fn compute_marg_prior_model_cost_change(
         &self,
         mld: &MargLinData<S>,
@@ -904,8 +793,6 @@ impl<S: LieScalar> BundleAdjustmentBase<S> {
         }
         let delta: DVector<S> = self.compute_delta(&mld.order)?;
 
-        // `:519-522`; `:524` is the squared arm, which the port has no prior
-        // for (D68).
         let rows: usize = mld.h.nrows();
         let mut l_diff: S = S::zero();
         for k in 0..rows {
@@ -922,7 +809,6 @@ impl<S: LieScalar> BundleAdjustmentBase<S> {
     }
 
     /// Save every state and every landmark parameter, `backup`
-    /// (`ba_base.h:118-122`).
     pub fn backup(&mut self) {
         for state in self.frame_states.values_mut() {
             state.backup();
@@ -933,7 +819,7 @@ impl<S: LieScalar> BundleAdjustmentBase<S> {
         self.lmdb.backup();
     }
 
-    /// Undo the last increment everywhere, `restore` (`ba_base.h:124-128`).
+    /// Undo the last increment everywhere, `restore`.
     ///
     /// This is what a rejected Levenberg-Marquardt step runs.
     pub fn restore(&mut self) {
@@ -973,7 +859,7 @@ mod tests {
     const MSDMI: &str = include_str!("../tests/fixtures/msdmi_calib.json");
     const MSDMG: &str = include_str!("../tests/fixtures/msdmg_calib.json");
 
-    /// `TestConstants<double>` (`basalt-headers/test/include/test_utils.h:10-14`).
+    /// `TestConstants<double>`.
     const EPS_F64: f64 = 1e-8;
     const MAX_NORM_F64: f64 = 1e-3;
 
@@ -1007,7 +893,7 @@ mod tests {
         Se3::exp(&tangent)
     }
 
-    /// `test_jacobian` (`basalt-headers/test/include/test_utils.h:22-61`):
+    /// `test_jacobian` :
     /// central differences at `eps`, compared with `isApprox(max_norm)`, i.e.
     /// `|Jn - Ja| <= max_norm * min(|Jn|, |Ja|)`, with an all-zero special case.
     fn test_jacobian<const R: usize, const C: usize>(
@@ -1040,9 +926,9 @@ mod tests {
         );
     }
 
-    // ─── the ported C++ tests ──────────────────────────────────────────────
+    // Bundle-adjustment invariants.
 
-    /// `RelPoseTest` (`test/src/test_vio.cpp:289-330`), with the deterministic
+    /// `RelPoseTest`, with the deterministic
     /// tangents above in place of `Sophus::Vector6d::Random()`.
     #[test]
     fn rel_pose_jacobians_match_finite_differences() {
@@ -1076,22 +962,16 @@ mod tests {
         });
     }
 
-    /// `LinearizePointsTest` (`test/src/test_vio.cpp:332-398`).
-    ///
-    /// The C++ test uses `ExtendedUnifiedCamera`, which this port parses but
-    /// does not project with (`camera.rs`); the two shipped reference models —
-    /// msd-index cam0 (kb4) and msd-g2 cam0 (radtan8) — stand in, so the test
-    /// exercises the calibrations the estimator actually runs on. Everything
-    /// else follows the C++ line for line: the observation is manufactured by
-    /// projecting the landmark, so the residual is zero at the linearization
-    /// point, and both Jacobians go to `test_jacobian` at basalt's tolerances.
+    /// Check residual and pose/landmark Jacobians using the shipped kb4 and radtan8
+    /// models. Projecting the landmark constructs an observation with zero residual
+    /// at the linearization point; finite differences check both Jacobians.
     #[test]
     fn linearize_point_jacobians_match_finite_differences() {
         for (name, text) in [("kb4 msdmi cam0", MSDMI), ("radtan8 msdmg cam0", MSDMG)] {
             let calibration: Calibration<f64> = calib(text);
             let cam: CameraEnum<f64> = CameraEnum::from_model(&calibration.intrinsics[0]).unwrap();
 
-            // `cam.unproject(Vector2d::Random() * 50, point3d)` (`:338`).
+            // `cam.unproject(Vector2d::Random() * 50, point3d)`.
             let mut point3d: Vector4<f64> = Vector4::zeros();
             let centre: [f64; 4] = cam.focal_and_principal_point();
             assert!(cam.unproject(
@@ -1113,7 +993,7 @@ mod tests {
             let t_t_h_se3: Se3<f64> = t_w_t.inverse() * t_w_h;
             let t_t_h: Matrix4<f64> = t_t_h_se3.matrix();
 
-            // The observation is where the landmark actually lands (`:349-356`).
+            // The observation is where the landmark actually lands.
             let mut p_trans: Vector4<f64> = StereographicParam::unproject(&kpt_pos.direction);
             p_trans[3] = kpt_pos.inv_dist;
             p_trans = t_t_h * p_trans;
@@ -1137,8 +1017,7 @@ mod tests {
             ));
             assert_abs_diff_eq!(res.norm(), 0.0, epsilon = 1e-9);
 
-            // `d_res_d_xi` is taken against the **coupled** left-multiplied
-            // `se3_expd(x) * T_t_h` of the C++ test (`:370`).
+            // Differentiate the coupled left-multiplied update `se3_expd(x) * T_t_h` here.
             test_jacobian(&format!("{name} d_res_d_xi"), &d_res_d_xi, |x| {
                 let moved: Matrix4<f64> = (Se3::exp(x) * t_t_h_se3).matrix();
                 let mut res: Vector2<f64> = Vector2::zeros();
@@ -1343,7 +1222,7 @@ mod tests {
             // Recomputed from the landmarks, without touching `compute_error`'s
             // machinery: project each landmark into each target and apply
             // `0.5 * (2 - w) * (w / sigma^2) * |r|^2` with `w` the raw-pixel
-            // Huber weight (`ba_base.cpp:179-182`).
+            // Huber weight.
             let mut want: f64 = 0.0;
             let mut count: usize = 0;
             let mut downweighted: usize = 0;
@@ -1584,7 +1463,7 @@ mod tests {
         assert_eq!(cost32, 1.0);
 
         // The threshold is on the raw pixel norm, before `1/sigma`
-        // (papers-part2 §13 D14): a residual of exactly the threshold is *not*
+        // (papers-part2 §13 ): a residual of exactly the threshold is *not*
         // downweighted only because the comparison is strict `<`.
         let at: Vector2<f64> = Vector2::new(1.0, 0.0);
         assert_eq!(huber_cost(&at, at.norm(), 1.0, 0.5).0, 1.0);
@@ -1593,7 +1472,7 @@ mod tests {
     }
 
     /// The three marginalization-prior helpers agree with each other and with
-    /// the algebra written out in `ba_base.cpp:390-419`.
+    /// the algebra written out in.
     ///
     /// The prior is a quadratic in the drift since its own linearization point,
     /// so all three have to use the same `delta`, and each squares `J_m` on its
@@ -1647,7 +1526,6 @@ mod tests {
             .linearize_marg_prior(&mld, &aom, &mut h, &mut b)
             .unwrap();
 
-        // `:427-431`.
         let want_h: DMatrix<f64> = j.transpose() * &j;
         let want_b: DVector<f64> = j.transpose() * (&r_vec + &j * &delta);
         let j_delta: DVector<f64> = &j * &delta;
@@ -1664,7 +1542,7 @@ mod tests {
         let error_only: f64 = estimator.compute_marg_prior_error(&mld).unwrap();
         assert_eq!(error_only, error);
 
-        // `computeMargPriorModelCostChange` (`:519-522`).
+        // `computeMargPriorModelCostChange`.
         let inc: DVector<f64> =
             DVector::from_iterator(POSE_SIZE, (0..POSE_SIZE).map(|_| next() / 10.0));
         let l_diff: f64 = estimator
@@ -1678,7 +1556,7 @@ mod tests {
             epsilon = 1e-12 * want_l_diff.abs().max(1.0)
         );
 
-        // An ordering the window disagrees with is rejected (`:383-388`).
+        // An ordering the window disagrees with is rejected.
         let mut wrong: AbsOrderMap = AbsOrderMap::new();
         wrong.push(0, POSE_VEL_BIAS_SIZE).unwrap();
         let mut h3: DMatrix<f64> = DMatrix::zeros(POSE_SIZE, POSE_SIZE);
@@ -1690,7 +1568,7 @@ mod tests {
             BaError::MargOrderMismatch { frame_id: 0 }
         );
 
-        // And a prior whose matrix does not match its own ordering (`:379`).
+        // And a prior whose matrix does not match its own ordering.
         let ragged: MargLinData<f64> = MargLinData {
             order: order.clone(),
             h: DMatrix::zeros(rows, POSE_SIZE - 1),
@@ -1701,8 +1579,7 @@ mod tests {
             BaError::MargPriorSize { .. }
         ));
 
-        // A shape C++ indexes without asserting, which would be a panic here
-        // (decision D32): a residual that is not as long as `H` is tall.
+        // A residual whose length differs from the matrix height must be refused (D32).
         let empty_b: MargLinData<f64> = MargLinData {
             order: order.clone(),
             h: j,

--- a/packages/slam-rs/crates/slam-rs/src/calib.rs
+++ b/packages/slam-rs/crates/slam-rs/src/calib.rs
@@ -1,36 +1,12 @@
-//! basalt's camera-IMU calibration, read with serde.
+//! Camera-IMU calibration read with serde.
 //!
-//! Ported from `thirdparty/basalt-headers/include/basalt/calibration/calibration.hpp`
-//! and `calib_bias.hpp`. The on-disk shape is cereal's again: a `value0`
-//! wrapper, `T_imu_cam` as `{px, py, pz, qx, qy, qz, qw}`
-//! (`serialization/eigen_io.h:148-153`) and `intrinsics` as
-//! `{"camera_type": ..., "intrinsics": {...}}`
-//! (`serialization/headers_serialization.h:55-72`), so every shipped
-//! `*_calib.json` is a free test fixture (decision D18).
+//! JSON uses a `value0` wrapper, `T_imu_cam` entries with
+//! `{px, py, pz, qx, qy, qz, qw}`, and typed `intrinsics` objects.
+//! Projection and analytic Jacobians live in the camera module.
 //!
-//! Projection math is **not** here. This PR stores the camera parameters in the
-//! shape basalt stores them and stops; `project`/`unproject` and their analytic
-//! Jacobians land with the camera module.
-//!
-//! ## Two deliberate divergences
-//!
-//! * **The quaternion is normalized on read.** cereal writes the four
-//!   coefficients straight into Eigen's storage without normalizing; a
-//!   calibration a few ulps off unit length would then be a non-rotation. The
-//!   port normalizes and rejects a zero-norm quaternion instead of producing
-//!   NaNs (decision D32).
-//! * **Per-camera resolution is real data.** basalt assumes every camera shares
-//!   `resolution[0]` (`frame_to_frame_optical_flow.h:108-109`); the port keeps
-//!   one entry per camera because the msd-g2 recordings are stored rotated into
-//!   portrait (decision D30).
-//!
-//! ## The fixtures
-//!
-//! `msdmi_calib.json` (2 kb4 cameras, Valve Index), `msdmg_calib.json` (4
-//! pinhole-radtan8, HP Reverb G2), `euroc_ds_calib.json` (2 double-sphere, and
-//! the only shipped file with a vignette spline and mocap keys) and
-//! `robocap_calib.json` (4 kb4 at 960x540, the only one with non-default
-//! IMU noise).
+//! Quaternions are normalized on read; zero-norm values are rejected to avoid
+//! NaNs (D32). Each camera retains its own resolution because msd-g2 cameras
+//! can be stored with different portrait orientations (D30).
 
 use std::collections::BTreeMap;
 
@@ -64,8 +40,7 @@ pub enum CalibError {
         /// Number of `resolution` entries.
         resolutions: usize,
     },
-    /// A camera model name that is not one of the six basalt ships in its
-    /// calibration files.
+    /// A camera model name outside the six supported calibration variants.
     #[error("camera {index}: unknown camera model {model:?}")]
     UnknownCameraModel {
         /// Index of the offending camera.
@@ -106,10 +81,7 @@ struct Value0<T> {
     value0: T,
 }
 
-/// A rigid transform in basalt's on-disk form.
-///
-/// The rotation is stored `xyzw`, which is Eigen's internal quaternion order
-/// (`serialization/eigen_io.h:150-153`), not the `wxyz` a maths text would use.
+/// A rigid transform in the calibration JSON format, with `xyzw` quaternion order.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 struct PoseJson<S> {
     px: S,
@@ -166,7 +138,7 @@ mod vector3_json {
     }
 }
 
-/// Pinhole, `fx fy cx cy` (`camera/pinhole_camera.hpp:88`).
+/// Pinhole, `fx fy cx cy`.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct PinholeParams<S> {
     /// Focal length along image x, pixels.
@@ -179,7 +151,7 @@ pub struct PinholeParams<S> {
     pub cy: S,
 }
 
-/// Kannala-Brandt with four radial terms (`camera/kannala_brandt_camera4.hpp:91`).
+/// Kannala-Brandt with four radial terms.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct Kb4Params<S> {
     /// Focal length along image x, pixels.
@@ -200,13 +172,9 @@ pub struct Kb4Params<S> {
     pub k4: S,
 }
 
-/// Pinhole with the eight-term rational Brown-Conrady distortion
-/// (`camera/pinhole_radtan8_camera.hpp:114`).
-///
-/// The parameter order on disk is `k1 k2 p1 p2 k3 k4 k5 k6`: the two tangential
-/// terms sit **between** the radial ones, matching OpenCV's layout and
-/// `serialization/headers_serialization.h:144-153`. `rpmax` is stored beside
-/// the twelve optimized parameters rather than inside them.
+/// Pinhole with eight-term rational Brown-Conrady distortion.
+/// The disk order is `k1 k2 p1 p2 k3 k4 k5 k6`, matching OpenCV.
+/// `rpmax` is stored beside the twelve optimized parameters.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct Radtan8Params<S> {
     /// Focal length along image x, pixels.
@@ -237,7 +205,7 @@ pub struct Radtan8Params<S> {
     pub rpmax: S,
 }
 
-/// Double sphere (`camera/double_sphere_camera.hpp:89`).
+/// Double sphere.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct DoubleSphereParams<S> {
     /// Focal length along image x, pixels.
@@ -254,7 +222,7 @@ pub struct DoubleSphereParams<S> {
     pub alpha: S,
 }
 
-/// Extended unified (`camera/extended_camera.hpp:90`).
+/// Extended unified.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct ExtendedUnifiedParams<S> {
     /// Focal length along image x, pixels.
@@ -271,7 +239,7 @@ pub struct ExtendedUnifiedParams<S> {
     pub beta: S,
 }
 
-/// Unified / Mei (`camera/unified_camera.hpp:89`).
+/// Unified / Mei.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct UnifiedParams<S> {
     /// Focal length along image x, pixels.
@@ -286,21 +254,12 @@ pub struct UnifiedParams<S> {
     pub alpha: S,
 }
 
-/// One camera's projection model, `basalt::GenericCamera`
-/// (`camera/generic_camera.hpp:75-77`).
+/// One camera's projection model.
 ///
-/// The six variants are the ones that appear in shipped calibration files.
-/// basalt's variant also holds `fisheye624`, which no reference calibration
-/// uses; it is left out until a dataset needs it.
-///
-/// **Three of the six parse and are then refused.** `ds`, `eucm` and `ucm`
-/// have no projection in this port — D13 keeps the pinhole, kb4 and
-/// pinhole-radtan8 the shipped rigs use — so
-/// [`crate::camera::CameraEnum::from_model`] answers them with
-/// `CameraError::UnsupportedModel`. They are modelled here rather than left to
-/// serde so that a EuRoC-shaped calibration reports *which* model cannot be
-/// used, instead of a parse error naming a field; `euroc_ds_calib.json` is the
-/// fixture that pins it.
+/// Six variants can be parsed. `ds`, `eucm` and `ucm` have no projection
+/// implementation and return `CameraError::UnsupportedModel` from
+/// [`crate::camera::CameraEnum::from_model`] (D13). Parsing them first lets the
+/// error name the unsupported model rather than an unrelated JSON field.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "camera_type", content = "intrinsics")]
 pub enum CameraModel<S> {
@@ -325,7 +284,7 @@ pub enum CameraModel<S> {
 }
 
 impl<S: Copy> CameraModel<S> {
-    /// The model name basalt writes into `camera_type`, `getName()`.
+    /// The model name stored in `camera_type`.
     pub fn name(&self) -> &'static str {
         match self {
             Self::Pinhole(_) => "pinhole",
@@ -337,14 +296,9 @@ impl<S: Copy> CameraModel<S> {
         }
     }
 
-    /// The optimized parameters in basalt's `getParam()` order.
-    ///
-    /// `fx fy cx cy` first in every model, then the model's own terms; the
-    /// distortion coefficients alone are `params()[4..]`. For
-    /// `pinhole-radtan8` this is the twelve-vector basalt optimizes, and
-    /// `rpmax` is not in it: it is a fixed bound, which
-    /// [`CameraModel::valid_radius`] reports instead
-    /// (`serialization/headers_serialization.h:144-153`).
+    /// The optimized parameter vector: `fx fy cx cy`, then model-specific terms.
+    /// Distortion coefficients are `params()[4..]`. For `pinhole-radtan8`, `rpmax`
+    /// is a fixed bound outside the twelve-vector; see [`CameraModel::valid_radius`].
     pub fn params(&self) -> Vec<S> {
         match self {
             Self::Pinhole(p) => vec![p.fx, p.fy, p.cx, p.cy],
@@ -373,7 +327,7 @@ impl<S: Copy> CameraModel<S> {
 }
 
 impl<S: LieScalar> CameraModel<S> {
-    /// `GenericCamera::cast` (`camera/generic_camera.hpp`): the same model in
+    /// `GenericCamera::cast` : the same model in
     /// another scalar.
     pub fn cast<T: LieScalar>(&self) -> CameraModel<T> {
         let convert = |value: S| -> T { T::from_literal(value.to_f64()) };
@@ -437,7 +391,7 @@ impl<S: LieScalar> CameraModel<S> {
 }
 
 /// Static accelerometer calibration: bias plus a lower-triangular scale
-/// (`calibration/calib_bias.hpp:44-125`, 9 parameters).
+/// (9 parameters).
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct CalibAccelBias<S> {
@@ -454,7 +408,7 @@ impl<S: LieScalar> Default for CalibAccelBias<S> {
 }
 
 impl<S: LieScalar> CalibAccelBias<S> {
-    /// The bias and the scale matrix (`calib_bias.hpp:86-94`).
+    /// The bias and the scale matrix.
     ///
     /// The scale is lower triangular: column 0 is `(s1, s2, s3)`, then
     /// `(1,1) = s4`, `(2,1) = s5`, `(2,2) = s6`. Everything above the diagonal
@@ -473,16 +427,13 @@ impl<S: LieScalar> CalibAccelBias<S> {
         (bias, scale)
     }
 
-    /// `a_c = (I + S) a_r - b` (`calib_bias.hpp:101-107`).
+    /// `a_c = (I + S) a_r - b`.
     pub fn calibrated(&self, raw: &Vector3<S>) -> Vector3<S> {
         let (bias, scale) = self.bias_and_scale();
         raw + scale * raw - bias
     }
 
-    /// The inverse map, `invertCalibration` (`calib_bias.hpp:114-122`).
-    ///
-    /// Returns `None` when `I + S` is singular, where the C++ would hand back
-    /// an Eigen inverse full of infinities.
+    /// The inverse calibration map; returns `None` when `I + S` is singular.
     pub fn raw(&self, calibrated: &Vector3<S>) -> Option<Vector3<S>> {
         let (bias, scale) = self.bias_and_scale();
         let inverse: Matrix3<S> = (Matrix3::identity() + scale).try_inverse()?;
@@ -491,7 +442,7 @@ impl<S: LieScalar> CalibAccelBias<S> {
 }
 
 /// Static gyroscope calibration: bias plus a full 3x3 scale
-/// (`calibration/calib_bias.hpp:128-205`, 12 parameters).
+/// (12 parameters).
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct CalibGyroBias<S> {
@@ -508,7 +459,7 @@ impl<S: LieScalar> Default for CalibGyroBias<S> {
 }
 
 impl<S: LieScalar> CalibGyroBias<S> {
-    /// The bias and the scale matrix (`calib_bias.hpp:165-170`).
+    /// The bias and the scale matrix.
     ///
     /// Column-major: `(s1, s2, s3)`, `(s4, s5, s6)`, `(s7, s8, s9)`. Unlike the
     /// accelerometer's, this one is full, because it also absorbs the rotation
@@ -524,13 +475,13 @@ impl<S: LieScalar> CalibGyroBias<S> {
         (bias, scale)
     }
 
-    /// `w_c = (I + S) w_r - b` (`calib_bias.hpp:176-182`).
+    /// `w_c = (I + S) w_r - b`.
     pub fn calibrated(&self, raw: &Vector3<S>) -> Vector3<S> {
         let (bias, scale) = self.bias_and_scale();
         raw + scale * raw - bias
     }
 
-    /// The inverse map, `invertCalibration` (`calib_bias.hpp:189-197`).
+    /// The inverse map, `invertCalibration`.
     pub fn raw(&self, calibrated: &Vector3<S>) -> Option<Vector3<S>> {
         let (bias, scale) = self.bias_and_scale();
         let inverse: Matrix3<S> = (Matrix3::identity() + scale).try_inverse()?;
@@ -539,15 +490,14 @@ impl<S: LieScalar> CalibGyroBias<S> {
 }
 
 /// One camera's vignetting curve, a uniform B-spline over radius
-/// (`calibration.hpp:158`, `RdSpline<1, 4, Scalar>`).
+/// (`RdSpline<1, 4, Scalar>`).
 ///
 /// Parsed so a calibration round-trips; nothing reads it. cereal writes the
-/// three members unnamed (`serialization/headers_serialization.h:243-249`), so
+/// three members unnamed, so
 /// on disk they are `value0`, `value1` and `value2`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VignetteSpline<S> {
-    /// Start of the spline's domain. basalt reuses the time axis for radius in
-    /// pixels times 1e9 (`calibration.hpp:152-157`).
+    /// Start of the spline domain, using radius in pixels times 1e9 as the time axis.
     #[serde(rename = "value0")]
     pub start_t_ns: i64,
     /// Knot spacing on the same axis.
@@ -558,8 +508,7 @@ pub struct VignetteSpline<S> {
     pub knots: Vec<[S; 1]>,
 }
 
-/// The camera-IMU calibration, `basalt::Calibration`
-/// (`calibration/calibration.hpp:51-186`).
+/// The camera-IMU calibration.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Calibration<S: LieScalar> {
     /// Camera pose in the IMU frame, one per camera: `p_i = T_i_c p_c`.
@@ -617,8 +566,7 @@ struct CalibrationJson<S: LieScalar> {
 }
 
 impl<S: LieScalar> Default for CalibrationJson<S> {
-    /// `Calibration::Calibration()` (`calibration.hpp:60-70`): the reasonable
-    /// defaults basalt starts from before a file overwrites them.
+    /// Default calibration values, overridden by fields present in a file.
     fn default() -> Self {
         Self {
             t_imu_cam: Vec::new(),
@@ -677,15 +625,13 @@ pub struct CameraParts<S> {
     pub cx: S,
     /// Principal point y, pixels.
     pub cy: S,
-    /// The catalog's model name. `"kb4"` and `"radtan8"` are what
-    /// `catalog_feed` produces; basalt's own `"pinhole-radtan8"`, `"pinhole"`,
-    /// `"ds"`, `"eucm"` and `"ucm"` are accepted too.
+    /// Catalog model name. Accepts `kb4`, `radtan8`, `pinhole-radtan8`,
+    /// `pinhole`, `ds`, `eucm` and `ucm`.
     pub model: String,
     /// Exactly the coefficients the model uses: four for `kb4`, eight for
     /// `radtan8` in the order `k1 k2 p1 p2 k3 k4 k5 k6`.
     pub distortion: Vec<S>,
-    /// basalt's `rpmax`, when the recording carries one. Required by
-    /// `radtan8`; ignored by every other model.
+    /// The recording's `rpmax`, required for `radtan8` and ignored by other models.
     pub distortion_valid_radius: Option<S>,
     /// The camera pose in the IMU frame as a 4x4 matrix, flattened in C order
     /// (row by row) — what `numpy.ndarray.ravel()` gives for the
@@ -716,11 +662,9 @@ pub struct ImuParts<S> {
 }
 
 impl<S: LieScalar + Serialize + DeserializeOwned> Calibration<S> {
-    /// Read one of basalt's calibration files.
-    ///
-    /// Unknown keys are collected and logged rather than rejected: EuRoC's
-    /// calibration carries a mocap block and msd-g2's carries a `comment`, and
-    /// neither belongs to the VIO struct.
+    /// Read a calibration JSON file.
+    /// Unknown keys are collected and logged: mocap blocks and descriptive comments
+    /// need not be part of the VIO calibration struct.
     pub fn from_json_str(text: &str) -> Result<Self, CalibError> {
         let wrapper: Value0<CalibrationJson<S>> = serde_json::from_str(text)?;
         let raw: CalibrationJson<S> = wrapper.value0;
@@ -765,7 +709,7 @@ impl<S: LieScalar + Serialize + DeserializeOwned> Calibration<S> {
         })
     }
 
-    /// Write the calibration back in basalt's shape, wrapper and all.
+    /// Write calibration JSON with its `value0` wrapper.
     pub fn to_json_string(&self) -> Result<String, CalibError> {
         let raw: CalibrationJson<S> = CalibrationJson {
             t_imu_cam: self.t_i_c.iter().map(PoseJson::from_se3).collect(),
@@ -792,14 +736,9 @@ impl<S: LieScalar> Calibration<S> {
         self.intrinsics.len()
     }
 
-    /// `Calibration::cast` (`calibration.hpp:113-136`): the whole rig in
-    /// another scalar.
-    ///
-    /// basalt builds its frontend from `cal.template cast<Scalar>()`
-    /// (`optical_flow.h:204`), so a `Calibration<f64>` read from the JSON is what
-    /// the file gives and a `Calibration<f32>` is what the frontend runs on
-    /// (decision D05). `unknown` is carried across unchanged; the C++ has no
-    /// such field.
+    /// Convert the whole rig to another scalar type.
+    /// JSON is read as f64 and the frontend uses an f32 calibration (D05).
+    /// Unknown fields are carried across unchanged.
     pub fn cast<T: LieScalar>(&self) -> Calibration<T> {
         let convert = |value: S| -> T { T::from_literal(value.to_f64()) };
         let convert3 = |value: &Vector3<S>| -> Vector3<T> {
@@ -835,24 +774,18 @@ impl<S: LieScalar> Calibration<S> {
     }
 
     /// Discrete-time gyroscope noise, `sigma_c sqrt(rate)`
-    /// (`calibration.hpp:186`).
     pub fn discrete_time_gyro_noise_std(&self) -> Vector3<S> {
         self.gyro_noise_std * self.imu_update_rate.sqrt()
     }
 
     /// Discrete-time accelerometer noise, `sigma_c sqrt(rate)`
-    /// (`calibration.hpp:193`).
     pub fn discrete_time_accel_noise_std(&self) -> Vector3<S> {
         self.accel_noise_std * self.imu_update_rate.sqrt()
     }
 
-    /// Build a calibration from what the catalog feed reports.
-    ///
-    /// The Python side already turns a recording's statics into
-    /// `CameraCalib`/`ImuCalib` dataclasses; this takes the same fields so the
-    /// PyO3 layer copies numbers rather than re-deriving them. The noise
-    /// densities are isotropic there and become the three equal components
-    /// basalt stores.
+    /// Build a calibration from catalog camera and IMU fields.
+    /// The PyO3 layer copies these values rather than deriving them again.
+    /// Isotropic noise densities become three equal components.
     pub fn from_catalog_parts(
         cameras: &[CameraParts<S>],
         imu: &ImuParts<S>,
@@ -885,13 +818,10 @@ impl<S: LieScalar> Calibration<S> {
     }
 }
 
-/// A rigid transform from a row-major 4x4, rejecting anything that is not one.
-///
-/// Sophus's rotation-matrix constructor requires **both** orthogonality and a
-/// positive determinant (`Sophus/sophus/so3.hpp:536-541`). Checking only the
-/// first lets a reflection through, and Eigen's matrix-to-quaternion conversion
-/// then returns a rotation that is not the input at all — `diag(-1, 1, 1)`
-/// becomes the identity, silently discarding the camera's geometry.
+/// Build a rigid transform from a row-major 4x4 matrix.
+/// A valid rotation must be orthogonal and have a positive determinant.
+/// Orthogonality alone accepts reflections, which cannot be represented by a
+/// rotation quaternion without losing the input geometry.
 fn pose_from_row_major<S: LieScalar>(m: &[S; 16], index: usize) -> Result<Se3<S>, CalibError> {
     let rotation: Matrix3<S> = Matrix3::new(m[0], m[1], m[2], m[4], m[5], m[6], m[8], m[9], m[10]);
     let residual: Matrix3<S> = rotation.transpose() * rotation - Matrix3::identity();
@@ -954,8 +884,7 @@ fn camera_model_from_parts<S: LieScalar>(
                 k4: d[3],
             }))
         }
-        // `catalog_feed` calls the model `radtan8`; basalt calls the same thing
-        // `pinhole-radtan8`. Both names land here.
+        // Accept both `radtan8` and `pinhole-radtan8` for the same model.
         "radtan8" | "pinhole-radtan8" => {
             expect(8, "pinhole-radtan8")?;
             Ok(CameraModel::PinholeRadtan8(Radtan8Params {
@@ -971,8 +900,7 @@ fn camera_model_from_parts<S: LieScalar>(
                 k4: d[5],
                 k5: d[6],
                 k6: d[7],
-                // basalt's own default when a calibration omits it
-                // (`camera/pinhole_radtan8_camera.hpp`): no radial cut-off.
+                // An omitted radius means no radial cut-off.
                 rpmax: camera.distortion_valid_radius.unwrap_or_else(S::zero),
             }))
         }
@@ -1136,7 +1064,7 @@ mod tests {
         assert!(calib.intrinsics.iter().all(|m| m.name() == "kb4"));
         assert_eq!(calib.resolution, vec![[960, 540]; 4]);
         assert_eq!(calib.imu_update_rate, 200.0);
-        // Kalibr numbers, not basalt's MSD defaults.
+        // Kalibr noise values for this rig.
         assert_abs_diff_eq!(
             calib.gyro_noise_std,
             Vector3::repeat(0.000_730_044_281_254_7),
@@ -1194,7 +1122,7 @@ mod tests {
         let calib: Calibration<f64> = Calibration::from_json_str(text).unwrap();
         let q: [f64; 4] = calib.t_i_c[0].rotation.quaternion_xyzw();
         assert_abs_diff_eq!(q[3], 1.0, epsilon = 1e-15);
-        // Everything absent falls back to basalt's constructor defaults.
+        // Absent fields retain the constructor defaults.
         assert_eq!(calib.imu_update_rate, 200.0);
         assert_abs_diff_eq!(calib.accel_noise_std, Vector3::repeat(0.016), epsilon = 0.0);
 
@@ -1345,14 +1273,13 @@ mod tests {
             epsilon = 1e-15
         );
 
-        // The result serializes into basalt's own shape and reads back.
+        // Calibration JSON round-trips with its wrapper.
         let text: String = calib.to_json_string().unwrap();
         let reread: Calibration<f64> = Calibration::from_json_str(&text).unwrap();
         assert_close(&calib, &reread, "from_catalog_parts");
     }
 
-    /// The catalog spells the eight-coefficient model `radtan8`; basalt spells
-    /// it `pinhole-radtan8`. Both must produce the same variant.
+    /// Both `radtan8` and `pinhole-radtan8` must select the same variant.
     #[test]
     fn the_catalog_radtan8_name_is_accepted() {
         let coefficients: Vec<f64> = vec![0.1, 0.2, 0.001, 0.002, 0.3, 0.4, 0.5, 0.6];
@@ -1413,10 +1340,8 @@ mod tests {
         ));
     }
 
-    /// A reflection is orthonormal, so the orthogonality check alone lets it
-    /// through, and Eigen's conversion then turns `diag(-1, 1, 1)` into the
-    /// identity — a camera silently pointing somewhere else. Sophus rejects it
-    /// on the determinant (`Sophus/sophus/so3.hpp:539-540`) and so does this.
+    /// A reflection is orthogonal but has negative determinant. Reject it before
+    /// quaternion conversion can silently change the camera geometry.
     #[test]
     fn catalog_parts_reject_a_reflected_rotation() {
         let mut camera: CameraParts<f64> = a_camera("kb4", vec![0.1; 4]);

--- a/packages/slam-rs/crates/slam-rs/src/camera.rs
+++ b/packages/slam-rs/crates/slam-rs/src/camera.rs
@@ -1,76 +1,22 @@
-//! basalt's camera models: projection, unprojection and their analytic Jacobians.
+//! Camera projection, unprojection and analytic Jacobians.
 //!
-//! Ported line by line from
-//! `thirdparty/basalt-headers/include/basalt/camera/{pinhole_camera,kannala_brandt_camera4,pinhole_radtan8_camera}.hpp`.
-//! Every formula and every domain check below names the C++ line it comes from,
-//! because the accuracy gate cannot tell a transcription slip from an estimator
-//! bug (decision D14).
+//! [`Camera::project`] writes a pixel and returns validity for a 4-D homogeneous
+//! point. Optional borrowed Jacobian matrices avoid allocation and dynamic dispatch
+//! (D11). Projection Jacobians are 2x4 and 2xN; unprojection Jacobians are 4x2
+//! and 4xN. The homogeneous coordinate has a zero derivative. Unprojection
+//! returns a unit bearing with fourth component zero.
 //!
-//! ## The signature
+//! Pinhole, kb4 and pinhole-radtan8 are implemented. `ds`, `eucm` and `ucm`
+//! parse in [`crate::calib`] but return [`CameraError::UnsupportedModel`].
+//! The intrinsic counts are 4, 8 and 12 respectively.
 //!
-//! basalt projects a **4-D homogeneous** point and writes the result through an
-//! out parameter, returning a validity flag:
+//! The radtan8 valid radius is read from calibration and held constant by
+//! [`PinholeRadtan8::apply_inc`], including during finite differences. Its
+//! unprojection Jacobian is unsupported and returns a typed error.
 //!
-//! ```cpp
-//! // pinhole_radtan8_camera.hpp:301-302
-//! bool project(const Eigen::MatrixBase<DerivedPoint3D>& p3d, Eigen::MatrixBase<DerivedPoint2D>& proj,
-//!              DerivedJ3D d_proj_d_p3d = nullptr, DerivedJparam d_proj_d_param = nullptr) const;
-//! ```
-//!
-//! The port keeps that shape: [`Camera::project`] fills a `Vector2` and returns
-//! `bool`, and [`Camera::project_with_jacobians`] takes the two Jacobians as
-//! `Option<&mut …>`. C++ selects the Jacobian blocks with `if constexpr` on a
-//! template parameter; the Rust equivalent is a monomorphized `Option` that the
-//! optimizer folds away, so neither form allocates and neither is a `Box<dyn>`
-//! (decision D11).
-//!
-//! Layouts follow basalt exactly: `d_proj_d_p3d` is 2x4 with a zero fourth
-//! column (the homogeneous coordinate never enters the projection),
-//! `d_proj_d_param` is 2xN with N = 4 for pinhole, 8 for kb4 and 12 for
-//! pinhole-radtan8, `d_p3d_d_proj` is 4x2 and `d_p3d_d_param` is 4xN, both with
-//! a zero fourth row. [`Camera::unproject`] returns a unit-norm bearing whose
-//! fourth component is zero, which is what `p3d.setZero()` followed by three
-//! assignments produces in C++ (`kannala_brandt_camera4.hpp:366-369`).
-//!
-//! ## What is here and what is not
-//!
-//! V0 ships `pinhole`, `kb4` and `pinhole-radtan8`: the models the reference
-//! datasets use (msd-index and RoboCap are kb4, msd-g2 is pinhole-radtan8) plus
-//! the pinhole the VIT binding maps `DISTORTION_NONE` onto (decision D11).
-//! `ds`, `eucm` and `ucm` parse in [`crate::calib`] and are rejected here with
-//! [`CameraError::UnsupportedModel`].
-//!
-//! Two pieces of the C++ are deliberately absent:
-//!
-//! * **`PinholeRadtan8Camera::computeRpmax()`** (`:131-242`), the gradient-ascent
-//!   estimate of the valid radius. Every calibration this port reads carries
-//!   `rpmax` on disk, and the ABS_QR VIO path does not optimize intrinsics, so
-//!   the estimate has no caller. [`PinholeRadtan8::apply_inc`] therefore leaves
-//!   `rpmax` alone where C++ recomputes it (`:688-691`) — which is also what
-//!   makes a finite-difference check of `d_proj_d_param` meaningful, since the
-//!   analytic Jacobian treats `rpmax` as a constant.
-//! * **`d_p3d_d_proj` for pinhole-radtan8**, which C++ does not have either: it
-//!   asserts (`:657-659`). The port returns
-//!   [`CameraError::UnprojectJacobianUnsupported`] rather than asserting.
-//!
-//! ## Scalars
-//!
-//! Generic over [`LieScalar`] (`f32` and `f64`) because the frontend runs `f32`
-//! and the estimator is instantiated at both (decision D05). Two rules, and they
-//! point in opposite directions:
-//!
-//! * **No domain check is promoted.** Every one compares a `Scalar` against
-//!   `Sophus::Constants<Scalar>::epsilonSqrt()`, which is `sqrt(1e-10)` in double
-//!   and `sqrt(1e-5)` in float, so the branch is genuinely precision-dependent
-//!   and the port reproduces it as it stands.
-//! * **`atan2` is promoted**, in kb4's projection only. The header imports `cos`,
-//!   `sin` and `sqrt` from `std` (`kannala_brandt_camera4.hpp:48-50`) but not
-//!   `atan2`, so the unqualified call at `:153` takes the `double` overload from
-//!   `<math.h>` and the float instantiation computes its angle in double. The
-//!   port does the same; see the comment at the call site for the measurement.
-//!
-//! Both are decision D37's rule — do in `f64` exactly what the C++ does in
-//! `double`, and no more — read off the C++ rather than assumed.
+//! Both scalar lanes retain precision-specific domain thresholds: `sqrt(1e-10)`
+//! for f64 and `sqrt(1e-5)` for f32. The kb4 projection angle is computed in f64
+//! and rounded back to the selected scalar to reduce angle rounding error.
 
 use nalgebra::{Matrix2, Matrix2x4, Matrix4x2, SMatrix, SVector, Vector2, Vector4};
 
@@ -83,13 +29,13 @@ pub enum CameraError {
     /// A model that [`crate::calib`] parses but this module does not project with.
     #[error("camera model {model} is parsed but its projection is not implemented")]
     UnsupportedModel {
-        /// basalt's name for the model, as written in `camera_type`.
+        /// Model name stored in `camera_type`.
         model: &'static str,
     },
-    /// basalt has no analytic unprojection Jacobian for this model.
+    /// An analytic unprojection Jacobian is unavailable for this model.
     #[error("camera model {model} has no analytic unprojection Jacobian")]
     UnprojectJacobianUnsupported {
-        /// basalt's name for the model, as written in `camera_type`.
+        /// Model name stored in `camera_type`.
         model: &'static str,
     },
     /// The calibration does not carry one resolution per camera.
@@ -102,13 +48,10 @@ pub enum CameraError {
     },
 }
 
-/// One camera model: basalt's `project`/`unproject` pair.
-///
-/// The associated `Params` vector is basalt's `param_` in `getParam()` order,
-/// which is also the order `operator+=` increments and the column order of
-/// `d_proj_d_param`.
+/// A camera model with projection and unprojection.
+/// `Params` uses the intrinsic parameter order, shared by increments and Jacobian columns.
 pub trait Camera<S: LieScalar>: Copy {
-    /// basalt's `N`, the number of intrinsic parameters.
+    /// Number of intrinsic parameters.
     const NUM_PARAMS: usize;
 
     /// `VecN`: the intrinsic parameters in `getParam()` order.
@@ -117,7 +60,7 @@ pub trait Camera<S: LieScalar>: Copy {
     /// `Mat2N`: the projection Jacobian with respect to the intrinsics.
     type ParamJacobian: Copy;
 
-    /// basalt's `getName()`, the string that appears in `camera_type`.
+    /// Model name stored in `camera_type`.
     fn name(&self) -> &'static str;
 
     /// `getParam()`.
@@ -126,10 +69,8 @@ pub trait Camera<S: LieScalar>: Copy {
     /// `operator+=`: increment the intrinsics, as the calibration optimizer does.
     fn apply_inc(&mut self, inc: &Self::Params);
 
-    /// Project a homogeneous point, filling `proj`; `false` outside the valid domain.
-    ///
-    /// `proj` is written even when the point is invalid, exactly as the C++
-    /// does: the caller checks the flag, not the pixel.
+    /// Project a homogeneous point, filling `proj`; return `false` outside the domain.
+    /// The pixel may be written even for invalid input, so callers must check validity.
     #[inline]
     fn project(&self, p3d: &Vector4<S>, proj: &mut Vector2<S>) -> bool {
         self.project_with_jacobians(p3d, proj, None, None)
@@ -148,11 +89,8 @@ pub trait Camera<S: LieScalar>: Copy {
     fn unproject(&self, proj: &Vector2<S>, p3d: &mut Vector4<S>) -> bool;
 }
 
-/// The models whose unprojection basalt differentiates: `pinhole` and `kb4`.
-///
-/// `pinhole-radtan8` is not one of them (`pinhole_radtan8_camera.hpp:657-659`
-/// asserts), and the C++ test file has the matching tests commented out
-/// (`test/src/test_camera.cpp:374-379`).
+/// Models with analytic unprojection Jacobians: pinhole and kb4.
+/// Radtan8 unprojection has no analytic Jacobian implementation.
 pub trait UnprojectJacobians<S: LieScalar>: Camera<S> {
     /// `Mat4N`: the unprojection Jacobian with respect to the intrinsics.
     type UnprojectParamJacobian: Copy;
@@ -169,14 +107,14 @@ pub trait UnprojectJacobians<S: LieScalar>: Camera<S> {
 
 // ─── pinhole ──────────────────────────────────────────────────────────────
 
-/// `basalt::PinholeCamera` (`pinhole_camera.hpp:55`), N = 4.
+/// Pinhole projection with four parameters.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Pinhole<S: LieScalar> {
     param: SVector<S, 4>,
 }
 
 impl<S: LieScalar> Pinhole<S> {
-    /// Build from `[fx, fy, cx, cy]` (`pinhole_camera.hpp:77`).
+    /// Build from `[fx, fy, cx, cy]`.
     pub fn new(param: SVector<S, 4>) -> Self {
         Self { param }
     }
@@ -199,7 +137,6 @@ impl<S: LieScalar> Camera<S> for Pinhole<S> {
         self.param += inc;
     }
 
-    /// `pinhole_camera.hpp:119-166`.
     fn project_with_jacobians(
         &self,
         p3d: &Vector4<S>,
@@ -216,15 +153,12 @@ impl<S: LieScalar> Camera<S> for Pinhole<S> {
         let y: S = p3d[1];
         let z: S = p3d[2];
 
-        // :134-135
         proj[0] = fx * x / z + cx;
         proj[1] = fy * y / z + cy;
 
-        // :137
         let is_valid: bool = z >= S::sophus_epsilon_sqrt();
 
         if let Some(jacobian) = d_proj_d_p3d {
-            // :142-149
             jacobian.fill(S::zero());
             let z2: S = z * z;
             jacobian[(0, 0)] = fx / z;
@@ -234,7 +168,6 @@ impl<S: LieScalar> Camera<S> for Pinhole<S> {
         }
 
         if let Some(jacobian) = d_proj_d_param {
-            // :156-160
             jacobian.fill(S::zero());
             jacobian[(0, 0)] = x / z;
             jacobian[(0, 2)] = S::one();
@@ -245,7 +178,6 @@ impl<S: LieScalar> Camera<S> for Pinhole<S> {
         is_valid
     }
 
-    /// `pinhole_camera.hpp:190-254`.
     fn unproject(&self, proj: &Vector2<S>, p3d: &mut Vector4<S>) -> bool {
         self.unproject_with_jacobians(proj, p3d, None, None)
     }
@@ -254,7 +186,6 @@ impl<S: LieScalar> Camera<S> for Pinhole<S> {
 impl<S: LieScalar> UnprojectJacobians<S> for Pinhole<S> {
     type UnprojectParamJacobian = SMatrix<S, 4, 4>;
 
-    /// `pinhole_camera.hpp:190-254`.
     fn unproject_with_jacobians(
         &self,
         proj: &Vector2<S>,
@@ -267,7 +198,6 @@ impl<S: LieScalar> UnprojectJacobians<S> for Pinhole<S> {
         let cx: S = self.param[2];
         let cy: S = self.param[3];
 
-        // :201-212
         let mx: S = (proj[0] - cx) / fx;
         let my: S = (proj[1] - cy) / fy;
         let r2: S = mx * mx + my * my;
@@ -280,7 +210,6 @@ impl<S: LieScalar> UnprojectJacobians<S> for Pinhole<S> {
         p3d[2] = norm_inv;
 
         if d_p3d_d_proj.is_some() || d_p3d_d_param.is_some() {
-            // :215-228
             let d_norm_inv_d_r2: S = -c::<S>(0.5) * norm_inv * norm_inv * norm_inv;
             let two: S = c(2.0);
 
@@ -295,13 +224,11 @@ impl<S: LieScalar> UnprojectJacobians<S> for Pinhole<S> {
             c1[2] = two * my * d_norm_inv_d_r2 / fy;
 
             if let Some(jacobian) = d_p3d_d_proj {
-                // :232-233
                 jacobian.set_column(0, &c0);
                 jacobian.set_column(1, &c1);
             }
 
             if let Some(jacobian) = d_p3d_d_param {
-                // :240-244
                 jacobian.set_column(2, &(-c0));
                 jacobian.set_column(3, &(-c1));
                 jacobian.set_column(0, &(-c0 * mx));
@@ -309,30 +236,29 @@ impl<S: LieScalar> UnprojectJacobians<S> for Pinhole<S> {
             }
         }
 
-        // :253
         true
     }
 }
 
 // ─── kb4 ──────────────────────────────────────────────────────────────────
 
-/// `basalt::KannalaBrandtCamera4` (`kannala_brandt_camera4.hpp:63`), N = 8.
+/// Kannala-Brandt projection with four radial terms and eight parameters.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct KannalaBrandt4<S: LieScalar> {
     param: SVector<S, 8>,
 }
 
 impl<S: LieScalar> KannalaBrandt4<S> {
-    /// Build from `[fx, fy, cx, cy, k1, k2, k3, k4]` (`kannala_brandt_camera4.hpp:86`).
+    /// Build from `[fx, fy, cx, cy, k1, k2, k3, k4]`.
     pub fn new(param: SVector<S, 8>) -> Self {
         Self { param }
     }
 
-    /// `solveTheta<ITER>` (`kannala_brandt_camera4.hpp:274-308`).
+    /// `solveTheta<ITER>`.
     ///
     /// Three Newton steps on `d(theta) - r_theta = 0`, with no convergence test
     /// and no guard on `d_func_d_theta`: the count is fixed at the call site
-    /// (`:359`, `solveTheta<3>`) and that is the whole stopping rule.
+    /// (`solveTheta<3>`) and that is the whole stopping rule.
     fn solve_theta(&self, r_theta: S, d_func_d_theta: &mut S) -> S {
         let k1: S = self.param[4];
         let k2: S = self.param[5];
@@ -343,7 +269,6 @@ impl<S: LieScalar> KannalaBrandt4<S> {
         for _ in 0..3 {
             let theta2: S = theta * theta;
 
-            // :284-292
             let mut func: S = k4 * theta2;
             func += k3;
             func *= theta2;
@@ -354,7 +279,6 @@ impl<S: LieScalar> KannalaBrandt4<S> {
             func += S::one();
             func *= theta;
 
-            // :294-301
             let mut derivative: S = c::<S>(9.0) * k4 * theta2;
             derivative += c::<S>(7.0) * k3;
             derivative *= theta2;
@@ -365,7 +289,6 @@ impl<S: LieScalar> KannalaBrandt4<S> {
             derivative += S::one();
             *d_func_d_theta = derivative;
 
-            // :304
             theta += (r_theta - func) / derivative;
         }
 
@@ -390,7 +313,6 @@ impl<S: LieScalar> Camera<S> for KannalaBrandt4<S> {
         self.param += inc;
     }
 
-    /// `kannala_brandt_camera4.hpp:129-260`.
     fn project_with_jacobians(
         &self,
         p3d: &Vector4<S>,
@@ -411,25 +333,14 @@ impl<S: LieScalar> Camera<S> for KannalaBrandt4<S> {
         let y: S = p3d[1];
         let z: S = p3d[2];
 
-        // :148-149
         let r2: S = x * x + y * y;
         let r: S = r2.sqrt();
 
         let mut is_valid: bool = true;
         if r > S::sophus_epsilon_sqrt() {
-            // :153-167. atan2(r, z) accepts z < 0: a fisheye sees behind its
-            // own plane, which is why this branch never invalidates a point.
-            //
-            // The angle is computed in `f64` and rounded back even in the `f32`
-            // instantiation, because that is what the C++ does. The header's
-            // `using` declarations (`:48-50`) cover `cos`, `sin` and `sqrt` but
-            // **not** `atan2`, so the unqualified call at `:153` resolves to
-            // `::atan2(double, double)` from `<math.h>` and the float arguments
-            // are promoted. Measured on this host: `atan2f(4.123105526f, -1.0f)`
-            // is `0x3fe784b5` while the promoted call gives `0x3fe784b6`, and
-            // that one bit of angle is 6e-5 px on basalt's own kb4 test camera.
-            // Same rule as decision D37, applied to a call instead of a
-            // comparison.
+            // `atan2(r, z)` permits negative z: a fisheye can see behind its own plane.
+            // Compute the angle in f64 and round back for the f32 lane; a one-bit angle
+            // change can move the projected pixel near a branch boundary.
             let theta: S = S::from_literal(r.to_f64().atan2(z.to_f64()));
             let theta2: S = theta * theta;
 
@@ -446,12 +357,10 @@ impl<S: LieScalar> Camera<S> for KannalaBrandt4<S> {
             let mx: S = x * r_theta / r;
             let my: S = y * r_theta / r;
 
-            // :169-170
             proj[0] = fx * mx + cx;
             proj[1] = fy * my + cy;
 
             if let Some(jacobian) = d_proj_d_p3d {
-                // :174-201
                 let d_r_d_x: S = x / r;
                 let d_r_d_y: S = y / r;
 
@@ -489,7 +398,6 @@ impl<S: LieScalar> Camera<S> for KannalaBrandt4<S> {
             }
 
             if let Some(jacobian) = d_proj_d_param {
-                // :208-219
                 jacobian.fill(S::zero());
                 jacobian[(0, 0)] = mx;
                 jacobian[(0, 2)] = S::one();
@@ -505,8 +413,7 @@ impl<S: LieScalar> Camera<S> for KannalaBrandt4<S> {
                 }
             }
         } else {
-            // :225-256. Too close to the optical axis for `atan2` to be stable,
-            // so the model degenerates to a pinhole and the sign of z decides.
+            // Near the optical axis, use the pinhole limit and let the sign of z decide validity.
             if z < S::sophus_epsilon_sqrt() {
                 is_valid = false;
             }
@@ -535,7 +442,6 @@ impl<S: LieScalar> Camera<S> for KannalaBrandt4<S> {
         is_valid
     }
 
-    /// `kannala_brandt_camera4.hpp:337-455`.
     fn unproject(&self, proj: &Vector2<S>, p3d: &mut Vector4<S>) -> bool {
         self.unproject_with_jacobians(proj, p3d, None, None)
     }
@@ -544,7 +450,6 @@ impl<S: LieScalar> Camera<S> for KannalaBrandt4<S> {
 impl<S: LieScalar> UnprojectJacobians<S> for KannalaBrandt4<S> {
     type UnprojectParamJacobian = SMatrix<S, 4, 8>;
 
-    /// `kannala_brandt_camera4.hpp:337-455`.
     fn unproject_with_jacobians(
         &self,
         proj: &Vector2<S>,
@@ -557,7 +462,6 @@ impl<S: LieScalar> UnprojectJacobians<S> for KannalaBrandt4<S> {
         let cx: S = self.param[2];
         let cy: S = self.param[3];
 
-        // :348-369
         let mx: S = (proj[0] - cx) / fx;
         let my: S = (proj[1] - cy) / fy;
 
@@ -581,7 +485,6 @@ impl<S: LieScalar> UnprojectJacobians<S> for KannalaBrandt4<S> {
         p3d[2] = cos_theta;
 
         if d_p3d_d_proj.is_some() || d_p3d_d_param.is_some() {
-            // :372-417
             let mut d_thetad_d_mx: S = S::zero();
             let mut d_thetad_d_my: S = S::zero();
             let mut d_scaling_d_thetad: S = S::zero();
@@ -626,13 +529,11 @@ impl<S: LieScalar> UnprojectJacobians<S> for KannalaBrandt4<S> {
             c1[2] = d_res2_d_my / fy;
 
             if let Some(jacobian) = d_p3d_d_proj {
-                // :421-422
                 jacobian.set_column(0, &c0);
                 jacobian.set_column(1, &c1);
             }
 
             if let Some(jacobian) = d_p3d_d_param {
-                // :429-443
                 jacobian.fill(S::zero());
 
                 jacobian.set_column(2, &(-c0));
@@ -652,18 +553,15 @@ impl<S: LieScalar> UnprojectJacobians<S> for KannalaBrandt4<S> {
             }
         }
 
-        // :454
         true
     }
 }
 
 // ─── pinhole-radtan8 ──────────────────────────────────────────────────────
 
-/// `basalt::PinholeRadtan8Camera` (`pinhole_radtan8_camera.hpp:69`), N = 12 plus `rpmax`.
-///
-/// `rpmax` bounds the radius in the z = 1 plane where the rational distortion
-/// is still injective (`:116-130`); zero means unbounded. It is stored beside
-/// the twelve optimized parameters, not inside them (`:729-733`).
+/// Rational Brown-Conrady projection with twelve parameters and `rpmax`.
+/// The radius bounds the injective region in the z = 1 plane. Zero is unbounded.
+/// It is stored separately from the optimized parameters.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PinholeRadtan8<S: LieScalar> {
     param: SVector<S, 12>,
@@ -671,22 +569,18 @@ pub struct PinholeRadtan8<S: LieScalar> {
 }
 
 impl<S: LieScalar> PinholeRadtan8<S> {
-    /// Build from `[fx, fy, cx, cy, k1, k2, p1, p2, k3, k4, k5, k6]` and `rpmax`
-    /// (`pinhole_radtan8_camera.hpp:100-103`).
-    ///
-    /// Unlike the C++ constructor there is no `rpmax = -1` sentinel that
-    /// triggers `computeRpmax()`: the port never estimates the radius, it reads
-    /// it from the calibration.
+    /// Build from `[fx, fy, cx, cy, k1, k2, p1, p2, k3, k4, k5, k6]` and `rpmax`.
+    /// The radius is supplied by calibration, never estimated by this constructor.
     pub fn new(param: SVector<S, 12>, rpmax: S) -> Self {
         Self { param, rpmax }
     }
 
-    /// `getRpmax()` (`pinhole_radtan8_camera.hpp:702`).
+    /// `getRpmax()`.
     pub fn rpmax(&self) -> S {
         self.rpmax
     }
 
-    /// `distort` (`pinhole_radtan8_camera.hpp:505-563`): the normalized point
+    /// `distort` : the normalized point
     /// `(x', y')` mapped to `(x'', y'')`, with an optional 2x2 Jacobian.
     pub fn distort(
         &self,
@@ -707,7 +601,6 @@ impl<S: LieScalar> PinholeRadtan8<S> {
         let s2: S = c(2.0);
         let s3: S = c(3.0);
 
-        // :515-524
         let xp: S = undist[0];
         let yp: S = undist[1];
         let rp2: S = xp * xp + yp * yp;
@@ -719,7 +612,7 @@ impl<S: LieScalar> PinholeRadtan8<S> {
         dist[1] = yp * cdist + delta_y;
 
         if let Some(jacobian) = d_dist_d_undist {
-            // :530-559, sympy-derived in the C++ and transcribed verbatim.
+            // Analytic distortion Jacobian.
             let v0: S = xp * xp;
             let v1: S = yp * yp;
             let v2: S = v0 + v1;
@@ -762,13 +655,12 @@ impl<S: LieScalar> Camera<S> for PinholeRadtan8<S> {
         self.param
     }
 
-    /// `operator+=` (`pinhole_radtan8_camera.hpp:688-691`) **without** the
+    /// `operator+=` **without** the
     /// `rpmax_ = computeRpmax()` that follows it: see the module docs.
     fn apply_inc(&mut self, inc: &Self::Params) {
         self.param += inc;
     }
 
-    /// `pinhole_radtan8_camera.hpp:301-494`.
     fn project_with_jacobians(
         &self,
         p3d: &Vector4<S>,
@@ -798,7 +690,6 @@ impl<S: LieScalar> Camera<S> for PinholeRadtan8<S> {
         let s2: S = c(2.0);
         let s3: S = c(3.0);
 
-        // :324-336
         let xp: S = x / z;
         let yp: S = y / z;
         let rp2: S = xp * xp + yp * yp;
@@ -811,7 +702,6 @@ impl<S: LieScalar> Camera<S> for PinholeRadtan8<S> {
         proj[0] = fx * xpp + cx;
         proj[1] = fy * ypp + cy;
 
-        // :338-340
         let positive_z: bool = z >= S::sophus_epsilon_sqrt();
         let in_injective_area: bool = if self.rpmax == s0 {
             true
@@ -821,7 +711,7 @@ impl<S: LieScalar> Camera<S> for PinholeRadtan8<S> {
         let is_valid: bool = positive_z && in_injective_area;
 
         if let Some(jacobian) = d_proj_d_p3d {
-            // :348-398, sympy-derived in the C++ and transcribed verbatim.
+            // Analytic projection Jacobian with respect to the point.
             jacobian.fill(s0);
 
             let v0: S = p1 * y;
@@ -871,7 +761,7 @@ impl<S: LieScalar> Camera<S> for PinholeRadtan8<S> {
         }
 
         if let Some(jacobian) = d_proj_d_param {
-            // :405-488, sympy-derived in the C++ and transcribed verbatim.
+            // Analytic projection Jacobian with respect to the parameters.
             jacobian.fill(s0);
 
             let w0: S = z * z * z * z * z * z;
@@ -945,10 +835,8 @@ impl<S: LieScalar> Camera<S> for PinholeRadtan8<S> {
         let cx: S = self.param[2];
         let cy: S = self.param[3];
 
-        // :610-611
         let dist: Vector2<S> = Vector2::new((proj[0] - cx) / fx, (proj[1] - cy) / fy);
 
-        // :619-630
         let mut undist: Vector2<S> = dist;
         let eps: S = S::sophus_epsilon_sqrt();
         for _ in 0..5 {
@@ -970,14 +858,12 @@ impl<S: LieScalar> Camera<S> for PinholeRadtan8<S> {
         let xp: S = undist[0];
         let yp: S = undist[1];
 
-        // :651-655
         let norm_inv: S = S::one() / (xp * xp + yp * yp + S::one()).sqrt();
         p3d.fill(S::zero());
         p3d[0] = xp * norm_inv;
         p3d[1] = yp * norm_inv;
         p3d[2] = norm_inv;
 
-        // :664-666
         let rp2: S = xp * xp + yp * yp;
         if self.rpmax == S::zero() {
             true
@@ -989,15 +875,8 @@ impl<S: LieScalar> Camera<S> for PinholeRadtan8<S> {
 
 // ─── the variant ──────────────────────────────────────────────────────────
 
-/// `basalt::GenericCamera` (`generic_camera.hpp:62`), narrowed to V0's models.
-///
-/// basalt dispatches with `std::visit` and warns that a per-point visit is
-/// "**SLOW** … requires vtable lookup for every projection"
-/// (`generic_camera.hpp:127-129`); a Rust enum matched inside the loop is a
-/// jump table over three monomorphized bodies, with no vtable and no `Box<dyn>`.
-///
-/// `ds`, `eucm` and `ucm` parse in [`crate::calib::CameraModel`] but have no
-/// variant here: [`CameraEnum::from_model`] rejects them (decision D11).
+/// Dispatch among the three implemented projection models without a vtable.
+/// `ds`, `eucm` and `ucm` parse but are rejected by [`CameraEnum::from_model`] (D11).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum CameraEnum<S: LieScalar> {
     /// `pinhole`.
@@ -1032,7 +911,7 @@ impl<S: LieScalar> CameraEnum<S> {
         }
     }
 
-    /// basalt's `getName()` (`generic_camera.hpp:96`).
+    /// The model name.
     pub fn name(&self) -> &'static str {
         match self {
             Self::Pinhole(cam) => cam.name(),
@@ -1076,7 +955,7 @@ impl<S: LieScalar> CameraEnum<S> {
     }
 
     /// Project and fill the 2x4 point Jacobian, the only one
-    /// `GenericCamera::project` exposes (`generic_camera.hpp:135`).
+    /// `GenericCamera::project` exposes.
     #[inline]
     pub fn project_with_jacobian(
         &self,
@@ -1103,10 +982,8 @@ impl<S: LieScalar> CameraEnum<S> {
         }
     }
 
-    /// Unproject and fill the 4x2 Jacobian (`generic_camera.hpp:157`).
-    ///
-    /// `pinhole-radtan8` has none: C++ asserts, the port returns
-    /// [`CameraError::UnprojectJacobianUnsupported`].
+    /// Unproject and fill the 4x2 Jacobian.
+    /// Radtan8 returns [`CameraError::UnprojectJacobianUnsupported`].
     pub fn unproject_with_jacobian(
         &self,
         proj: &Vector2<S>,
@@ -1125,12 +1002,8 @@ impl<S: LieScalar> CameraEnum<S> {
     }
 }
 
-/// One camera of a rig: a projection model plus the size of the images it produces.
-///
-/// basalt reads `resolution[0]` for every camera
-/// (`frame_to_frame_optical_flow.h:108-109`); the port carries a resolution per
-/// camera because the msd-g2 recordings are stored rotated into portrait and
-/// the cameras of one rig then disagree (decision D30).
+/// A projection model and its camera's own image size.
+/// Per-camera resolutions support rigs whose stored orientations differ (D30).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RigCamera<S: LieScalar> {
     /// The projection model.
@@ -1171,18 +1044,10 @@ impl<S: LieScalar> RigCamera<S> {
         self.resolution[1]
     }
 
-    /// `Image::InBounds(p, border)` for floating-point coordinates
-    /// (`image/image.h:695-705`).
-    ///
-    /// The `offset` of one that the C++ adds for floating-point scalars is what
-    /// keeps `interp` from reading the row past the last one, so a keypoint at
-    /// `border` is in and a keypoint at `height - border - 1` is out.
-    ///
-    /// No production caller: the frontend asks
-    /// [`crate::image::ImageU16::in_bounds`], the same C++ predicate over the
-    /// buffer it is about to read. This one answers from the *calibrated*
-    /// resolution, which is what `tests/camera_jacobians.rs` needs to say where
-    /// a projection lands on the sensor.
+    /// Floating-point image bounds with a one-pixel interpolation margin.
+    /// A coordinate at `border` is in; one at `height - border - 1` is out.
+    /// Tests use the calibrated resolution here. The frontend uses
+    /// [`crate::image::ImageU16::in_bounds`] on the actual buffer.
     pub fn in_bounds(&self, uv: &Vector2<S>, border: S) -> bool {
         let width: S = c(f64::from(self.resolution[0]));
         let height: S = c(f64::from(self.resolution[1]));
@@ -1201,7 +1066,7 @@ mod tests {
     use super::*;
     use approx::assert_abs_diff_eq;
 
-    /// `KannalaBrandtCamera4::getTestProjections()` (`kannala_brandt_camera4.hpp:491`).
+    /// `KannalaBrandtCamera4::getTestProjections()`.
     fn kb4_test_camera<S: LieScalar>() -> KannalaBrandt4<S> {
         KannalaBrandt4::new(SVector::<S, 8>::from([
             c(379.045),
@@ -1217,7 +1082,7 @@ mod tests {
 
     #[test]
     fn a_pinhole_projects_and_unprojects_a_known_point() {
-        // Euroc intrinsics, `pinhole_camera.hpp:287`.
+        // Euroc intrinsics.
         let camera: Pinhole<f64> = Pinhole::new(SVector::<f64, 4>::from([
             460.76484651566468,
             459.4051018049483,
@@ -1246,7 +1111,7 @@ mod tests {
         let camera: Pinhole<f64> =
             Pinhole::new(SVector::<f64, 4>::from([400.0, 400.0, 320.0, 240.0]));
         let mut uv: Vector2<f64> = Vector2::zeros();
-        // `pinhole_camera.hpp:137`: the bound is epsilonSqrt, not zero.
+        // the bound is epsilonSqrt, not zero.
         assert!(!camera.project(&Vector4::new(0.1, 0.1, -1.0, 1.0), &mut uv));
         assert!(uv.iter().all(|value| value.is_finite()));
         assert!(!camera.project(&Vector4::new(0.1, 0.1, 1e-8, 1.0), &mut uv));
@@ -1257,10 +1122,10 @@ mod tests {
     fn kb4_accepts_a_point_behind_its_own_plane_but_not_on_the_negative_axis() {
         let camera: KannalaBrandt4<f64> = kb4_test_camera();
         let mut uv: Vector2<f64> = Vector2::zeros();
-        // r > epsilonSqrt: `kannala_brandt_camera4.hpp:152` never invalidates,
+        // r > epsilonSqrt: never invalidates,
         // which is how a 190-degree fisheye sees behind itself.
         assert!(camera.project(&Vector4::new(1.0, 0.0, -1.0, 1.0), &mut uv));
-        // r <= epsilonSqrt and z < epsilonSqrt: `:226`.
+        // r <= epsilonSqrt and z < epsilonSqrt:.
         assert!(!camera.project(&Vector4::new(0.0, 0.0, -1.0, 1.0), &mut uv));
         assert!(uv.iter().all(|value| value.is_finite()));
     }
@@ -1278,7 +1143,7 @@ mod tests {
         let rpmax: f64 = camera.rpmax();
         assert_abs_diff_eq!(rpmax, 2.72763729095459, epsilon = 0.0);
 
-        // rp2 = (x/z)^2 + (y/z)^2 is compared against rpmax^2 (`:339`), so a
+        // rp2 = (x/z)^2 + (y/z)^2 is compared against rpmax^2, so a
         // point on the x axis at z = 1 is in or out by its x alone.
         let mut uv: Vector2<f64> = Vector2::zeros();
         let inside: Vector4<f64> = Vector4::new(rpmax - 1e-6, 0.0, 1.0, 1.0);
@@ -1325,7 +1190,7 @@ mod tests {
 
     #[test]
     fn radtan8_without_a_valid_radius_is_unbounded() {
-        // `:339`: rpmax == 0 means "injective everywhere", not "nothing is valid".
+        // rpmax == 0 means "injective everywhere", not "nothing is valid".
         let camera: PinholeRadtan8<f64> = PinholeRadtan8::new(
             SVector::<f64, 12>::from([
                 269.06, 269.16, 324.33, 245.22, 0.6257, 0.4661, -0.000185, -4.288e-5, 0.00417,
@@ -1388,7 +1253,7 @@ mod tests {
         assert_eq!(rig[0].model.name(), "kb4");
         assert_eq!([rig[0].width(), rig[0].height()], [960, 960]);
 
-        // `image/image.h:704`: border <= u < w - border - 1.
+        // border <= u < w - border - 1.
         assert!(rig[0].in_bounds(&Vector2::new(0.0, 0.0), 0.0));
         assert!(rig[0].in_bounds(&Vector2::new(958.999, 958.999), 0.0));
         assert!(!rig[0].in_bounds(&Vector2::new(959.0, 0.0), 0.0));

--- a/packages/slam-rs/crates/slam-rs/src/config.rs
+++ b/packages/slam-rs/crates/slam-rs/src/config.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Which linearization the estimator runs (`vio_config.h:42`).
+/// Which linearization the estimator runs.
 ///
 /// Only [`LinearizationType::AbsQr`] is ported (decision D13); the other two
 /// parse so a config that names them is still readable.
@@ -21,7 +21,7 @@ pub enum LinearizationType {
     RelSc,
 }
 
-/// How the frontend guesses where a feature moved (`vio_config.h:43`).
+/// How the frontend guesses where a feature moved.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MatchingGuessType {
     /// Start from the same pixel.
@@ -35,13 +35,13 @@ pub enum MatchingGuessType {
     ReprojAvgDepth,
 }
 
-/// Which keyframe gets marginalized (`vio_config.h:44`).
+/// Which keyframe gets marginalized.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum KeyframeMargCriteria {
-    /// The shared-feature ratio rule (`sqrt_keypoint_vio.cpp:814`).
+    /// The shared-feature ratio rule.
     #[serde(rename = "KF_MARG_DEFAULT")]
     Default,
-    /// The fork's forward-vector rule (`sqrt_keypoint_vio.cpp:770`).
+    /// The forward-vector eviction rule.
     #[serde(rename = "KF_MARG_FORWARD_VECTOR")]
     ForwardVector,
 }
@@ -54,17 +54,14 @@ pub enum ConfigError {
     Parse(#[from] serde_json::Error),
 }
 
-/// cereal's outer wrapper: every basalt JSON is one object under `value0`.
+/// The JSON wrapper: one object under `value0`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Value0<T> {
     #[serde(rename = "value0")]
     value0: T,
 }
 
-/// basalt's `VioConfig` (`include/basalt/utils/vio_config.h:46-128`).
-///
-/// The scalar widths follow the C++ exactly (`float` vs `double` vs `int`), so a
-/// value that is `float` there cannot silently gain precision here.
+/// VIO configuration with explicit scalar widths for numerical fields.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct VioConfig {
@@ -144,18 +141,11 @@ pub struct VioConfig {
     /// Non-finite or non-positive values use zero.
     #[serde(rename = "port.redetect_survivor_ratio")]
     pub port_redetect_survivor_ratio: f32,
-    /// LM steps the non-keyframe frame update gets; `0` solves the whole window
-    /// on every frameset (D76).
-    ///
-    /// `0` — every basalt file's value and [`VioConfig::default`]'s — is
-    /// basalt's own schedule: `optimize` runs the 87-unknown sliding window on
-    /// every frameset. Above zero a frameset that took no keyframe instead
-    /// solves the newest state's 15 unknowns against fixed landmarks and its IMU
-    /// factor, and the joint solve runs at keyframes only. The loop is the
-    /// window's, inclusive as `vio_max_iterations` is, so `5` is a budget of
-    /// **six** trials — accepted and backtracked together — not five; the two
-    /// caps mean the same thing on purpose. Carried by the profile overlay alone
-    /// (`configs/profiles/fast.json`); the `port.` spelling is D75's.
+    /// LM steps for a non-keyframe update; zero solves the whole window each frameset (D76).
+    /// Above zero, non-keyframes solve only the newest state's 15 unknowns against
+    /// fixed landmarks and its IMU factor. Keyframes still run the joint solve.
+    /// The iteration cap is inclusive and shared with backtracking: five permits six
+    /// trials. `configs/profiles/fast.json` selects this schedule through the `port.` key.
     #[serde(rename = "port.frame_update_max_iterations")]
     pub port_frame_update_max_iterations: i32,
 
@@ -178,9 +168,7 @@ pub struct VioConfig {
     /// Tracked-keypoint ratio below which a new keyframe is made.
     #[serde(rename = "config.vio_new_kf_keypoints_thresh")]
     pub vio_new_kf_keypoints_thresh: f32,
-    /// Estimator debug output. Parsed because every shipped JSON carries it,
-    /// and read by nothing: in C++ it gates console prints and the nullspace
-    /// and eigenvalue diagnostics, which the port does not carry (D68).
+    /// Parsed compatibility field for estimator debug output; currently unused (D68).
     #[serde(rename = "config.vio_debug")]
     pub vio_debug: bool,
     /// Nullspace and eigenvalue logging. Parsed and read by nothing, for the
@@ -216,9 +204,7 @@ pub struct VioConfig {
     /// Damping ceiling; exceeding it abandons the frame's optimization.
     #[serde(rename = "config.vio_lm_lambda_max")]
     pub vio_lm_lambda_max: f64,
-    /// Inert: the Jacobian-scaling code it would select is commented out
-    /// (`sqrt_keypoint_vio.cpp:1211-1212`), matching the paper's statement that
-    /// scaling is skipped.
+    /// Inert: Jacobian scaling is absent from the estimator (D68).
     #[serde(rename = "config.vio_scale_jacobian")]
     pub vio_scale_jacobian: bool,
     /// Gauge prior weight on the first pose.
@@ -245,7 +231,7 @@ pub struct VioConfig {
 }
 
 impl Default for VioConfig {
-    /// `VioConfig::VioConfig()` (`src/utils/vio_config.cpp:47-128`).
+    /// `VioConfig::VioConfig()`.
     fn default() -> Self {
         Self {
             optical_flow_type: "frame_to_frame".to_owned(),
@@ -310,7 +296,7 @@ impl VioConfig {
         Ok(wrapper.value0)
     }
 
-    /// Write the config back in basalt's shape, wrapper and all.
+    /// Write configuration JSON with its `value0` wrapper.
     pub fn to_json_string(&self) -> Result<String, ConfigError> {
         Ok(serde_json::to_string_pretty(&Value0 { value0: self })?)
     }
@@ -365,7 +351,7 @@ mod tests {
 
         assert_eq!(index.optical_flow_image_safe_radius, 472.0);
         assert_eq!(g2.optical_flow_image_safe_radius, 340.0);
-        // The RoboCap driver points at this file (`python/robocap_vit.toml:8`).
+        // The RoboCap driver points at this file (`python/robocap_vit.toml).
         assert_eq!(odyssey.optical_flow_image_safe_radius, 388.0);
 
         let mut normalised: VioConfig = g2.clone();

--- a/packages/slam-rs/crates/slam-rs/src/config.rs
+++ b/packages/slam-rs/crates/slam-rs/src/config.rs
@@ -351,7 +351,7 @@ mod tests {
 
         assert_eq!(index.optical_flow_image_safe_radius, 472.0);
         assert_eq!(g2.optical_flow_image_safe_radius, 340.0);
-        // The RoboCap driver points at this file (`python/robocap_vit.toml).
+        // The RoboCap driver points at this file (`python/robocap_vit.toml`).
         assert_eq!(odyssey.optical_flow_image_safe_radius, 388.0);
 
         let mut normalised: VioConfig = g2.clone();

--- a/packages/slam-rs/crates/slam-rs/src/estimator/frame_update.rs
+++ b/packages/slam-rs/crates/slam-rs/src/estimator/frame_update.rs
@@ -1,46 +1,16 @@
-//! The non-keyframe frame update (D76): the newest state alone, against fixed
-//! landmarks and its IMU factor.
+//! The non-keyframe update: solve only the newest state against fixed landmarks
+//! and its IMU factor (D76). It runs when `port.frame_update_max_iterations > 0`
+//! and no keyframe was taken. Zero keeps the full-window schedule.
 //!
-//! basalt has no counterpart. It is a fixed-lag smoother and re-solves the whole
-//! sliding window on every frameset ([`SqrtKeypointVio::optimize`]); cuVSLAM
-//! instead solves only the newest pose against constant landmarks per frame
-//! (`libs/pnp/multicam_pnp.cpp`) and runs bundle adjustment at keyframes, and
-//! this is that schedule's cheap half. It runs only when
-//! `port.frame_update_max_iterations` is above zero and only on a frameset that
-//! took no keyframe; at the knob's `0` default nothing here is reached and the
-//! estimator is basalt's, frame for frame.
+//! The residuals, Jacobians, robust weights, IMU factor, damped solve, damping
+//! policy and convergence predicate are shared with the window solve. The prior
+//! covers frozen blocks, while the newest state is unfrozen, so its cost is
+//! constant in this update. If the prior does order the newest state, this path
+//! declines the frame and the joint solve handles it.
 //!
-//! Everything numeric is borrowed rather than restated: the residual and its
-//! pose Jacobian are [`linearize_point`] and [`linearize_relative_pose`], the robust
-//! weight is the landmark block's own [`compute_error_weight`], the IMU factor is
-//! [`ImuBlock::linearize`], and the damped solve is [`damped_solve`] — the same
-//! pivoted LU factorization the window solve runs. The damping policy is
-//! [`LmDamping`](super::LmDamping)'s own and the convergence test is
-//! [`lm_converged`], so the two schedules cannot drift apart on either. There is
-//! one reprojection model in the crate.
-//!
-//! ## What is held, and why the prior is not here
-//!
-//! Landmarks, their host keyframes and every older state are constants, so the
-//! only free block is the newest state's 15 unknowns. The marginalization prior
-//! covers only blocks frozen at a linearization point — `computeDelta` refuses
-//! any other (`ba_base.cpp:294`) — and the newest state is appended unfrozen, so
-//! the prior's cost does not depend on the one variable this solves for and
-//! contributes neither a Jacobian nor a gradient. [`SqrtKeypointVio::frame_update`]
-//! checks that per frame and hands the frameset back to the joint solve if the
-//! prior ever does order it.
-//!
-//! ## The loop
-//!
-//! The window loop's shape, constant for constant: `lambda` reset to
-//! `vio_lm_lambda_initial` every frame (D11), `lambda·diag(H)` damping with the
-//! same floor (D10), the budget shared with backtracking (D12), the increment
-//! negated before it is applied (D13), and the shared Nielsen update and
-//! `1e-6`/`1e-4` convergence pair above. One difference, and it is a
-//! simplification the window cannot make: with nothing eliminated, the model's
-//! predicted decrease is `−(inc·b + ½ incᵀ H inc)` in closed form, which is what
-//! `backSubstitute` accumulates block by block when there are no landmark
-//! columns to substitute back.
+//! Lambda resets each frame; diagonal damping, the shared backtracking budget,
+//! negated increment and Nielsen update follow the window loop. With no landmark
+//! elimination, predicted decrease is `−(inc·b + ½ incᵀ H inc)` directly.
 
 use nalgebra::{DMatrix, DVector, Matrix2x6, Matrix4, Matrix6, Vector2, Vector6};
 
@@ -251,7 +221,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             return Ok(Err(FrameUpdateDecline::NoImuFactor));
         };
 
-        // `:1249`, D11: the trust region has no memory across framesets.
+        // D11: the trust region has no memory across framesets.
         damping.lambda = S::from_literal(config.vio_lm_lambda_initial);
 
         let mark: std::time::Instant = std::time::Instant::now();
@@ -298,7 +268,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             state.backup();
             state.apply_inc(&inc);
 
-            // `:1477`, folded left to right like the window's.
+            // folded left to right like the window's.
             let mut step_norminf: S = S::zero();
             for value in inc.iter() {
                 step_norminf = eigen_maxi(step_norminf, value.abs());
@@ -356,7 +326,6 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
                 continue;
             }
 
-            // `:1585-1598`.
             damping.escalate();
             let Some(state) = ba.frame_states.get_mut(&t_ns) else {
                 // Unreachable, as above.
@@ -447,10 +416,10 @@ fn linearize_state<S: LieScalar>(
                         camera_count: cameras.len(),
                     })?;
 
-            // `linearization_abs_qr.cpp:207-241`: the Jacobian at the
+            // the Jacobian at the
             // linearization point, the value at the current state when either
             // end is frozen. A landmark hosted by this frameset has no pose
-            // Jacobian at all (`:235-239`), which is what an identity relative
+            // Jacobian at all, which is what an identity relative
             // pose means.
             let (t_t_h, d_rel_d_t): (Matrix4<S>, Matrix6<S>) = if tcid_h == tcid_t {
                 (Matrix4::identity(), Matrix6::zeros())
@@ -510,11 +479,10 @@ fn linearize_state<S: LieScalar>(
                     proj: None,
                 },
             );
-            // `landmark_block_abs_dynamic.hpp:152`.
             if options.use_valid_projections_only && !valid {
                 continue;
             }
-            // `:153-163`: zeroed, never fatal.
+            // zeroed, never fatal.
             if !d_res_d_xi.iter().all(|v| v.to_f64().is_finite()) {
                 log::warn!(
                     "d_res_d_xi is not valid in the frame update, lm = {:?}",
@@ -523,7 +491,7 @@ fn linearize_state<S: LieScalar>(
                 d_res_d_xi.fill(S::zero());
             }
 
-            // `:168-179`, with the host block dropped: the landmark and its host
+            // with the host block dropped: the landmark and its host
             // are constants here.
             let res_squared: S = res[0] * res[0] + res[1] * res[1];
             let (weighted_error, weight) = compute_error_weight(res_squared, options);

--- a/packages/slam-rs/crates/slam-rs/src/estimator/mod.rs
+++ b/packages/slam-rs/crates/slam-rs/src/estimator/mod.rs
@@ -856,7 +856,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
     /// marginalization removed, for the V2 Rerun rung (D51).
     ///
     /// The landmark position is `host_pose * T_i_c * unproject(direction) /
-    /// inv_dist`, exactly as builds the landmark bundle, and a
+    /// inv_dist`, exactly as the landmark bundle is built, and a
     /// landmark whose host has left the window is skipped as it is there.
     pub fn snapshot(&self) -> WindowSnapshot<S> {
         let states: Vec<WindowState<S>> = self

--- a/packages/slam-rs/crates/slam-rs/src/estimator/mod.rs
+++ b/packages/slam-rs/crates/slam-rs/src/estimator/mod.rs
@@ -1,94 +1,30 @@
-//! The sliding-window VIO driver: `SqrtKeypointVioEstimator<Scalar>`.
+//! The offline sliding-window VIO driver.
 //!
-//! A port of `src/vi_estimator/sqrt_keypoint_vio.cpp` and
-//! `include/basalt/vi_estimator/sqrt_keypoint_vio.h` on the ABS_QR plus
-//! square-root-marginalization path only (D13), composing what the stages below
-//! already built: [`crate::ba_base::BundleAdjustmentBase`] for the window and
-//! the reprojection error, [`crate::imu::IntegratedImuMeasurement`] for the
-//! preintegration, [`crate::linearize::LinearizationAbsQR`] for the linearized
-//! problem and [`crate::marg::marginalize`] for the prior.
+//! The driver composes bundle adjustment, IMU preintegration, square-root
+//! linearization and marginalization. `process_frame` initializes from an
+//! accelerometer sample, integrates `(prev_t, curr_t]`, and calls `measure`.
+//! Measurement predicts the state, files observations, votes on a keyframe,
+//! triangulates landmarks, then optimizes and marginalizes.
 //!
-//! ## What the driver itself is
-//!
-//! Three functions, and they are the whole algorithm:
-//!
-//! * [`SqrtKeypointVio::process_frame`] is `proc_func`'s loop body
-//!   (`:263-355`): initialise from one accelerometer sample if this is the first
-//!   frame, preintegrate the IMU samples that fall in `(prev_t, curr_t]`, then
-//!   `measure`.
-//! * `SqrtKeypointVio::measure` (`:422-575`) predicts the new state, files the
-//!   observations, votes on a keyframe, triangulates what the window does not
-//!   yet know, and calls `optimize_and_marg`.
-//! * `optimize` (`optimize.rs`, `:1201-1639`) is the Levenberg–Marquardt loop
-//!   and `marginalize` (`schedule.rs`, `:707-1198`) is the schedule plus the
-//!   call into the square-root helper.
-//!
-//! ## Threading: none (D17)
-//!
-//! basalt runs this on its own thread behind a bounded `vision_data_queue` and
-//! a 3000-deep `imu_data_queue`, and drops framesets when
-//! `vio_enforce_realtime` is set. Offline mode has no threads and no drops:
-//! [`SqrtKeypointVio::push_imu`] appends to an unbounded buffer and
-//! `process_frame` runs to completion in the calling thread, so no queue state
-//! can reach an estimator decision. `vio_enforce_realtime` is therefore refused
-//! at construction rather than silently ignored — `src/vio.cpp:307-309` forces
-//! it off for offline replay anyway.
-//!
-//! ## What is deliberately not here
-//!
-//! `scheduleResetState`/`resetState` (`:120-195`): the VIT path only reaches it
-//! from Monado's reset request, and `measure` returning an error is the port's
-//! signal instead. `out_marg_queue` (`:952-978`), which exports `MargData` for
-//! the NFR mapper that D13 puts out of scope. `takeLongTermKeyframe` is
-//! implemented ([`SqrtKeypointVio::take_long_term_keyframe`]) because the
-//! `take_ltkf` branch inside `measure` is on the shipped path, but nothing in
-//! the VIO calls it. The visualization payloads (`:643-663`) become
-//! [`SqrtKeypointVio::snapshot`], which returns values; the Rerun rung that logs
-//! them is stage S9's (D03).
+//! Processing is synchronous (D17). IMU samples enter an unbounded buffer and
+//! frames run to completion in the calling thread. Realtime queue dropping is
+//! unsupported and `vio_enforce_realtime` is refused. Snapshots return values
+//! for visualization. Long-term keyframes are supported; mapper output is not.
 //!
 //! ## Where an error leaves the window
 //!
-//! Three classes, and only the first is retryable. The class is the **call site**, not the variant:
-//! [`EstimatorError::BundleAdjustment`] and [`EstimatorError::State`] are each raised from more
-//! than one, and the sites fall in different classes.
+//! The call site determines whether an error is retryable:
+//! 1. Validation before mutation leaves the estimator untouched. Correct the
+//!    input and retry, or construct a new estimator after a constructor error.
+//! 2. Errors after IMU consumption but before state insertion leave the old
+//!    window but consume the required samples. Rebuild the estimator.
+//! 3. Errors after insertion leave an advanced window; retrying would duplicate
+//!    observations. Rebuild the estimator.
 //!
-//! 1. **Raised before anything moves**, so the estimator is untouched and the
-//!    caller may retry with a corrected input: [`EstimatorError::CameraCountMismatch`]
-//!    and [`EstimatorError::NonMonotonicFrame`] from [`SqrtKeypointVio::process_frame`]'s
-//!    validation, and [`EstimatorError::UnsupportedPath`], [`EstimatorError::EnforceRealtime`],
-//!    [`EstimatorError::EmptyWindow`] and one [`EstimatorError::BundleAdjustment`] site from
-//!    [`SqrtKeypointVio::new`]: [`BaError::Camera`], raised while
-//!    [`BundleAdjustmentBase::new`] resolves the rig's projection models
-//!    (`ba_base.rs:647`, `camera.rs:1058`), which returns before an estimator
-//!    exists at all, so a corrected calibration may be passed to a new one.
-//! 2. **Raised after the IMU queue was consumed but before the new state was
-//!    filed.** [`EstimatorError::ImuQueueRanDry`] and [`EstimatorError::Imu`] come out of the
-//!    preintegration loops, which have already popped samples; and
-//!    [`EstimatorError::PreviousStateMissing`] comes out of `measure`'s prediction, after
-//!    the same pops. The window still holds the frames it did, but the samples
-//!    that interval needed are gone, so the same frameset can never be
-//!    integrated again: not retryable either.
-//! 3. **Raised after the new state, its observations and its preintegration
-//!    were inserted** — every remaining variant, and all but one of the sites
-//!    inside `measure`: the window-invariant breaks, `NumericallyInvalid` from
-//!    the LM loop, and anything `Linearize`, `Marginalize`, `BundleAdjustment`,
-//!    `Landmark` or `State` refuses there. The window has advanced by one
-//!    frameset while `prev_frame` has not, so retrying the same frameset would
-//!    file its observations twice.
-//!
-//!    One class-3 site sits before `measure`: `process_frame`'s initialization
-//!    pushes the first ordering entry (`:281-283`) after it has filed the first
-//!    state, so its [`EstimatorError::State`] would leave that same advanced window. It
-//!    cannot fire — the push is the first into a fresh [`AbsOrderMap`], with
-//!    nothing for `DuplicateFrame` to collide with and a fixed
-//!    `POSE_VEL_BIAS_SIZE` that cannot overflow the offset — and stays a `?`
-//!    because D32 leaves no room for the `unwrap` that would replace it.
-//!
-//! basalt has one answer to classes 2 and 3: it resets the whole estimator
-//! (`proc_func`'s `return false`, `scheduleResetState` at `:120-195`), which
-//! this port does not have. A caller that sees one of them must rebuild the
-//! estimator. Stage S9's Realtime mode is where the reset belongs (D5 of the S8
-//! simplify list).
+//! `BundleAdjustment` and `State` errors occur at multiple sites, so their
+//! variants alone do not establish retryability. Initialization also inserts a
+//! state before its first ordering entry. That ordering insertion cannot fail
+//! for a fresh map and fixed block size, but still uses a typed result (D32).
 
 mod frame_update;
 mod optimize;
@@ -128,11 +64,11 @@ pub use schedule::{EvictionReason, KeyframeEviction, MarginalizationStats};
 /// [`EstimatorError::KeyframeNotInWindow`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WindowRole {
-    /// A pose block, `frame_poses` (`:794`, `:849`).
+    /// A pose block, `frame_poses`.
     Pose,
-    /// A state block, `frame_states` (`:854`).
+    /// A state block, `frame_states`.
     State,
-    /// An entry in `num_points_kf`, the landmarks a keyframe hosts (`:827`).
+    /// An entry in `num_points_kf`, the landmarks a keyframe hosts.
     HostedLandmarkCount,
 }
 
@@ -147,15 +83,9 @@ impl std::fmt::Display for WindowRole {
     }
 }
 
-/// Everything the driver can refuse.
-///
-/// basalt's equivalents are `BASALT_ASSERT`s, an `std::out_of_range` from a
-/// `.at()`, or a `return false` that makes `proc_func` reset the whole state.
-/// Under D32 none of them may panic on data, so each becomes a variant here.
-///
-/// **Which errors leave the window where** is a property of the call site, not
-/// of the variant, and is set out under "Where an error leaves the window" in
-/// the module header.
+/// Typed failures from the driver (D32).
+/// Whether the window is unchanged depends on the call site, as described in
+/// the module documentation, rather than on the error variant alone.
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum EstimatorError {
     /// `vio_linearization_type` is not `ABS_QR`, or `vio_sqrt_marg` is false:
@@ -202,8 +132,7 @@ pub enum EstimatorError {
         /// What it holds.
         value: f64,
     },
-    /// The damping bounds cross, so no `lambda` satisfies both (`:1415`,
-    /// `:1595`).
+    /// The damping bounds cross, so no `lambda` satisfies both (
     #[error("vio_lm_lambda_min {min} must not exceed vio_lm_lambda_max {max}")]
     DampingRangeReversed {
         /// `vio_lm_lambda_min`.
@@ -211,7 +140,7 @@ pub enum EstimatorError {
         /// `vio_lm_lambda_max`.
         max: f64,
     },
-    /// The rig has fewer than the two cameras `optical_flow.h:210` requires,
+    /// The rig has fewer than the two cameras requires,
     /// its intrinsics and extrinsics disagree, or a frameset carries a
     /// different number of cameras than the rig.
     #[error("expected {expected} cameras, got {actual}")]
@@ -221,7 +150,7 @@ pub enum EstimatorError {
         /// Cameras the rejected input carries.
         actual: usize,
     },
-    /// Frame timestamps must strictly increase: `:309-313` asserts both the
+    /// Frame timestamps must strictly increase: asserts both the
     /// duplicate and the reordering, because a zero `dt` makes the
     /// preintegration invalid.
     #[error("frameset at {t_ns} ns does not follow the previous frameset at {previous_t_ns} ns")]
@@ -231,9 +160,7 @@ pub enum EstimatorError {
         /// Timestamp of the rejected frameset.
         t_ns: i64,
     },
-    /// The window disagrees with the marginalization prior's ordering
-    /// (`:1227`, `:1237`). C++ asserts, or throws out of `.at()` when the frame
-    /// is missing from the prior altogether.
+    /// The window disagrees with the marginalization prior's ordering.
     #[error("frame {frame_id} sits at {found:?} in the window but at {expected:?} in the prior")]
     PriorOrderMismatch {
         /// The disagreeing frame.
@@ -243,9 +170,7 @@ pub enum EstimatorError {
         /// `(index, size)` the window just built.
         found: (usize, usize),
     },
-    /// A keyframe the eviction score reads is missing from the window
-    /// (`:824`, `:845-856`, `:794`) — `.at()` calls that C++ would throw out
-    /// of.
+    /// An eviction candidate is missing from the window.
     #[error("keyframe {frame_id} is not in the window as a {wanted}")]
     KeyframeNotInWindow {
         /// The keyframe the score wanted.
@@ -253,18 +178,14 @@ pub enum EstimatorError {
         /// What the score wanted it as.
         wanted: WindowRole,
     },
-    /// `measure` predicts the new state from `frame_states.at(last_state_t_ns)`
-    /// (`:428`), which C++ throws out of when the previous state has already
-    /// been marginalized.
+    /// The previous state needed to predict the new state is missing.
     #[error("the previous state at {t_ns} ns is not in the window")]
     PreviousStateMissing {
         /// `last_state_t_ns`.
         t_ns: i64,
     },
-    /// An IMU factor's endpoint is in the ordering but not in `frame_states`
-    /// (`sc_ba_base.cpp:671-672`, two `.at()` calls C++ throws out of).
-    /// Skipping the factor would drop its residual from the true cost and so
-    /// change which LM step is accepted, silently.
+    /// An IMU endpoint is in the ordering but absent from `frame_states`.
+    /// Skipping it would silently change the objective and the accepted LM step.
     #[error("the imu factor over ({start_t_ns}, {end_t_ns}] ns has no state at {missing_t_ns} ns")]
     ImuFactorStateMissing {
         /// `get_start_t_ns()`.
@@ -274,11 +195,8 @@ pub enum EstimatorError {
         /// Whichever endpoint the window is missing; the start when both are.
         missing_t_ns: i64,
     },
-    /// A keypoint `measure` recorded as unconnected is missing from the camera's
-    /// own keypoint map when the triangulation reads its pixel back (`:514`'s
-    /// `opt_flow_meas->keypoints.at(i).at(lm_id)`, which C++ throws out of).
-    /// The two come from the same frameset a few lines apart, so a miss means
-    /// the frameset changed under the loop.
+    /// An unconnected keypoint is missing when triangulation reads its pixel.
+    /// Both maps come from the same frameset, so this violates an internal invariant.
     #[error("keypoint {kpt_id:?} is unconnected in camera {cam_id} but not in its keypoint map")]
     UnconnectedKeypointMissing {
         /// The camera whose map the id came from.
@@ -286,24 +204,21 @@ pub enum EstimatorError {
         /// The id `measure` filed as unconnected.
         kpt_id: KeypointId,
     },
-    /// The state window is shorter than the marginalization's own advance
-    /// (`:724`): C++ advances the iterator past `end()` and dereferences it.
+    /// The state window is too short for the marginalization advance.
     #[error("{states} states cannot spare the {states_to_remove} the marginalization removes")]
     StateWindowTooShort {
         /// States in the window.
         states: usize,
-        /// `states_to_remove` (`:720-724`).
+        /// `states_to_remove`.
         states_to_remove: usize,
     },
-    /// A frame in the window is missing from the ordering `optimize` built
-    /// from that same window a few lines earlier (`:1468`, `:1472`, both
-    /// `.at()` calls C++ would throw out of).
+    /// A window frame is absent from the ordering built for that window.
     #[error("frame {frame_id} is in the window but not in its ordering")]
     FrameNotInOrdering {
         /// The frame the increment could not be applied to.
         frame_id: FrameId,
     },
-    /// The eviction loop found no keyframe to marginalize, which `:872` asserts
+    /// The eviction loop found no keyframe to marginalize, which asserts
     /// is impossible ("the logic above is faulty").
     #[error("no keyframe could be selected for marginalization out of {candidates} candidates")]
     NoKeyframeToMarginalize {
@@ -329,7 +244,7 @@ pub enum EstimatorError {
     /// when it was frozen.
     #[error("state: {0}")]
     State(#[from] StateError),
-    /// The IMU queue ran dry while skipping forward to the frameset (`:265-271`)
+    /// The IMU queue ran dry while skipping forward to the frameset
     /// after the coverage test found a sample past it, which means
     /// [`SqrtKeypointVio::push_imu`]'s ordering invariant broke. Not
     /// [`FrameOutcome::NeedMoreImu`]: the skip has consumed samples by then, so
@@ -339,7 +254,7 @@ pub enum EstimatorError {
         /// The frameset being initialized on.
         t_ns: i64,
     },
-    /// `linearizeProblem` reported `numerically_valid == false`, which `:1301`
+    /// `linearizeProblem` reported `numerically_valid == false`, which
     /// prints as "did not expect numerical failure during linearization" and
     /// then fails the frame.
     #[error("linearization was not numerically valid at frame {t_ns} ns")]
@@ -349,19 +264,10 @@ pub enum EstimatorError {
     },
 }
 
-/// `OpticalFlowResult` as the estimator reads it (`optical_flow.h:186-215`).
-///
-/// The frontend produces much more — the input images, the responses, the
-/// pyramid levels, the timing block — and the backend reads exactly this: one
-/// map of keypoint id to observed pixel per camera, plus the frameset
-/// timestamp. Keeping the estimator's input this narrow is what lets the oracle
-/// gate replay the **C++'s own** flow stream into the Rust window without a
-/// frontend in the loop.
-///
-/// The pixels are `f32` whatever the estimator's scalar is, because
-/// `AffineCompact2f` is: `:437` and `:511` cast them to `Scalar` at the point of
-/// use, so an `f64` estimator sees `f32` values widened, never `f64` precision
-/// the frontend never had.
+/// The estimator's flow input: a frameset timestamp and one keypoint-to-pixel map
+/// per camera. This boundary permits backend tests without running the frontend.
+/// Pixels are f32 even in the f64 estimator; widening cannot add precision that
+/// the frontend did not produce.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FlowObservations {
     /// Frameset timestamp, nanoseconds on the IMU clock.
@@ -383,21 +289,17 @@ impl FlowObservations {
 /// What one `process_frame` call did.
 #[derive(Debug, Clone, PartialEq)]
 pub enum FrameOutcome<S: LieScalar> {
-    /// The buffered IMU samples do not yet reach past the frameset, so nothing
-    /// was consumed and the window is unchanged. basalt's `pop` blocks here;
-    /// Offline mode returns instead (D17).
+    /// IMU coverage does not extend past this frameset. Nothing was consumed and
+    /// the window is unchanged, so the caller can add samples and retry (D17).
     NeedMoreImu,
     /// The frame was measured. The statistics are per frame and are the input
     /// to the S9 Rerun rung.
     Measured(Box<FrameStats<S>>),
 }
 
-/// Nanosecond marks basalt pushes into the frame's `TimeStats`
-/// (`:1627-1636`), as durations rather than cumulative timestamps.
-///
-/// Wall-clock measurements, so they differ run to run. Nothing reads them: they
-/// are reported, never compared, which is what keeps `process_frame`
-/// bit-reproducible (D17).
+/// Per-frame stage durations in nanoseconds.
+/// Wall-clock timings vary between runs and are reported but never used in
+/// estimator decisions, preserving deterministic replay (D17).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct StageTimings {
     /// IMU integration before measure plus state prediction and append inside it.
@@ -429,14 +331,14 @@ pub struct FrameStats<S: LieScalar> {
     pub connected: Vec<usize>,
     /// `unconnected_obs[cam].size()`, keypoints the window has never seen.
     pub unconnected: Vec<usize>,
-    /// Whether `take_kf` was set when this frame arrived (`:473`).
+    /// Whether `take_kf` was set when this frame arrived.
     pub took_keyframe: bool,
-    /// Whether the keyframe vote of `:454-456` fired on this frame.
+    /// Whether the keyframe vote of fired on this frame.
     pub keyframe_vote: bool,
-    /// `frames_after_kf` (`:202`) after the update: the vote's rate limiter,
+    /// `frames_after_kf` after the update: the vote's rate limiter,
     /// zero on a keyframe and one more than the last frame otherwise.
     pub frames_after_kf: i32,
-    /// `num_points_added` (`:552`), zero on a non-keyframe.
+    /// `num_points_added`, zero on a non-keyframe.
     pub num_points_added: usize,
     /// Keyframes after the update, oldest first.
     pub kf_ids: Vec<FrameId>,
@@ -448,14 +350,14 @@ pub struct FrameStats<S: LieScalar> {
     pub num_observations: usize,
     /// Landmarks `vio_marg_lost_landmarks` would drop this frame.
     pub num_lost_landmarks: usize,
-    /// `opt_started` (`:1207`) after this frameset: false until five states
+    /// `opt_started` after this frameset: false until five states
     /// have accumulated, true from the first linearization on.
     pub opt_started: bool,
     /// One entry per LM step, accepted or rejected, in order.
     pub lm: Vec<LmIteration<S>>,
     /// Why the LM loop stopped.
     pub termination: LmTermination,
-    /// The marginalization, when the trigger of `:717` fired.
+    /// The marginalization, when the trigger of fired.
     pub marginalization: Option<MarginalizationStats>,
     /// What D76's frame update did with this frameset: never attempted, taken,
     /// or refused by a named precondition.
@@ -488,13 +390,13 @@ pub struct WindowState<S: LieScalar> {
     pub t_w_i: Se3<S>,
     /// The nine dof beyond the pose, `None` for a pose-only block.
     pub vel_bias: Option<VelBias<S>>,
-    /// Whether the linearization point is frozen (`imu_types.h:109`).
+    /// Whether the linearization point is frozen.
     pub linearized: bool,
     /// Whether this frame is a keyframe.
     pub keyframe: bool,
     /// Whether this frame is a long-term keyframe.
     pub long_term_keyframe: bool,
-    /// `frame_idx`, the monotonic index basalt keeps for the UI (`:207`).
+    /// Monotonic frame index for the UI.
     pub frame_index: Option<usize>,
 }
 
@@ -516,7 +418,7 @@ pub struct SnapshotLandmark<S: LieScalar> {
 /// The window and its landmarks, for the V2 visual-validation rung (D51).
 ///
 /// `getAllPosesMap`, `get_current_points` and the `VioVisualizationData` fields
-/// (`:643-663`) collapsed into one value the caller reads once per frame. The
+///  collapsed into one value the caller reads once per frame. The
 /// core logs nothing itself (D03).
 #[derive(Debug, Clone, PartialEq)]
 pub struct WindowSnapshot<S: LieScalar> {
@@ -532,32 +434,26 @@ pub struct WindowSnapshot<S: LieScalar> {
     pub marginalized: Vec<FrameId>,
 }
 
-/// LM damping, the four fields of `sqrt_keypoint_vio.h:241` in one place.
+/// LM damping, the four fields of in one place.
 #[derive(Debug, Clone, Copy, PartialEq)]
 struct LmDamping<S: LieScalar> {
-    /// `lambda`, reset to `vio_lm_lambda_initial` every frame (D11, `:1249`).
+    /// `lambda`, reset to `vio_lm_lambda_initial` every frame (D11).
     lambda: S,
-    /// `min_lambda`, the floor of the damped diagonal (`:1415`).
+    /// `min_lambda`, the floor of the damped diagonal.
     min_lambda: S,
-    /// `max_lambda`; exceeding it terminates the frame (`:1595`).
+    /// `max_lambda`; exceeding it terminates the frame.
     max_lambda: S,
     /// `lambda_vee`, the Nielsen escalation factor, reset to 2 on an accept.
     lambda_vee: S,
 }
 
-/// `vee_factor` and `initial_vee`, both the compile-time constant 2.0
-/// (`sqrt_keypoint_vio.h:239-240`), not config fields.
+/// The compile-time Nielsen escalation constants, both 2.0.
 const VEE_FACTOR: f64 = 2.0;
 
 impl<S: LieScalar> LmDamping<S> {
-    /// `:1557-1562`: Nielsen's update after a step the objective accepted.
-    ///
-    /// `std::pow<Scalar>(x, 3)` deduces the exponent as `int`, so
-    /// `__promote_2<Scalar, int>` is `double` in both instantiations and the
-    /// power and the `1 −` happen in `double` before narrowing back — which is
-    /// why this is `to_f64().powf(3.0)` and not `x * x * x`. Both maxima are
-    /// `eigen_maxi` because `cwiseMax` is `numext::maxi`, which keeps a NaN on
-    /// the left where `f32::max` would drop it.
+    /// Nielsen's update after an accepted step.
+    /// The cubic and subtraction run in f64 before narrowing. Both maxima retain
+    /// a NaN on the left, allowing the caller to detect non-finite damping.
     fn accept(&mut self, relative_decrease: S) {
         let x: S = S::from_literal(2.0) * relative_decrease - S::one();
         let gain: S = S::from_literal(1.0 - x.to_f64().powf(3.0));
@@ -567,34 +463,26 @@ impl<S: LieScalar> LmDamping<S> {
         self.lambda_vee = S::from_literal(VEE_FACTOR);
     }
 
-    /// `:1585-1586`: the geometric escalation after a rejected step, which the
-    /// damped solve's own retry on a non-finite increment (`:1424-1425`) makes
-    /// with the same two lines.
+    /// Geometrically escalate damping after a rejected step or failed solve.
     fn escalate(&mut self) {
         self.lambda = self.lambda_vee * self.lambda;
         self.lambda_vee *= S::from_literal(VEE_FACTOR);
     }
 
-    /// `:1595`: whether the escalation has taken the frame past `max_lambda`.
-    ///
-    /// Both loops ask it after the rollback, where C++ asks it; nothing between
-    /// the escalation and the question touches the damping.
+    /// Check whether escalation exceeded the maximum lambda after rollback.
     fn exhausted(&self) -> bool {
         self.lambda > self.max_lambda
     }
 }
 
-/// `:1565-1568`: whether an accepted step is the last one the frame takes.
-///
-/// Both tolerances are hard-coded in C++ too. The window solve and D76's frame
-/// update ask this of their own `f_diff` and `step_norminf`, and there is one
-/// predicate so the two schedules cannot come to converge on different terms.
+/// Shared convergence predicate for the window and frame-update schedules.
+/// Both use the same fixed cost and infinity-norm tolerances.
 fn lm_converged<S: LieScalar>(f_diff: S, step_norminf: S) -> bool {
     (f_diff > S::zero() && f_diff < S::from_literal(optimize::FUNCTION_TOLERANCE))
         || step_norminf < S::from_literal(optimize::STEP_TOLERANCE)
 }
 
-/// `SqrtKeypointVioEstimator<Scalar>` (`sqrt_keypoint_vio.h:50-248`).
+/// `SqrtKeypointVioEstimator<Scalar>`.
 #[derive(Debug, Clone)]
 pub struct SqrtKeypointVio<S: LieScalar> {
     /// The sliding window: `frame_states`, `frame_poses`, `lmdb` and the
@@ -603,56 +491,55 @@ pub struct SqrtKeypointVio<S: LieScalar> {
     /// snapshot is the window's only view.
     pub(crate) ba: BundleAdjustmentBase<S>,
 
-    /// `prev_frame` (`:198`), the frameset the last `measure` consumed.
+    /// `prev_frame`, the frameset the last `measure` consumed.
     prev_frame: Option<Arc<FlowObservations>>,
-    /// `take_kf` (`:201`), true at construction so the first frame is a
-    /// keyframe (`:61`).
+    /// `take_kf`, true at construction so the first frame is a
+    /// keyframe.
     take_kf: bool,
-    /// `frames_after_kf` (`:202`), the rate limiter of `:455`.
+    /// Frames since the last keyframe, used to rate-limit keyframe selection.
     frames_after_kf: i32,
-    /// `frame_count` (`:203`), the source of `frame_idx`.
+    /// `frame_count`, the source of `frame_idx`.
     frame_count: usize,
-    /// `kf_ids` (`:204`).
+    /// `kf_ids`.
     kf_ids: BTreeSet<FrameId>,
-    /// `ltkfs` (`:205`), exempt from the `max_kfs` budget (`:717`).
+    /// `ltkfs`, exempt from the `max_kfs` budget.
     ltkfs: BTreeSet<FrameId>,
-    /// `take_ltkf` (`:206`).
+    /// `take_ltkf`.
     take_ltkf: bool,
-    /// `frame_idx` (`:207`).
+    /// `frame_idx`.
     frame_idx: BTreeMap<FrameId, usize>,
-    /// `last_state_t_ns` (`:209`).
+    /// `last_state_t_ns`.
     last_state_t_ns: i64,
-    /// `imu_meas` (`:210`), one preintegration per consecutive state pair.
+    /// `imu_meas`, one preintegration per consecutive state pair.
     imu_meas: BTreeMap<i64, IntegratedImuMeasurement<S>>,
-    /// `g` (`:212`), `(0, 0, -9.81)` unless the caller overrides it.
+    /// `g`, `(0, 0, -9.81)` unless the caller overrides it.
     g: Vector3<S>,
-    /// `prev_opt_flow_res` (`:216`), kept so a new keyframe can gather every
-    /// observation of a keypoint across the live window (`:491-505`).
+    /// `prev_opt_flow_res`, kept so a new keyframe can gather every
+    /// observation of a keypoint across the live window.
     prev_opt_flow_res: BTreeMap<FrameId, Arc<FlowObservations>>,
-    /// `num_points_kf` (`:218`). Never erased, exactly as basalt never erases
-    /// it — `:824` reads it for keyframes that left the window long ago.
+    /// Hosted-point counts retained even after a keyframe leaves the window.
     num_points_kf: BTreeMap<FrameId, usize>,
-    /// `marg_data` (`:221`), the square-root prior.
+    /// `marg_data`, the square-root prior.
     marg_data: MargLinData<S>,
-    /// `gyro_bias_sqrt_weight` (`:226`), `1 / gyro_bias_std`.
+    /// `gyro_bias_sqrt_weight`, `1 / gyro_bias_std`.
     gyro_bias_sqrt_weight: Vector3<S>,
-    /// `accel_bias_sqrt_weight` (`:226`).
+    /// `accel_bias_sqrt_weight`.
     accel_bias_sqrt_weight: Vector3<S>,
-    /// `max_states` (`:228`).
+    /// `max_states`.
     max_states: usize,
-    /// `max_kfs` (`:229`).
+    /// `max_kfs`.
     max_kfs: usize,
-    /// `T_w_i_init` (`:231`), the pose the first accelerometer sample gave.
+    /// `T_w_i_init`, the pose the first accelerometer sample gave.
     t_w_i_init: Se3<S>,
-    /// `initialized` (`:233`).
+    /// `initialized`.
     initialized: bool,
-    /// `opt_started` (`:234`), which flips once `frame_states.size() > 4`.
+    /// `opt_started`, which flips once `frame_states.size() > 4`.
     opt_started: bool,
-    /// `config` (`:237`).
+    /// `config`.
     config: VioConfig,
-    /// The four damping fields of `:241`.
+    /// The four damping configuration fields.
     damping: LmDamping<S>,
-    /// The estimator's own preintegration noise (`:228-229` of the constructor
+    /// The estimator's own preintegration noise ( of the constructor
     /// body). The frontend runs a second, independent preintegrator (D24) and
     /// the two are deliberately not shared.
     noise: ImuNoise<S>,
@@ -662,11 +549,10 @@ pub struct SqrtKeypointVio<S: LieScalar> {
     /// See [`Self::initial_bias_gyro`].
     initial_bias_accel: Vector3<S>,
 
-    /// `imu_data_queue` (`vio_estimator.h:91`), unbounded here: Offline mode
+    /// `imu_data_queue`, unbounded here: Offline mode
     /// never drops a sample and never blocks (D17, D24).
     imu_queue: VecDeque<ImuSample>,
-    /// C++'s loop-local `data` (`:296`), the one sample already popped and
-    /// calibrated. It survives across frames, so it is state, not a local.
+    /// The calibrated sample already popped from the queue, retained across frames.
     pending: Option<(i64, Vector3<S>, Vector3<S>)>,
     /// The newest timestamp [`Self::push_imu`] has accepted, whether that
     /// sample is still in [`Self::imu_queue`] or has already moved into
@@ -692,22 +578,12 @@ pub struct SqrtKeypointVio<S: LieScalar> {
     scratch: OptimizeScratch<S>,
 }
 
-/// Every live scalar the estimator's own arithmetic needs, checked before any
-/// of that arithmetic runs.
-///
-/// The estimator divides by the two bias deviations (`:226`) and by the squared
-/// observation deviation (`ba_base.cpp:181`), takes the square root of the IMU
-/// rate (`calibration.hpp:186`) and of the three initial prior weights
-/// (`:87-93`), and compares `lambda` against both damping bounds (`:1415`,
-/// `:1595`). basalt does all of it unchecked, on numbers that reach it from a
-/// device driver and a file it ships; here they reach it from a caller, so a
-/// value outside its domain is bad input refused at the boundary (D32) rather
-/// than a NaN or an infinity in a live prior. The `VioConfig` and `Calibration`
-/// parsers stay syntax-only: what a number has to be is a property of the
-/// arithmetic that reads it, and `Calibration` is also the frontend's.
-///
-/// The Nielsen escalation factor is not here: it is the compile-time
-/// [`VEE_FACTOR`], not a config field.
+/// Validate numerical domains before estimator arithmetic runs (D32).
+/// Bias and observation deviations are divisors; IMU rate and initial prior
+/// weights enter square roots; damping values enter comparisons. Invalid values
+/// must be refused before they create NaNs or infinities in a live prior.
+/// Parsers remain syntax-only because these constraints belong to the consuming
+/// algorithm. The Nielsen factor is a compile-time constant, not a config field.
 fn validate_scalars<S: LieScalar>(
     calibration: &Calibration<S>,
     config: &VioConfig,
@@ -757,14 +633,14 @@ fn validate_scalars<S: LieScalar>(
 }
 
 impl<S: LieScalar> SqrtKeypointVio<S> {
-    /// `SqrtKeypointVioEstimator(g, calib, config)` (`:57-117`).
+    /// `SqrtKeypointVioEstimator(g, calib, config)`.
     ///
     /// Sets the square-root gauge prior on the first state: `sqrt(init_pose_weight)`
     /// on indices 0 to 2 and on index 5 alone, and `sqrt(init_ba_weight)` /
-    /// `sqrt(init_bg_weight)` on 9 to 11 and 12 to 14 (`:87-93`, D18). Roll and
+    /// `sqrt(init_bg_weight)` on 9 to 11 and 12 to 14 (D18). Roll and
     /// pitch (3 and 4) are left free because gravity observes them. The
     /// **square root** is what the sqrt branch stores; the Hessian branch
-    /// (`:96-102`) stores the weight itself and is unreachable here (D13).
+    ///  stores the weight itself and is unreachable here (D13).
     ///
     /// # Errors
     ///
@@ -795,7 +671,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
                 max_kfs: config.vio_max_kfs,
             });
         }
-        // `optical_flow.h:210` and `vit_tracker.cpp:181`: a hard precondition,
+        //  and : a hard precondition,
         // because the epipolar filter needs a second camera.
         if calibration.t_i_c.len() < 2 {
             return Err(EstimatorError::CameraCountMismatch {
@@ -803,11 +679,8 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
                 actual: calibration.t_i_c.len(),
             });
         }
-        // The rig is one list of cameras: `intrinsics` carries the projections
-        // and `t_i_c` the extrinsics, and every camera id downstream indexes
-        // both. basalt reads them out of one `Calibration` and never checks,
-        // so a JSON with two extrinsics and one intrinsic would index out of
-        // range deep inside the triangulation; refuse it here instead.
+        // Each camera id indexes both intrinsics and extrinsics. Reject ragged lists
+        // before triangulation can read beyond either list.
         if calibration.intrinsics.len() != calibration.t_i_c.len() {
             return Err(EstimatorError::CameraCountMismatch {
                 expected: calibration.t_i_c.len(),
@@ -821,7 +694,6 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         let gyro_bias_sqrt_weight: Vector3<S> = calibration.gyro_bias_std.map(|v| S::one() / v);
         let accel_bias_sqrt_weight: Vector3<S> = calibration.accel_bias_std.map(|v| S::one() / v);
 
-        // `:71-73`.
         let obs_std_dev: S = S::from_literal(config.vio_obs_std_dev);
         let huber_thresh: S = S::from_literal(config.vio_obs_huber_thresh);
         let ba: BundleAdjustmentBase<S> =
@@ -832,7 +704,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             h: DMatrix::zeros(POSE_VEL_BIAS_SIZE, POSE_VEL_BIAS_SIZE),
             b: DVector::zeros(POSE_VEL_BIAS_SIZE),
         };
-        // `:87-93`, the square-root branch.
+        // the square-root branch.
         let pose_weight_sqrt: S = S::from_literal(config.vio_init_pose_weight).sqrt();
         let ba_weight_sqrt: S = S::from_literal(config.vio_init_ba_weight).sqrt();
         let bg_weight_sqrt: S = S::from_literal(config.vio_init_bg_weight).sqrt();
@@ -846,7 +718,6 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         Ok(Self {
             ba,
             prev_frame: None,
-            // `:61`.
             take_kf: true,
             frames_after_kf: 0,
             frame_count: 0,
@@ -886,11 +757,9 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         })
     }
 
-    /// The same estimator with basalt's own gravity, `(0, 0, -9.81)`
-    /// (`imu_types.h:63`), which is what `src/vio.cpp` and the VIT path pass.
+    /// Construct with gravity `(0, 0, -9.81)`.
     ///
     /// # Errors
-    ///
     /// As [`Self::new`].
     pub fn with_default_gravity(
         calibration: Calibration<S>,
@@ -899,7 +768,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         Self::new(gravity::<S>(), calibration, config)
     }
 
-    /// `takeLongTermKeyframe()` (`:124-127`): the next `measure` moves the
+    /// `takeLongTermKeyframe()` : the next `measure` moves the
     /// newest keyframe into `ltkfs`, where the `max_kfs` budget cannot evict it.
     ///
     /// Nothing in the VIO path calls this; it is a Monado/API hook.
@@ -907,20 +776,10 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         self.take_ltkf = true;
     }
 
-    /// `addIMUToQueue` (`:370-373`) plus the `popFromImuDataQueue` cast
-    /// (`:377-390`).
-    ///
-    /// Samples must arrive in order; a sample that does not follow the last one
-    /// **accepted** is dropped rather than reordered, because the integration
-    /// reads the stream strictly forward. "Accepted" is
-    /// [`Self::newest_imu_t_ns`], not the queue's back: the newest sample may
-    /// already sit in `Self::pending`, leaving the queue empty and an older
-    /// sample free to slot in behind it. The drop is reachable only from a
-    /// direct `SqrtKeypointVio` user, which is `tests/vio_oracle.rs`:
-    /// [`Vio::push_imu`](crate::Vio::push_imu) refuses the same sample with a
-    /// typed error before it gets here. The static bias calibration
-    /// (`calib_bias.hpp:101-107`) is applied when the sample is popped, as
-    /// `:298-299` does, not here.
+    /// Append an IMU sample only if it follows the newest accepted timestamp.
+    /// That timestamp includes the pending sample even when the queue is empty.
+    /// Direct callers have older samples dropped; [`Vio::push_imu`](crate::Vio::push_imu)
+    /// refuses them with a typed error. Static bias calibration occurs when popping.
     pub fn push_imu(&mut self, sample: ImuSample) {
         if let Some(newest) = self.newest_imu_t_ns
             && sample.t_ns <= newest
@@ -935,7 +794,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
     /// [`Self::process_frame`] needs before it may consume anything (D17).
     ///
     /// Strictly past, because a sample landing exactly on the frameset is
-    /// consumed and the integration loop pops again (`:322-328`). The newest
+    /// consumed and the integration loop pops again. The newest
     /// accepted sample is never popped past — the skip loop stops at the
     /// previous frameset and the integration loop at this one, both below it —
     /// so this reads `Self::newest_imu_t_ns` rather than walking the queue.
@@ -953,17 +812,17 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         self.newest_imu_t_ns
     }
 
-    /// Whether the window has a state (`initialized`, `:233`).
+    /// Whether the window has a state (`initialized`).
     pub fn is_initialized(&self) -> bool {
         self.initialized
     }
 
-    /// `get_t_ns()` (`:138`), the newest state's timestamp.
+    /// `get_t_ns()`, the newest state's timestamp.
     pub fn last_state_t_ns(&self) -> i64 {
         self.last_state_t_ns
     }
 
-    /// `get_state()` (`:143`), the newest state, or `None` before the window has
+    /// `get_state()`, the newest state, or `None` before the window has
     /// one.
     pub fn state(&self) -> Option<&PoseVelBiasState<S>> {
         self.ba
@@ -972,7 +831,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             .map(PoseVelBiasStateWithLin::state)
     }
 
-    /// The keyframes, oldest first (`kf_ids`, `:204`).
+    /// The keyframes, oldest first (`kf_ids`).
     pub fn kf_ids(&self) -> impl Iterator<Item = FrameId> + '_ {
         self.kf_ids.iter().copied()
     }
@@ -982,7 +841,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         &self.marg_data
     }
 
-    /// `num_points_kf` (`:218`), landmarks hosted per keyframe when it was
+    /// `num_points_kf`, landmarks hosted per keyframe when it was
     /// created.
     pub fn num_points_kf(&self) -> &BTreeMap<FrameId, usize> {
         &self.num_points_kf
@@ -997,7 +856,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
     /// marginalization removed, for the V2 Rerun rung (D51).
     ///
     /// The landmark position is `host_pose * T_i_c * unproject(direction) /
-    /// inv_dist`, exactly as `:628-640` builds the landmark bundle, and a
+    /// inv_dist`, exactly as builds the landmark bundle, and a
     /// landmark whose host has left the window is skipped as it is there.
     pub fn snapshot(&self) -> WindowSnapshot<S> {
         let states: Vec<WindowState<S>> = self
@@ -1066,24 +925,14 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         }
     }
 
-    /// One iteration of `proc_func`'s loop (`:263-355`).
-    ///
-    /// Pops and calibrates the IMU samples this frameset needs, initialises the
-    /// window from the first accelerometer sample if it has none
-    /// (`:263-296`, D17 of papers-part2 §13: there is no other initialization
-    /// stage), preintegrates `(prev_t, curr_t]` into one measurement with the
-    /// **previous state's** biases as the linearization point (`:302-304`), and
-    /// calls `Self::measure`.
-    ///
-    /// Returns [`FrameOutcome::NeedMoreImu`] and leaves everything untouched
-    /// when the buffer does not yet reach past `frame.t_ns`: basalt blocks on
-    /// its queue instead, and Offline mode must not let the arrival order of a
-    /// sample reach a decision (D17).
+    /// Process one frameset synchronously.
+    /// Initialize from the first accelerometer sample if needed, then preintegrate
+    /// `(prev_t, curr_t]` using the previous state's biases and call `measure`.
+    /// Return [`FrameOutcome::NeedMoreImu`] without mutation when coverage does not
+    /// extend past the frameset. Arrival order must not affect decisions (D17).
     ///
     /// # Errors
-    ///
-    /// [`EstimatorError`] on a non-monotonic frameset, a frameset of the wrong
-    /// width, or anything `measure` refuses.
+    /// [`EstimatorError`] for invalid frameset order or width, or a failure in `measure`.
     pub fn process_frame(
         &mut self,
         frame: Arc<FlowObservations>,
@@ -1098,7 +947,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         if let Some(prev) = &self.prev_frame
             && frame.t_ns <= prev.t_ns
         {
-            // `:309-313`, both asserts.
+            // both asserts.
             return Err(EstimatorError::NonMonotonicFrame {
                 previous_t_ns: prev.t_ns,
                 t_ns: frame.t_ns,
@@ -1122,7 +971,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         let mut meas: Option<IntegratedImuMeasurement<S>> = None;
 
         if !self.initialized {
-            // `:265-271`: skip forward to the frameset, then take that sample's
+            // skip forward to the frameset, then take that sample's
             // accelerometer reading as the whole initialization.
             //
             // No `NeedMoreImu` exit here, and that is the point: the skip has
@@ -1139,7 +988,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
                 }
             };
 
-            // `:273-278`: zero velocity, zero translation, and the rotation that
+            // zero velocity, zero translation, and the rotation that
             // takes the measured acceleration onto +Z.
             let vel_w_i_init: Vector3<S> = Vector3::zeros();
             self.t_w_i_init = Se3::new(gravity_from_first_accel(&accel), Vector3::zeros());
@@ -1170,14 +1019,13 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
                 .insert(self.last_state_t_ns, self.frame_count);
             self.frame_count += 1;
 
-            // `:281-283`: the first ordering entry, one 15-dof state at index 0.
+            // the first ordering entry, one 15-dof state at index 0.
             let mut order: AbsOrderMap = AbsOrderMap::new();
             order.push(self.last_state_t_ns, POSE_VEL_BIAS_SIZE)?;
             self.marg_data.order = order;
 
             self.initialized = true;
         } else if let Some(prev) = self.prev_frame.clone() {
-            // `:300-336`.
             let (bias_gyro, bias_accel) = match self.ba.frame_states.get(&self.last_state_t_ns) {
                 Some(state) => (state.state().bias_gyro, state.state().bias_accel),
                 None => (self.initial_bias_gyro, self.initial_bias_accel),
@@ -1185,7 +1033,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             let mut pim: IntegratedImuMeasurement<S> =
                 IntegratedImuMeasurement::new(prev.t_ns, &bias_gyro, &bias_accel);
 
-            // `:315-336`, the loop `IntegratedImuMeasurement::accumulate_to`
+            // the loop `IntegratedImuMeasurement::accumulate_to`
             // owns for both preintegrators.
             let noise: ImuNoise<S> = self.noise;
             let pending: Option<Popped<S>> = self.pending.take();
@@ -1203,17 +1051,13 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         let integration_ns: u64 = duration_ns(predict_started);
         let mut stats: FrameStats<S> = self.measure(Arc::clone(&frame), meas)?;
         stats.timings.predict_ns += integration_ns;
-        // `:354`, and only on success.
+        // and only on success.
         self.prev_frame = Some(frame);
         Ok(FrameOutcome::Measured(Box::new(stats)))
     }
 
-    /// `popFromImuDataQueue` (`:377-390`) followed by the static bias
-    /// calibration of `:298-299`.
-    ///
-    /// The cast to `Scalar` happens **before** the calibration, as it does in
-    /// C++: the queue holds `ImuData<double>` and `popFromImuDataQueue` casts,
-    /// then `getCalibrated` runs in `Scalar`.
+    /// Pop an IMU sample, cast it to the estimator scalar, then apply static bias
+    /// calibration in that scalar.
     fn pop_calibrated(&mut self) -> Option<(i64, Vector3<S>, Vector3<S>)> {
         let sample: ImuSample = self.imu_queue.pop_front()?;
         let gyro: Vector3<S> = sample.gyro.map(S::from_literal);
@@ -1225,11 +1069,11 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         ))
     }
 
-    /// `measure(opt_flow_meas, meas)` (`:422-575`).
+    /// `measure(opt_flow_meas, meas)`.
     ///
     /// **Contract: `frame.cameras.len() == self.ba.calib.t_i_c.len()`, which is
     /// at least two.** [`Self::process_frame`] checks the frameset width
-    /// against the rig (`:309`) and [`Self::new`] refuses a rig of fewer than
+    /// against the rig and [`Self::new`] refuses a rig of fewer than
     /// two cameras, so camera 0 exists and the per-camera vectors below are
     /// indexed directly rather than re-validated here.
     ///
@@ -1246,7 +1090,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         let num_cams: usize = frame.cameras.len();
         debug_assert_eq!(num_cams, self.ba.calib.t_i_c.len());
 
-        // `:427-441`: predict the new state from the previous one and the
+        // predict the new state from the previous one and the
         // preintegration, then file it under the frameset's timestamp.
         if let Some(pim) = meas {
             let previous: PoseVelBiasState<S> =
@@ -1280,11 +1124,10 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
 
         let predict_ns: u64 = duration_ns(started);
 
-        // `:444`.
         self.prev_opt_flow_res
             .insert(frame.t_ns, Arc::clone(&frame));
 
-        // `:447-451`: file every observation the window already hosts, and
+        // file every observation the window already hosts, and
         // remember the rest per camera.
         let mut connected: Vec<usize> = vec![0; num_cams];
         let mut num_points_connected: BTreeMap<FrameId, usize> = BTreeMap::new();
@@ -1309,7 +1152,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             }
         }
 
-        // `:454-456`, D21: camera 0 alone votes, rate-limited to one keyframe
+        // D21: camera 0 alone votes, rate-limited to one keyframe
         // every `vio_min_frames_after_kf + 1` frames.
         //
         // The division is `Scalar(int) / size_t`, so the denominator is
@@ -1333,7 +1176,6 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         let took_keyframe: bool = self.take_kf;
         let mut num_points_added: usize = 0;
         if self.take_kf {
-            // `:473-552`.
             self.take_kf = false;
             self.frames_after_kf = 0;
             self.kf_ids.insert(self.last_state_t_ns);
@@ -1349,7 +1191,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             0
         };
 
-        // `:555-563`: every landmark this frameset did not see, in any camera.
+        // every landmark this frameset did not see, in any camera.
         let mut lost_landmarks: BTreeSet<LandmarkId> = BTreeSet::new();
         if self.config.vio_marg_lost_landmarks {
             for lm in self.ba.lmdb.landmarks() {
@@ -1360,7 +1202,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             }
         }
 
-        // `:566`, plus D76's gate: above zero, `port.frame_update_max_iterations`
+        // plus D76's gate: above zero, `port.frame_update_max_iterations`
         // moves the joint solve to the framesets that took a keyframe and gives
         // the others the newest state alone. The frame update declines a
         // frameset it cannot serve, and the joint solve owns the warmup.
@@ -1389,7 +1231,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         timings.marginalize_ns = marg.elapsed_ns;
         timings.measure_ns = duration_ns(started);
 
-        // `:1642-1653`, read off the window the two stages above left behind.
+        // read off the window the two stages above left behind.
         Ok(FrameStats {
             t_ns: frame.t_ns,
             connected,
@@ -1412,47 +1254,30 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         })
     }
 
-    /// `:474-552`: triangulate every unconnected observation into a new
-    /// landmark hosted by this frameset.
+    /// Triangulate unconnected observations into landmarks hosted by this frameset.
     ///
-    /// For each unconnected id, gather **every** observation of it across the
-    /// live `prev_opt_flow_res` (`:491-505`), then try each gathered image in
-    /// `TimeCamId` order as the second view: unproject both pixels, form
-    /// `T_0_1 = T_i_c[host]⁻¹ · T_i0_i1 · T_i_c[other]`, skip a baseline shorter
-    /// than `vio_min_triangulation_dist` (`:530`), DLT-triangulate, and accept
-    /// iff every coefficient is finite and `0 < inv_dist < 3` (`:534`). On
-    /// acceptance **all** gathered observations are filed, not only the pair
-    /// that triangulated (`:546-548`).
+    /// Gather all observations of each id in the live window and try second views
+    /// in `TimeCamId` order. Unproject both pixels, form
+    /// `T_0_1 = T_i_c[host]⁻¹ · T_i0_i1 · T_i_c[other]`, reject short baselines,
+    /// and accept finite DLT results only when `0 < inv_dist < 3`.
+    /// On acceptance, file all gathered observations, not just the successful pair.
+    /// Each camera may host landmarks.
     ///
-    /// The host camera is `i`, not camera 0: the database is genuinely
-    /// N-camera.
-    ///
-    /// **Contract: every camera id below is in the rig**, so the rig is
-    /// indexed directly. `cam_id` indexes `unconnected_obs`, which
-    /// [`Self::measure`] builds with one entry per frameset camera, and
-    /// `tcido.cam_id` names a camera of a frameset [`Self::process_frame`]
-    /// already accepted; both are therefore `< t_i_c.len()`, and
-    /// [`Self::new`] refuses a calibration whose `intrinsics` and `t_i_c`
-    /// disagree.
-    ///
-    /// **Deliberate deviation from the C++ line shape:** `:519-521` re-reads
-    /// the host pose and re-inverts it and the host camera's extrinsic for
-    /// every candidate pair. Nothing in the loop moves the host frame's pose
-    /// or the calibration, so they are resolved once each — the same values
-    /// from the same inputs, in the same products.
+    /// All camera ids have been validated against the rig. Host pose and calibration
+    /// stay constant throughout the loop, so their inverses are computed once.
     fn triangulate_unconnected(
         &mut self,
         frame: &FlowObservations,
         unconnected_obs: &[BTreeSet<KeypointId>],
     ) -> Result<usize, EstimatorError> {
         debug_assert_eq!(unconnected_obs.len(), self.ba.calib.t_i_c.len());
-        // `:509`: the squared threshold is formed in `double` and cast, so the
+        // the squared threshold is formed in `double` and cast, so the
         // `f32` instantiation compares against `(float)(0.05 * 0.05)`.
         let min_triang_distance2: S = S::from_literal(
             self.config.vio_min_triangulation_dist * self.config.vio_min_triangulation_dist,
         );
         let mut num_points_added: usize = 0;
-        // `:519`'s `T_i0_inv`: the host is this frameset, for every landmark
+        // 's `T_i0_inv`: the host is this frameset, for every landmark
         // and every pair.
         let t_i0_inv: Se3<S> = self
             .ba
@@ -1467,12 +1292,12 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             let t_i_c0_inv: Se3<S> = self.ba.calib.t_i_c[cam_id].inverse();
             for kpt_id in ids {
                 let lm_id: LandmarkId = LandmarkId::from(*kpt_id);
-                // `:487`: another camera of this frameset may have hosted it
+                // another camera of this frameset may have hosted it
                 // already.
                 if self.ba.lmdb.landmark_exists(lm_id) {
                     continue;
                 }
-                // `:514`'s `.at(lm_id)`: `measure` took this id out of
+                // 's `.at(lm_id)`: `measure` took this id out of
                 // `host_keypoints` itself, so a miss is an invariant break, not
                 // a landmark to skip (D32).
                 let Some(p0_pixel) = host_keypoints.get(kpt_id) else {
@@ -1483,9 +1308,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
                 };
                 let p0: Vector2<S> = cast_pixel::<S>(p0_pixel);
 
-                // `:491-505`: every image of this id in the live window,
-                // ordered by `TimeCamId` because C++ collects into a
-                // `std::map`.
+                // Visit every image of this id in the live window in `TimeCamId` order.
                 let mut kp_obs: BTreeMap<TimeCamId, Vector2<S>> = BTreeMap::new();
                 for (other_t_ns, other) in &self.prev_opt_flow_res {
                     for (other_cam, keypoints) in other.cameras.iter().enumerate() {
@@ -1500,7 +1323,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
 
                 let mut accepted: Option<Landmark<S>> = None;
                 for (tcido, p1) in &kp_obs {
-                    // `:512-517`: an unprojection the camera rejects skips this
+                    // an unprojection the camera rejects skips this
                     // pair, not the landmark.
                     let mut p0_3d: Vector4<S> = Vector4::zeros();
                     let mut p1_3d: Vector4<S> = Vector4::zeros();
@@ -1511,7 +1334,6 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
                         continue;
                     }
 
-                    // `:519-522`.
                     let other_pose: Se3<S> =
                         *self.ba.get_pose_state_with_lin(tcido.frame_id)?.pose();
                     let t_i0_i1: Se3<S> = t_i0_inv * other_pose;
@@ -1549,7 +1371,6 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
                     }
                 }
 
-                // `:545-549`.
                 if let Some(landmark) = accepted {
                     self.ba.lmdb.add_landmark(lm_id, &landmark);
                     num_points_added += 1;
@@ -1562,7 +1383,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         Ok(num_points_added)
     }
 
-    /// `ImuLinData` as `:1264` and `:913` build it.
+    /// `ImuLinData` as and build it.
     fn imu_lin_data(&self) -> ImuLinData<S> {
         ImuLinData {
             g: self.g,
@@ -1572,15 +1393,9 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
     }
 }
 
-/// `fixed_kfs`: the keyframes whose pose Jacobians a linearization zeroes.
-///
-/// C++ builds the same set twice — `:924` for the marginalization's own
-/// linearization and `:1258` for the optimization's — so with
-/// `vio_fix_long_term_keyframes` on the long-term keyframes are fixed in the
-/// prior the window computes as well as in the increment it solves. `None` and
-/// an empty set mean the same thing to
-/// [`LinearizationAbsQR`](crate::linearize::LinearizationAbsQR); `None` is what
-/// the flag being off says.
+/// Keyframes whose pose Jacobians are zeroed in both optimization and marginalization.
+/// With `vio_fix_long_term_keyframes`, long-term poses stay fixed in the prior
+/// and in the solved increment. `None` and an empty set have the same numerical effect.
 fn fixed_keyframes<'a>(
     config: &VioConfig,
     ltkfs: &'a BTreeSet<FrameId>,
@@ -1592,7 +1407,7 @@ fn fixed_keyframes<'a>(
     }
 }
 
-/// `AffineCompact2f::translation().cast<Scalar>()` (`:437`).
+/// `AffineCompact2f::translation().cast<Scalar>()`.
 fn cast_pixel<S: LieScalar>(pixel: &Vector2<f32>) -> Vector2<S> {
     Vector2::new(
         S::from_literal(f64::from(pixel.x)),
@@ -1628,23 +1443,11 @@ mod tests {
         }
     }
 
-    /// The rig is one list of cameras, and
-    /// [`SqrtKeypointVio::triangulate_unconnected`] indexes the projections and
-    /// the extrinsics with the same id.
-    /// D32 at the API boundary: every scalar the estimator's own arithmetic
-    /// divides by, takes the square root of or compares against is checked
-    /// before any of that arithmetic runs.
-    ///
-    /// basalt runs it anyway: a negative `vio_init_pose_weight` puts a NaN on
-    /// the prior's diagonal (`:87-93`), a zero bias deviation an infinity in the
-    /// bias weight (`:226`), a negative `imu_update_rate` a NaN in both IMU
-    /// covariances (`calibration.hpp:186`), and a zero `vio_obs_std_dev` an
-    /// infinity in every Huber weight (`ba_base.cpp:181`). Every shipped
-    /// fixture is inside every domain, which is why no oracle lane can see
-    /// this.
-    ///
-    /// The values are the estimator's own scalar widened back to `f64`, so the
-    /// calibration probes use numbers `f32` holds exactly.
+    /// Check rig list lengths and all scalar domains at the boundary (D32).
+    /// Negative prior weights or IMU rates produce NaNs under square root; zero bias
+    /// or observation deviations produce infinities. Valid shipped calibrations
+    /// cannot exercise these failures, so explicit invalid inputs are required.
+    /// The probes use values exactly representable in f32 before widening to f64.
     #[test]
     fn a_scalar_outside_its_domain_is_refused_before_the_estimator_exists() {
         let refuse_config = |mutate: &dyn Fn(&mut VioConfig)| -> EstimatorError {
@@ -1789,12 +1592,9 @@ mod tests {
         );
     }
 
-    /// `push_imu` compares with the newest sample it has **accepted**, not with
-    /// the queue's back: once that sample has moved into `pending` the queue is
-    /// empty, and comparing with its back let an older sample slot in behind
-    /// the pending one, so a later integration met reversed timestamps
-    /// (`:947`'s loop). basalt cannot hit this — its queue is the only buffer —
-    /// but the port's public API could.
+    /// Compare IMU timestamps with the newest accepted sample, including `pending`.
+    /// Comparing only with an empty queue would let an older sample enter behind it
+    /// and reverse timestamps during integration.
     #[test]
     fn an_imu_sample_behind_the_pending_one_is_dropped() {
         let mut estimator: SqrtKeypointVio<f32> = estimator();
@@ -1823,15 +1623,9 @@ mod tests {
         );
     }
 
-    /// `:514`'s `opt_flow_meas->keypoints.at(i).at(lm_id)`: the triangulation
-    /// reads the host pixel back out of the map `measure` took the unconnected
-    /// id from, and C++ throws when it is not there. The port used to skip the
-    /// landmark silently (D32).
-    ///
-    /// Only a test can build this: `measure` fills `unconnected_obs[cam]` by
-    /// iterating `frame.cameras[cam]` and hands the same `frame` on, so the
-    /// two agree by construction on every ported path. The call below pairs an
-    /// id with a frameset that never carried it.
+    /// A missing host pixel must return an error instead of silently skipping a landmark.
+    /// Production `measure` builds both maps from the same frameset. This test
+    /// constructs inconsistent input explicitly to check that invariant (D32).
     #[test]
     fn an_unconnected_keypoint_missing_from_its_own_frameset_is_refused() {
         let mut estimator: SqrtKeypointVio<f32> = estimator();

--- a/packages/slam-rs/crates/slam-rs/src/estimator/optimize.rs
+++ b/packages/slam-rs/crates/slam-rs/src/estimator/optimize.rs
@@ -1,28 +1,13 @@
-//! `SqrtKeypointVioEstimator::optimize()` (`sqrt_keypoint_vio.cpp:1201-1639`).
+//! Levenberg-Marquardt optimization with an inner backtracking loop.
 //!
-//! A Levenberg–Marquardt loop with an inner backtracking loop, tabulated line
-//! by line in papers-part2 §12.7. Five things about it are basalt's and not the
-//! textbook's, and all five are reproduced here:
-//!
-//! * **`lambda` is reset every frame** to `vio_lm_lambda_initial` (`:1249`,
-//!   D11), so the trust region has no memory across framesets.
-//! * **The damping is `lambda · diag(H)` with a floor**, not `lambda·I`
-//!   (`:1415`, D10).
-//! * **The 7-iteration budget is shared with backtracking**: `it++` fires on a
-//!   rejection too (`:1592`, D12), so a frame that backtracks three times gets
-//!   four real linearizations.
-//! * **The increment is negated** before back-substitution (`:1450`, D13),
-//!   because `ba_utils.h:117` computes `π(x) − z` where the paper writes
-//!   `z − π(x)`.
-//! * **No Jacobian scaling and no landmark or pose damping** (D9/D34): the four
-//!   calls are commented out in the shipped source, and damping enters only
-//!   through the reduced system's diagonal. `backSubstitute` still calls
-//!   `setLandmarkDamping(0)` on itself; here there is nothing to undo, because
-//!   the three damping rows are never written.
-//!
-//! The accept test compares the true cost decrease with the linearized model's,
-//! and the model's includes the landmarks' own gain — it is positive at
-//! `inc = 0` (pr10-linearize.md finding 1). Nothing here "fixes" that.
+//! Lambda resets each frame (D11). Damping is `lambda · diag(H)` with a floor
+//! (D10), and rejected trials consume the same iteration budget as accepted ones
+//! (D12). The increment is negated before back-substitution because residuals
+//! are `π(x) − z` (D13). There is no Jacobian scaling or landmark/pose damping;
+//! only the reduced system's diagonal is damped (D34, D68).
+//! The acceptance test compares true cost decrease with predicted decrease,
+//! including the eliminated landmarks' own gain, which can be positive at zero
+//! pose increment.
 
 use std::collections::BTreeMap;
 
@@ -42,7 +27,7 @@ use crate::types::{
     Vector9, Vector15,
 };
 
-/// `max_num_iter` for the damped solve (`:1408`).
+/// `max_num_iter` for the damped solve.
 const MAX_SOLVE_ATTEMPTS: u32 = 3;
 
 /// Everything one `optimize` call works in that outlives the call.
@@ -76,13 +61,13 @@ impl<S: LieScalar> Default for OptimizeScratch<S> {
     }
 }
 
-/// The two hard-coded convergence constants of `:1566`, which are **not**
+/// The two hard-coded convergence constants, which are **not**
 /// config fields.
 pub(super) const FUNCTION_TOLERANCE: f64 = 1e-6;
 /// See [`FUNCTION_TOLERANCE`].
 pub(super) const STEP_TOLERANCE: f64 = 1e-4;
 
-/// `H.diagonal().segment<POSE_SIZE>(idx).array() = 1e20` (`:1400`), the value
+/// `H.diagonal().segment<POSE_SIZE>(idx).array() = 1e20`, the value
 /// `vio_fix_long_term_keyframes` pins a long-term keyframe's rows with.
 const FIXED_KEYFRAME_WEIGHT: f64 = 1e20;
 
@@ -97,84 +82,70 @@ pub(super) type SolveOutcome<S> = (Vec<LmIteration<S>>, LmTermination, StageTimi
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LmTermination {
     /// `opt_started` was false and `frame_states.size() <= 4`, so no
-    /// linearization ran at all (`:1207`).
+    /// linearization ran at all.
     NotStarted,
-    /// `(f_diff > 0 && f_diff < 1e-6) || step_norminf < 1e-4` (`:1565-1568`).
+    /// `(f_diff > 0 && f_diff < 1e-6) || step_norminf < 1e-4`.
     Converged,
-    /// The iteration budget ran out without converging (`:1283`).
+    /// The iteration budget ran out without converging.
     MaxIterations,
-    /// `lambda > max_lambda` after a rejection (`:1595-1598`).
+    /// `lambda > max_lambda` after a rejection.
     MaxDamping,
 }
 
-/// One step of the LM loop, accepted or rejected.
-///
-/// The five error components are split because their sum is what the accept
-/// test compares and a parity gap has to be attributable: the marg-prior term
-/// deliberately drops `½rᵀr` and can be negative (`ba_base.cpp:452-455`, D20),
-/// so a port that folds it into one number cannot tell which term drifted.
+/// One accepted or rejected LM step.
+/// Separate error components make changes in the objective attributable. The
+/// prior omits `½rᵀr` and can be negative (D20), so its term remains visible.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LmIteration<S: LieScalar> {
-    /// `it` when this step ran (`:1283`).
+    /// `it` when this step ran.
     pub iteration: i32,
-    /// `j`, the backtracking index inside this linearization (`:1350`).
+    /// `j`, the backtracking index inside this linearization.
     pub backtrack: i32,
-    /// `error_total` from `linearizeProblem` (`:1297`).
+    /// `error_total` from `linearizeProblem`.
     pub error_before: S,
-    /// `after_error_total` (`:1500`).
+    /// `after_error_total`.
     pub error_after: S,
-    /// `computeError`'s reprojection cost after the increment (`:1487`).
+    /// `computeError`'s reprojection cost after the increment.
     pub vision_error: S,
-    /// `computeImuError`'s `imu_error` (`:1492`).
+    /// `computeImuError`'s `imu_error`.
     pub imu_error: S,
     /// `computeImuError`'s `bg_error`.
     pub bias_gyro_error: S,
     /// `computeImuError`'s `ba_error`.
     pub bias_accel_error: S,
-    /// `computeMargPriorError` after the increment (`:1488`).
+    /// `computeMargPriorError` after the increment.
     pub marg_prior_error: S,
-    /// `l_diff` from `backSubstitute` (`:1454`).
+    /// `l_diff` from `backSubstitute`.
     pub l_diff: S,
-    /// `f_diff = error_total − after_error_total` (`:1509`).
+    /// `f_diff = error_total − after_error_total`.
     pub f_diff: S,
-    /// `relative_decrease = f_diff / l_diff` (`:1511`).
+    /// `relative_decrease = f_diff / l_diff`.
     pub relative_decrease: S,
-    /// `lambda` as the retry loop left it (`:1571`), which is what
-    /// `sqrt_keypoint_vio.h:209` calls "the value the damped solve used": the
-    /// escalated one after a non-finite increment, not the value the iteration
-    /// started with. Every attempt escalates on failure, the last one included,
-    /// so three failures record a `lambda` no attempt used — the fork's number
-    /// all the same.
+    /// Lambda after the retry loop. Every failure escalates it, including the last
+    /// attempt, so three failures record a value that no attempt used.
     pub lambda: S,
-    /// `step_norminf = inc.array().abs().maxCoeff()` (`:1477`).
+    /// `step_norminf = inc.array().abs().maxCoeff()`.
     pub step_norminf: S,
-    /// How many times the damped LDLT was retried (`:1410-1430`); more than one
+    /// How many times the damped LDLT was retried; more than one
     /// means the first increment was not finite.
     pub solve_attempts: u32,
-    /// `step_is_valid = l_diff > 0` (`:1528`).
+    /// `step_is_valid = l_diff > 0`.
     pub step_is_valid: bool,
-    /// `step_is_successful` (`:1529`), i.e. whether the increment was kept.
+    /// `step_is_successful`, i.e. whether the increment was kept.
     pub accepted: bool,
 }
 
 impl<S: LieScalar> SqrtKeypointVio<S> {
-    /// `optimize()` (`:1201-1639`), returning the LM trail, why it stopped and
-    /// the stages it timed. Whether it ran at all is `self.opt_started`, which
-    /// it sets.
+    /// Optimize and return the LM trail, stop reason and stage durations.
+    /// `self.opt_started` records whether optimization ran.
     ///
     /// # Errors
-    ///
-    /// [`EstimatorError::PriorOrderMismatch`] where C++ asserts the window
-    /// agrees with the prior (`:1227`, `:1237`),
-    /// [`EstimatorError::NumericallyInvalid`] where it prints "did not expect
-    /// numerical failure during linearization" and fails the frame
-    /// (`:1300-1303`), [`EstimatorError::FrameNotInOrdering`] where `:1468`
-    /// and `:1472` read the ordering with `.at()`, and the linearization's own
-    /// errors.
+    /// Returns typed errors for prior-order mismatch, invalid linearization,
+    /// missing ordering entries and failures from the linearizer.
     pub(super) fn optimize(&mut self, t_ns: i64) -> Result<SolveOutcome<S>, EstimatorError> {
         let mut lm: Vec<LmIteration<S>> = Vec::new();
         let mut timings: StageTimings = StageTimings::default();
-        // `:1207`: five states have to accumulate before the first
+        // five states have to accumulate before the first
         // optimization.
         if !self.opt_started && self.ba.frame_states.len() <= 4 {
             return Ok((lm, LmTermination::NotStarted, timings));
@@ -182,9 +153,8 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         self.opt_started = true;
 
         let imu_lin: ImuLinData<S> = self.imu_lin_data();
-        // The nine estimator members the C++ reads, as disjoint field borrows:
-        // the linearizer needs `ba` mutably while `marg_data` and `imu_meas`
-        // are borrowed into its inputs.
+        // Borrow estimator fields separately so the linearizer can mutate `ba` while
+        // borrowing the prior and IMU inputs.
         let Self {
             ref mut ba,
             ref mut damping,
@@ -201,17 +171,9 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             ref mut increment,
         } = *scratch;
 
-        // `:1221-1242`: poses first, then states, both in ascending timestamp
-        // order, and each entry checked against the prior's. C++ reads the prior
-        // with `.at()` for the poses (an out-of-range throw when it disagrees) and
-        // guards the states with `aom.items < marg_data.order.size()`, because the
-        // newest states are not in the prior yet.
-        //
-        // This is deliberately not `marg::window::build_absolute_ordering`: that
-        // one is `:726-763`, which walks the same two maps but stops at
-        // `last_state_to_marg` and returns the marginalization's own split. basalt
-        // writes the two loops out twice for the same reason, and merging them
-        // would mean one function with two payloads and two stopping rules.
+        // Order poses before states, each by timestamp, and check the prior prefix.
+        // This differs from marginalization ordering, which stops at
+        // `last_state_to_marg` and returns its own keep/marginalize split.
         let mut aom: AbsOrderMap = AbsOrderMap::new();
         for frame_id in ba.frame_poses.keys().copied() {
             let index: usize = aom.push(frame_id, POSE_SIZE)?;
@@ -237,10 +199,10 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             }
         }
 
-        // `:1249`, D11.
+        // D11.
         damping.lambda = S::from_literal(config.vio_lm_lambda_initial);
 
-        // `:1266-1267`: every interval, with no `aom` filter — unlike
+        // every interval, with no `aom` filter — unlike
         // `marginalize`, which keeps only the intervals both of whose ends are in
         // the ordering.
         let imu_input: ImuInput<'_, S> = ImuInput {
@@ -252,11 +214,11 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             imu: Some(&imu_input),
             used_frames: None,
             lost_landmarks: None,
-            // `:1258`: the same set `marginalize` builds at `:924`.
+            // Fix the same long-term keyframes as marginalization.
             fixed_frames: fixed_keyframes(config, ltkfs),
         };
 
-        // `:1268-1274`: one linearizer for the whole frame; the outer loop
+        // one linearizer for the whole frame; the outer loop
         // re-linearizes into it rather than rebuilding it.
         let mut lqr: LinearizationAbsQR<S> =
             LinearizationAbsQR::new(ba, &aom, LinearizationOptions::default(), &inputs)?;
@@ -267,23 +229,19 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         let mut it: i32 = 0;
         let mut termination: Option<LmTermination> = None;
 
-        // `:1283`.
         while it <= config.vio_max_iterations && termination.is_none() {
             let mark: std::time::Instant = std::time::Instant::now();
-            // `:1297-1303`.
             let (error_total, numerically_valid) = lqr.linearize_problem(ba, &inputs)?;
             if !numerically_valid {
                 return Err(EstimatorError::NumericallyInvalid { t_ns });
             }
-            // `:1320`.
             lqr.perform_qr()?;
             timings.linearize_ns += duration_ns(mark);
 
-            // `:1350`: the inner loop shares `it` with the outer one.
+            // the inner loop shares `it` with the outer one.
             let mut backtrack: i32 = 0;
             while it <= config.vio_max_iterations && termination.is_none() {
                 let mark: std::time::Instant = std::time::Instant::now();
-                // `:1393`.
                 let (h, b) = lqr.get_dense_h_b_into(ba, &inputs, dense)?;
                 // The reduced system is the ordering's: every `(idx, size)` in
                 // `aom` is a block of it, and every frame of the two maps has
@@ -292,12 +250,11 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
                 // below index it under that invariant.
                 debug_assert_eq!(h.nrows(), aom.total_size());
 
-                // `:1395-1406`.
                 if config.vio_fix_long_term_keyframes {
                     let weight: S = S::from_literal(FIXED_KEYFRAME_WEIGHT);
                     for t_ns in ltkfs {
                         let Some((idx, size)) = aom.get(*t_ns) else {
-                            // `:1397-1399`: C++ prints "[UNEXPECTED]" and skips.
+                            // Skip the unexpected missing entry.
                             log::warn!(
                                 "[UNEXPECTED] long-term keyframe {t_ns} ns is not in the ordering"
                             );
@@ -315,10 +272,9 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
                     }
                 }
 
-                // `:1408-1430`.
                 let (inc_valid, solve_attempts): (bool, u32) =
                     damped_solve(h, b, damping, solve, increment);
-                // `:1432`: C++ warns and carries on with the non-finite increment.
+                // Continue with the non-finite increment after exhausting retries.
                 if !inc_valid {
                     log::warn!(
                         "frame {t_ns} ns: increment still not finite after {MAX_SOLVE_ATTEMPTS} damped solves"
@@ -326,17 +282,15 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
                 }
                 timings.solver_ns += duration_ns(mark);
 
-                // `:1443`.
                 ba.backup();
 
-                // `:1447-1454`, D13: negate, then back-substitute.
+                // D13: negate, then back-substitute.
                 let mark: std::time::Instant = std::time::Instant::now();
                 increment.neg_mut();
                 let inc: &DVector<S> = increment;
                 let l_diff: S = lqr.back_substitute(ba, &inputs, inc)?;
                 timings.back_substitution_ns += duration_ns(mark);
 
-                // `:1466-1474`.
                 for (frame_id, state) in &mut ba.frame_poses {
                     let Some((idx, _)) = aom.get(*frame_id) else {
                         return Err(EstimatorError::FrameNotInOrdering {
@@ -358,16 +312,14 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
                     state.apply_inc(&step);
                 }
 
-                // `:1477`: `inc.array().abs().maxCoeff()`. `maxCoeff` folds with
-                // `numext::maxi`, which is order-independent for finite values, so a
-                // sequential fold is the same number; with a non-finite increment
-                // the fold order can matter and this one is left to right.
+                // Fold absolute increment coefficients left to right. Order can matter when
+                // an increment contains non-finite values.
                 let mut step_norminf: S = S::zero();
                 for value in inc.iter() {
                     step_norminf = eigen_maxi(step_norminf, value.abs());
                 }
 
-                // `:1484-1497`: the true cost at the new state.
+                // the true cost at the new state.
                 let mark: std::time::Instant = std::time::Instant::now();
                 let (vision_error, _) = ba.compute_error(None, S::zero())?;
                 let marg_prior_error: S = ba.compute_marg_prior_error(marg_data)?;
@@ -379,17 +331,14 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
                     &accel_bias_weight,
                     &imu_lin.g,
                 )?;
-                // `:1495`: `vision += ((imu + bg) + ba)`, in that association.
+                // `vision += ((imu + bg) + ba)`, in that association.
                 let vision_and_inertial: S =
                     vision_error + ((imu_error + bias_gyro_error) + bias_accel_error);
                 timings.error_ns += duration_ns(mark);
 
-                // `:1500`.
                 let error_after: S = vision_and_inertial + marg_prior_error;
-                // `:1509-1511`.
                 let f_diff: S = error_total - error_after;
                 let relative_decrease: S = f_diff / l_diff;
-                // `:1528-1529`.
                 let step_is_valid: bool = l_diff > S::zero();
                 let accepted: bool = step_is_valid && relative_decrease > S::zero();
 
@@ -406,11 +355,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
                     l_diff,
                     f_diff,
                     relative_decrease,
-                    // `:1571`: the fork reads `lambda` here, after the retry
-                    // loop, so a non-finite first solve is recorded with the
-                    // escalated value the next one would use — "the value the
-                    // damped solve used" (`sqrt_keypoint_vio.h:209`). Nothing
-                    // between the loop and this push moves it.
+                    // Record lambda after retries, including any escalation after the final failure.
                     lambda: damping.lambda,
                     step_norminf,
                     solve_attempts,
@@ -425,11 +370,10 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
                     if lm_converged(f_diff, step_norminf) {
                         termination = Some(LmTermination::Converged);
                     }
-                    // `:1571`: leave the inner loop and re-linearize.
+                    // leave the inner loop and re-linearize.
                     break;
                 }
 
-                // `:1585-1598`.
                 damping.escalate();
                 ba.restore();
                 it += 1;
@@ -516,17 +460,10 @@ pub(super) fn damped_solve<S: LieScalar>(
     }
 }
 
-/// `ScBundleAdjustmentBase::computeImuError` (`sc_ba_base.cpp:657-704`), which
-/// the QR path calls even though everything else about it is Schur-complement
-/// machinery (`sqrt_keypoint_vio.cpp:1490-1492`).
-///
-/// Three sums: the whitened preintegration residual, and one random-walk term
-/// per bias. Intervals of zero length and intervals whose two ends are not both
-/// in the ordering are skipped (`:667`, `:672`); an interval that is in the
-/// ordering but has no state is [`EstimatorError::ImuFactorStateMissing`],
-/// where C++ throws out of `states.at()`.
-///
-/// Each quadratic form uses fixed-order folds over its residual coefficients.
+/// IMU cost: whitened preintegration plus one random-walk term per bias.
+/// Skip zero-length intervals and intervals not fully in the ordering. A missing
+/// state for an ordered endpoint returns [`EstimatorError::ImuFactorStateMissing`].
+/// Quadratic forms use fixed-order residual folds.
 fn compute_imu_error<S: LieScalar>(
     aom: &AbsOrderMap,
     states: &BTreeMap<FrameId, PoseVelBiasStateWithLin<S>>,
@@ -550,7 +487,7 @@ fn compute_imu_error<S: LieScalar>(
         }
         let (Some(start_state), Some(end_state)) = (states.get(&start_t), states.get(&end_t))
         else {
-            // `:671-672` are `.at()` calls: both endpoints are in `aom`, so a
+            //  are `.at()` calls: both endpoints are in `aom`, so a
             // miss in `frame_states` is an invariant break, and skipping the
             // factor would drop its residual from the true cost and change
             // which LM step is accepted (D32).
@@ -590,7 +527,7 @@ fn compute_imu_error<S: LieScalar>(
         }
         imu_error += S::from_literal(0.5) * quadratic;
 
-        // `:688`: `dt` in seconds, formed as `int64 · Scalar(1e-9)`.
+        // `dt` in seconds, formed as `int64 · Scalar(1e-9)`.
         let dt: S = S::from_literal(meas.get_dt_ns() as f64) * S::from_literal(1e-9);
         let res_bg: Vector3<S> = start.bias_gyro - end.bias_gyro;
         let gyro_dt: Vector3<S> = gyro_bias_weight / dt;
@@ -623,7 +560,7 @@ mod tests {
     use crate::types::PoseVelBiasState;
 
     /// `lambda`, `min_lambda`, `max_lambda`, `lambda_vee` as `optimize` starts a
-    /// frame: `lambda_vee` is [`VEE_FACTOR`], as `:1249-1251` resets it.
+    /// frame: `lambda_vee` is [`VEE_FACTOR`], as resets it.
     fn damping(lambda: f64, min_lambda: f64) -> LmDamping<f64> {
         LmDamping {
             lambda,
@@ -633,9 +570,7 @@ mod tests {
         }
     }
 
-    /// A single finite solve leaves `lambda` alone, so the value the trace
-    /// records is the one the iteration started with — the oracle's case, and
-    /// the reason the fixture cannot see the retry bug.
+    /// A finite first solve leaves the recorded lambda at its initial value.
     #[test]
     fn a_finite_solve_records_the_lambda_it_used() {
         let h: DMatrix<f64> = DMatrix::identity(3, 3);
@@ -718,11 +653,8 @@ mod tests {
         }
     }
 
-    /// A system the damping cannot rescue: every attempt fails, so `lambda` is
-    /// escalated three times (`:1426-1427` runs after the third failure too)
-    /// and the trace records `lambda · 2 · 4 · 8` — the value the port captured
-    /// **before** the loop until this fix, where the fork reads it after
-    /// (`:1571`, `sqrt_keypoint_vio.h:209`).
+    /// Three failed attempts escalate lambda by `2 · 4 · 8`, including after the
+    /// last failure. The trace must record that final value.
     #[test]
     fn a_solve_that_never_becomes_finite_records_the_escalated_lambda() {
         let h: DMatrix<f64> = DMatrix::identity(3, 3);
@@ -767,7 +699,7 @@ mod tests {
         assert_eq!(lm.lambda_vee, 4.0);
     }
 
-    /// `computeImuError` reads both endpoints with `.at()` (`sc_ba_base.cpp:671-672`).
+    /// `computeImuError` reads both endpoints with `.at()`.
     /// Skipping a factor whose state is gone understates the true cost and can
     /// flip the LM accept test, so the port refuses instead.
     ///

--- a/packages/slam-rs/crates/slam-rs/src/estimator/schedule.rs
+++ b/packages/slam-rs/crates/slam-rs/src/estimator/schedule.rs
@@ -1,34 +1,16 @@
-//! `SqrtKeypointVioEstimator::marginalize()` (`sqrt_keypoint_vio.cpp:707-1198`).
+//! Marginalization scheduling: select full states, velocity/bias blocks, poses
+//! and keyframes to remove. [`crate::marg::marginalize`] owns the algebra.
 //!
-//! Only the **schedule** lives here: which states lose their velocity and bias,
-//! which lose everything, which pose blocks go, and which keyframe the budget
-//! evicts. The algebra — the second linearization over the evicted keyframes'
-//! landmarks, the index split, the rank-revealing flat QR and the re-anchoring —
-//! is [`crate::marg::marginalize`], from stage S7.
+//! `states_to_remove = frame_states.size() - max_states + 1`: at a full window,
+//! the oldest state leaves and the second oldest is kept and frozen.
+//! The keyframe budget is lazy: eviction requires both an exceeded keyframe
+//! budget and a keyframe leaving the state window. A newly selected keyframe
+//! can therefore keep the count one above the configured budget until demotion.
+//! The shipped frame spacing and state-window sizes bound this overshoot.
 //!
-//! Two things make the schedule subtle:
-//!
-//! * `states_to_remove` is `frame_states.size() − max_states + 1`, so
-//!   `last_state_to_marg` is the **second** oldest state when the window is
-//!   full, not the oldest (`:720-724`). The oldest state leaves; the second
-//!   oldest is kept whole and has its linearization point frozen.
-//! * The keyframe budget is **lazy**. The eviction loop runs only while
-//!   `kf_ids.size() > max_kfs && !states_to_marg_vel_bias.empty()` (`:767`),
-//!   and nothing in the body shrinks `states_to_marg_vel_bias` — the keyframes
-//!   leaving the *state* window this step. A frame that has just been voted a
-//!   keyframe is still a state, so it cannot be evicted, and `kf_ids` sits one
-//!   over `max_kfs` until it is demoted to a pose block. On the smoke segment
-//!   that is framesets 49-50 and 56-57, eight keyframes against
-//!   `vio_max_kfs = 7`, and the C++ does exactly the same. The overshoot is at
-//!   most one because `vio_min_frames_after_kf = 5` puts keyframes six
-//!   framesets apart while a state leaves after `vio_max_states = 3` — which is
-//!   also why `states_to_marg_vel_bias` holds at most one entry and the newest
-//!   keyframe is always inside the two the eviction score skips.
-//!
-//! `KF_MARG_DEFAULT`'s second pass is a DSO-derived distance score whose own
-//! comment admits it "seems to mostly marginalize the oldest keyframe"
-//! (`:832-836`, D22) — which is not what it does; see
-//! [`SqrtKeypointVio::evict_by_default`].
+//! The default rule first checks tracked-feature ratios, then minimizes a
+//! DSO-derived distance score. Its self-distance term makes proximity to the
+//! newest keyframe dominate the second pass (D22).
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -47,13 +29,11 @@ use crate::types::{FrameId, LandmarkId};
 pub enum EvictionReason {
     /// `KF_MARG_DEFAULT` first pass: the oldest keyframe whose tracked
     /// fraction fell below `vio_kf_marg_feature_ratio`, or which the current
-    /// frame does not observe at all (`:822-829`).
+    /// frame does not observe at all.
     FeatureRatio,
     /// `KF_MARG_DEFAULT` second pass: the minimum of the DSO distance score
-    /// (`:845-867`).
     DistanceScore,
     /// `KF_MARG_FORWARD_VECTOR`: the least distinctive viewing direction
-    /// (`:788-812`).
     ForwardVector,
 }
 
@@ -69,43 +49,36 @@ pub struct KeyframeEviction {
 /// What one marginalization did.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MarginalizationStats {
-    /// `states_to_remove` (`:720`).
+    /// `states_to_remove`.
     pub states_to_remove: usize,
-    /// The state that is kept whole and frozen (`:724`, `:1086-1087`).
+    /// The state that is kept whole and frozen.
     pub last_state_to_marg: FrameId,
     /// Pose blocks that leave: the non-keyframes, plus the evicted keyframes
-    /// (`:733`, `:875`).
     pub poses_to_marg: Vec<FrameId>,
-    /// States that leave entirely (`:754`).
+    /// States that leave entirely.
     pub states_to_marg_all: Vec<FrameId>,
-    /// Keyframe states demoted to pose blocks (`:752`).
+    /// Keyframe states demoted to pose blocks.
     pub states_to_marg_vel_bias: Vec<FrameId>,
-    /// Keyframes the budget evicted, oldest first (`:874`).
+    /// Keyframes the budget evicted, oldest first.
     pub kfs_to_marg: Vec<FrameId>,
     /// Which criterion pass chose each eviction, in the order they happened.
     pub evictions: Vec<KeyframeEviction>,
-    /// `idx_to_keep.size()` (`:1005`).
+    /// `idx_to_keep.size()`.
     pub kept_indices: usize,
     /// `idx_to_marg.size()`.
     pub marg_indices: usize,
-    /// Whether the marginalization's own linearization was numerically valid.
-    /// basalt discards this; the port reports it, because a marginalization run
-    /// on an invalid linearization is worth knowing about.
+    /// Whether the marginalization linearization was numerically valid.
     pub numerically_valid: bool,
-    /// `asize`, the width of the ordering the split was taken over (`:898`).
-    ///
-    /// It witnesses that the split covers the ordering: `kept_indices +
-    /// marg_indices == ordering_size` is what "every variable is either kept or
-    /// marginalized" means, and `tests/vio_oracle.rs` asserts that sum.
+    /// Ordering width; kept and marginalized index counts must sum to this value.
     pub ordering_size: usize,
-    /// `marg_order_new`, as `(frame, index, size)` (`:1120-1133`).
+    /// `marg_order_new`, as `(frame, index, size)`.
     pub prior_order: Vec<(FrameId, usize, usize)>,
 }
 
 /// What one call to [`SqrtKeypointVio::marginalize`] did, on its way into
 /// [`FrameStats`].
 ///
-/// Everything is empty when the trigger of `:717` did not fire, which is the
+/// Everything is empty when the trigger of did not fire, which is the
 /// common case: the window marginalizes on roughly one frameset in two.
 #[derive(Debug, Clone, Default)]
 pub(super) struct MarginalizationOutcome {
@@ -116,13 +89,9 @@ pub(super) struct MarginalizationOutcome {
 }
 
 impl<S: LieScalar> SqrtKeypointVio<S> {
-    /// `:465-472`: move the newest keyframe out of the `max_kfs` budget, if
-    /// [`SqrtKeypointVio::take_long_term_keyframe`] asked for it.
-    ///
-    /// The long-term keyframes are counted on the other side of `:717`'s pose
-    /// budget and are never eviction candidates, so this is the one way a
-    /// keyframe leaves the budget without leaving the window. The request is
-    /// consumed whether or not there was a keyframe to demote, as in C++.
+    /// Move the newest keyframe outside the ordinary budget when requested.
+    /// Long-term keyframes are never eviction candidates. Consume the request even
+    /// when no keyframe can be moved.
     pub(super) fn demote_long_term_keyframe(&mut self) {
         if !self.take_ltkf {
             return;
@@ -134,25 +103,20 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         self.take_ltkf = false;
     }
 
-    /// `marginalize(num_points_connected, lost_landmaks)` (`:707-1198`),
-    /// returning what it did and how long it took. Every component is
-    /// `None`/zero when the trigger of `:717` did not fire.
+    /// Run marginalization and return its decisions and duration.
+    /// Components stay empty or zero if the trigger does not fire.
     ///
     /// # Errors
-    ///
-    /// [`EstimatorError`] where C++ asserts or reads out of range: a keyframe
-    /// the eviction score needs that is not in the window, a window that
-    /// disagrees with the prior's ordering, or no selectable keyframe.
+    /// Returns [`EstimatorError`] for missing candidate frames, prior-order mismatch
+    /// or absence of a selectable keyframe.
     pub(super) fn marginalize(
         &mut self,
         num_points_connected: &BTreeMap<FrameId, usize>,
         lost_landmarks: &BTreeSet<LandmarkId>,
     ) -> Result<MarginalizationOutcome, EstimatorError> {
-        // `:710-713`.
         if !self.opt_started {
             return Ok(MarginalizationOutcome::default());
         }
-        // `:717`.
         if !(self.ba.frame_poses.len() > self.ltkfs.len() + self.max_kfs
             || self.ba.frame_states.len() >= self.max_states)
         {
@@ -160,23 +124,20 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         }
         let mark: std::time::Instant = std::time::Instant::now();
 
-        // `:720-724`. C++ computes this in `size_t` and stores it in an `int`,
-        // so a window shorter than `max_states - 1` wraps to a negative count
-        // and the advance does not happen; saturating arithmetic is that
-        // behaviour written down.
+        // Saturating arithmetic leaves a short window with no states to advance past.
         let states_to_remove: usize =
             (self.ba.frame_states.len() + 1).saturating_sub(self.max_states);
         let Some(last_state_to_marg) = self.ba.frame_states.keys().nth(states_to_remove).copied()
         else {
-            // C++ advances the iterator past `end()` and dereferences it.
+            // Refuse an advance beyond the state window.
             return Err(EstimatorError::StateWindowTooShort {
                 states: self.ba.frame_states.len(),
                 states_to_remove,
             });
         };
 
-        // `:731-740`: every pose block that is neither a keyframe nor a
-        // long-term keyframe. The ordering assertion of `:737` happens inside
+        // every pose block that is neither a keyframe nor a
+        // long-term keyframe. The ordering assertion of happens inside
         // `marg::marginalize`, which rebuilds the same `AbsOrderMap`.
         let mut poses_to_marg: BTreeSet<FrameId> = BTreeSet::new();
         for frame_id in self.ba.frame_poses.keys().copied() {
@@ -185,7 +146,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             }
         }
 
-        // `:744-763`: the states older than `last_state_to_marg` split by
+        // the states older than `last_state_to_marg` split by
         // whether they are keyframes.
         let mut states_to_marg_vel_bias: BTreeSet<FrameId> = BTreeSet::new();
         let mut states_to_marg_all: BTreeSet<FrameId> = BTreeSet::new();
@@ -202,7 +163,6 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             }
         }
 
-        // `:767-880`.
         let mut kfs_to_marg: BTreeSet<FrameId> = BTreeSet::new();
         let mut evictions: Vec<KeyframeEviction> = Vec::new();
         while self.kf_ids.len() > self.max_kfs && !states_to_marg_vel_bias.is_empty() {
@@ -227,7 +187,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             schedule: &schedule,
             imu_lin_data: Some(self.imu_lin_data()),
             lost_landmarks: Some(lost_landmarks),
-            // `:924`: the same set `optimize` builds at `:1258`.
+            // Fix the same long-term keyframes as optimization.
             fixed_frames: fixed_keyframes(&self.config, &self.ltkfs),
             options: MarginalizeOptions {
                 marg_lost_landmarks: self.config.vio_marg_lost_landmarks,
@@ -240,7 +200,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             &inputs,
         )?;
 
-        // `:1091-1094` and `:1108-1111`: the two estimator-side maps
+        //  and : the two estimator-side maps
         // `marg::marginalize` does not own. A demoted keyframe keeps both — it
         // is still in the window as a pose.
         self.last_marginalized.clear();
@@ -278,38 +238,22 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
         })
     }
 
-    /// `KF_MARG_DEFAULT` (`:814-868`).
+    /// Default keyframe eviction.
     ///
-    /// First pass: walk from the oldest keyframe, skipping the newest two, and
-    /// take the first whose tracked fraction is below
-    /// `vio_kf_marg_feature_ratio` — or which the current frame does not
-    /// observe at all, which is what `num_points_connected.count(*it) == 0`
-    /// means. The ratio is computed in **`float`** whatever the estimator's
-    /// scalar is (`static_cast<float>` at `:826`) and then promoted to `double`
-    /// for the comparison, so the `f64` instantiation compares a
-    /// single-precision quotient. That cast cannot change the outcome for any
-    /// count the window can hold: distinct quotients of counts below a million
-    /// are at least `1e-6` apart while one `f32` ulp near `0.1` is `7.5e-9`,
-    /// and the one quotient that lands exactly on the threshold —
-    /// `connected · 10 == hosted` — rounds *up* in `f32` and so fails the
-    /// strict `<` in both precisions. It is ported because it is what the C++
-    /// computes, not because a decision turns on it.
+    /// First choose the oldest eligible keyframe whose tracked-feature ratio is
+    /// below the threshold, or which the current frame does not observe. Skip the
+    /// newest two. The quotient is computed in f32 and widened for comparison.
     ///
-    /// Second pass: the DSO score `sqrt(‖p_i − p_last‖) · Σ_j 1/(‖p_i − p_j‖ +
-    /// 1e-5)`, minimized, with the sum running over the candidate set
-    /// *including `i` itself* (`:848`). That self term is `1/1e-5 = 1e5` and
-    /// swamps the metre-scale distances to the other keyframes, so what
-    /// actually discriminates is `sqrt(‖p_i − p_last‖)` and the candidate
-    /// **nearest the newest keyframe** is evicted — not the oldest that the
-    /// comment at `:832-836` expects. The norms are Eigen's three-coefficient
-    /// reduction, whose order differs between the precisions (D47).
+    /// Otherwise minimize `sqrt(‖p_i − p_last‖) · Σ_j 1/(‖p_i − p_j‖ + 1e-5)`.
+    /// The sum includes the candidate itself, contributing `1e5`. This dominates
+    /// metre-scale distances, so proximity to the newest keyframe drives eviction.
     fn evict_by_default(
         &self,
         num_points_connected: &BTreeMap<FrameId, usize>,
     ) -> Result<KeyframeEviction, EstimatorError> {
         let candidates: Vec<FrameId> = self.eviction_candidates();
 
-        // `:820-830`. The `||` at `:823-824` short-circuits on the missing
+        // The `||` at short-circuits on the missing
         // connection *before* it reads `num_points_kf.at(*it)`, so a keyframe
         // absent from both maps is evicted rather than refused.
         for frame_id in &candidates {
@@ -319,8 +263,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
                     reason: EvictionReason::FeatureRatio,
                 });
             };
-            // `:827` reads `num_points_kf.at(*it)`; basalt never erases the
-            // map, so a keyframe the frame does see always has an entry.
+            // Hosted counts are retained, so an observed keyframe must have an entry.
             let Some(hosted) = self.num_points_kf.get(frame_id).copied() else {
                 return Err(EstimatorError::KeyframeNotInWindow {
                     frame_id: *frame_id,
@@ -336,14 +279,14 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             }
         }
 
-        // `:838-867`. `:842`: `std::numeric_limits<Scalar>::max()`.
+        // : `std::numeric_limits<Scalar>::max()`.
         let mut min_score: S = S::largest();
         let mut min_score_id: Option<FrameId> = None;
-        // `:841`: `*kf_ids.crbegin()`. Every candidate comes out of `kf_ids`,
+        // `*kf_ids.crbegin()`. Every candidate comes out of `kf_ids`,
         // so an empty keyframe set has no candidate either and the one
         // `NoKeyframeToMarginalize` below reports it.
         if let Some(last_kf) = self.kf_ids.iter().next_back().copied() {
-            // `:854`: `frame_states.at(last_kf)`. The newest keyframe is the
+            // `frame_states.at(last_kf)`. The newest keyframe is the
             // newest frame whenever `take_kf` fired on it, and keyframes are at
             // least six frames apart, so it is a state in every shipped
             // configuration.
@@ -356,7 +299,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             let last_translation: Vector3<S> = last_state.state().t_w_i.translation;
             for frame_id in &candidates {
                 let here: Vector3<S> = self.keyframe_pose(*frame_id)?.translation;
-                // `:848-853`: the sum runs over the same candidate set, so a
+                // the sum runs over the same candidate set, so a
                 // keyframe's distance to itself contributes `1 / 1e-5`.
                 let mut denom: S = S::zero();
                 for other in &candidates {
@@ -372,7 +315,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
                 }
             }
         }
-        // `:872`: "if no frame was selected, the logic above is faulty".
+        // "if no frame was selected, the logic above is faulty".
         min_score_id
             .map(|frame_id| KeyframeEviction {
                 frame_id,
@@ -383,18 +326,12 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             })
     }
 
-    /// `KF_MARG_FORWARD_VECTOR` (`:770-813`), the fork's own criterion.
-    ///
-    /// Score each candidate keyframe by the sum of angles between its camera-0
-    /// forward vector and every other keyframe's — long-term keyframes
-    /// included, which is the difference from the default criterion's candidate
-    /// set — and evict the minimum, i.e. the least distinctive viewing
-    /// direction. `acos` is called unqualified inside `namespace basalt`, so the
-    /// `float` instantiation resolves to `::acosf` (the same overload trap as
-    /// `atan2` in D42); computing in `S` reproduces that.
+    /// Forward-vector eviction: sum camera-0 viewing-direction angles against other
+    /// keyframes, including long-term keyframes, and evict the minimum.
+    /// The least distinctive direction leaves. Angles use the estimator scalar.
     fn evict_by_forward_vector(&self) -> Result<KeyframeEviction, EstimatorError> {
         let candidates: Vec<FrameId> = self.eviction_candidates();
-        // `:781-786`: the scored-against set is `ltkfs ∪ kf_ids`, again without
+        // the scored-against set is `ltkfs ∪ kf_ids`, again without
         // its own newest two.
         let mut all_kfs: BTreeSet<FrameId> = self.ltkfs.clone();
         all_kfs.extend(self.kf_ids.iter().copied());
@@ -404,7 +341,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             .take(all_kfs.len().saturating_sub(2))
             .collect();
 
-        // `:788`: `std::numeric_limits<Scalar>::max()`.
+        // `std::numeric_limits<Scalar>::max()`.
         let mut min_score: S = S::largest();
         let mut min_score_id: Option<FrameId> = None;
         for frame_id in &candidates {
@@ -412,8 +349,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             let mut score: S = S::zero();
             for other in &against {
                 let fwd2: (S, S) = self.forward_vector_2d(*other)?;
-                // `fwd1.dot(fwd2)` on a 2-vector is Eigen's coefficient-based
-                // product: `a0 * b0 + a1 * b1`.
+                // Two-vector dot product: `a0 * b0 + a1 * b1`.
                 let dot: S = fwd1.0 * fwd2.0 + fwd1.1 * fwd2.1;
                 // `std::clamp(v, lo, hi)` = `v < lo ? lo : (hi < v ? hi : v)`,
                 // which returns a NaN unchanged.
@@ -441,9 +377,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             })
     }
 
-    /// `kf_ids` without its newest two (`std::prev(kf_ids.end(), 2)` at `:819`
-    /// and `:840`), empty when there are two or fewer — which is the
-    /// `kf_ids.size() > 2` guard C++ writes to keep `std::prev` valid.
+    /// All keyframes except the newest two; empty when there are at most two.
     fn eviction_candidates(&self) -> Vec<FrameId> {
         if self.kf_ids.len() <= 2 {
             return Vec::new();
@@ -455,8 +389,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             .collect()
     }
 
-    /// `frame_poses.at(ts).getPose()` (`:794`, `:849`), which C++ throws out of
-    /// when the keyframe is not a pose block.
+    /// Look up a keyframe pose block, returning an error if absent.
     fn keyframe_pose(&self, frame_id: FrameId) -> Result<Se3<S>, EstimatorError> {
         self.ba
             .frame_poses
@@ -468,7 +401,7 @@ impl<S: LieScalar> SqrtKeypointVio<S> {
             })
     }
 
-    /// `get_forward_vector2d` (`:792-798`): the camera-0 optical axis in the
+    /// `get_forward_vector2d` : the camera-0 optical axis in the
     /// world frame, projected onto the horizontal plane.
     ///
     /// Camera 0 exists: [`SqrtKeypointVio::new`] refuses a rig of fewer than
@@ -502,7 +435,7 @@ mod tests {
 
     /// Six keyframes one metre apart along `x` at the given azimuths, the
     /// newest also a state because the distance score reads
-    /// `frame_states.at(last_kf)` (`:854`), each hosting ten landmarks.
+    /// `frame_states.at(last_kf)`, each hosting ten landmarks.
     ///
     /// The azimuth is a rotation about the **world z**, so it turns the
     /// camera-0 forward vector's `(x, y)` part without changing its length —
@@ -558,12 +491,8 @@ mod tests {
         vio.kf_ids.iter().map(|t_ns| (*t_ns, 10)).collect()
     }
 
-    /// `fixed_kfs` reaches **both** linearizations. C++ builds it at `:924`
-    /// for the marginalization and at `:1258` for the optimization, so with
-    /// `vio_fix_long_term_keyframes` on a long-term keyframe's pose Jacobians
-    /// are zeroed in the prior it computes as well as in the increment it
-    /// solves. No shipped config sets the flag and nothing in the VIO calls
-    /// `take_long_term_keyframe`, so this is the only coverage.
+    /// Long-term keyframes are fixed in both the optimization and marginalization
+    /// linearizations, so their pose Jacobians are zero in both.
     #[test]
     fn a_long_term_keyframe_is_fixed_in_both_linearizations() {
         let mut vio: SqrtKeypointVio<f64> =
@@ -586,9 +515,9 @@ mod tests {
         );
     }
 
-    /// `takeLongTermKeyframe()` (`:124-127`) and the demotion it asks for
-    /// (`:465-472`): the newest keyframe leaves `kf_ids` for `ltkfs`, which
-    /// moves it to the other side of `:717`'s pose budget and out of the
+    /// `takeLongTermKeyframe()` and the demotion it asks for
+    /// the newest keyframe leaves `kf_ids` for `ltkfs`, which
+    /// moves it to the other side of 's pose budget and out of the
     /// eviction candidates. Nothing in the VIO path calls it — it is the
     /// Monado/API hook — so this is its only coverage.
     #[test]
@@ -623,7 +552,7 @@ mod tests {
         assert_eq!(vio.ltkfs.len(), 1);
     }
 
-    /// `std::prev(kf_ids.end(), 2)` (`:819`, `:840`) and the `kf_ids.size() > 2`
+    /// `std::prev(kf_ids.end(), 2)` and the `kf_ids.size() > 2`
     /// guard that keeps it valid.
     #[test]
     fn the_newest_two_keyframes_are_never_candidates() {
@@ -639,7 +568,7 @@ mod tests {
         assert!(two.eviction_candidates().is_empty());
     }
 
-    /// `:822-829` first pass: the oldest keyframe below
+    ///  first pass: the oldest keyframe below
     /// `vio_kf_marg_feature_ratio`, and nothing newer even if it is worse.
     #[test]
     fn the_ratio_pass_takes_the_oldest_poorly_tracked_keyframe() {
@@ -656,7 +585,7 @@ mod tests {
         );
     }
 
-    /// `num_points_connected.count(*it) == 0` (`:823`): a keyframe the current
+    /// `num_points_connected.count(*it) == 0` : a keyframe the current
     /// frame does not observe at all is taken by the **first** pass, whatever
     /// its hosted count — the missing entry and the low ratio are one `||`.
     #[test]
@@ -673,15 +602,9 @@ mod tests {
         );
     }
 
-    /// `:845-867` second pass: the DSO score is
-    /// `sqrt(‖p_i − p_last‖) · Σ_j 1/(‖p_i − p_j‖ + 1e-5)`, and the sum runs
-    /// over the candidate set **including `i` itself** (`:848`), so every
-    /// candidate carries a `1/1e-5 = 1e5` self term that swamps the metre-scale
-    /// distances to the others. What is left to discriminate is
-    /// `sqrt(‖p_i − p_last‖)`, so the candidate **nearest the newest keyframe**
-    /// is evicted — on six keyframes a metre apart, the newest candidate, not
-    /// the oldest that basalt's comment expects (`:832-836`, D22). Dropping the
-    /// self term, which reads like a bug, would invert the answer.
+    /// The distance score includes a `1e5` self term. On equally spaced keyframes,
+    /// this makes the candidate nearest the newest keyframe leave (D22).
+    /// Removing the self term would change the selection.
     #[test]
     fn the_distance_pass_takes_the_candidate_nearest_the_newest_keyframe() {
         let vio: SqrtKeypointVio<f64> = a_window_of_keyframes(KeyframeMargCriteria::Default, FLAT);
@@ -694,7 +617,7 @@ mod tests {
         );
     }
 
-    /// `:788-812`: the score is the sum of angles to every other keyframe, so
+    /// the score is the sum of angles to every other keyframe, so
     /// the minimum is the least distinctive viewing direction. With three
     /// candidates sharing an azimuth and a fourth a radian away, the eviction
     /// has to come out of the cluster — which of the three it is depends on
@@ -714,8 +637,8 @@ mod tests {
         );
     }
 
-    /// `frame_poses.at(ts)` (`:794`, `:849`) and `frame_states.at(last_kf)`
-    /// (`:854`) both throw when the window disagrees with `kf_ids`; the port
+    /// `frame_poses.at(ts)` and `frame_states.at(last_kf)`
+    ///  both throw when the window disagrees with `kf_ids`; the port
     /// returns the typed error instead (D32).
     #[test]
     fn a_keyframe_missing_from_the_window_is_a_typed_error() {
@@ -741,7 +664,7 @@ mod tests {
             })
         );
 
-        // Missing from **both** maps: `:823` sees `count(*it) == 0` first, so
+        // Missing from **both** maps: sees `count(*it) == 0` first, so
         // the keyframe is evicted and the hosted count is never read.
         let mut unseen: SqrtKeypointVio<f64> =
             a_window_of_keyframes(KeyframeMargCriteria::Default, FLAT);

--- a/packages/slam-rs/crates/slam-rs/src/frontend/cell.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/cell.rs
@@ -2,16 +2,13 @@
 use super::detect::FAST_BORDER;
 use crate::image::ImageU16;
 
-/// `const int EDGE_THRESHOLD = 19` (`keypoints.cpp:55`).
+/// `const int EDGE_THRESHOLD = 19`.
 pub const EDGE_THRESHOLD: f32 = 19.0;
 
-/// The shared feature-count matrix, with the shape the caller allocated it for.
-///
-/// basalt sizes `cells` from **camera 0** (`frame_to_frame_optical_flow.h:119`)
-/// and then lets `detectKeypointsWithCells` index it with the *detected* image's
-/// own grid arithmetic (`keypoints.cpp:148`). For a rig whose cameras differ in
-/// size those two disagree, and the C++ reads out of range; carrying the shape
-/// explicitly is what lets the port skip such a cell instead.
+/// Shared feature counts with an explicit allocated shape.
+/// The frontend sizes occupancy from camera 0 while detection uses each camera's
+/// own grid. Explicit dimensions let mixed-resolution rigs skip cells outside
+/// the shared matrix instead of indexing beyond it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Occupancy<'a> {
     /// Feature counts, row-major over `rows` x `columns`.
@@ -22,7 +19,7 @@ pub struct Occupancy<'a> {
     pub columns: usize,
 }
 
-/// `basalt::Rect` (`utils/keypoints.h:55-61`): a half-open rectangle in pixels.
+/// A half-open rectangle in pixels.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Rect {
     /// Left edge.
@@ -36,14 +33,14 @@ pub struct Rect {
 }
 
 impl Rect {
-    /// `Rect::inBounds` (`keypoints.h:60`).
+    /// `Rect::inBounds`.
     #[inline]
     pub fn in_bounds(&self, x: f32, y: f32) -> bool {
         x >= self.x && x < self.x + self.w && y >= self.y && y < self.y + self.h
     }
 }
 
-/// `basalt::Masks` (`utils/keypoints.h:63-79`): regions of the image to ignore.
+/// Image regions to ignore.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Masks {
     /// The rectangles; a point inside any of them is masked.
@@ -51,13 +48,13 @@ pub struct Masks {
 }
 
 impl Masks {
-    /// `Masks::inBounds` (`keypoints.h:66-68`): inside *any* rectangle.
+    /// `Masks::inBounds` : inside *any* rectangle.
     #[inline]
     pub fn in_bounds(&self, x: f32, y: f32) -> bool {
         self.masks.iter().any(|mask| mask.in_bounds(x, y))
     }
 
-    /// `Masks::operator+=` (`keypoints.h:70-73`): append, never merge.
+    /// `Masks::operator+=` : append, never merge.
     pub fn extend(&mut self, other: &Masks) {
         self.masks.extend_from_slice(&other.masks);
     }
@@ -77,12 +74,8 @@ impl Masks {
 /// counts per camera.
 pub const MAX_CELLS: usize = crate::frontend::tracker::MAX_CAPACITY;
 
-/// basalt's centred detection grid (`keypoints.cpp:140-144`).
-///
-/// `x_start = (w % cell) / 2` and `x_stop = x_start + cell * (w / cell - 1)`, so
-/// the grid is centred in the image and its last cell ends one cell short of the
-/// right edge. The same arithmetic drives `updateCellCounts` and `addKeypoint`
-/// (`frame_to_frame_optical_flow.h:110-113`), which is why it lives in one place.
+/// Centered detection grid: `x_start = (w % cell) / 2` and
+/// `x_stop = x_start + cell * (w / cell - 1)`. Shared by detection and cell counts.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CellGrid {
     /// `PATCH_SIZE`, i.e. `optical_flow_detection_grid_size`.
@@ -116,11 +109,8 @@ impl CellGrid {
         (0..columns).flat_map(move |column| (0..rows).map(move |row| (column, row)))
     }
 
-    /// The grid an image of `width` x `height` gets for a `cell`-pixel grid.
-    ///
-    /// `None` when the image is narrower or shorter than one cell: the C++
-    /// `x_start + PATCH_SIZE * (w / PATCH_SIZE - 1)` underflows `size_t` there
-    /// and the loop reads far outside the image.
+    /// Build a cell grid, returning `None` if either image side is smaller than one cell.
+    /// This prevents underflow in the final-cell index.
     pub fn new(width: usize, height: usize, cell: usize) -> Option<Self> {
         if cell == 0 || width < cell || height < cell {
             return None;
@@ -138,14 +128,9 @@ impl CellGrid {
         })
     }
 
-    /// The occupancy cell a keypoint falls in (`frame_to_frame_optical_flow.h:727-728`).
-    ///
-    /// The C++ computes `(kp.x - x_start) / c` in the estimator's **float**
-    /// scalar and casts to `int`, so a coordinate just left of `x_start` gives a
-    /// quotient in `(-1, 0]` that truncates to `0` rather than a negative index.
-    /// The saturating cast here does the same for the values the frontend can
-    /// produce and, unlike the C++, cannot index out of range on the ones it
-    /// cannot (trap 15).
+    /// Map a keypoint to an occupancy cell.
+    /// The f32 quotient is truncated towards zero: a point just left of the origin
+    /// maps to column zero. Saturating conversion prevents an invalid index (trap 15).
     #[inline]
     pub fn cell_of(&self, x: f32, y: f32) -> (usize, usize) {
         let column: i32 = ((x - self.x_start as f32) / self.cell as f32) as i32;
@@ -156,7 +141,7 @@ impl CellGrid {
         )
     }
 
-    /// Whether a keypoint is inside the grid at all (`frame_to_frame_optical_flow.h:711`).
+    /// Whether a keypoint is inside the grid at all.
     #[inline]
     pub fn contains(&self, x: f32, y: f32) -> bool {
         x >= self.x_start as f32
@@ -176,21 +161,14 @@ pub struct DetectorConfig {
     pub min_threshold: i32,
     /// `optical_flow_detection_max_threshold`.
     pub max_threshold: i32,
-    /// `optical_flow_image_safe_radius`; `0` switches the gate off (`keypoints.cpp:178`).
+    /// `optical_flow_image_safe_radius`; `0` switches the gate off.
     pub safe_radius: f32,
 }
 
-/// The rung the halving threshold ladder stops at, whatever the config says.
-///
-/// basalt's ladder is `while (points_added < num_points_cell && threshold >=
-/// min_threshold) { ...; threshold /= 2; }` (`keypoints.cpp:162`, `:187`), and
-/// integer division halves 1 to 0 and then 0 to 0 for ever: a
-/// `min_threshold` of `0` or less makes **the C++ loop non-terminating too**, on
-/// the same cell, and the port reproduced that hang. The frontend refuses such a
-/// config up front ([`crate::frontend::flow::FrontendError::ThresholdLadderNeverEnds`]),
-/// and this floor is the second line: the detector is public, so a caller that
-/// builds a [`DetectorConfig`] by hand gets the ladder run down to a threshold of
-/// 1 and no further, rather than a wedged process (decision D32).
+/// Lowest rung of the detector's halving threshold ladder.
+/// Integer division leaves zero unchanged, so allowing a non-positive lower
+/// threshold could loop forever. The frontend refuses such configurations, and
+/// this floor also protects direct detector callers (D32).
 pub const LOWEST_THRESHOLD_RUNG: i32 = 1;
 
 /// The thresholds [`super::detect::detect_keypoints_with_cells`]'s ladder visits, in order.

--- a/packages/slam-rs/crates/slam-rs/src/frontend/detect.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/detect.rs
@@ -1,57 +1,18 @@
-//! Grid-cell FAST detection, ported from `src/utils/keypoints.cpp:132-205`.
+//! Grid-cell FAST detection over a centered grid.
 //!
-//! `detectKeypointsWithCells` walks a centred grid of `PATCH_SIZE` cells, skips
-//! the cells that already hold enough features, copies each cell down to 8 bits
-//! and runs `cv::FAST` on it with a halving threshold ladder, keeping the
-//! strongest corners that survive a distance-to-centre gate, the rectangle masks
-//! and an edge margin.
+//! Skip occupied cells, walk a halving threshold ladder, then keep the strongest
+//! corners that pass masks, safe radius and edge margins. Kornia's rectangle
+//! entry point lets this module own the cell geometry. Shrink the candidate
+//! rectangle by the three-pixel FAST ring radius on every side.
 //!
-//! ## What comes from kornia-rs, and what this wrapper adds
+//! The rectangle scanner scans whole rows, so call it once per row band and
+//! threshold and filter columns per cell. Cropping changes kornia's width-dependent
+//! local-maximum filter, so it is not interchangeable with this scan.
 //!
-//! kornia's grid detector was written against this exact function
-//! (`kornia-imgproc/src/features/cells.rs:92-99`), but its grid starts at `(0, 0)`
-//! with ceil-division cells while basalt centres the grid and stops one cell
-//! early. Rather than accept different cell boundaries, this wrapper keeps
-//! basalt's geometry and calls kornia's **rectangle** entry point
-//! [`kornia_imgproc::features::fast_detect_rect_u8`] (`cells.rs:141`), which is the layer the inventory
-//! recommends for "basalt-style consumers that already own a grid walker"
-//! (`cells.rs:20-22`). The rectangle is shrunk by the FAST ring radius on every
-//! side, because `cv::FAST` on a `PATCH_SIZE`-square sub-image detects only at
-//! sub-coordinates `[3, PATCH_SIZE - 3)`; a rectangle over the whole cell would
-//! detect in a three-pixel band the C++ never looks at.
-//!
-//! That entry point scans **whole rows** whatever columns the rectangle asks
-//! for, so the call is made once per `(cell row, threshold)` over the whole
-//! width and each cell filters its own columns out of the result — see `Band`,
-//! which also records why a cell-sized crop is not the same detection
-//! (kornia turns its in-block local-maximum filter on at `width >= 800`).
-//!
-//! **The scores are the same quantity, off by one.** At `arc_length == 9` kornia
-//! returns `corner_score_9_scalar(...) / 255.0` (`fast.rs:705-711`, `:838-873`):
-//! the max over the sixteen arc starts of the min saturating difference along the
-//! arc, which is the smallest threshold at which the pixel stops being a corner.
-//! OpenCV's `cornerScore` returns `max(a0, -b0) - 1`
-//! (`modules/features2d/src/fast_score.cpp`), i.e. the largest threshold at which
-//! it is **still** a corner — one less. [`opencv_corner_score`] applies that
-//! subtraction the moment a candidate comes back, so suppression, ranking and
-//! [`KeypointsData::responses`] all carry the integer `cv::FAST` reports.
-//!
-//! **Non-maximum suppression is this wrapper's job.** `cv::FAST`'s third argument
-//! defaults to `nonmaxSuppression = true`, and `fast_detect_rect_u8` performs
-//! none (`cells.rs:138`). Without it the port emits every pixel along a strong
-//! edge where the C++ emits only the local peaks — on a synthetic image of flat
-//! bright squares the port produced sixteen corners where `cv::FAST` produces
-//! **none**, because every candidate there ties with its neighbour.
-//! `suppress_non_maxima` reproduces OpenCV's rule exactly: a candidate survives
-//! only when its score is **strictly greater** than all eight neighbours', a
-//! neighbour that is not itself a candidate scoring zero. Strictness on both
-//! sides is why a plateau of equal scores yields nothing, which is OpenCV's
-//! behaviour and the reason for that sixteen-versus-zero.
-//!
-//! What is left is genuinely different and is accepted, not worked around
-//! (decision D09, trap 2): `cv::FAST` walks the whole cell in one pass with its
-//! own three-row score ring, and `std::sort` (`keypoints.cpp:166`) is not stable
-//! while the sort here is, so ties inside a cell retain their scan order.
+//! Convert normalized scores to integer corner scores by multiplying by 255 and
+//! subtracting one. Suppression requires a score strictly greater than all eight
+//! neighbors, with zero for non-candidates. Equal-score plateaus yield no corners.
+//! Stable sorting retains scan order among tied scores (D09, trap 2).
 
 mod band;
 pub use super::cell::{
@@ -74,10 +35,7 @@ pub use kornia_imgproc::features::FastCorner;
 
 use crate::image::ImageU16;
 
-/// What the detector can refuse.
-///
-/// The occupancy matrix is a caller-supplied buffer, so its size is an input
-/// like any other: the C++ indexes it unchecked (`keypoints.cpp:148`, trap 15).
+/// Detector input failures, including invalid caller-supplied occupancy dimensions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum DetectError {
     /// A backend claimed selection but returned a malformed key vector.
@@ -149,15 +107,12 @@ pub enum DetectError {
     },
 }
 
-/// `basalt::KeypointsData`'s two frontend fields (`utils/common_types.h`).
-///
-/// Parallel arrays rather than a vector of structs, for the same reason every
-/// other per-keypoint buffer here is (`cubecl-portability.md` §12.2), and cleared
-/// and refilled in place so the per-frame path allocates only when a frame beats
-/// the previous high-water mark.
+/// Detected corners and responses in parallel arrays.
+/// Buffers are cleared and filled in place, allocating only above the previous
+/// high-water mark (`cubecl-portability.md` §12.2).
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct KeypointsData {
-    /// `kd.corners`, in the C++'s cell scan order.
+    /// Corners in cell scan order.
     pub corners: Vec<[f32; 2]>,
     /// `kd.corner_responses`, one per corner.
     pub responses: Vec<f32>,
@@ -409,38 +364,16 @@ impl DetectorScratch {
     }
 }
 
-/// `detectKeypointsWithCells` (`keypoints.cpp:132-205`).
-///
-/// `grid` is **the detected image's own** geometry, as the C++ derives it from
-/// `img_raw.w`/`.h` (`:140-144`); `occupancy` is the shared feature-count matrix,
-/// which basalt shapes from camera 0. The two agree for a rig whose cameras share
-/// a resolution and differ otherwise, which is why they are separate arguments.
-/// Cells at or over `num_points_cell` are skipped whole (`:148`); a cell whose
-/// index falls outside `occupancy` is skipped too, where the C++ reads out of
-/// range.
-///
-/// The threshold ladder is [`threshold_rungs`]: `max_threshold`, then repeatedly
-/// halved by integer division until it would drop below `min_threshold` — 40, 20,
-/// 10, 5 for the shipped configs (`:160-188`) — and it stops early as soon as the
-/// cell's budget is full. The last rung is never below [`LOWEST_THRESHOLD_RUNG`],
-/// which is what makes the ladder finite for every `min_threshold`; basalt's own
-/// is not.
-/// Within one threshold the surviving corners are ordered by descending response
-/// (`:166-167`) and taken until the budget is met, each having to clear the safe
-/// radius (`:178`), the masks (`:179`) and `EDGE_THRESHOLD` (`:180`).
-///
-/// `max_corners` caps the whole call. basalt has no such cap; the port needs one
-/// because every downstream buffer is fixed-capacity, and truncating in the
-/// detector's own scan order is what keeps a frame processable without ever
-/// discarding a keypoint that already exists.
+/// Detect corners with the image's own grid and a separate shared occupancy matrix.
+/// The shapes can differ for mixed-resolution rigs. Skip full cells and cells
+/// outside occupancy. Halve the threshold until the minimum or cell budget is
+/// reached, never below [`LOWEST_THRESHOLD_RUNG`]. Sort survivors by descending
+/// response and apply safe radius, masks and edge margin.
+/// `max_corners` caps the call in scan order to protect fixed-capacity buffers.
 ///
 /// # Errors
-///
-/// [`DetectError::OccupancyShapeOverflow`] when the declared shape does not fit
-/// in a `usize`, [`DetectError::OccupancyTooSmall`] when the counts buffer is
-/// shorter than the shape it was declared with, or
-/// [`DetectError::GrayViewRefused`] on an 8-bit view the image geometry should
-/// have made impossible.
+/// Returns typed errors for occupancy overflow, a short count buffer or an
+/// invalid gray image view.
 #[allow(clippy::too_many_arguments)]
 pub fn detect_keypoints_with_cells(
     image: &ImageU16,
@@ -497,7 +430,7 @@ pub fn detect_keypoints_with_cells(
     } = scratch;
 
     // `float dist_to_center = {full_x - img_raw.w / 2, ...}.norm()` — an integer
-    // halving of the size, then a float subtraction (`keypoints.cpp:176`).
+    // halving of the size, then a float subtraction.
     let centre_x: f32 = (width / 2) as f32;
     let centre_y: f32 = (height / 2) as f32;
 
@@ -567,7 +500,7 @@ pub fn detect_keypoints_with_cells(
             candidates.clear();
             if grid.cell > 2 * FAST_BORDER {
                 // `fast_detect_rect_u8` clamps the rectangle to the ring
-                // margin on every side (`cells.rs:12-15`); the columns this
+                // margin on every side (`cells.rs); the columns this
                 // cell keeps out of its row band are that clamp.
                 let first: f32 = (x + FAST_BORDER) as f32;
                 // The right clamp is the one a caller-supplied grid can
@@ -607,8 +540,7 @@ pub fn detect_keypoints_with_cells(
                 let full_y: f32 = corner.xy[1];
                 let dx: f32 = full_x - centre_x;
                 let dy: f32 = full_y - centre_y;
-                // `Eigen::Vector2f{...}.norm()` is `sqrt(dx*dx + dy*dy)`,
-                // not `hypot` (`keypoints.cpp:176`).
+                // Distance is `sqrt(dx*dx + dy*dy)`.
                 let dist_to_center: f32 = (dx * dx + dy * dy).sqrt();
 
                 if config.safe_radius != 0.0 && dist_to_center >= config.safe_radius {

--- a/packages/slam-rs/crates/slam-rs/src/frontend/detect.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/detect.rs
@@ -500,7 +500,7 @@ pub fn detect_keypoints_with_cells(
             candidates.clear();
             if grid.cell > 2 * FAST_BORDER {
                 // `fast_detect_rect_u8` clamps the rectangle to the ring
-                // margin on every side (`cells.rs); the columns this
+                // margin on every side (`cells.rs`); the columns this
                 // cell keeps out of its row band are that clamp.
                 let first: f32 = (x + FAST_BORDER) as f32;
                 // The right clamp is the one a caller-supplied grid can

--- a/packages/slam-rs/crates/slam-rs/src/frontend/detect/band.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/detect/band.rs
@@ -9,15 +9,15 @@ use kornia_imgproc::features::{Rect as KorniaRect, fast_detect_rect_u8};
 pub const FAST_BORDER: usize = 3;
 
 /// kornia's Bresenham ring: ring point `k` sits `FAST_RING_ROW[k]` rows and
-/// [`FAST_RING_COLUMN`]`[k]` columns from the centre (`fast.rs).
+/// [`FAST_RING_COLUMN`]`[k]` columns from the centre (`fast.rs`).
 pub const FAST_RING_ROW: [i32; 16] = [0, 1, 2, 3, 3, 3, 2, 1, 0, -1, -2, -3, -3, -3, -2, -1];
 /// The column half of [`FAST_RING_ROW`]'s ring.
 pub const FAST_RING_COLUMN: [i32; 16] = [3, 3, 2, 1, 0, -1, -2, -3, -3, -3, -2, -1, 0, 1, 2, 3];
 
-/// Lanes in one block of kornia's in-block local-maximum filter (`fast.rs).
+/// Lanes in one block of kornia's in-block local-maximum filter (`fast.rs`).
 pub const FAST_FILTER_LANES: usize = 16;
 
-/// The width at which kornia turns that filter on (`fast.rs).
+/// The width at which kornia turns that filter on (`fast.rs`).
 const FAST_FILTER_WIDTH: usize = 800;
 
 /// Where kornia's local-maximum filter stops, and whether it runs at all.
@@ -26,7 +26,7 @@ const FAST_FILTER_WIDTH: usize = 800;
 /// *inside its own sixteen-lane block*, the blocks are aligned to the image's
 /// own left margin, and the scalar tail past the last whole block is
 /// unfiltered — kornia's SIMD loop runs while `x + 16 <= width - margin`
-/// (`fast.rs). So the alignment and the tail are part of the corner set,
+/// (`fast.rs`). So the alignment and the tail are part of the corner set,
 /// not an implementation detail, and this is the one place that arithmetic
 /// lives: the CPU sweep gets it from kornia itself, and the GPU kernel and
 /// `tests/fast_model.rs` read it here rather than each spelling it out.
@@ -44,7 +44,7 @@ const FAST_ARC_LENGTH: usize = 9;
 /// One cell row's raw FAST candidates at one threshold, over the whole image width.
 ///
 /// `fast_detect_rect_u8` detects over **whole rows** and filters the result by
-/// column (`cells.rs), so the scan a cell asks for depends only on its
+/// column (`cells.rs`), so the scan a cell asks for depends only on its
 /// row band and its threshold — the nineteen cells of one grid row at one rung
 /// all pay for the same 960-wide sweep. Scanning it once and filtering each
 /// cell's columns out of it is the same call with the same arguments, so the
@@ -52,7 +52,7 @@ const FAST_ARC_LENGTH: usize = 9;
 ///
 /// The whole-image width is what the scan has to keep: kornia's kernel turns its
 /// in-block local-maximum filter on at `width >= 800` and aligns its sixteen-lane
-/// blocks to the image's own left margin (`fast.rs), so a cell-sized
+/// blocks to the image's own left margin (`fast.rs`), so a cell-sized
 /// copy would detect a different set.
 ///
 /// Both scanners hold one of these, which is why it lives here beside the trait

--- a/packages/slam-rs/crates/slam-rs/src/frontend/detect/band.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/detect/band.rs
@@ -5,19 +5,19 @@ use kornia_image::{Image, ImageSize};
 use kornia_imgproc::features::{Rect as KorniaRect, fast_detect_rect_u8};
 
 /// The Bresenham radius `cv::FAST` and kornia both skip at a border
-/// (`cells.rs:151`, `fast.rs:494`).
+/// (`cells.rs, `fast.rs).
 pub const FAST_BORDER: usize = 3;
 
 /// kornia's Bresenham ring: ring point `k` sits `FAST_RING_ROW[k]` rows and
-/// [`FAST_RING_COLUMN`]`[k]` columns from the centre (`fast.rs:489-490`).
+/// [`FAST_RING_COLUMN`]`[k]` columns from the centre (`fast.rs).
 pub const FAST_RING_ROW: [i32; 16] = [0, 1, 2, 3, 3, 3, 2, 1, 0, -1, -2, -3, -3, -3, -2, -1];
 /// The column half of [`FAST_RING_ROW`]'s ring.
 pub const FAST_RING_COLUMN: [i32; 16] = [3, 3, 2, 1, 0, -1, -2, -3, -3, -3, -2, -1, 0, 1, 2, 3];
 
-/// Lanes in one block of kornia's in-block local-maximum filter (`fast.rs:539`).
+/// Lanes in one block of kornia's in-block local-maximum filter (`fast.rs).
 pub const FAST_FILTER_LANES: usize = 16;
 
-/// The width at which kornia turns that filter on (`fast.rs:517`).
+/// The width at which kornia turns that filter on (`fast.rs).
 const FAST_FILTER_WIDTH: usize = 800;
 
 /// Where kornia's local-maximum filter stops, and whether it runs at all.
@@ -26,7 +26,7 @@ const FAST_FILTER_WIDTH: usize = 800;
 /// *inside its own sixteen-lane block*, the blocks are aligned to the image's
 /// own left margin, and the scalar tail past the last whole block is
 /// unfiltered — kornia's SIMD loop runs while `x + 16 <= width - margin`
-/// (`fast.rs:524`). So the alignment and the tail are part of the corner set,
+/// (`fast.rs). So the alignment and the tail are part of the corner set,
 /// not an implementation detail, and this is the one place that arithmetic
 /// lives: the CPU sweep gets it from kornia itself, and the GPU kernel and
 /// `tests/fast_model.rs` read it here rather than each spelling it out.
@@ -44,7 +44,7 @@ const FAST_ARC_LENGTH: usize = 9;
 /// One cell row's raw FAST candidates at one threshold, over the whole image width.
 ///
 /// `fast_detect_rect_u8` detects over **whole rows** and filters the result by
-/// column (`cells.rs:20-35`), so the scan a cell asks for depends only on its
+/// column (`cells.rs), so the scan a cell asks for depends only on its
 /// row band and its threshold — the nineteen cells of one grid row at one rung
 /// all pay for the same 960-wide sweep. Scanning it once and filtering each
 /// cell's columns out of it is the same call with the same arguments, so the
@@ -52,7 +52,7 @@ const FAST_ARC_LENGTH: usize = 9;
 ///
 /// The whole-image width is what the scan has to keep: kornia's kernel turns its
 /// in-block local-maximum filter on at `width >= 800` and aligns its sixteen-lane
-/// blocks to the image's own left margin (`fast.rs:517`, `:524`), so a cell-sized
+/// blocks to the image's own left margin (`fast.rs), so a cell-sized
 /// copy would detect a different set.
 ///
 /// Both scanners hold one of these, which is why it lives here beside the trait
@@ -106,24 +106,11 @@ impl BandCache {
     }
 }
 
-/// The CPU [`CornerScan`]: kornia's `fast_detect_rect_u8`, one sweep per
-/// `(row band, threshold)`.
-///
-/// basalt copies each cell into its own `cv::Mat` with `sub_img_raw(x, y) >> 8`
-/// (`keypoints.cpp:152-157`); one whole-image shift produces the same bytes and
-/// lets every cell be a zero-copy rectangle over it. The narrowed frame is
-/// built **once per frame** and kept: rebuilding the view per band call instead
-/// copies the whole frame forty times a frameset, which measured 40.1 ms against
-/// 9.4 ms on MIO07/1500 with every value unchanged.
-///
-/// And the frame is narrowed **into** that image rather than into a staging
-/// buffer it is then built from. `Image::from_size_slice` is `data.to_vec()`, so
-/// the old shape kept the frame twice — a `Vec<u8>` and the image's own copy —
-/// and paid a whole-frame `memcpy` per camera per frameset (0.9 MB at 960x960)
-/// for the second. kornia's `Image` derefs to its tensor, which has
-/// `as_slice_mut`, so the narrowing pass can write straight into the pixels the
-/// detector will read, and the image is reallocated only when the geometry
-/// changes.
+/// CPU [`CornerScan`]: one kornia rectangle sweep per row band and threshold.
+/// Narrow the u16 frame to u8 once per frame; all cells then use zero-copy rectangles.
+/// Rebuilding per band copied the whole frame repeatedly and measured 40.1 ms
+/// against 9.4 ms on MIO07/1500. Write directly into kornia's image storage to
+/// avoid a second full-frame copy; reallocate only when geometry changes.
 #[derive(Default)]
 pub struct CpuCornerScan {
     /// The narrowed frame, `None` until the first [`CornerScan::scan`], and
@@ -172,7 +159,7 @@ impl CornerScan for CpuCornerScan {
                 })?,
             ),
         };
-        // `sub_ptr[x] = (sub_img_raw(x, y) >> 8)` (`keypoints.cpp:156`), once,
+        // `sub_ptr[x] = (sub_img_raw(x, y) >> 8)`, once,
         // straight into the pixels the detector reads. One row's slice at a
         // time, not one `push` per pixel: the capacity check a `push` carries is
         // what stops the narrowing from vectorising.
@@ -225,20 +212,11 @@ impl CornerScan for CpuCornerScan {
     }
 }
 
-/// kornia's normalised FAST score as OpenCV's integer `cornerScore`.
-///
-/// kornia returns `corner_score_9_scalar(...) / 255.0` (`fast.rs:710`), the
-/// smallest threshold at which the pixel stops being a corner. OpenCV returns
-/// that minus one — the largest threshold at which it is still a corner
-/// (`fast_score.cpp`, `threshold = std::max(a0, -b0) - 1`). The subtraction is a
-/// constant shift, so it cannot change an ordering, but it is what makes the
-/// number the port reports equal to the one `cv::FAST` writes into
-/// `cv::KeyPoint::response` and basalt copies into `keypoint_responses`.
-///
-/// It is applied before suppression rather than after, so the scores compared
-/// against a non-candidate's zero are OpenCV's own. Nothing reaches zero: a
-/// candidate found at threshold `t` scores at least `t`, and the ladder's floor
-/// is `optical_flow_detection_min_threshold`.
+/// Convert normalized kornia FAST scores to OpenCV integer corner scores.
+/// Kornia reports the first threshold that rejects the corner; OpenCV reports
+/// the last that accepts it, one less. Convert before suppression so comparison
+/// against a non-candidate's zero uses the same score convention.
+/// Candidates at threshold `t` score at least `t`, and the ladder has a positive floor.
 #[inline]
 pub fn opencv_corner_score(normalized: f32) -> f32 {
     (normalized * 255.0).round() - 1.0

--- a/packages/slam-rs/crates/slam-rs/src/frontend/detect/tests.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/detect/tests.rs
@@ -68,7 +68,7 @@ fn occupancy<'a>(counts: &'a [i32], grid: &CellGrid) -> Occupancy<'a> {
     }
 }
 
-/// `keypoints.cpp:140-144` on a 960x960 frame with `grid_size = 50`.
+///  on a 960x960 frame with `grid_size = 50`.
 #[test]
 fn the_grid_is_centred_and_stops_one_cell_early() {
     let grid: CellGrid = CellGrid::new(960, 960, 50).unwrap();
@@ -97,8 +97,7 @@ fn a_different_image_size_gives_a_different_grid_start() {
     assert!(!small.contains(210.0, 80.0));
 }
 
-/// The C++ `x_start + PATCH_SIZE * (w / PATCH_SIZE - 1)` underflows when the
-/// image is narrower than one cell; the port refuses the geometry instead.
+/// An image smaller than one cell must be refused before grid arithmetic underflows.
 #[test]
 fn an_image_narrower_than_a_cell_has_no_grid() {
     assert!(CellGrid::new(30, 200, 50).is_none());
@@ -106,7 +105,7 @@ fn an_image_narrower_than_a_cell_has_no_grid() {
     assert!(CellGrid::new(200, 200, 0).is_none());
 }
 
-/// A coordinate left of `x_start` truncates to column 0 in C++, not to -1.
+/// A coordinate just left of `x_start` truncates to column zero.
 #[test]
 fn a_coordinate_before_the_grid_lands_in_the_first_cell() {
     let grid: CellGrid = CellGrid::new(960, 960, 50).unwrap();
@@ -153,7 +152,7 @@ fn corners_are_found_and_stay_inside_the_edge_threshold() {
     }
 }
 
-/// The per-cell budget (`keypoints.cpp:173`) is `num_points_cell`.
+/// The per-cell budget is `num_points_cell`.
 #[test]
 fn no_cell_yields_more_than_its_budget() {
     let image: ImageU16 = dotted_image(200, 200, 16);
@@ -188,14 +187,9 @@ fn no_cell_yields_more_than_its_budget() {
     );
 }
 
-/// A `min_threshold` the halving ladder can never reach must still terminate.
-///
-/// basalt hangs here: `threshold /= 2` reaches 1, then 0, and `0 >= 0` keeps
-/// the loop alive for ever on the first empty cell (`keypoints.cpp:162`,
-/// `:187`). A blank frame is the worst case, because no cell ever fills its
-/// budget and every rung of the ladder is walked. The test finishing at all is
-/// the assertion; the counts are the same as a `min_threshold` of 1 gives,
-/// which is what the floor makes the ladder run.
+/// The threshold ladder must terminate even with a non-positive requested minimum.
+/// A blank frame walks every rung because no cell fills. The result must match
+/// a minimum of one, which is the enforced floor.
 #[test]
 fn a_non_positive_min_threshold_still_terminates() {
     let blank: ImageU16 = ImageU16::zeros(200, 200).unwrap();
@@ -322,7 +316,7 @@ fn a_valid_min_threshold_is_left_alone() {
     assert!(config().min_threshold > LOWEST_THRESHOLD_RUNG);
 }
 
-/// `keypoints.cpp:148`: an occupied cell is skipped whole.
+/// an occupied cell is skipped whole.
 #[test]
 fn an_occupied_cell_is_skipped() {
     let image: ImageU16 = dotted_image(200, 200, 16);
@@ -362,7 +356,7 @@ fn an_occupied_cell_is_skipped() {
     assert_eq!(out.len(), 0);
 }
 
-/// `keypoints.cpp:179`: a masked corner is dropped.
+/// a masked corner is dropped.
 #[test]
 fn a_mask_over_the_whole_image_drops_everything() {
     let image: ImageU16 = dotted_image(200, 200, 16);
@@ -393,7 +387,7 @@ fn a_mask_over_the_whole_image_drops_everything() {
     assert!(out.is_empty());
 }
 
-/// `keypoints.cpp:178`: outside `safe_radius` of the image centre, nothing is kept.
+/// outside `safe_radius` of the image centre, nothing is kept.
 #[test]
 fn the_safe_radius_gate_keeps_only_the_middle() {
     let image: ImageU16 = dotted_image(200, 200, 16);
@@ -511,8 +505,7 @@ fn a_short_occupancy_buffer_is_refused() {
     );
 }
 
-/// A detection grid wider than the occupancy matrix skips the cells that
-/// fall outside it, where the C++ indexes out of range (trap 15).
+/// Skip detection cells outside the allocated occupancy shape (trap 15).
 #[test]
 fn a_cell_outside_the_occupancy_matrix_is_skipped() {
     let image: ImageU16 = dotted_image(300, 200, 16);
@@ -543,7 +536,7 @@ fn a_cell_outside_the_occupancy_matrix_is_skipped() {
     }
 }
 
-/// `keypoints.h:66-68`: masked means inside *any* rectangle, half-open.
+/// masked means inside *any* rectangle, half-open.
 #[test]
 fn masks_are_half_open_and_disjunctive() {
     let masks: Masks = Masks {
@@ -618,7 +611,7 @@ fn suppression_thins_a_run_of_candidates() {
     assert_eq!(kept, vec![11.0, 14.0, 16.0]);
 }
 /// OpenCV's `cornerScore` is one less than the smallest threshold at which
-/// the pixel stops being a corner (`fast_score.cpp`), which is what kornia
+/// the pixel stops being a corner, which is what kornia
 /// returns. An isolated maximum-contrast peak therefore scores 254, not 255.
 #[test]
 fn the_response_is_opencvs_corner_score() {

--- a/packages/slam-rs/crates/slam-rs/src/frontend/flow.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/flow.rs
@@ -756,7 +756,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
             // `cells` below, one `i32` per cell per camera, and a `Vec` too long
             // to exist panics rather than returning (decision D32); and every
             // camera is detected on its own grid, which bounds that camera's
-            // detection scan on every frame (`detect.rs). Saturating like
+            // detection scan on every frame (`detect.rs`). Saturating like
             // the sibling ceilings: a product that leaves `usize` is past it.
             if grid.rows.saturating_mul(grid.columns) > MAX_CELLS {
                 return Err(FrontendError::TooManyCells {

--- a/packages/slam-rs/crates/slam-rs/src/frontend/flow.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/flow.rs
@@ -1,57 +1,16 @@
-//! `basalt::FrameToFrameOpticalFlow`, ported from
-//! `frame_to_frame_optical_flow.h:103-749`.
+//! Frame-to-frame optical flow.
+//! Each frameset builds camera pyramids, tracks existing points, updates occupancy,
+//! detects and matches new points, then applies the epipolar filter.
 //!
-//! One call to [`FrameToFrameOpticalFlow::process_frame`] is basalt's
-//! `processFrame` (`:203-292`): build a pyramid per camera, track every keypoint
-//! from the previous frame, refresh the occupancy grid, detect and match new
-//! points, and drop the ones that fail the epipolar test.
+//! The driver is generic over pyramid and tracker backends. Callers supply pose
+//! prediction and depth feedback; this module has no IMU queue or processing
+//! thread (D17). Recall and multiscale-flow variants are unsupported.
 //!
-//! The driver is generic over the pyramid builder and the tracker
-//! ([`crate::pyramid::PyramidBuilder`], [`PatchTracker`]), both defaulting to the
-//! CPU backends, and no signature here names a concrete pyramid: a CubeCL
-//! backend arrives through [`FrameToFrameOpticalFlow::with_backends`]
-//! (`cubecl-portability.md` §12.1).
-//!
-//! ## What the port leaves out, and why
-//!
-//! * **The queues and the processing thread.** `processingLoop` (`:122-155`) pops
-//!   images off a TBB queue, drains four feedback queues and preintegrates the
-//!   IMU itself. Here the caller drives the frontend one frameset at a time and
-//!   hands in the two things those queues carried: the predicted pose pair and
-//!   the average scene depth. Nothing in this module knows the IMU exists
-//!   (decision D17: offline lockstep first).
-//! * **Recall.** `recallPoints` (`:526-575`) is off in every shipped config, and
-//!   it leaks a patch stack per landmark by design (`:590`, trap 18).
-//! * **The GUI bookkeeping.** `tracking_guesses`, `matching_guesses` and
-//!   `recall_guesses` (`optical_flow.h:110-112`) are only filled when `show_gui`
-//!   is set and are never read by the estimator.
-//! * **`OpticalFlowResult::pyramid_levels`.** Only
-//!   `MultiscaleFrameToFrameOpticalFlow` writes it (`:57-59`), and that variant
-//!   is out of scope, so [`Keypoints`] does not carry the field: it was always
-//!   empty, and a `Vec` cloned twice per frameset for a variant that does not
-//!   exist is storage nothing fills or reads.
-//!
-//! ## Five places the port does not match the C++ exactly
-//!
-//! * **The essential matrix is per camera** (deviation X03). `optical_flow.h:210`
-//!   computes the cam0-cam1 matrix once and stores it under every index, which is
-//!   wrong for cameras 2 and up. Each camera uses its own relative pose.
-//! * **Image bounds come from each camera's own resolution.** basalt reads
-//!   `calib.resolution.at(0)` for the whole rig (`:108-109`, trap 16); msd-g2's
-//!   cameras are stored rotated and do not share one (decision D30). The
-//!   detection grid is per camera as well, which is what the C++ does
-//!   (`keypoints.cpp:140-144` derives it from the image it is handed); the
-//!   *occupancy* matrix keeps camera 0's shape, which is also what the C++ does
-//!   (`:119`), so the two can disagree on a mixed-resolution rig and a cell whose
-//!   index falls outside the matrix is skipped where the C++ reads out of range.
-//! * **`getNumCams() >= 2` is not required** (trap 17). With one camera the
-//!   matching and filtering passes are skipped instead of indexing `T_i_c[1]`.
-//! * **The second mask test moves one step later.** `trackPoints` tests
-//!   `masks2.inBounds` between the forward and the backward track (`:352`); here
-//!   the whole forward pass runs, then the whole backward pass, so the test is
-//!   applied to the same tracked position afterwards. The same points are
-//!   dropped; the only cost is a backward track that would have been skipped.
-//! * **There is a keypoint budget.** See [`FrontendOptions::max_keypoints`].
+//! Essential matrices and image bounds are per camera. Detection uses each
+//! camera's geometry while occupancy retains camera 0's shape; out-of-range
+//! cells are skipped. Single-camera rigs skip stereo matching and filtering.
+//! Forward and backward passes are batched, with masks applied afterwards to
+//! the same positions. A keypoint budget bounds preallocated storage.
 
 use std::marker::PhantomData;
 
@@ -86,29 +45,20 @@ struct TrackPass {
     offered: Vec<usize>,
 }
 
-/// What [`Keypoints::responses`] holds where basalt's `keypoint_responses` map
-/// has no entry: the same `-1` its `addKeypoint` default argument stores (`:726`).
+/// Sentinel response `-1` for a keypoint without a detector score.
 pub const NO_RESPONSE: f32 = -1.0;
 
-/// The port's own frontend knobs, kept out of [`VioConfig`] so that basalt's
-/// JSON still round-trips byte for byte.
+/// Frontend options kept separate from the serialized VIO configuration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FrontendOptions {
     /// Workers the tracking passes run on (decision D31). One is the
     /// deterministic reference lane; any value gives the same numbers.
     pub threads: usize,
-    /// Keypoints one camera may carry, and the capacity every buffer is sized for.
-    ///
-    /// basalt has no such cap: its maps grow. The port needs one because the
-    /// tracker's storage is preallocated (§12.2 forbids growing a buffer on the
-    /// per-frame path), so detection and stereo matching **stop adding** once a
-    /// camera reaches it, in the detector's own scan order. Keypoints that
-    /// already exist are never dropped to make room, and the frame stays
-    /// processable. The default is about eight times what the shipped 50-pixel
-    /// grid can produce on a 960x960 frame, so nothing in the reference
-    /// configuration comes near it, and
-    /// [`crate::frontend::tracker::MAX_CAPACITY`] is the ceiling a caller may
-    /// ask for.
+    /// Maximum keypoints per camera and the capacity used for its buffers.
+    /// Detection and matching stop adding in scan order when full, preserving existing
+    /// tracks and keeping the frame processable. The default exceeds the shipped
+    /// 50-pixel grid's capacity on a 960x960 image; the caller's upper limit is
+    /// [`crate::frontend::tracker::MAX_CAPACITY`].
     pub max_keypoints: usize,
 }
 
@@ -124,14 +74,10 @@ impl Default for FrontendOptions {
     }
 }
 
-/// The pose pair basalt's own IMU preintegration produces (`:261-262`).
-///
-/// `processingLoop` predicts the current frame's pose from the last state it got
-/// back from the estimator (`:147-150`) and `processFrame` turns the pair into a
-/// per-camera `T_c1_c2` that seeds the tracker. Handing it in keeps this module
-/// free of the IMU: with both poses at the identity — which is what basalt itself
-/// runs with until the first state arrives (`:140-147`) — the guess is the same
-/// pixel reprojected through `depth_guess`.
+/// Previous and predicted poses supplied by IMU preintegration.
+/// Keeping them as inputs makes the frontend independent of IMU processing.
+/// Two identities produce a depth-based reprojection of the same pixel until
+/// the first estimated state arrives.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct PosePrediction {
     /// `latest_state->T_w_i`, the pose of the previous frame.
@@ -140,31 +86,18 @@ pub struct PosePrediction {
     pub t_w_i_current: Se3<f32>,
 }
 
-/// One camera's tracked keypoints, in structure-of-arrays form.
-///
-/// basalt's `Keypoints` is an `Eigen::aligned_map<KeypointId, AffineCompact2f>`
-/// (`optical_flow.h:68`), i.e. an ordered map. The order is load-bearing — it is
-/// the order `filterPointsForCam` walks and the order new ids are handed out in —
-/// so this keeps the ids **sorted ascending** with the parallel arrays beside
-/// them, and looks up by binary search. The warps live in a [`FlowTransforms`],
-/// six flat coefficient arrays with the keypoint index fast-varying, so no
-/// per-keypoint record is an array of structs (§12.2). No hash map appears
-/// anywhere on the per-frame path.
+/// Tracked keypoints in structure-of-arrays form.
+/// Ids stay sorted ascending for deterministic filtering and id assignment,
+/// with binary-search lookup. [`FlowTransforms`] stores six coefficient arrays
+/// with keypoint index varying fastest; no per-frame hash map is needed.
 #[derive(Debug, Default, PartialEq)]
 pub struct Keypoints {
-    /// Keypoint ids, ascending. `LandmarkId == KeypointId` (`optical_flow.h:71`).
+    /// Keypoint ids, ascending. `LandmarkId == KeypointId`.
     pub ids: Vec<KeypointId>,
     /// The 2x3 warp of each keypoint, in the same order as [`Keypoints::ids`].
     pub transforms: FlowTransforms,
-    /// The detector response of each keypoint, `-1` where there is none.
-    ///
-    /// basalt keeps the responses in a second map that only `addKeypoint` writes
-    /// (`:730`), so a keypoint carried forward by `trackPoints` or inserted by
-    /// `addKeypoints` from the stereo match (`:734-741`) has **no entry at all**.
-    /// [`NO_RESPONSE`] is what `addKeypoint`'s own default argument stores for
-    /// "no response" (`:726`), so one array with that sentinel says the same
-    /// thing as the C++'s two maps. The value itself is OpenCV's integer
-    /// `cornerScore`, which is what the C++ records.
+    /// Detector responses, using [`NO_RESPONSE`] for tracked or stereo-matched points
+    /// without a score. Detected points carry integer OpenCV-style corner scores.
     pub responses: Vec<f32>,
 }
 
@@ -243,7 +176,7 @@ impl Keypoints {
         }
     }
 
-    /// `std::map::insert`, which **keeps** an existing entry (`:740`).
+    /// `std::map::insert`, which **keeps** an existing entry.
     ///
     /// Returns whether the keypoint was new.
     fn insert_if_absent(&mut self, id: KeypointId, transform: &AffineCompact2f) -> bool {
@@ -271,14 +204,8 @@ impl Keypoints {
 /// What one frameset produced: one [`Keypoints`] per camera.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct FlowFrame {
-    // `Vec::clone_from` copies element by element through `Keypoints::clone_from`
-    // above, so deriving here keeps the buffer-preserving property.
-    /// Frameset timestamp in nanoseconds, `None` before the first frameset commits.
-    ///
-    /// basalt writes `t_ns = -1` until then (`optical_flow.h:172`), which makes
-    /// `-1` — and every other negative timestamp — ambiguous. The port carries
-    /// the absence in the type instead, so any `i64` is a timestamp like any
-    /// other.
+    // Frameset timestamp, absent until the first successful commit.
+    // Using `Option` leaves every i64 value, including negative values, valid as a timestamp.
     pub t_ns: Option<i64>,
     /// One entry per camera, in rig order.
     pub cameras: Vec<Keypoints>,
@@ -466,12 +393,9 @@ pub enum FrontendError {
     },
 }
 
-/// `basalt::FrameToFrameOpticalFlow<Scalar, Pattern>` with `Scalar = f32`.
-///
-/// Generic over the pyramid builder and the tracker, both defaulting to the CPU
-/// backends: a CubeCL implementation of [`PyramidBuilder`] and [`PatchTracker`]
-/// drops in through [`FrameToFrameOpticalFlow::with_backends`] and no public
-/// signature here names a concrete pyramid (§12.1).
+/// Frame-to-frame optical flow in f32, generic over pyramid and tracker backends.
+/// [`FrameToFrameOpticalFlow::with_backends`] selects implementations without
+/// exposing a concrete pyramid in the driver's public signatures.
 #[derive(Debug)]
 pub struct FrameToFrameOpticalFlow<
     P: Pattern,
@@ -482,16 +406,15 @@ pub struct FrameToFrameOpticalFlow<
     options: FrontendOptions,
     calib: Calibration<f32>,
     cameras: Vec<RigCamera<f32>>,
-    /// `E`, one 4x4 essential matrix per camera (`optical_flow.h:207-213`).
+    /// `E`, one 4x4 essential matrix per camera.
     essential: Vec<Matrix4<f32>>,
-    /// One detection grid per camera, from that camera's own image size, as the
-    /// C++ derives it inside `detectKeypointsWithCells` (`keypoints.cpp:140-144`).
+    /// One detection grid per camera, derived from that camera's image size.
     detection_grids: Vec<CellGrid>,
-    /// The occupancy grid, shaped from camera 0 as `cells` is (`:119`).
+    /// The occupancy grid, shaped from camera 0 as `cells` is.
     occupancy_grid: CellGrid,
-    /// `cells`, `(h/c + 1) x (w/c + 1)` counts per camera (`:119`).
+    /// `cells`, `(h/c + 1) x (w/c + 1)` counts per camera.
     cells: Vec<Vec<i32>>,
-    /// `last_keypoint_id` (`optical_flow.h:174`), the global landmark id space.
+    /// `last_keypoint_id`, the global landmark id space.
     last_keypoint_id: u64,
     /// Camera 0's keypoint count as the last **detecting** frameset left it,
     /// which is what `port.redetect_survivor_ratio` measures survivors against
@@ -501,13 +424,10 @@ pub struct FrameToFrameOpticalFlow<
     /// which is what makes "how many of these keypoints are new" answerable
     /// after the fact rather than only inside the call that produced them.
     last_keypoint_id_before_frame: u64,
-    /// `t_ns` (`optical_flow.h:172`), `None` until the first frame commits.
-    ///
-    /// basalt's `-1` sentinel is not ported: `processFrame` reads `t_ns < 0` as
-    /// "no previous frame", which would make a frameset at a negative timestamp
-    /// reset tracking instead of continuing it.
+    /// Timestamp of the last committed frame; `None` means no previous frame.
+    /// Negative timestamps remain valid and do not reset tracking.
     t_ns: Option<i64>,
-    /// `frame_counter` (`optical_flow.h:173`).
+    /// `frame_counter`.
     frame_counter: u64,
     /// `depth_guess`, seeded from the config and refreshed by the estimator.
     depth_guess: f32,
@@ -526,20 +446,19 @@ pub struct FrameToFrameOpticalFlow<
     tracker: T,
     patches: T::Patches,
     /// The source keypoint ids of each lane of the batch in flight, in map order
-    /// (`:299`, `:306`).
     ///
     /// Per lane rather than per call because a batch's passes are all launched
     /// before any of them is read, and mapping a tracked slot back to its
     /// keypoint needs this after the download.
     passes: Vec<TrackPass>,
-    /// The source warps of the pass being submitted, in the same order (`:300`,
-    /// `:307`). One buffer for the batch: a temporal pass overwrites it before
+    /// The source warps of the pass being submitted, in the same order (
+    /// ). One buffer for the batch: a temporal pass overwrites it before
     /// the next one, and every stereo pass of a frameset tracks the same
     /// camera-0 keypoints, so they share one copy of it.
     source: FlowTransforms,
     /// The source positions the forward patches are built at.
     positions: PointsSoA,
-    /// `transform_2` once the depth guess has been applied (`:342`).
+    /// `transform_2` once the depth guess has been applied.
     guesses: FlowTransforms,
     /// The ids that survived, in ascending source order, with their warps.
     tracked_ids: Vec<KeypointId>,
@@ -559,7 +478,7 @@ pub struct FrameToFrameOpticalFlow<
     detected: KeypointsData,
     /// The keypoints `addPointsForCamera(0)` produced, to be matched onward.
     new_cam0: Keypoints,
-    /// Ids the epipolar filter removes, ascending (`std::set`, `:669`).
+    /// Ids the epipolar filter removes, ascending (`std::set`).
     to_remove: Vec<KeypointId>,
     frame: FlowFrame,
     /// The keypoint state as it was before the frame in flight; see
@@ -608,12 +527,11 @@ struct FrameState {
 }
 
 impl<P: Pattern> FrameToFrameOpticalFlow<P, CpuPyramidBuilder, CpuPatchTracker<P>> {
-    /// `FrameToFrameOpticalFlow(conf, cal)` (`frame_to_frame_optical_flow.h:103-120`)
+    /// `FrameToFrameOpticalFlow(conf, cal)`
     /// on the CPU backends.
     ///
     /// The calibration arrives in `f64` — that is what the JSON gives — and is
     /// cast to `f32` here, as `OpticalFlowTyped`'s constructor does
-    /// (`optical_flow.h:204`).
     ///
     /// # Errors
     ///
@@ -688,12 +606,8 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
                 return Err(FrontendError::NegativeConfig { field, value });
             }
         }
-        // The detector's threshold ladder halves by integer division, so a
-        // `min_threshold` at or below zero never ends it — in basalt as much as
-        // here (`keypoints.cpp:162`, `:187`). The detector floors its own last
-        // rung as well ([`LOWEST_THRESHOLD_RUNG`]), but a config that asks for a
-        // ladder the C++ would hang on is refused rather than quietly run at a
-        // threshold nobody asked for.
+        // Refuse a non-positive minimum: integer halving would remain at zero forever.
+        // The public detector also floors its last rung as a second line of protection.
         let min_threshold: i32 = config.optical_flow_detection_min_threshold;
         if min_threshold < LOWEST_THRESHOLD_RUNG {
             return Err(FrontendError::ThresholdLadderNeverEnds {
@@ -722,14 +636,9 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         Ok(())
     }
 
-    /// The port's own knobs, which arrive from the caller rather than a basalt file.
-    ///
-    /// Every value a caller may type is bounded here, whatever backends the
-    /// frontend is then built on: [`FrameToFrameOpticalFlow::with_backends`]
-    /// takes a tracker that is already built, so [`PatchSoA::new`]'s own
-    /// ceilings — the second line under these — never run on that seam.
-    ///
-    /// [`PatchSoA::new`]: crate::frontend::tracker::PatchSoA::new
+    /// Validate caller-supplied frontend options independently of the selected backend.
+    /// A prebuilt tracker passed to `with_backends` does not run `PatchSoA::new`, so
+    /// the frontend must enforce its own bounds at this seam.
     fn validate_options(options: &FrontendOptions) -> Result<(), FrontendError> {
         // rayon spawns exactly what it is asked for, so an unbounded `threads`
         // exhausts the machine's threads instead of returning an error; zero is
@@ -802,7 +711,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         }
 
         let calib: Calibration<f32> = calibration.cast();
-        // `calib.T_i_c[i]` is indexed for every camera (`:264-265`, `:651`); a
+        // `calib.T_i_c[i]` is indexed for every camera; a
         // calibration with fewer poses than models would index past the end.
         if calib.t_i_c.len() != calib.intrinsics.len() {
             return Err(FrontendError::RaggedExtrinsics {
@@ -820,7 +729,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
             .map(|index| {
                 if index == 0 {
                     // `T_c0_c0` has no baseline, so `t.normalized()` would be
-                    // NaN; nothing reads index 0 either way (`:704`).
+                    // NaN; nothing reads index 0 either way.
                     return Matrix4::zeros();
                 }
                 let t_i_j: Se3<f32> = calib.t_i_c[0].inverse() * calib.t_i_c[index];
@@ -829,8 +738,8 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
             .collect();
 
         // `detectKeypointsWithCells` derives its grid from the image it is given
-        // (`keypoints.cpp:140-144`), so every camera gets its own; `cells` is
-        // shaped from camera 0 alone (`:119`), so that shape is separate.
+        // so every camera gets its own; `cells` is
+        // shaped from camera 0 alone, so that shape is separate.
         let cell: usize = config.optical_flow_detection_grid_size as usize;
         let mut detection_grids: Vec<CellGrid> = Vec::with_capacity(num_cams);
         for (camera, rig_camera) in cameras.iter().enumerate() {
@@ -847,7 +756,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
             // `cells` below, one `i32` per cell per camera, and a `Vec` too long
             // to exist panics rather than returning (decision D32); and every
             // camera is detected on its own grid, which bounds that camera's
-            // detection scan on every frame (`detect.rs:494`). Saturating like
+            // detection scan on every frame (`detect.rs). Saturating like
             // the sibling ceilings: a product that leaves `usize` is past it.
             if grid.rows.saturating_mul(grid.columns) > MAX_CELLS {
                 return Err(FrontendError::TooManyCells {
@@ -910,7 +819,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         self.cameras.len()
     }
 
-    /// The next keypoint id that will be handed out (`optical_flow.h:174`).
+    /// The next keypoint id that will be handed out.
     pub fn last_keypoint_id(&self) -> u64 {
         self.last_keypoint_id
     }
@@ -925,7 +834,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         self.last_keypoint_id_before_frame
     }
 
-    /// Framesets processed so far (`optical_flow.h:173`).
+    /// Framesets processed so far.
     pub fn frame_counter(&self) -> u64 {
         self.frame_counter
     }
@@ -950,13 +859,12 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         &self.cells[camera]
     }
 
-    /// The grid `cells` is shaped and indexed by, from camera 0 (`:119`).
+    /// The grid `cells` is shaped and indexed by, from camera 0.
     pub fn occupancy_grid(&self) -> CellGrid {
         self.occupancy_grid
     }
 
     /// The grid one camera is *detected* on, from its own image size
-    /// (`keypoints.cpp:140-144`).
     ///
     /// # Panics
     ///
@@ -965,15 +873,11 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         self.detection_grids[camera]
     }
 
-    /// One camera's essential matrix against camera 0 (`optical_flow.h:221`).
-    ///
-    /// Index 0 is the zero matrix: camera 0 has no epipolar geometry against
-    /// itself, and `filterPoints` starts at camera 1 (`:704`), so nothing reads
-    /// it. The C++ leaves the cam0-cam1 matrix there instead, equally unread.
+    /// This camera's essential matrix relative to camera 0.
+    /// Entry zero is the zero matrix and is not read by epipolar filtering.
     ///
     /// # Panics
-    ///
-    /// If `camera` is past the end of the rig.
+    /// If `camera` is outside the rig.
     pub fn essential(&self, camera: usize) -> Matrix4<f32> {
         self.essential[camera]
     }
@@ -984,17 +888,16 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
     }
 
     /// Timestamp of the most recent frameset, `None` before the first
-    /// (`optical_flow.h:172`).
     pub fn t_ns(&self) -> Option<i64> {
         self.t_ns
     }
 
-    /// `depth_guess`: the estimator's average scene depth (`optical_flow.h:164`).
+    /// `depth_guess`: the estimator's average scene depth.
     pub fn depth_guess(&self) -> f32 {
         self.depth_guess
     }
 
-    /// `depth_guess`: the estimator's average scene depth (`optical_flow.h:164`).
+    /// `depth_guess`: the estimator's average scene depth.
     pub fn set_depth_guess(&mut self, depth: f32) {
         self.depth_guess = depth;
     }
@@ -1021,9 +924,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         t_ns: i64,
         sizes: impl ExactSizeIterator<Item = (usize, usize)>,
     ) -> Result<(), FrontendError> {
-        // Tracking is frame to frame, so a frameset that does not follow the last
-        // one has no previous frame of its own; basalt never sees one because its
-        // `processingLoop` reads a monotonic queue.
+        // Tracking requires a frameset strictly after the last committed timestamp.
         if let Some(previous_t_ns) = self.t_ns
             && t_ns <= previous_t_ns
         {
@@ -1039,13 +940,8 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
                 actual: sizes.len(),
             });
         }
-        // The geometry is the calibration's from here on: the camera model
-        // projects with the calibrated intrinsics, the detection grid is derived
-        // from the calibrated size, and the occupancy matrix is allocated from
-        // it. A frame of another size is not a smaller view of the same scene —
-        // its pixels mean different bearings — so it is refused rather than
-        // tracked against geometry it does not belong to. basalt never checks:
-        // its `img_data` comes from the device the calibration describes.
+        // Image size must match calibration: a different pixel geometry changes bearings,
+        // so reject it before tracking with incompatible intrinsics and cell grids.
         for (camera, (actual_width, actual_height)) in sizes.enumerate() {
             let expected_width: usize = self.cameras[camera].width() as usize;
             let expected_height: usize = self.cameras[camera].height() as usize;
@@ -1062,33 +958,17 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         Ok(())
     }
 
-    /// `processFrame` (`frame_to_frame_optical_flow.h:203-292`).
+    /// Process one frameset of widened 16-bit images.
+    /// `prediction` supplies previous and predicted poses; identities mean no state yet.
+    /// Missing mask lists suppress nothing.
     ///
-    /// `images` holds one frame per camera, already widened to 16 bits.
-    /// `prediction` is the pose pair the estimator's feedback would have
-    /// produced; two identities mean "no state has arrived yet", which is what
-    /// basalt runs with until the backend answers (`:140-147`). `masks` may be
-    /// shorter than the rig or empty, in which case the missing cameras suppress
-    /// nothing.
-    ///
-    /// **A rejected frame is as if it never happened.** The C++ has no such
-    /// problem because it never rejects a frame; the port can, at three points —
-    /// the frameset width, a pyramid geometry, and any error a pluggable backend
-    /// returns from the middle of tracking — and every one of them must leave the
-    /// frontend exactly as the last successful frame did. So the whole call runs
-    /// against a *staging* pyramid set with `pyramid` still holding the previous
-    /// frame, over a snapshot of the keypoint state; only after tracking, the
-    /// cell counts, the add/match passes and the epipolar filter have all
-    /// succeeded do the two pyramid sets swap and the clock advance. On any error
-    /// the keypoints, the occupancy counts and the id counter are restored and
-    /// the timestamp never moved.
+    /// A rejected frame leaves the frontend at its last successful state. Build into
+    /// staging pyramids and snapshot keypoints; swap pyramids and advance the clock
+    /// only after every pass succeeds. On failure restore keypoints, counts and ids.
     ///
     /// # Errors
-    ///
-    /// [`FrontendError`] when the frameset does not move the clock forward, when
-    /// it is the wrong width, when an image is not the size the calibration gives
-    /// that camera, when a pyramid refuses the geometry, or when the tracker or
-    /// detector refuses an input.
+    /// Returns [`FrontendError`] for invalid timestamp, camera count, image geometry,
+    /// pyramid geometry, or tracker/detector input.
     pub fn process_frame(
         &mut self,
         t_ns: i64,
@@ -1206,7 +1086,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
             }
         } else {
             // `for (i) trackPoints(old_pyramid[i], pyramid[i], ..., T_c1_c2, i, i)`
-            // (`:261-271`), as one batch: every camera's pass is launched, then
+            // as one batch: every camera's pass is launched, then
             // one download answers all of them. A camera's pass reads only its
             // own two pyramids and writes only its own lane, so batching moves
             // no arithmetic — it removes the per-camera wait, which on the GPU
@@ -1225,7 +1105,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
             for camera in 0..num_cams {
                 self.finish_camera(camera);
             }
-            // `for (i) updateCellCounts(i)` (`:277`).
+            // `for (i) updateCellCounts(i)`.
             for camera in 0..num_cams {
                 self.update_cell_counts(camera);
             }
@@ -1251,7 +1131,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
 
     /// Build this frame's pyramids into the staging set, touching nothing else.
     ///
-    /// `pyramid->at(i).setFromImage(img, config.optical_flow_levels)` (`:245-249`),
+    /// `pyramid->at(i).setFromImage(img, config.optical_flow_levels)`,
     /// with the allocation reused whenever the geometry is unchanged.
     fn build_staging(&mut self, images: &[ImageU16]) -> Result<(), FrontendError> {
         let levels: usize = self.config.optical_flow_levels as usize;
@@ -1288,9 +1168,9 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
     }
 
     /// One camera's frame-to-frame track launched into its own lane:
-    /// `trackPoints(..., cam, cam)` (`:267-270`) up to the download.
+    /// `trackPoints(..., cam, cam)` up to the download.
     fn submit_camera(&mut self, camera: usize, t_c1_c2: &Se3<f32>) -> Result<(), FrontendError> {
-        // Source and destination are the same slot (`:299-308`, `:371`), so the
+        // Source and destination are the same slot, so the
         // ids and warps are copied out first — and the slot is only cleared once
         // the track has succeeded, so a refused frame does not lose the camera's
         // keypoints.
@@ -1307,13 +1187,13 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         self.finish_track_points(camera);
         self.frame.cameras[camera].clear();
         for (slot, id) in self.tracked_ids.iter().enumerate() {
-            // `keypoint_map_2.insert(result.begin(), result.end())` (`:372`); the
+            // `keypoint_map_2.insert(result.begin(), result.end())`; the
             // cell counts are rebuilt afterwards by `updateCellCounts`.
             self.frame.cameras[camera].set(*id, &self.tracked.get(slot), NO_RESPONSE);
         }
     }
 
-    /// The launching half of `trackPoints` (`:294-375`): the mask test, the
+    /// The launching half of `trackPoints` : the mask test, the
     /// guesses, the patch build and the tracker's own kernels, into `lane`.
     ///
     /// Reads the pass source IDs and shared source warps, then records its
@@ -1330,7 +1210,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         t_c1_c2: &Se3<f32>,
         tracking: bool,
     ) -> Result<(), FrontendError> {
-        // `use_depth = tracking || (matching && guess_type != SAME_PIXEL)` (`:316`).
+        // `use_depth = tracking || (matching && guess_type != SAME_PIXEL)`.
         let use_depth: bool = tracking
             || self.config.optical_flow_matching_guess_type != MatchingGuessType::SamePixel;
         let depth: f32 = self.depth_guess;
@@ -1342,12 +1222,12 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         for index in 0..self.source.len() {
             let transform_1: AffineCompact2f = self.source.get(index);
             let t1: Vector2<f32> = transform_1.translation;
-            // `if (masks1.inBounds(t1.x(), t1.y())) continue;` (`:329`).
+            // `if (masks1.inBounds(t1.x(), t1.y())) continue;`.
             if self.masks[cam1].in_bounds(t1.x, t1.y) {
                 continue;
             }
-            // `off = t2 - t2_guess` with `t2 == t1` (`:333-340`), then `t2 -= off`
-            // (`:342`), so the guess is simply `t2_guess`.
+            // `off = t2 - t2_guess` with `t2 == t1`, then `t2 -= off`
+            // so the guess is simply `t2_guess`.
             let translation: Vector2<f32> = if use_depth {
                 project_between_cams(&self.cameras, &t1, depth, t_c1_c2, cam1, cam2).1
             } else {
@@ -1362,7 +1242,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         }
 
         // The forward source patches come from the previous frame when tracking
-        // and from this frame's camera 0 when matching (`:267`, `:652`). This
+        // and from this frame's camera 0 when matching. This
         // frame is `staging` until the call commits.
         let source_pyramid: &B::Pyramid = if tracking {
             &self.pyramid[cam1]
@@ -1392,7 +1272,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         for slot in result.tracked() {
             let slot: usize = *slot as usize;
             let transform: AffineCompact2f = result.transform(slot);
-            // `if (masks2.inBounds(t2.x(), t2.y())) continue;` (`:352`).
+            // `if (masks2.inBounds(t2.x(), t2.y())) continue;`.
             if self.masks[cam2].in_bounds(transform.translation.x, transform.translation.y) {
                 continue;
             }
@@ -1402,12 +1282,12 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         }
     }
 
-    /// `updateCellCounts` (`:707-716`): rebuild one camera's occupancy from scratch.
+    /// `updateCellCounts` : rebuild one camera's occupancy from scratch.
     fn update_cell_counts(&mut self, camera: usize) {
         self.cells[camera].fill(0);
         for index in 0..self.frame.cameras[camera].len() {
             let position: Vector2<f32> = self.frame.cameras[camera].transforms.translation(index);
-            // `if (p[0] < x_start || ... || p[1] >= y_stop + c) continue;` (`:711`).
+            // `if (p[0] < x_start ||... || p[1] >= y_stop + c) continue;`.
             if !self.occupancy_grid.contains(position.x, position.y) {
                 continue;
             }
@@ -1416,7 +1296,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         }
     }
 
-    /// The `cells(y, x)++` half of `addKeypoint`/`addKeypoints` (`:729`, `:738`).
+    /// The `cells(y, x)++` half of `addKeypoint`/`addKeypoints`.
     fn bump_cell(&mut self, camera: usize, transform: &AffineCompact2f) {
         let (row, column) = self
             .occupancy_grid
@@ -1424,7 +1304,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         self.cells[camera][row * self.occupancy_grid.columns + column] += 1;
     }
 
-    /// `removeKeypoint` (`:743-749`): drop a keypoint and decrement its cell.
+    /// `removeKeypoint` : drop a keypoint and decrement its cell.
     fn remove_keypoint(&mut self, camera: usize, id: KeypointId) {
         let Some(transform) = self.frame.cameras[camera].remove(id) else {
             return;
@@ -1435,7 +1315,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         self.cells[camera][row * self.occupancy_grid.columns + column] -= 1;
     }
 
-    /// `addPointsForCamera` (`:577-610`): detect in the empty cells, register the
+    /// `addPointsForCamera` : detect in the empty cells, register the
     /// corners under fresh ids, and record camera 0's as the ones to match onward.
     ///
     /// Detection is capped at the camera's remaining budget
@@ -1462,11 +1342,11 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
             .max_keypoints
             .saturating_sub(self.frame.cameras[camera].len());
 
-        // `detectKeypointsWithCells(pyramid->at(cam_id).lvl(0), ...)` (`:579-582`),
+        // `detectKeypointsWithCells(pyramid->at(cam_id).lvl(0)...)`,
         // on this camera's own grid and the rig's shared occupancy matrix.
         //
         // Level 0 of the staging pyramid is this frame's input image copied in
-        // unchanged (`image_pyr.h:73`), and the caller still holds it, so the
+        // unchanged, and the caller still holds it, so the
         // detector reads the image itself: same pixels, and no copy out of the
         // pyramid — whose seam lends nothing (deviation X04).
         self.detected.corners.clear();
@@ -1498,26 +1378,21 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
             let transform: AffineCompact2f =
                 AffineCompact2f::at(Vector2::new(corner[0], corner[1]));
             let id: KeypointId = KeypointId(self.last_keypoint_id);
-            // `addKeypoint` (`:726-732`): bump the cell, then register.
+            // `addKeypoint` : bump the cell, then register.
             self.bump_cell(camera, &transform);
             self.frame.cameras[camera].set(id, &transform, response);
             if camera == 0 {
                 self.new_cam0.set(id, &transform, response);
             }
-            // `last_keypoint_id++` (`:606`), the global landmark id space.
+            // `last_keypoint_id++`, the global landmark id space.
             self.last_keypoint_id += 1;
         }
         Ok(())
     }
 
-    /// `addKeypoints` (`:734-741`): bump a cell for **every** offered keypoint,
-    /// then insert the ones whose id is not already present.
-    ///
-    /// The double count when a keypoint is both tracked in camera *i* and matched
-    /// into it from camera 0 is basalt's, not a slip: `std::map::insert` keeps the
-    /// existing entry while the loop above it has already incremented the cell.
-    /// The budget is the port's own: once the camera is full, the remaining
-    /// matches are dropped and their cells are not bumped either.
+    /// Bump occupancy for each offered keypoint, then insert ids that are new.
+    /// A point both tracked and matched increments twice while retaining its existing
+    /// entry. Once capacity is reached, further matches neither insert nor bump cells.
     fn add_keypoints(&mut self, camera: usize) {
         let count: usize = self.tracked_ids.len();
         for slot in 0..count {
@@ -1530,18 +1405,9 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         }
     }
 
-    /// `cam0OverlapCellsMasksForCam` (`:612-635`): mask the cells of camera
-    /// `camera` that project into camera 0 at `depth_guess`.
-    ///
-    /// The grid walked here is the frontend's own `x_start`/`x_stop`, which the
-    /// C++ takes from camera 0 (`:110-113`) whatever camera is being masked.
-    /// The rectangles are appended to camera `camera`'s own mask list, which
-    /// `run_passes` clears once per frameset: `optical_flow_detection_nonoverlap`
-    /// is `true` in every shipped config, so returning a fresh `Masks` here
-    /// allocated and freed up to `rows x columns` = 361 `Rect` per camera per
-    /// frameset on the msd rigs — the one per-frame allocation left in a module
-    /// whose doc promises none. The destructure is what lets one field be
-    /// written while the others are read.
+    /// Mask camera cells that project into camera 0 at `depth_guess`.
+    /// Use the frontend grid bounds and append to reusable per-camera mask lists.
+    /// Reusing those lists avoids allocating hundreds of rectangles each frameset.
     fn append_cam0_overlap_masks(&mut self, camera: usize) {
         let Self {
             masks,
@@ -1587,28 +1453,13 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         }
     }
 
-    /// Whether this frameset runs [`FrameToFrameOpticalFlow::add_points`] at
-    /// all (D75).
-    ///
-    /// basalt detects on every frameset, and `port.redetect_survivor_ratio` at
-    /// its `0` default keeps that exactly — this returns `true` before anything
-    /// else is read. Above zero the frameset detects only once camera 0 has
-    /// fallen below that fraction of the count the last detecting frameset left
-    /// it with, which is cuVSLAM's `SelectKeyframe` rule (survivors under 41 %
-    /// of the last detection) rather than a fixed target count, so it needs no
-    /// per-rig tuning.
-    ///
-    /// **The whole frameset is gated, on camera 0 alone.** `add_points` is one
-    /// unit — camera 0's detection, the cross-camera match that carries its new
-    /// keypoints into cameras 1..n, and the non-overlap detection on those same
-    /// cameras — so gating it per camera would leave a rig half detected, with
-    /// camera 0's new ids never matched onward. Camera 0 is also the only camera
-    /// the keyframe vote reads (`estimator/mod.rs`, D21), so its survivor count
-    /// is the state this decision is about.
-    ///
-    /// Pure in the frameset's own state: this frame's camera-0 count, the count
-    /// the last detecting frameset ended with, and a config field. No timer, no
-    /// frame index, nothing the estimator fed back, so a replay repeats it.
+    /// Decide whether the whole frameset detects again (D75).
+    /// A zero survivor-ratio setting detects every frame. Above zero, camera 0 must
+    /// fall below the configured fraction of its count after the last detection.
+    /// This relative budget needs no per-rig target count.
+    /// Gate the whole frameset so new camera-0 ids can be matched into every other
+    /// camera. Only camera 0 votes on keyframes, so its count is the relevant input.
+    /// No timing or arrival-order state participates; replay remains deterministic.
     fn should_detect(&self) -> bool {
         let ratio: f32 = self.config.port_redetect_survivor_ratio;
         // A ratio that is not a positive number is the knob switched off, NaN
@@ -1626,7 +1477,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         survivors < ratio * self.last_detect_count as f32
     }
 
-    /// `addPoints` (`:637-666`): detect on camera 0, match onward, then detect
+    /// `addPoints` : detect on camera 0, match onward, then detect
     /// again on the cameras that do not overlap camera 0.
     fn add_points(&mut self, images: &[ImageU16]) -> Result<(), FrontendError> {
         // Camera 0's cell winners are already on the host: `run_passes`
@@ -1636,7 +1487,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         self.add_points_for_camera(0, images)?;
 
         // `for (i = 1; i < getNumCams(); i++) trackPoints(pyr0, pyri, kpts0, ...)`
-        // (`:643-654`). With one camera there is nothing to match into (trap 17).
+        // With one camera there is nothing to match into (trap 17).
         // One batch again: camera *i*'s match reads camera 0's new keypoints and
         // writes camera *i* alone, so the whole rig is launched before any of it
         // is downloaded.
@@ -1686,7 +1537,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         self.detector.take_cells()?;
         self.timings.detect_ns += duration_ns(mark);
 
-        // `if (!config.optical_flow_detection_nonoverlap) continue;` (`:657-664`).
+        // `if (!config.optical_flow_detection_nonoverlap) continue;`.
         if self.config.optical_flow_detection_nonoverlap {
             for camera in 1..self.cameras.len() {
                 self.append_cam0_overlap_masks(camera);
@@ -1696,7 +1547,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         Ok(())
     }
 
-    /// `filterPointsForCam` (`:668-701`): drop the keypoints camera `camera`
+    /// `filterPointsForCam` : drop the keypoints camera `camera`
     /// shares with camera 0 whose epipolar error is too large.
     fn filter_points_for_cam(&mut self, camera: usize) {
         self.to_remove.clear();
@@ -1718,7 +1569,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
             let ok1: bool = self.cameras[camera].model.unproject(&proj1, &mut p3d1);
 
             if ok0 && ok1 {
-                // `std::abs(p3d0.transpose() * E[cam] * p3d1)` (`:692`), in the
+                // `std::abs(p3d0.transpose() * E[cam] * p3d1)`, in the
                 // estimator's scalar and only then widened for the comparison.
                 let error: f32 = (p3d0.transpose() * essential * p3d1)[(0, 0)].abs();
                 if error > threshold {
@@ -1729,7 +1580,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
             }
         }
 
-        // `for (int id : kp_to_remove) removeKeypoint(cam_id, id);` (`:700`), a
+        // `for (int id : kp_to_remove) removeKeypoint(cam_id, id);`, a
         // `std::set`, so ascending; `self.to_remove` is built in id order
         // already. Indexed rather than drained because `remove_keypoint` takes
         // `&mut self`, and the list does not change while it runs.
@@ -1740,7 +1591,7 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
         self.to_remove.clear();
     }
 
-    /// `filterPoints` (`:703-705`): every camera but camera 0.
+    /// `filterPoints` : every camera but camera 0.
     fn filter_points(&mut self) {
         for camera in 1..self.cameras.len() {
             self.filter_points_for_cam(camera);
@@ -1748,18 +1599,16 @@ impl<P: Pattern, B: PyramidBuilder, T: PatchTracker<Pattern = P, Pyramid = B::Py
     }
 }
 
-/// `computeEssential` (`utils/keypoints.h:101-107`).
+/// `computeEssential`.
 ///
 /// `E.topLeftCorner<3,3>() = hat(t.normalized()) * R`, computed in `double`
-/// because that is what `optical_flow.h:209-212` casts to before calling it, and
+/// because that is what casts to before calling it, and
 /// cast back to the estimator's scalar afterwards.
 fn compute_essential(t_0_1: &Se3<f64>) -> Matrix4<f64> {
     let translation: Vector3<f64> = t_0_1.translation;
     let rotation = t_0_1.rotation.matrix();
     let mut essential: Matrix4<f64> = Matrix4::zeros();
-    // `Eigen::normalized()` is `v / v.norm()`, which is NaN for a zero baseline;
-    // the C++ does the same, and a rig with two coincident cameras has no
-    // epipolar geometry to test against anyway.
+    // Normalizing a zero baseline yields NaNs: coincident cameras have no epipolar geometry.
     let normalized: Vector3<f64> = translation / translation.norm();
     essential
         .fixed_view_mut::<3, 3>(0, 0)
@@ -1767,21 +1616,16 @@ fn compute_essential(t_0_1: &Se3<f64>) -> Matrix4<f64> {
     essential
 }
 
-/// `Ed.cast<Scalar>()` (`optical_flow.h:212`).
+/// `Ed.cast<Scalar>()`.
 fn cast_matrix4(matrix: &Matrix4<f64>) -> Matrix4<f32> {
     Matrix4::from_iterator(matrix.iter().map(|value| *value as f32))
 }
 
-/// `Calibration::projectBetweenCams` (`calibration/calibration.hpp:79-95`).
-///
-/// Returns the validity flag *and* the pixel. `trackPoints` discards the flag and
-/// uses whatever `project` wrote (`frame_to_frame_optical_flow.h:338`), while
-/// `cam0OverlapCellsMasksForCam` reads it (`:625-627`); both behaviours are the
-/// C++'s, so the pixel is always produced and the caller decides.
+/// Project between cameras, returning both validity and the written pixel.
+/// Tracking uses the pixel; overlap masking also checks validity.
 ///
 /// # Panics
-///
-/// If `i` or `j` is past the end of `cameras`.
+/// If either camera index is outside the rig.
 pub fn project_between_cams(
     cameras: &[RigCamera<f32>],
     ci_uv: &Vector2<f32>,
@@ -1796,7 +1640,7 @@ pub fn project_between_cams(
     ci_xyzw.w = 1.0;
 
     // `T_ci_cj.inverse() * ci_xyzw`: Sophus rotates and translates the first
-    // three components and carries the fourth through unchanged (`se3.hpp`).
+    // three components and carries the fourth through unchanged.
     let inverse: Se3<f32> = t_ci_cj.inverse();
     let point: Vector3<f32> = inverse * Vector3::new(ci_xyzw.x, ci_xyzw.y, ci_xyzw.z);
     let cj_xyzw: Vector4<f32> = Vector4::new(point.x, point.y, point.z, ci_xyzw.w);

--- a/packages/slam-rs/crates/slam-rs/src/frontend/mod.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/mod.rs
@@ -1,29 +1,10 @@
-//! The optical-flow frontend: patterns, patches, the SE(2) KLT tracker, grid FAST
-//! detection and the frame-to-frame driver.
+//! Optical-flow frontend: sampling patterns, patch factors, SE(2) KLT tracking,
+//! grid FAST detection and the frame-to-frame driver.
+//! Only frame-to-frame flow and Pattern51 are selected by shipped configs.
 //!
-//! Ported from `include/basalt/optical_flow/` and `src/utils/keypoints.cpp` of
-//! the basalt VIO fork. Only `FrameToFrameOpticalFlow` is here: every shipped
-//! config sets `optical_flow_type = "frame_to_frame"`, so `PatchOpticalFlow` and
-//! `MultiscaleFrameToFrameOpticalFlow` are out of scope, and the recall
-//! subsystem is off in every shipped config and leaks patches by design, so it is
-//! left out too (trap 18).
-//!
-//! ```text
-//!   patterns  Pattern52 / Pattern51                patterns.h
-//!   se2       AffineCompact2f, SE2::exp           optical_flow.h:66, se2.hpp:609
-//!   ldlt      Eigen's pivoted LDLT, 3x3           Cholesky/LDLT.h
-//!   patch     OpticalFlowPatch, residual          patch.h
-//!   tracker   PatchSoA, CpuPatchTracker           frame_to_frame_optical_flow.h:294-438
-//!   detect    grid-cell FAST over kornia-rs       keypoints.cpp:132-205
-//!   parallel  the explicit thread budget          decision D31
-//! ```
-//!
-//! The whole frontend is `f32` on `u16` pixels (decision D05), the per-patch
-//! buffers are structure-of-arrays with the patch index fast-varying, the
-//! per-frame path preallocates, and every loop has a fixed bound with a converged
-//! flag — the CubeCL seam rules from `cubecl-portability.md` §12, applied from
-//! the first CPU commit so a GPU backend arrives as a new [`tracker::PatchTracker`]
-//! rather than a rewrite.
+//! The frontend uses f32 arithmetic on u16 pixels (D05). Per-patch buffers put
+//! patch index first in storage order, and frame buffers are reused. Fixed loop
+//! bounds and explicit validity flags support CPU and GPU stage implementations.
 
 pub mod cell;
 pub mod detect;

--- a/packages/slam-rs/crates/slam-rs/src/frontend/parallel.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/parallel.rs
@@ -1,17 +1,7 @@
-//! The frontend's one and only source of parallelism.
-//!
-//! basalt runs the per-keypoint tracking loop through `tbb::parallel_for` over a
-//! `blocked_range` (`frame_to_frame_optical_flow.h:368-369`) and the per-camera
-//! pyramid build the same way (`:224-228`, `:245-249`). Decision D31 fixes how
-//! that lands in Rust: a **fixed chunk size**, per-chunk sequential accumulation,
-//! and an **explicit thread count** from the config — never the ambient rayon
-//! global pool, whose width depends on the machine and on whatever else in the
-//! process touched rayon first.
-//!
-//! Every loop routed through here is a pure function of the index, so the
-//! chunking cannot change a result; the fixed chunk size is belt and braces, and
-//! the tests run `threads = 1` against `threads = 4` and require identical
-//! output.
+//! Explicit frontend parallelism (D31).
+//! Use fixed chunks, sequential accumulation within chunks and a configured
+//! thread count instead of the ambient Rayon pool. Each loop is a pure function
+//! of its index; tests require identical output at one and four threads.
 
 use rayon::prelude::*;
 use rayon::{ThreadPool, ThreadPoolBuildError, ThreadPoolBuilder};

--- a/packages/slam-rs/crates/slam-rs/src/frontend/patch.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/patch.rs
@@ -1,51 +1,15 @@
-//! `basalt::OpticalFlowPatch`, ported from `optical_flow/patch.h`.
+//! Mean-normalized patches and cached inverse-compositional SE(2) factors.
 //!
-//! A patch is a pattern of taps sampled around a keypoint, mean-normalised, plus
-//! the cached inverse-compositional factor `H_se2^-1 J_se2^T` that turns a
-//! residual into an SE(2) increment. The three pieces are:
+//! Sampling computes raw taps and gradients, then applies the derivative of the
+//! normalization factor. Build `H = JᵀJ` in tap order using rank-one updates,
+//! invert the 3x3 factor with guarded pivoted LDLT, then apply it to each stored
+//! Jacobian column. The product-rule correction is required for the right warp.
 //!
-//! * `set_data` — `patch.h:73-99`, sample and mean-normalise, optionally
-//!   through an SE(2) warp. The tracking path never samples without the
-//!   Jacobian, so it lives in this module's tests, where the ported
-//!   `test_patch.cpp` cases are its only callers.
-//! * [`set_data_jac_se2`] — `patch.h:101-142`, the same sampling with the
-//!   gradient, the SE(2) warp Jacobian, and the product-rule term that comes
-//!   from differentiating the `1/mean` factor.
-//! * [`OpticalFlowPatch::set_from_image`] — `patch.h:144-166`, which forms
-//!   `H = J^T J`, inverts it with Eigen's pivoted LDLT and caches `H^-1 J^T`.
-//! * [`OpticalFlowPatch::residual`] — `patch.h:168-202`, the mean-normalised SSD
-//!   residual of a warped pattern against the stored data.
-//!
-//! ## Two deliberate departures from the C++ shape
-//!
-//! **Nothing bigger than a 3x3 is ever held per patch.** `setDataJacSe2` builds
-//! `MatrixP3 J_se2` and `setFromImage` then forms `J^T J` and `H^-1 J^T` from it
-//! (`patch.h:147-156`) — 624 bytes of `f32` Jacobian, over the ~512-byte
-//! per-thread private budget that goes racy on Vulkan/SPIR-V
-//! (`cubecl-portability.md` §12.2, CubeCL issue #1336). Here the whole build is
-//! a **streaming write into the caller's storage**: [`build_patch`] takes the
-//! destination `data` and `J^T` arrays with explicit strides, writes the raw
-//! rows straight into them, accumulates `J^T J` one rank-1 outer product per tap
-//! while it finalises those rows, and applies `H^-1` to the stored `J^T` one
-//! column at a time. The largest live temporary is a 3x3 matrix plus a 3-vector
-//! — under 112 bytes, whatever the pattern.
-//!
-//! Because the strides are parameters, the same body fills the packed
-//! [`OpticalFlowPatch`] record (stride 1) and the tracker's structure-of-arrays
-//! (stride = the patch capacity, so the patch index varies fastest). The
-//! tracking path uses the second and never constructs the first.
-//!
-//! The equivalence to the C++ is exact as algebra — `J^T J = sum_i row_i^T row_i`
-//! and `(H^-1 J^T)[:, i] = H^-1 (J^T[:, i])`. The summation order of `J^T J` is
-//! tap index ascending; Eigen's blocked product may add in another order, so the
-//! 3x3 can differ in the last `f32` bits.
-//!
-//! **`residual` takes the warp, not a pre-multiplied pattern.** The C++ builds
-//! `transformed_pat = transform.linear() * pattern2` and adds the translation
-//! columnwise (`frame_to_frame_optical_flow.h:411-412`) before calling
-//! `residual(img, transformed_pattern, res)`. [`AffineCompact2::warp_tap`]
-//! performs the same two multiplies and one add per tap in the same order, so
-//! fusing them removes a 2xP transient without changing a bit.
+//! [`build_patch`] writes into caller storage with explicit strides, serving
+//! both packed test records and the tracker's structure-of-arrays layout.
+//! The largest temporary is a 3x3 matrix plus a 3-vector, avoiding a full patch
+//! Jacobian in per-thread GPU storage. Residual sampling warps one tap at a time,
+//! avoiding a transient transformed-pattern matrix.
 
 use std::marker::PhantomData;
 
@@ -57,29 +21,19 @@ use crate::frontend::se2::AffineCompact2;
 use crate::image::ImageU16;
 use crate::lie::LieScalar;
 
-/// The border every patch tap is sampled with, `img.InBounds(p, 2)`
-/// (`patch.h:87`, `:117`, `:173`).
-///
-/// `interpGrad` alone needs 1 (`image.h:424`); basalt asks for 2 everywhere on
-/// the patch path so that a tap and its gradient stencil are both inside.
+/// Two-pixel patch border, keeping taps and their gradient stencils inside the image.
 pub const PATCH_BORDER: f32 = 2.0;
 
-/// What a patch can be sampled from.
-///
-/// basalt templates `setData`/`setDataJacSe2` on the image type
-/// (`patch.h:73`, `:101`) so its own tests can substitute an analytic function
-/// for a real image (`test/src/test_patch.cpp:11-30`), and the port does the
-/// same. Monomorphised, so a tap costs no more than a direct call; the GPU seam
-/// rule against per-pixel virtual dispatch (`cubecl-portability.md` §12.3 item 5)
-/// is about the *stage* traits, and this is not one.
+/// A patch sampling source. Tests can supply analytic functions in place of images.
+/// Static dispatch avoids per-tap virtual calls.
 pub trait PatchSource<S: LieScalar> {
-    /// `img.InBounds(p, border)` (`image.h:694-705`).
+    /// `img.InBounds(p, border)`.
     fn in_bounds(&self, x: S, y: S, border: S) -> bool;
 
-    /// `img.interp<Scalar>(p)` (`image.h:396-415`).
+    /// `img.interp<Scalar>(p)`.
     fn interp(&self, x: S, y: S) -> S;
 
-    /// `img.interpGrad<Scalar>(p)` (`image.h:418-469`): `[value, d/dx, d/dy]`.
+    /// `img.interpGrad<Scalar>(p)` : `[value, d/dx, d/dy]`.
     fn interp_grad(&self, x: S, y: S) -> (S, [S; 2]);
 }
 
@@ -100,35 +54,18 @@ impl PatchSource<f32> for ImageU16 {
     }
 }
 
-/// `OpticalFlowPatch::setDataJacSe2` (`patch.h:101-142`), writing a strided `J^T`.
+/// Write a strided transposed SE(2) sampling Jacobian.
+/// `data[i * data_stride]` is tap i; row/element strides address the three Jacobian rows.
 ///
-/// `data[i * data_stride]` is tap `i`; `jacobian_transpose[r * jt_row_stride + i
-/// * jt_element_stride]` is `J_se2(i, r)`. Writing the **transpose** is what the
-/// caller needs next, and letting the caller pick the strides is what lets one
-/// body fill both a packed record and a structure-of-arrays whose patch index
-/// varies fastest (`cubecl-portability.md` §12.2).
-///
-/// The four steps, in the C++'s order:
-///
-/// 1. per tap, `Jw_se2` is `[[1, 0, -p_y], [0, 1, p_x]]` for the *pattern* offset
-///    `p` (`patch.h:107-115`), and `J.row(i) = grad^T Jw_se2` (`:121`);
-///    `grad_sum_se2` accumulates the raw rows (`:122`);
-/// 2. `mean = sum / n` and `mean_inv = n / sum` (`:129`, `:131`) — two separate
-///    divisions, not reciprocals of each other;
-/// 3. the product-rule correction `J.row(i) -= grad_sum^T * data[i] / sum`
-///    applied with the **raw** `data[i]`, then `data[i] *= mean_inv` (`:135-136`);
-///    rows of invalid taps are zeroed (`:138`);
-/// 4. `J_se2 *= mean_inv` (`:141`), folded into step 3's loop here — every
-///    element is multiplied once either way.
-///
-/// Step 3 is the term the papers never write out; dropping it gives a Jacobian
-/// that looks right and converges to the wrong warp (`papers-part2.md` §12.1).
-///
-/// Returns the mean and the number of taps that were in bounds.
+/// First form `gradᵀ [[1, 0, -p_y], [0, 1, p_x]]` and accumulate raw row sums.
+/// Compute `mean = sum/n` and `mean_inv = n/sum` separately. Subtract the
+/// product-rule term `grad_sumᵀ * raw_data[i] / sum`, zero invalid rows, then
+/// scale valid data and Jacobians by `mean_inv`. Omitting the product-rule term
+/// converges to the wrong warp (`papers-part2.md` §12.1).
+/// Returns the mean and valid tap count.
 ///
 /// # Panics
-///
-/// If either array is too short for `P::SIZE` taps at the given strides.
+/// If either array is too short for the pattern and strides.
 #[allow(clippy::too_many_arguments)]
 pub fn set_data_jac_se2<P: Pattern, S: LieScalar, Src: PatchSource<S>>(
     source: &Src,
@@ -155,7 +92,7 @@ pub fn set_data_jac_se2<P: Pattern, S: LieScalar, Src: PatchSource<S>>(
             data[i * data_stride] = value;
             sum += value;
             // `valGrad.tail<2>().transpose() * Jw_se2` with
-            // `Jw_se2 = [[1, 0, -tap_y], [0, 1, tap_x]]` (`patch.h:107-115`).
+            // `Jw_se2 = [[1, 0, -tap_y], [0, 1, tap_x]]`.
             let row: [S; 3] = [grad[0], grad[1], grad[0] * -tap_y + grad[1] * tap_x];
             for r in 0..3 {
                 jacobian_transpose[r * jt_row_stride + i * jt_element_stride] = row[r];
@@ -189,22 +126,14 @@ pub fn set_data_jac_se2<P: Pattern, S: LieScalar, Src: PatchSource<S>>(
     (mean, num_valid_points)
 }
 
-/// `setFromImage` (`patch.h:144-166`) as a streaming write into caller storage.
-///
-/// Fills `data` and `jacobian_transpose` — which on return holds
-/// `H_se2^-1 J_se2^T`, not `J_se2^T` — at the strides described on
-/// [`set_data_jac_se2`], and returns `(mean, valid)`.
-///
-/// `H_se2 = J^T J` (`patch.h:151`) is accumulated one rank-1 outer product per
-/// tap straight off the stored rows, inverted with Eigen's pivoted LDLT
-/// ([`ldlt_inverse3`], `:154`), and applied to the stored `J^T` one column at a
-/// time (`:156`). Nothing bigger than the 3x3 is live at any point. `valid` is
-/// `mean > eps` and everything finite (`:164-165`): an all-black patch cannot be
-/// normalised and would otherwise carry `inf` into the tracker.
+/// Build a patch factor in caller storage at the supplied strides.
+/// On return the Jacobian buffer contains `H^-1 Jᵀ`, formed by tap-ordered
+/// rank-one updates, guarded 3x3 LDLT and column-wise multiplication.
+/// Return `(mean, valid)`; validity requires positive mean above epsilon and
+/// finite values, so a black patch cannot introduce infinities into tracking.
 ///
 /// # Panics
-///
-/// If either array is too short for `P::SIZE` taps at the given strides.
+/// If either array is too short for the pattern and strides.
 pub fn build_patch<P: Pattern, Src: PatchSource<f32>>(
     source: &Src,
     pos: &Vector2<f32>,
@@ -252,20 +181,11 @@ pub fn build_patch<P: Pattern, Src: PatchSource<f32>>(
     (mean, mean > f32::EPSILON && finite)
 }
 
-/// `basalt::OpticalFlowPatch<Scalar, Pattern>` (`patch.h:45-214`), `Scalar = f32`.
-///
-/// **The reference form, not the tracking path.** The tracker samples straight
-/// into [`crate::frontend::tracker::PatchSoA`]'s strided arrays and never builds
-/// a packed per-patch record. This type is what the ported `test_patch.cpp`
-/// cases and `tests/gpu_kernels.rs`'s patch-build tolerance test measure
-/// against: both go through the same [`build_patch`] with different strides, so
-/// it is the same arithmetic read at a packed stride.
-///
-/// The stored state is `patch.h:204-213`: the source position, the
-/// mean-normalised taps with `-1` marking the ones that fell outside, the cached
-/// `H_se2^-1 J_se2^T`, the mean, and the validity flag. The buffers are sized for
-/// the largest pattern and only the first `P::SIZE` entries are used, so one
-/// layout serves every pattern.
+/// Packed f32 patch record used by tests.
+/// Tracking builds directly into strided arrays through the same [`build_patch`].
+/// The record stores source position, normalized taps, cached `H^-1 Jᵀ`, mean
+/// and validity. Negative taps mark invalid samples. Only `P::SIZE` entries of
+/// the maximum-sized buffers are used.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct OpticalFlowPatch<P: Pattern> {
     /// `pos`, the centre this patch was sampled at, in the level's pixel frame.
@@ -276,7 +196,7 @@ pub struct OpticalFlowPatch<P: Pattern> {
     pub h_se2_inv_j_se2_t: [[f32; MAX_PATTERN_SIZE]; 3],
     /// `mean`, the average of the taps that were in bounds.
     pub mean: f32,
-    /// `valid`: whether this patch may be tracked (`patch.h:164-165`).
+    /// `valid`: whether this patch may be tracked.
     pub valid: bool,
     /// The pattern this patch was sampled with.
     pattern: PhantomData<P>,
@@ -296,14 +216,14 @@ impl<P: Pattern> Default for OpticalFlowPatch<P> {
 }
 
 impl<P: Pattern> OpticalFlowPatch<P> {
-    /// `OpticalFlowPatch(img, pos)` (`patch.h:71`): build a patch in one step.
+    /// `OpticalFlowPatch(img, pos)` : build a patch in one step.
     pub fn new<Src: PatchSource<f32>>(source: &Src, pos: Vector2<f32>) -> Self {
         let mut patch: Self = Self::default();
         patch.set_from_image(source, pos);
         patch
     }
 
-    /// `setFromImage` (`patch.h:144-166`), into this record's packed storage.
+    /// `setFromImage`, into this record's packed storage.
     ///
     /// A thin call into [`build_patch`] at stride 1. The tracking path does not
     /// come through here: it points [`build_patch`] straight at its
@@ -328,19 +248,19 @@ impl<P: Pattern> OpticalFlowPatch<P> {
         self.valid = valid;
     }
 
-    /// `residual` (`patch.h:168-202`), with the warp applied per tap.
+    /// `residual`, with the warp applied per tap.
     ///
     /// Samples `img` at `transform * pattern2.col(i)`; a tap outside the image is
-    /// marked `-1` and contributes nothing (`:173-179`). An all-black target
-    /// (`sum < epsilon`) zeroes the residual and fails (`:183-186`). Every tap
+    /// marked `-1` and contributes nothing. An all-black target
+    /// (`sum < epsilon`) zeroes the residual and fails. Every tap
     /// valid in **both** the target and the stored source becomes
-    /// `num_valid_points * val / sum - data[i]` (`:193`) — note that the target's
+    /// `num_valid_points * val / sum - data[i]` — note that the target's
     /// count and sum come from the taps in bounds in the *target*, while
     /// `data[i]` was normalised by the source's own count, so the two
     /// normalisations differ whenever the patch straddles a border
-    /// (`papers-part2.md` §13 deviation D5). Everything else is zeroed (`:197`).
+    /// (`papers-part2.md` §13 deviation D5). Everything else is zeroed.
     ///
-    /// Returns `true` only when more than half the pattern survived (`:201`).
+    /// Returns `true` only when more than half the pattern survived.
     ///
     /// # Panics
     ///
@@ -412,17 +332,12 @@ pub fn patch_residual<P: Pattern, Src: PatchSource<f32>>(
     num_residuals > P::SIZE / 2
 }
 
-/// `H_se2_inv_J_se2_T * res` over a strided 3xP array
-/// (`frame_to_frame_optical_flow.h:419`, without the leading minus).
-///
-/// `element_stride` separates two taps of one row and `row_stride` two rows, so
-/// the same body reads the packed per-patch buffer and the tracker's SoA. The
-/// sum runs over taps in ascending index order, which fixes the reduction order
-/// the way decision D31 asks; Eigen's vectorised `3xP * P` may add in another.
+/// Multiply a strided 3xP factor by the residual, without a leading minus.
+/// The same routine reads packed and structure-of-arrays storage. Sum taps in
+/// ascending order for determinism (D31).
 ///
 /// # Panics
-///
-/// If `h_inv_jt` or `residual` is too short for three rows of `P::SIZE` taps.
+/// If factor or residual storage is too short.
 #[inline]
 pub fn patch_increment<P: Pattern>(
     h_inv_jt: &[f32],
@@ -446,27 +361,13 @@ pub fn patch_increment<P: Pattern>(
 mod tests {
     #![allow(clippy::unwrap_used)]
 
-    /// `OpticalFlowPatch::setData` (`patch.h:73-99`), the reference form.
-    ///
-    /// The tracking path never samples without the Jacobian, so this is here
-    /// rather than in the module: it is what the ported `test_patch.cpp` cases
-    /// below compare [`set_data_jac_se2`] against.
-    ///
-    /// Samples the pattern around `pos`, optionally through the SE(2) warp `se2`
-    /// (`p = pos + (*se2) * pattern2.col(i)`, `patch.h:82`), marks out-of-bounds taps
-    /// with `-1` (`:93`) and divides every tap by the mean of the valid ones (`:98`).
-    /// Note that `data /= mean` scales the `-1` markers too, exactly as the C++ does;
-    /// the sign is what later tests look at, and it survives a positive mean.
-    ///
-    /// Returns the number of taps that were in bounds. `data` must be at least
-    /// `P::SIZE` long; only that prefix is written.
+    /// Test sampling without Jacobians, optionally through an SE(2) warp.
+    /// Mark out-of-bounds taps negative, then normalize by the valid-tap mean.
+    /// Scaling the markers preserves their sign for a positive mean.
+    /// Return the valid count and write only the pattern-sized prefix.
     ///
     /// # Panics
-    ///
     /// If `data` is shorter than `P::SIZE`.
-    // The loop variable is the pattern tap index, shared by `data`, `P::OFFSETS`
-    // and the C++ `for (int i = 0; i < PATTERN_SIZE; i++)` this mirrors; an
-    // `enumerate` over one of them would name the wrong thing.
     #[allow(clippy::needless_range_loop)]
     fn set_data<P: Pattern, S: LieScalar, Src: PatchSource<S>>(
         source: &Src,
@@ -500,8 +401,7 @@ mod tests {
             }
         }
 
-        // `mean = sum / num_valid_points; data /= mean;` (`patch.h:97-98`). The int
-        // is converted to the scalar before the division, as C++ does.
+        // Convert the valid count to the scalar before mean division.
         let mean: S = sum / S::from_literal(num_valid_points as f64);
         for value in data.iter_mut().take(P::SIZE) {
             *value /= mean;
@@ -514,7 +414,7 @@ mod tests {
     use crate::frontend::se2::se2_exp;
     use approx::assert_abs_diff_eq;
 
-    /// `test/src/test_patch.cpp:11-30`: `sin(x/100 + y/20)`, always in bounds,
+    /// `sin(x/100 + y/20)`, always in bounds,
     /// with the analytic value and gradient.
     struct SmoothFunction;
 
@@ -533,13 +433,12 @@ mod tests {
         }
     }
 
-    /// The probe point of both C++ tests: `(231, 123) + (0.4, 0.34345)`
-    /// (`test_patch.cpp:33-37`, `:49-53`).
+    /// Subpixel probe at `(231, 123) + (0.4, 0.34345)`.
     fn probe() -> Vector2<f64> {
         Vector2::new(231.0 + 0.4, 123.0 + 0.34345)
     }
 
-    /// Port of `TEST(Patch, ImageInterpolateGrad)` (`test_patch.cpp:32-46`):
+    /// Port of `TEST(Patch, ImageInterpolateGrad)` :
     /// the gradient `interpGrad` returns is the derivative of `interp`.
     #[test]
     fn image_interpolate_grad() {
@@ -547,7 +446,7 @@ mod tests {
         let point: Vector2<f64> = probe();
         let (_, grad): (f64, [f64; 2]) = image.interp_grad(point.x, point.y);
 
-        // `test_jacobian`'s central difference, `test/include/test_utils.h`.
+        // `test_jacobian`'s central difference.
         let step: f64 = 1e-6;
         for axis in 0..2 {
             let mut plus: Vector2<f64> = point;
@@ -560,7 +459,7 @@ mod tests {
         }
     }
 
-    /// Port of `TEST(Patch, PatchSe2Jac)` (`test_patch.cpp:48-83`), first half:
+    /// Port of `TEST(Patch, PatchSe2Jac)`, first half:
     /// `setDataJacSe2` and `setData` agree on the mean and the normalised data.
     #[test]
     fn patch_se2_jac_data_matches_set_data() {
@@ -591,7 +490,7 @@ mod tests {
         }
     }
 
-    /// Port of `TEST(Patch, PatchSe2Jac)` (`test_patch.cpp:70-82`), second half:
+    /// Port of `TEST(Patch, PatchSe2Jac)`, second half:
     /// `J_se2` is the derivative of the normalised data with respect to the SE(2)
     /// warp, at the identity.
     #[test]
@@ -681,7 +580,7 @@ mod tests {
         }
     }
 
-    /// `patch.h:164-165`: an all-black patch has mean zero, so it is not valid.
+    /// an all-black patch has mean zero, so it is not valid.
     #[test]
     fn an_all_black_patch_is_not_valid() {
         let image: ImageU16 = ImageU16::zeros(64, 64).unwrap();
@@ -690,7 +589,7 @@ mod tests {
         assert!(!patch.valid);
     }
 
-    /// `patch.h:183-186`: a residual against an all-black target zeroes and fails.
+    /// a residual against an all-black target zeroes and fails.
     #[test]
     fn a_residual_against_black_fails_and_zeroes() {
         let image: ImageU16 = textured_image(64, 64);
@@ -708,7 +607,7 @@ mod tests {
         assert_eq!(&residual[..Pattern51::SIZE], &[0.0; Pattern51::SIZE][..]);
     }
 
-    /// `patch.h:201`: with most of the pattern off the edge, the residual is
+    /// with most of the pattern off the edge, the residual is
     /// rejected however good the surviving taps are.
     #[test]
     fn a_residual_with_half_the_pattern_outside_is_rejected() {
@@ -725,7 +624,7 @@ mod tests {
         assert!(!survived);
     }
 
-    /// `patch.h:93`, `:125`: a tap outside the image is marked negative, and the
+    /// : a tap outside the image is marked negative, and the
     /// mean-normalisation of `setData` keeps the sign.
     #[test]
     fn out_of_bounds_taps_stay_negative() {

--- a/packages/slam-rs/crates/slam-rs/src/frontend/patterns.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/patterns.rs
@@ -1,31 +1,7 @@
-//! basalt's four sampling patterns, ported from `optical_flow/patterns.h`.
-//!
-//! Each pattern is a fixed set of 2-D offsets from a keypoint. The C++ stores
-//! them as `constexpr Scalar pattern_raw[][2]` and maps them into a column-major
-//! `Eigen::Matrix<Scalar, 2, PATTERN_SIZE>`, so column `i` of `pattern2` is
-//! exactly `(pattern_raw[i][0], pattern_raw[i][1])` (`patterns.h:75-77`). Here
-//! that is one `[[f32; 2]]` slice in the same order, so index `i` is column `i`.
-//!
-//! * [`Pattern52`] — 52 taps at unit half-spacing, `patterns.h:107-126`.
-//! * [`Pattern51`] — `0.5 * Pattern52`, `patterns.h:146`.
-//!
-//! **Every shipped config sets `optical_flow_pattern = 51`**
-//! (`data/default_config.json`, `data/msd/*_config.json`), i.e. 52 taps at half
-//! spacing, so every sample of the shipped frontend is a genuine bilinear
-//! interpolation rather than a pixel read.
-//! [`crate::frontend::flow::FrameToFrameOpticalFlow`] refuses any other value,
-//! and the binding hard-codes `Pattern51`.
-//!
-//! The C++ has two more tables that are **not** ported, because no config
-//! selects them and nothing here could exercise them: `Pattern24`
-//! (`patterns.h:44-79`, 24 taps) and `Pattern50` (`patterns.h:148-158`,
-//! `0.75 * Pattern52`). Adding either back is a `Pattern` impl over its raw
-//! table beside `Pattern51`'s.
-//!
-//! The port is `f32` only (decision D05: the frontend runs `f32` on `u16`
-//! pixels). The scale factors are exact binary fractions and every raw offset is
-//! a small integer, so `0.5 *` and `0.75 *` are exact in both `f32` and the
-//! `double` Eigen evaluates them in.
+//! Fixed 2-D sampling offsets for optical-flow patches.
+//! [`Pattern52`] has 52 taps; [`Pattern51`] scales them by one half.
+//! Shipped configs select Pattern51 and the binding requires it, so sampling
+//! uses bilinear interpolation. Offsets and the binary scale are exact in f32.
 
 /// Taps in the largest pattern, and therefore the capacity of every per-patch buffer.
 ///
@@ -35,11 +11,7 @@
 /// patterns.
 pub const MAX_PATTERN_SIZE: usize = 52;
 
-/// One of basalt's sampling patterns, as a compile-time choice.
-///
-/// The C++ passes the pattern as a template template parameter
-/// (`OpticalFlowTyped<Scalar, Pattern>`, `optical_flow.h:184`); the port passes
-/// it as a type parameter with the same effect: no indirection at a tap.
+/// Compile-time sampling pattern; the type parameter avoids per-tap indirection.
 pub trait Pattern: Copy + Clone + Send + Sync + 'static {
     /// `Pattern::PATTERN_SIZE`.
     const SIZE: usize;
@@ -47,11 +19,11 @@ pub trait Pattern: Copy + Clone + Send + Sync + 'static {
     /// The number `optical_flow_pattern` carries in the config JSON.
     const CODE: i32;
 
-    /// The offsets, index `i` being column `i` of the C++ `pattern2`.
+    /// Tap offsets in sampling order.
     const OFFSETS: &'static [[f32; 2]];
 }
 
-/// `Pattern52` (`patterns.h:81-131`), 52 taps at spacing 2.
+/// `Pattern52`, 52 taps at spacing 2.
 ///
 /// ```text
 ///          00  01  02  03
@@ -66,7 +38,6 @@ pub trait Pattern: Copy + Clone + Send + Sync + 'static {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Pattern52;
 
-/// `patterns.h:107-126`, verbatim.
 const PATTERN52_RAW: [[f32; 2]; 52] = [
     [-3.0, 7.0],
     [-1.0, 7.0],
@@ -128,7 +99,7 @@ impl Pattern for Pattern52 {
     const OFFSETS: &'static [[f32; 2]] = &PATTERN52_RAW;
 }
 
-/// `factor * Pattern52`, the way `patterns.h:146` and `:158` build the other two.
+/// `factor * Pattern52`, the way and build the other two.
 const fn scaled_pattern52(factor: f32) -> [[f32; 2]; 52] {
     let mut out: [[f32; 2]; 52] = [[0.0; 2]; 52];
     let mut i: usize = 0;
@@ -139,11 +110,11 @@ const fn scaled_pattern52(factor: f32) -> [[f32; 2]; 52] {
     out
 }
 
-/// `Pattern51` = `0.5 * Pattern52` (`patterns.h:133-146`), the shipped pattern.
+/// `Pattern51` = `0.5 * Pattern52`, the shipped pattern.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Pattern51;
 
-/// `0.5 * Pattern52::pattern2` (`patterns.h:146`).
+/// `0.5 * Pattern52::pattern2`.
 const PATTERN51_RAW: [[f32; 2]; 52] = scaled_pattern52(0.5);
 
 impl Pattern for Pattern51 {
@@ -176,7 +147,7 @@ mod tests {
         }
     }
 
-    /// The layout of the ASCII art in `patterns.h:82-101`: eight rows of
+    /// The layout of the ASCII art in : eight rows of
     /// descending `y`, and each row's `x` ascending.
     #[test]
     fn pattern52_rows_run_from_the_top_down_and_left_to_right() {
@@ -205,7 +176,7 @@ mod tests {
     }
 
     /// Both patterns are symmetric about the origin, which is what makes the
-    /// SE(2) rotation column of `Jw_se2` (`patch.h:114-115`) mean-free before
+    /// SE(2) rotation column of `Jw_se2` mean-free before
     /// normalisation.
     #[test]
     fn the_patterns_are_symmetric_about_the_origin() {

--- a/packages/slam-rs/crates/slam-rs/src/frontend/se2.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/se2.rs
@@ -1,31 +1,13 @@
-//! The 2-D warp the KLT tracker optimises: `Eigen::AffineCompact2f` and `Sophus::SE2::exp`.
-//!
-//! basalt stores a keypoint as an `Eigen::AffineCompact2f` — a 2x3 matrix whose
-//! left 2x2 block is the linear part and whose last column is the translation
-//! (`optical_flow.h:66`). The tracker's update is
-//! `transform *= SE2::exp(inc).matrix()` (`frame_to_frame_optical_flow.h:428`),
-//! where Eigen composes a compact 2x3 with a homogeneous 3x3 as the plain matrix
-//! product `2x3 * 3x3`, which is the same thing as composing the two 3x3
-//! transforms and dropping the last row.
-//!
-//! Only `exp` is needed: nothing on the tracking path takes a `log`, an inverse
-//! or an adjoint of an SE(2) element.
-//!
-//! The type is generic in the scalar for the same reason basalt's is
-//! (`OpticalFlowTyped<Scalar, Pattern>`, `optical_flow.h:184`): the shipped
-//! frontend runs `f32` ([`AffineCompact2f`], decision D05), and the ported
-//! `test_patch.cpp` Jacobian checks run `f64`, where a central difference is
-//! sharp enough to be a real test.
+//! The KLT tracker's 2-D affine warp and SE(2) exponential.
+//! A 2x2 linear part and translation compose as the first two rows of a
+//! homogeneous matrix product. Tracking needs only the exponential.
+//! The frontend uses f32; f64 supports sharp finite-difference Jacobian tests.
 
 use nalgebra::{Matrix2, Vector2, Vector3};
 
 use crate::lie::LieScalar;
 
-/// `Eigen::AffineCompact2<S>`: a 2x2 linear part and a translation.
-///
-/// The C++ type is a 2x3 matrix; keeping the two blocks apart costs nothing and
-/// names them the way `frame_to_frame_optical_flow.h` does
-/// (`transform.linear()`, `transform.translation()`).
+/// A 2x2 linear part and a translation, stored as separate blocks.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AffineCompact2<S: LieScalar> {
     /// `transform.linear()`, the 2x2 block.
@@ -34,7 +16,7 @@ pub struct AffineCompact2<S: LieScalar> {
     pub translation: Vector2<S>,
 }
 
-/// The frontend's warp type, `Eigen::AffineCompact2f` (`optical_flow.h:66`).
+/// The frontend's f32 affine warp.
 pub type AffineCompact2f = AffineCompact2<f32>;
 
 impl<S: LieScalar> Default for AffineCompact2<S> {
@@ -44,7 +26,7 @@ impl<S: LieScalar> Default for AffineCompact2<S> {
 }
 
 impl<S: LieScalar> AffineCompact2<S> {
-    /// `Eigen::AffineCompact2f::Identity()`.
+    /// Identity warp.
     pub fn identity() -> Self {
         Self {
             linear: Matrix2::identity(),
@@ -53,7 +35,6 @@ impl<S: LieScalar> AffineCompact2<S> {
     }
 
     /// An identity rotation at `position`, as `addPointsForCamera` builds one
-    /// (`frame_to_frame_optical_flow.h:600-601`).
     pub fn at(position: Vector2<S>) -> Self {
         Self {
             linear: Matrix2::identity(),
@@ -61,9 +42,7 @@ impl<S: LieScalar> AffineCompact2<S> {
         }
     }
 
-    /// `*this * other`, the 2x3-by-3x3 product Eigen performs for `operator*=`.
-    ///
-    /// `linear = self.linear * other.linear` and
+    /// Compose warps: `linear = self.linear * other.linear` and
     /// `translation = self.linear * other.translation + self.translation`.
     #[inline]
     pub fn compose(&self, other: &Self) -> Self {
@@ -92,7 +71,6 @@ impl<S: LieScalar> AffineCompact2<S> {
     /// The affine image of a pattern tap: `linear * tap + translation`.
     ///
     /// This is one column of the `transformed_pat` the tracker builds at
-    /// `frame_to_frame_optical_flow.h:411-412`
     /// (`transform.linear().matrix() * pattern2`, then `colwise() += translation`),
     /// in the same multiply-then-add order, so fusing the two statements into
     /// this call is bit-identical to materialising the 2xP matrix first.
@@ -105,27 +83,15 @@ impl<S: LieScalar> AffineCompact2<S> {
     }
 }
 
-/// `Sophus::SE2<S>::exp` (`Sophus/sophus/se2.hpp:609-630`), as an affine warp.
-///
-/// The tangent is `(t_x, t_y, theta)`. Three details are load-bearing and are
-/// reproduced literally:
-///
-/// * `SO2::exp(theta)` builds `SO2(cos theta, sin theta)` (`so2.hpp:453-457`),
-///   and that two-argument constructor **normalises** (`so2.hpp:415-418`,
-///   `:173-180`, `length = hypot(re, im)`). In `f32` the normalisation is not a
-///   no-op, and the normalised components are the ones the `V` factor below
-///   divides by.
-/// * The small-angle branch triggers at `Sophus::Constants<S>::epsilon()`
-///   (`common.hpp:166`, `:182-186`): `1e-10` in `f64` and `1e-5` in `f32`, both
-///   far larger than the machine epsilon `nalgebra` would pick, which is why
-///   [`LieScalar::SOPHUS_EPSILON`] exists.
-/// * The translation is `V(theta) * upsilon` written out as two scalar
-///   expressions (`se2.hpp:626-628`), not as a matrix product.
+/// SE(2) exponential for tangent `(t_x, t_y, theta)`.
+/// Normalize the sine/cosine pair before using it in the translation factor.
+/// The small-angle thresholds are `1e-10` in f64 and `1e-5` in f32.
+/// Translation is `V(theta) * upsilon`, evaluated as two scalar expressions.
 #[inline]
 pub fn se2_exp<S: LieScalar>(tangent: &Vector3<S>) -> AffineCompact2<S> {
     let one: S = S::one();
     let theta: S = tangent[2];
-    // `SO2<Scalar>::exp(theta)` — cos/sin, then normalise (`so2.hpp:415-418`).
+    // `SO2<Scalar>::exp(theta)` — cos/sin, then normalise.
     let cos_theta: S = theta.cos();
     let sin_theta: S = theta.sin();
     let length: S = cos_theta.hypot(sin_theta);

--- a/packages/slam-rs/crates/slam-rs/src/frontend/tracker.rs
+++ b/packages/slam-rs/crates/slam-rs/src/frontend/tracker.rs
@@ -1,65 +1,16 @@
-//! The SE(2) inverse-compositional KLT tracker, ported from
-//! `frame_to_frame_optical_flow.h:294-438`.
+//! Inverse-compositional SE(2) KLT tracking.
+//! Run bounded Gauss-Newton steps per level, coarse to fine, then track backward
+//! and keep points that return close enough to their sources.
 //!
-//! Three C++ functions come across:
+//! [`PatchTracker`] and [`SourcePatches`] use an associated pyramid type so CPU
+//! and GPU backends share the driver. Buffers use structure-of-arrays storage
+//! with patch index varying fastest and allocate only above their high-water mark.
 //!
-//! * `trackPointAtLevel` (`:404-438`) — up to `optical_flow_max_iterations`
-//!   Gauss-Newton steps on one pyramid level;
-//! * `trackPoint` (`:377-402`) — the coarse-to-fine sweep, with the source patch
-//!   rebuilt from the previous frame's pyramid at every level;
-//! * `trackPoints` (`:294-375`) — the whole keypoint set forward, then backward,
-//!   keeping only the tracks that come back to where they started.
-//!
-//! ## The stage seam
-//!
-//! [`PatchTracker`] and [`SourcePatches`] are the trait pair the frontend is
-//! generic over (`cubecl-portability.md` §12.1). Neither names a concrete
-//! pyramid: the pyramid type is associated, bounded by
-//! [`crate::pyramid::Pyramid`], so a CubeCL backend supplies its own device-side
-//! pyramid, patch storage and tracker and the driver compiles against it
-//! unchanged. [`CpuPatchTracker`] and [`PatchSoA`] are the CPU pair.
-//!
-//! ## Data layout
-//!
-//! Every per-patch buffer here is structure-of-arrays with the **patch index
-//! fast-varying**, so thread *i* of a warp reads element *i*: the patch taps and
-//! Jacobians in [`PatchSoA`], the positions in [`PointsSoA`], and the 2x3 warps
-//! in [`FlowTransforms`], whose six coefficients live in six flat arrays rather
-//! than one array of six-float records (§12.2). Nothing on this path is a map,
-//! and nothing on it allocates once the buffers have reached their high-water
-//! mark.
-//!
-//! ## What the port moves, and why nothing moves numerically
-//!
-//! **The source patches are hoisted into a [`PatchSoA`].** `trackPoint` builds
-//! `PatchT p(old_pyr.lvl(level), old_transform.translation() / scale)` inside its
-//! level loop (`:388`). That patch depends only on the previous pyramid, the
-//! source position and the level — never on anything the tracker computes — so
-//! building all of them up front is the same arithmetic in a different order, and
-//! it is the split a GPU wants: one kernel over (patch, level), then one over
-//! patches. The forward patches come in as an argument; the backward ones are
-//! built inside [`CpuPatchTracker`], because their positions are the forward
-//! result.
-//!
-//! **The three passes are separated.** basalt does forward track, mask test and
-//! backward track inside one per-point body. Here the forward pass runs over all
-//! points, then the backward patches are built, then the backward pass runs.
-//! Points are independent, so per-point values are identical; the mask test that
-//! sat between the two passes moves to the caller, which drops the same points
-//! one step later (see [`super::flow`]).
-//!
-//! **Loops have fixed bounds.** The C++ conditions its `for` on `patch_valid`
-//! (`:383`, `:408`). Breaking out early and running to the end with a no-op give
-//! the same numbers here, and only the second form ports to a GPU where the whole
-//! warp runs the maximum count anyway (§12.2). Invalid points therefore idle
-//! instead of exiting.
-//!
-//! **The masks and the depth guess stay outside.** `trackPoints` reads
-//! `masks1`/`masks2` and calls `calib.projectBetweenCams` (`:329`, `:335-342`),
-//! which would drag the calibration into the tracker. The driver applies both and
-//! hands over the already-offset guesses; the offset itself is recovered here as
-//! `source position - guess`, exactly the `off` the C++ adds back before the
-//! backward track (`:357`).
+//! Source patches depend only on the previous pyramid, position and level, so
+//! build them before tracking. Backward patches depend on forward results and
+//! are built between passes. Invalid points idle through fixed loop bounds to
+//! keep GPU execution uniform. Masks and depth guesses stay in the driver;
+//! the tracker receives guesses and recovers their source-position offsets.
 
 use nalgebra::{Matrix2, Vector2, Vector3};
 
@@ -70,41 +21,26 @@ use crate::frontend::se2::{AffineCompact2f, se2_exp};
 use crate::image::ImageU16;
 use crate::pyramid::{Pyramid, PyramidU16};
 
-/// The increment guard at `frame_to_frame_optical_flow.h:425`.
+/// Upper bound for a valid increment.
 ///
 /// `pub(crate)` so the GPU lane's kernels alias it rather than re-declaring the
 /// number: the two lanes have no compiler coupling otherwise.
 pub(crate) const MAX_INCREMENT_INFINITY_NORM: f32 = 1e6;
 
-/// `const int filter_margin = 2` (`frame_to_frame_optical_flow.h:430`).
+/// `const int filter_margin = 2`.
 ///
 /// `pub(crate)` for the same reason as [`MAX_INCREMENT_INFINITY_NORM`].
 pub(crate) const FILTER_MARGIN: f32 = 2.0;
 
-/// The most keypoints a tracker may be sized for.
-///
-/// basalt needs no such ceiling: its keypoint maps grow, so its memory follows
-/// the scene. The port preallocates every per-patch buffer
-/// ([`FrontendOptions::max_keypoints`](super::flow::FrontendOptions::max_keypoints)),
-/// which turns the budget into a memory request that arrives from outside — over
-/// the Python boundary among other places — and `2^63` keypoints panicked
-/// `Vec::with_capacity` with a capacity overflow before this existed.
-///
-/// A million keypoints is about 3.4 kB of patch storage each at pattern 51 over
-/// four pyramid levels, so roughly 7 GB across the two [`PatchSoA`] a
-/// [`CpuPatchTracker`] holds: far more than any rig this port runs (the shipped
-/// 50-pixel grid on a 960x960 frame produces about 400) and far below the point
-/// where the products in [`PatchSoA::new`] leave the `usize` range.
+/// Maximum tracker capacity, bounding caller-controlled preallocation.
+/// A million keypoints already implies roughly 7 GB across two patch sets with
+/// four Pattern51 levels, far above the shipped grid's needs. Rejecting larger
+/// requests prevents capacity arithmetic overflow at the public boundary.
 pub const MAX_CAPACITY: usize = 1 << 20;
 
-/// The most pyramid levels a tracker may be sized for.
-///
-/// `num_levels` is `optical_flow_levels + 1` and every per-patch buffer is sized
-/// with it, so it multiplies the capacity above. Each level halves both sides of
-/// the image: at 24 levels the top of the pyramid is one pixel of a 16-million
-/// pixel-wide frame, and basalt ships 3. Without a ceiling here a config asking
-/// for `10^12` levels turned into a 600-petabyte `Vec`, and a `Vec` that cannot be
-/// allocated aborts the process rather than returning.
+/// Maximum pyramid level count, limiting the capacity multiplier.
+/// Each level halves image dimensions. Unbounded counts could request storage
+/// large enough to abort allocation instead of returning an input error.
 pub const MAX_LEVELS: usize = 24;
 
 /// What the tracker can refuse.
@@ -296,13 +232,8 @@ impl PointsSoA {
     }
 }
 
-/// A list of `Eigen::AffineCompact2f` warps in six flat arrays.
-///
-/// The C++ keeps them as 2x3 matrices in a map (`optical_flow.h:66-68`), which
-/// gives one coefficient a stride of six floats across keypoints. Splitting the
-/// six coefficients into six arrays is the layout §12.2 asks for; callers that
-/// want one warp back get it through [`FlowTransforms::get`], which costs six
-/// loads and no indirection.
+/// Affine warps in six flat coefficient arrays, with keypoint index varying fastest.
+/// [`FlowTransforms::get`] reconstructs one warp with six loads.
 #[derive(Debug, Default, PartialEq)]
 pub struct FlowTransforms {
     m00: Vec<f32>,
@@ -775,7 +706,7 @@ impl<P: Pattern> PatchSoA<P> {
         self.num_levels
     }
 
-    /// Whether one patch at one level may be tracked (`patch.h:164-165`).
+    /// Whether one patch at one level may be tracked.
     ///
     /// # Panics
     ///
@@ -804,7 +735,7 @@ impl<P: Pattern> SourcePatches for PatchSoA<P> {
     /// Build every patch at every level from `pyramid`.
     ///
     /// One patch per entry of `positions`, at `position / (1 << level)` — the
-    /// `old_transform.translation() / scale` of `frame_to_frame_optical_flow.h:388`.
+    /// Source position divided by the pyramid scale.
     /// [`build_patch`] writes straight into this structure's arrays, so no packed
     /// per-patch record is ever built (§12.2).
     ///
@@ -836,7 +767,7 @@ impl<P: Pattern> SourcePatches for PatchSoA<P> {
                     actual: pyramid.num_levels(),
                 });
             };
-            // `const Scalar scale = 1 << level` (`frame_to_frame_optical_flow.h:384`).
+            // `const Scalar scale = 1 << level`.
             let scale: f32 = (1u32 << level) as f32;
             for index in 0..count {
                 if !selected.is_none_or(|flags| flags[index]) {
@@ -1090,16 +1021,12 @@ pub trait PatchTracker {
     /// The source-patch storage it consumes.
     type Patches: SourcePatches<Pyramid = Self::Pyramid>;
 
-    /// Track every patch of `patches` from `prev` into `next`.
-    ///
-    /// `transforms_in[i]` is basalt's `transform_2` before tracking: the linear
-    /// part of the source keypoint and the translation the caller guesses. The
-    /// source position itself is `patches.position(i)`.
+    /// Track source patches from `prev` to `next`.
+    /// `transforms_in` supplies source linear parts and guessed translations;
+    /// source positions come from `patches`.
     ///
     /// # Errors
-    ///
-    /// [`TrackerError`] when the inputs do not match the shape the tracker was
-    /// built for.
+    /// [`TrackerError`] if inputs do not match the allocated tracker geometry.
     fn track(
         &mut self,
         prev: &Self::Pyramid,
@@ -1264,7 +1191,7 @@ impl<P: Pattern> CpuPatchTracker<P> {
 
         out.reset(count);
 
-        // ── forward: `trackPoint(pyr_1, pyr_2, transform_1, transform_2)` (`:349`)
+        // ── forward: `trackPoint(pyr_1, pyr_2, transform_1, transform_2)`
         let max_iterations: usize = self.max_iterations;
         let num_levels: usize = self.num_levels;
         let (target_width, target_height): (f32, f32) = level0_size(next);
@@ -1274,7 +1201,7 @@ impl<P: Pattern> CpuPatchTracker<P> {
                 &mut self.forward_valid[..count],
                 |index| {
                     let guess: Vector2<f32> = transforms_in.translation(index);
-                    // `valid = t2(0) >= 0 && t2(1) >= 0 && t2(0) < w && t2(1) < h` (`:346`).
+                    // `valid = t2(0) >= 0 && t2(1) >= 0 && t2(0) < w && t2(1) < h`.
                     if guess.x < 0.0
                         || guess.y < 0.0
                         || guess.x >= target_width
@@ -1316,7 +1243,7 @@ impl<P: Pattern> CpuPatchTracker<P> {
             backward.build(next, backward_positions, Some(&forward_valid[..count]))?;
         }
 
-        // ── backward: `trackPoint(pyr_2, pyr_1, transform_2, transform_1_recovered)` (`:359`)
+        // ── backward: `trackPoint(pyr_2, pyr_1, transform_2, transform_1_recovered)`
         let backward: &PatchSoA<P> = &self.backward;
         let forward: &FlowTransforms = &self.forward;
         let forward_valid: &[bool] = &self.forward_valid[..count];
@@ -1331,8 +1258,8 @@ impl<P: Pattern> CpuPatchTracker<P> {
                     if !forward_valid[index] {
                         return (kept, false);
                     }
-                    // `off = t2 - t2_guess` with `t2 == t1` at that point (`:339`),
-                    // so `off == source position - guess`; `t1_recovered += off` (`:357`).
+                    // `off = t2 - t2_guess` with `t2 == t1` at that point,
+                    // so `off == source position - guess`; `t1_recovered += off`.
                     let source: Vector2<f32> = patches.position(index);
                     let offset: Vector2<f32> = source - transforms_in.translation(index);
                     let recovered_guess: Vector2<f32> = forward.translation(index) + offset;
@@ -1348,7 +1275,7 @@ impl<P: Pattern> CpuPatchTracker<P> {
                     if !ok {
                         return (kept, false);
                     }
-                    // `dist2 = (t1 - t1_recovered).squaredNorm()` (`:362`).
+                    // `dist2 = (t1 - t1_recovered).squaredNorm()`.
                     let dist2: f32 = (source - recovered.translation).norm_squared();
                     (kept, dist2 < max_recovered_dist2)
                 },
@@ -1360,13 +1287,7 @@ impl<P: Pattern> CpuPatchTracker<P> {
     }
 }
 
-/// Level 0's `(width, height)` as floats, standing in for basalt's `w`, `h`.
-///
-/// basalt reads `calib.resolution.at(0)` for every camera
-/// (`frame_to_frame_optical_flow.h:108-109`, trap 16); the port reads the target
-/// camera's own level-0 size, which is the same number for a rig whose cameras
-/// share a resolution and the right one for msd-g2, whose cameras do not
-/// (decision D30).
+/// Target camera's level-zero dimensions as floats, supporting mixed-resolution rigs.
 fn level0_size(pyramid: &PyramidU16) -> (f32, f32) {
     // `check_track_inputs` refuses a pyramid with fewer levels than the patch
     // set, and the patch set always has at least one, so level 0 is there. The
@@ -1379,12 +1300,12 @@ fn level0_size(pyramid: &PyramidU16) -> (f32, f32) {
     }
 }
 
-/// `trackPoint` (`frame_to_frame_optical_flow.h:377-402`).
+/// `trackPoint`.
 ///
 /// Coarse to fine, with the translation divided by `1 << level` on the way in and
-/// multiplied back on the way out (`:386`, `:396`) — both exact in `f32`, since
-/// the scale is a power of two. The linear part starts at the identity (`:381`)
-/// and is composed with the source's at the end (`:399`), so the SE(2) rotation
+/// multiplied back on the way out — both exact in `f32`, since
+/// the scale is a power of two. The linear part starts at the identity
+/// and is composed with the source's at the end, so the SE(2) rotation
 /// is re-estimated from scratch at every frame pair and never warm-started
 /// (`papers-part2.md` §13 deviation D7).
 fn track_point<P: Pattern>(
@@ -1404,8 +1325,7 @@ fn track_point<P: Pattern>(
 
     for level in (0..num_levels).rev() {
         if !patch_valid {
-            // The C++ `for` exits here (`:383`); running the remaining levels as
-            // a no-op keeps the bound fixed and the numbers identical.
+            // Idle through remaining levels after failure to keep loop bounds fixed.
             continue;
         }
         let scale: f32 = (1u32 << level) as f32;
@@ -1430,13 +1350,13 @@ fn track_point<P: Pattern>(
     (transform, patch_valid)
 }
 
-/// `trackPointAtLevel` (`frame_to_frame_optical_flow.h:404-438`).
+/// `trackPointAtLevel`.
 ///
 /// One Gauss-Newton step is: warp the pattern, take the mean-normalised residual,
 /// `inc = -H_se2^-1 J_se2^T r`, reject a non-finite or huge increment
-/// (`:422-425`, because `SE2::exp` crashes on NaN), apply it on the right
-/// (`transform *= SE2::exp(inc)`, `:428`) and require the new centre to stay two
-/// pixels inside the image (`:430-432`).
+/// (because `SE2::exp` crashes on NaN), apply it on the right
+/// (`transform *= SE2::exp(inc)`) and require the new centre to stay two
+/// pixels inside the image.
 fn track_point_at_level<P: Pattern>(
     image: &ImageU16,
     patches: &PatchSoA<P>,
@@ -1454,7 +1374,7 @@ fn track_point_at_level<P: Pattern>(
 
     for _ in 0..max_iterations {
         if !patch_valid {
-            // `for (iteration = 0; patch_valid && ...)` (`:408`), as a no-op.
+            // `for (iteration = 0; patch_valid &&...)`, as a no-op.
             continue;
         }
 
@@ -1475,9 +1395,7 @@ fn track_point_at_level<P: Pattern>(
             );
 
             patch_valid &= increment.iter().all(|value| value.is_finite());
-            // `inc.lpNorm<Eigen::Infinity>()` is `cwiseAbs().maxCoeff()`, whose
-            // reduction is `(a < b) ? b : a` from element 0 — spelled out so a
-            // NaN takes the same branch it takes in C++.
+            // Fold absolute coefficients from element zero, retaining a left-hand NaN.
             let mut infinity_norm: f32 = increment[0].abs();
             for row in 1..3 {
                 let candidate: f32 = increment[row].abs();

--- a/packages/slam-rs/crates/slam-rs/src/gpu/detect.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/detect.rs
@@ -293,7 +293,7 @@ impl<R: Runtime> GpuCornerScan<R> {
                 // and one under zero is every candidate.
                 threshold: select.threshold.clamp(0, 255) as u32,
                 safe_radius: select.safe_radius,
-                // `img_raw.w / 2` is an integer halving (`keypoints.cpp:176`).
+                // `img_raw.w / 2` is an integer halving.
                 centre_x: (width / 2) as f32,
                 centre_y: (height / 2) as f32,
             },
@@ -671,7 +671,7 @@ impl<R: Runtime> CornerScan for GpuCornerScan<R> {
             return Err(DetectError::NotScanned);
         };
         // `row_start = rows.start.max(margin)`, `row_end = rows.end.min(height -
-        // margin)` (`fast.rs:495-498`).
+        // margin)` (`fast.rs).
         let first: usize = request.y.max(FAST_BORDER);
         let last: usize = (request.y + request.rows).min(self.height.saturating_sub(FAST_BORDER));
         let (width, stride): (usize, usize) = (self.width, self.words);

--- a/packages/slam-rs/crates/slam-rs/src/gpu/detect.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/detect.rs
@@ -671,7 +671,7 @@ impl<R: Runtime> CornerScan for GpuCornerScan<R> {
             return Err(DetectError::NotScanned);
         };
         // `row_start = rows.start.max(margin)`, `row_end = rows.end.min(height -
-        // margin)` (`fast.rs).
+        // margin)` (`fast.rs`).
         let first: usize = request.y.max(FAST_BORDER);
         let last: usize = (request.y + request.rows).min(self.height.saturating_sub(FAST_BORDER));
         let (width, stride): (usize, usize) = (self.width, self.words);

--- a/packages/slam-rs/crates/slam-rs/src/gpu/kernels/cell_select.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/kernels/cell_select.rs
@@ -145,7 +145,7 @@ fn fast_cell_select_kernel(
         last_y = height - SELECT_MARGIN;
     }
 
-    // `border <= x && x < w - border - 1` (`image.h:687-689`), hoisted.
+    // `border <= x && x < w - border - 1`, hoisted.
     let edge_x = f32::cast_from(width) - SELECT_EDGE - 1.0f32;
     let edge_y = f32::cast_from(height) - SELECT_EDGE - 1.0f32;
 
@@ -280,8 +280,7 @@ fn fast_cell_select_kernel(
                     let fy = f32::cast_from(y);
                     let dx = fx - centre_x;
                     let dy = fy - centre_y;
-                    // `Eigen::Vector2f{...}.norm()`, not `hypot`
-                    // (`keypoints.cpp:176`).
+                    // Use sqrt of the sum of squares, not hypot.
                     let distance = f32::sqrt(dx * dx + dy * dy);
                     let mut inside = true;
                     if safe_radius != 0.0f32 && distance >= safe_radius {

--- a/packages/slam-rs/crates/slam-rs/src/gpu/kernels/fast.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/kernels/fast.rs
@@ -13,7 +13,7 @@ use cubecl::prelude::*;
 /// bias cancels without a signed intermediate.
 pub(crate) const RING_BIAS: usize = 3;
 
-/// kornia's `corner_score_9_scalar` (`fast.rs:838`) over every pixel.
+/// kornia's `corner_score_9_scalar` (`fast.rs) over every pixel.
 ///
 /// The score is FAST-9's own: the maximum over the sixteen arc starts of the
 /// minimum over nine consecutive saturating differences, on the bright and the
@@ -48,7 +48,7 @@ fn fast_score_kernel(
         terminate!();
     }
 
-    // `sub_ptr[x] = (sub_img_raw(x, y) >> 8)` (`keypoints.cpp:156`), on the
+    // `sub_ptr[x] = (sub_img_raw(x, y) >> 8)`, on the
     // device: uploading the `u16` frame and shifting here costs 0.9 MB more over
     // the bus and saves a whole-frame pass on the host, which measured the
     // larger of the two.
@@ -117,7 +117,7 @@ const FILTER_LANES: usize = crate::frontend::detect::FAST_FILTER_LANES;
 /// The last lane of a block, which has no right-hand neighbour to beat.
 const FILTER_LAST: usize = FILTER_LANES - 1;
 
-/// kornia's in-block local-maximum filter (`fast.rs:539-553`).
+/// kornia's in-block local-maximum filter (`fast.rs).
 ///
 /// Turned on at `width >= 800`, where dense-corner images emit so many
 /// candidates that `Vec::push` dominates the CPU kernel; kornia keeps a lane

--- a/packages/slam-rs/crates/slam-rs/src/gpu/kernels/fast.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/kernels/fast.rs
@@ -13,7 +13,7 @@ use cubecl::prelude::*;
 /// bias cancels without a signed intermediate.
 pub(crate) const RING_BIAS: usize = 3;
 
-/// kornia's `corner_score_9_scalar` (`fast.rs) over every pixel.
+/// kornia's `corner_score_9_scalar` (`fast.rs`) over every pixel.
 ///
 /// The score is FAST-9's own: the maximum over the sixteen arc starts of the
 /// minimum over nine consecutive saturating differences, on the bright and the
@@ -117,7 +117,7 @@ const FILTER_LANES: usize = crate::frontend::detect::FAST_FILTER_LANES;
 /// The last lane of a block, which has no right-hand neighbour to beat.
 const FILTER_LAST: usize = FILTER_LANES - 1;
 
-/// kornia's in-block local-maximum filter (`fast.rs).
+/// kornia's in-block local-maximum filter (`fast.rs`).
 ///
 /// Turned on at `width >= 800`, where dense-corner images emit so many
 /// candidates that `Vec::push` dominates the CPU kernel; kornia keeps a lane

--- a/packages/slam-rs/crates/slam-rs/src/gpu/kernels/layout.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/kernels/layout.rs
@@ -36,7 +36,8 @@ pub const TILE_H: u32 = 8;
 pub(crate) const PATCH_BORDER: f32 = crate::frontend::patch::PATCH_BORDER;
 /// `const int filter_margin = 2`.
 pub(crate) const FILTER_MARGIN: f32 = crate::frontend::tracker::FILTER_MARGIN;
-/// The increment guard at.
+/// Upper bound for a valid increment, aliased from the CPU tracker so both
+/// lanes share one number.
 pub(crate) const MAX_INCREMENT_INFINITY_NORM: f32 =
     crate::frontend::tracker::MAX_INCREMENT_INFINITY_NORM;
 /// `Sophus::Constants<float>::epsilon()`.

--- a/packages/slam-rs/crates/slam-rs/src/gpu/kernels/layout.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/kernels/layout.rs
@@ -32,14 +32,14 @@ pub const TILE_H: u32 = 8;
 // The four numbers below are the CPU lane's own, aliased rather than
 // re-declared: a kernel that drifted from its reference by a constant would
 // still compile, and `FILTER_LANES` below already shows the shape.
-/// `border` on every patch tap, `PATCH_BORDER` (`patch.h:87`).
+/// `border` on every patch tap, `PATCH_BORDER`.
 pub(crate) const PATCH_BORDER: f32 = crate::frontend::patch::PATCH_BORDER;
-/// `const int filter_margin = 2` (`frame_to_frame_optical_flow.h:430`).
+/// `const int filter_margin = 2`.
 pub(crate) const FILTER_MARGIN: f32 = crate::frontend::tracker::FILTER_MARGIN;
-/// The increment guard at `frame_to_frame_optical_flow.h:425`.
+/// The increment guard at.
 pub(crate) const MAX_INCREMENT_INFINITY_NORM: f32 =
     crate::frontend::tracker::MAX_INCREMENT_INFINITY_NORM;
-/// `Sophus::Constants<float>::epsilon()` (`common.hpp:182-186`).
+/// `Sophus::Constants<float>::epsilon()`.
 pub(crate) const SOPHUS_EPSILON: f32 = <f32 as crate::lie::LieScalar>::SOPHUS_EPSILON;
 
 /// A device buffer and the element count the kernel will see in it.

--- a/packages/slam-rs/crates/slam-rs/src/gpu/kernels/patch.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/kernels/patch.rs
@@ -4,22 +4,12 @@ use super::layout::*;
 use super::sampling::{in_bounds, interp_grad_into};
 use cubecl::prelude::*;
 
-// Per-frame launchers use launch_unchecked. Stage shape checks establish
-// the binding lengths; each raw binding keeps its handle and element count
-// together. The storage probe alone retains checked launch mode.
-// ── Eigen's pivoted LDLT at size three ───────────────────────────────────────
+// Per-frame launchers use unchecked launch after stage shape validation.
+// Each binding retains its handle and element count; only the storage probe uses checked launch.
 
-/// `internal::ldlt_inplace<Lower>::unblocked` at size 3 (`LDLT.h:277-380`),
-/// in place on a row-major 3x3.
-///
-/// A transcription of [`crate::frontend::ldlt::ldlt_inverse3`]'s first half,
-/// including the part that matters: on a rank-deficient `H` the pivot below
-/// `numeric_limits<float>::min()` is *skipped* rather than divided by, so a
-/// patch on a one-dimensional texture comes out with a finite zero-valued
-/// `H^-1 J^T` and stays valid, as it does in the C++.
-///
-/// `transpositions` and the early-out for an all-zero diagonal use a flag
-/// rather than a `return`, which a `#[cube]` function does not have.
+/// In-place guarded pivoted LDLT on a row-major 3x3 matrix.
+/// Tiny pivots get zero weight instead of division, keeping rank-deficient patch
+/// factors finite. Flags replace early returns for uniform device execution.
 #[cube]
 fn ldlt_decompose3(mat: &mut Array<f32>, transpositions: &mut Array<usize>) {
     let mut temp = Array::<f32>::new(3usize);
@@ -27,7 +17,7 @@ fn ldlt_decompose3(mat: &mut Array<f32>, transpositions: &mut Array<usize>) {
 
     for k in 0..3usize {
         if !done {
-            // "Find largest diagonal element" (`LDLT.h:305-307`); `maxCoeff`
+            // "Find largest diagonal element"; `maxCoeff`
             // reports the first index of the maximum, so ties take the earliest.
             let mut biggest = k;
             for i in (k + 1usize)..3usize {
@@ -39,7 +29,6 @@ fn ldlt_decompose3(mat: &mut Array<f32>, transpositions: &mut Array<usize>) {
 
             if k != biggest {
                 // "taking care to consider only the lower triangular part"
-                // (`LDLT.h:311-324`).
                 for j in 0..k {
                     let swap = mat[k * 3usize + j];
                     mat[k * 3usize + j] = mat[biggest * 3usize + j];
@@ -60,7 +49,7 @@ fn ldlt_decompose3(mat: &mut Array<f32>, transpositions: &mut Array<usize>) {
                 }
             }
 
-            // The delayed column updates through `temp` (`LDLT.h:326-338`).
+            // The delayed column updates through `temp`.
             if k > 0usize {
                 for i in 0..k {
                     temp[i] = mat[i * 3usize + i] * mat[k * 3usize + i];
@@ -79,7 +68,7 @@ fn ldlt_decompose3(mat: &mut Array<f32>, transpositions: &mut Array<usize>) {
                 }
             }
 
-            // LAPACK's cutoff of exactly zero (`LDLT.h:340-361`).
+            // LAPACK's cutoff of exactly zero.
             let pivot = mat[k * 3usize + k];
             let pivot_is_valid = f32::abs(pivot) > 0.0f32;
             if k == 0usize && !pivot_is_valid {
@@ -98,11 +87,11 @@ fn ldlt_decompose3(mat: &mut Array<f32>, transpositions: &mut Array<usize>) {
     }
 }
 
-/// `LDLT::_solve_impl_transposed<true>` at size 3 (`LDLT.h:543-577`), in place
+/// `LDLT::_solve_impl_transposed<true>` at size 3, in place
 /// on a row-major 3x3 right-hand side.
 #[cube]
 fn ldlt_solve3(mat: &Array<f32>, transpositions: &Array<usize>, rhs: &mut Array<f32>) {
-    // `dst = m_transpositions * rhs`: k ascending (`ProductEvaluators.h:1194`).
+    // `dst = m_transpositions * rhs`: k ascending.
     for k in 0..3usize {
         let target = transpositions[k];
         if target != k {
@@ -123,7 +112,7 @@ fn ldlt_solve3(mat: &Array<f32>, transpositions: &Array<usize>, rhs: &mut Array<
             }
         }
     }
-    // "more precisely, use pseudo-inverse of D" (`LDLT.h:551-568`): the
+    // "more precisely, use pseudo-inverse of D" : the
     // tolerance is `numeric_limits<float>::min()`, the smallest positive normal.
     for i in 0..3usize {
         let d = mat[i * 3usize + i];
@@ -164,7 +153,7 @@ fn ldlt_solve3(mat: &Array<f32>, transpositions: &Array<usize>, rhs: &mut Array<
 
 // ── the patch build ──────────────────────────────────────────────────────────
 
-/// `patch::build_patch` (`patch.h:101-166`) over one patch at one level.
+/// `patch::build_patch` over one patch at one level.
 ///
 /// One cube per `(patch, level)`, one unit per pattern tap. Three reductions
 /// run on unit 0 in ascending tap order — the tap sum with `grad_sum_se2`, the
@@ -172,7 +161,7 @@ fn ldlt_solve3(mat: &Array<f32>, transpositions: &Array<usize>, rhs: &mut Array<
 /// order is the value (decision D31).
 ///
 /// The product-rule correction that comes from differentiating the `1/mean`
-/// factor (`patch.h:135`) is applied with the **raw** tap, before the tap is
+/// factor is applied with the **raw** tap, before the tap is
 /// normalised, and the rows of out-of-bounds taps are zeroed: dropping that
 /// term gives a Jacobian that looks right and converges to the wrong warp.
 #[cube(launch, launch_unchecked)]
@@ -218,7 +207,7 @@ fn patch_build_kernel(
     let mut okflag = SharedMemory::<usize>::new(TAP_SLOTS);
     let mut red = SharedMemory::<f32>::new(16usize);
 
-    // `const Scalar scale = 1 << level` (`frame_to_frame_optical_flow.h:384`).
+    // `const Scalar scale = 1 << level`.
     let scale = f32::cast_from(1usize << level);
     let pos_x = positions[pos_x_base + patch] / scale;
     let pos_y = positions[pos_y_base + patch] / scale;
@@ -261,7 +250,7 @@ fn patch_build_kernel(
                 );
             }
             // `valGrad.tail<2>().transpose() * Jw_se2` with
-            // `Jw_se2 = [[1, 0, -tap_y], [0, 1, tap_x]]` (`patch.h:107-115`).
+            // `Jw_se2 = [[1, 0, -tap_y], [0, 1, tap_x]]`.
             grad_t[tap] = grad_x[tap] * -tap_y + grad_y[tap] * tap_x;
             okflag[tap] = 1usize;
         } else {
@@ -291,7 +280,7 @@ fn patch_build_kernel(
         }
         let points = f32::cast_from(valid_points);
         red[0usize] = sum;
-        // `mean = sum / n` and `mean_inv = n / sum` (`patch.h:129`, `:131`) are
+        // `mean = sum / n` and `mean_inv = n / sum` are
         // two separate divisions, not reciprocals of each other.
         red[1usize] = sum / points;
         red[2usize] = points / sum;
@@ -319,7 +308,7 @@ fn patch_build_kernel(
     sync_cube();
 
     if tap == 0usize {
-        // `H_se2 = J^T J` (`patch.h:151`), one rank-1 outer product per tap.
+        // `H_se2 = J^T J`, one rank-1 outer product per tap.
         let mut hessian = Array::<f32>::new(9usize);
         for i in 0..9usize {
             hessian[i] = 0.0f32;
@@ -355,7 +344,7 @@ fn patch_build_kernel(
     sync_cube();
 
     if tap < taps {
-        // `H_se2_inv_J_se2_T.col(i) = H^-1 * J^T.col(i)` (`patch.h:156`).
+        // `H_se2_inv_J_se2_T.col(i) = H^-1 * J^T.col(i)`.
         let c0 = grad_x[tap];
         let c1 = grad_y[tap];
         let c2 = grad_t[tap];
@@ -380,7 +369,7 @@ fn patch_build_kernel(
     sync_cube();
 
     if tap == 0usize {
-        // `valid = mean > eps && H^-1 J^T finite && data finite` (`patch.h:164`).
+        // `valid = mean > eps && H^-1 J^T finite && data finite`.
         let mut finite = true;
         for i in 0..taps {
             if okflag[i] == 0usize {

--- a/packages/slam-rs/crates/slam-rs/src/gpu/kernels/pyramid.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/kernels/pyramid.rs
@@ -7,7 +7,7 @@ use cubecl::prelude::*;
 // together. The storage probe alone retains checked launch mode.
 // ── the pyramid ──────────────────────────────────────────────────────────────
 
-/// `border101` for an index past the high end (`image_pyr.h:83`).
+/// `border101` for an index past the high end.
 ///
 /// `h - 1 - |h - 1 - x|`, written without an absolute value so it needs no
 /// signed intermediate: below `h` it is the identity, at or above it the
@@ -17,7 +17,7 @@ fn reflect_high(x: usize, h: usize) -> usize {
     if x < h { x } else { h + h - 2usize - x }
 }
 
-/// `std::abs(2 * r - k)` (`image_pyr.h:110-111`), which is the *other*
+/// `std::abs(2 * r - k)`, which is the *other*
 /// reflection: about zero rather than about the far edge. Trap 3 of the
 /// architecture dossier is that these two are not one function.
 // `usize::abs_diff` is not in CubeCL's kernel language, so the subtraction is
@@ -47,18 +47,10 @@ fn subsample_band(
         + usize::cast_from(src[row_base + c4])
 }
 
-/// [`crate::pyramid::subsample`] (`image_pyr.h:99-140`) as one fused 5x5 pass.
-///
-/// The CPU port runs the separable form: a vertical pass into an `i32`
-/// accumulator, then a horizontal pass with one rounding at the very end. Both
-/// passes are exact integer sums, so the fused 5x5 here is **bit-exact** with
-/// it — which is why this kernel's tolerance test asserts equality rather than
-/// a bound. Row indices reflect about the source height and column indices
-/// about the source width, exactly as the transposed C++ accumulator makes
-/// them (see the CPU docstring). Every pixel is non-negative and the
-/// accumulator peaks at `65535 * 16 * 16 = 16,776,960`, so `usize` carries it and
-/// `>> 8` is the C++ shift rather than a division that would differ on a
-/// negative value.
+/// Fused 5x5 counterpart of [`crate::pyramid::subsample`].
+/// Exact integer sums and one final rounding make it equal to the separable CPU
+/// filter. Reflect rows about source height and columns about source width.
+/// The maximum accumulator is `65535 * 16 * 16`, which fits the working integer.
 #[cube(launch, launch_unchecked)]
 #[allow(clippy::too_many_arguments)]
 fn subsample_kernel(
@@ -94,7 +86,7 @@ fn subsample_kernel(
         + 4usize * subsample_band(src, src_base + r3 * src_width, c0, c1, col2, c3, c4)
         + subsample_band(src, src_base + r4 * src_width, c0, c1, col2, c3, c4);
 
-    // `T val = ((val_int + (1 << 7)) >> 8)` (`image_pyr.h:135`).
+    // `T val = ((val_int + (1 << 7)) >> 8)`.
     dst[dst_base + r * dst_width + c] = u16::cast_from((acc + 128usize) >> 8usize);
 }
 

--- a/packages/slam-rs/crates/slam-rs/src/gpu/kernels/sampling.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/kernels/sampling.rs
@@ -7,7 +7,7 @@ use cubecl::prelude::*;
 // together. The storage probe alone retains checked launch mode.
 // ── sampling ─────────────────────────────────────────────────────────────────
 
-/// `ImageU16::in_bounds` (`image.h:694-705`).
+/// `ImageU16::in_bounds`.
 #[cube]
 pub(crate) fn in_bounds(x: f32, y: f32, border: f32, width: usize, height: usize) -> bool {
     border <= x
@@ -22,8 +22,7 @@ fn at(image: &Array<u16>, base: usize, stride: usize, x: usize, y: usize) -> f32
     f32::cast_from(image[base + y * stride + x])
 }
 
-/// `ImageU16::interp` (`image.h:396-415`), with the multiplication grouping and
-/// the summation order the CPU port reproduces from Eigen.
+/// Bilinear sampling with the CPU implementation's multiplication grouping and sum order.
 #[cube]
 pub(crate) fn interp(image: &Array<u16>, base: usize, stride: usize, x: f32, y: f32) -> f32 {
     let ix = usize::cast_from(x);
@@ -38,7 +37,7 @@ pub(crate) fn interp(image: &Array<u16>, base: usize, stride: usize, x: f32, y: 
         + dx * dy * at(image, base, stride, ix + 1usize, iy + 1usize)
 }
 
-/// `ImageU16::interp_grad` (`image.h:418-469`) writing its three results into
+/// `ImageU16::interp_grad` writing its three results into
 /// three shared arrays at `slot`.
 ///
 /// The value is the bilinear surface; the gradient is the *central difference*

--- a/packages/slam-rs/crates/slam-rs/src/gpu/kernels/track.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/kernels/track.rs
@@ -51,24 +51,14 @@ fn compose_se2_exp(state: &mut SharedMemory<f32>, t0: f32, t1: f32, theta: f32) 
     state[5usize] = m10 * exp_x + m11 * exp_y + state[5usize];
 }
 
-/// `tracker::track_point` and `track_point_at_level`
-/// (`frame_to_frame_optical_flow.h:377-438`), one cube per patch.
-///
-/// The coarse-to-fine sweep and the Gauss-Newton loop both run to their fixed
-/// bounds with a shared `alive` flag standing in for the C++ loop conditions —
-/// the CPU port already made that substitution and proved it changes no value
-/// (§12.2). Every `sync_cube` here is cube-uniform: the flag lives in shared
-/// memory and is read into a local *after* a barrier, so a unit never skips a
-/// barrier its neighbours reach.
-///
-/// `check_guess_bounds` is the `valid = t2 in [0, w) x [0, h)` test at `:346`,
-/// which the forward pass makes and the backward pass does not. When it fails
-/// the C++ returns the plain identity rather than the composed warp, and so
-/// does this: `alive[2usize]` records whether the sweep ran at all.
+/// Coarse-to-fine KLT, one cube per patch.
+/// Fixed-bound loops use a shared alive flag. Read it after barriers so no unit
+/// skips a barrier reached by its neighbors. Forward tracking checks the initial
+/// guess bounds; backward tracking does not. An invalid initial guess returns
+/// identity, recorded separately from failure after the sweep starts.
 #[cube(launch, launch_unchecked)]
-// `!(x < y)` is deliberate: it is how the C++ spells the increment guard, so a
-// NaN takes the branch it takes there. The initialisers of the locals that
-// stand in for an `if` expression are never read, which is the point.
+// Negated comparisons reject NaNs. Conditional store values use locals to avoid
+// the device compiler's conditional-store miscompile.
 #[allow(
     clippy::too_many_arguments,
     clippy::neg_cmp_op_on_partial_ord,
@@ -79,12 +69,8 @@ fn klt_kernel(
     pyramid_b: &Array<u16>,
     meta: &Array<u32>,
     store: &Array<f32>,
-    // One binding, read and written, not two views of the same buffer. Every
-    // caller passes the same handle for both roles — the C++ composes the warp
-    // in place (`:399`) — and wgpu refuses a buffer bound `STORAGE_READ_ONLY`
-    // and `STORAGE_READ_WRITE` in one dispatch, which is a validation error on
-    // any adapter whose pool does not merge the two slices into one binding.
-    // The cap's Mali G610 is that adapter.
+    // Compose the warp in place through one read/write binding. Binding the same
+    // buffer separately as read-only and read/write is invalid on some wgpu adapters.
     transforms: &mut Array<f32>,
     capacity: usize,
     taps: usize,
@@ -135,7 +121,7 @@ fn klt_kernel(
         }
         alive[0usize] = entered;
         alive[2usize] = entered;
-        // `transform.linear = identity`, `transform.translation = guess` (`:381`).
+        // `transform.linear = identity`, `transform.translation = guess`.
         state[0usize] = 1.0f32;
         state[1usize] = 0.0f32;
         state[2usize] = 0.0f32;
@@ -150,12 +136,12 @@ fn klt_kernel(
         if tap == 0usize {
             alive[1usize] = alive[0usize];
             if alive[0usize] == 1usize {
-                // `transform.translation /= scale` (`:386`), exact for a power of two.
+                // `transform.translation /= scale`, exact for a power of two.
                 let scale = f32::cast_from(1usize << level);
                 state[8usize] = scale;
                 state[4usize] /= scale;
                 state[5usize] /= scale;
-                // `patch_valid &= patches.valid(level, index)` (`:389`).
+                // `patch_valid &= patches.valid(level, index)`.
                 if store[4usize * data_len + level * capacity + patch] == 0.0f32 {
                     alive[0usize] = 0usize;
                 }
@@ -170,7 +156,7 @@ fn klt_kernel(
 
         for _iteration in 0..max_iterations {
             let sampling = alive[0usize] == 1usize;
-            // `residual(img, transform * pattern2, res)` (`patch.h:168-202`),
+            // `residual(img, transform * pattern2, res)`,
             // with the warp applied per tap.
             if sampling && tap < taps {
                 let tap_x = f32::reinterpret(meta[pattern + tap * 2usize]);
@@ -202,7 +188,7 @@ fn klt_kernel(
                         valid_points += 1u32;
                     }
                 }
-                // An all-black target cannot be normalised (`patch.h:183-186`).
+                // An all-black target cannot be normalised.
                 if sum < f32::new(f32::EPSILON) {
                     alive[0usize] = 0usize;
                 }
@@ -213,7 +199,7 @@ fn klt_kernel(
 
             let solving = alive[0usize] == 1usize;
             if solving && tap < taps {
-                // `res[i] = num_valid_points * val / sum - data[i]` (`patch.h:193`).
+                // `res[i] = num_valid_points * val / sum - data[i]`.
                 let sum = state[6usize];
                 let points = state[7usize];
                 let stored = store[(level * taps + tap) * capacity + patch];
@@ -239,11 +225,11 @@ fn klt_kernel(
                         residuals += 1u32;
                     }
                 }
-                // `return num_residuals > PATTERN_SIZE / 2` (`patch.h:201`).
+                // `return num_residuals > PATTERN_SIZE / 2`.
                 if residuals * 2u32 <= u32::cast_from(taps) {
                     alive[0usize] = 0usize;
                 } else {
-                    // `inc = -H_se2_inv_J_se2_T * res` (`:419`), taps ascending.
+                    // `inc = -H_se2_inv_J_se2_T * res`, taps ascending.
                     let mut sum_0 = 0.0f32;
                     let mut sum_1 = 0.0f32;
                     let mut sum_2 = 0.0f32;
@@ -256,8 +242,7 @@ fn klt_kernel(
                     let inc_1 = -sum_1;
                     let inc_2 = -sum_2;
                     let mut ok = is_finite(inc_0) && is_finite(inc_1) && is_finite(inc_2);
-                    // `inc.lpNorm<Infinity>()` is `(a < b) ? b : a` from element 0,
-                    // spelled out so a NaN takes the branch it takes in C++.
+                    // Fold the infinity norm from element zero, retaining a left-hand NaN.
                     let mut infinity_norm = f32::abs(inc_0);
                     if infinity_norm < f32::abs(inc_1) {
                         infinity_norm = f32::abs(inc_1);
@@ -270,7 +255,7 @@ fn klt_kernel(
                     }
                     if ok {
                         compose_se2_exp(&mut state, inc_0, inc_1, inc_2);
-                        // The new centre must stay two pixels inside (`:430-432`).
+                        // The new centre must stay two pixels inside.
                         if !in_bounds(state[4usize], state[5usize], FILTER_MARGIN, width, height) {
                             ok = false;
                         }
@@ -284,8 +269,7 @@ fn klt_kernel(
         }
 
         if tap == 0usize && alive[1usize] == 1usize {
-            // `transform.translation *= scale` (`:396`), which the C++ runs even
-            // when the level just failed.
+            // Scale translation even when this level failed.
             let scale = state[8usize];
             state[4usize] *= scale;
             state[5usize] *= scale;
@@ -295,7 +279,7 @@ fn klt_kernel(
 
     if tap == 0usize {
         if alive[2usize] == 1usize {
-            // `transform.linear = old_linear * transform.linear` (`:399`).
+            // `transform.linear = old_linear * transform.linear`.
             // Read into locals before the first write: the four coefficients
             // are at the indices the composed warp overwrites.
             let o00 = transforms[patch];
@@ -321,7 +305,7 @@ fn klt_kernel(
     }
 }
 
-/// The backward pass's inputs, from the forward result (`:355-359`).
+/// The backward pass's inputs, from the forward result.
 ///
 /// `off = t2 - t2_guess` with `t2 == t1` at that point, so
 /// `off == source position - guess`, and `t1_recovered = forward + off`; the
@@ -350,13 +334,13 @@ fn prepare_backward_kernel(
     out[6usize * count + index] = forward[6usize * count + index];
 }
 
-/// The recovered-distance test that decides a track (`:362-364`).
+/// The recovered-distance test that decides a track.
 ///
 /// The warp published is always the *forward* one; only the validity flag comes
 /// from the backward pass, exactly as `trackPoints` keeps `transform_1` and
 /// tests `(t1 - t1_recovered).squaredNorm()`.
 #[cube(launch, launch_unchecked)]
-// As `klt_kernel`: `!(dist2 < max)` is the C++'s own spelling of the test.
+// Use `!(dist2 < max)` so a NaN fails the distance guard.
 #[allow(clippy::too_many_arguments, clippy::neg_cmp_op_on_partial_ord)]
 fn finish_kernel(
     forward: &Array<f32>,

--- a/packages/slam-rs/crates/slam-rs/src/gpu/patches.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/patches.rs
@@ -231,7 +231,7 @@ impl<P: Pattern, R: Runtime> GpuPatches<P, R> {
     ///
     /// The offset is `source position - guess` per patch, which the backward
     /// pass adds back to the forward result
-    /// (`frame_to_frame_optical_flow.h:357`). It is computed on the host because
+    /// It is computed on the host because
     /// both terms are already there, and it rides in this buffer because the
     /// build needs the buffer anyway. The position runs stay zero on purpose: a
     /// backward build reads its positions out of the *forward result*, on the
@@ -268,7 +268,7 @@ impl<P: Pattern, R: Runtime> GpuPatches<P, R> {
     /// This is what keeps the backward pass on the device: its patches sit at
     /// the *forward* translations, which are already in the forward result
     /// buffer, so `positions` points there and nothing round-trips through the
-    /// host (`frame_to_frame_optical_flow.h:355`).
+    /// host.
     pub(super) fn launch_build_from(
         &self,
         pyramid: &GpuPyramid<R>,

--- a/packages/slam-rs/crates/slam-rs/src/gpu/pyramid.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/pyramid.rs
@@ -14,7 +14,7 @@ use crate::pyramid::{MIN_SIDE, Pyramid, PyramidError};
 ///
 /// The corner scanner and the pyramid builder are handed the *same* frame: the
 /// detector's input is level 0 of the pyramid this builder has just filled
-/// (`keypoints.cpp:152`, `image_pyr.h:73`). On the host that costs nothing —
+/// On the host that costs nothing —
 /// the caller still owns the image — but on a device it is a second upload of
 /// the whole frame. So the builder publishes level 0 here under the camera
 /// index [`crate::pyramid::PyramidBuilder::build`] gives it, and
@@ -89,18 +89,11 @@ pub struct GpuPyramid<R: Runtime> {
 }
 
 impl<R: Runtime> GpuPyramid<R> {
-    /// Allocate every level for a `width` x `height` frame and write `meta`.
-    ///
-    /// `num_levels` is basalt's, so the pyramid holds `num_levels + 1` levels
-    /// (0 through `num_levels`), matching [`crate::pyramid::PyramidU16`].
+    /// Allocate levels zero through `num_levels` and write device metadata.
     ///
     /// # Errors
-    ///
-    /// [`PyramidError::TooSmall`] when a level would be under the 5-tap
-    /// kernel's reach, as the CPU pyramid refuses it, and for `num_levels == 0`,
-    /// which the CPU pyramid accepts and this one cannot allocate;
-    /// [`GpuError::BufferTooLong`] when a pyramid buffer would be longer than
-    /// the `u32` its device metadata indexes it with.
+    /// Refuse geometry below the five-tap kernel's reach, zero requested levels,
+    /// and buffers exceeding the u32 device index range.
     fn new(
         client: ComputeClient<R>,
         width: usize,
@@ -305,7 +298,7 @@ impl<R: Runtime> crate::pyramid::PyramidBuilder for GpuPyramidBuilder<R> {
         )
     }
 
-    /// `ManagedImagePyr::setFromImage` (`image_pyr.h:70-80`) on the device.
+    /// `ManagedImagePyr::setFromImage` on the device.
     ///
     /// One upload for level 0 and one launch per halving. No synchronisation:
     /// the frame is left in flight and the tracker's own launches queue behind

--- a/packages/slam-rs/crates/slam-rs/src/gpu/track.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/track.rs
@@ -227,7 +227,7 @@ impl<P: Pattern, R: Runtime> PatchTracker for GpuPatchTracker<P, R> {
 }
 
 impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
-    /// `trackPoints` (`frame_to_frame_optical_flow.h:294-375`) on the device,
+    /// `trackPoints` on the device,
     /// launched into the next free lane and left there.
     fn submit_inner(
         &mut self,
@@ -291,8 +291,8 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
                 f32::as_bytes(&self.staging[..TRANSFORM_RUNS * count]),
             );
 
-            // `off = source position - guess` (`:339`), which the backward guess
-            // adds back (`:357`). Both terms are on the host already, so the offset
+            // `off = source position - guess`, which the backward guess
+            // adds back. Both terms are on the host already, so the offset
             // rides along in the backward patch set's positions buffer instead of
             // costing a kernel.
             let guess_x: &[f32] = transforms_in.translations_x();
@@ -316,7 +316,7 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
                 patches.launch_build(prev, patches.bases());
             }
 
-            // ── forward: `trackPoint(pyr_1, pyr_2, transform_1, transform_2)` (`:349`).
+            // ── forward: `trackPoint(pyr_1, pyr_2, transform_1, transform_2)`.
             kernels::launch_klt::<R>(
                 &self.client,
                 next.buffers(),
@@ -351,7 +351,7 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
                 },
             );
 
-            // ── backward: `trackPoint(pyr_2, pyr_1, transform_2, recovered)` (`:359`).
+            // ── backward: `trackPoint(pyr_2, pyr_1, transform_2, recovered)`.
             let backward_view = (&self.backward, TRANSFORM_RUNS * count);
             kernels::launch_klt::<R>(
                 &self.client,
@@ -364,7 +364,7 @@ impl<P: Pattern, R: Runtime> GpuPatchTracker<P, R> {
                 false,
             );
 
-            // ── `dist2 = (t1 - t1_recovered).squaredNorm() < max` (`:362`).
+            // ── `dist2 = (t1 - t1_recovered).squaredNorm() < max`.
             kernels::launch_finish::<R>(
                 &self.client,
                 forward_view,

--- a/packages/slam-rs/crates/slam-rs/src/image.rs
+++ b/packages/slam-rs/crates/slam-rs/src/image.rs
@@ -1,32 +1,8 @@
-//! The frontend's image container and its bilinear sampling.
-//!
-//! Ported from `thirdparty/basalt-headers/include/basalt/image/image.h`. Only
-//! the parts the VIO frontend runs on are here: an owned 16-bit grayscale
-//! buffer, `interp`, `interpGrad` and the floating-point `InBounds`. The cubic
-//! spline interpolators (`image.h:473-671`), the sub-image views and the
-//! `Eigen` overloads are not ported: nothing on the ABS_QR path calls them, and
-//! a borrowed sub-image view is exactly what the GPU seam forbids.
-//!
-//! ## Why 16 bits
-//!
-//! basalt widens every 8-bit source by eight bits on read
-//! (`src/vit/vit_tracker.cpp:534`, `include/basalt/io/dataset_io_euroc.h:102`)
-//! and runs the whole frontend at `uint16_t`. Keeping `u8` internally would
-//! change the last bits of every interpolation and therefore the trajectory,
-//! which is trap 4 of the architecture dossier (decision D08, tradeoff T02).
-//!
-//! ## Two divergences from the C++, both deliberate
-//!
-//! * **Row pitch is in elements, not bytes.** `Image<T>::pitch` is a byte
-//!   pitch cast through `unsigned char*` (`image.h:247`). A `Vec<u16>` cannot
-//!   express an odd byte pitch, and nothing in basalt produces one, so
-//!   [`ImageU16::stride`] counts `u16`s.
-//! * **The `u8 -> u16` copy honours the source byte stride.** basalt's shim
-//!   reads the source with a linear index (`vit_tracker.cpp:531-534`), which is
-//!   only right when `stride == width`, and the Python binding enforces that
-//!   (`python/vit_binding.py:285-286`). dav1d hands back padded rows (line size
-//!   1024 for a 960-wide frame), so the port takes the stride instead
-//!   (decision D28, trap 5). With `stride_bytes == width` the two agree.
+//! Owned u16 grayscale images and bilinear sampling for the frontend.
+//! Eight-bit input is widened by `u8 << 8`, preserving interpolation precision
+//! (D08). Row strides count u16 elements internally and bytes on input.
+//! Honor padded source rows, such as a 1024-byte decoder stride for a 960-pixel
+//! image (D28). Flat owned buffers support upload without repacking.
 
 use thiserror::Error;
 
@@ -73,12 +49,8 @@ pub enum ImageError {
     },
 }
 
-/// An owned 16-bit grayscale image: `height` rows of `width` pixels, `stride` apart.
-///
-/// One flat `Vec<u16>` with an explicit row stride, not a `Vec<Vec<u16>>` and
-/// not basalt's packed mipmap: a flat buffer plus `(width, height, stride)` is
-/// what a CubeCL `create_from_slice` wants, and anything else needs a repack
-/// per frame (deviation X04).
+/// An owned flat u16 image with explicit width, height and row stride.
+/// This layout can be uploaded as one buffer without per-frame repacking.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ImageU16 {
     data: Vec<u16>,
@@ -119,15 +91,11 @@ impl ImageU16 {
         })
     }
 
-    /// Widen an 8-bit image into a fresh 16-bit one, `u8 << 8` as basalt does.
-    ///
-    /// `stride_bytes` is the distance between the starts of two source rows;
-    /// `bytes` must hold at least `stride_bytes * height` of them.
+    /// Widen an 8-bit image with `u8 << 8`, honoring `stride_bytes` between rows.
+    /// The buffer must cover `stride_bytes * height` bytes.
     ///
     /// # Errors
-    ///
-    /// [`ImageError::StrideTooSmall`], [`ImageError::SizeOverflow`] or
-    /// [`ImageError::ShortBuffer`] when the geometry and the buffer disagree.
+    /// Returns stride, overflow or short-buffer errors when geometry is invalid.
     pub fn from_u8_strided(
         bytes: &[u8],
         width: usize,
@@ -267,24 +235,18 @@ impl ImageU16 {
         }
     }
 
-    /// The pixel at `(x, y)` with no bounds check beyond Rust's own.
+    /// Read a pixel after validating `x < width && y < height`.
     ///
-    /// The frontend's inner loops call this after [`ImageU16::in_bounds`]; the
-    /// invariant is `x < width && y < height`, and a violation panics on the
-    /// slice index rather than reading a neighbouring row, which is what
-    /// basalt's `operator()` does in release builds (`image.h:251-259`).
+    /// # Panics
+    /// If the resulting slice index is outside storage.
     #[inline]
     fn at(&self, x: usize, y: usize) -> f32 {
         f32::from(self.data[y * self.stride + x])
     }
 
-    /// basalt's floating-point bounds test, `image.h:687-689`.
-    ///
-    /// `border <= x && x < w - border - 1 && border <= y && y < h - border - 1`.
-    /// The extra `- 1` is what makes an integer coordinate of `w - 1`
-    /// out of bounds: [`ImageU16::interp`] reads `ix + 1` unconditionally.
-    /// `interp` needs `border >= 0`, `interp_grad` needs `border >= 1`
-    /// (`image.h:402`, `:424`).
+    /// Floating-point bounds: `border <= x < w - border - 1`, and likewise for y.
+    /// The extra pixel leaves room for interpolation's unconditional neighbor read.
+    /// Use border zero for values and at least one for gradients.
     pub fn in_bounds(&self, x: f32, y: f32, border: f32) -> bool {
         border <= x
             && x < (self.width as f32 - border - 1.0)
@@ -292,27 +254,13 @@ impl ImageU16 {
             && y < (self.height as f32 - border - 1.0)
     }
 
-    /// Bilinear sample at `(x, y)`, `image.h:396-415`.
-    ///
-    /// ```text
-    /// int ix = x;  int iy = y;
-    /// S dx = x - ix;   S dy = y - iy;
-    /// S ddx = 1 - dx;  S ddy = 1 - dy;
-    /// return ddx * ddy * (*this)(ix, iy)     + ddx * dy * (*this)(ix, iy + 1)
-    ///      + dx  * ddy * (*this)(ix + 1, iy) + dx  * dy * (*this)(ix + 1, iy + 1);
-    /// ```
-    ///
-    /// The multiplication grouping and the summation order are reproduced as
-    /// written: in `f32` both are load-bearing, and `interp_grad` below depends
-    /// on this function being exactly the bilinear surface it interpolates.
-    /// `int ix = x` truncates toward zero, which is a floor only for
-    /// non-negative `x`; that is guaranteed by `in_bounds(x, y, 0)`, which the
-    /// caller must satisfy (basalt asserts it only under
-    /// `BASALT_ENABLE_BOUNDS_CHECKS`, `image.h:402`).
+    /// Bilinear sampling with fixed multiplication grouping and summation order.
+    /// Interpolate the four surrounding pixels with weights formed from x/y fractions.
+    /// Truncation towards zero equals floor only for non-negative coordinates;
+    /// callers must establish `in_bounds(x, y, 0)` first.
     ///
     /// # Panics
-    ///
-    /// If `(x, y)` is outside the image, on the slice index.
+    /// If sampling indexes outside image storage.
     #[inline]
     pub fn interp(&self, x: f32, y: f32) -> f32 {
         debug_assert!(self.in_bounds(x, y, 0.0), "interp needs InBounds(x, y, 0)");
@@ -332,33 +280,13 @@ impl ImageU16 {
             + dx * dy * self.at(ix + 1, iy + 1)
     }
 
-    /// Bilinear sample and gradient at `(x, y)`, `image.h:418-469`.
-    ///
-    /// The value is [`ImageU16::interp`]; the gradient is the *central
-    /// difference of the bilinear surface at unit spacing*, not the analytic
-    /// derivative of that surface:
-    ///
-    /// ```text
-    /// res[1] = 0.5 * (res_px - res_mx);   // res_px = bilinear at (x + 1, y)
-    /// res[2] = 0.5 * (res_py - res_my);   // res_py = bilinear at (x, y + 1)
-    /// ```
-    ///
-    /// (`image.h:454`, `:466`), which is why basalt's own comment calls it
-    /// "bilinear interpolation of the gradient image from central differences"
-    /// (`image.h:289-291`) and warns it is not the gradient of the interpolated
-    /// function (`image.h:323-326`). It reads twelve pixels, `ix - 1` through
-    /// `ix + 2` and `iy - 1` through `iy + 2`, so the caller must satisfy
-    /// `in_bounds(x, y, 1)` (`image.h:424`).
-    ///
-    /// A fused whole-image `dx`/`dy` pass is deliberately absent: the KLT
-    /// tracker samples a sparse 52-tap pattern per patch and calls this per
-    /// tap, so a dense gradient image would be built and thrown away. The GPU
-    /// seam expects the fused "downsample + gradient" kernel to arrive with the
-    /// tracker, in [`crate::pyramid::PyramidBuilder`], not here.
+    /// Bilinear value and unit-spacing central differences of the bilinear surface.
+    /// The gradient is not its analytic derivative. The stencil reaches from `ix-1`
+    /// to `ix+2` and `iy-1` to `iy+2`, requiring `in_bounds(x, y, 1)`.
+    /// Sparse 52-tap KLT sampling avoids building a dense gradient image.
     ///
     /// # Panics
-    ///
-    /// If `(x, y)` is less than one pixel from the border, on the slice index.
+    /// If the gradient stencil indexes outside image storage.
     #[inline]
     pub fn interp_grad(&self, x: f32, y: f32) -> (f32, [f32; 2]) {
         debug_assert!(
@@ -454,7 +382,7 @@ mod tests {
     use proptest::prelude::*;
 
     /// `sin(x / 100 + y / 20)` sampled into `u16`, the image form of
-    /// `SmoothFunction` in `test/src/test_patch.cpp:11-30`.
+    /// Smooth analytic sampling function.
     const SMOOTH_AMPLITUDE: f64 = 20_000.0;
     const SMOOTH_OFFSET: f64 = 32_768.0;
 
@@ -640,19 +568,9 @@ mod tests {
         assert_abs_diff_eq!(image.interp(1.0, 1.5), 200.0, epsilon = 1e-4);
     }
 
-    /// Port of `TEST(Patch, ImageInterpolateGrad)`, `test/src/test_patch.cpp:32-46`.
-    ///
-    /// The C++ test evaluates `interpGrad` on `SmoothFunction`, an analytic
-    /// `sin(x/100 + y/20)`, and checks its Jacobian against numerical
-    /// differentiation of `interp` at the same point. The port samples that
-    /// same function into a real `ImageU16` and checks the same thing at the
-    /// same coordinate, `offset (231, 123) + (0.4, 0.34345)`.
-    ///
-    /// The step is one pixel, not an infinitesimal: `interpGrad`'s gradient is
-    /// by construction the unit-spacing central difference of the bilinear
-    /// surface (`image.h:447-466`), so the two agree to rounding. A second,
-    /// looser check against the analytic derivative of the sine catches a
-    /// swapped or sign-flipped axis, which the exact identity alone would not.
+    /// Sample a smooth sine into an image and compare `interp_grad` with unit-step
+    /// central differences of `interp`. A looser check against the sine's analytic
+    /// derivative also catches swapped or sign-flipped axes.
     #[test]
     fn image_interpolate_grad() {
         let image: ImageU16 = smooth_image(512, 256);
@@ -704,7 +622,7 @@ mod tests {
         }
 
         /// `interp_grad` is exactly the value and the unit-spacing central
-        /// differences of `interp` (`image.h:447-466`). Not bit-exact only
+        /// differences of `interp`. Not bit-exact only
         /// because `interp(x + 1, y)` recomputes `dx` from a different float.
         #[test]
         fn interp_grad_is_the_central_difference_of_interp(
@@ -722,8 +640,7 @@ mod tests {
         }
 
         /// On a smooth image the gradient agrees with a central finite
-        /// difference of `interp` taken at half-pixel steps, which is the check
-        /// `test_jacobian` performs in `test_patch.cpp`.
+        /// difference of `interp` taken at half-pixel steps.
         #[test]
         fn gradients_match_finite_differences_on_a_smooth_image(
             x in 30.0f32..480.0,

--- a/packages/slam-rs/crates/slam-rs/src/imu.rs
+++ b/packages/slam-rs/crates/slam-rs/src/imu.rs
@@ -1,75 +1,22 @@
-//! IMU preintegration: the pseudo-measurement between two frames, its
-//! covariance, its bias Jacobians and the 9-vector residual the estimator
-//! whitens.
+//! IMU preintegration, covariance, bias Jacobians and whitened residuals.
 //!
-//! Ported line by line from
-//! `thirdparty/basalt-headers/include/basalt/imu/preintegration.h` and
-//! `.../imu/imu_types.h`, plus the between-frames accumulation loop in
-//! `src/vi_estimator/sqrt_keypoint_vio.cpp:315-336` and the block that consumes
-//! the result, `include/basalt/linearization/imu_block.hpp`.
+//! The estimator uses midpoint rotation `ΔR exp(½ Δt ω)`, retains `½ a Δt²`
+//! in position, and orders the state `[translation, rotation, velocity]` (D12).
+//! The full state appends gyro and accelerometer biases. Gyro-bias correction
+//! is pre-multiplied, requiring right inverse Jacobians for state blocks and a
+//! left inverse Jacobian for the gyro-bias block. Position residuals include
+//! `−v_i Δt`.
 //!
-//! # basalt is not Forster
+//! Covariance whitening uses guarded pivoted LDLT. Tiny or negative pivots receive
+//! zero weight; singular inputs yield a congruence generalized inverse, not
+//! necessarily a Moore-Penrose inverse. The 9x9 factor is recomputed per request
+//! to avoid interior mutability. Pivot selection precedes column updates.
 //!
-//! basalt cites Forster et al. 2017 and then deviates from it in four ways
-//! (decision D12). Every one of them is reproduced here, because each changes
-//! the numbers:
-//!
-//! 1. **Midpoint rotation** (`preintegration.h:85-88`). Forster Eq. (36) rotates
-//!    the acceleration by the rotation at the *start* of the interval; basalt
-//!    rotates by `ΔR · exp(½ Δt ω)`, an RK2-style midpoint. It propagates into
-//!    `d_next_d_accel` (`:105-106`) and into the `rightJacobianSO3(½ Δt ω)` of
-//!    `d_next_d_gyro` (`:113,116`).
-//! 2. **The position update keeps `½ a Δt²`** (`preintegration.h:93-94`), which
-//!    Paper 1's Eq. (12) drops. That is why `d_next_d_curr(0,3)` is non-zero
-//!    (`:100`) and `d_next_d_accel(0,0)` is `½ R Δt²` (`:105`).
-//! 3. **State ordering is `[translation, rotation, velocity]`**, not Forster's
-//!    `(ΔR, Δv, Δp)`. Provable from the Jacobian block writes, not from any
-//!    comment: `d_next_d_curr(0,6).diagonal() = dt` is `∂p/∂v` (`:98`) and
-//!    `(6,3) = hat(-a_world dt)` is `∂v/∂R` (`:99`). The residual agrees
-//!    (`:217`, `:219`, `:224`), and the 15-vector is
-//!    `[t(3), R(3), v(3), b_g(3), b_a(3)]` — confirmed by the `+9` and `+12`
-//!    column offsets in `imu_block.hpp:57-58`.
-//! 4. **The gyro-bias correction is pre-multiplied**
-//!    (`preintegration.h:219-221`), where Forster Eq. (44) puts it inside the
-//!    transpose on the right. The consequence is two *different* inverse
-//!    Jacobians in one function: [`right_jacobian_inv_so3`] for the state blocks
-//!    (`:228`) and [`left_jacobian_inv_so3`] for the gyro-bias block
-//!    (`:256-257`). Swapping them is a silent bias bug.
-//!
-//! Two more, from the same reading:
-//!
-//! * The inverse covariance is formed through a guarded pivoted LDLT. Pivots
-//!   below the smallest positive normal value get zero weight. For singular
-//!   covariance this is a generalized inverse through congruence, not a
-//!   Moore-Penrose inverse, and it need not annihilate the null space.
-//! * Paper 1's Eq. (20) omits the `− v_i Δt` term. The code has it
-//!   (`preintegration.h:214`) and so does this port.
-//!
-//! # Deviations of this port from the C++
-//!
-//! * **No `mutable` cache on the square-root inverse covariance.** C++ caches it
-//!   behind a dirty flag (`preintegration.h:163`, `:271-274`, `:328-330`);
-//!   [`IntegratedImuMeasurement::get_cov_inv_sqrt`] recomputes the 9x9 LDLT on
-//!   every call instead, which needs no interior mutability and costs a few
-//!   hundred flops against the ~10⁸ the frontend spends on the same frame.
-//! * **The small pivoted LDLT stays local.** It pivots on the original diagonal,
-//!   then updates the selected column. Negative or tiny pivots get zero weight
-//!   during whitening, which keeps degenerate covariance finite.
-//! * **Jacobians are all-or-nothing.** C++ takes four nullable out-pointers;
-//!   every in-tree caller either asks for all of them or none
-//!   (`imu_block.hpp:41-48`), so the port has one plain method and one
-//!   `_with_jacobians` method.
-//! * **`predict_state` sets the timestamp.** `preintegration.h:174-181` never
-//!   writes `state1.t_ns`, so the frontend's long-lived `predicted_state` keeps
-//!   whatever it held before (`frame_to_frame_optical_flow.h:149`). The port
-//!   returns a fresh state and fills in `state0.t_ns + dt_ns`.
-//! * **Gravity initialization uses a closed-form cross-product axis.**
-//! * **Asserts become typed errors or tests.** `propagateState` asserts
-//!   `data.t_ns > curr_state.t_ns` (`preintegration.h:79-80`); here that is
-//!   [`ImuError::NonMonotonicSample`] (decision D32). The residual's
-//!   `BASALT_ASSERT(ba_diff.segment<3>(3).isApproxToConstant(0))` (`:211`) holds
-//!   structurally — `d_next_d_accel` has no rotation rows and `F`'s rotation
-//!   rows are `[0 I 0]` — so it is a test, not a runtime check.
+//! Callers request all Jacobians or none. Prediction returns a fresh state with
+//! an updated timestamp, and gravity initialization uses a cross-product axis.
+//! Non-monotonic samples return typed errors (D32). Accelerometer bias cannot
+//! change delta rotation because its input Jacobian has zero rotation rows and
+//! the transition's rotation rows are `[0 I 0]`; tests enforce this identity.
 
 use nalgebra::{DMatrix, DVector, Matrix3, SMatrix, Vector3};
 
@@ -82,9 +29,8 @@ use crate::types::{
 };
 
 /// Where the gyroscope bias starts inside a 15-vector state block: the `+9` of
-/// `imu_block.hpp:57`.
 const BIAS_GYRO_OFFSET: usize = POSE_VEL_SIZE;
-/// Where the accelerometer bias starts: the `+12` of `imu_block.hpp:58`.
+/// Accelerometer bias starts at offset 12 in the full state.
 const BIAS_ACCEL_OFFSET: usize = POSE_VEL_SIZE + 3;
 
 /// A `Vector3<f64>` in the measurement's scalar type.
@@ -102,22 +48,14 @@ pub type Matrix9x6<S> = SMatrix<S, POSE_VEL_SIZE, 6>;
 /// The IMU block's Jacobian: 15 rows over the two 15-column states.
 pub type Matrix15x30<S> = SMatrix<S, POSE_VEL_BIAS_SIZE, { 2 * POSE_VEL_BIAS_SIZE }>;
 
-/// Gravity in the world frame, `basalt::constants::g`
-/// (`include/basalt/utils/imu_types.h:63`).
+/// Gravity in the world frame.
 pub fn gravity<S: LieScalar>() -> Vector3<S> {
     Vector3::new(S::zero(), S::zero(), c::<S>(-9.81))
 }
 
-/// One timestamped gyroscope and accelerometer reading, `basalt::ImuData`
-/// (`imu_types.h:244-273`).
-///
-/// `f64` regardless of the estimator's scalar: timestamps are nanoseconds and
-/// IMU integration runs in double (decision D05), exactly as basalt's frontend
-/// does with its `IntegratedImuMeasurement<double>`
-/// (`frame_to_frame_optical_flow.h:142`). The samples are already through the
-/// static IMU calibration — `calib.calib_accel_bias.getCalibrated(...)`
-/// (`sqrt_keypoint_vio.cpp:235-236`) — and carry no bias correction; that
-/// happens at the linearization point inside [`IntegratedImuMeasurement::integrate`].
+/// Timestamped gyroscope and accelerometer reading stored in f64.
+/// Samples have static calibration applied. Linearization-point bias correction
+/// occurs during integration.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct ImuSample {
     /// Timestamp of the sample, in nanoseconds.
@@ -128,11 +66,8 @@ pub struct ImuSample {
     pub accel: Vector3<f64>,
 }
 
-/// The two diagonal noise covariances `integrate` needs.
-///
-/// basalt squares the *discrete-time* noise densities
-/// (`sqrt_keypoint_vio.cpp:228-229`), which are the continuous ones scaled by
-/// `sqrt(imu_update_rate)` (`calibration.hpp:190,196`).
+/// Diagonal noise covariances: square continuous-time densities after multiplying
+/// by `sqrt(imu_update_rate)` to obtain discrete-time densities.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ImuNoise<S: LieScalar> {
     /// Diagonal of the accelerometer noise covariance.
@@ -143,7 +78,6 @@ pub struct ImuNoise<S: LieScalar> {
 
 impl<S: LieScalar> ImuNoise<S> {
     /// The noise the estimator builds from a calibration
-    /// (`sqrt_keypoint_vio.cpp:228-229`).
     pub fn from_calibration(calib: &Calibration<S>) -> Self {
         Self {
             accel_cov: calib
@@ -156,18 +90,11 @@ impl<S: LieScalar> ImuNoise<S> {
     }
 }
 
-/// What the preintegration refuses to do.
-///
-/// The core never panics on data (decision D32): every ordering violation the
-/// C++ handles with `BASALT_ASSERT` or by breaking out of the processing loop is
-/// a value here.
+/// Typed preintegration failures; invalid data must not panic (D32).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum ImuError {
-    /// A sample does not strictly follow the integrated interval.
-    ///
-    /// `propagateState` asserts `data.t_ns > curr_state.t_ns`
-    /// (`preintegration.h:79-80`); a duplicate timestamp is a zero `dt`, which
-    /// makes the whole measurement singular.
+    /// A sample fails to strictly follow the integrated interval. Duplicate timestamps
+    /// would give zero duration and a singular measurement.
     #[error("imu sample at {t_ns} ns does not follow the integrated state at {previous_t_ns} ns")]
     NonMonotonicSample {
         /// End of what has been integrated so far, relative to the start time.
@@ -177,7 +104,7 @@ pub enum ImuError {
     },
     /// Two frame timestamps that are equal or go backwards.
     ///
-    /// `sqrt_keypoint_vio.cpp:307-313` asserts both of these separately, and its
+    ///  asserts both of these separately, and its
     /// message says a zero time delta "leads to invalid IMU integration".
     #[error("frame interval [{t0_ns}, {t1_ns}] ns is empty or reversed")]
     NonMonotonicFrames {
@@ -186,11 +113,7 @@ pub enum ImuError {
         /// Timestamp of the current frame.
         t1_ns: i64,
     },
-    /// The interval does not start where the measurement was constructed.
-    ///
-    /// C++ cannot get this wrong: `measure()` builds the measurement with
-    /// `prev_frame->t_ns` and then integrates from that same variable
-    /// (`sqrt_keypoint_vio.cpp:304`, `:315`).
+    /// The requested interval starts at a different time from the measurement.
     #[error("interval starts at {t0_ns} ns but the measurement starts at {start_t_ns} ns")]
     StartTimeMismatch {
         /// Start time the measurement was constructed with.
@@ -198,10 +121,7 @@ pub enum ImuError {
         /// Start of the interval the caller asked for.
         t0_ns: i64,
     },
-    /// The interval cannot be closed because no sample follows the frame.
-    ///
-    /// basalt reaches the same state and ends the estimator: `if (!data.get())
-    /// break;` inside the closing step (`sqrt_keypoint_vio.cpp:331`).
+    /// No sample follows the frame to close the integration interval.
     #[error("no imu sample after {t1_ns} ns to close the interval with")]
     MissingSampleAfterFrame {
         /// Timestamp the interval had to reach.
@@ -218,7 +138,7 @@ pub enum ImuError {
 }
 
 /// The three Jacobians of one propagation step
-/// (`preintegration.h:96-119`, `F`, `A` and `G` at `:154-158`).
+/// (`F`, `A` and `G` at ).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PropagationJacobians<S: LieScalar> {
     /// `F = ∂next/∂curr`, Paper 1 Eq. (13)'s `J_f^s`.
@@ -229,28 +149,20 @@ pub struct PropagationJacobians<S: LieScalar> {
     pub d_next_d_gyro: Matrix9x3<S>,
 }
 
-/// The residual's Jacobians (`preintegration.h:227-258`).
+/// The residual's Jacobians.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ImuResidualJacobians<S: LieScalar> {
-    /// `∂r/∂state0` (`preintegration.h:230-239`).
+    /// `∂r/∂state0`.
     pub d_res_d_state0: Matrix9<S>,
-    /// `∂r/∂state1` (`preintegration.h:241-247`).
+    /// `∂r/∂state1`.
     pub d_res_d_state1: Matrix9<S>,
-    /// `∂r/∂[b_g, b_a]`: gyro bias in columns 0-2, accel bias in columns 3-5.
-    ///
-    /// C++ returns the two 9x3 blocks separately and the block writes them to
-    /// `start_idx + 9` and `start_idx + 12` (`imu_block.hpp:57-58`), which is
-    /// this layout — the bias half of the 15-vector
-    /// `[t(3), R(3), v(3), b_g(3), b_a(3)]`.
+    /// Bias Jacobian: gyro bias in columns 0–2, accelerometer bias in columns 3–5.
+    /// These occupy offsets 9 and 12 of the full `[t, R, v, b_g, b_a]` state.
     pub d_res_d_bias: Matrix9x6<S>,
 }
 
-/// A pseudo-measurement built from consecutive IMU samples,
-/// `basalt::IntegratedImuMeasurement` (`preintegration.h:49-335`).
-///
-/// The delta state's `t_ns` is elapsed nanoseconds since [`Self::get_start_t_ns`],
-/// not absolute time: `integrate` subtracts the start time from every sample
-/// (`preintegration.h:148`).
+/// A pseudo-measurement from consecutive IMU samples.
+/// Delta time is elapsed nanoseconds from [`Self::get_start_t_ns`], not absolute time.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct IntegratedImuMeasurement<S: LieScalar> {
     start_t_ns: i64,
@@ -263,7 +175,7 @@ pub struct IntegratedImuMeasurement<S: LieScalar> {
 }
 
 impl<S: LieScalar> Default for IntegratedImuMeasurement<S> {
-    /// `preintegration.h:123-130`: everything zero, start time zero.
+    /// everything zero, start time zero.
     fn default() -> Self {
         Self::new(0, &Vector3::zeros(), &Vector3::zeros())
     }
@@ -275,7 +187,7 @@ pub type Popped<S> = (i64, Vector3<S>, Vector3<S>);
 
 impl<S: LieScalar> IntegratedImuMeasurement<S> {
     /// An empty measurement starting at `start_t_ns`, linearized about the two
-    /// biases (`preintegration.h:133-139`).
+    /// biases.
     pub fn new(start_t_ns: i64, bias_gyro: &Vector3<S>, bias_accel: &Vector3<S>) -> Self {
         Self {
             start_t_ns,
@@ -288,21 +200,15 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
         }
     }
 
-    /// Propagate one state by one bias-corrected sample, with the three
-    /// Jacobians (`preintegration.h:76-120`, `propagateState`).
-    ///
-    /// `t_ns`, `accel` and `gyro` are C++'s `data` after the correction at
-    /// `:147-150`: the timestamp is relative to the measurement's start and the
-    /// biases are already removed. All three Jacobians are always computed
-    /// because every caller in the C++ asks for all three (`:158`).
+    /// Propagate one state with a bias-corrected sample and compute all three Jacobians.
+    /// The timestamp is relative to the measurement start; biases are already removed.
     pub fn propagate_state(
         curr_state: &PoseVelState<S>,
         t_ns: i64,
         accel: &Vector3<S>,
         gyro: &Vector3<S>,
     ) -> Result<(PoseVelState<S>, PropagationJacobians<S>), ImuError> {
-        // `:79-80` is an assert in C++; here it is the error that keeps a
-        // duplicate or reordered sample from producing a singular measurement.
+        // Refuse duplicate or reordered samples before they create a singular measurement.
         if t_ns <= curr_state.t_ns {
             return Err(ImuError::NonMonotonicSample {
                 previous_t_ns: curr_state.t_ns,
@@ -329,12 +235,12 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
             vel_w_i: curr_state.vel_w_i + accel_world * dt, // `:92`
         };
         next_state.t_w_i.rotation = curr_state.t_w_i.rotation * So3::exp(&(*gyro * dt)); // `:91`
-        // `:93-94`, deviation 2: the quadratic term stays.
+        // deviation 2: the quadratic term stays.
         next_state.t_w_i.translation = curr_state.t_w_i.translation
             + curr_state.vel_w_i * dt
             + accel_world * c::<S>(0.5) * dt * dt;
 
-        // `:96-101`. Only the *diagonal* of the (0,6) block is set, so the port
+        // Only the *diagonal* of the (0,6) block is set, so the port
         // writes three entries rather than a scaled identity.
         let mut d_next_d_curr: Matrix9<S> = Matrix9::identity();
         for i in 0..3 {
@@ -348,7 +254,6 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
             .fixed_view_mut::<3, 3>(0, 3)
             .copy_from(&(hat_accel_dt * dt * c::<S>(0.5)));
 
-        // `:103-107`
         let mut d_next_d_accel: Matrix9x3<S> = Matrix9x3::zeros();
         d_next_d_accel
             .fixed_view_mut::<3, 3>(0, 0)
@@ -357,7 +262,6 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
             .fixed_view_mut::<3, 3>(6, 0)
             .copy_from(&(rr_w_i_new_2 * dt));
 
-        // `:109-119`
         let mut d_next_d_gyro: Matrix9x3<S> = Matrix9x3::zeros();
         let jr: Matrix3<S> = right_jacobian_so3(&(*gyro * dt));
         let jr2: Matrix3<S> = right_jacobian_so3(&(*gyro * (c::<S>(0.5) * dt)));
@@ -382,7 +286,7 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
         ))
     }
 
-    /// Fold one sample into the measurement (`preintegration.h:146-167`).
+    /// Fold one sample into the measurement.
     ///
     /// `accel_cov` and `gyro_cov` are the diagonals of the discrete-time noise
     /// covariances. Nothing here allocates: every matrix is a fixed-size
@@ -406,7 +310,7 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
     ///
     /// The backend needs this: `popFromImuDataQueue` casts to `Scalar`
     /// **before** `calib_accel_bias.getCalibrated` runs
-    /// (`sqrt_keypoint_vio.cpp:377-390`, `:298-299`), so the static bias
+    /// so the static bias
     /// calibration of an `f32` estimator happens in `f32`. Calibrating in `f64`
     /// and casting afterwards is a different number.
     ///
@@ -421,7 +325,7 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
         accel_cov: &Vector3<S>,
         gyro_cov: &Vector3<S>,
     ) -> Result<(), ImuError> {
-        // `:147-150`: relative time, bias removed at the linearization point.
+        // relative time, bias removed at the linearization point.
         let t_ns: i64 =
             sample_t_ns
                 .checked_sub(self.start_t_ns)
@@ -436,53 +340,29 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
             Self::propagate_state(&self.delta_state, t_ns, &accel, &gyro)?; // `:158`
 
         self.delta_state = new_state; // `:160`
-        // `:161-162`, Paper 1 Eq. (21).
+        // Paper 1 Eq. (21).
         self.cov = j.d_next_d_curr * self.cov * j.d_next_d_curr.transpose()
             + j.d_next_d_accel * Matrix3::from_diagonal(accel_cov) * j.d_next_d_accel.transpose()
             + j.d_next_d_gyro * Matrix3::from_diagonal(gyro_cov) * j.d_next_d_gyro.transpose();
-        // `:165-166`, Paper 1 Eqs. (15)-(16).
+        // Paper 1 Eqs. (15)-(16).
         self.d_state_d_ba = -j.d_next_d_accel + j.d_next_d_curr * self.d_state_d_ba;
         self.d_state_d_bg = -j.d_next_d_gyro + j.d_next_d_curr * self.d_state_d_bg;
         Ok(())
     }
 
-    /// Accumulate every sample that belongs between two frames, exactly as
-    /// `measure()`'s producer loop does (`sqrt_keypoint_vio.cpp:315-336`).
+    /// Accumulate samples over one frame interval.
+    /// Skip samples at or before `skip_past_ns`, then integrate through `until_ns`.
+    /// If the interval remains short, retime the first later sample to the boundary
+    /// and integrate its own values, without interpolation. Return that pending
+    /// sample at its original timestamp for the next frame.
     ///
-    /// The three parts, in order:
-    ///
-    /// 1. Skip while `sample.t_ns <= skip_past_ns` (`:315-320`).
-    /// 2. Integrate while `sample.t_ns <= until_ns` (`:322-328`).
-    /// 3. If the accumulated interval still ends before `until_ns`, take the
-    ///    first sample *after* it, **retime that sample to `until_ns` and
-    ///    integrate it with its own accel and gyro** (`:330-336`, and the same
-    ///    code with the comment "Pretend last IMU sample before now happened
-    ///    now" at `frame_to_frame_optical_flow.h:194-198`). There is **no
-    ///    interpolation**: the values integrated over that last partial step are
-    ///    the later sample's, not a blend. The port does none either. basalt
-    ///    restores the timestamp afterwards, so the sample is still available to
-    ///    the next frame at its own time — which is why it comes back out.
-    ///
-    /// `pending` is the one sample already popped, C++'s loop-local `data`
-    /// (`:296`); it is taken by value and the new one returned, so the caller's
-    /// own `&mut self` is free for `pop`. An empty `pending` is primed from
-    /// `pop` first, as both call sites did inline.
-    ///
-    /// **Both producers drive this**: the estimator's own preintegration and
-    /// the second, independent one the frontend keeps (D24). They differ only
-    /// in where the samples come from and in the noise, which is what `pop` and
-    /// `noise` are; the per-sample arithmetic is
-    /// [`Self::integrate_calibrated`] either way.
+    /// Both frontend and estimator preintegrators use this loop (D24), with their
+    /// own sample source and noise model. Passing pending state by value leaves
+    /// the caller free to mutate its queue through `pop`.
     ///
     /// # Errors
-    ///
-    /// [`ImuError::NonMonotonicFrames`] on an empty or reversed frame gap,
-    /// [`ImuError::StartTimeMismatch`] when `skip_past_ns` is not the time the
-    /// measurement was built with, [`ImuError::MissingSampleAfterFrame`] when
-    /// nothing follows the frame to close the interval with, and whatever
-    /// [`Self::integrate_calibrated`] refuses. Both live producers precheck a
-    /// sample strictly after the frame, so none of these can fire on the
-    /// shipped path.
+    /// Refuse reversed intervals, a mismatched start time, missing closing samples
+    /// or any input rejected by [`Self::integrate_calibrated`].
     pub fn accumulate_to(
         &mut self,
         pending: Option<Popped<S>>,
@@ -491,7 +371,7 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
         until_ns: i64,
         noise: &ImuNoise<S>,
     ) -> Result<Option<Popped<S>>, ImuError> {
-        // `:307-313`: the frame gap is what the measurement integrates over, so
+        // the frame gap is what the measurement integrates over, so
         // an empty or reversed one has no measurement.
         if until_ns <= skip_past_ns {
             return Err(ImuError::NonMonotonicFrames {
@@ -499,7 +379,7 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
                 t1_ns: until_ns,
             });
         }
-        // `:304` builds the measurement with `prev_frame->t_ns` and `:315`
+        //  builds the measurement with `prev_frame->t_ns` and
         // skips past that same variable. Any other origin times every sample
         // against a start the measurement does not have.
         if skip_past_ns != self.start_t_ns {
@@ -511,14 +391,14 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
 
         let mut pending: Option<Popped<S>> = pending.or_else(&mut pop);
 
-        // `:315-320`: discard everything at or before the previous frameset.
+        // discard everything at or before the previous frameset.
         while let Some((t_ns, _, _)) = pending {
             if t_ns > skip_past_ns {
                 break;
             }
             pending = pop();
         }
-        // `:322-328`: integrate everything up to and including the frameset.
+        // integrate everything up to and including the frameset.
         while let Some((t_ns, gyro, accel)) = pending {
             if t_ns > until_ns {
                 break;
@@ -526,10 +406,7 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
             self.integrate_calibrated(t_ns, &accel, &gyro, &noise.accel_cov, &noise.gyro_cov)?;
             pending = pop();
         }
-        // `:330-336`: close the interval exactly on the frameset. basalt ends
-        // the estimator when its queue is dry here (`if (!data.get()) break;`);
-        // a measurement that stops short of the frame is silently wrong, so it
-        // is refused instead of returned.
+        // A measurement stopping before the frame is invalid; require a closing sample.
         if self.start_t_ns + self.get_dt_ns() < until_ns {
             let Some((_, gyro, accel)) = pending else {
                 return Err(ImuError::MissingSampleAfterFrame { t1_ns: until_ns });
@@ -539,7 +416,7 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
         Ok(pending)
     }
 
-    /// Predict the state at the end of the interval (`preintegration.h:174-181`).
+    /// Predict the state at the end of the interval.
     ///
     /// **Unchecked precondition:** `state0` is the state at
     /// [`Self::get_start_t_ns`]. The delta this applies is relative to that
@@ -549,21 +426,19 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
     /// stands still while the motion still applies. Both callers hold the
     /// precondition by construction and neither reads the timestamp: the
     /// estimator files the predicted state under the frameset's own `t_ns`
-    /// (`:427-441`) and the frontend takes only the pose
-    /// (`frame_to_frame_optical_flow.h:149`). Checking it would make this
+    ///  and the frontend takes only the pose
+    /// Checking it would make this
     /// fallible on the LM path for a value nothing there reads, which is the
     /// review follow-up rather than this fix round.
     pub fn predict_state(&self, state0: &PoseVelState<S>, g: &Vector3<S>) -> PoseVelState<S> {
         let dt: S = c::<S>(self.delta_state.t_ns as f64) * c::<S>(1e-9); // `:175`
         let mut state1: PoseVelState<S> = PoseVelState {
-            // C++ never writes `t_ns` here; see the module deviations.
+            // Advance the predicted timestamp by the integrated duration.
             t_ns: state0.t_ns.saturating_add(self.delta_state.t_ns),
             t_w_i: state0.t_w_i,
-            // `:178`
             vel_w_i: state0.vel_w_i + *g * dt + state0.t_w_i.rotation * self.delta_state.vel_w_i,
         };
         state1.t_w_i.rotation = state0.t_w_i.rotation * self.delta_state.t_w_i.rotation; // `:177`
-        // `:179-180`
         state1.t_w_i.translation = state0.t_w_i.translation
             + state0.vel_w_i * dt
             + *g * c::<S>(0.5) * dt * dt
@@ -571,7 +446,7 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
         state1
     }
 
-    /// The 9-vector residual between two states (`preintegration.h:200-261`).
+    /// The 9-vector residual between two states.
     ///
     /// Ordered `[translation(3), rotation(3), velocity(3)]` (deviation 3).
     pub fn residual(
@@ -585,7 +460,7 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
         self.residual_parts(state0, g, state1, curr_bg, curr_ba).0
     }
 
-    /// [`Self::residual`] plus the three Jacobians (`preintegration.h:227-258`).
+    /// [`Self::residual`] plus the three Jacobians.
     pub fn residual_with_jacobians(
         &self,
         state0: &PoseVelState<S>,
@@ -600,7 +475,6 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
         let res_rot: Vector3<S> = res.fixed_rows::<3>(3).into_owned();
         let j: Matrix3<S> = right_jacobian_inv_so3(&res_rot); // `:228`
 
-        // `:230-239`
         let mut d_res_d_state0: Matrix9<S> = Matrix9::zeros();
         d_res_d_state0
             .fixed_view_mut::<3, 3>(0, 0)
@@ -621,7 +495,6 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
             .fixed_view_mut::<3, 3>(6, 6)
             .copy_from(&-r0_inv);
 
-        // `:241-247`
         let mut d_res_d_state1: Matrix9<S> = Matrix9::zeros();
         d_res_d_state1
             .fixed_view_mut::<3, 3>(0, 0)
@@ -633,8 +506,8 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
             .fixed_view_mut::<3, 3>(6, 6)
             .copy_from(&r0_inv);
 
-        // `:250-258`. The gyro half is `-d_state_d_bg` with its rotation rows
-        // *replaced* — note the missing minus sign there, which is basalt's.
+        // Gyro-bias columns start as `-d_state_d_bg`, then replace the rotation rows
+        // with the rotation correction Jacobian, without that minus sign.
         let mut d_res_d_bias: Matrix9x6<S> = Matrix9x6::zeros();
         d_res_d_bias
             .fixed_view_mut::<9, 3>(0, 0)
@@ -658,8 +531,8 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
     }
 
     /// The residual and the four intermediates its Jacobians reuse:
-    /// `R0_inv` (`preintegration.h:213`), `tmp` (`:214`), `tmp2` (`:223`) and
-    /// `dt` (`:203`).
+    /// `R0_inv`, `tmp`, `tmp2` and
+    /// `dt`.
     fn residual_parts(
         &self,
         state0: &PoseVelState<S>,
@@ -670,29 +543,27 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
     ) -> (Vector9<S>, Matrix3<S>, Vector3<S>, Vector3<S>, S) {
         let dt: S = c::<S>(self.delta_state.t_ns as f64) * c::<S>(1e-9); // `:203`
 
-        // `:208-209`, Paper 1 Eq. (17).
+        // Paper 1 Eq. (17).
         let bg_diff: Vector9<S> = self.d_state_d_bg * (curr_bg - self.bias_gyro_lin);
         let ba_diff: Vector9<S> = self.d_state_d_ba * (curr_ba - self.bias_accel_lin);
 
         let r0_inv: Matrix3<S> = state0.t_w_i.rotation.inverse().matrix(); // `:213`
-        // `:214-215`. The `− vel * dt` term is the one Paper 1's Eq. (20) omits.
+        // The `− vel * dt` term is the one Paper 1's Eq. (20) omits.
         let tmp: Vector3<S> = r0_inv
             * (state1.t_w_i.translation
                 - state0.t_w_i.translation
                 - state0.vel_w_i * dt
                 - *g * c::<S>(0.5) * dt * dt);
-        // `:223`
         let tmp2: Vector3<S> = r0_inv * (state1.vel_w_i - state0.vel_w_i - *g * dt);
 
         let mut res: Vector9<S> = Vector9::zeros();
-        // `:217-218`
         res.fixed_rows_mut::<3>(0).copy_from(
             &(tmp
                 - (self.delta_state.t_w_i.translation
                     + bg_diff.fixed_rows::<3>(0)
                     + ba_diff.fixed_rows::<3>(0))),
         );
-        // `:219-221`, deviation 4: the gyro-bias correction is pre-multiplied.
+        // deviation 4: the gyro-bias correction is pre-multiplied.
         res.fixed_rows_mut::<3>(3).copy_from(
             &(So3::exp(&bg_diff.fixed_rows::<3>(3).into_owned())
                 * self.delta_state.t_w_i.rotation
@@ -700,7 +571,6 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
                 * state0.t_w_i.rotation)
                 .log(),
         );
-        // `:224-225`
         res.fixed_rows_mut::<3>(6).copy_from(
             &(tmp2
                 - (self.delta_state.vel_w_i
@@ -711,34 +581,32 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
         (res, r0_inv, tmp, tmp2, dt)
     }
 
-    /// Elapsed time of the measurement, in nanoseconds (`preintegration.h:264`).
+    /// Elapsed time of the measurement, in nanoseconds.
     pub fn get_dt_ns(&self) -> i64 {
         self.delta_state.t_ns
     }
 
-    /// Start time of the measurement, in nanoseconds (`preintegration.h:267`).
+    /// Start time of the measurement, in nanoseconds.
     pub fn get_start_t_ns(&self) -> i64 {
         self.start_t_ns
     }
 
-    /// The preintegrated delta state (`preintegration.h:294`).
+    /// The preintegrated delta state.
     pub fn get_delta_state(&self) -> &PoseVelState<S> {
         &self.delta_state
     }
 
-    /// The measurement covariance (`preintegration.h:290`).
+    /// The measurement covariance.
     pub fn get_cov(&self) -> &Matrix9<S> {
         &self.cov
     }
 
     /// Jacobian of the delta state with respect to the accelerometer bias
-    /// (`preintegration.h:297`).
     pub fn get_d_state_d_ba(&self) -> &Matrix9x3<S> {
         &self.d_state_d_ba
     }
 
     /// Jacobian of the delta state with respect to the gyroscope bias
-    /// (`preintegration.h:300`).
     pub fn get_d_state_d_bg(&self) -> &Matrix9x3<S> {
         &self.d_state_d_bg
     }
@@ -749,7 +617,6 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
     /// finite, zero weight in those factor coordinates. The singular result is
     /// a generalized inverse through congruence, not a Moore-Penrose inverse.
     pub fn get_cov_inv_sqrt(&self) -> Matrix9<S> {
-        // `:306-307`
         let mut mat: Matrix9<S> = self.cov;
         let transpositions: [usize; POSE_VEL_SIZE] = ldlt_in_place(&mut mat);
 
@@ -760,7 +627,7 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
                 m.swap_rows(k, pivot);
             }
         }
-        // `:310`: `matrixL()` is a *unit* lower triangular view, so the stored
+        // `matrixL()` is a *unit* lower triangular view, so the stored
         // diagonal (which holds D) is not read here.
         for i in 0..POSE_VEL_SIZE {
             for k in 0..i {
@@ -771,7 +638,7 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
                 }
             }
         }
-        // `:312-320`. The comparison is against
+        // The comparison is against
         // `std::numeric_limits<Scalar>::min()`, so a *negative* pivot — what a
         // rank-deficient covariance actually produces, see [`ldlt_in_place`] —
         // zeroes its row rather than taking the square root of a negative.
@@ -788,7 +655,7 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
         m
     }
 
-    /// The inverse covariance, `Mᵀ M` (`preintegration.h:270-277`).
+    /// The inverse covariance, `Mᵀ M`.
     pub fn get_cov_inv(&self) -> Matrix9<S> {
         let m: Matrix9<S> = self.get_cov_inv_sqrt();
         m.transpose() * m
@@ -800,7 +667,6 @@ impl<S: LieScalar> IntegratedImuMeasurement<S> {
 static ANTIPARALLEL_WARNING: std::sync::Once = std::sync::Once::new();
 
 /// The initial orientation from one accelerometer sample
-/// (`src/vi_estimator/sqrt_keypoint_vio.cpp:277-278`).
 ///
 /// Align measured specific force with world +Z. Only roll and pitch are
 /// observable. Near antiparallel inputs use a cross-product axis orthogonal
@@ -838,7 +704,6 @@ pub fn gravity_from_first_accel<S: LieScalar>(accel: &Vector3<S>) -> So3<S> {
         return So3::from_unit_quaternion(nalgebra::UnitQuaternion::new_normalize(quaternion));
     }
 
-    // `:719-723`
     let axis: Vector3<S> = v0.cross(&v1);
     let s: S = ((S::one() + dot) * c::<S>(2.0)).sqrt();
     let inv_s: S = S::one() / s;
@@ -885,7 +750,7 @@ fn ldlt_in_place<S: LieScalar>(mat: &mut Matrix9<S>) -> [usize; POSE_VEL_SIZE] {
     let mut transpositions: [usize; POSE_VEL_SIZE] = [0; POSE_VEL_SIZE];
 
     for k in 0..size {
-        // `:305-307`. `maxCoeff` keeps the *first* maximum, so the comparison
+        // `maxCoeff` keeps the *first* maximum, so the comparison
         // has to be strict.
         let mut pivot: usize = k;
         for i in (k + 1)..size {
@@ -896,7 +761,7 @@ fn ldlt_in_place<S: LieScalar>(mat: &mut Matrix9<S>) -> [usize; POSE_VEL_SIZE] {
         transpositions[k] = pivot;
 
         if pivot != k {
-            // `:313-321`: a symmetric swap written to keep only the lower
+            // a symmetric swap written to keep only the lower
             // triangle valid, which is all the rest of the algorithm reads.
             for column in 0..k {
                 let swapped: S = mat[(k, column)];
@@ -918,7 +783,7 @@ fn ldlt_in_place<S: LieScalar>(mat: &mut Matrix9<S>) -> [usize; POSE_VEL_SIZE] {
             }
         }
 
-        // `:330-339`: the delayed update. Column `k` is brought up to date from
+        // the delayed update. Column `k` is brought up to date from
         // the columns already factorized; the trailing diagonal is not touched.
         let rs: usize = size - k - 1;
         if k > 0 {
@@ -947,7 +812,7 @@ fn ldlt_in_place<S: LieScalar>(mat: &mut Matrix9<S>) -> [usize; POSE_VEL_SIZE] {
         let pivot_is_valid: bool = real_akk.abs() > S::zero();
 
         if k == 0 && !pivot_is_valid {
-            // `:348-357`: the whole diagonal is zero, so there is nothing left
+            // the whole diagonal is zero, so there is nothing left
             // to do but fill in the identity transpositions. The empty
             // measurement takes this branch and whitens to zero.
             for (j, entry) in transpositions.iter_mut().enumerate() {
@@ -965,47 +830,37 @@ fn ldlt_in_place<S: LieScalar>(mat: &mut Matrix9<S>) -> [usize; POSE_VEL_SIZE] {
     transpositions
 }
 
-/// The linearization point the IMU block needs, `basalt::ImuLinData`
-/// (`include/basalt/utils/imu_types.h:306-315`).
+/// Linearization inputs for an IMU factor.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ImuLinData<S: LieScalar> {
     /// Gravity in the world frame.
     pub g: Vector3<S>,
     /// `1 / gyro_bias_std`, the square-root weight of the gyro random walk
-    /// (`sqrt_keypoint_vio.cpp:107-108`).
     pub gyro_bias_weight_sqrt: Vector3<S>,
     /// `1 / accel_bias_std`, the same for the accelerometer.
     pub accel_bias_weight_sqrt: Vector3<S>,
 }
 
-/// One linearized IMU factor: 15 whitened rows over two 15-column states.
-///
-/// A partial port of `basalt::ImuBlock` (`include/basalt/linearization/imu_block.hpp`)
-/// — enough to show how the residual and its Jacobians are consumed. The parts
-/// that belong to the square-root linearizer (`add_dense_Q2Jp_Q2r`,
-/// `scaleJp_cols`, `addJp_diag2`, `backSubstitute`) land with that stage.
-///
-/// Rows 0-8 are the whitened preintegration residual, rows 9-11 the gyro-bias
-/// random walk and rows 12-14 the accel-bias random walk. Columns 0-14 belong to
-/// the start state and 15-29 to the end state.
+/// An IMU factor with 15 whitened rows over two 15-column states.
+/// Rows 0–8 are preintegration, 9–11 gyro-bias random walk, and 12–14
+/// accelerometer-bias random walk. Start-state columns precede end-state columns.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ImuBlock<S: LieScalar> {
-    /// `Jp` (`imu_block.hpp:21`, `:54-79`).
+    /// `Jp`.
     pub jp: Matrix15x30<S>,
-    /// `r` (`imu_block.hpp:22`, `:60-81`).
+    /// `r`.
     pub r: Vector15<S>,
     /// What `linearizeImu` returns: `imu_error + bg_error + ba_error`
-    /// (`imu_block.hpp:85`).
     pub error: S,
 }
 
 impl<S: LieScalar> ImuBlock<S> {
-    /// `ImuBlock::linearizeImu` (`imu_block.hpp:25-86`).
+    /// `ImuBlock::linearizeImu`.
     ///
     /// The residual is evaluated at the *linearized* states together with its
-    /// Jacobians (`:41-43`) and then, if either state has a frozen linearization
+    /// Jacobians and then, if either state has a frozen linearization
     /// point, re-evaluated at the current states for its **value only**
-    /// (`:45-48`). Skipping that second evaluation is trap 7 of the architecture
+    /// Skipping that second evaluation is trap 7 of the architecture
     /// dossier: it drifts rather than fails.
     pub fn linearize(
         meas: &IntegratedImuMeasurement<S>,
@@ -1056,7 +911,6 @@ impl<S: LieScalar> ImuBlock<S> {
         let dt: S = c::<S>(meas.get_dt_ns() as f64) * c::<S>(1e-9); // `:63`
         let sqrt_dt: S = dt.sqrt();
 
-        // `:65-73`
         let gyro_bias_weight_dt: Vector3<S> = lin_data.gyro_bias_weight_sqrt / sqrt_dt;
         let res_bg: Vector3<S> = start_state.state().bias_gyro - end_state.state().bias_gyro;
         jp.fixed_view_mut::<3, 3>(9, start_idx + BIAS_GYRO_OFFSET)
@@ -1067,7 +921,6 @@ impl<S: LieScalar> ImuBlock<S> {
         r.fixed_rows_mut::<3>(9).copy_from(&weighted_bg);
         let bg_error: S = c::<S>(0.5) * weighted_bg.norm_squared();
 
-        // `:75-83`
         let accel_bias_weight_dt: Vector3<S> = lin_data.accel_bias_weight_sqrt / sqrt_dt;
         let res_ba: Vector3<S> = start_state.state().bias_accel - end_state.state().bias_accel;
         jp.fixed_view_mut::<3, 3>(12, start_idx + BIAS_ACCEL_OFFSET)
@@ -1085,12 +938,8 @@ impl<S: LieScalar> ImuBlock<S> {
         }
     }
 
-    /// Scatter `JᵀJ` and `Jᵀr` into a dense Hessian and gradient
-    /// (`imu_block.hpp:104-129`).
-    ///
-    /// `start_idx` and `end_idx` are the two states' offsets in the stacked
-    /// state vector, which C++ reads from the `AbsOrderMap`. Out-of-range
-    /// offsets are ignored rather than panicking (decision D32).
+    /// Scatter `JᵀJ` and `Jᵀr` at the supplied start/end state offsets.
+    /// Out-of-range offsets are ignored instead of panicking (D32).
     pub fn add_dense_h_b(
         &self,
         start_idx: usize,
@@ -1128,12 +977,12 @@ impl<S: LieScalar> ImuBlock<S> {
     }
 
     /// Scatter the 15 whitened rows into the stacked square-root system,
-    /// `add_dense_Q2Jp_Q2r` (`imu_block.hpp:88-102`).
+    /// `add_dense_Q2Jp_Q2r`.
     ///
     /// `row_start_idx` is where this interval's rows begin; the driver advances
     /// it by `POSE_VEL_BIAS_SIZE` per interval
-    /// (`linearization_abs_qr.cpp:496-502`). Both column blocks are **added**,
-    /// not assigned (`:95-101`), which matters only if two intervals were ever
+    /// Both column blocks are **added**,
+    /// not assigned, which matters only if two intervals were ever
     /// given the same rows.
     ///
     /// Out-of-range offsets are ignored rather than panicking (decision D32),
@@ -1169,12 +1018,11 @@ impl<S: LieScalar> ImuBlock<S> {
     }
 
     /// This factor's share of the model cost change, `backSubstitute`
-    /// (`imu_block.hpp:159-183`).
     ///
     /// There is nothing to back-substitute — the IMU block has no eliminated
     /// variables — so the whole method is the `l_diff` accumulation
     /// `l_diff -= (J inc)ᵀ (0.5 (J inc) + r)` over the two states' slices of the
-    /// increment (`:166-182`).
+    /// increment.
     pub fn back_substitute(
         &self,
         start_idx: usize,
@@ -1191,7 +1039,7 @@ impl<S: LieScalar> ImuBlock<S> {
         if !fits(start_idx) || !fits(end_idx) {
             return;
         }
-        // `pose_inc_reduced` (`:166-168`): the start state's block, then the
+        // `pose_inc_reduced` : the start state's block, then the
         // end state's.
         let mut reduced: SMatrix<S, { 2 * POSE_VEL_BIAS_SIZE }, 1> = SMatrix::zeros();
         for i in 0..size {
@@ -1220,15 +1068,9 @@ mod tests {
     use nalgebra::SVector;
     use proptest::prelude::*;
 
-    // ── Test support ────────────────────────────────────────────────────
-    //
-    // Two things the C++ tests lean on are not ported: `Se3Spline<5>` (a
-    // cumulative B-spline on SE(3), out of V0 scope per papers.md §5, and about
-    // 700 lines for a ground-truth generator) and Eigen's `Random()`. In their
-    // place: `Trajectory` below is an analytic sum of sinusoids whose pose,
-    // world velocity, world acceleration and *body* angular velocity are all
-    // closed form, and `Rng` is a seeded xorshift so nothing flakes — Eigen's
-    // `Random()` never reseeds, so the C++ tests are deterministic too.
+    // Test support uses a smooth analytic trajectory with closed-form pose, velocity,
+    // acceleration and body angular velocity, plus a seeded xorshift generator.
+    // This keeps tests deterministic without a spline dependency.
 
     /// xorshift64*, so every ported test runs the same numbers each time.
     struct Rng(u64);
@@ -1247,7 +1089,7 @@ mod tests {
             x.wrapping_mul(0x2545_f491_4f6c_dd1d)
         }
 
-        /// Uniform on `[-1, 1]`, which is what `Eigen::Vector3d::Random()` gives.
+        /// Uniform value in `[-1, 1]`.
         fn uniform(&mut self) -> f64 {
             (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64 * 2.0 - 1.0
         }
@@ -1257,7 +1099,7 @@ mod tests {
             low + (self.uniform() + 1.0) * 0.5 * (high - low)
         }
 
-        /// `Eigen::Vector3d::Random()`.
+        /// Three independent uniform values in `[-1, 1]`.
         fn vector3(&mut self) -> Vector3<f64> {
             Vector3::new(self.uniform(), self.uniform(), self.uniform())
         }
@@ -1268,15 +1110,9 @@ mod tests {
         }
     }
 
-    /// A smooth analytic trajectory, standing in for `Se3Spline<5>` with a
-    /// random knot sequence.
-    ///
-    /// Position is `A_k sin(w_k t + f_k)` per axis, so velocity and acceleration
-    /// are exact. Orientation is `exp(phi(t))` with
-    /// `phi_k(t) = B_k sin(u_k t + g_k)`, and the body angular velocity is
-    /// exactly `J_r(phi) phi_dot` — the right Jacobian already ported in
-    /// [`right_jacobian_so3`]. The frequencies are small enough that basalt's
-    /// midpoint integrator reaches the C++ tolerances over the same 20 s horizon.
+    /// Smooth analytic trajectory: sinusoidal position gives exact velocity and
+    /// acceleration. For `R = exp(phi(t))`, body angular velocity is `J_r(phi) phi_dot`.
+    /// Low frequencies keep midpoint integration error bounded over the 20-second test.
     struct Trajectory {
         pos_amp: Vector3<f64>,
         pos_freq: Vector3<f64>,
@@ -1351,9 +1187,7 @@ mod tests {
             right_jacobian_so3(&self.rotation_vector(t)) * self.rotation_vector_dot(t)
         }
 
-        /// The sample basalt's tests build: specific force in the body frame and
-        /// the body angular velocity, stamped at the *middle* of the interval
-        /// (`test_preintegration.cpp:74-81`).
+        /// Body-frame specific force and angular velocity sampled at the interval midpoint.
         fn sample(&self, t_ns: i64, dt_ns: i64) -> ImuSample {
             let pose: Se3<f64> = self.pose(t_ns);
             ImuSample {
@@ -1364,13 +1198,9 @@ mod tests {
         }
     }
 
-    /// `test_jacobian` from `thirdparty/basalt-headers/test/include/test_utils.h:22-61`.
-    ///
-    /// Central differences at `x0 = 0` — every call site in the fork passes a
-    /// zero `x0` — with Eigen's two comparisons: `isZero(prec)` is
-    /// `norm() <= prec` and `isApprox(other, prec)` is
-    /// `(a - b).norm() <= prec * min(|a|, |b|)`. `TestConstants<double>` is
-    /// `epsilon = 1e-8`, `max_norm = 1e-3` (`test_utils.h:10-14`).
+    /// Central differences at zero with epsilon `1e-8` and norm tolerance `1e-3`.
+    /// Zero comparison uses the absolute norm; relative comparison scales by the
+    /// smaller input norm.
     fn test_jacobian<const R: usize, const C: usize>(
         name: &str,
         ja: &SMatrix<f64, R, C>,
@@ -1411,11 +1241,10 @@ mod tests {
         }
     }
 
-    /// `TestConstants<double>::epsilon` (`test_utils.h:12`).
+    /// `TestConstants<double>::epsilon`.
     const DEFAULT_EPS: f64 = 1e-8;
-    /// `TestConstants<double>::max_norm` (`test_utils.h:13`).
+    /// `TestConstants<double>::max_norm`.
     const DEFAULT_MAX_NORM: f64 = 1e-3;
-    /// `test_preintegration.cpp:43-44` and `test_vio.cpp:14-15`.
     const ACCEL_STD_DEV: f64 = 0.23;
     const GYRO_STD_DEV: f64 = 0.0027;
 
@@ -1426,22 +1255,16 @@ mod tests {
         }
     }
 
-    /// `Eigen::MatrixBase::isApprox`, the relative comparison the fork asserts with.
+    /// Relative matrix comparison scaled by the smaller input norm.
     fn is_approx(a: &Vector3<f64>, b: &Vector3<f64>, precision: f64) -> bool {
         (a - b).norm() <= precision * a.norm().min(b.norm())
     }
 
-    // ── Ported: thirdparty/basalt-headers/test/src/test_preintegration.cpp ──
-    //
-    // Four of the six cases are ported. `CovarianceTest` (`:496-589`) is not:
-    // it is a 1 000-run Monte Carlo over 100 samples whose `kl <= 0.08` bound
-    // only holds at that sample count, which is ~10^5 unoptimised integrations
-    // and does not fit a gate that has to finish in seconds. Its content is
-    // covered instead by `the_first_covariance_step_is_the_noise_input_alone`
-    // and the symmetric-PSD / `MᵀM cov = I` property below. `RandomWalkTest`
-    // (`:591+`) tests Eigen's random number generator, not preintegration.
+    // Preintegration invariants include the first covariance step, symmetric positive
+    // semidefiniteness and the whitening identity. These directly check covariance
+    // behavior without a large Monte Carlo run.
 
-    /// `ImuPreintegrationTestCase.PredictTestGT` (`test_preintegration.cpp:56-99`).
+    /// `ImuPreintegrationTestCase.PredictTestGT`.
     ///
     /// 2 000 samples over 20 s, then `predictState` from the true state at 0 has
     /// to land on the true state at the end: velocity and translation within a
@@ -1491,11 +1314,7 @@ mod tests {
         );
     }
 
-    /// `ImuPreintegrationTestCase.PredictTest` (`test_preintegration.cpp:101-182`).
-    ///
-    /// `F`, `A` and `G` against central differences at every step of the sweep.
-    /// The C++ passes `eps = 1e-8` explicitly for the gyro block, which is the
-    /// `double` default anyway.
+    /// Compare transition and noise-input Jacobians with central differences at each step.
     #[test]
     fn propagate_state_jacobians_match_finite_differences() {
         let mut rng: Rng = Rng::new(0x5eed_0002);
@@ -1578,7 +1397,7 @@ mod tests {
         }
     }
 
-    /// `ImuPreintegrationTestCase.ResidualTest` (`test_preintegration.cpp:184-282`).
+    /// `ImuPreintegrationTestCase.ResidualTest`.
     ///
     /// The residual at the true end state is zero to `1e-6` per coefficient, and
     /// the four Jacobians match central differences at a perturbed end state.
@@ -1660,7 +1479,7 @@ mod tests {
     }
 
     /// The samples `BiasTest` and `ResidualBiasTest` share
-    /// (`test_preintegration.cpp:299-309`): 100 samples over 1 s with both
+    /// 100 samples over 1 s with both
     /// biases added in.
     fn biased_samples(
         trajectory: &Trajectory,
@@ -1695,7 +1514,7 @@ mod tests {
         meas
     }
 
-    /// `ImuPreintegrationTestCase.BiasTest` (`test_preintegration.cpp:284-372`).
+    /// `ImuPreintegrationTestCase.BiasTest`.
     ///
     /// The two bias Jacobians against re-integrating the same samples about a
     /// perturbed linearization point, compared through `PoseVelState::diff`.
@@ -1734,13 +1553,9 @@ mod tests {
         );
     }
 
-    /// `ImuPreintegrationTestCase.ResidualBiasTest` (`test_preintegration.cpp:374-494`).
-    ///
-    /// The first-order bias correction inside the residual has to agree with an
-    /// actual re-integration about the shifted bias (relative `1e-4`), and the
-    /// two bias Jacobians have to match finite differences taken *through* that
-    /// re-integration — the gyro one with the looser `max_norm = 1e-2` the C++
-    /// passes at `:492`.
+    /// Bias correction must agree with reintegration about the shifted bias within
+    /// relative `1e-4`. Compare both bias Jacobians through reintegration, with the
+    /// gyro Jacobian's norm tolerance `1e-2`.
     #[test]
     fn residual_bias_correction_agrees_with_reintegration() {
         let mut rng: Rng = Rng::new(0x5eed_0005);
@@ -1799,9 +1614,9 @@ mod tests {
         );
     }
 
-    // ── Ported: test/src/test_vio.cpp ───────────────────────────────────
+    // IMU factor invariants.
 
-    /// `ScBundleAdjustmentBase::checkNullspace` (`src/vi_estimator/sc_ba_base.cpp:485-639`),
+    /// `ScBundleAdjustmentBase::checkNullspace`,
     /// restricted to the pose-velocity-bias blocks the two IMU tests use — the
     /// pose-only branch belongs to the visual factors.
     ///
@@ -1820,7 +1635,7 @@ mod tests {
         let size: usize = order.total_size();
         let mut increments: [DVector<f64>; 6] = std::array::from_fn(|_| DVector::zeros(size));
 
-        // `:525-539`: the centroid the rotations turn about.
+        // the centroid the rotations turn about.
         let mut mean_trans: Vector3<f64> = Vector3::zeros();
         for (frame_id, _, _) in order.iter() {
             mean_trans += frame_states[&frame_id].state_lin().t_w_i.translation;
@@ -1835,7 +1650,7 @@ mod tests {
                 increments[3 + axis][offset + 3 + axis] = eps; // `:548-550`
             }
 
-            // `:564-573` and `:576-585`: the rotation increments also move the
+            //  and : the rotation increments also move the
             // translations (about the centroid) and the velocities.
             let j: Matrix3<f64> = -So3::hat(&(state.t_w_i.translation - mean_trans)) * eps;
             let j_vel: Matrix3<f64> = -So3::hat(&state.vel_w_i) * eps;
@@ -1858,11 +1673,11 @@ mod tests {
         result
     }
 
-    /// `ScBundleAdjustmentBase::computeImuError` (`src/vi_estimator/sc_ba_base.cpp:657-704`),
+    /// `ScBundleAdjustmentBase::computeImuError`,
     /// for the measurements the two IMU tests hold, summed into one number.
     ///
     /// Note `gyro_bias_weight / dt` here against `gyro_bias_weight_sqrt / sqrt(dt)`
-    /// in the block (`imu_block.hpp:65`): the caller passes the squared weight.
+    /// in the block : the caller passes the squared weight.
     fn compute_imu_error(
         order: &AbsOrderMap,
         states: &HashMap<i64, PoseVelBiasStateWithLin<f64>>,
@@ -1902,7 +1717,6 @@ mod tests {
     }
 
     /// Noisy samples over `[from_ns, to_ns)`, as both nullspace tests build them
-    /// (`test_vio.cpp:52-74`).
     fn noisy_samples(
         trajectory: &Trajectory,
         bg: &Vector3<f64>,
@@ -1940,7 +1754,7 @@ mod tests {
         meas
     }
 
-    /// `test_vio.cpp:82-86, 104-105`: both weights are `1e3`.
+    /// both weights are `1e3`.
     fn lin_data() -> ImuLinData<f64> {
         ImuLinData {
             g: gravity::<f64>(),
@@ -1949,7 +1763,7 @@ mod tests {
         }
     }
 
-    /// `VioTestSuite.ImuNullspace2Test` (`test/src/test_vio.cpp:28-147`).
+    /// `VioTestSuite.ImuNullspace2Test`.
     ///
     /// One IMU factor between two full states: the block's `H` and `b` have to
     /// reproduce the error change to `2e-2` for ten small random increments, and
@@ -1994,7 +1808,7 @@ mod tests {
         block.add_dense_h_b(0, POSE_VEL_BIAS_SIZE, &mut h, &mut b);
         let e0: f64 = block.error;
 
-        // `:114-136`: the quadratic model has to predict the error change.
+        // the quadratic model has to predict the error change.
         let gyro_weight: Vector3<f64> = ild.gyro_bias_weight_sqrt.map(|v: f64| v * v);
         let accel_weight: Vector3<f64> = ild.accel_bias_weight_sqrt.map(|v: f64| v * v);
         for _ in 0..10 {
@@ -2028,15 +1842,14 @@ mod tests {
         assert!(null_res[1].abs() <= 1e-8, "y {}", null_res[1]);
         assert!(null_res[2].abs() <= 1e-8, "z {}", null_res[2]);
         assert!(null_res[5].abs() <= 1e-6, "yaw {}", null_res[5]);
-        // Not in the C++, which only prints these: gravity makes roll and pitch
-        // observable, so they — and any random direction — must carry real
-        // information. Without this an all-zero `H` would pass vacuously.
+        // Gravity makes roll and pitch observable; require real information in those
+        // and random directions so an all-zero Hessian cannot pass vacuously.
         assert!(null_res[3].abs() > 1.0, "roll {}", null_res[3]);
         assert!(null_res[4].abs() > 1.0, "pitch {}", null_res[4]);
         assert!(null_res[6].abs() > 1.0, "random {}", null_res[6]);
     }
 
-    /// `VioTestSuite.ImuNullspace3Test` (`test/src/test_vio.cpp:151-286`).
+    /// `VioTestSuite.ImuNullspace3Test`.
     ///
     /// Two consecutive IMU factors over three states; the same four directions
     /// have to stay in the nullspace once both blocks are accumulated.
@@ -2108,9 +1921,8 @@ mod tests {
         assert!(null_res[1].abs() <= 1e-8, "y {}", null_res[1]);
         assert!(null_res[2].abs() <= 1e-8, "z {}", null_res[2]);
         assert!(null_res[5].abs() <= 1e-6, "yaw {}", null_res[5]);
-        // Not in the C++, which only prints these: gravity makes roll and pitch
-        // observable, so they — and any random direction — must carry real
-        // information. Without this an all-zero `H` would pass vacuously.
+        // Gravity makes roll and pitch observable; require real information in those
+        // and random directions so an all-zero Hessian cannot pass vacuously.
         assert!(null_res[3].abs() > 1.0, "roll {}", null_res[3]);
         assert!(null_res[4].abs() > 1.0, "pitch {}", null_res[4]);
         assert!(null_res[6].abs() > 1.0, "random {}", null_res[6]);
@@ -2118,10 +1930,8 @@ mod tests {
 
     // ── Port-specific tests ─────────────────────────────────────────────
 
-    /// The `BASALT_ASSERT` at `preintegration.h:211` holds structurally: the
-    /// accelerometer bias cannot move the rotation part of the delta state,
-    /// because `d_next_d_accel` has no rotation rows and `F`'s rotation rows are
-    /// `[0 I 0]`.
+    /// Accelerometer bias cannot move delta rotation: its input Jacobian has zero
+    /// rotation rows and the transition's rotation rows are `[0 I 0]`.
     #[test]
     fn the_accel_bias_jacobian_never_touches_rotation() {
         let mut rng: Rng = Rng::new(0x5eed_0008);
@@ -2140,7 +1950,7 @@ mod tests {
 
     /// The empty measurement is exactly zero everywhere, and its square-root
     /// inverse covariance is zero rather than infinite — the pseudo-inverse
-    /// branch at `preintegration.h:313-319`.
+    /// branch.
     #[test]
     fn an_empty_measurement_has_a_zero_pseudo_inverse() {
         let meas: IntegratedImuMeasurement<f64> = IntegratedImuMeasurement::default();
@@ -2204,8 +2014,8 @@ mod tests {
         /// and `G`.
         ///
         /// `cov_n = Σ_{k<n} F^k Q (F^k)ᵀ` with `Q = A Σa Aᵀ + G Σg Gᵀ`
-        /// (`preintegration.h:161-162`), `d_state_d_ba_n = -Σ_{k<n} F^k A` and
-        /// `d_state_d_bg_n = -Σ_{k<n} F^k G` (`:165-166`). One step, thirty
+        /// `d_state_d_ba_n = -Σ_{k<n} F^k A` and
+        /// `d_state_d_bg_n = -Σ_{k<n} F^k G`. One step, thirty
         /// steps and sub-millisecond intervals all fall out of the ranges.
         #[test]
         fn the_covariance_recurrence_matches_its_closed_form(
@@ -2365,7 +2175,7 @@ mod tests {
     /// empty interval, an interval starting somewhere else, and an interval it
     /// could not close — the last as `Ok` with a measurement shorter than the
     /// frame gap. Both producers precheck a sample strictly after the frame
-    /// (`sqrt_keypoint_vio.cpp:265-271` through `imu_covers_frame`, and
+    /// ( through `imu_covers_frame`, and
     /// `Vio::track`'s own coverage test), so none of this can fire on the
     /// shipped path; a public method promising to close the interval exactly
     /// must say so anyway (D32).
@@ -2381,7 +2191,7 @@ mod tests {
             move || samples.next()
         };
 
-        // An empty interval: `:307-313` asserts it, because a zero time delta
+        // An empty interval: asserts it, because a zero time delta
         // "leads to invalid IMU integration".
         assert_eq!(
             meas().accumulate_to(None, feed(vec![sample(1)]), 0, 0, &noise),
@@ -2418,7 +2228,7 @@ mod tests {
         );
 
         // The sample that does follow closes the interval exactly on the frame
-        // and comes back out at its own time (`:330-336`).
+        // and comes back out at its own time.
         let mut closed: IntegratedImuMeasurement<f64> = meas();
         let pending: Option<Popped<f64>> = closed
             .accumulate_to(
@@ -2433,7 +2243,7 @@ mod tests {
         assert_eq!(closed.get_dt_ns(), 10);
     }
 
-    /// `Quaternion::FromTwoVectors(accel, UnitZ)` (`sqrt_keypoint_vio.cpp:278`)
+    /// `Quaternion::FromTwoVectors(accel, UnitZ)`
     /// rotates the measured specific force onto the world `+Z` axis, so gravity
     /// lands along `-Z`.
     #[test]
@@ -2543,7 +2353,7 @@ mod tests {
 
     /// The 9x6 bias Jacobian carries the gyro block in columns 0-2 and the accel
     /// block in 3-5, which is what the estimator's `start_idx + 9` and
-    /// `start_idx + 12` column offsets mean (`imu_block.hpp:57-58`).
+    /// `start_idx + 12` column offsets mean.
     #[test]
     fn the_bias_jacobian_columns_are_gyro_then_accel() {
         let mut rng: Rng = Rng::new(0x5eed_000c);
@@ -2564,13 +2374,13 @@ mod tests {
         );
         let (res, jacobians) = meas.residual_with_jacobians(&state0, &g, &state1, &bg, &ba);
 
-        // The accel half is exactly `-d_state_d_ba` (`preintegration.h:250`).
+        // The accel half is exactly `-d_state_d_ba`.
         assert_eq!(
             jacobians.d_res_d_bias.fixed_view::<9, 3>(0, 3).into_owned(),
             -meas.get_d_state_d_ba()
         );
         // The gyro half is `-d_state_d_bg` with its rotation rows replaced by
-        // `+ leftJacobianInv(res_rot) * d_state_d_bg(3,0)` (`:252-257`).
+        // `+ leftJacobianInv(res_rot) * d_state_d_bg(3,0)`.
         let gyro_half: Matrix9x3<f64> =
             jacobians.d_res_d_bias.fixed_view::<9, 3>(0, 0).into_owned();
         assert_eq!(
@@ -2641,10 +2451,10 @@ mod tests {
     }
 
     /// The square-root and the squared form of the same factor agree:
-    /// `Q2Jpᵀ Q2Jp = H` and `Q2Jpᵀ Q2r = b` (`imu_block.hpp:88-129`).
+    /// `Q2Jpᵀ Q2Jp = H` and `Q2Jpᵀ Q2r = b`.
     ///
-    /// `addJp_diag2` (`:145-157`) must likewise be the squared column norms of
-    /// the same scattered Jacobian, and `backSubstitute` (`:159-183`) the model
+    /// `addJp_diag2` must likewise be the squared column norms of
+    /// the same scattered Jacobian, and `backSubstitute` the model
     /// cost change of the same `J` and `r`.
     #[test]
     fn the_imu_block_exports_agree_with_each_other() {
@@ -2710,7 +2520,7 @@ mod tests {
     }
 
     /// A frozen linearization point changes only the residual *value*, not the
-    /// Jacobians (`imu_block.hpp:45-48`, trap 7 of the architecture dossier).
+    /// Jacobians (trap 7 of the architecture dossier).
     #[test]
     fn the_block_re_evaluates_the_residual_at_a_linearized_state() {
         let mut rng: Rng = Rng::new(0x5eed_000d);
@@ -2745,7 +2555,7 @@ mod tests {
         let frozen: ImuBlock<f64> = ImuBlock::linearize(&meas, &ild, &frozen0, &plain1);
         // Same linearization point, so the Jacobian is untouched...
         assert_eq!(frozen.jp, reference.jp);
-        // ...but the residual moved with the state.
+        // but the residual moved with the state.
         assert!((frozen.r - reference.r).norm() > 1e-6);
     }
 

--- a/packages/slam-rs/crates/slam-rs/src/landmark.rs
+++ b/packages/slam-rs/crates/slam-rs/src/landmark.rs
@@ -1,35 +1,11 @@
-//! Landmarks: the stereographic parameterisation, the landmark record, and the
-//! database the linearizer walks.
+//! Landmark parameterization, records and database.
+//! A landmark has a two-dimensional stereographic direction and inverse distance,
+//! anchored to a host frame and camera. The homogeneous fourth component is
+//! inverse distance; zero represents infinity.
 //!
-//! Ported from `thirdparty/basalt-headers/include/basalt/camera/stereographic_param.hpp`
-//! and `include/basalt/vi_estimator/landmark_database.{h,cpp}`.
-//!
-//! A basalt landmark is **three** parameters — a 2-D stereographic `direction`
-//! and a scalar `inv_dist` — anchored to a host frame *and camera*
-//! (`landmark_database.h:54-92`). The 3-D point is
-//! `unproject(direction)` with the fourth homogeneous slot overwritten by
-//! `inv_dist` (`ba_utils.h:91-92`), so a landmark at infinity is `inv_dist = 0`
-//! and needs no special case.
-//!
-//! Two deliberate departures from the C++ containers, both about determinism
-//! and about the shape the GPU phase wants:
-//!
-//! * **Every map is a `BTreeMap`, never a `HashMap`** (decision D31). C++ uses
-//!   `unordered_map` for `kpts` and for the outer `observations` level, and the
-//!   error sum in [`crate::ba_base::BundleAdjustmentBase::compute_error`] walks
-//!   host frames in that container's order. Floating-point addition is not
-//!   associative, so the port cannot reproduce libstdc++'s bucket order and does
-//!   not try: it sums in sorted [`TimeCamId`] order, which is reproducible on
-//!   every machine and every run. The difference is at the level of the last
-//!   bits of one sum.
-//! * **The landmarks live in a `Vec`, with a `BTreeMap` from id to index**
-//!   (the GPU seam rule: dense arrays plus an index map, never a per-element
-//!   hash map). The `Vec` is kept sorted by [`LandmarkId`], so iterating it is
-//!   the same order as iterating the index, and a later CubeCL kernel can take
-//!   `landmarks()` as one contiguous buffer. Mutation keeps the two in step:
-//!   [`LandmarkDatabase::add_landmark`] inserts in place and
-//!   [`LandmarkDatabase::remove_landmark`] removes in place, both rebuilding the
-//!   index entries the shift invalidated.
+//! Maps use sorted keys for deterministic accumulation (D31). Landmarks occupy
+//! an id-sorted vector with an id-to-index map, supporting contiguous access.
+//! Insertion and removal rebuild index entries affected by the shift.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::marker::PhantomData;
@@ -39,26 +15,19 @@ use nalgebra::{Matrix2x4, Matrix4x2, Vector2, Vector4};
 use crate::lie::{LieScalar, c};
 use crate::types::{FrameId, LandmarkId, TimeCamId};
 
-/// Stereographic projection: the minimal 2-parameter chart on the unit sphere
-/// basalt parameterises landmark directions with
-/// (`stereographic_param.hpp:53-152`).
-///
-/// The chart is smooth and bijective everywhere except at the projection point,
-/// which is why basalt can carry a direction as two unconstrained numbers and
-/// increment them additively.
+/// Two-parameter stereographic chart on the unit sphere.
+/// It is smooth and bijective except at the projection point, permitting additive
+/// direction increments.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct StereographicParam<S: LieScalar> {
     _scalar: PhantomData<S>,
 }
 
 impl<S: LieScalar> StereographicParam<S> {
-    /// `project` (`stereographic_param.hpp:79-106`): `[x, y] / (z + |p|)`.
-    ///
-    /// The fourth component of `p3d` is ignored, exactly as the C++ ignores it:
-    /// only `head<3>()` reaches the norm.
+    /// Project as `[x, y] / (z + |p|)`, ignoring the homogeneous fourth component.
     #[inline]
     pub fn project(p3d: &Vector4<S>) -> Vector2<S> {
-        // `p3d.template head<3>().norm()` (`:80`) — the name `sqrt` is basalt's.
+        // Use only the spatial three-vector's norm.
         let sqrt: S = p3d.fixed_rows::<3>(0).norm();
         let norm: S = p3d[2] + sqrt;
         let norm_inv: S = S::one() / norm;
@@ -66,7 +35,6 @@ impl<S: LieScalar> StereographicParam<S> {
     }
 
     /// [`Self::project`] with the 2x4 Jacobian `d_r_d_p`
-    /// (`stereographic_param.hpp:86-103`).
     #[inline]
     pub fn project_with_jacobian(p3d: &Vector4<S>, d_r_d_p: &mut Matrix2x4<S>) -> Vector2<S> {
         let sqrt: S = p3d.fixed_rows::<3>(0).norm();
@@ -93,11 +61,11 @@ impl<S: LieScalar> StereographicParam<S> {
         res
     }
 
-    /// `unproject` (`stereographic_param.hpp:124-151`):
+    /// `unproject` :
     /// `eta * [u, v, 1] - [0, 0, 1]` with `eta = 2 / (1 + u^2 + v^2)`.
     ///
     /// The fourth component comes back **zero**, not one: the caller overwrites
-    /// it with the landmark's inverse distance (`ba_utils.h:92`), which is what
+    /// it with the landmark's inverse distance, which is what
     /// makes the 4-vector a homogeneous point.
     #[inline]
     pub fn unproject(proj: &Vector2<S>) -> Vector4<S> {
@@ -116,11 +84,9 @@ impl<S: LieScalar> StereographicParam<S> {
     }
 
     /// [`Self::unproject`] with the 4x2 Jacobian `d_r_d_p`
-    /// (`stereographic_param.hpp:133-148`).
     ///
     /// Row 3 is zero: the homogeneous slot does not depend on the direction, so
     /// the inverse-distance column of the residual Jacobian is separate
-    /// (`ba_utils.h:132`).
     #[inline]
     pub fn unproject_with_jacobian(proj: &Vector2<S>, d_r_d_p: &mut Matrix4x2<S>) -> Vector4<S> {
         let x2: S = proj[0] * proj[0];
@@ -155,19 +121,18 @@ impl<S: LieScalar> StereographicParam<S> {
 }
 
 /// One landmark: three optimised parameters, a host image, and its observations
-/// (`landmark_database.h:54-92`).
 #[derive(Debug, Clone, PartialEq)]
 pub struct Landmark<S: LieScalar> {
     /// Stereographic direction in the host camera frame, `direction`.
     pub direction: Vector2<S>,
     /// Inverse distance along that direction, `inv_dist`. Never negative: the
-    /// increment is projected at zero (`landmark_block_abs_dynamic.hpp:326`).
+    /// increment is projected at zero.
     pub inv_dist: S,
     /// The image the direction is expressed in, `host_kf_id`.
     pub host_kf_id: TimeCamId,
     /// Where the landmark was seen, keyed by image, `obs`.
     pub obs: BTreeMap<TimeCamId, Vector2<S>>,
-    /// The database key, `id` (`landmark_database.h:70`).
+    /// The database key, `id`.
     pub id: LandmarkId,
     backup_direction: Vector2<S>,
     backup_inv_dist: S,
@@ -177,7 +142,6 @@ impl<S: LieScalar> Landmark<S> {
     /// A landmark with no observations yet.
     ///
     /// The four fields here are exactly the four `addLandmark` copies
-    /// (`landmark_database.cpp:41-47`).
     pub fn new(id: LandmarkId, host_kf_id: TimeCamId, direction: Vector2<S>, inv_dist: S) -> Self {
         Self {
             direction,
@@ -190,28 +154,20 @@ impl<S: LieScalar> Landmark<S> {
         }
     }
 
-    /// Save the three optimised parameters, `backup` (`landmark_database.h:72-75`).
-    ///
-    /// Only the parameters: the observations and the host are not touched by a
-    /// Levenberg-Marquardt step, so C++ does not save them either.
+    /// Save the three optimized parameters. LM steps do not change observations or hosts.
     pub fn backup(&mut self) {
         self.backup_direction = self.direction;
         self.backup_inv_dist = self.inv_dist;
     }
 
-    /// Undo the last increment, `restore` (`landmark_database.h:77-80`).
+    /// Undo the last increment, `restore`.
     pub fn restore(&mut self) {
         self.direction = self.backup_direction;
         self.inv_dist = self.backup_inv_dist;
     }
 }
 
-/// What the database refuses to do.
-///
-/// basalt asserts in both cases (`landmark_database.cpp:123`, `:216`) and
-/// `getLandmark` calls `std::unordered_map::at`, which throws. The port returns
-/// a typed error instead: the estimator runs inside a released GIL where a
-/// panic aborts the process (decision D32, trap 15).
+/// Typed database failures prevent data errors from panicking with the GIL released (D32).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum LandmarkError {
     /// An observation, a removal or a query named a landmark the database has
@@ -220,18 +176,17 @@ pub enum LandmarkError {
     UnknownLandmark(LandmarkId),
 }
 
-/// basalt's `min_num_obs` (`landmark_database.h:159`): a landmark with fewer
-/// observations than this carries no information and is deleted.
+/// Minimum observations needed for a landmark to retain information.
 const MIN_NUM_OBS: usize = 2;
 
 /// The landmark store and the host -> target -> landmark adjacency the
-/// linearizer iterates (`landmark_database.h:94-160`).
+/// linearizer iterates.
 ///
 /// The adjacency is not a cache: `observations` is what
 /// [`crate::ba_base::BundleAdjustmentBase::compute_error`] and the linearizer
 /// walk, and every mutation keeps it exactly consistent with the landmarks'
 /// own `obs` maps — an empty target set drops the target, an empty target map
-/// drops the host (`landmark_database.cpp:178-205`).
+/// drops the host.
 #[derive(Debug, Clone)]
 pub struct LandmarkDatabase<S: LieScalar> {
     /// Sorted by `LandmarkId`; `index` maps an id to a position here.
@@ -256,30 +211,16 @@ impl<S: LieScalar> LandmarkDatabase<S> {
         }
     }
 
-    /// Forget everything, `clear` (`landmark_database.h:106-109`).
+    /// Forget everything, `clear`.
     pub fn clear(&mut self) {
         self.kpts.clear();
         self.index.clear();
         self.observations.clear();
     }
 
-    /// Add or overwrite a landmark's parameters, `addLandmark`
-    /// (`landmark_database.cpp:41-47`).
-    ///
-    /// C++ writes through `kpts[lm_id]`, which default-constructs a landmark
-    /// when the id is new and then copies **four** fields: `direction`,
-    /// `inv_dist`, `host_kf_id` and `id`. It does *not* copy `obs`, so
-    /// re-adding an existing id keeps that landmark's observations and its
-    /// adjacency entries. The port reproduces that.
-    ///
-    /// **Deviation.** Re-adding an existing id with a *different* host leaves
-    /// C++'s adjacency filed under the old host while the landmark claims the
-    /// new one, and `removeLandmarkHelper` then looks the landmark up under a
-    /// host that does not list it (`landmark_database.cpp:180-187`). The
-    /// estimator never does this — a landmark id comes from a keypoint and is
-    /// added once (`sqrt_keypoint_vio.cpp:535-539`) — so rather than reproduce a
-    /// latent inconsistency the port moves the existing observations to the new
-    /// host and keeps the invariant.
+    /// Add or overwrite parameters while preserving existing observations.
+    /// If the host changes, move adjacency entries to the new host so both database
+    /// views stay consistent.
     pub fn add_landmark(&mut self, lm_id: LandmarkId, pos: &Landmark<S>) {
         match self.index.get(&lm_id) {
             Some(&at) => {
@@ -318,11 +259,7 @@ impl<S: LieScalar> LandmarkDatabase<S> {
         }
     }
 
-    /// Record that `lm_id` was seen at `pos` in `tcid_target`, `addObservation`
-    /// (`landmark_database.cpp:121-128`).
-    ///
-    /// C++ asserts the landmark exists; the port returns
-    /// [`LandmarkError::UnknownLandmark`].
+    /// Record an observation, or return [`LandmarkError::UnknownLandmark`] for an absent id.
     pub fn add_observation(
         &mut self,
         tcid_target: TimeCamId,
@@ -348,14 +285,12 @@ impl<S: LieScalar> LandmarkDatabase<S> {
         Ok(())
     }
 
-    /// A landmark by id, `getLandmark` (`landmark_database.cpp:131-138`).
-    ///
-    /// C++ uses `at`, which throws; the port returns `None`.
+    /// Look up a landmark by id; return `None` if absent.
     pub fn get_landmark(&self, lm_id: LandmarkId) -> Option<&Landmark<S>> {
         self.index.get(&lm_id).and_then(|&at| self.kpts.get(at))
     }
 
-    /// A landmark by id, mutable (`landmark_database.cpp:131-133`).
+    /// A landmark by id, mutable.
     ///
     /// Only the three optimised parameters may be written through this handle;
     /// changing `obs` or `host_kf_id` here would desynchronise the adjacency,
@@ -368,27 +303,25 @@ impl<S: LieScalar> LandmarkDatabase<S> {
     }
 
     /// Whether an id is in the database, `landmarkExists`
-    /// (`landmark_database.cpp:151-154`).
     pub fn landmark_exists(&self, lm_id: LandmarkId) -> bool {
         self.index.contains_key(&lm_id)
     }
 
     /// Every landmark, in id order — one dense slice, for the GPU seam.
     ///
-    /// `getLandmarks` (`landmark_database.cpp:146-149`) hands back the whole
+    /// `getLandmarks` hands back the whole
     /// `unordered_map`; this is the same content in a reproducible order.
     pub fn landmarks(&self) -> &[Landmark<S>] {
         &self.kpts
     }
 
     /// The host -> target -> landmark-set adjacency, `getObservations`
-    /// (`landmark_database.cpp:140-144`).
     pub fn observations(&self) -> &BTreeMap<TimeCamId, BTreeMap<TimeCamId, BTreeSet<LandmarkId>>> {
         &self.observations
     }
 
     /// The images that host at least one landmark, `getHostKfs`
-    /// (`landmark_database.cpp:89-97`), in sorted order.
+    /// in sorted order.
     pub fn host_kfs(&self) -> Vec<TimeCamId> {
         self.observations.keys().copied().collect()
     }
@@ -396,7 +329,7 @@ impl<S: LieScalar> LandmarkDatabase<S> {
     /// The targets one host is observed in, and the landmarks in each.
     ///
     /// The per-(host, target) iteration the linearizer needs: one relative pose
-    /// `T_t_h` is hoisted per pair (`ba_base.cpp:145-160`), and every landmark
+    /// `T_t_h` is hoisted per pair, and every landmark
     /// in the set reuses it.
     pub fn targets_for_host(
         &self,
@@ -405,13 +338,12 @@ impl<S: LieScalar> LandmarkDatabase<S> {
         self.observations.get(&tcid)
     }
 
-    /// Number of landmarks, `numLandmarks` (`landmark_database.cpp:156-159`).
+    /// Number of landmarks, `numLandmarks`.
     pub fn num_landmarks(&self) -> usize {
         self.kpts.len()
     }
 
     /// Number of (landmark, target) pairs in the adjacency, `numObservations`
-    /// (`landmark_database.cpp:161-170`).
     pub fn num_observations(&self) -> usize {
         self.observations
             .values()
@@ -420,8 +352,7 @@ impl<S: LieScalar> LandmarkDatabase<S> {
             .sum()
     }
 
-    /// Delete one landmark and its adjacency, `removeLandmark`
-    /// (`landmark_database.cpp:207-211`). A missing id is a no-op, as in C++.
+    /// Delete a landmark and its adjacency. A missing id is a no-op.
     pub fn remove_landmark(&mut self, lm_id: LandmarkId) {
         if let Some(&at) = self.index.get(&lm_id) {
             self.remove_landmark_at(at);
@@ -429,17 +360,16 @@ impl<S: LieScalar> LandmarkDatabase<S> {
     }
 
     /// The marginalization sweep, `removeKeyframes`
-    /// (`landmark_database.cpp:65-87`).
     ///
     /// Three rules, in this order and no other:
     ///
     /// 1. a landmark **hosted** by a frame in `kfs_to_marg` is deleted outright
-    ///    (`:70-71`) — its direction is expressed in a frame that is about to
+    ///    — its direction is expressed in a frame that is about to
     ///    stop existing, so nothing can be salvaged;
     /// 2. otherwise, every observation made in a frame in any of the three sets
-    ///    is dropped (`:73-78`);
+    ///    is dropped;
     /// 3. then the `min_num_obs = 2` sweep deletes what is left with fewer than
-    ///    two observations (`:80-84`).
+    ///    two observations.
     ///
     /// Note rule 1 short-circuits rule 2: a landmark hosted by a marginalized
     /// keyframe never reaches the observation loop.
@@ -460,7 +390,7 @@ impl<S: LieScalar> LandmarkDatabase<S> {
         );
     }
 
-    /// Save every landmark's parameters, `backup` (`landmark_database.h:141-143`).
+    /// Save every landmark's parameters, `backup`.
     pub fn backup(&mut self) {
         for kpt in &mut self.kpts {
             kpt.backup();
@@ -468,7 +398,6 @@ impl<S: LieScalar> LandmarkDatabase<S> {
     }
 
     /// Undo every landmark's last increment, `restore`
-    /// (`landmark_database.h:145-147`).
     pub fn restore(&mut self) {
         for kpt in &mut self.kpts {
             kpt.restore();
@@ -477,13 +406,8 @@ impl<S: LieScalar> LandmarkDatabase<S> {
 
     // ─── internals ────────────────────────────────────────────────────────
 
-    /// The shared body of `removeFrame` and `removeKeyframes`: delete whole
-    /// landmarks whose host `drop_host` selects, drop the observations
-    /// `keep_obs` rejects, then run the `min_num_obs` sweep
-    /// (`landmark_database.cpp:49-87`).
-    ///
-    /// One pass over the dense `Vec` with `retain`, and one index rebuild, in
-    /// place of C++'s iterator-erasing loop; both leave the same database.
+    /// Remove selected hosts and observations, then delete under-observed landmarks.
+    /// Use one retain pass over the dense vector and one index rebuild.
     fn retain_observations(
         &mut self,
         keep_obs: impl Fn(TimeCamId) -> bool,
@@ -517,7 +441,7 @@ impl<S: LieScalar> LandmarkDatabase<S> {
     }
 
     /// Erase the landmark at a known position and every adjacency entry it owns,
-    /// `removeLandmarkHelper` (`landmark_database.cpp:177-192`).
+    /// `removeLandmarkHelper`.
     fn remove_landmark_at(&mut self, at: usize) {
         let Some(kpt) = self.kpts.get(at) else {
             return;
@@ -532,12 +456,8 @@ impl<S: LieScalar> LandmarkDatabase<S> {
         self.reindex_from(at);
     }
 
-    /// One adjacency entry, `removeLandmarkObservationHelper`
-    /// (`landmark_database.cpp:194-205`) minus the landmark-side erase.
-    ///
-    /// C++ dereferences the result of `observations.find` unchecked; a landmark
-    /// added but never observed makes that a null dereference. The port skips
-    /// the missing entry.
+    /// Remove one adjacency entry, skipping it if absent.
+    /// A landmark added without observations has no entry to remove.
     fn detach_observation(&mut self, host: TimeCamId, target: TimeCamId, lm_id: LandmarkId) {
         detach_one(&mut self.observations, host, target, lm_id);
     }
@@ -556,7 +476,7 @@ impl<S: LieScalar> LandmarkDatabase<S> {
 }
 
 /// Drop `lm_id` from `observations[host][target]`, then the empty containers
-/// above it (`landmark_database.cpp:198-202`).
+/// above it.
 fn detach_one(
     observations: &mut BTreeMap<TimeCamId, BTreeMap<TimeCamId, BTreeSet<LandmarkId>>>,
     host: TimeCamId,
@@ -578,7 +498,6 @@ fn detach_one(
 }
 
 /// The same for every target of one landmark, `removeLandmarkHelper`
-/// (`landmark_database.cpp:180-189`).
 fn detach_landmark<S: LieScalar>(
     observations: &mut BTreeMap<TimeCamId, BTreeMap<TimeCamId, BTreeSet<LandmarkId>>>,
     host: TimeCamId,
@@ -689,7 +608,6 @@ mod tests {
     #[test]
     fn adding_a_landmark_twice_keeps_its_observations() {
         // `addLandmark` copies four fields and leaves `obs` alone
-        // (`landmark_database.cpp:41-47`).
         let mut db: LandmarkDatabase<f64> = a_database();
         let host: TimeCamId = tcid(10, 0);
         let mut again: Landmark<f64> = landmark(0, host);

--- a/packages/slam-rs/crates/slam-rs/src/lib.rs
+++ b/packages/slam-rs/crates/slam-rs/src/lib.rs
@@ -1,16 +1,8 @@
-//! Visual-inertial odometry core.
-//!
-//! The crate is deliberately free of Python, Rerun and GPU code: it consumes
-//! grayscale images and IMU samples and returns plain values. Python plumbing
-//! (catalog feed, evaluation, logging) lives in the `slam_rs` package and the
-//! bindings in `slam-rs-py`; `slam-rs-cli` is a placeholder binary whose only
-//! working subcommand is `version`.
-//!
-//! [`Vio`] is the Offline driver (D17): [`Vio::push_imu`] buffers samples and
-//! [`Vio::track`] runs the frontend and then the estimator to completion in the
-//! calling thread, so every result is final and a repeat run over the same input
-//! is bit-identical. Realtime mode — basalt's two threads joined by bounded
-//! queues — is stage S10's.
+//! Visual-inertial odometry core consuming grayscale images and IMU samples.
+//! Python catalog, evaluation and logging live in `slam_rs`; bindings live in
+//! `slam-rs-py`. The CLI currently provides only `version`.
+//! [`Vio`] buffers IMU samples and processes frames synchronously, returning final
+//! values with deterministic replay (D17). GPU frontend support is feature-gated.
 
 pub mod ba_base;
 pub mod calib;
@@ -70,13 +62,9 @@ pub(crate) fn duration_ns(started: std::time::Instant) -> u64 {
     u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX)
 }
 
-/// How far the estimator has got.
-///
-/// Offline mode has exactly these two states: basalt's estimator initialises
-/// inside the same `process_frame` that measures
-/// (`sqrt_keypoint_vio.cpp:263-296`), so a measured frameset always has a state
-/// and an uncovered one never does. There is no third, "initialising" status a
-/// caller could branch on.
+/// Offline status: a measured frame has a state; an uncovered frame needs more IMU.
+/// Initialization happens in the same call that first measures, so no separate
+/// initializing status is exposed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum VioStatus {
     /// The frame arrived before the IMU samples that cover it. Nothing moved —
@@ -155,13 +143,8 @@ pub enum VioError {
         /// Timestamp of the rejected sample.
         t_ns: i64,
     },
-    /// A sample carries a value that is not a number.
-    ///
-    /// basalt does not check: its samples come from a device driver. Here they
-    /// come from a caller, and one non-finite component reaches both
-    /// preintegrators and poisons every state after it with nothing to undo it —
-    /// so it is bad input, refused at the boundary (D32), not a NaN the
-    /// estimator is asked to survive.
+    /// An IMU sample has a non-finite component. Refuse it at the boundary before
+    /// it contaminates both preintegrators and all following states (D32).
     #[error("imu sample at {t_ns} ns has a non-finite {field}")]
     NonFiniteImu {
         /// Timestamp of the rejected sample.
@@ -445,30 +428,12 @@ fn build_frontend(
     }
 }
 
-/// The estimator, driven one frameset at a time (D17, D24).
-///
-/// One `track` call is basalt's whole pipeline for one frameset, in the calling
-/// thread and in basalt's order:
-///
-/// 1. the frontend's own preintegration over `(t_prev, t_now]` and the pose
-///    prediction it feeds the KLT (`frame_to_frame_optical_flow.h:138-152`) —
-///    the estimator runs a **second, independent** preintegrator (D24) and the
-///    two are deliberately not shared;
-/// 2. `processFrame`, which produces the tracked keypoints;
-/// 3. the estimator's own IMU consumption and `measure`, which optimises and
-///    marginalizes;
-/// 4. the two feedback values basalt pushes back to the frontend: the newest
-///    state, and — because every shipped config sets
-///    `optical_flow_matching_guess_type = REPROJ_AVG_DEPTH` — the average scene
-///    depth from `computeProjections` (`sqrt_keypoint_vio.cpp:583-604`).
-///
-/// Nothing about arrival order can reach a decision: there are no queues, no
-/// drops (`vio_enforce_realtime` is refused) and no threads, which is what makes
-/// a repeat run bit-identical.
-///
-/// The frontend is `f32` throughout, as `FrameToFrameOpticalFlow<float,
-/// Pattern51>` is; the estimator's scalar is the type parameter, and `f32` is
-/// the shipped precision the reference lane runs (Q07).
+/// Synchronous frameset pipeline (D17, D24).
+/// First preintegrate for the frontend prediction, run optical flow, then run
+/// the estimator's independent preintegrator, measurement, optimization and
+/// marginalization. Feed back the newest state and average scene depth.
+/// The two preintegrators remain independent. No timing or queue dropping enters
+/// a decision. The frontend uses f32; the estimator scalar is selectable.
 #[derive(Debug)]
 pub struct Vio<S: lie::LieScalar = f32> {
     frontend: FrontendLane,
@@ -476,18 +441,14 @@ pub struct Vio<S: lie::LieScalar = f32> {
     /// The frontend's own IMU buffer (D24). The same samples reach the
     /// estimator through its own queue.
     frontend_imu: std::collections::VecDeque<imu::ImuSample>,
-    /// The frontend's already-popped sample, `processImu`'s `data` (`:169`).
+    /// The frontend's already-popped sample, `processImu`'s `data`.
     frontend_pending: Option<imu::Popped<f64>>,
-    /// `latest_state` (`frame_to_frame_optical_flow.h:141-146`), which doubles
-    /// as basalt's `first_state_arrived` (`:143`): `None` until the estimator
-    /// has published one. `predicted_state` (`:150`) is a member there and a
-    /// local here — nothing outside the prediction that produces it reads it.
+    /// Most recent estimated state; absent until the estimator publishes one.
     latest_state: Option<types::PoseVelBiasState<f64>>,
-    /// The frontend's own preintegration noise, `accel_cov`/`gyro_cov` at
-    /// `frame_to_frame_optical_flow.h:105-106`.
+    /// The frontend's own accelerometer and gyroscope preintegration noise.
     frontend_noise: imu::ImuNoise<f64>,
     /// The static bias calibration, applied to the frontend's samples in `f32`
-    /// and cast back to `f64` (`:171-178`).
+    /// and cast back to `f64`.
     calib_f32: calib::Calibration<f32>,
     /// Widened frames, reused so a steady-state `track` does not allocate.
     frames: Vec<image::ImageU16>,
@@ -495,7 +456,7 @@ pub struct Vio<S: lie::LieScalar = f32> {
     masks: Vec<frontend::detect::Masks>,
     /// Cameras in the rig; every frameset must carry exactly this many.
     camera_count: usize,
-    /// The last frameset's timestamp, `t_ns` in the frontend (`:172`).
+    /// The last frameset's timestamp, `t_ns` in the frontend.
     last_frame_t_ns: Option<i64>,
     /// What the last `track` decided; the S9 Rerun rung reads this.
     last_stats: Option<Box<estimator::FrameStats<S>>>,
@@ -528,14 +489,11 @@ impl<S: lie::LieScalar> PreparedTrack<'_, S> {
 }
 
 impl<S: lie::LieScalar> Vio<S> {
-    /// Build the pipeline from basalt's own config and calibration (D18).
+    /// Build the pipeline from configuration and calibration (D18).
     ///
     /// # Errors
-    ///
-    /// [`VioError::Frontend`] when the config names another flow type or
-    /// pattern or the rig is unusable, and [`VioError::Estimator`] when the
-    /// config asks for a path this port does not have — `vio_linearization_type`
-    /// other than `ABS_QR`, `vio_sqrt_marg` false, or `vio_enforce_realtime`.
+    /// Reject unsupported flow types or patterns, unusable rigs, linearization other
+    /// than `ABS_QR`, disabled square-root marginalization and realtime enforcement.
     pub fn new(
         config: config::VioConfig,
         calibration: calib::Calibration<f64>,
@@ -700,10 +658,7 @@ impl<S: lie::LieScalar> Vio<S> {
             });
         }
 
-        // `frame_to_frame_optical_flow.h:138-152`: the prediction the KLT is
-        // seeded with. Until the estimator has produced a state both poses are
-        // the identity, which is basalt's `first_state_arrived == false` path —
-        // and here that flag is `latest_state` being `None`.
+        // Before the first estimated state, both prediction poses are identity.
         let mark: std::time::Instant = std::time::Instant::now();
         let prediction: frontend::flow::PosePrediction = match self.latest_state {
             Some(latest) => {
@@ -720,7 +675,7 @@ impl<S: lie::LieScalar> Vio<S> {
         };
         self.frontend_timings.imu_ns = duration_ns(mark);
 
-        // `vit_tracker.cpp:534`: the `u8 << 8` widening the whole frontend
+        // the `u8 << 8` widening the whole frontend
         // assumes, into buffers that are reused frame to frame.
         self.frames
             .resize_with(images.len(), image::ImageU16::default);
@@ -749,7 +704,6 @@ impl<S: lie::LieScalar> Vio<S> {
         self.last_frame_t_ns = Some(t_ns);
 
         // The estimator reads only the ids and the observed pixels
-        // (`optical_flow.h:186-215`).
         let mut observations: estimator::FlowObservations =
             estimator::FlowObservations::new(t_ns, self.camera_count);
         debug_assert_eq!(
@@ -771,13 +725,13 @@ impl<S: lie::LieScalar> Vio<S> {
             .process_frame(std::sync::Arc::new(observations))?;
 
         // The estimator initialises inside the same `process_frame` that
-        // measures (`:263-296`), so a `Measured` outcome always has a state and
+        // measures, so a `Measured` outcome always has a state and
         // the outcome alone decides the status.
         let status: VioStatus = match outcome {
             estimator::FrameOutcome::NeedMoreImu => VioStatus::NeedMoreImu,
             estimator::FrameOutcome::Measured(stats) => {
                 self.last_stats = Some(stats);
-                // `:592-620`: the two feedback values, in basalt's order.
+                // Return the newest state, then the depth feedback.
                 self.publish_state();
                 self.publish_depth_guess()?;
                 VioStatus::Tracking
@@ -817,12 +771,12 @@ impl<S: lie::LieScalar> Vio<S> {
         }
     }
 
-    /// `processImu(curr_t_ns)` (`frame_to_frame_optical_flow.h:157-201`).
+    /// `processImu(curr_t_ns)`.
     ///
     /// The same three-part loop the estimator runs, over the frontend's own
     /// buffer and at `f64`: skip up to the previous frame, integrate up to this
     /// one, then close the interval by retiming the next sample. The bias
-    /// calibration happens in `f32` and is cast back (`:171-178`), which is what
+    /// calibration happens in `f32` and is cast back, which is what
     /// `Calibration<Scalar>` with `Scalar = float` means here.
     /// # Errors
     ///
@@ -837,7 +791,7 @@ impl<S: lie::LieScalar> Vio<S> {
         let prev_t_ns: i64 = self.last_frame_t_ns.unwrap_or(-1);
         let mut pim: imu::IntegratedImuMeasurement<f64> =
             imu::IntegratedImuMeasurement::new(prev_t_ns, &latest.bias_gyro, &latest.bias_accel);
-        // `:190-198`, the same three-part loop the estimator's own
+        // the same three-part loop the estimator's own
         // preintegration runs, through `IntegratedImuMeasurement::accumulate_to`.
         let noise: imu::ImuNoise<f64> = self.frontend_noise;
         let pending: Option<imu::Popped<f64>> = self.frontend_pending.take();
@@ -852,7 +806,7 @@ impl<S: lie::LieScalar> Vio<S> {
     }
 
     /// One sample off the frontend's buffer, calibrated in `f32` and cast back
-    /// to `f64` (`frame_to_frame_optical_flow.h:171-178`).
+    /// to `f64`.
     fn frontend_pop(&mut self) -> Option<imu::Popped<f64>> {
         let sample: imu::ImuSample = self.frontend_imu.pop_front()?;
         let accel: Vector3<f32> = self
@@ -866,7 +820,7 @@ impl<S: lie::LieScalar> Vio<S> {
         Some((sample.t_ns, gyro.cast(), accel.cast()))
     }
 
-    /// `opt_flow_state_queue->push(data)` (`sqrt_keypoint_vio.cpp:620`).
+    /// `opt_flow_state_queue->push(data)`.
     fn publish_state(&mut self) {
         if let Some(state) = self.estimator.state() {
             self.latest_state = Some(types::PoseVelBiasState {
@@ -879,28 +833,10 @@ impl<S: lie::LieScalar> Vio<S> {
         }
     }
 
-    /// `opt_flow_depth_guess_queue->push(avg_depth)` (`:583-604`).
-    ///
-    /// `num_features / Σ inverse-depth`, or `optical_flow_matching_default_depth`
-    /// when the sum is not positive. Only computed when the config asks for
-    /// `REPROJ_AVG_DEPTH`, which every shipped config does.
-    ///
-    /// **The reduction is `f64` on both instantiations because the C++ one is**
-    /// (D42): `computeProjections` is called with `Scalar2 = double`
-    /// (`ba_base.cpp:540,558`), so every `proj` is widened to `Vector4d` on the
-    /// way into the vector, and `:592-593` declares `avg_invdepth` and
-    /// `num_features` as `double` whatever `Scalar` is. `to_f64()` here is that
-    /// `cast<double>`, and the division follows it.
-    ///
-    /// One deviation, and it is on the way **out**: C++ carries the guess as a
-    /// `double` from the queue (`vio_estimator.h:108`) into
-    /// `OpticalFlowBase::depth_guess` (`optical_flow.h:164`), while the port's
-    /// frontend holds it as `f32` (`FrameToFrameOpticalFlow::depth_guess`), so
-    /// the quotient is rounded once here. The guess only seeds the KLT's
-    /// matching window, and the f64 backend lane reproduces the C++ trajectory
-    /// to 2.5e-13 m over 4,095 framesets with the same rounding in place, so it
-    /// reaches no decision on the shipped path; widening the frontend's field is
-    /// the fix if one ever does.
+    /// Average scene depth is `num_features / Σ inverse-depth`, or the configured
+    /// default when the sum is not positive. Compute only for `REPROJ_AVG_DEPTH`.
+    /// Both estimator lanes reduce in f64, then round once into the frontend's f32
+    /// depth guess, which seeds the KLT matching window.
     fn publish_depth_guess(&mut self) -> Result<(), VioError> {
         // No `t_i_c.is_empty()` clause: `SqrtKeypointVio::new` refuses a rig of
         // fewer than two cameras and is the only way to build the estimator a
@@ -1048,8 +984,7 @@ mod tests {
         }
     }
 
-    /// The package's own MSDMI config, the file `reference_segments.toml` names
-    /// and the C++ reference runs loaded.
+    /// MSDMI configuration named by the package manifest.
     const MSDMI_CONFIG: &str = include_str!("../../../configs/msdmi_config.json");
 
     fn pipeline() -> Vio<f32> {
@@ -1071,11 +1006,9 @@ mod tests {
         .unwrap()
     }
 
-    /// A frameset that arrives before the IMU covering it reports
-    /// [`VioStatus::NeedMoreImu`] and the frontend does **not** run: it would
-    /// swap its pyramids and advance its clock and counter, and the retry the
-    /// status invites would then track the frameset against itself (D17).
-    /// `vio_parity.rs` proves the retry itself; this proves nothing moved.
+    /// Insufficient IMU coverage must return [`VioStatus::NeedMoreImu`] before the
+    /// frontend advances pyramids, clock or ids. Otherwise a retry tracks the frame
+    /// against itself. This test checks that nothing moved (D17).
     #[test]
     fn a_frameset_ahead_of_the_imu_needs_more_imu() {
         let mut vio: Vio<f32> = pipeline();

--- a/packages/slam-rs/crates/slam-rs/src/lie.rs
+++ b/packages/slam-rs/crates/slam-rs/src/lie.rs
@@ -1,42 +1,13 @@
-//! SO(3) and SE(3) with basalt's exact conventions.
+//! SO(3), SE(3), group Jacobians and decoupled pose increments.
+//! SO(3) operations delegate to kornia-algebra through scalar adapters (S33).
+//! This module supplies reported-angle conventions, composition normalization,
+//! inverse Jacobians and SE(3) operations.
 //!
-//! basalt builds on Sophus, so the conventions are Sophus's throughout: the
-//! quaternion, the atan-based log, `Constants<Scalar>::epsilon()` small-angle
-//! branches, and the group Jacobians basalt adds on top in
-//! `thirdparty/basalt-headers/include/basalt/utils/sophus_utils.hpp`. No Rust
-//! crate carries the two inverse right/left Jacobians or the *decoupled* SE(3)
-//! convention, which is why this module exists (decision D06).
-//!
-//! **SO(3)'s six group operations are not ported.** `exp`, `log`, `matrix`,
-//! `inverse` and the action on a point come from `kornia_algebra::lie::SO3F32`
-//! and `SO3F64` through [`LieScalar`]'s five `so3_*` adapters (S33); the
-//! adjoint is the matrix. What this module still owns around them is what
-//! upstream does not have: the `theta` [`So3::exp_and_theta`] and
-//! [`So3::log_and_theta`] report, which is Sophus's convention and not the
-//! tangent's magnitude, the renormalization on composition, and everything
-//! SE(3). Upstream's small-angle thresholds differ from Sophus's in `f32`
-//! (1e-8 against 1e-5) and coincide in `f64`; across that gap the two Taylor
-//! forms agree to well under an `f32` ulp, so the branch moves and the value
-//! does not.
-//!
-//! Two conventions are load-bearing and easy to get wrong:
-//!
-//! * **Tangent order is translation first.** Sophus's `SE3::Tangent` is
-//!   `(upsilon, omega)` (`Sophus/sophus/se3.hpp:850`), and so is basalt's
-//!   decoupled pair `se3_expd`/`se3_logd` (`sophus_utils.hpp:62,82`).
-//! * **The pose increment is left-multiplied.** `PoseState::incPose` does
-//!   `t += inc[0..3]; R = exp(inc[3..6]) * R`
-//!   (`thirdparty/basalt-headers/include/basalt/imu/imu_types.h:96-99`), which
-//!   is neither the coupled nor the decoupled exponential — see
-//!   [`Se3::apply_inc`].
-//!
-//! Two *different* small-angle branches live here on purpose. [`Se3::exp`] and
-//! [`Se3::log`] need Sophus's own `SO3::leftJacobian`/`leftJacobianInverse`
-//! (`Sophus/sophus/so3.hpp:570,594`), whose Taylor branch stops one term
-//! earlier than basalt's own left Jacobian (`sophus_utils.hpp:312`), which
-//! [`left_jacobian_inv_so3`] inverts. The
-//! difference is below the branch threshold, but reproducing each at its own
-//! call site keeps the port literal.
+//! Tangents put translation first. Estimator updates add translation directly
+//! and left-multiply rotation by `exp(inc[3..6])`; every state block and prior
+//! uses this convention. Coupled SE(3) operations instead use a translation factor.
+//! Their small-angle Taylor branches stop one term earlier than the standalone
+//! SO(3) Jacobians, so each call retains its own formula.
 
 use kornia_algebra::{SO3F32, SO3F64, Vec3AF32, Vec3F64};
 use nalgebra::{
@@ -45,7 +16,7 @@ use nalgebra::{
 
 /// A scalar the Lie module can run in: `f32` and `f64`.
 ///
-/// The extra methods carry `Sophus::Constants<Scalar>` (`Sophus/sophus/common.hpp:165-196`),
+/// The extra methods carry `Sophus::Constants<Scalar>`,
 /// whose epsilon is `1e-10` in double and `1e-5` in float. `nalgebra`'s own
 /// `RealField::default_epsilon` is the machine epsilon and would move every
 /// small-angle branch, so it is not used.
@@ -66,39 +37,17 @@ pub trait LieScalar: RealField + Copy {
     /// This is coarser than machine epsilon to stabilize gravity initialization.
     fn eigen_dummy_precision() -> Self;
 
-    /// `std::numeric_limits<Scalar>::min()`: the smallest positive normal value.
-    ///
-    /// Not `RealField::min_value()`, which is the most *negative* finite value
-    /// despite its doc comment. basalt compares an LDLT pivot against this
-    /// constant to decide whether a direction is rank deficient
-    /// (`basalt-headers/include/basalt/imu/preintegration.h:314`), so the two
-    /// must mean the same thing.
+    /// Smallest positive normal scalar, used to give tiny LDLT pivots zero weight.
+    /// This is not the most negative finite value returned by `RealField::min_value`.
     fn min_positive() -> Self;
 
-    /// `std::numeric_limits<Scalar>::max()`: the largest finite value.
-    ///
-    /// basalt seeds both keyframe-eviction scores with it
-    /// (`sqrt_keypoint_vio.cpp:788`, `:842`) so the first candidate always
-    /// wins the `score < min_score` test.
+    /// Largest finite scalar, used to initialize eviction score minima.
     fn largest() -> Self;
 
-    /// SO(3)'s exponential map at this precision, `kornia_algebra::lie::SO3F32::exp`
-    /// or `SO3F64::exp`, in and out in basalt's `[qx, qy, qz, qw]` order.
-    ///
-    /// The five `so3_*` methods exist because `kornia-algebra` has two concrete
-    /// SO(3) types where [`So3`] has one generic one, and the scalar trait is
-    /// where this port already dispatches on precision. They are an adapter, not
-    /// an interface: [`So3`] is the type to use. Arrays rather than
-    /// `nalgebra` values because that is what both sides already hand out —
-    /// `glam` is `[x, y, z, w]` and so is `Sophus`'s storage — so the conversion
-    /// is a move, not an allocation.
-    ///
-    /// Upstream's small-angle branch is `theta < 1e-8` in `f32` and `theta <
-    /// 1e-10` in `f64`, against Sophus's `theta < 1e-5` and `theta < 1e-10`. The
-    /// `f64` thresholds coincide; in `f32` the two Taylor forms agree to well
-    /// under an `f32` ulp across the gap, so the branch moves and the value does
-    /// not. What [`So3::exp_and_theta`] still owns is the *reported* `theta`,
-    /// which Sophus zeroes on its own branch and [`Se3::exp`] reads.
+    /// SO(3) exponential through kornia-algebra, in `[qx, qy, qz, qw]` order.
+    /// The scalar adapters bridge concrete f32/f64 types without allocation.
+    /// Reported theta retains this module's small-angle convention even where the
+    /// underlying exponential uses a different Taylor threshold.
     fn so3_exp(omega: &[Self; 3]) -> [Self; 4];
 
     /// SO(3)'s logarithm, `SO3F32::log` or `SO3F64::log`, from `[qx, qy, qz, qw]`.
@@ -120,7 +69,7 @@ pub trait LieScalar: RealField + Copy {
     /// The action on a point, `SO3F32 * Vec3AF32` or `SO3F64 * Vec3F64`.
     fn so3_act(quaternion_xyzw: &[Self; 4], point: &[Self; 3]) -> [Self; 3];
 
-    /// Exact-as-possible conversion of a literal, standing in for C++'s `Scalar(x)`.
+    /// Convert a literal to the selected scalar as accurately as possible.
     fn from_literal(value: f64) -> Self;
 
     /// Convert to `f64` for diagnostics and scalar conversion.
@@ -219,11 +168,7 @@ impl LieScalar for f32 {
     }
 }
 
-/// `Scalar(x)` in C++: a literal in the caller's scalar type.
-///
-/// The crate's one spelling of it. `estimator/*`, `marg/*` and
-/// `linearize/abs_qr.rs` say `S::from_literal(...)` directly, which is the same
-/// call; everything with enough literals for the noise to matter imports this.
+/// A literal in the caller's scalar type, through `S::from_literal`.
 #[inline]
 pub(crate) fn c<S: LieScalar>(value: f64) -> S {
     S::from_literal(value)
@@ -260,13 +205,8 @@ impl<S: LieScalar> So3<S> {
         Self { quaternion }
     }
 
-    /// Normalize `(x, y, z, w)` into a rotation.
-    ///
-    /// basalt's cereal reader writes the four coefficients straight into the
-    /// quaternion without normalizing (`serialization/eigen_io.h:148-153`); the
-    /// port normalizes, so a calibration file that is a few ulps off unit length
-    /// still yields a valid rotation. Returns `None` for a zero-norm input,
-    /// which would otherwise produce NaNs.
+    /// Normalize `(x, y, z, w)` into a rotation, correcting small calibration drift.
+    /// Return `None` for a zero-norm quaternion rather than producing NaNs.
     pub fn from_quaternion_xyzw(x: S, y: S, z: S, w: S) -> Option<Self> {
         let quaternion: Quaternion<S> = Quaternion::new(w, x, y, z);
         if !quaternion.norm().is_finite() || quaternion.norm() <= S::zero() {
@@ -277,7 +217,7 @@ impl<S: LieScalar> So3<S> {
         })
     }
 
-    /// `Sophus::SO3::cast` (`Sophus/sophus/so3.hpp`): the same rotation in
+    /// `Sophus::SO3::cast` : the same rotation in
     /// another scalar.
     ///
     /// Sophus casts the four coefficients and hands them to the quaternion
@@ -301,10 +241,7 @@ impl<S: LieScalar> So3<S> {
         &self.quaternion
     }
 
-    /// The four coefficients in basalt's on-disk order, `(qx, qy, qz, qw)`.
-    ///
-    /// Eigen stores a quaternion `xyzw`, and cereal writes `so3().data()[0..3]`
-    /// followed by `[3]` (`serialization/eigen_io.h:150-153`).
+    /// Quaternion coefficients in JSON order `(qx, qy, qz, qw)`.
     pub fn quaternion_xyzw(&self) -> [S; 4] {
         let q = self.quaternion.as_ref();
         [q.i, q.j, q.k, q.w]
@@ -323,7 +260,7 @@ impl<S: LieScalar> So3<S> {
 
     /// [`So3::exp`] plus `theta = |omega|`, which is zero on the Taylor branch.
     ///
-    /// `Sophus::SO3::expAndTheta` (`Sophus/sophus/so3.hpp:716`) reports the same
+    /// `Sophus::SO3::expAndTheta` reports the same
     /// `theta` it branched on, and [`Se3::exp`] feeds it straight into the left
     /// Jacobian, so the two travel together. The **rotation** is upstream's; the
     /// `theta` is still Sophus's convention, including the zero it reports on its
@@ -347,7 +284,7 @@ impl<S: LieScalar> So3<S> {
     /// `new_unchecked` because every upstream operation that produces one starts
     /// from a unit quaternion and stays on the sphere to within rounding — the
     /// same assumption Sophus makes when it asserts rather than normalises
-    /// (`so3.hpp:747-750`). The one place the assumption is not free is
+    /// The one place the assumption is not free is
     /// composition, which is why [`So3::mul`] normalises.
     #[inline]
     fn from_kornia_quaternion(xyzw: [S; 4]) -> Self {
@@ -367,7 +304,7 @@ impl<S: LieScalar> So3<S> {
     /// Taylor branch.
     ///
     /// `Sophus::SO3::logAndTheta` returns `2 n^2 / w` for a near-identity
-    /// rotation (`Sophus/sophus/so3.hpp:311`), i.e. second order in the vector
+    /// rotation, i.e. second order in the vector
     /// part, while the tangent itself is first order. [`Se3::log`] passes that
     /// `theta` to the inverse left Jacobian, and substituting `|log|` there
     /// moves it onto the ill-conditioned branch, so the pair travels together
@@ -388,7 +325,7 @@ impl<S: LieScalar> So3<S> {
         let tangent: Vector3<S> = self.log();
         let theta: S = if squared_n < epsilon * epsilon {
             // A unit quaternion with a vanishing vector part has |w| ~ 1, so the
-            // division is safe; Sophus asserts the same thing (`so3.hpp:306`).
+            // division is safe; Sophus asserts the same thing.
             c::<S>(2.0) * squared_n / w
         } else if w < S::zero() {
             // w < 0 means the rotation is past pi; Sophus wraps it to a negative
@@ -402,9 +339,9 @@ impl<S: LieScalar> So3<S> {
 
     /// The inverse rotation, `kornia_algebra::lie::SO3F32::inverse` /
     /// `SO3F64::inverse` — the conjugate of a unit quaternion, which is what
-    /// Sophus takes too (`Sophus/sophus/so3.hpp:267-269`).
+    /// Sophus takes too.
     ///
-    /// Sophus's constructor then renormalizes (`:548-553`), so this one does
+    /// Sophus's constructor then renormalizes, so this one does
     /// too. Conjugating only flips signs, so the renormalization is a no-op
     /// here — it is kept for the same reason Sophus keeps it: every path that
     /// produces an `So3` leaves it unit length.
@@ -431,8 +368,8 @@ impl<S: LieScalar> std::ops::Mul for So3<S> {
     /// Compose two rotations, renormalizing the product.
     ///
     /// Sophus's `operator*` hands the raw quaternion product to the `SO3`
-    /// quaternion constructor (`Sophus/sophus/so3.hpp:378-389`), which calls
-    /// `normalize()` (`:548-553`, `:339-345`). `nalgebra`'s
+    /// quaternion constructor, which calls
+    /// `normalize()`. `nalgebra`'s
     /// `UnitQuaternion * UnitQuaternion` does not: it trusts the invariant and
     /// lets rounding accumulate. Over a long chain that matters — composing one
     /// small rotation 100,000 times in `f32` drifts the norm to 1.00105 without
@@ -444,7 +381,7 @@ impl<S: LieScalar> std::ops::Mul for So3<S> {
     }
 }
 
-/// `Sophus::SO3::normalize()` (`Sophus/sophus/so3.hpp:339-345`).
+/// `Sophus::SO3::normalize()`.
 ///
 /// Sophus refuses a quaternion shorter than its epsilon; here the inputs are
 /// always products or conjugates of unit quaternions, so the norm is within a
@@ -497,12 +434,8 @@ impl<S: LieScalar> Se3<S> {
         }
     }
 
-    /// The coupled exponential map, ported from `Sophus/sophus/se3.hpp:850-859`.
-    ///
-    /// The tangent is `(upsilon, omega)` and the translation is `V(omega)
-    /// upsilon`, so translation and rotation are **not** independent. basalt's
-    /// state increments use [`Se3::exp_decoupled`] and [`Se3::apply_inc`]
-    /// instead.
+    /// Coupled exponential: translation is `V(omega) upsilon`.
+    /// State updates use [`Se3::exp_decoupled`] and [`Se3::apply_inc`] instead.
     pub fn exp(tangent: &Vector6<S>) -> Self {
         let upsilon: Vector3<S> = tangent.fixed_rows::<3>(0).into_owned();
         let omega: Vector3<S> = tangent.fixed_rows::<3>(3).into_owned();
@@ -514,7 +447,7 @@ impl<S: LieScalar> Se3<S> {
         }
     }
 
-    /// The coupled logarithm, ported from `Sophus/sophus/se3.hpp:237-252`.
+    /// Coupled logarithm.
     pub fn log(&self) -> Vector6<S> {
         let (omega, theta) = self.rotation.log_and_theta();
         let v_inv: Matrix3<S> = sophus_left_jacobian_inv_so3(&omega, theta);
@@ -522,11 +455,7 @@ impl<S: LieScalar> Se3<S> {
         Vector6::new(upsilon.x, upsilon.y, upsilon.z, omega.x, omega.y, omega.z)
     }
 
-    /// basalt's decoupled exponential, `Sophus::se3_expd`
-    /// (`basalt-headers/include/basalt/utils/sophus_utils.hpp:82-89`).
-    ///
-    /// The head of the tangent becomes the translation directly; only the tail
-    /// goes through `SO3::exp`.
+    /// Decoupled exponential: tangent head becomes translation and the tail uses SO(3) exp.
     pub fn exp_decoupled(tangent: &Vector6<S>) -> Self {
         Self {
             rotation: So3::exp(&tangent.fixed_rows::<3>(3).into_owned()),
@@ -534,15 +463,8 @@ impl<S: LieScalar> Se3<S> {
         }
     }
 
-    /// basalt's decoupled logarithm, `Sophus::se3_logd`
-    /// (`basalt-headers/include/basalt/utils/sophus_utils.hpp:62-68`).
-    ///
-    /// No production caller: the estimator moves states with
-    /// [`Self::exp_decoupled`] and [`Self::apply_inc`] and never reads a
-    /// tangent back. It is kept as the ported pair's other half, and it is what
-    /// pins `exp_decoupled` — the round-trip proptests here and the
-    /// finite-difference Jacobians in `ba_base`'s tests take their tangents
-    /// through it.
+    /// Decoupled logarithm, inverse to [`Self::exp_decoupled`].
+    /// Used by round-trip and finite-difference tests; production updates do not read tangents back.
     pub fn log_decoupled(&self) -> Vector6<S> {
         let omega: Vector3<S> = self.rotation.log();
         Vector6::new(
@@ -568,7 +490,6 @@ impl<S: LieScalar> Se3<S> {
     }
 
     /// The homogeneous 4x4 matrix, `Sophus::SE3::matrix()`
-    /// (`Sophus/sophus/se3.hpp:275-280`).
     ///
     /// The rotation block uses [`So3::matrix`]; the final column is translation.
     pub fn matrix(&self) -> Matrix4<S> {
@@ -582,7 +503,7 @@ impl<S: LieScalar> Se3<S> {
     }
 
     /// The affine 3x4 matrix, `Sophus::SE3::matrix3x4()`
-    /// (`Sophus/sophus/se3.hpp:285-290`): `[R | t]`.
+    /// `[R | t]`.
     pub fn matrix3x4(&self) -> Matrix3x4<S> {
         let mut res: Matrix3x4<S> = Matrix3x4::zeros();
         res.fixed_view_mut::<3, 3>(0, 0)
@@ -601,10 +522,8 @@ impl<S: LieScalar> Se3<S> {
         }
     }
 
-    /// The adjoint, ported from `Sophus/sophus/se3.hpp:105-113`.
-    ///
-    /// With the `(upsilon, omega)` tangent order the blocks are
-    /// `[[R, hat(t) R], [0, R]]`, and `Adj(T) xi = log(T exp(xi) T^-1)`.
+    /// Adjoint for translation-first tangents: `[[R, hat(t) R], [0, R]]`.
+    /// It satisfies `Adj(T) xi = log(T exp(xi) T^-1)`.
     pub fn adjoint(&self) -> Matrix6<S> {
         let r: Matrix3<S> = self.rotation.matrix();
         let mut res: Matrix6<S> = Matrix6::zeros();
@@ -615,13 +534,8 @@ impl<S: LieScalar> Se3<S> {
         res
     }
 
-    /// basalt's pose increment, `PoseState::incPose`
-    /// (`basalt-headers/include/basalt/imu/imu_types.h:96-99`).
-    ///
-    /// `t += inc[0..3]` and `R = exp(inc[3..6]) R`: translation first, and the
-    /// rotation increment multiplies from the **left**. This is the single most
-    /// copied convention in the estimator — every state block, every Jacobian
-    /// column and the marginalization prior all assume it.
+    /// Pose increment: `t += inc[0..3]`, `R = exp(inc[3..6]) R`.
+    /// State blocks, Jacobians and priors all require this left-multiplied rotation convention.
     pub fn apply_inc(&mut self, inc: &Vector6<S>) {
         self.translation += inc.fixed_rows::<3>(0);
         self.rotation = So3::exp(&inc.fixed_rows::<3>(3).into_owned()) * self.rotation;
@@ -647,9 +561,7 @@ impl<S: LieScalar> std::ops::Mul<Vector3<S>> for Se3<S> {
     }
 }
 
-/// Right Jacobian of SO(3): `exp(phi + eps) ~ exp(phi) exp(J eps)`.
-///
-/// Ported from `basalt-headers/include/basalt/utils/sophus_utils.hpp:145-168`.
+/// Right SO(3) Jacobian: `exp(phi + eps) ~ exp(phi) exp(J eps)`.
 pub fn right_jacobian_so3<S: LieScalar>(phi: &Vector3<S>) -> Matrix3<S> {
     let phi_norm2: S = phi.norm_squared();
     let phi_hat: Matrix3<S> = So3::hat(phi);
@@ -669,12 +581,8 @@ pub fn right_jacobian_so3<S: LieScalar>(phi: &Vector3<S>) -> Matrix3<S> {
     j
 }
 
-/// Inverse right Jacobian of SO(3): `log(exp(phi) exp(eps)) ~ phi + J eps`.
-///
-/// Ported from `basalt-headers/include/basalt/utils/sophus_utils.hpp:180-216`.
-/// basalt asserts `|phi| <= pi` there; the port drops the assert (decision D32,
-/// the core never panics on data) and lets an over-rotated input take the same
-/// zeroth-order branch the C++ takes at exactly pi.
+/// Inverse right SO(3) Jacobian: `log(exp(phi) exp(eps)) ~ phi + J eps`.
+/// Over-rotated inputs use the same zeroth-order branch as pi, without panic (D32).
 pub fn right_jacobian_inv_so3<S: LieScalar>(phi: &Vector3<S>) -> Matrix3<S> {
     let phi_norm2: S = phi.norm_squared();
     let phi_hat: Matrix3<S> = So3::hat(phi);
@@ -685,10 +593,7 @@ pub fn right_jacobian_inv_so3<S: LieScalar>(phi: &Vector3<S>) -> Matrix3<S> {
     j
 }
 
-/// Inverse left Jacobian of SO(3): `log(exp(eps) exp(phi)) ~ phi + J eps`.
-///
-/// Ported from `basalt-headers/include/basalt/utils/sophus_utils.hpp:348-384`,
-/// with the same dropped assert as [`right_jacobian_inv_so3`].
+/// Inverse left SO(3) Jacobian: `log(exp(eps) exp(phi)) ~ phi + J eps`.
 pub fn left_jacobian_inv_so3<S: LieScalar>(phi: &Vector3<S>) -> Matrix3<S> {
     let phi_norm2: S = phi.norm_squared();
     let phi_hat: Matrix3<S> = So3::hat(phi);
@@ -699,14 +604,9 @@ pub fn left_jacobian_inv_so3<S: LieScalar>(phi: &Vector3<S>) -> Matrix3<S> {
     j
 }
 
-/// The `hat(phi)^2` term both inverse SO(3) Jacobians add.
-///
-/// The three branches are basalt's (`sophus_utils.hpp:191-215`): the closed
-/// form on `(0, pi)`, a zeroth-order expansion at pi where `sin` vanishes, and
-/// the Taylor value `1/12` at zero.
-///
-/// Evaluate the threshold and denominator in the input scalar type.
-/// The constant branches divide the matrix directly by their denominator.
+/// The `hat(phi)^2` term in both inverse SO(3) Jacobians.
+/// Use the closed form on `(0, pi)`, a zeroth-order expansion at pi where sine
+/// vanishes, and `1/12` at zero. Thresholds and denominators use the input scalar.
 fn inverse_jacobian_second_order_term<S: LieScalar>(
     phi_hat2: &Matrix3<S>,
     phi_norm2: S,
@@ -729,12 +629,8 @@ fn inverse_jacobian_second_order_term<S: LieScalar>(
     }
 }
 
-/// Sophus's own left Jacobian, `SO3::leftJacobian`
-/// (`Sophus/sophus/so3.hpp:570-591`).
-///
-/// Used only by [`Se3::exp`], because that is what `SE3::exp` calls. It differs
-/// from basalt's own left Jacobian (`sophus_utils.hpp:312-337`) in the Taylor
-/// branch, which stops at `I + Omega/2` instead of adding `Omega^2/6`.
+/// Left Jacobian for coupled [`Se3::exp`]. Its Taylor branch stops at
+/// `I + Omega/2`, unlike the standalone Jacobian's additional `Omega^2/6` term.
 fn sophus_left_jacobian_so3<S: LieScalar>(omega: &Vector3<S>, theta: S) -> Matrix3<S> {
     let theta_sq: S = theta * theta;
     let big_omega: Matrix3<S> = So3::hat(omega);
@@ -750,7 +646,7 @@ fn sophus_left_jacobian_so3<S: LieScalar>(omega: &Vector3<S>, theta: S) -> Matri
 }
 
 /// Sophus's own inverse left Jacobian, `SO3::leftJacobianInverse`
-/// (`Sophus/sophus/so3.hpp:594-620`). Used only by [`Se3::log`].
+/// Used only by [`Se3::log`].
 fn sophus_left_jacobian_inv_so3<S: LieScalar>(omega: &Vector3<S>, theta: S) -> Matrix3<S> {
     let theta_sq: S = theta * theta;
     let big_omega: Matrix3<S> = So3::hat(omega);
@@ -828,7 +724,7 @@ mod tests {
     /// The one value in this module checked by hand rather than against a
     /// finite difference: `SO3::exp([0.1, 0.2, 0.3])` under Sophus's formula
     /// `w = cos(theta/2)`, `v = sin(theta/2)/theta * omega`
-    /// (`Sophus/sophus/so3.hpp:735-741`) with `theta = |omega|`.
+    ///  with `theta = |omega|`.
     #[test]
     fn exp_matches_the_hand_computed_sophus_quaternion() {
         let rotation: So3<f64> = So3::exp(&Vector3::new(0.1, 0.2, 0.3));
@@ -918,7 +814,7 @@ mod tests {
     /// A long chain of compositions must not leak unit length.
     ///
     /// `nalgebra`'s `UnitQuaternion * UnitQuaternion` skips the renormalization
-    /// Sophus does on every product (`Sophus/sophus/so3.hpp:378-389`), and
+    /// Sophus does on every product, and
     /// 100,000 `f32` compositions of one small rotation take the norm to
     /// 1.0010456 without it — a rotation matrix off by 7e-3, which the
     /// estimator's window would carry straight into the residuals.
@@ -985,8 +881,7 @@ mod tests {
         }
     }
 
-    /// Near pi the closed form's `sin` denominator vanishes; basalt swaps in a
-    /// zeroth-order expansion (`sophus_utils.hpp:212-214`) and so do we.
+    /// Near pi, use a zeroth-order expansion to avoid the vanishing sine denominator.
     #[test]
     fn the_inverse_jacobians_stay_finite_at_pi() {
         let phi: Vector3<f64> = Vector3::new(std::f64::consts::PI, 0.0, 0.0);
@@ -1008,7 +903,7 @@ mod tests {
     }
 
     /// The decoupled exponential puts the tangent head into the translation
-    /// untouched, which the coupled one does not (`sophus_utils.hpp:82-89`).
+    /// untouched, which the coupled one does not.
     #[test]
     fn the_decoupled_exponential_differs_from_the_coupled_one() {
         let tangent: Vector6<f64> = Vector6::new(1.0, 0.0, 0.0, 0.0, 0.0, 1.0);
@@ -1024,7 +919,6 @@ mod tests {
 
     /// `apply_inc` is neither exponential: the rotation multiplies from the left
     /// and the translation is added in the world frame
-    /// (`basalt-headers/include/basalt/imu/imu_types.h:96-99`).
     #[test]
     fn apply_inc_left_multiplies_the_rotation() {
         let base: Se3<f64> = Se3::new(
@@ -1157,9 +1051,7 @@ mod tests {
             prop_assert!((right_jacobian_so3(&phi) * right_jacobian_inv_so3(&phi) - identity).norm() < 1e-11);
         }
 
-        /// basalt's `J_l(phi) = J_r(phi)^T` (`sophus_utils.hpp:145` vs `:312`),
-        /// which is what pins [`left_jacobian_inv_so3`]: the right-hand pair is
-        /// checked against finite differences and against each other above.
+        /// Check `J_l(phi) = J_r(phi)^T` alongside inverse and finite-difference identities.
         #[test]
         fn the_left_jacobian_is_the_right_jacobian_transposed(phi in tangent3()) {
             prop_assert!(

--- a/packages/slam-rs/crates/slam-rs/src/linearize/abs_qr.rs
+++ b/packages/slam-rs/crates/slam-rs/src/linearize/abs_qr.rs
@@ -1,17 +1,7 @@
-//! The absolute-pose square-root linearizer.
-//!
-//! `LinearizationAbsQR<Scalar, POSE_SIZE>`
-//! (`include/basalt/linearization/linearization_abs_qr.hpp`,
-//! `src/linearization/linearization_abs_qr.cpp`): owns one landmark block per
-//! landmark, one IMU block per preintegrated interval, and the marginalization
-//! prior, and turns them into the dense reduced camera system the
-//! Levenberg-Marquardt loop solves.
-//!
-//! **Borrowing.** C++ keeps raw pointers to the estimator, the marginalization
-//! data and the IMU data for the linearizer's whole life (`:56-64`). The port
-//! passes them in at each call instead — `estimator` and a
-//! [`LinearizationInputs`] — so nothing here is self-referential and stage S8
-//! can hold the linearizer across an iteration while it mutates the window.
+//! Absolute-pose square-root linearization.
+//! Landmark blocks, IMU factors and the prior form the reduced camera system.
+//! Inputs are borrowed per call, allowing the estimator to retain the linearizer
+//! while updating the window without self-referential storage.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -26,17 +16,16 @@ use crate::linearize::reduce::deterministic_reduce_scalar;
 use crate::linearize::{DenseHbWorkspace, LinearizeError, RelPoseLin, linearize_relative_pose};
 use crate::types::{AbsOrderMap, FrameId, LandmarkId, MargLinData, POSE_VEL_BIAS_SIZE, TimeCamId};
 
-/// `LinearizationBase<Scalar, POSE_SIZE>::Options` (`linearization_base.hpp:23-26`),
+/// `LinearizationBase<Scalar, POSE_SIZE>::Options`,
 /// without the `linearization_type` field: only `ABS_QR` is ported (decision D13).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LinearizationOptions<S: LieScalar> {
-    /// The landmark blocks' options (`:24`).
+    /// The landmark blocks' options.
     pub lb_options: LandmarkBlockOptions<S>,
 }
 
 impl<S: LieScalar> Default for LinearizationOptions<S> {
-    /// basalt's defaults. Written out rather than derived: `#[derive(Default)]`
-    /// would demand `S: Default`, which `LieScalar` does not.
+    /// Explicit defaults avoid requiring `S: Default` beyond `LieScalar`.
     fn default() -> Self {
         Self {
             lb_options: LandmarkBlockOptions::default(),
@@ -44,11 +33,7 @@ impl<S: LieScalar> Default for LinearizationOptions<S> {
     }
 }
 
-/// `ImuLinData<Scalar>` plus the measurements it indexes
-/// (`imu_types.h:306-315`), which C++ carries as a `std::map` of pointers.
-///
-/// The key is the start timestamp of the interval; the end timestamp is
-/// `start + measurement.get_dt_ns()` (`imu_block.hpp:29-30`).
+/// IMU measurements indexed by start timestamp; end time is start plus duration.
 #[derive(Debug, Clone)]
 pub struct ImuInput<'a, S: LieScalar> {
     /// Gravity and the two bias random-walk square-root weights.
@@ -57,29 +42,24 @@ pub struct ImuInput<'a, S: LieScalar> {
     pub measurements: Vec<(i64, &'a IntegratedImuMeasurement<S>)>,
 }
 
-/// Everything `LinearizationAbsQR`'s constructor takes as a pointer in C++
-/// (`linearization_abs_qr.hpp:41-46`).
-///
-/// `last_state_to_marg` is not here: C++ takes it and immediately `UNUSED`s it
-/// (`linearization_abs_qr.cpp:67`).
+/// Borrowed inputs needed for a linearization call.
 #[derive(Debug)]
 pub struct LinearizationInputs<'a, S: LieScalar> {
     /// The square-root marginalization prior, if there is one.
     pub marg: Option<&'a MargLinData<S>>,
     /// The preintegrated IMU intervals, if the estimator is inertial.
     pub imu: Option<&'a ImuInput<'a, S>>,
-    /// Restrict the landmarks to those hosted by these frames (`:117-122`).
+    /// Restrict the landmarks to those hosted by these frames.
     pub used_frames: Option<&'a BTreeSet<FrameId>>,
-    /// ...or to these landmarks (`:120-121`).
+    /// or to these landmarks.
     pub lost_landmarks: Option<&'a BTreeSet<LandmarkId>>,
-    /// Frames whose pose Jacobians are zeroed (`:223-224`) and whose landmarks
-    /// are not optimised (`:140`).
+    /// Frames whose pose Jacobians are zeroed and whose landmarks
+    /// are not optimised.
     pub fixed_frames: Option<&'a BTreeSet<FrameId>>,
 }
 
 impl<S: LieScalar> Default for LinearizationInputs<'_, S> {
-    /// Every C++ pointer null: a visual-only problem with no prior and no
-    /// restriction (`linearization_abs_qr.hpp:41-46` default arguments).
+    /// An unrestricted visual-only problem without an IMU factor or prior.
     fn default() -> Self {
         Self {
             marg: None,
@@ -104,40 +84,33 @@ struct ImuMeta {
 #[derive(Debug, Clone)]
 pub struct LinearizationAbsQR<S: LieScalar> {
     options: LinearizationOptions<S>,
-    /// `landmark_ids` (`:104`), sorted (`:127`).
+    /// `landmark_ids`, sorted.
     landmark_ids: Vec<LandmarkId>,
-    /// `landmark_blocks` (`:105`), parallel to `landmark_ids`.
+    /// `landmark_blocks`, parallel to `landmark_ids`.
     landmark_blocks: Vec<LandmarkBlock<S>>,
-    /// `landmark_block_idx` (`:111`): the prefix sum of `numQ2rows()`.
+    /// `landmark_block_idx` : the prefix sum of `numQ2rows()`.
     landmark_block_idx: Vec<usize>,
-    /// `num_rows_Q2r` (`:135`).
+    /// `num_rows_Q2r`.
     num_rows_q2r: usize,
-    /// `relative_pose_lin` (`:126`) as a dense table, so the blocks hold an
+    /// `relative_pose_lin` as a dense table, so the blocks hold an
     /// index rather than a pointer. The `(host, target)` -> slot map that
     /// builds it is a local in [`Self::new`]: nothing needs it once the blocks
     /// have their indices.
     rel_pose_pairs: Vec<(TimeCamId, TimeCamId)>,
     rel_pose_lin: Vec<RelPoseLin<S>>,
-    /// One per preintegrated interval (`:106`, `:163-167`).
+    /// One per preintegrated interval.
     imu_meta: Vec<ImuMeta>,
     /// Filled by [`Self::linearize_problem`]; empty before it runs.
     imu_blocks: Vec<ImuBlock<S>>,
-    /// `aom` (`:119`).
+    /// `aom`.
     aom: AbsOrderMap,
 }
 
 impl<S: LieScalar> LinearizationAbsQR<S> {
-    /// The constructor (`linearization_abs_qr.cpp:50-172`).
-    ///
-    /// Allocates one relative pose per (host, target) pair of the landmark
-    /// database, selects and **sorts** the landmark ids (`:115-127` — the
-    /// comment says "for better visualization", but it is also what makes the
-    /// row order of the stacked system reproducible), allocates every landmark
-    /// block, and builds the prefix sum of their `Q₂` row counts.
-    ///
-    /// C++ asserts that the options' Huber threshold and observation sigma are
-    /// the estimator's (`:69-73`); the port copies them from the estimator
-    /// instead, so they cannot disagree.
+    /// Allocate relative poses and landmark blocks in sorted landmark order,
+    /// then build the prefix sum of reduced row counts. Sorting fixes row order.
+    /// Copy Huber threshold and observation deviation from the estimator so options
+    /// cannot disagree.
     pub fn new(
         estimator: &BundleAdjustmentBase<S>,
         aom: &AbsOrderMap,
@@ -147,7 +120,7 @@ impl<S: LieScalar> LinearizationAbsQR<S> {
         options.lb_options.huber_parameter = estimator.huber_thresh;
         options.lb_options.obs_std_dev = estimator.obs_std_dev;
 
-        // `:76-111`: one `RelPoseLin` per (host, target) pair.
+        // one `RelPoseLin` per (host, target) pair.
         let mut rel_pose_pairs: Vec<(TimeCamId, TimeCamId)> = Vec::new();
         let mut rel_pose_index: BTreeMap<(TimeCamId, TimeCamId), usize> = BTreeMap::new();
         for (tcid_h, target_map) in estimator.lmdb.observations() {
@@ -160,8 +133,7 @@ impl<S: LieScalar> LinearizationAbsQR<S> {
         }
         let rel_pose_lin: Vec<RelPoseLin<S>> = vec![RelPoseLin::default(); rel_pose_pairs.len()];
 
-        // `:115-127`. The database already keeps its landmarks id-sorted, so the
-        // `std::sort` of `:127` is the iteration order here.
+        // Landmarks already iterate in sorted id order.
         let mut landmark_ids: Vec<LandmarkId> = Vec::new();
         for lm in estimator.lmdb.landmarks() {
             let keep: bool = match (inputs.used_frames, inputs.lost_landmarks) {
@@ -176,7 +148,6 @@ impl<S: LieScalar> LinearizationAbsQR<S> {
             }
         }
 
-        // `:132-150`.
         let mut landmark_blocks: Vec<LandmarkBlock<S>> = Vec::with_capacity(landmark_ids.len());
         for &lm_id in &landmark_ids {
             let lm: &Landmark<S> = estimator
@@ -195,7 +166,6 @@ impl<S: LieScalar> LinearizationAbsQR<S> {
             )?);
         }
 
-        // `:152-161`.
         let mut landmark_block_idx: Vec<usize> = Vec::with_capacity(landmark_blocks.len());
         let mut num_rows_q2r: usize = 0;
         for block in &landmark_blocks {
@@ -205,12 +175,8 @@ impl<S: LieScalar> LinearizationAbsQR<S> {
                 .ok_or(LinearizeError::LayoutOverflow)?;
         }
 
-        // `:163-167`. C++ computes `start_t + dt` unchecked and then indexes
-        // the ordering with `at()` inside every method that uses the block
-        // (`imu_block.hpp:89-93` and its four siblings), which throws on a
-        // missing frame and silently misplaces a 15x15 write on a frame that is
-        // in the ordering with a *pose-sized* slot. Both are resolved here,
-        // once, so the per-iteration path cannot fail (decision D32).
+        // Resolve IMU endpoints and full-state block sizes once at construction.
+        // Check timestamp addition and offsets before the repeated scatter path (D32).
         let mut imu_meta: Vec<ImuMeta> = Vec::new();
         if let Some(imu) = inputs.imu {
             for (start_t, meas) in &imu.measurements {
@@ -230,10 +196,7 @@ impl<S: LieScalar> LinearizationAbsQR<S> {
                         start: *start_t,
                         end: end_t,
                     })?;
-                // An IMU factor is 15 columns wide at each end
-                // (`imu_block.hpp:21`). A pose-only slot next to one is not a
-                // narrower factor, it is a different problem: C++ would write
-                // fifteen columns over a six-column slot and into its neighbour.
+                // Each IMU endpoint needs 15 columns; a six-column pose slot would overwrite its neighbor.
                 for (frame, size) in [(*start_t, start_size), (end_t, end_size)] {
                     if size != POSE_VEL_BIAS_SIZE {
                         return Err(LinearizeError::ImuStateNotFullSize { frame, size });
@@ -262,36 +225,22 @@ impl<S: LieScalar> LinearizationAbsQR<S> {
         })
     }
 
-    /// `linearizeProblem(&numerically_valid)` (`:200-277`): the residual, its
-    /// Jacobians and the total error at the current state.
-    ///
-    /// Three stages, in this order and with this summation order:
-    ///
-    /// 1. every relative pose and its two Jacobians (`:207-241`), taken at the
-    ///    **linearization point** (`getPoseLin`) and then re-evaluated for its
-    ///    value alone at the current state when either end is frozen
-    ///    (`:229-232`) — first-estimate Jacobians, trap 7;
-    /// 2. the landmark blocks, folded in landmark order through
-    ///    `crate::linearize::reduce`, deterministic and independent of thread count;
-    /// 3. the IMU blocks (`:266-268`) and then the marginalization prior
-    ///    (`:270-274`), both serial in C++ too.
-    ///
-    /// Returns `(error, numerically_valid)`.
+    /// Linearize in fixed order: relative poses, landmark blocks, IMU blocks, prior.
+    /// Relative-pose Jacobians use frozen linearization points while values are
+    /// reevaluated at current states (trap 7). Landmark folds are independent of
+    /// thread count. Return error and numerical validity.
     pub fn linearize_problem(
         &mut self,
         estimator: &BundleAdjustmentBase<S>,
         inputs: &LinearizationInputs<'_, S>,
     ) -> Result<(S, bool), LinearizeError> {
-        // `:201-204`.
-
-        // 1. the relative poses (`:207-241`).
+        // 1. the relative poses.
         for (i, (tcid_h, tcid_t)) in self.rel_pose_pairs.iter().enumerate() {
             let Some(rpl) = self.rel_pose_lin.get_mut(i) else {
                 // Unreachable: the two vectors are built together.
                 return Err(LinearizeError::LayoutOverflow);
             };
             if tcid_h == tcid_t {
-                // `:235-239`.
                 rpl.t_t_h = Matrix4::identity();
                 rpl.d_rel_d_h = Matrix6::zeros();
                 rpl.d_rel_d_t = Matrix6::zeros();
@@ -318,7 +267,7 @@ impl<S: LieScalar> LinearizationAbsQR<S> {
                         camera_count: estimator.calib.t_i_c.len(),
                     })?;
 
-            // `:219-221`: Jacobians at the linearization point.
+            // Jacobians at the linearization point.
             let mut d_rel_d_h: Matrix6<S> = Matrix6::zeros();
             let mut d_rel_d_t: Matrix6<S> = Matrix6::zeros();
             let t_t_h: Se3<S> = linearize_relative_pose(
@@ -330,7 +279,6 @@ impl<S: LieScalar> LinearizationAbsQR<S> {
                 Some(&mut d_rel_d_t),
             );
 
-            // `:223-224`.
             if let Some(fixed) = inputs.fixed_frames {
                 if fixed.contains(&tcid_h.frame_id) {
                     d_rel_d_h = Matrix6::zeros();
@@ -369,7 +317,7 @@ impl<S: LieScalar> LinearizationAbsQR<S> {
                 Ok(acc + contribution)
             })?;
 
-        // 3a. the IMU blocks (`:266-268`).
+        // 3a. the IMU blocks.
         self.imu_blocks.clear();
         if let Some(imu) = inputs.imu {
             for (meta, (_, meas)) in self.imu_meta.iter().zip(imu.measurements.iter()) {
@@ -392,7 +340,7 @@ impl<S: LieScalar> LinearizationAbsQR<S> {
             }
         }
 
-        // 3b. the marginalization prior (`:270-274`).
+        // 3b. the marginalization prior.
         if let Some(marg) = inputs.marg {
             error += estimator.compute_marg_prior_error(marg)?;
         }
@@ -400,7 +348,7 @@ impl<S: LieScalar> LinearizationAbsQR<S> {
         Ok((error, numerically_valid))
     }
 
-    /// `performQR()` (`:280-287`): eliminate every block's landmark columns.
+    /// `performQR()` : eliminate every block's landmark columns.
     pub fn perform_qr(&mut self) -> Result<(), LinearizeError> {
         let options: LandmarkBlockOptions<S> = self.options.lb_options;
         for block in &mut self.landmark_blocks {
@@ -409,15 +357,9 @@ impl<S: LieScalar> LinearizationAbsQR<S> {
         Ok(())
     }
 
-    /// `get_dense_H_b(H, b)` (`:511-563`): the reduced camera system.
-    ///
-    /// Fold landmark contributions in landmark order into one reusable dense
-    /// accumulator through `crate::linearize::reduce`. The fold is deterministic
-    /// and independent of thread count.
-    ///
-    /// The order of the additions after the landmark blocks is basalt's: IMU
-    /// (`:553`), then the marginalization prior (`:559`). `:556`'s pose damping
-    /// is not one of them (D68).
+    /// Build the dense reduced camera system with a reusable accumulator.
+    /// Fold landmarks in deterministic order, then add IMU factors and the prior.
+    /// There are no pose-damping rows (D68).
     pub fn get_dense_h_b(
         &self,
         estimator: &BundleAdjustmentBase<S>,
@@ -435,7 +377,7 @@ impl<S: LieScalar> LinearizationAbsQR<S> {
     /// The reduced system is the workspace's own accumulator, handed back by
     /// reference: the Levenberg-Marquardt loop builds one per inner step and
     /// throws it away, so nothing wants an owned copy. The caller may write
-    /// into both — `sqrt_keypoint_vio.cpp:1395-1406` pins a fixed keyframe's
+    /// into both — pins a fixed keyframe's
     /// rows in place — because the next call zeroes the whole square rather
     /// than only the columns the reduction recorded.
     pub fn get_dense_h_b_into<'w>(
@@ -447,12 +389,12 @@ impl<S: LieScalar> LinearizationAbsQR<S> {
         let opt_size: usize = self.aom.total_size();
         let (h, b) = workspace.reduce(opt_size, &self.landmark_blocks)?;
 
-        // `add_dense_H_b_imu` (`:640-653`).
+        // `add_dense_H_b_imu`.
         for (block, meta) in self.imu_blocks.iter().zip(self.imu_meta.iter()) {
             block.add_dense_h_b(meta.start_idx, meta.end_idx, h, b);
         }
 
-        // `add_dense_H_b_marg_prior` (`:600-631`). `:595-598`'s pose-damping
+        // `add_dense_H_b_marg_prior`. 's pose-damping
         // diagonal is not here: nothing sets it (D68).
         if let Some(marg) = inputs.marg {
             estimator.linearize_marg_prior(marg, &self.aom, h, b)?;
@@ -461,13 +403,9 @@ impl<S: LieScalar> LinearizationAbsQR<S> {
         Ok((h, b))
     }
 
-    /// `get_dense_Q2Jp_Q2r(Q2Jp, Q2r)` (`:462-509`): the stacked square-root
-    /// system the marginalization of stage S7 consumes.
-    ///
-    /// The row budget, in this order (`:464-482`): the landmark blocks'
-    /// `num_rows_Q2r`, then 15 rows per IMU interval, then the marginalization
-    /// prior's rows. C++ reserves `aom.total_size` rows of pose damping between
-    /// the last two; nothing sets it (D68), so the port has no such rows.
+    /// Export the stacked square-root system for marginalization.
+    /// Rows are landmark contributions, 15 per IMU interval, then the prior.
+    /// No unused pose-damping rows are reserved (D68).
     pub fn get_dense_q2jp_q2r(
         &self,
         estimator: &BundleAdjustmentBase<S>,
@@ -487,7 +425,6 @@ impl<S: LieScalar> LinearizationAbsQR<S> {
         let mut q2jp: DMatrix<S> = DMatrix::zeros(total_size, poses_size);
         let mut q2r: DVector<S> = DVector::zeros(total_size);
 
-        // `:484-493`.
         for (block, &start) in self
             .landmark_blocks
             .iter()
@@ -496,23 +433,17 @@ impl<S: LieScalar> LinearizationAbsQR<S> {
             block.get_dense_q2jp_q2r(&mut q2jp, &mut q2r, start)?;
         }
 
-        // `:496-502`.
         let mut start_idx: usize = imu_start_idx;
         for (block, meta) in self.imu_blocks.iter().zip(self.imu_meta.iter()) {
             block.add_dense_q2jp_q2r(meta.start_idx, meta.end_idx, start_idx, &mut q2jp, &mut q2r);
             start_idx += POSE_VEL_BIAS_SIZE;
         }
 
-        // `get_dense_Q2Jp_Q2r_marg_prior` (`:573-593`), trap 8: the prior's
+        // `get_dense_Q2Jp_Q2r_marg_prior`, trap 8: the prior's
         // residual is re-anchored at the current state as `H * delta + b`.
         if let Some(marg) = inputs.marg {
-            // The prior's columns are written into the *first* `marg_cols`
-            // columns of the stacked system (`:587-589`), which is only correct
-            // if its ordering is the window's prefix. `linearizeMargPrior`
-            // asserts exactly that before it does the same thing in Hessian
-            // form (`ba_base.cpp:383-388`); the square-root export in C++ does
-            // not, and would silently attach a frame's columns to another
-            // frame. The port checks both paths.
+            // Prior columns occupy the window prefix. Check ordering in both dense and
+            // square-root exports to avoid attaching one frame's columns to another.
             estimator.check_marg_prior_order(marg, &self.aom)?;
             let delta: DVector<S> = estimator.compute_delta(&marg.order)?;
             let (marg_rows, marg_cols) = (marg.h.nrows(), marg.h.ncols());
@@ -531,16 +462,9 @@ impl<S: LieScalar> LinearizationAbsQR<S> {
         Ok((q2jp, q2r))
     }
 
-    /// `backSubstitute(pose_inc)` (`:297-321`): apply the pose increment to the
-    /// landmarks and return the model cost change the whole problem predicts.
-    ///
-    /// **Reduction site 2 of 4** (`:307`): the per-block `l_diff` is summed in
-    /// block order. The IMU blocks (`:309-311`) and the prior (`:313-318`) add
-    /// theirs afterwards, in that order.
-    ///
-    /// The increment this takes is basalt's **negated** one
-    /// (`sqrt_keypoint_vio.cpp:1450`), the other half of the flipped residual
-    /// sign of `ba_utils.h:117`.
+    /// Apply pose increments to landmarks and return the predicted cost change.
+    /// Sum blocks in order, then IMU factors, then the prior. The input increment
+    /// must already be negated to compensate for the residual sign.
     pub fn back_substitute(
         &mut self,
         estimator: &mut BundleAdjustmentBase<S>,
@@ -586,7 +510,7 @@ impl<S: LieScalar> LinearizationAbsQR<S> {
     }
 
     /// The options the blocks were built with, `options_`
-    /// (`linearization_abs_qr.hpp:102`), including the Huber threshold and the
+    /// including the Huber threshold and the
     /// pixel sigma copied off the estimator.
     pub fn options(&self) -> &LinearizationOptions<S> {
         &self.options

--- a/packages/slam-rs/crates/slam-rs/src/linearize/dense_hb.rs
+++ b/packages/slam-rs/crates/slam-rs/src/linearize/dense_hb.rs
@@ -7,21 +7,11 @@ use super::landmark_block::{DenseHbScratch, LandmarkBlock};
 use super::reduce::deterministic_reduce;
 use crate::lie::LieScalar;
 
-/// One subtree's partial `(H, b)` of the dense reduction, and the columns it holds.
-///
-/// C++ gives every TBB task a full `total_size` x `total_size` partial and adds
-/// the whole square at each join (`:513-542`), but a subtree only ever writes
-/// the pose columns its landmarks observe — 22 of 85 on the median MIO10 frame
-/// for one landmark, and the union of a subtree's landmarks above that. The
-/// rest is `+0.0` on both sides of a join and `+0.0` after a reset, so keeping
-/// the square but touching only `columns` is the same arithmetic; see
-/// [`LandmarkBlock::active_cols`] for why `+= +0.0` here is the identity.
-///
-/// This partial is the one destination that argument holds for: it is created
-/// zeroed and [`Self::reset`] puts back `+0.0`, never `-0.0`, so no coefficient
-/// a skipped write would have changed exists. A block whose own columns are not
-/// the identity to skip — [`LandmarkBlock::active_writeback_is_exact`] — is
-/// added at full width instead.
+/// Partial dense `(H, b)` and the columns it touched.
+/// Only observed pose columns need updates if skipped writes are exact identities.
+/// Storage resets to positive zero, so untouched coefficients remain positive zero.
+/// Blocks with non-finite or signed-zero-sensitive writes use full width instead;
+/// see [`LandmarkBlock::active_writeback_is_exact`].
 #[derive(Debug, Clone)]
 struct DensePartial<S: LieScalar> {
     /// The partial `H`, full size, zero outside `columns` x `columns`.
@@ -113,20 +103,10 @@ impl<S: LieScalar> DensePartial<S> {
         }
     }
 
-    /// Add one landmark block's `(H, b)` and record the columns it wrote.
-    ///
-    /// The two halves belong together: [`Self::mark`] records what a join and a
-    /// reset will touch and the writeback is what writes it, so a drift between
-    /// them would leave coefficients no join adds and no reset clears — a
-    /// silently wrong reduction that no test would catch. Marking **after** the
-    /// add is what makes every column in range: the add is the check on the
-    /// block's layout.
-    ///
-    /// Which of the two writebacks runs is the block's own answer: the observed
-    /// columns when skipping the rest is the identity, the full width when it is
-    /// not, and then every column is marked because the full width writes every
-    /// column — a NaN spread into a column the block never observed is part of
-    /// the sum basalt takes (decision D32).
+    /// Add a landmark contribution and mark its written columns together.
+    /// Mark only after the add validates layout. Exact sparse writes mark observed
+    /// columns; full-width writes also mark NaNs propagated into unobserved columns,
+    /// so joins and resets cannot miss them (D32).
     fn accumulate(
         &mut self,
         block: &LandmarkBlock<S>,
@@ -291,12 +271,8 @@ mod tests {
         block
     }
 
-    /// The reduction adds a non-finite block at full width, bit for bit with the
-    /// system the C++ path writes, and marks every column it wrote.
-    ///
-    /// Skipping the block's unobserved columns would drop those NaNs — the
-    /// reduced camera system would come out finite where basalt's is not
-    /// (decision D32) — and leave coefficients no join adds and no reset clears.
+    /// Non-finite blocks must write and mark every column. Skipping unobserved columns
+    /// would suppress NaNs and leave coefficients outside join/reset bookkeeping (D32).
     #[test]
     fn a_non_finite_block_is_reduced_at_full_width() {
         let block: LandmarkBlock<f64> = a_block_carrying_a_nan();

--- a/packages/slam-rs/crates/slam-rs/src/linearize/landmark_block.rs
+++ b/packages/slam-rs/crates/slam-rs/src/linearize/landmark_block.rs
@@ -1,11 +1,6 @@
-//! One landmark's rows of the linear system, and the QR that eliminates it.
-//!
-//! `LandmarkBlockAbsDynamic<Scalar, POSE_SIZE>`
-//! (`include/basalt/linearization/landmark_block_abs_dynamic.hpp`), the block of
-//! CVPR 2021 Fig. 2: one dense buffer laid out `[ J_p | pad | J_l(3) | r ]`,
-//! three Householder reflections that rotate the landmark columns to upper
-//! triangular, and the two halves that fall out of it — rows `0..3` (`Q₁`) for
-//! back-substitution, rows `3..` (`Q₂`) for the reduced camera system.
+//! Landmark rows `[J_p | pad | J_l(3) | r]` and their QR elimination.
+//! Three reflections triangularize landmark columns. The first three rows
+//! support back-substitution; remaining rows form the reduced camera system.
 
 use nalgebra::{DMatrix, DVector, Matrix2x3, Matrix2x6, Matrix3, Vector2, Vector3};
 
@@ -20,24 +15,22 @@ use crate::qr::{
 };
 use crate::types::{AbsOrderMap, LandmarkId, POSE_SIZE, TimeCamId};
 
-/// `LandmarkBlock<Scalar>::Options` (`landmark_block.hpp:31-48`).
+/// `LandmarkBlock<Scalar>::Options`.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LandmarkBlockOptions<S: LieScalar> {
-    /// Householder rather than Givens for the elimination (`:33`). basalt ships
-    /// `true` and the shipped VIO never changes it.
+    /// Select Householder instead of Givens elimination; defaults to true.
     pub use_householder: bool,
     /// Zero the residual and Jacobian of a projection the camera rejected
-    /// (`:37`), rather than keeping whatever the model wrote.
+    /// rather than keeping whatever the model wrote.
     pub use_valid_projections_only: bool,
     /// Huber threshold in **raw pixels**, or zero for a plain squared norm
-    /// (`:40`).
     pub huber_parameter: S,
-    /// Standard deviation of the reprojection error, in pixels (`:43`).
+    /// Standard deviation of the reprojection error, in pixels.
     pub obs_std_dev: S,
 }
 
 impl<S: LieScalar> Default for LandmarkBlockOptions<S> {
-    /// basalt's defaults (`landmark_block.hpp:33-47`).
+    /// Default landmark-block options.
     fn default() -> Self {
         Self {
             use_householder: true,
@@ -81,7 +74,7 @@ impl<S: LieScalar> Default for DenseHbScratch<S> {
     }
 }
 
-/// `LandmarkBlock<Scalar>::State` (`landmark_block.hpp:50`).
+/// `LandmarkBlock<Scalar>::State`.
 ///
 /// `Uninitialized` is unreachable in the port — [`LandmarkBlock::allocate`] is a
 /// constructor, so there is no half-built block to be in that state — and is
@@ -101,19 +94,13 @@ pub enum LandmarkBlockState {
     Marginalized,
 }
 
-/// One observation's place in the block, resolved once at allocation.
-///
-/// C++ keeps two parallel vectors — `pose_lin_vec` (a `RelPoseLin*`, null when
-/// the target frame is not in the ordering, `:70-75`) and `pose_tcid_vec` — and
-/// looks the two absolute offsets up with `at()` on every linearization
-/// (`:139-140`). The port resolves both at allocation and stores them, so the
-/// per-observation path has no map lookup and no way to throw.
+/// Observation offsets and relative-pose index resolved at allocation.
+/// This avoids repeated map lookups and fallible indexing during linearization.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct BlockObservation {
     /// Where the landmark was seen.
     tcid_t: TimeCamId,
-    /// Index into the driver's relative-pose table, or `None` for an
-    /// observation dropped for marginalization (C++'s null pointer, `:74`).
+    /// Relative-pose index, or `None` when marginalization drops this observation.
     rel_pose: Option<usize>,
     /// Column offset of the host frame's pose block.
     abs_h_idx: usize,
@@ -123,22 +110,22 @@ struct BlockObservation {
 
 /// One landmark's block of the linear system.
 ///
-/// Layout (`landmark_block_abs_dynamic.hpp:83-96`, architecture §1.3):
+/// Layout (architecture §1.3):
 ///
 /// ```text
-/// num_rows    = 2 * observations + 3          // 3 landmark-damping rows (:85)
-/// padding_idx = aom.total_size                // (:83)
-/// padding_size= (4 - padding_idx % 4) % 4     // 16-byte alignment (:87-88)
-/// lm_idx      = padding_idx + padding_size    // (:90)
-/// res_idx     = lm_idx + 3                    // (:91)
-/// num_cols    = res_idx + 1, asserted % 4 == 0 (:92-96)
+/// num_rows    = 2 * observations + 3          // 3 landmark-damping rows ()
+/// padding_idx = aom.total_size                // ()
+/// padding_size= (4 - padding_idx % 4) % 4     // 16-byte alignment ()
+/// lm_idx      = padding_idx + padding_size    // ()
+/// res_idx     = lm_idx + 3                    // ()
+/// num_cols    = res_idx + 1, asserted % 4 == 0 ()
 /// ```
 ///
 /// Storage is column major. Each reflection updates views of the existing
 /// matrix using a preallocated unit-axis buffer.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LandmarkBlock<S: LieScalar> {
-    /// `storage` (`:530`): `[ J_p | pad | J_l | r ]`, `num_rows` x `num_cols`.
+    /// `storage` : `[ J_p | pad | J_l | r ]`, `num_rows` x `num_cols`.
     storage: DMatrix<S>,
     /// One entry per observation, in `lm.obs` order.
     observations: Vec<BlockObservation>,
@@ -146,11 +133,11 @@ pub struct LandmarkBlock<S: LieScalar> {
     ///
     /// Every other column of `0..padding_idx` stays exactly zero for the block's
     /// whole life: `linearizeLandmark` only ever writes `block<2, 6>` at an
-    /// observation's host and target offsets (`:178-179`), and the Householder
+    /// observation's host and target offsets, and the Householder
     /// reflections and Givens rotations that follow act on rows, which cannot
     /// move a zero column off zero. An observation dropped for marginalization
-    /// writes nothing at all — `:137` skips it for want of a relative pose, and
-    /// its `abs_t_idx` is the `0` sentinel of `:74`, which is a column of
+    /// writes nothing because it has no relative pose, and
+    /// its `abs_t_idx` is the `0` sentinel, which is a column of
     /// whichever frame the ordering puts first — so it is left out.
     /// [`Self::add_dense_h_b_active`] is the only reader, and
     /// `dense_h_b_touches_only_observed_columns` and
@@ -163,26 +150,26 @@ pub struct LandmarkBlock<S: LieScalar> {
     active_cols: Vec<usize>,
     /// The landmark this block belongs to.
     lm_id: LandmarkId,
-    /// `lm_ptr->host_kf_id` (`:525`).
+    /// `lm_ptr->host_kf_id`.
     host_kf_id: TimeCamId,
-    /// `is_fixed_` (`:552`): the landmark is not optimised.
+    /// `is_fixed_` : the landmark is not optimised.
     is_fixed: bool,
     padding_idx: usize,
     lm_idx: usize,
     res_idx: usize,
     num_rows: usize,
     num_cols: usize,
-    /// `state` (`:547`).
+    /// `state`.
     state: LandmarkBlockState,
-    /// The `tempVector2` of `:443`, the essential part of the reflector.
+    /// Reusable reflection-axis scratch.
     work_essential: Vec<S>,
 }
 
-/// `compute_error_weight` (`:456-470`).
+/// `compute_error_weight`.
 ///
 /// Returns `(weighted_error, weight)`. Note the Huber test is on the
 /// **squared** residual against the squared threshold, and that both are in
-/// raw pixels: the `1 / obs_std_dev` scaling happens afterwards (`:170-172`),
+/// raw pixels: the `1 / obs_std_dev` scaling happens afterwards,
 /// which is the "effective 2 sigma" deviation of papers-part2 §13.
 ///
 /// A free function rather than a method because the estimator's non-keyframe
@@ -207,17 +194,9 @@ pub fn compute_error_weight<S: LieScalar>(
 }
 
 impl<S: LieScalar> LandmarkBlock<S> {
-    /// `allocateLandmark` (`:35-104`).
-    ///
-    /// `rel_pose_index` maps a `(host, target)` pair to its slot in the driver's
-    /// relative-pose table; C++ stores the pointer itself (`:67-75`). An
-    /// observation whose target frame is not in `aom` is kept with no relative
-    /// pose, which is how a measurement dropped during marginalization survives
-    /// allocation and contributes nothing (`:70-75`, and the comment at
-    /// `:125-135` that says this should not happen in the first place).
-    ///
-    /// C++ asserts the host frame is in the ordering (`:62`) and that the
-    /// relative pose exists (`:68`); both are typed errors here (decision D32).
+    /// Allocate a landmark block from the ordering and relative-pose index table.
+    /// Targets outside the ordering retain zero-contribution observations with no
+    /// relative pose. A missing host or required pose returns a typed error (D32).
     pub fn allocate(
         lm_id: LandmarkId,
         lm: &Landmark<S>,
@@ -226,8 +205,7 @@ impl<S: LieScalar> LandmarkBlock<S> {
         is_fixed: bool,
     ) -> Result<Self, LinearizeError> {
         let host: TimeCamId = lm.host_kf_id;
-        // `BASALT_ASSERT(aom.abs_order_map.count(lm.host_kf_id.frame_id) > 0)`
-        // (`:62`) — a landmark block without its host frame cannot be built.
+        // A landmark block requires its host frame in the ordering.
         let (abs_h_idx, _) = aom
             .get(host.frame_id)
             .ok_or(LinearizeError::HostNotInOrdering {
@@ -237,7 +215,7 @@ impl<S: LieScalar> LandmarkBlock<S> {
         let mut observations: Vec<BlockObservation> = Vec::with_capacity(lm.obs.len());
         for &tcid_t in lm.obs.keys() {
             let rel_pose: Option<usize> = match aom.get(tcid_t.frame_id) {
-                // `:71` — in the ordering, so the pair must have a relative pose.
+                //  — in the ordering, so the pair must have a relative pose.
                 Some(_) => Some(rel_pose_index(host, tcid_t).ok_or(
                     LinearizeError::MissingRelativePose {
                         host: host.frame_id,
@@ -246,7 +224,7 @@ impl<S: LieScalar> LandmarkBlock<S> {
                         target_cam: tcid_t.cam_id,
                     },
                 )?),
-                // `:74` — dropped for marginalization.
+                //  — dropped for marginalization.
                 None => None,
             };
             let abs_t_idx: usize = aom.get(tcid_t.frame_id).map_or(0, |(idx, _)| idx);
@@ -258,7 +236,7 @@ impl<S: LieScalar> LandmarkBlock<S> {
             });
         }
 
-        // The layout arithmetic of `:83-96`, every step checked: the sizes come
+        // Check every step of layout arithmetic: the sizes come
         // from a caller-supplied ordering, and an overflow here would silently
         // wrap into a buffer that aliases its own blocks (decision D32).
         let padding_idx: usize = aom.total_size();
@@ -278,11 +256,11 @@ impl<S: LieScalar> LandmarkBlock<S> {
         let num_cols: usize = res_idx
             .checked_add(1)
             .ok_or(LinearizeError::LayoutOverflow)?;
-        // `BASALT_ASSERT(num_cols % 4 == 0)` (`:96`).
+        // The padded column count must be a multiple of four.
         if num_cols % 4 != 0 {
             return Err(LinearizeError::UnalignedBlock { num_cols });
         }
-        // `storage.resize(num_rows, num_cols)` (`:98`). Each dimension being
+        // `storage.resize(num_rows, num_cols)`. Each dimension being
         // representable is not enough: nalgebra multiplies them, and the
         // allocator wants the byte count, which must fit in an `isize`
         // (decision D32). An ordering carrying one absurd block size reaches
@@ -303,8 +281,7 @@ impl<S: LieScalar> LandmarkBlock<S> {
                 cols: num_cols,
             });
         }
-        // Every pose block must fit: C++ writes `block<2, 6>(obs_idx, abs_idx)`
-        // with no bound check (`:178-179`).
+        // Check that every six-column pose block fits before writing.
         for obs in &observations {
             if obs.rel_pose.is_some() {
                 let end: usize = obs
@@ -323,7 +300,7 @@ impl<S: LieScalar> LandmarkBlock<S> {
 
         let mut active_cols: Vec<usize> = Vec::with_capacity(2 * POSE_SIZE * observations.len());
         for obs in &observations {
-            // A dropped observation is skipped at `:137` and writes nothing;
+            // A dropped observation is skipped at and writes nothing;
             // its `abs_t_idx` is the `0` sentinel, not a column it owns.
             if obs.rel_pose.is_none() {
                 continue;
@@ -354,15 +331,15 @@ impl<S: LieScalar> LandmarkBlock<S> {
         })
     }
 
-    /// `linearizeLandmark` (`:110-191`): fill the block at the current
+    /// `linearizeLandmark` : fill the block at the current
     /// linearization point and return this landmark's share of the error.
     ///
     /// Three behaviours are deliberate and are kept (trap 11, decision D32):
     /// a projection the camera rejected contributes **nothing** when
-    /// `use_valid_projections_only` is set (`:152`); a non-finite Jacobian block
-    /// is **zeroed with a warning**, not an error (`:153-163`, which the comment
-    /// at `:165-166` says used to set `NumericalFailure`); and the two pose
-    /// blocks are accumulated with `+=` (`:178-179`), which is what makes a
+    /// `use_valid_projections_only` is set; a non-finite Jacobian block
+    /// is **zeroed with a warning**, not an error (which the comment
+    /// at says used to set `NumericalFailure`); and the two pose
+    /// blocks are accumulated with `+=`, which is what makes a
     /// landmark observed in its own host frame — where the host and target
     /// columns coincide — come out right.
     pub fn linearize_landmark(
@@ -372,14 +349,14 @@ impl<S: LieScalar> LandmarkBlock<S> {
         cameras: &[CameraEnum<S>],
         options: &LandmarkBlockOptions<S>,
     ) -> Result<S, LinearizeError> {
-        // `storage.setZero()` (`:115-117`).
+        // `storage.setZero()`.
         self.storage.fill(S::zero());
 
         let mut error_sum: S = S::zero();
 
         for (i, obs) in self.observations.iter().enumerate() {
             let Some(rel_idx) = obs.rel_pose else {
-                // `if (pose_lin_vec[i])` (`:137`): a dropped measurement.
+                // `if (pose_lin_vec[i])` : a dropped measurement.
                 continue;
             };
             let rel: &RelPoseLin<S> =
@@ -425,17 +402,16 @@ impl<S: LieScalar> LandmarkBlock<S> {
                 },
             );
 
-            // `if (is_fixed_) d_res_d_p.setZero()` (`:150`).
+            // `if (is_fixed_) d_res_d_p.setZero()`.
             if self.is_fixed {
                 d_res_d_p.fill(S::zero());
             }
 
-            // `:152`.
             if options.use_valid_projections_only && !valid {
                 continue;
             }
 
-            // `:153-163`: zeroed, never fatal.
+            // zeroed, never fatal.
             if !d_res_d_xi.iter().all(|v| v.to_f64().is_finite()) {
                 log::warn!(
                     "d_res_d_xi is not valid, lm = Landmark(id={:?}, host_kf_id={:?})",
@@ -453,14 +429,13 @@ impl<S: LieScalar> LandmarkBlock<S> {
                 d_res_d_p.fill(S::zero());
             }
 
-            // `:168-172`. `res.squaredNorm()` is a contiguous two-coefficient
+            // `res.squaredNorm()` is a contiguous two-coefficient
             // reduction, so there is only one order to take.
             let res_squared: S = res[0] * res[0] + res[1] * res[1];
             let (weighted_error, weight) = compute_error_weight(res_squared, options);
             let sqrt_weight: S = weight.sqrt() / options.obs_std_dev;
             error_sum += weighted_error / (options.obs_std_dev * options.obs_std_dev);
 
-            // `:174-175`.
             for r in 0..2 {
                 for col in 0..3 {
                     self.storage[(obs_idx + r, self.lm_idx + col)] =
@@ -469,7 +444,7 @@ impl<S: LieScalar> LandmarkBlock<S> {
                 self.storage[(obs_idx + r, self.res_idx)] = sqrt_weight * res[r];
             }
 
-            // `:177-179`. The scaling happens once, in place, and then both pose
+            // The scaling happens once, in place, and then both pose
             // blocks are accumulated.
             d_res_d_xi *= sqrt_weight;
             let host_block: Matrix2x6<S> = d_res_d_xi * rel.d_rel_d_h;
@@ -490,7 +465,7 @@ impl<S: LieScalar> LandmarkBlock<S> {
         Ok(error_sum)
     }
 
-    /// `performQR` (`:193-206`): eliminate the three landmark columns.
+    /// `performQR` : eliminate the three landmark columns.
     pub fn perform_qr(&mut self, options: &LandmarkBlockOptions<S>) -> Result<(), LinearizeError> {
         if self.state != LandmarkBlockState::Linearized {
             return Err(LinearizeError::WrongState {
@@ -507,20 +482,13 @@ impl<S: LieScalar> LandmarkBlock<S> {
         Ok(())
     }
 
-    /// `performQRHouseholder` (`:441-454`): three reflections, each applied to
+    /// `performQRHouseholder` : three reflections, each applied to
     /// the whole width of the block.
     fn perform_qr_householder(&mut self) {
         for k in 0..3 {
-            // `remainingRows = num_rows - k - 3` (`:446`): the damping rows are
-            // excluded, so the reflection never touches them.
-            //
-            // **Deviation.** With fewer than two observations the count runs
-            // out and C++ calls `makeHouseholder` on a segment of length zero,
-            // whose `tail` is then a block of length -1 — an assertion in a
-            // debug build and undefined behaviour in a release one. basalt
-            // never builds such a block (`min_num_obs = 2`,
-            // `landmark_database.cpp:207`), but the port must not be the thing
-            // that crashes if one ever appears, so the reflection is skipped.
+            // Exclude damping rows from reflection. Skip an empty reflection when fewer
+            // than two observations leave insufficient rows; malformed sparse blocks must
+            // not cause an out-of-range access.
             let remaining_rows: usize = self.num_rows.saturating_sub(k + 3);
             if remaining_rows == 0 {
                 continue;
@@ -542,13 +510,9 @@ impl<S: LieScalar> LandmarkBlock<S> {
         }
     }
 
-    /// `performQRGivens` (`:429-439`): Golub & Van Loan Algorithm 5.2.4.
-    ///
-    /// Not reached with basalt's shipped options (`use_householder = true`), and
-    /// kept because it is the reference the Householder path is checked against.
+    /// Givens QR (Golub & Van Loan Algorithm 5.2.4), retained to check Householder elimination.
     fn perform_qr_givens(&mut self) {
-        // C++'s `num_rows - 4` underflows on a block with no observations; see
-        // the note in [`Self::perform_qr_householder`].
+        // Guard empty observation sets before subtracting the row offset.
         if self.num_rows < 4 {
             return;
         }
@@ -565,22 +529,11 @@ impl<S: LieScalar> LandmarkBlock<S> {
         }
     }
 
-    /// `backSubstitute(pose_inc, l_diff)` (`:253-327`): recover this landmark's
-    /// increment from the pose increment, add its share of the model cost
-    /// change, and apply it.
-    ///
-    /// Two behaviours worth naming:
-    ///
-    /// * a singular `Q1Jl` is **warned about and skipped**, not an error
-    ///   (`:263-269`, trap 11), and an unusually small determinant only warns;
-    /// * the inverse distance is **projected**, not clamped:
-    ///   `max(0, inv_dist + inc[2])` (`:326`, trap 12).
-    ///
-    /// C++ also undoes the damping before the model cost change (`:310`) and
-    /// scales the increment by `Jl_col_scale` after it (`:322-323`); the port
-    /// carries neither, because nothing damps or scales (D34, D68).
-    ///
-    /// `pose_inc` must be `aom.total_size` long (`:259`).
+    /// Recover and apply the landmark increment, adding its predicted cost decrease.
+    /// A singular `Q1Jl` warns and skips the landmark; a small determinant only warns.
+    /// Project inverse distance with `max(0, inv_dist + inc[2])` (traps 11–12).
+    /// There is no landmark damping or Jacobian scaling (D34, D68).
+    /// The pose increment must span the full ordering.
     pub fn back_substitute(
         &mut self,
         lm: &mut Landmark<S>,
@@ -593,7 +546,7 @@ impl<S: LieScalar> LandmarkBlock<S> {
                 found: self.state,
             });
         }
-        // `if (is_fixed_) return` (`:256`).
+        // `if (is_fixed_) return`.
         if self.is_fixed {
             return Ok(());
         }
@@ -604,7 +557,7 @@ impl<S: LieScalar> LandmarkBlock<S> {
             });
         }
 
-        // `Q1Jl` (`:261`), the upper triangle of the 3x3 at the top of the
+        // `Q1Jl`, the upper triangle of the 3x3 at the top of the
         // landmark columns.
         let mut q1jl: Matrix3<S> = Matrix3::zeros();
         for r in 0..3 {
@@ -616,7 +569,7 @@ impl<S: LieScalar> LandmarkBlock<S> {
         // The product of the triangular diagonal detects a singular landmark.
         let det: S = (q1jl[(0, 0)] * q1jl[(1, 1)] * q1jl[(2, 2)]).abs();
         if det == S::zero() {
-            // `:264-266`, trap 11: skip this landmark, keep the rest.
+            // trap 11: skip this landmark, keep the rest.
             log::warn!(
                 "det(Q1Jl) == 0, skipping backsubstitution for lm: Landmark(id={:?}, host_kf_id={:?})",
                 self.lm_id,
@@ -624,7 +577,6 @@ impl<S: LieScalar> LandmarkBlock<S> {
             );
             return Ok(());
         } else if det < c::<S>(0.01) {
-            // `:267-269`.
             log::warn!(
                 "Unusually small det(Q1Jl)={}, lm: Landmark(id={:?}, host_kf_id={:?})",
                 det.to_f64(),
@@ -633,7 +585,7 @@ impl<S: LieScalar> LandmarkBlock<S> {
             );
         }
 
-        // `Q1Jr + Q1Jp * pose_inc` (`:271-274`).
+        // `Q1Jr + Q1Jp * pose_inc`.
         let mut rhs: Vector3<S> = Vector3::zeros();
         for r in 0..3 {
             let mut acc: S = S::zero();
@@ -654,14 +606,14 @@ impl<S: LieScalar> LandmarkBlock<S> {
         }
         inc = -inc;
 
-        // `:310` calls `setLandmarkDamping(0)` here, to undo the damping before
+        //  calls `setLandmarkDamping(0)` here, to undo the damping before
         // the model cost change. The port has no damping (D34, D68) and the
         // three damping rows are provably still zero — `storage` starts zeroed,
         // the observations fill rows `0..2*obs`, and both QR paths stop at
         // `num_rows - 3` — so there is nothing to undo.
 
         // `QJinc = storage.topLeftCorner(num_rows - 3, padding_idx) * pose_inc`
-        // (`:313`), then `QJinc.head<3>() += Q1Jl * inc` (`:316`) with `Q1Jl`
+        // then `QJinc.head<3>() += Q1Jl * inc` with `Q1Jl`
         // re-read from the now-undamped storage.
         let q2_rows: usize = self.num_rows - 3;
         let mut qjinc: DVector<S> = DVector::zeros(q2_rows);
@@ -680,15 +632,14 @@ impl<S: LieScalar> LandmarkBlock<S> {
             qjinc[r] += acc;
         }
 
-        // `diff = QJinc^T * (0.5 * QJinc + Qr)` (`:318-320`).
+        // `diff = QJinc^T * (0.5 * QJinc + Qr)`.
         let mut diff: S = S::zero();
         for r in 0..q2_rows {
             diff += qjinc[r] * (c::<S>(0.5) * qjinc[r] + self.storage[(r, self.res_idx)]);
         }
         *l_diff -= diff;
 
-        // `:322-326`, without `:322-323`'s `Jl_col_scale` multiply: the scale
-        // is all ones with nothing to scale the columns (D68).
+        // No column-scale multiplication is needed because Jacobian scaling is absent (D68).
         lm.direction[0] += inc[0];
         lm.direction[1] += inc[1];
         let updated: S = lm.inv_dist + inc[2];
@@ -700,7 +651,7 @@ impl<S: LieScalar> LandmarkBlock<S> {
         Ok(())
     }
 
-    /// `get_dense_Q2Jp_Q2r(Q2Jp, Q2r, start_idx)` (`:472-478`): the null-space
+    /// `get_dense_Q2Jp_Q2r(Q2Jp, Q2r, start_idx)` : the null-space
     /// rows, the ones the marginalization QR of stage S7 consumes.
     ///
     /// Rows `3..num_rows` of the block become rows
@@ -714,7 +665,7 @@ impl<S: LieScalar> LandmarkBlock<S> {
         start_idx: usize,
     ) -> Result<(), LinearizeError> {
         let rows: usize = self.num_q2rows();
-        // C++ asserts the column count (`:475`) and indexes the rows unchecked.
+        // Validate destination rows and columns before writing.
         if q2jp.ncols() != self.padding_idx {
             return Err(LinearizeError::StackedSystemSize {
                 expected: self.padding_idx,
@@ -750,16 +701,8 @@ impl<S: LieScalar> LandmarkBlock<S> {
         0..self.padding_idx
     }
 
-    /// `add_dense_H_b(H, b)` (`:494-500`): `H += JᵀJ`, `b += Jᵀr` over the same
-    /// `Q₂` rows.
-    ///
-    /// **Full width**: every column of `0..padding_idx` is written, as the C++
-    /// writes it, because `h` and `b` are the caller's and this method knows
-    /// nothing about what is in them. `Self::add_dense_h_b_active` is the same
-    /// sum over the observed columns only, for the one caller that owns its
-    /// destination and can prove the rest is the identity.
-    ///
-    /// Sum each coefficient over rows in increasing order.
+    /// Add `Q₂J_pᵀ Q₂J_p` and `Q₂J_pᵀ Q₂r` at full width.
+    /// Every column before padding is written, including non-finite propagation.
     pub fn add_dense_h_b(
         &self,
         h: &mut DMatrix<S>,
@@ -791,19 +734,8 @@ impl<S: LieScalar> LandmarkBlock<S> {
         Ok(())
     }
 
-    /// Whether the skip [`Self::add_dense_h_b_active`] makes is the identity on
-    /// a destination that is `+0.0` outside [`Self::active_cols`].
-    ///
-    /// The skipped writes are `x += Σ (a * 0)` over the columns the block does
-    /// not observe. That is `x += ±0.0`, which leaves a `+0.0` `x` alone — but
-    /// only while every factor is finite and those columns really are zero.
-    /// Neither is free: [`Landmark::add_observation`] accepts a non-finite
-    /// keypoint, the Huber weight carries the NaN past the Jacobian checks of
-    /// [`Self::linearize_landmark`], and the Householder reflections of
-    /// `crate::qr`'s reflections act on whole rows, which spreads it into columns the
-    /// block never observed. One pass over the `Q₂` rows decides both, and a
-    /// block that fails takes the full-width path so those NaNs are written
-    /// (decision D32: NaN handling mirrors basalt).
+    /// Use sparse writeback only when skipping inactive columns preserves every value,
+    /// including NaNs and signed zero (D32).
     pub(crate) fn active_writeback_is_exact(&self) -> bool {
         let rows: usize = self.num_q2rows();
         let mut active = self.active_cols.iter().copied().peekable();
@@ -828,7 +760,7 @@ impl<S: LieScalar> LandmarkBlock<S> {
         (0..rows).all(|r| self.storage[(3 + r, self.res_idx)].to_f64().is_finite())
     }
 
-    /// C++ asserts the destination is big enough (`:496`); a typed error here.
+    /// Refuse a destination that is too small with a typed error.
     fn check_dense_h_b_size(&self, h: &DMatrix<S>, b: &DVector<S>) -> Result<(), LinearizeError> {
         if h.nrows() < self.padding_idx
             || h.ncols() < self.padding_idx
@@ -901,8 +833,7 @@ impl<S: LieScalar> LandmarkBlock<S> {
         }
     }
 
-    /// `numQ2rows()` (`:426`): `num_rows - 3`, the rows the reduced camera
-    /// system takes. Note this counts the `Q₁` rows too — the name is basalt's.
+    /// Stored row count minus the three reserved damping rows; includes the `Q₁` rows.
     pub fn num_q2rows(&self) -> usize {
         self.num_rows - 3
     }
@@ -912,23 +843,19 @@ impl<S: LieScalar> LandmarkBlock<S> {
         self.lm_id
     }
 
-    /// `getState()` (`:424`).
+    /// `getState()`.
     pub fn state(&self) -> LandmarkBlockState {
         self.state
     }
 
-    /// `isNumericalFailure()` (`:22`).
-    ///
-    /// Always false in the port for the same reason it is almost always false in
-    /// C++: the comment at `:165-166` records that the `NumericalFailure` branch
-    /// was removed in favour of zeroing the offending Jacobian.
+    /// Numerical-failure status remains false: invalid Jacobians are zeroed instead.
     pub fn is_numerical_failure(&self) -> bool {
         self.state == LandmarkBlockState::NumericalFailure
     }
 
     /// The layout: `(num_rows, num_cols, padding_idx, lm_idx, res_idx)`.
     ///
-    /// The arithmetic of `:83-96` is the thing most likely to go wrong in a
+    /// Layout arithmetic is the part most likely to go wrong in a
     /// port, so it is observable and the fixture checks all five numbers.
     pub fn layout(&self) -> (usize, usize, usize, usize, usize) {
         (
@@ -940,7 +867,7 @@ impl<S: LieScalar> LandmarkBlock<S> {
         )
     }
 
-    /// The block buffer, `storage` (`:530`), row `r`, column `c`.
+    /// The block buffer, `storage`, row `r`, column `c`.
     pub fn storage(&self) -> &DMatrix<S> {
         &self.storage
     }
@@ -1152,9 +1079,9 @@ mod tests {
 
     /// A measurement dropped during marginalization writes no pose columns.
     ///
-    /// `linearizeLandmark` skips an observation with no relative pose (`:137`),
+    /// `linearizeLandmark` skips an observation with no relative pose,
     /// so nothing ever writes at its `abs_t_idx` — which is the `0` sentinel of
-    /// `:74`, another frame's first column. The block here is hosted in frame 1,
+    /// another frame's first column. The block here is hosted in frame 1,
     /// so that sentinel is not the host's own offset and the two are told apart:
     /// columns `0..6` stay zero through the linearization and the QR, and the
     /// dense system is the full loop's either way.
@@ -1196,7 +1123,7 @@ mod tests {
         assert_dense_h_b_is_the_full_loop(&block);
     }
 
-    /// The layout arithmetic of `:83-96` on every remainder of the padding rule.
+    /// The layout arithmetic of on every remainder of the padding rule.
     #[test]
     fn the_layout_pads_to_a_multiple_of_four() {
         for frames in 1..=6usize {
@@ -1216,7 +1143,7 @@ mod tests {
         }
     }
 
-    /// A host frame outside the ordering is `:62`'s assertion, typed.
+    /// A host frame outside the ordering is 's assertion, typed.
     #[test]
     fn a_host_outside_the_ordering_is_an_error() {
         let (_, lm, _) = fixture(1);
@@ -1227,7 +1154,7 @@ mod tests {
         );
     }
 
-    /// A missing relative pose is `:68`'s assertion, typed.
+    /// A missing relative pose is 's assertion, typed.
     #[test]
     fn a_missing_relative_pose_is_an_error() {
         let (aom, lm, _) = fixture(1);
@@ -1235,8 +1162,7 @@ mod tests {
         assert!(matches!(err, LinearizeError::MissingRelativePose { .. }));
     }
 
-    /// The state machine of `landmark_block.hpp:50`: every method that C++
-    /// asserts a state for returns a typed error instead.
+    /// Out-of-order block operations return typed state errors.
     #[test]
     fn methods_refuse_to_run_out_of_order() {
         let (aom, lm, rel) = fixture(1);
@@ -1245,7 +1171,7 @@ mod tests {
         assert_eq!(block.state(), LandmarkBlockState::Allocated);
         assert!(!block.is_numerical_failure());
 
-        // `performQR` asserts `Linearized` (`:194`).
+        // `performQR` asserts `Linearized`.
         assert_eq!(
             block.perform_qr(&options()).unwrap_err(),
             LinearizeError::WrongState {
@@ -1262,7 +1188,7 @@ mod tests {
         block.perform_qr(&options()).unwrap();
         assert_eq!(block.state(), LandmarkBlockState::Marginalized);
 
-        // `:259`: the increment is the whole ordering.
+        // the increment is the whole ordering.
         let mut l_diff: f64 = 0.0;
         let mut moved: Landmark<f64> = lm.clone();
         assert_eq!(
@@ -1276,13 +1202,10 @@ mod tests {
         );
     }
 
-    /// Two of basalt's deliberate non-failures (trap 11).
-    ///
-    /// A landmark seen **once** gives a `2 x 3` `J_l`, so after the QR the third
-    /// diagonal of `Q1Jl` is zero, `det(Q1Jl) == 0`, and `backSubstitute` warns
-    /// and returns without touching the landmark (`:263-266`). A **fixed**
-    /// landmark returns even earlier (`:256`). Neither is an error, and turning
-    /// either into one would change the estimator.
+    /// Singular and fixed landmarks are skipped without error (trap 11).
+    /// One observation gives rank at most two, so the third triangular diagonal is
+    /// zero and back-substitution leaves the landmark untouched. Fixed landmarks
+    /// return even earlier.
     #[test]
     fn a_singular_landmark_block_is_skipped_not_an_error() {
         let (aom, mut lm, rel) = fixture(1);
@@ -1307,14 +1230,14 @@ mod tests {
         assert_eq!(moved.inv_dist, lm.inv_dist);
         assert_eq!(l_diff, 0.0);
 
-        // And a fixed block returns before it even looks (`:256`).
+        // And a fixed block returns before it even looks.
         let (aom, lm, rel) = fixture(1);
         let mut fixed: LandmarkBlock<f64> =
             LandmarkBlock::allocate(lm.id, &lm, &index, &aom, true).unwrap();
         fixed
             .linearize_landmark(&lm, &rel, &cameras(), &options())
             .unwrap();
-        // `is_fixed_` zeroes `d_res_d_p` (`:150`), so the landmark columns are
+        // `is_fixed_` zeroes `d_res_d_p`, so the landmark columns are
         // empty before the QR ever runs.
         let (_, _, _, lm_idx, _) = fixed.layout();
         for row in 0..4 {
@@ -1332,10 +1255,8 @@ mod tests {
         assert_eq!(l_diff, 0.0);
     }
 
-    /// An observation whose target frame is not in the ordering is dropped:
-    /// C++ stores a null `RelPoseLin*` for it (`:70-75`) and skips it at `:137`,
-    /// leaving its two rows zero. That is how a measurement dropped during
-    /// marginalization survives allocation and contributes nothing.
+    /// An observation outside the ordering retains two zero rows and contributes
+    /// nothing after marginalization drops its relative pose.
     #[test]
     fn an_observation_outside_the_ordering_leaves_its_rows_zero() {
         let (aom, mut lm, rel) = fixture(1);
@@ -1364,11 +1285,11 @@ mod tests {
                 );
             }
         }
-        // ...and the two live observations did write.
+        // and the two live observations did write.
         assert!(block.storage().rows(0, 4).iter().any(|v| *v != 0.0));
     }
 
-    /// The Huber branch of `compute_error_weight` (`:456-470`): below the
+    /// The Huber branch of `compute_error_weight` : below the
     /// threshold the weight is one, above it the error grows linearly rather
     /// than quadratically.
     #[test]
@@ -1389,7 +1310,7 @@ mod tests {
         assert!((weight_out - 0.5).abs() < 1e-15, "{weight_out}");
         assert!((error_out - 0.5 * 1.5 * 0.5 * res_squared).abs() < 1e-15);
 
-        // With the threshold off it is a plain squared norm (`:466-468`).
+        // With the threshold off it is a plain squared norm.
         let plain: LandmarkBlockOptions<f64> = LandmarkBlockOptions {
             huber_parameter: 0.0,
             ..opt
@@ -1399,10 +1320,7 @@ mod tests {
         assert_eq!(error, 0.5 * res_squared);
     }
 
-    /// An ordering with one absurd block size passes every per-dimension check
-    /// and then multiplies out to a matrix nalgebra cannot allocate. C++ calls
-    /// `storage.resize(num_rows, num_cols)` (`:98`), which would abort in the
-    /// allocator; the port refuses first (decision D32).
+    /// Refuse matrix-size overflow before nalgebra allocation can abort (D32).
     #[test]
     fn a_block_too_large_to_allocate_is_an_error() {
         let (_, lm, _) = fixture(1);

--- a/packages/slam-rs/crates/slam-rs/src/linearize/mod.rs
+++ b/packages/slam-rs/crates/slam-rs/src/linearize/mod.rs
@@ -1,32 +1,9 @@
-//! The square-root linearization: landmark blocks, the IMU block, and the
-//! absolute-pose QR driver that turns a window into `H` and `b`.
-//!
-//! Ported from `include/basalt/linearization/` and
-//! `src/linearization/linearization_abs_qr.cpp`. Only basalt's `ABS_QR` variant
-//! is here (decision D13): of its three linearizations and three marginalization
-//! variants, `ABS_QR` plus square-root marginalization is what every shipped
-//! config selects, and `ABS_SC` / `REL_SC` are out of scope.
-//!
-//! The shape of one optimizer iteration, from `sqrt_keypoint_vio.cpp:1289-1470`:
-//!
-//! ```text
-//! error = lqr.linearize_problem()      // :1297   residual + Jacobians, per block
-//!         lqr.perform_qr()             // :1320   3 Householder reflections per block
-//!         lqr.get_dense_h_b(&mut H, &mut b)  // :1393  H += Q2Jp^T Q2Jp, b += Q2Jp^T Q2r
-//!         inc = (H + lambda diag(H))^-1 b    // :1414-1430
-//!         inc = -inc                         // :1450   the residual-sign compensation
-//! l_diff= lqr.back_substitute(inc)     // :1454   landmark increments + model cost change
-//! ```
-//!
-//! **No damping and no Jacobian scaling** (D34, D68). `setPoseDamping`,
-//! `setLandmarkDamping`, `scaleJl_cols`, `scaleJp_cols` and `getJp_diag2` are
-//! commented out in the fork's own `optimize()` — `:1307-1317`, `:1361-1377`
-//! and `:1461-1463` — so the port omits them. Damping enters through the
-//! `H.diagonal() * lambda` of the dense solve instead (`:1415-1417`), which is
-//! the estimator's business.
-//!
-//! **Determinism.** Reductions fold in landmark order, independent of the
-//! Rayon thread count. Repeated inputs produce bit-identical outputs.
+//! Square-root linearization into a reduced camera system.
+//! Only `ABS_QR` with square-root marginalization is supported (D13, D68).
+//! Each iteration linearizes, eliminates landmarks, builds `H` and `b`, solves
+//! the damped system, negates the increment, and back-substitutes landmarks.
+//! Damping belongs to the dense solve; landmark/pose damping and Jacobian scaling
+//! are absent. Landmark reductions use fixed order independent of Rayon width.
 
 mod abs_qr;
 mod dense_hb;
@@ -87,26 +64,25 @@ pub fn reflect_column<S: LieScalar>(
     Ok(())
 }
 
-/// `RelPoseLin<Scalar>` (`landmark_block.hpp:16-26`): one (host, target) pair's
+/// `RelPoseLin<Scalar>` : one (host, target) pair's
 /// relative pose and the two 6x6 Jacobians of that pose against the two absolute
 /// pose increments.
 ///
 /// Hoisted per pair rather than per observation, because every landmark hosted
 /// in the same image and seen in the same image shares it
-/// (`linearization_abs_qr.cpp:207-241`).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RelPoseLin<S: LieScalar> {
-    /// `T_t_h` (`:21`), as a 4x4 so the residual can multiply the homogeneous
+    /// `T_t_h`, as a 4x4 so the residual can multiply the homogeneous
     /// landmark straight through.
     pub t_t_h: Matrix4<S>,
-    /// `d_rel_d_h` (`:22`).
+    /// `d_rel_d_h`.
     pub d_rel_d_h: Matrix6<S>,
-    /// `d_rel_d_t` (`:23`).
+    /// `d_rel_d_t`.
     pub d_rel_d_t: Matrix6<S>,
 }
 
 impl<S: LieScalar> Default for RelPoseLin<S> {
-    /// `RelPoseLin()`'s in-class initialisers: all three zero (`:21-23`).
+    /// `RelPoseLin()`'s in-class initialisers: all three zero.
     fn default() -> Self {
         Self {
             t_t_h: Matrix4::zeros(),
@@ -163,30 +139,21 @@ mod tests {
     }
 }
 
-/// What the linearizer refuses to do.
-///
-/// Every variant replaces a C++ assertion, an `at()` that would throw, or an
-/// unchecked index. The estimator runs with the GIL released, where a panic
-/// aborts the process (decision D32), so the arithmetic that sizes the blocks is
-/// checked once at allocation and the per-observation path cannot fail on
-/// indexing afterwards.
-///
-/// Two basalt behaviours that look like errors are deliberately **not** here: a
-/// non-finite Jacobian is zeroed with a warning
-/// (`landmark_block_abs_dynamic.hpp:153-163`) and a singular `Q1Jl` skips its
-/// landmark's back-substitution with a warning (`:264-269`). Turning either into
-/// an `Err` would change the estimator's behaviour (trap 11).
+/// Typed linearization failures (D32).
+/// Check allocation arithmetic once so repeated observation indexing is valid.
+/// Non-finite Jacobians are zeroed with a warning, and singular landmark factors
+/// skip back-substitution with a warning; neither is a fatal error (trap 11).
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum LinearizeError {
     /// A landmark's host frame is not in the absolute ordering
-    /// (`landmark_block_abs_dynamic.hpp:62` asserts).
+    /// ( asserts).
     #[error("landmark block host frame {frame_id} is not in the absolute ordering")]
     HostNotInOrdering {
         /// The host frame.
         frame_id: FrameId,
     },
     /// No relative pose was allocated for a (host, target) pair the landmark
-    /// database says exists (`:68` asserts).
+    /// database says exists ( asserts).
     #[error("no relative pose for host ({host}, {host_cam}) -> target ({target}, {target_cam})")]
     MissingRelativePose {
         /// Host frame.
@@ -217,10 +184,10 @@ pub enum LinearizeError {
         /// How many the rig has.
         camera_count: usize,
     },
-    /// The block layout arithmetic of `:83-96` overflowed.
+    /// The block layout arithmetic of overflowed.
     #[error("landmark block layout arithmetic overflowed")]
     LayoutOverflow,
-    /// `num_cols % 4 != 0`, which C++ asserts (`:96`).
+    /// Padded column count is not divisible by four.
     #[error("landmark block has {num_cols} columns, which is not a multiple of 4")]
     UnalignedBlock {
         /// The column count that failed the check.
@@ -234,7 +201,7 @@ pub enum LinearizeError {
         /// The ordering's total size.
         total_size: usize,
     },
-    /// A method was called out of order; C++ asserts on `state`.
+    /// A method was called out of state-machine order.
     #[error("landmark block is {found:?}, expected {expected:?}")]
     WrongState {
         /// What the operation needed.
@@ -251,7 +218,7 @@ pub enum LinearizeError {
         found: usize,
     },
     /// `backSubstitute` was given a pose increment of the wrong length
-    /// (`:259` asserts).
+    /// ( asserts).
     #[error("pose increment has {found} rows, expected {expected}")]
     PoseIncrementSize {
         /// The ordering's total size.
@@ -270,8 +237,7 @@ pub enum LinearizeError {
         /// End timestamp.
         end: FrameId,
     },
-    /// An IMU interval's end timestamp does not fit in an `i64`; C++ computes
-    /// `start_t + dt` unchecked (`imu_block.hpp:30`).
+    /// An IMU endpoint timestamp overflows i64.
     #[error("IMU interval from {start} ns lasting {dt_ns} ns overflows the timestamp")]
     ImuIntervalOverflow {
         /// Start timestamp.
@@ -279,9 +245,7 @@ pub enum LinearizeError {
         /// The measurement's duration.
         dt_ns: i64,
     },
-    /// An IMU factor's endpoint has a pose-sized block in the ordering. The
-    /// factor is 15 columns wide at each end (`imu_block.hpp:21`), so a 6-column
-    /// slot means C++ writes over the neighbouring state.
+    /// An IMU endpoint has a six-column pose slot instead of the required 15-column state.
     #[error("frame {frame} carries a {size}-column block, but an IMU factor needs 15")]
     ImuStateNotFullSize {
         /// The frame that disagrees.
@@ -316,8 +280,7 @@ pub enum LinearizeError {
         /// Columns asked for.
         cols: usize,
     },
-    /// The marginalization prior's ordering disagrees with the window's, which
-    /// C++ asserts block by block (`ba_base.cpp:383-388`).
+    /// Prior and window block orderings disagree.
     #[error("the marginalization prior's ordering does not match the window's at frame {frame_id}")]
     MargOrderMismatch {
         /// The frame that disagrees.

--- a/packages/slam-rs/crates/slam-rs/src/linearize/relative_pose.rs
+++ b/packages/slam-rs/crates/slam-rs/src/linearize/relative_pose.rs
@@ -7,7 +7,7 @@ use crate::lie::{LieScalar, Se3};
 use crate::types::PoseStateWithLin;
 
 /// Jacobians at the linearization point, then only the transform at the current
-/// state when either end is frozen (`linearization_abs_qr.cpp:219-232`).
+/// state when either end is frozen.
 ///
 /// Callers handle identical image pairs before resolving states: their transform
 /// is identity and their Jacobians are zero, with no `compute_rel_pose` call.

--- a/packages/slam-rs/crates/slam-rs/src/marg/helper.rs
+++ b/packages/slam-rs/crates/slam-rs/src/marg/helper.rs
@@ -1,24 +1,8 @@
-//! `MargHelper<Scalar>` (`include/basalt/vi_estimator/marg_helper.h`,
-//! `src/vi_estimator/marg_helper.cpp`): the routine that turns a linear system
-//! over `keep ∪ marg` into an equivalent one over `keep` alone.
-//!
-//! [`marginalize_helper_sqrt_to_sqrt`] takes `Q₂J_p`, `Q₂r` to `J_m`, `r_m`
-//! (`marg_helper.cpp:247-327`), and it is the only one of the C++'s three the
-//! port carries: the linearization is `ABS_QR` and `vio_sqrt_marg` is on in
-//! every shipped configuration, so `marginalize()` takes the
-//! `is_lin_sqrt && marg_data.is_sqrt` branch (`sqrt_keypoint_vio.cpp:1071-1073`)
-//! and `SqrtKeypointVio::new` refuses the flag off (D68).
-//!
-//! **It consumes its input.** C++ takes `MatX&` and ends with
-//! `abs_H.resize(0, 0)` (`:325-326`); the port takes the matrices **by value**,
-//! which says the same thing in a way the compiler checks.
-//!
-//! **The columns are permuted marg first** (`:259-273`), so that a flat QR
-//! sweeping left to right eliminates the marginalized variables before it
-//! reaches the kept ones and the rows below the marginalized rank are exactly
-//! the prior. The C++'s two squared forms permuted keep first because they took
-//! a Schur complement, which wanted the block to invert in the bottom-right
-//! corner.
+//! Eliminate marginalized variables from a square-root system.
+//! [`marginalize_helper_sqrt_to_sqrt`] consumes matrices by value and produces
+//! the prior Jacobian and residual. Put marginalized columns first, then sweep
+//! QR left to right; rows below their rank constrain only kept variables.
+//! Only square-root marginalization is supported (D68).
 
 use std::collections::BTreeSet;
 
@@ -41,12 +25,7 @@ pub struct ReducedSystem<S: LieScalar> {
     pub b: DVector<S>,
 }
 
-/// Validate the index sets against a system of `total` columns.
-///
-/// C++ has one assertion, `keep_size + marg_size == abs_H.cols()` (`:47`), and
-/// trusts the caller for the rest; an index out of range or shared between the
-/// two sets is an out-of-bounds read there. The port checks all three
-/// (decision D32).
+/// Validate complete, disjoint, in-range keep/marginalize index sets (D32).
 fn check_indices(
     idx_to_keep: &BTreeSet<usize>,
     idx_to_marg: &BTreeSet<usize>,
@@ -75,14 +54,14 @@ fn check_indices(
     Ok((keep_size, marg_size))
 }
 
-/// `MargHelper::marginalizeHelperSqrtToSqrt` (`marg_helper.cpp:247-327`).
+/// `MargHelper::marginalizeHelperSqrtToSqrt`.
 ///
 /// A rank-revealing Householder QR over the whole stacked `[J_marg | J_keep]`,
 /// swept column by column. Every column that produces a reflector with
 /// `|beta| > sqrt(epsilon)` consumes one row of rank; a column that does not is
 /// zeroed and the rank does not advance. `marg_rank` is the rank reached when
-/// the last marginalized column is done (`:316`), and the prior is the block of
-/// rows `[marg_rank, total_rank)` against the kept columns (`:322-323`) — the
+/// the last marginalized column is done, and the prior is the block of
+/// rows `[marg_rank, total_rank)` against the kept columns — the
 /// part of the residual the marginalized variables can no longer explain.
 ///
 /// The rank policy uses the absolute threshold `sqrt(epsilon)` on `beta`.
@@ -97,7 +76,6 @@ pub fn marginalize_helper_sqrt_to_sqrt<S: LieScalar>(
     let rows: usize = q2jp.nrows();
     let cols: usize = q2jp.ncols();
     let (keep_size, marg_size) = check_indices(idx_to_keep, idx_to_marg, cols)?;
-    // `:254`.
     if q2r.nrows() != rows {
         return Err(MargError::RhsLengthMismatch {
             rows,
@@ -114,7 +92,6 @@ pub fn marginalize_helper_sqrt_to_sqrt<S: LieScalar>(
     let permuted: DMatrix<S> = DMatrix::from_fn(rows, cols, |i, j| q2jp[(i, indices[j])]);
     q2jp = permuted;
 
-    // `:280-318`.
     let rank_threshold: S = S::default_epsilon().sqrt();
     let mut marg_rank: usize = 0;
     let mut total_rank: usize = 0;
@@ -133,9 +110,8 @@ pub fn marginalize_helper_sqrt_to_sqrt<S: LieScalar>(
         let (h_coeff, beta) = make_householder(&q2jp, k, base, remaining_rows, &mut essential);
 
         if beta.abs() > rank_threshold {
-            // `:302`.
             q2jp[(base, k)] = beta;
-            // `:304-305`: the reflection on `bottomRightCorner(remainingRows,
+            // the reflection on `bottomRightCorner(remainingRows,
             // remainingCols)`, which starts at row `base`, column `k + 1`.
             apply_householder_on_the_left_block(
                 &mut q2jp,
@@ -148,7 +124,7 @@ pub fn marginalize_helper_sqrt_to_sqrt<S: LieScalar>(
                 &essential[..remaining_rows],
                 h_coeff,
             );
-            // `:306`: the same reflection on the residual, in lockstep.
+            // the same reflection on the residual, in lockstep.
             apply_householder_on_the_left_vec(
                 &mut q2r,
                 base,
@@ -158,33 +134,28 @@ pub fn marginalize_helper_sqrt_to_sqrt<S: LieScalar>(
             );
             total_rank += 1;
         } else {
-            // `:309`.
             q2jp[(base, k)] = S::zero();
         }
 
-        // `:313`: overwrite the Householder vector with zeros. `remainingRows`
+        // overwrite the Householder vector with zeros. `remainingRows`
         // is the value from **before** the rank advanced.
         for i in (base + 1)..rows {
             q2jp[(i, k)] = S::zero();
         }
 
-        // `:316`: `k == marg_size - 1` on a signed index, so with nothing to
-        // marginalize C++ compares against `-1` and never fires.
+        // With no marginalized columns there is no boundary at which to capture marginal rank.
         if k + 1 == marg_size {
             marg_rank = total_rank;
         }
     }
 
-    // `:320-323`.
     let keep_valid_rows: usize = (total_rank - marg_rank).max(1);
     let mut h: DMatrix<S> = DMatrix::zeros(keep_valid_rows, keep_size);
     let mut b: DVector<S> = DVector::zeros(keep_valid_rows);
     for i in 0..keep_valid_rows {
         let row: usize = marg_rank + i;
-        // `max(total_rank - marg_rank, 1)` can ask for a row past the end when
-        // the marginalized part alone exhausted the rank; C++ reads out of
-        // range there, the port leaves the row zero — which is the answer the
-        // arithmetic gives: nothing is left to constrain the kept variables.
+        // If marginalized variables exhaust the rank, leave the minimum output row zero:
+        // no remaining constraint acts on kept variables.
         if row >= rows {
             break;
         }
@@ -200,9 +171,7 @@ pub fn marginalize_helper_sqrt_to_sqrt<S: LieScalar>(
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]
-    // The probe columns below are the fork's `%.17g` printout, carried over
-    // verbatim even where the scalar does not need every figure. Keeping the
-    // printout is what makes them evidence.
+    // Keep probe constants at their recorded precision.
     #![allow(clippy::excessive_precision)]
 
     use super::*;
@@ -243,9 +212,7 @@ mod tests {
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(32))]
 
-        /// The square-root QR marginalization and the dense Schur complement of
-        /// the same full-rank problem agree, which is basalt's own
-        /// `VoMargSqrtLinearizationTest` argument applied to `MargHelper`.
+        /// Square-root marginalization must equal the dense Schur complement for a full-rank problem.
         #[test]
         fn the_qr_marginalization_is_the_schur_complement(
             values in prop::collection::vec(-1.5f64..1.5, 96..97),
@@ -314,8 +281,7 @@ mod tests {
         );
     }
 
-    /// Marginalizing nothing is the identity on the information, which is the
-    /// `marg_size == 0` corner where C++ compares `k` against `-1`.
+    /// Marginalizing no variables preserves information.
     #[test]
     fn marginalizing_nothing_keeps_the_whole_system() {
         let j: DMatrix<f64> = DMatrix::from_fn(5, 3, |i, jj| ((i * 3 + jj) as f64).sin());

--- a/packages/slam-rs/crates/slam-rs/src/marg/helper.rs
+++ b/packages/slam-rs/crates/slam-rs/src/marg/helper.rs
@@ -111,8 +111,8 @@ pub fn marginalize_helper_sqrt_to_sqrt<S: LieScalar>(
 
         if beta.abs() > rank_threshold {
             q2jp[(base, k)] = beta;
-            // the reflection on `bottomRightCorner(remainingRows,
-            // remainingCols)`, which starts at row `base`, column `k + 1`.
+            // the reflection acts on the trailing block that starts at row
+            // `base`, column `k + 1`.
             apply_householder_on_the_left_block(
                 &mut q2jp,
                 BlockSpan {

--- a/packages/slam-rs/crates/slam-rs/src/marg/mod.rs
+++ b/packages/slam-rs/crates/slam-rs/src/marg/mod.rs
@@ -1,39 +1,11 @@
-//! Square-root marginalization: the rank-revealing QR helper and the sliding
-//! window mechanics that drive it.
+//! Square-root marginalization and sliding-window updates.
+//! The schedule supplies removals; this module builds ordering, linearizes,
+//! splits indices, eliminates variables, freezes the newest prior state,
+//! shrinks the window, and re-anchors the residual.
 //!
-//! Ported from `include/basalt/vi_estimator/marg_helper.h`,
-//! `src/vi_estimator/marg_helper.cpp`, the second half of
-//! `src/vi_estimator/sqrt_keypoint_vio.cpp`'s `marginalize()` and
-//! `src/vi_estimator/sqrt_ba_base.cpp`.
-//!
-//! ```text
-//! marginalize()                     sqrt_keypoint_vio.cpp
-//!   build the absolute ordering       :726-763
-//!   linearize the window + prior      :905-942
-//!   split keep / marg indices         :980-1003
-//!   MargHelper::...                   :1069-1083
-//!   setLinTrue on the newest state    :1085-1088   (trap 7)
-//!   shrink frame_states/poses/lmdb    :1090-1118
-//!   new prior order                   :1120-1137
-//!   b -= H * delta                    :1170-1172   (trap 8)
-//! ```
-//!
-//! **What is here and what is stage S8's.** This module takes the four sets the
-//! schedule produced — which keyframes, poses and states leave, and which state
-//! becomes the prior's newest block — as [`MarginalizeSchedule`] and does
-//! everything downstream of that decision. The scoring at
-//! `sqrt_keypoint_vio.cpp:767-880`, the `states_to_remove` count and the
-//! keyframe bookkeeping are not ported here.
-//!
-//! **Why the QR and not the Schur complement.** The prior is stored as a
-//! Jacobian `J_m` and a residual `r_m` rather than as `H` and `b`, and
-//! marginalizing is one flat, rank-revealing Householder QR over the stacked
-//! `[J_marg | J_keep]` (papers-part2 §12). Squaring the system to eliminate a
-//! block would square its condition number, which is the whole point of the
-//! square-root formulation; the QR never forms `JᵀJ` at all. basalt keeps the
-//! squared form behind `vio_sqrt_marg` as the 2019 baseline the 2021 paper
-//! compared against; the port carries only the square-root form, because
-//! `SqrtKeypointVio::new` refuses the flag off (D68).
+//! Keeping a Jacobian and residual avoids forming `JᵀJ` and squaring the condition
+//! number. Only square-root priors are supported (D68). Scheduling and keyframe
+//! scores belong to the estimator module.
 
 mod helper;
 mod window;
@@ -47,24 +19,18 @@ use crate::ba_base::BaError;
 use crate::linearize::LinearizeError;
 use crate::types::{FrameId, StateError};
 
-/// One of the five things [`MarginalizeSchedule`] decides, named so a refusal
-/// can say which of them was wrong.
-///
-/// The C++ builds all five out of the window itself
-/// (`sqrt_keypoint_vio.cpp:724-880`), so every relationship between them is an
-/// invariant of that construction rather than something checked; the port
-/// checks them, and this is how it reports which one broke.
+/// Schedule component named in a validation failure.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScheduleSet {
-    /// `last_state_to_marg` (`:724`).
+    /// `last_state_to_marg`.
     LastStateToMarg,
-    /// `kfs_to_marg` (`:766`).
+    /// `kfs_to_marg`.
     KfsToMarg,
-    /// `poses_to_marg` (`:729`).
+    /// `poses_to_marg`.
     PosesToMarg,
-    /// `states_to_marg_all` (`:743`).
+    /// `states_to_marg_all`.
     StatesToMargAll,
-    /// `states_to_marg_vel_bias` (`:742`).
+    /// `states_to_marg_vel_bias`.
     StatesToMargVelBias,
 }
 
@@ -81,15 +47,10 @@ impl std::fmt::Display for ScheduleSet {
     }
 }
 
-/// What marginalization refuses to do.
-///
-/// Every variant replaces a C++ assertion, an `at()` that would throw, or an
-/// unchecked index; the estimator runs with the GIL released, where a panic
-/// aborts the process (decision D32).
+/// Typed marginalization failures prevent data-dependent panics (D32).
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum MargError {
-    /// `keep_size + marg_size == abs_H.cols()` (`marg_helper.cpp:47`, `:132`,
-    /// `:253`).
+    /// Kept and marginalized counts do not cover the system.
     #[error("{keep} kept plus {marg} marginalized indices do not cover {total} columns")]
     IndexCountMismatch {
         /// Size of `idx_to_keep`.
@@ -99,8 +60,7 @@ pub enum MargError {
         /// Columns of the system.
         total: usize,
     },
-    /// An index names a column the system does not have; C++ would read out of
-    /// range.
+    /// An index names a nonexistent system column.
     #[error("index {index} is out of range for a system of {total} columns")]
     IndexOutOfRange {
         /// The offending index.
@@ -114,7 +74,7 @@ pub enum MargError {
         /// The offending index.
         index: usize,
     },
-    /// `Q2Jp.rows() == Q2r.rows()` (`marg_helper.cpp:254`), or a right-hand
+    /// `Q2Jp.rows() == Q2r.rows()`, or a right-hand
     /// side that does not match a square system.
     #[error("the system has {rows} rows and the right-hand side {rhs}")]
     RhsLengthMismatch {
@@ -123,15 +83,13 @@ pub enum MargError {
         /// Rows of the vector.
         rhs: usize,
     },
-    /// The prior's ordering disagrees with the window's, which C++ asserts
-    /// block by block (`sqrt_keypoint_vio.cpp:736`, `:758-759`).
+    /// The prior ordering disagrees with the window ordering.
     #[error("the marginalization prior's ordering does not match the window at frame {frame_id}")]
     PriorOrderMismatch {
         /// The frame that disagrees.
         frame_id: FrameId,
     },
     /// `marg_data.H.cols() == marg_data.order.total_size`
-    /// (`sqrt_keypoint_vio.cpp:1145`, `sqrt_ba_base.cpp:52`).
     #[error("the prior is {cols} columns wide but its ordering covers {total_size}")]
     PriorWidthMismatch {
         /// Columns of `H`.
@@ -145,7 +103,7 @@ pub enum MargError {
         /// The frame that is missing.
         frame_id: FrameId,
     },
-    /// `last_state_to_marg` was already frozen (`sqrt_keypoint_vio.cpp:1086`
+    /// `last_state_to_marg` was already frozen (
     /// asserts it is not).
     #[error("frame {frame_id} is already at its linearization point")]
     AlreadyLinearized {
@@ -153,14 +111,13 @@ pub enum MargError {
         frame_id: FrameId,
     },
     /// A full state in the ordering is in none of the three sets and is not
-    /// `last_state_to_marg` (`sqrt_keypoint_vio.cpp:999` asserts).
+    /// `last_state_to_marg` ( asserts).
     #[error("state {frame_id} is neither marginalized nor the last state to marginalize")]
     UnscheduledState {
         /// The state the schedule forgot.
         frame_id: FrameId,
     },
     /// A block in the ordering is neither a pose nor a full state
-    /// (`sqrt_keypoint_vio.cpp:990`, `sqrt_ba_base.cpp:91-93`).
     #[error("frame {frame_id} has a block of {size} rows, which is neither 6 nor 15")]
     UnexpectedBlockSize {
         /// The offending frame.
@@ -168,16 +125,8 @@ pub enum MargError {
         /// Its block size.
         size: usize,
     },
-    /// A schedule set names a frame the marginalization ordering does not hold
-    /// as the kind of block that set is about — a pose block for
-    /// `poses_to_marg`, a full state for the two state sets.
-    ///
-    /// C++ trusts the construction: `frame_states.at(id)` throws on a frame
-    /// that is not there, `frame_poses.erase(id)` silently does nothing, and a
-    /// state newer than `last_state_to_marg` is not in the ordering at all —
-    /// so it is deleted without ever being marginalized
-    /// (`sqrt_keypoint_vio.cpp:1090-1112`). Either way the window is already
-    /// half rewritten by the time it shows.
+    /// A schedule set names a missing frame or the wrong block kind.
+    /// Validate before mutation so no state can be deleted without marginalization.
     #[error(
         "{set} names frame {frame_id}, which the ordering does not hold as a {block}-row block"
     )]
@@ -189,8 +138,7 @@ pub enum MargError {
         /// The block size that set requires.
         block: usize,
     },
-    /// Two schedule sets C++ fills in mutually exclusive branches
-    /// (`sqrt_keypoint_vio.cpp:745-750`) name the same frame.
+    /// Mutually exclusive schedule sets name the same frame.
     #[error("frame {frame_id} is in both {first} and {second}")]
     ScheduleSetsOverlap {
         /// The first set.
@@ -201,9 +149,9 @@ pub enum MargError {
         frame_id: FrameId,
     },
     /// `kfs_to_marg` is not a subset of `poses_to_marg`, which
-    /// `sqrt_keypoint_vio.cpp:875-876` guarantees by adding every keyframe it
+    ///  guarantees by adding every keyframe it
     /// picks to both. Without it the keyframe's landmarks are dropped
-    /// (`:1114`) while the frame itself survives.
+    ///  while the frame itself survives.
     #[error("frame {frame_id} is marginalized as a keyframe but not as a pose")]
     KeyframeNotInPosesToMarg {
         /// The offending frame.

--- a/packages/slam-rs/crates/slam-rs/src/marg/window.rs
+++ b/packages/slam-rs/crates/slam-rs/src/marg/window.rs
@@ -1,25 +1,10 @@
-//! The sliding-window half of `SqrtKeypointVioEstimator::marginalize`
-//! (`src/vi_estimator/sqrt_keypoint_vio.cpp:707-1198`): everything that happens
-//! **after** the schedule has decided what leaves.
+//! Apply a marginalization schedule to the sliding window.
+//! Build ordering, linearize with the current prior, split indices, eliminate,
+//! shrink state and landmark maps, then re-anchor the new prior.
 //!
-//! The schedule itself — the keyframe scoring at `:767-880`, the
-//! `states_to_remove` count at `:720-724`, and the `kf_ids` bookkeeping — is
-//! stage S8's and is not here. This module takes those four sets as
-//! [`MarginalizeSchedule`] and does the rest: build the absolute ordering,
-//! linearize the window with the current prior, split the ordering into kept
-//! and marginalized indices, run [`marginalize_helper_sqrt_to_sqrt`], shrink
-//! the window and the landmark database, and re-anchor the new prior.
-//!
-//! Two traps of the architecture dossier live here and are called out at the
-//! lines that implement them:
-//!
-//! * **Trap 7** — the state that stays behind as the prior's newest block is
-//!   frozen at its linearization point, `setLinTrue()` (`:1086-1088`). Without
-//!   it the prior's `delta` means nothing and the drift is silent.
-//! * **Trap 8** — the prior comes out of the helper linearized at `x = 0`, and
-//!   is put back into its delta-independent form by
-//!   `marg_data.b -= marg_data.H * delta` (`:1170-1172`). Its mirror on the way
-//!   in is `linearization_abs_qr.cpp:592`.
+//! Freeze the newest prior state before computing its delta (trap 7).
+//! Convert the helper's residual back to delta-independent form by subtracting
+//! `H * delta` (trap 8); omitting either step causes silent drift.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -35,35 +20,29 @@ use crate::types::{
     AbsOrderMap, FrameId, LandmarkId, MargLinData, POSE_SIZE, POSE_VEL_BIAS_SIZE, PoseStateWithLin,
 };
 
-/// What the schedule decided, `sqrt_keypoint_vio.cpp:724-880`.
-///
-/// `poses_to_marg` names pose blocks that leave, `kfs_to_marg` the subset of
-/// those that were keyframes hosting landmarks, `states_to_marg_all` full
-/// states that leave outright, and `states_to_marg_vel_bias` full states that
-/// keep their pose and lose their velocity and biases. So `poses_to_marg` is
-/// disjoint from both state sets, the two state sets are disjoint from each
-/// other, and `kfs_to_marg` is a subset of `poses_to_marg` rather than
-/// disjoint from it. C++ gets all of that from how it builds them; the port
-/// checks it (`validate_schedule`).
+/// Scheduled removals: poses, their hosted keyframes, full states, and state
+/// velocity/bias blocks. Pose removals and the two state sets are disjoint;
+/// keyframe removals are a subset of pose removals. Validate these relationships
+/// before changing the window.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct MarginalizeSchedule {
-    /// `last_state_to_marg` (`:724`): the newest state the ordering reaches and
+    /// `last_state_to_marg` : the newest state the ordering reaches and
     /// the one that becomes the prior's 15-dof block.
     pub last_state_to_marg: FrameId,
-    /// `kfs_to_marg` (`:766`).
+    /// `kfs_to_marg`.
     pub kfs_to_marg: BTreeSet<FrameId>,
-    /// `poses_to_marg` (`:729`), a superset of `kfs_to_marg`.
+    /// `poses_to_marg`, a superset of `kfs_to_marg`.
     pub poses_to_marg: BTreeSet<FrameId>,
-    /// `states_to_marg_all` (`:743`).
+    /// `states_to_marg_all`.
     pub states_to_marg_all: BTreeSet<FrameId>,
-    /// `states_to_marg_vel_bias` (`:742`).
+    /// `states_to_marg_vel_bias`.
     pub states_to_marg_vel_bias: BTreeSet<FrameId>,
 }
 
 /// The configuration bits `marginalize()` reads.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct MarginalizeOptions {
-    /// `config.vio_marg_lost_landmarks` (`:1116`).
+    /// `config.vio_marg_lost_landmarks`.
     pub marg_lost_landmarks: bool,
 }
 
@@ -73,11 +52,11 @@ pub struct MarginalizeInputs<'a, S: LieScalar> {
     /// What the schedule decided.
     pub schedule: &'a MarginalizeSchedule,
     /// Gravity and the two bias random-walk weights; `None` for a visual-only
-    /// window (`ImuLinData` at `:913`).
+    /// window (`ImuLinData` at ).
     pub imu_lin_data: Option<ImuLinData<S>>,
-    /// `lost_landmaks` (`:709`), the landmarks the frontend stopped tracking.
+    /// `lost_landmaks`, the landmarks the frontend stopped tracking.
     pub lost_landmarks: Option<&'a BTreeSet<LandmarkId>>,
-    /// `fixed_kfs` (`:924`): `ltkfs` when `config.vio_fix_long_term_keyframes`
+    /// `fixed_kfs` : `ltkfs` when `config.vio_fix_long_term_keyframes`
     /// is on, empty otherwise.
     pub fixed_frames: Option<&'a BTreeSet<FrameId>>,
     /// Flags.
@@ -87,28 +66,21 @@ pub struct MarginalizeInputs<'a, S: LieScalar> {
 /// What one marginalization produced besides the updated prior.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MarginalizeOutput<S: LieScalar> {
-    /// `aom` (`:726-763`): the ordering the marginalization linearized over.
+    /// `aom` : the ordering the marginalization linearized over.
     pub aom: AbsOrderMap,
-    /// `idx_to_keep` (`:980-1003`).
+    /// `idx_to_keep`.
     pub idx_to_keep: BTreeSet<usize>,
-    /// `idx_to_marg` (`:980-1003`).
+    /// `idx_to_marg`.
     pub idx_to_marg: BTreeSet<usize>,
     /// What `linearizeProblem` reported for the window that is leaving.
     pub error: S,
-    /// `numerically_valid`: false when a landmark block held a non-finite
-    /// Jacobian, which basalt zeroes with a warning rather than failing.
+    /// False if a landmark Jacobian was non-finite and zeroed with a warning.
     pub numerically_valid: bool,
 }
 
-/// Build the absolute ordering the marginalization runs over
-/// (`sqrt_keypoint_vio.cpp:726-763`).
-///
-/// Every pose block first, in timestamp order, then the full states up to and
-/// including `last_state_to_marg` — states newer than that are simply not in
-/// the system. Each block is checked against the prior's ordering as C++
-/// asserts (`:736`, `:758-759`): the prior must be a prefix of the window at
-/// exactly the same offsets, or the two systems do not describe the same
-/// variables.
+/// Order all poses by timestamp, then states through `last_state_to_marg`.
+/// The prior must be an exact prefix at the same offsets; otherwise the two
+/// systems assign different variables to the same columns.
 fn build_absolute_ordering<S: LieScalar>(
     estimator: &BundleAdjustmentBase<S>,
     marg_data: &MargLinData<S>,
@@ -117,7 +89,7 @@ fn build_absolute_ordering<S: LieScalar>(
     let mut aom: AbsOrderMap = AbsOrderMap::new();
     for frame_id in estimator.frame_poses.keys() {
         let offset: usize = aom.push(*frame_id, POSE_SIZE)?;
-        // `:736`: unconditional, because C++ uses `at()`.
+        // Every prior pose must have a matching ordering entry.
         if marg_data.order.get(*frame_id) != Some((offset, POSE_SIZE)) {
             return Err(MargError::PriorOrderMismatch {
                 frame_id: *frame_id,
@@ -125,13 +97,12 @@ fn build_absolute_ordering<S: LieScalar>(
         }
     }
     for frame_id in estimator.frame_states.keys() {
-        // `:745`.
         if *frame_id > last_state_to_marg {
             break;
         }
         let offset: usize = aom.push(*frame_id, POSE_VEL_BIAS_SIZE)?;
-        // `:758-759`: the comparison is against `aom.items` **before** the
-        // increment at `:762`, so a state past the end of the prior is not
+        // the comparison is against `aom.items` **before** the
+        // increment, so a state past the end of the prior is not
         // checked — it is the one entering it.
         if aom.items() <= marg_data.order.items()
             && marg_data.order.get(*frame_id) != Some((offset, POSE_VEL_BIAS_SIZE))
@@ -144,33 +115,13 @@ fn build_absolute_ordering<S: LieScalar>(
     Ok(aom)
 }
 
-/// Check the whole schedule against the linearized ordering, before anything
-/// mutates.
-///
-/// C++ builds the four sets and `last_state_to_marg` out of the window itself
-/// (`sqrt_keypoint_vio.cpp:724-880`) and then trusts them: `:1090-1112` erases
-/// what they name with `frame_states.at()` (which throws on a frame that is not
-/// there) and `frame_poses.erase()` (which silently does nothing), in that
-/// order, so a schedule that disagrees with the window takes effect *before* it
-/// is noticed — and a state newer than `last_state_to_marg` is not in the
-/// ordering at all, so it is deleted without having been marginalized. Every
-/// relationship below is an invariant of C++'s construction, and checking them
-/// here is what keeps a refused marginalization from leaving a half-rewritten
-/// window (decision D32).
-///
-/// Membership in `aom` is the same question as membership in the live maps:
-/// [`build_absolute_ordering`] just walked `frame_poses` and the prefix of
-/// `frame_states` up to `last_state_to_marg`, and nothing has changed since.
-/// The block size is what tells a pose from a full state, and it is what keeps
-/// `poses_to_marg` disjoint from the two state sets: it must hold 6-row blocks
-/// and they must hold 15-row blocks. The two state sets are checked against
-/// each other below; `kfs_to_marg` is checked to be a *subset* of
-/// `poses_to_marg`, which is what C++ builds it as.
-///
-/// The window's own linearization precondition is a different question, over a
-/// different ordering: `check_prior_blocks_linearized`.
+/// Validate the entire schedule before mutation (D32).
+/// Ordering membership establishes frame membership; block sizes distinguish
+/// poses from full states. Check disjoint state sets and that removed keyframes
+/// are a subset of removed poses. This prevents partial updates on refusal.
+/// Frozen-linearization preconditions are checked separately over the new prior.
 fn validate_schedule(aom: &AbsOrderMap, schedule: &MarginalizeSchedule) -> Result<(), MargError> {
-    // `:729` and `:876`: every pose that leaves is a pose block of the window.
+    //  and : every pose that leaves is a pose block of the window.
     for frame_id in &schedule.poses_to_marg {
         if !matches!(aom.get(*frame_id), Some((_, POSE_SIZE))) {
             return Err(MargError::ScheduledFrameNotInOrdering {
@@ -181,7 +132,6 @@ fn validate_schedule(aom: &AbsOrderMap, schedule: &MarginalizeSchedule) -> Resul
         }
     }
 
-    // `:875-876`.
     for frame_id in &schedule.kfs_to_marg {
         if !schedule.poses_to_marg.contains(frame_id) {
             return Err(MargError::KeyframeNotInPosesToMarg {
@@ -190,8 +140,8 @@ fn validate_schedule(aom: &AbsOrderMap, schedule: &MarginalizeSchedule) -> Resul
         }
     }
 
-    // `:743` and `:742`: both state sets are full states of the window, and
-    // `:745`'s `if (kv.first != last_state_to_marg)` keeps the newest state out
+    //  and : both state sets are full states of the window, and
+    // 's `if (kv.first != last_state_to_marg)` keeps the newest state out
     // of both — it is the one that becomes the prior's own block.
     for (set, frames) in [
         (ScheduleSet::StatesToMargAll, &schedule.states_to_marg_all),
@@ -218,7 +168,7 @@ fn validate_schedule(aom: &AbsOrderMap, schedule: &MarginalizeSchedule) -> Resul
         }
     }
 
-    // `:747-750`: the two state sets are an if/else over the same frame.
+    // the two state sets are an if/else over the same frame.
     if let Some(frame_id) = schedule
         .states_to_marg_all
         .intersection(&schedule.states_to_marg_vel_bias)
@@ -234,14 +184,9 @@ fn validate_schedule(aom: &AbsOrderMap, schedule: &MarginalizeSchedule) -> Resul
     Ok(())
 }
 
-/// The ordering the new prior gets, `marg_order_new` (`:1120-1133`).
-///
-/// C++ builds it by walking the **already shrunk** `frame_poses`; the port
-/// builds it from the sets instead, so the width check at `:1145` can run
-/// before anything mutates and a refusal leaves `marg_data` alone. The two
-/// give the same ordering: C++'s `frame_poses` at that point is
-/// `(frame_poses ∪ states_to_marg_vel_bias) \ poses_to_marg`, a `std::map` in
-/// ascending key order, which is what a [`BTreeSet`] of the same ids iterates.
+/// Construct the surviving prior ordering before mutation from
+/// `(frame_poses ∪ states_to_marg_vel_bias) \ poses_to_marg` in sorted order.
+/// This lets width validation fail without changing the prior or window.
 fn new_prior_ordering<S: LieScalar>(
     estimator: &BundleAdjustmentBase<S>,
     schedule: &MarginalizeSchedule,
@@ -261,22 +206,10 @@ fn new_prior_ordering<S: LieScalar>(
     Ok(order)
 }
 
-/// `computeDelta`'s own precondition on the ordering it is handed
-/// (`ba_base.cpp:294`, `:297`): every block of it frozen at its linearization
-/// point.
-///
-/// At `sqrt_keypoint_vio.cpp:1171` that ordering is the new prior's, so its
-/// 6-row blocks are the poses that survive plus the states that are about to be
-/// demoted ([`new_prior_ordering`]) — and demotion copies the state's
-/// `linearized` flag over (`imu_types.h:206-215`), which is exactly what
-/// [`BundleAdjustmentBase::get_pose_state_with_lin`] answers with for a block
-/// that is still a full state here. So both kinds are decidable before
-/// `:1090-1112` has moved anything, and the error is the one `compute_delta`
-/// would raise at `:1171`, only with the window still intact. The lookup cannot
-/// miss — [`new_prior_ordering`] builds the ordering out of those same two maps
-/// — so `?` carries its typed error rather than a branch that cannot be taken.
-/// The one 15-row block is `last_state_to_marg` (`ba_base.cpp:297`), which the
-/// caller checked is *not* linearized and is about to freeze (`:1086-1088`).
+/// Check that all surviving pose blocks are frozen before computing deltas.
+/// Demoted states carry their first six delta entries and frozen flag, so their
+/// precondition can be checked before demotion. The one full-state block is
+/// `last_state_to_marg`, which is checked unfrozen and will be frozen next.
 fn check_prior_blocks_linearized<S: LieScalar>(
     estimator: &BundleAdjustmentBase<S>,
     marg_order_new: &AbsOrderMap,
@@ -290,12 +223,11 @@ fn check_prior_blocks_linearized<S: LieScalar>(
 }
 
 /// Split the ordering into the indices that stay and the indices that go
-/// (`sqrt_keypoint_vio.cpp:980-1003`).
 ///
 /// A pose block goes whole or stays whole. A full state either goes whole
 /// (`states_to_marg_all`), keeps its six pose rows and loses the other nine
 /// (`states_to_marg_vel_bias`), or stays whole — and the last case is asserted
-/// to be `last_state_to_marg` alone (`:999`).
+/// to be `last_state_to_marg` alone.
 fn split_indices(
     aom: &AbsOrderMap,
     schedule: &MarginalizeSchedule,
@@ -319,14 +251,13 @@ fn split_indices(
                     idx_to_keep.extend(start_idx..start_idx + POSE_SIZE);
                     idx_to_marg.extend(start_idx + POSE_SIZE..start_idx + POSE_VEL_BIAS_SIZE);
                 } else {
-                    // `:999`.
                     if frame_id != schedule.last_state_to_marg {
                         return Err(MargError::UnscheduledState { frame_id });
                     }
                     idx_to_keep.extend(start_idx..start_idx + POSE_VEL_BIAS_SIZE);
                 }
             }
-            // C++ asserts `POSE_SIZE` or `POSE_VEL_BIAS_SIZE` (`:990`).
+            // Only pose and full-state block sizes are valid.
             size => return Err(MargError::UnexpectedBlockSize { frame_id, size }),
         }
     }
@@ -334,12 +265,9 @@ fn split_indices(
 }
 
 /// Linearize the window over `aom` with `prior` included and export the
-/// stacked square-root system (`sqrt_keypoint_vio.cpp:905-942`).
+/// stacked square-root system.
 ///
-/// The branch at `:935-939` chooses `get_dense_Q2Jp_Q2r` for a square-root
-/// prior and `get_dense_H_b` for a squared one. Only `ABS_QR` is ported
-/// (decision D13) and only a square-root prior can exist (D68), so the port
-/// takes the first unconditionally.
+/// Only square-root priors exist, so this always exports `Q2Jp` and `Q2r` (D68).
 fn linearize_for_marginalization<S: LieScalar>(
     estimator: &BundleAdjustmentBase<S>,
     aom: &AbsOrderMap,
@@ -350,21 +278,16 @@ fn linearize_for_marginalization<S: LieScalar>(
     let lin_inputs: LinearizationInputs<'_, S> = LinearizationInputs {
         marg: Some(prior),
         imu: imu_input,
-        // `:925`: only landmarks hosted by a marginalized keyframe, or lost.
+        // only landmarks hosted by a marginalized keyframe, or lost.
         used_frames: Some(&inputs.schedule.kfs_to_marg),
         lost_landmarks: inputs.lost_landmarks,
         fixed_frames: inputs.fixed_frames,
     };
-    // The defaults are safe: `LinearizationAbsQR::new` overwrites
-    // `huber_parameter` and `obs_std_dev` from the estimator
-    // (`linearization_abs_qr.cpp:69-73`, where C++ asserts they agree).
+    // The linearizer copies Huber threshold and observation deviation from the estimator.
     let mut lqr: LinearizationAbsQR<S> =
         LinearizationAbsQR::new(estimator, aom, LinearizationOptions::default(), &lin_inputs)?;
-    // `:928`.
     let (error, numerically_valid) = lqr.linearize_problem(estimator, &lin_inputs)?;
-    // `:932`.
     lqr.perform_qr()?;
-    // `:935-939`.
     let (h, b) = lqr.get_dense_q2jp_q2r(estimator, &lin_inputs)?;
     Ok(LinearizedWindow {
         h,
@@ -374,7 +297,7 @@ fn linearize_for_marginalization<S: LieScalar>(
     })
 }
 
-/// What one pass of `:905-942` produced.
+/// What one pass of produced.
 struct LinearizedWindow<S: LieScalar> {
     /// `Q2Jp_or_H`.
     h: DMatrix<S>,
@@ -386,25 +309,11 @@ struct LinearizedWindow<S: LieScalar> {
     numerically_valid: bool,
 }
 
-/// `SqrtKeypointVioEstimator::marginalize` from `:896` to `:1178`.
-///
-/// Mutates the window in place: `marg_data` becomes the new prior,
-/// `estimator.frame_states` / `frame_poses` / `lmdb` shrink, and the consumed
-/// IMU intervals leave `imu_meas`. Returns the ordering and the index split so
-/// stage S8 can log them.
-///
-/// The order of operations is basalt's, and two of the steps only work because
-/// of where they sit:
-///
-/// * `setLinTrue` on `last_state_to_marg` (`:1086-1088`) happens **before**
-///   `computeDelta`, so that state contributes a zero delta to the re-anchoring
-///   rather than the increment it accumulated as a free variable;
-/// * `marg_order_new` describes the window that *survives* — C++ builds it at
-///   `:1120-1133`, after the `states_to_marg_vel_bias` frames have been demoted
-///   into `frame_poses` and the `poses_to_marg` frames removed. The port
-///   computes the same set from the schedule instead
-///   (`new_prior_ordering`) so that `:1145`'s width check can run before the
-///   first mutation.
+/// Marginalize in place and return ordering and index split for diagnostics.
+/// The prior is replaced, frame and landmark maps shrink, and consumed IMU factors leave.
+/// Freeze `last_state_to_marg` before computing delta so its new prior delta is zero.
+/// Construct the surviving ordering from the schedule before mutation, allowing
+/// width and frozen-state checks to fail without a partial window update.
 pub fn marginalize<S: LieScalar>(
     estimator: &mut BundleAdjustmentBase<S>,
     marg_data: &mut MargLinData<S>,
@@ -414,11 +323,9 @@ pub fn marginalize<S: LieScalar>(
     let schedule: &MarginalizeSchedule = inputs.schedule;
     let last_state_to_marg: FrameId = schedule.last_state_to_marg;
 
-    // `:726-763`.
     let aom: AbsOrderMap = build_absolute_ordering(estimator, marg_data, last_state_to_marg)?;
 
-    // `:1086`: C++ asserts this before it freezes the state; the port checks it
-    // up front, so a refused marginalization leaves the window untouched.
+    // Check the freeze precondition before mutation so refusal leaves the window intact.
     match estimator.frame_states.get(&last_state_to_marg) {
         None => {
             return Err(MargError::FrameNotInWindow {
@@ -434,17 +341,14 @@ pub fn marginalize<S: LieScalar>(
     }
 
     // Everything the schedule claims about the window, checked here rather
-    // than discovered halfway through `:1090-1112`.
+    // than discovered halfway through.
     validate_schedule(&aom, schedule)?;
 
-    // `:1120-1133`, hoisted: the new prior's ordering is a function of the
-    // window and the schedule, so both the checks it carries — the
-    // linearization precondition `compute_delta` reaches only at `:1171`, and
-    // the `:1145` width check below — run before the first mutation.
+    // Compute the new ordering before mutation to check its width and frozen blocks.
     let marg_order_new: AbsOrderMap = new_prior_ordering(estimator, schedule)?;
     check_prior_blocks_linearized(estimator, &marg_order_new)?;
 
-    // `:915-922`: the intervals whose two ends are both in the ordering.
+    // the intervals whose two ends are both in the ordering.
     let imu_input: Option<ImuInput<'_, S>> = inputs.imu_lin_data.map(|lin_data| ImuInput {
         lin_data,
         measurements: imu_meas
@@ -458,14 +362,11 @@ pub fn marginalize<S: LieScalar>(
             .collect(),
     });
 
-    // `:905-942`.
     let live: LinearizedWindow<S> =
         linearize_for_marginalization(estimator, &aom, marg_data, imu_input.as_ref(), inputs)?;
 
-    // `:980-1003`.
     let (idx_to_keep, idx_to_marg) = split_indices(&aom, schedule)?;
 
-    // `:1145`.
     if idx_to_keep.len() != marg_order_new.total_size() {
         return Err(MargError::PriorWidthMismatch {
             cols: idx_to_keep.len(),
@@ -473,14 +374,13 @@ pub fn marginalize<S: LieScalar>(
         });
     }
 
-    // `:1069-1083`.
     let reduced: ReducedSystem<S> =
         marginalize_helper_sqrt_to_sqrt(live.h, live.b, &idx_to_keep, &idx_to_marg)?;
 
     // The linearization is done with the window; everything from here mutates.
     drop(imu_input);
 
-    // `:1085-1088`, trap 7. `validate_schedule` and the `:1086` check above
+    // trap 7. `validate_schedule` and the check above
     // both prove the lookup, so the `else` is unreachable; it is an error
     // rather than a skip because silently not freezing the state is trap 7
     // happening.
@@ -491,15 +391,13 @@ pub fn marginalize<S: LieScalar>(
     };
     state.set_linearized()?;
 
-    // `:1090-1096`.
     for id in &schedule.states_to_marg_all {
         estimator.frame_states.remove(id);
         imu_meas.remove(id);
     }
 
-    // `:1098-1105`: a keyframe that keeps its pose is demoted to a pose block,
+    // a keyframe that keeps its pose is demoted to a pose block,
     // carrying the first six entries of its delta and its `linearized` flag
-    // (`imu_types.h:206-215`).
     for id in &schedule.states_to_marg_vel_bias {
         // Proven by `validate_schedule`, like the lookup above: every frame in
         // this set is a 15-row block of the ordering, and the ordering was
@@ -513,19 +411,16 @@ pub fn marginalize<S: LieScalar>(
         imu_meas.remove(id);
     }
 
-    // `:1107-1112`.
     for id in &schedule.poses_to_marg {
         estimator.frame_poses.remove(id);
     }
 
-    // `:1114`.
     estimator.lmdb.remove_keyframes(
         &schedule.kfs_to_marg,
         &schedule.poses_to_marg,
         &schedule.states_to_marg_all,
     );
 
-    // `:1116-1118`.
     if inputs.options.marg_lost_landmarks
         && let Some(lost) = inputs.lost_landmarks
     {
@@ -534,17 +429,16 @@ pub fn marginalize<S: LieScalar>(
         }
     }
 
-    // `:1135-1137`. The width the helper produced is `idx_to_keep.len()`, and
-    // `:1145`'s check on it already ran above, against the same ordering.
+    // The helper output width equals the kept-index count, already checked against ordering.
     marg_data.h = reduced.h;
     marg_data.b = reduced.b;
     marg_data.order = marg_order_new;
 
-    // `:1147-1172`, trap 8. The prior comes out of the helper as
+    // trap 8. The prior comes out of the helper as
     // `P(x) = 0.5‖J x + res‖²`; putting it back into the delta-independent form
     // `P(x) = 0.5‖J (delta + x) + (res − J delta)‖²` is one subtraction.
     // This ordering's blocks were proven frozen before the first mutation
-    // (`check_prior_blocks_linearized`, and `:1086` above for the last state).
+    // (`check_prior_blocks_linearized`, and above for the last state).
     let delta: DVector<S> = estimator.compute_delta(&marg_data.order)?;
     subtract_h_delta(&mut marg_data.b, &marg_data.h, &delta);
 
@@ -557,7 +451,7 @@ pub fn marginalize<S: LieScalar>(
     })
 }
 
-/// `b -= H * delta` (`sqrt_keypoint_vio.cpp:1172`), written out so the
+/// `b -= H * delta`, written out so the
 /// summation order is fixed rather than nalgebra's.
 ///
 /// **Contract: `b.nrows() == h.nrows()` and `delta.nrows() == h.ncols()`.**

--- a/packages/slam-rs/crates/slam-rs/src/pyramid.rs
+++ b/packages/slam-rs/crates/slam-rs/src/pyramid.rs
@@ -1,70 +1,20 @@
-//! The frontend's integer Gaussian image pyramid.
+//! Integer Gaussian image pyramids for the frontend.
+//! A separable `[1, 4, 6, 4, 1]` filter uses reflect-101 borders, i32 accumulation
+//! and one final rounding `(value + 128) >> 8`. Each level halves both dimensions.
 //!
-//! Ported from `thirdparty/basalt-headers/include/basalt/image/image_pyr.h`.
-//! `subsample` (`image_pyr.h:99-140`) is reproduced operation for operation:
-//! a separable 5-tap `[1, 4, 6, 4, 1]` Gaussian with BORDER_REFLECT_101
-//! extrapolation, integer accumulation in an `i32` scratch buffer laid out
-//! row-major over `dst_height` x `src_width` — which reproduces C++'s
-//! transposed *arithmetic*, not its layout, see `subsample` — and one
-//! rounding at the very end, `(val + (1 << 7)) >> 8` (`image_pyr.h:135`).
-//! Each level halves both dimensions after filtering and rounds once to u16.
-//!
-//! ## What is not reproduced: the mipmap allocation
-//!
-//! basalt packs every level into one `w + w/2` wide buffer (`image_pyr.h:71`)
-//! and hands out sub-images (`lvl`, `image_pyr.h:146-152`). That is an
-//! allocation trick, not a numerical one, and it is the one thing the GPU seam
-//! forbids: a level must be a flat buffer with a stateable stride so it uploads
-//! as one `create_from_slice`. So [`PyramidU16`] owns one [`ImageU16`] per
-//! level and keeps basalt's level *geometry* — level `l` is
-//! `(width >> l, height >> l)` (`image_pyr.h:149-150`) — exactly (deviation X04).
-//!
-//! ## Level 0 is a copy, not a borrow
-//!
-//! basalt copies too (`lvl_internal(0).CopyFrom(other)`, `image_pyr.h:73`), and
-//! the seam rule is that no public signature returns a borrowed view into
-//! pyramid memory: the whole pyramid is one residency unit that a GPU backend
-//! uploads and owns. A borrowed level 0 would also tie the pyramid's lifetime
-//! to the input frame, which the per-frame reuse in
-//! [`CpuPyramidBuilder::build`] is built to avoid.
-//!
-//! ## Level counting
-//!
-//! `setFromImage(other, num_levels)` builds levels `1..=num_levels`
-//! (`image_pyr.h:75-79`), so basalt's `optical_flow_levels = 3` means **four**
-//! usable levels, 0 through 3. [`PyramidU16::with_capacity`] takes the same
-//! `num_levels` and allocates `num_levels + 1` levels.
-//!
-//! ## The seam lends nothing
-//!
-//! [`PyramidBuilder`] and its associated [`Pyramid`] type expose **no borrows**:
-//! only geometry ([`Pyramid::num_levels`], [`Pyramid::level_size`]) and a copy
-//! into a buffer the caller already owns ([`Pyramid::copy_level_into`]). That is
-//! the §12.3.2 rule — a GPU pyramid holds device handles and cannot lend a
-//! `&[u16]`, so generic frontend code written against `P: PyramidBuilder` must
-//! never be able to ask for one. The concrete CPU [`PyramidU16`] does keep one
-//! borrowing accessor, `level`, because the KLT tracker lands in this crate and
-//! reads pixels straight out of a CPU pyramid, but it is `pub(crate)`: the
-//! borrow stops at the crate boundary and cannot reach a public signature.
-//!
-//! ## No fused gradient here yet
-//!
-//! The CubeCL review wants "downsample + gradient" fused into one
-//! [`PyramidBuilder::build`] call. The KLT tracker samples a sparse 52-tap
-//! pattern and calls [`ImageU16::interp_grad`] per tap, so a dense gradient
-//! image would be built and discarded; the fused pass lands with the tracker,
-//! when there is a consumer that reads it.
+//! CPU levels own flat images; level zero is copied so pyramid lifetime and reuse
+//! are independent of input frames. Three requested reductions produce four
+//! levels, zero through three. The generic stage interface exposes geometry and
+//! copies into caller buffers, never borrowed device memory.
+//! Sparse KLT gradient sampling avoids constructing unused dense gradient images.
 
 use crate::image::{ImageError, ImageU16};
 
-/// The 5-tap Gaussian, `image_pyr.h:102`.
+/// The 5-tap Gaussian.
 const KERNEL: [i32; 5] = [1, 4, 6, 4, 1];
 
-/// Smallest side `subsample` can read: it indexes `abs(2 * 0 - 2) == 2`.
-///
-/// `image_pyr.h:110` reaches two rows above the first output row without a
-/// bounds check; in C++ that is out-of-range for a two-row image. The port
-/// refuses the geometry at construction instead (decision D32).
+/// Minimum filter side length: the first output reaches source index two.
+/// Refuse smaller geometry at construction (D32).
 pub(crate) const MIN_SIDE: usize = 3;
 
 /// The stage seam: build every level of one camera's pyramid in one call.
@@ -135,7 +85,7 @@ pub trait PyramidBuilder {
 /// memory and there is nothing to lend, so a `&[u16]` here would be an API
 /// that only the CPU backend could ever satisfy (deviation X04).
 pub trait Pyramid {
-    /// Levels held, which is basalt's `num_levels + 1`.
+    /// Stored level count, including level zero.
     fn num_levels(&self) -> usize;
 
     /// `(width, height, stride)` of one level, or `None` past the top.
@@ -235,16 +185,10 @@ pub struct PyramidU16 {
 }
 
 impl PyramidU16 {
-    /// Allocate every level for a `width` x `height` frame, zero-filled.
-    ///
-    /// `num_levels` is basalt's: `with_capacity(w, h, 3)` gives four levels,
-    /// 0 through 3, matching `optical_flow_levels = 3`.
+    /// Allocate zero-filled levels; three reductions give levels zero through three.
     ///
     /// # Errors
-    ///
-    /// [`PyramidError::TooSmall`] when a level would be narrower or shorter
-    /// than the kernel's reach, [`PyramidError::Image`] when the geometry does
-    /// not fit in a `usize`.
+    /// Refuse sides smaller than the kernel's reach or overflowing image geometry.
     pub fn with_capacity(
         width: usize,
         height: usize,
@@ -262,7 +206,7 @@ impl PyramidU16 {
         }
         let mut levels: Vec<ImageU16> = Vec::with_capacity(num_levels + 1);
         for level in 0..=num_levels {
-            // basalt's `lvl(l)`: `(orig_w >> lvl, image.h >> lvl)` (`image_pyr.h:149-150`).
+            // Level dimensions are original dimensions shifted right by the level index.
             levels.push(ImageU16::zeros(width >> level, height >> level)?);
         }
         Ok(Self { levels })
@@ -297,11 +241,7 @@ impl Pyramid for PyramidU16 {
     }
 }
 
-/// The CPU [`PyramidBuilder`]: basalt's `subsample`, level by level.
-///
-/// Owns the `i32` accumulator `subsample` needs (`image_pyr.h:105`) so the
-/// per-frame path allocates nothing once the builder has seen one frame of a
-/// given size.
+/// CPU pyramid builder with reusable i32 filtering scratch storage.
 #[derive(Debug, Clone, Default)]
 pub struct CpuPyramidBuilder {
     scratch: Vec<i32>,
@@ -326,7 +266,7 @@ impl PyramidBuilder for CpuPyramidBuilder {
         PyramidU16::with_capacity(width, height, num_levels)
     }
 
-    /// `ManagedImagePyr::setFromImage`, `image_pyr.h:70-80`.
+    /// `ManagedImagePyr::setFromImage`.
     ///
     /// `_camera` is unused here: the levels are host memory and the caller
     /// still holds `img`, so the detector reads the frame itself.
@@ -353,7 +293,7 @@ impl PyramidBuilder for CpuPyramidBuilder {
             });
         }
 
-        // `lvl_internal(0).CopyFrom(other)` (`image_pyr.h:73`). `copy_from` is
+        // `lvl_internal(0).CopyFrom(other)`. `copy_from` is
         // the same row-by-row copy, which is what a possibly strided source
         // needs; the geometry check above makes its resize a no-op.
         out.levels[0].copy_from(img)?;
@@ -373,7 +313,7 @@ impl PyramidBuilder for CpuPyramidBuilder {
 
 /// Scratch elements `subsample` needs at level 0, which is its largest use.
 ///
-/// `ManagedImage<int> tmp(img_sub.h, img.w)` (`image_pyr.h:105`) is
+/// `ManagedImage<int> tmp(img_sub.h, img.w)` is
 /// `img.w * (img.h / 2)` integers whichever way they are laid out; [`subsample`]
 /// holds them row-major over `dst_height` x `src_width`. A saturating product
 /// would turn an impossible geometry into a `vec!` that aborts the process, so
@@ -388,43 +328,22 @@ fn scratch_len(width: usize, height: usize) -> Result<usize, PyramidError> {
     Ok(len)
 }
 
-/// BORDER_REFLECT_101 for an index past the *high* end, `image_pyr.h:83`.
-///
-/// `h - 1 - |h - 1 - x|`. It is only a reflection for `x >= 0`; for a negative
-/// index basalt uses `std::abs` instead (`image_pyr.h:110-111`), which is the
-/// same reflection about 0 but a different expression. Trap 3 of the
-/// architecture dossier is precisely that these two are not one function.
+/// High-end reflect-101: `h - 1 - |h - 1 - x|` for non-negative x.
+/// Negative indices instead reflect with absolute value; the formulas are not
+/// interchangeable outside their domains (trap 3).
 #[inline]
 fn border101(x: i64, h: i64) -> i64 {
     h - 1 - (h - 1 - x).abs()
 }
 
-/// basalt's `subsample`, `image_pyr.h:99-140`, operation for operation.
-///
-/// C++ writes a **transposed** accumulator: `ManagedImage<int> tmp(img_sub.h,
-/// img.w)`, whose width is the destination height, holds `tmp(r, c)` with `r`
-/// the destination row and `c` the source column (`image_pyr.h:117`), and the
-/// horizontal pass walks its rows (`:126-136`). What that transposition decides
-/// is the *arithmetic*: `tmp.h` is the source width, so the second pass's
-/// `border101(2 * c + 2, tmp.h)` reflects about the source width, and that is
-/// reproduced here.
-///
-/// The **layout** is not reproduced, because it costs a cache line per
-/// coefficient in both directions: the vertical pass would stride its writes by
-/// `dst_height` and the horizontal pass would stride its `dst` writes by the
-/// row. The accumulator here is row-major over `dst_height` x `src_width`, so
-/// both passes run along their rows. Every value and every index is the one C++
-/// computes — the taps are integers, where an order is not a rounding.
-///
-/// There is exactly one rounding, at the end of the horizontal pass, so the
-/// separable form is bit-identical to a direct 5x5 convolution.
+/// Separable integer Gaussian subsampling.
+/// A row-major `dst_height × src_width` accumulator keeps both passes contiguous.
+/// Reflect the vertical pass about source height and the horizontal pass about
+/// source width. Exact integer sums and one final rounding equal direct 5x5 convolution.
 ///
 /// # Panics
-///
-/// If `src` is narrower or shorter than [`MIN_SIDE`], or `dst` is not
-/// `(src.width() >> 1, src.height() >> 1)`, or `scratch` is short. All three
-/// are established by [`PyramidU16::with_capacity`] and checked by
-/// [`CpuPyramidBuilder::build`].
+/// If source sides are below [`MIN_SIDE`], destination is not half-size, or scratch
+/// is short. Construction and builder checks establish these preconditions.
 fn subsample(src: &ImageU16, dst: &mut ImageU16, scratch: &mut [i32]) {
     let src_width: usize = src.width();
     let src_height: usize = src.height();
@@ -433,7 +352,7 @@ fn subsample(src: &ImageU16, dst: &mut ImageU16, scratch: &mut [i32]) {
     debug_assert_eq!(dst_width, src_width >> 1);
     debug_assert_eq!(dst_height, src_height >> 1);
 
-    // Vertical convolution, `image_pyr.h:108-121`, one accumulator row per
+    // Vertical convolution,, one accumulator row per
     // destination row.
     for r in 0..dst_height {
         let row2: i64 = 2 * r as i64;
@@ -463,18 +382,14 @@ fn subsample(src: &ImageU16, dst: &mut ImageU16, scratch: &mut [i32]) {
         }
     }
 
-    // Horizontal convolution, `image_pyr.h:123-139`. `tmp.h` is `src_width`, so
+    // Horizontal convolution. is `src_width`, so
     // the reflection is about the **source** width whichever way `tmp` is laid
     // out.
     for r in 0..dst_height {
         let band: &[i32] = &scratch[r * src_width..(r + 1) * src_width];
         for (c, pixel) in dst.row_mut(r).iter_mut().enumerate() {
-            // An interior column's five taps are the contiguous window
-            // `band[2c - 2 ..= 2c + 2]`. The reflection only bites at `c == 0`,
-            // where C++ takes `abs` of a negative index, and at the last column
-            // or two, where `2c + 2` runs past `src_width - 1`; peeling those
-            // out keeps the two `border101` calls and their four casts off the
-            // 230,400 interior columns of a level-0 pass.
+            // Interior five-tap windows are contiguous. Peel low/high border columns to keep
+            // reflection arithmetic out of the large interior loop.
             let value: i32 = match (2 * c)
                 .checked_sub(2)
                 .and_then(|first| band.get(first..)?.first_chunk::<5>())
@@ -502,7 +417,7 @@ fn subsample(src: &ImageU16, dst: &mut ImageU16, scratch: &mut [i32]) {
                         + KERNEL[4] * band[columns[4]]
                 }
             };
-            // `T val = ((val_int + (1 << 7)) >> 8)` (`image_pyr.h:135`). The
+            // `T val = ((val_int + (1 << 7)) >> 8)`. The
             // accumulator peaks at 65535 * 16 * 16, so the shift lands back in
             // `u16` exactly and the cast never truncates.
             *pixel = ((value + (1 << 7)) >> 8) as u16;
@@ -518,8 +433,7 @@ mod tests {
 
     use proptest::prelude::*;
 
-    /// True reflect-101, written the obvious way: mirror until the index lands
-    /// inside `[0, n)`. Independent of [`border101`] and of basalt's `abs`.
+    /// Independent reflect-101 implementation that repeatedly mirrors into `[0, n)`.
     fn reflect101_naive(mut index: i64, n: i64) -> i64 {
         assert!(n >= 2, "reflect-101 needs at least two samples");
         loop {
@@ -533,9 +447,7 @@ mod tests {
         }
     }
 
-    /// A direct 5x5 convolution with true reflect-101 borders and basalt's
-    /// single rounding. Independent of [`subsample`]: no separability, no
-    /// accumulator, no `abs`/`border101` split.
+    /// Independent direct 5x5 convolution with reflect-101 borders and one final rounding.
     fn subsample_naive(src: &ImageU16) -> ImageU16 {
         let width: usize = src.width() >> 1;
         let height: usize = src.height() >> 1;
@@ -592,7 +504,7 @@ mod tests {
 
     #[test]
     fn three_levels_means_four_usable_levels() {
-        // `optical_flow_levels = 3` -> levels 0..3 (`image_pyr.h:75-79`).
+        // `optical_flow_levels = 3` -> levels 0..3.
         let pyramid: PyramidU16 = build(&random_image(64, 48, 1), 3);
         assert_eq!(pyramid.num_levels(), 4);
         let sizes: Vec<(usize, usize)> = each_level(&pyramid)
@@ -604,7 +516,7 @@ mod tests {
 
     #[test]
     fn level_geometry_shifts_the_original_size() {
-        // `lvl(l)` is `(orig_w >> l, image.h >> l)` (`image_pyr.h:149-150`),
+        // `lvl(l)` is `(orig_w >> l, image.h >> l)`,
         // which for an odd side is not the same as halving the level below by
         // rounding up: 41 -> 20 -> 10 -> 5.
         let pyramid: PyramidU16 = build(&random_image(41, 27, 2), 3);
@@ -759,10 +671,8 @@ mod tests {
     #[test]
     fn border101_matches_the_naive_reflection_over_its_whole_domain() {
         for n in 2i64..24 {
-            // basalt calls `border101` with indices in `[0, 2 * (n - 1)]`
-            // (`image_pyr.h:112-113`) and `std::abs` below zero
-            // (`image_pyr.h:110-111`). Both agree with the naive reflection
-            // there, and `border101` does *not* below zero, which is trap 3.
+            // Check high-end reflection on `[0, 2*(n-1)]` and absolute-value reflection below
+            // zero against the independent implementation (trap 3).
             for x in 0..=2 * (n - 1) {
                 assert_eq!(
                     border101(x, n),
@@ -781,28 +691,11 @@ mod tests {
         }
     }
 
-    /// kornia-rs is the second, independent oracle for the same arithmetic.
-    ///
-    /// `pyrdown_u8` (`crates/kornia-imgproc/src/pyramid.rs:469`) runs the same
-    /// integer `[1,4,6,4,1]` kernel with reflect-101 borders and the same
-    /// single rounding, `(sum + 128) >> 8` (`:650`), against basalt's
-    /// `(val_int + (1 << 7)) >> 8` (`image_pyr.h:135`). It transposes the pass
-    /// order (horizontal first, `:498`) where basalt goes vertical first, which
-    /// changes nothing: both passes accumulate in integers and round once, so
-    /// each is exactly the 5x5 convolution.
-    ///
-    /// The comparison runs on `u16` pixels holding **0..255 unshifted**, not
-    /// the `<< 8` frontend values. The two are not comparable: rounding happens
-    /// on different magnitudes, so `subsample(v << 8) >> 8` is not
-    /// `subsample(v)` — the `<< 8` form keeps eight more bits of the weighted
-    /// sum before the shift discards them, and the two disagree by one LSB
-    /// wherever the discarded remainder crosses a half. That extra headroom is
-    /// exactly why basalt widens (kornia-rs inventory §2.1).
-    ///
-    /// Sizes are even on purpose: kornia sizes its output `div_ceil(2)`
-    /// (`pyramid.rs:473-474`) where basalt shifts right (`image_pyr.h:149`), so
-    /// on an odd side the two produce different geometries and only basalt's is
-    /// the reference.
+    /// Compare with kornia's independent integer pyramid filter.
+    /// Both use `[1,4,6,4,1]`, reflect-101 and one rounding `(sum + 128) >> 8`.
+    /// Use unshifted values 0–255: filtering widened `v << 8` and narrowing afterwards
+    /// rounds at a different magnitude and need not agree. Even dimensions avoid
+    /// kornia's ceil-half versus this crate's floor-half geometry difference.
     #[test]
     fn subsample_matches_kornia_pyrdown_u8_on_byte_valued_pixels() {
         use kornia_image::{Image, ImageSize};

--- a/packages/slam-rs/crates/slam-rs/src/types.rs
+++ b/packages/slam-rs/crates/slam-rs/src/types.rs
@@ -1,11 +1,5 @@
-//! The value types the estimator's state is built from.
-//!
-//! Ported from `include/basalt/utils/common_types.h`,
-//! `thirdparty/basalt-headers/include/basalt/imu/imu_types.h` and
-//! `include/basalt/utils/imu_types.h`. Nothing here optimizes: the point is
-//! that every index, every increment order and the fixed-linearization
-//! bookkeeping match the C++ exactly, because a sign or an offset wrong here
-//! shows up as slow drift rather than an obvious failure.
+//! Estimator state values, block indices and frozen-linearization bookkeeping.
+//! Correct offsets and increment conventions prevent silent trajectory drift.
 
 use std::collections::HashMap;
 
@@ -13,11 +7,11 @@ use nalgebra::{DMatrix, DVector, SVector, Vector3, Vector6};
 
 use crate::lie::{LieScalar, Se3};
 
-/// Degrees of freedom of a pose block (`imu_types.h:46`).
+/// Degrees of freedom of a pose block.
 pub const POSE_SIZE: usize = 6;
-/// Degrees of freedom of a pose-velocity block (`imu_types.h:47`).
+/// Degrees of freedom of a pose-velocity block.
 pub const POSE_VEL_SIZE: usize = 9;
-/// Degrees of freedom of a full state block (`imu_types.h:48`).
+/// Degrees of freedom of a full state block.
 pub const POSE_VEL_BIAS_SIZE: usize = 15;
 
 /// The 9-vector increment a pose-velocity state takes, and the width of the
@@ -27,17 +21,15 @@ pub type Vector9<S> = SVector<S, POSE_VEL_SIZE>;
 /// The 15-vector increment a full state takes.
 pub type Vector15<S> = SVector<S, POSE_VEL_BIAS_SIZE>;
 
-/// Identifies a frameset. basalt uses the frameset timestamp in nanoseconds as
-/// the id (`common_types.h:56`, `using FrameId = int64_t`).
+/// Frameset identifier, equal to its nanosecond timestamp.
 pub type FrameId = i64;
 
-/// Index of a camera on the rig (`common_types.h:59`, `using CamId = std::size_t`).
+/// Index of a camera on the rig (`using CamId = std::size_t`).
 pub type CamId = usize;
 
 /// One image: the frameset it belongs to and the camera that took it
-/// (`common_types.h:62-69`).
 ///
-/// The ordering is `frame_id` first, then `cam_id` (`common_types.h:76-79`), so
+/// The ordering is `frame_id` first, then `cam_id`, so
 /// a sorted collection groups a frameset's images together.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct TimeCamId {
@@ -55,22 +47,18 @@ impl TimeCamId {
 }
 
 impl std::fmt::Display for TimeCamId {
-    /// `frame_id _ cam_id`, as `operator<<` prints it (`common_types.h:71-74`).
+    /// `frame_id _ cam_id`, as `operator<<` prints it.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}_{}", self.frame_id, self.cam_id)
     }
 }
 
-/// A tracked 2D feature (`optical_flow.h:67`, `using KeypointId = size_t`).
+/// A tracked 2D feature (`using KeypointId = size_t`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct KeypointId(pub u64);
 
-/// A landmark in the estimator's database.
-///
-/// basalt aliases the two (`optical_flow.h:71`, `using LandmarkId = KeypointId`)
-/// because a landmark inherits the id of the keypoint that spawned it; the port
-/// keeps them as separate newtypes so a keypoint index cannot be passed where a
-/// landmark id belongs, with explicit conversions both ways.
+/// Landmark id inherited from its source keypoint.
+/// Separate newtypes with explicit conversions prevent mixing landmark and keypoint ids.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct LandmarkId(pub u64);
 
@@ -115,15 +103,9 @@ pub enum StateError {
     },
 }
 
-/// Where each frame's block starts in the stacked state vector.
-///
-/// Ported from `include/basalt/utils/imu_types.h:293-304`. basalt assigns
-/// offsets by accumulating `total_size` as it walks the keyframe poses and then
-/// the full states (`sqrt_keypoint_vio.cpp:731-762`), so the offsets follow
-/// insertion order; the C++ container is a `std::map`, i.e. key-ordered, and the
-/// two coincide because keyframes always carry older timestamps than the
-/// states. The port stores insertion order explicitly, which is what the offset
-/// arithmetic actually depends on.
+/// Frame block offsets in insertion order, accumulated from block sizes.
+/// Poses are inserted before full states; explicit order records the arithmetic
+/// that defines the stacked state vector.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AbsOrderMap {
     entries: Vec<(FrameId, usize, usize)>,
@@ -191,31 +173,21 @@ impl AbsOrderMap {
     }
 }
 
-/// The marginalization prior, `MargLinData<Scalar>`
-/// (`include/basalt/utils/imu_types.h:317-326`).
-///
-/// The field named `h` is **not** a Hessian: it is the Jacobian `J_m` of
-/// Paper 2 Eq. (4) and `b` is the residual `r_m`, which is the only form the QR
-/// linearizer accepts (`linearization_abs_qr.cpp:578`). C++ carries a squared
-/// form beside it behind `is_sqrt` (`ba_base.cpp:426-438`); the port does not,
-/// because `SqrtKeypointVio::new` refuses `vio_sqrt_marg == false` (D68), so
-/// that flag is judged in exactly one place.
-///
-/// `order` gives the prior's variables their offsets, and the linearizer
-/// requires them to be a prefix of the window's ordering
-/// (`ba_base.cpp:383-388`).
+/// Square-root marginalization prior. `h` stores Jacobian `J_m`, not a Hessian,
+/// and `b` stores residual `r_m`. Only this form is supported (D68).
+/// Its ordering must be a prefix of the window ordering.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MargLinData<S: LieScalar> {
-    /// The prior's ordering (`:323`).
+    /// The prior's ordering.
     pub order: AbsOrderMap,
-    /// `J_m` (`:324`).
+    /// `J_m`.
     pub h: DMatrix<S>,
-    /// `r_m` (`:325`).
+    /// `r_m`.
     pub b: DVector<S>,
 }
 
 impl<S: LieScalar> Default for MargLinData<S> {
-    /// basalt's in-class initialiser: square root, empty (`:321-325`).
+    /// An empty square-root prior.
     fn default() -> Self {
         Self {
             order: AbsOrderMap::new(),
@@ -225,7 +197,7 @@ impl<S: LieScalar> Default for MargLinData<S> {
     }
 }
 
-/// An SE(3) pose at a timestamp (`imu_types.h:51-105`).
+/// An SE(3) pose at a timestamp.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PoseState<S: LieScalar> {
     /// Timestamp of the state, in nanoseconds.
@@ -250,13 +222,8 @@ impl<S: LieScalar> PoseState<S> {
     }
 }
 
-/// An SE(3) pose and a world-frame linear velocity at a timestamp
-/// (`imu_types.h:109-167`).
-///
-/// This is the state IMU preintegration propagates: the preintegrated
-/// pseudo-measurement is itself a `PoseVelState` whose `t_ns` counts elapsed
-/// nanoseconds rather than absolute time (`preintegration.h:148`, `:325`).
-/// C++ derives it from `PoseState`; here the pose is a field.
+/// Pose and world-frame velocity at a timestamp.
+/// Preintegrated delta states use elapsed nanoseconds instead of absolute time.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PoseVelState<S: LieScalar> {
     /// Timestamp of the state, in nanoseconds.
@@ -278,7 +245,7 @@ impl<S: LieScalar> Default for PoseVelState<S> {
 }
 
 impl<S: LieScalar> PoseVelState<S> {
-    /// A pose-velocity state from its parts (`imu_types.h:124-125`).
+    /// A pose-velocity state from its parts.
     pub fn new(t_ns: i64, t_w_i: Se3<S>, vel_w_i: Vector3<S>) -> Self {
         Self {
             t_ns,
@@ -287,7 +254,7 @@ impl<S: LieScalar> PoseVelState<S> {
         }
     }
 
-    /// Apply a 9-vector increment, `PoseVelState::applyInc` (`imu_types.h:140-143`).
+    /// Apply a 9-vector increment, `PoseVelState::applyInc`.
     ///
     /// The layout is `[trans(3), rot(3), vel(3)]`; the pose goes through
     /// [`Se3::apply_inc`] and the velocity is added.
@@ -297,7 +264,7 @@ impl<S: LieScalar> PoseVelState<S> {
     }
 
     /// The increment that takes `self` to `other`, `PoseVelState::diff`
-    /// (`imu_types.h:156-162`), the inverse of [`PoseVelState::apply_inc`].
+    /// the inverse of [`PoseVelState::apply_inc`].
     ///
     /// No production caller: the estimator's states are 15-dof and use
     /// [`PoseVelBiasState::diff`]. This is the 9-dof one, and it is what the
@@ -316,7 +283,7 @@ impl<S: LieScalar> PoseVelState<S> {
 }
 
 /// Pose, velocity and the two IMU biases at a timestamp
-/// (`imu_types.h:184-241`), the block the estimator actually optimizes.
+/// the block the estimator actually optimizes.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PoseVelBiasState<S: LieScalar> {
     /// Timestamp of the state, in nanoseconds.
@@ -366,23 +333,17 @@ impl<S: LieScalar> PoseVelBiasState<S> {
         PoseState::new(self.t_ns, self.t_w_i)
     }
 
-    /// The pose and velocity part on its own.
-    ///
-    /// C++ gets this for free by inheritance — `IntegratedImuMeasurement::residual`
-    /// takes a `const PoseVelState&` and a `PoseVelBiasState` slices into it
-    /// (`imu_block.hpp:41-43`). The port hands over an explicit copy.
+    /// Copy the pose and velocity portion of the full state.
     pub fn pose_vel_state(&self) -> PoseVelState<S> {
         PoseVelState::new(self.t_ns, self.t_w_i, self.vel_w_i)
     }
 
     /// Apply a 15-vector increment, `PoseVelBiasState::applyInc`
-    /// (`imu_types.h:212-216`).
     ///
     /// The layout is `[trans(3), rot(3), vel(3), bias_gyro(3), bias_accel(3)]`:
     /// the pose goes through [`Se3::apply_inc`] and everything else is plain
     /// addition. The gyro bias comes **before** the accel bias, matching the
     /// prior weights the estimator installs at indices 9-11 and 12-14
-    /// (`sqrt_keypoint_vio.cpp:92-93`).
     pub fn apply_inc(&mut self, inc: &Vector15<S>) {
         self.t_w_i.apply_inc(&inc.fixed_rows::<6>(0).into_owned());
         self.vel_w_i += inc.fixed_rows::<3>(6);
@@ -391,7 +352,6 @@ impl<S: LieScalar> PoseVelBiasState<S> {
     }
 
     /// The increment that takes `self` to `other`, `PoseVelBiasState::diff`
-    /// (`imu_types.h:229-236`).
     ///
     /// The inverse of [`PoseVelBiasState::apply_inc`], so
     /// `self.diff(&other)` applied to `self` reproduces `other`.
@@ -412,12 +372,11 @@ impl<S: LieScalar> PoseVelBiasState<S> {
 }
 
 /// A pose block that can hold its linearization point fixed
-/// (`include/basalt/utils/imu_types.h:180-291`).
 ///
 /// Once [`PoseStateWithLin::set_linearized`] is called the Jacobians are frozen
 /// at `pose_linearized`, and every later increment accumulates into `delta` and
 /// is re-applied to that frozen pose rather than to the current one
-/// (`imu_types.h:240-248`). Skipping the accumulation still moves the estimate,
+/// Skipping the accumulation still moves the estimate,
 /// which is why the failure looks like drift instead of a crash (trap 7 of the
 /// architecture dossier).
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -446,7 +405,7 @@ impl<S: LieScalar> Default for PoseStateWithLin<S> {
 }
 
 impl<S: LieScalar> PoseStateWithLin<S> {
-    /// A pose block at a timestamp (`imu_types.h:192-197`).
+    /// A pose block at a timestamp.
     pub fn new(t_ns: i64, t_w_i: Se3<S>, linearized: bool) -> Self {
         Self {
             linearized,
@@ -460,7 +419,7 @@ impl<S: LieScalar> PoseStateWithLin<S> {
     }
 
     /// The pose block a full state collapses to when it leaves the window
-    /// (`imu_types.h:206-215`): the first six entries of the state's delta
+    /// the first six entries of the state's delta
     /// carry over, and the current pose is rebuilt from the frozen one.
     pub fn from_pose_vel_bias(other: &PoseVelBiasStateWithLin<S>) -> Self {
         let delta: Vector6<S> = other.delta().fixed_rows::<6>(0).into_owned();
@@ -473,7 +432,7 @@ impl<S: LieScalar> PoseStateWithLin<S> {
             pose_linearized,
             t_w_i_current,
             // `backup_delta.setZero()` with the comment "unused, but avoids
-            // uninitialized gcc warning" (`imu_types.h:211`); the two poses get
+            // uninitialized gcc warning"; the two poses get
             // the same treatment here because Rust has no uninitialized field.
             backup_delta: Vector6::zeros(),
             backup_pose_linearized: pose_linearized,
@@ -481,11 +440,8 @@ impl<S: LieScalar> PoseStateWithLin<S> {
         }
     }
 
-    /// Freeze the linearization point, `setLinTrue` (`imu_types.h:224-228`).
-    ///
-    /// basalt asserts the delta is zero here; the port returns an error instead
-    /// (decision D32, the core never panics on data), because freezing on top of
-    /// an accumulated increment would silently discard it.
+    /// Freeze the linearization point only when delta is zero.
+    /// Otherwise freezing would discard accumulated motion; return an error (D32).
     pub fn set_linearized(&mut self) -> Result<(), StateError> {
         if self.delta != Vector6::zeros() {
             return Err(StateError::NonZeroDeltaAtLinearization {
@@ -497,7 +453,7 @@ impl<S: LieScalar> PoseStateWithLin<S> {
         Ok(())
     }
 
-    /// Apply an increment, `applyInc` (`imu_types.h:240-248`).
+    /// Apply an increment, `applyInc`.
     pub fn apply_inc(&mut self, inc: &Vector6<S>) {
         if self.linearized {
             self.delta += inc;
@@ -508,24 +464,21 @@ impl<S: LieScalar> PoseStateWithLin<S> {
         }
     }
 
-    /// Save the mutable state, `backup` (`imu_types.h:254-258`).
-    ///
-    /// The `linearized` flag is deliberately **not** saved: C++ does not save it
-    /// either, because a rejected Levenberg-Marquardt step never changes it.
+    /// Save mutable state. The frozen flag is unchanged by LM trials, so need not be saved.
     pub fn backup(&mut self) {
         self.backup_delta = self.delta;
         self.backup_pose_linearized = self.pose_linearized;
         self.backup_t_w_i_current = self.t_w_i_current;
     }
 
-    /// Undo the last increments, `restore` (`imu_types.h:260-264`).
+    /// Undo the last increments, `restore`.
     pub fn restore(&mut self) {
         self.delta = self.backup_delta;
         self.pose_linearized = self.backup_pose_linearized;
         self.t_w_i_current = self.backup_t_w_i_current;
     }
 
-    /// The pose the residuals are evaluated at, `getPose` (`imu_types.h:250-256`).
+    /// The pose the residuals are evaluated at, `getPose`.
     pub fn pose(&self) -> &Se3<S> {
         if self.linearized {
             &self.t_w_i_current
@@ -534,7 +487,7 @@ impl<S: LieScalar> PoseStateWithLin<S> {
         }
     }
 
-    /// The pose the Jacobians are evaluated at, `getPoseLin` (`imu_types.h:258`).
+    /// The pose the Jacobians are evaluated at, `getPoseLin`.
     pub fn pose_lin(&self) -> &Se3<S> {
         &self.pose_linearized.t_w_i
     }
@@ -556,7 +509,6 @@ impl<S: LieScalar> PoseStateWithLin<S> {
 }
 
 /// A full state block that can hold its linearization point fixed
-/// (`include/basalt/utils/imu_types.h:68-178`).
 ///
 /// The same fixed-linearization rule as [`PoseStateWithLin`], on the 15-vector.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -585,7 +537,7 @@ impl<S: LieScalar> Default for PoseVelBiasStateWithLin<S> {
 }
 
 impl<S: LieScalar> PoseVelBiasStateWithLin<S> {
-    /// A state block from a plain state (`imu_types.h:88-91`).
+    /// A state block from a plain state.
     pub fn new(state: PoseVelBiasState<S>, linearized: bool) -> Self {
         Self {
             linearized,
@@ -598,10 +550,8 @@ impl<S: LieScalar> PoseVelBiasStateWithLin<S> {
         }
     }
 
-    /// Freeze the linearization point, `setLinTrue` (`imu_types.h:110-114`).
-    ///
-    /// See [`PoseStateWithLin::set_linearized`] for why this returns an error
-    /// where basalt asserts.
+    /// Freeze the linearization point with the same zero-delta precondition as
+    /// [`PoseStateWithLin::set_linearized`].
     pub fn set_linearized(&mut self) -> Result<(), StateError> {
         if self.delta != Vector15::zeros() {
             return Err(StateError::NonZeroDeltaAtLinearization {
@@ -613,7 +563,7 @@ impl<S: LieScalar> PoseVelBiasStateWithLin<S> {
         Ok(())
     }
 
-    /// Apply a 15-vector increment, `applyInc` (`imu_types.h:116-124`).
+    /// Apply a 15-vector increment, `applyInc`.
     ///
     /// Once linearized the increment accumulates into `delta` and the current
     /// state is recomputed from the frozen one — not from the previous current
@@ -628,7 +578,7 @@ impl<S: LieScalar> PoseVelBiasStateWithLin<S> {
         }
     }
 
-    /// Save the mutable state, `backup` (`imu_types.h:139-143`).
+    /// Save the mutable state, `backup`.
     ///
     /// As for [`PoseStateWithLin::backup`], the `linearized` flag is not saved.
     pub fn backup(&mut self) {
@@ -637,14 +587,14 @@ impl<S: LieScalar> PoseVelBiasStateWithLin<S> {
         self.backup_state_current = self.state_current;
     }
 
-    /// Undo the last increments, `restore` (`imu_types.h:145-149`).
+    /// Undo the last increments, `restore`.
     pub fn restore(&mut self) {
         self.delta = self.backup_delta;
         self.state_linearized = self.backup_state_linearized;
         self.state_current = self.backup_state_current;
     }
 
-    /// The state the residuals are evaluated at, `getState` (`imu_types.h:126-132`).
+    /// The state the residuals are evaluated at, `getState`.
     pub fn state(&self) -> &PoseVelBiasState<S> {
         if self.linearized {
             &self.state_current
@@ -653,7 +603,7 @@ impl<S: LieScalar> PoseVelBiasStateWithLin<S> {
         }
     }
 
-    /// The state the Jacobians are evaluated at, `getStateLin` (`imu_types.h:134`).
+    /// The state the Jacobians are evaluated at, `getStateLin`.
     pub fn state_lin(&self) -> &PoseVelBiasState<S> {
         &self.state_linearized
     }
@@ -734,7 +684,7 @@ mod tests {
     }
 
     /// The keyframe poses go in first and the full states after, exactly as
-    /// `sqrt_keypoint_vio.cpp:731-762` builds it.
+    ///  builds it.
     #[test]
     fn the_ordering_lays_blocks_out_end_to_end() {
         let mut order: AbsOrderMap = AbsOrderMap::new();
@@ -913,7 +863,7 @@ mod tests {
     }
 
     /// A full state that leaves the window becomes a pose block carrying the
-    /// first six entries of its delta (`imu_types.h:206-215`).
+    /// first six entries of its delta.
     #[test]
     fn a_state_block_collapses_into_a_pose_block() {
         let mut state_block: PoseVelBiasStateWithLin<f64> =
@@ -938,8 +888,7 @@ mod tests {
     proptest! {
         #![proptest_config(config())]
 
-        /// `p0.diff(p1) == inc` whenever `p1 = p0.apply_inc(inc)`, the identity
-        /// the C++ doc comment states (`imu_types.h:218-228`).
+        /// `p0.diff(p1) == inc` when `p1 = p0.apply_inc(inc)`.
         #[test]
         fn apply_inc_and_diff_round_trip(seed in prop::array::uniform15(-0.4f64..0.4)) {
             let inc: Vector15<f64> = Vector15::from_column_slice(&seed);

--- a/packages/slam-rs/crates/slam-rs/tests/camera_jacobians.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/camera_jacobians.rs
@@ -1,35 +1,15 @@
-//! `test_camera.cpp` ported: project/unproject round trips and analytic
-//! Jacobians against central finite differences, at `f64` and `f32`.
+//! Camera round trips and analytic Jacobians checked with central finite differences.
+//! Synthetic cameras exercise a full test grid. Shipped kb4 and radtan8 intrinsics
+//! are also checked within the sensor domain, where inverse iterations converge.
+//! Radtan8 uses a fixed valid-radius constant declared in this file; no external
+//! fixture supplies it. Pinhole cases use synthetic projections.
 //!
-//! The C++ file is `thirdparty/basalt-headers/test/src/test_camera.cpp` and its
-//! finite-difference helper is `test/include/test_utils.h:22-61`. Both are
-//! reproduced here down to the tolerances (`test_utils.h:10-20`) and the
-//! comparison rule Eigen's `isApprox`/`isZero` implement, so a failure here
-//! means what it means in the C++ suite: the analytic Jacobian is not the
-//! derivative of the projection beside it.
-//!
-//! Two families of test run:
-//!
-//! * **basalt's own test cameras over basalt's own grid**, a literal port. The
-//!   radtan8 one needs the `rpmax` that `computeRpmax()` estimates, which this
-//!   port does not implement; the number is read from the C++ oracle fixture
-//!   instead (`camera_oracle.json`, `radtan8_odyssey_computed_rpmax`).
-//! * **the shipped intrinsics** — msdmi (2 kb4), msdmg (4 pinhole-radtan8, each
-//!   with its own `rpmax`), robocap (4 kb4) — restricted to points that land on
-//!   the sensor. That restriction is not a fudge: at 90 degrees off axis a real
-//!   fisheye projects a thousand pixels outside a 960-pixel image, and there
-//!   `unproject`'s three Newton steps (`kannala_brandt_camera4.hpp:359`) do not
-//!   converge, so neither the round trip nor the unprojection Jacobian holds —
-//!   in basalt either. `camera_oracle.rs` covers those points instead, by
-//!   agreeing with the C++ number for number.
-//!
-//! No shipped calibration is a pinhole (EuRoC's is double sphere), so the
-//! pinhole cameras are basalt's own test projections (`pinhole_camera.hpp:287`).
+//! Far off-axis fisheye unprojection may not converge in three Newton steps.
+//! Those points are outside the round-trip sweep. Explicit regression tests
+//! below cover selected edge cases; no deleted fixture suite supplies coverage.
 
 #![allow(clippy::unwrap_used)]
-// Several constants below are basalt's own literals or a C++ `%.17g` printout,
-// carried over exactly even where an f64 does not need every figure. Keeping the
-// printout verbatim is what makes them evidence.
+// Retain the declared precision of regression constants.
 #![allow(clippy::excessive_precision)]
 
 use nalgebra::{Matrix2x4, Matrix4x2, SMatrix, SVector, Vector2, Vector4};
@@ -44,13 +24,10 @@ use slam_rs::lie::LieScalar;
 
 mod common;
 
-/// `computeRpmax()` for the Odyssey+ test intrinsics, taken from the C++ oracle
-/// fixture (`camera_oracle.json`, camera `radtan8_odyssey_computed_rpmax`).
-/// basalt's own test camera is constructed with it
-/// (`pinhole_radtan8_camera.hpp:102`, `test_camera.cpp:306`).
+/// Fixed valid radius for the synthetic Odyssey+ radtan8 intrinsics.
 const ODYSSEY_COMPUTED_RPMAX: f64 = 2.5927503282280915;
 
-/// `TestConstants<Scalar>` (`test/include/test_utils.h:10-20`), plus the serde
+/// `TestConstants<Scalar>`, plus the serde
 /// bounds the calibration reader needs so a sweep can be written once and run at
 /// both precisions.
 trait TestConstants: LieScalar + Serialize + DeserializeOwned {
@@ -78,13 +55,12 @@ impl TestConstants for f32 {
     }
 }
 
-/// `Eigen::DenseBase::isZero(prec)`: every coefficient is within `prec` of zero.
+/// Every coefficient lies within `prec` of zero.
 fn is_zero<S: LieScalar, const R: usize, const C: usize>(m: &SMatrix<S, R, C>, prec: S) -> bool {
     m.iter().all(|value| value.abs() <= prec)
 }
 
-/// `Eigen::DenseBase::isApprox(other, prec)`:
-/// `(a - b).norm() <= prec * min(a.norm(), b.norm())`.
+/// Relative comparison: `(a-b).norm() <= prec * min(a.norm(), b.norm())`.
 fn is_approx<S: LieScalar, const R: usize, const C: usize>(
     a: &SMatrix<S, R, C>,
     b: &SMatrix<S, R, C>,
@@ -111,8 +87,8 @@ fn f32_pixel_bound(value: f64, principal_point: f64) -> f64 {
     8.0 * f64::from(f32::EPSILON) * (value.abs() + principal_point.abs())
 }
 
-/// `test_jacobian` (`test/include/test_utils.h:22-61`), with `x0` always zero as
-/// every call site in `test_camera.cpp` passes `…::Zero()`.
+/// `test_jacobian`, with `x0` always zero as
+/// every call site in passes `…::Zero()`.
 fn assert_jacobian<S: TestConstants, const R: usize, const C: usize>(
     name: &str,
     analytic: &SMatrix<S, R, C>,
@@ -152,14 +128,10 @@ fn assert_jacobian<S: TestConstants, const R: usize, const C: usize>(
     );
 }
 
-/// Which Jacobians a sweep checks.
-///
-/// `d_proj_d_param` is the calibration optimizer's, and calibration runs in
-/// double; the estimator only ever asks for `d_proj_d_p3d`. On the msd-g2
-/// intrinsics the parameter columns for `k4, k5, k6` reach 1e4 near the edge of
-/// the valid radius, where neither a 1e-2 nor a 1e-3 central difference in `f32`
-/// is a derivative any more — so that combination is checked in `f64` and
-/// against the C++ fixture, not by finite differences in `f32`.
+/// Select point and/or intrinsic Jacobians for the sweep.
+/// Radtan8 denominator-parameter columns can reach 1e4 near the valid-radius edge,
+/// where f32 finite differences lose derivative resolution. Check those parameter
+/// columns in f64; the estimator uses the point Jacobian.
 #[derive(Clone, Copy, PartialEq)]
 enum Check {
     /// `d_proj_d_p3d` only.
@@ -168,7 +140,7 @@ enum Check {
     PointAndParam,
 }
 
-/// `testProjectJacobian` (`test_camera.cpp:40-90`): the grid is
+/// `testProjectJacobian` : the grid is
 /// `x, y in -10..=10`, `z in -1..=5`, homogeneous `w = 1`.
 ///
 /// `domain` narrows the sweep to the pixels a camera can actually produce; the
@@ -224,10 +196,8 @@ fn sweep_project_jacobians<S, const N: usize, Cam>(
     }
 }
 
-/// `testProjectUnproject` (`test_camera.cpp:158-187`): the unprojected bearing is
-/// the normalized point, to `epsilonSqrt`. The homogeneous coordinate is
-/// `0.23424` on the way in and zero on the way back, which is the C++'s own way
-/// of checking that projection ignores it and unprojection zeroes it.
+/// Projection ignores the input homogeneous component; unprojection returns it as
+/// zero and recovers the normalized spatial point within `epsilonSqrt`.
 fn sweep_project_unproject<S: TestConstants, Cam: Camera<S>>(
     camera: &Cam,
     domain: impl Fn(&Vector2<S>) -> bool,
@@ -264,7 +234,7 @@ fn sweep_project_unproject<S: TestConstants, Cam: Camera<S>>(
     }
 }
 
-/// `testUnprojectJacobians` (`test_camera.cpp:190-241`).
+/// `testUnprojectJacobians`.
 fn sweep_unproject_jacobians<S, const N: usize, Cam>(
     camera: &Cam,
     domain: impl Fn(&Vector2<S>) -> bool,
@@ -314,7 +284,7 @@ fn sweep_unproject_jacobians<S, const N: usize, Cam>(
     }
 }
 
-/// `PinholeCamera::getTestProjections()` (`pinhole_camera.hpp:281-295`): EuRoC
+/// `PinholeCamera::getTestProjections()` : EuRoC
 /// and TUM VI 512.
 fn basalt_pinholes<S: TestConstants>() -> Vec<Pinhole<S>> {
     vec![
@@ -333,7 +303,7 @@ fn basalt_pinholes<S: TestConstants>() -> Vec<Pinhole<S>> {
     ]
 }
 
-/// `KannalaBrandtCamera4::getTestProjections()` (`kannala_brandt_camera4.hpp:487-495`).
+/// `KannalaBrandtCamera4::getTestProjections()`.
 fn basalt_kb4<S: TestConstants>() -> KannalaBrandt4<S> {
     KannalaBrandt4::new(SVector::<S, 8>::from([
         S::from_literal(379.045),
@@ -347,7 +317,7 @@ fn basalt_kb4<S: TestConstants>() -> KannalaBrandt4<S> {
     ]))
 }
 
-/// `PinholeRadtan8Camera::getTestProjections()` (`pinhole_radtan8_camera.hpp:705-718`),
+/// `PinholeRadtan8Camera::getTestProjections()`,
 /// the Odyssey+, with the radius `computeRpmax()` estimates for it.
 fn basalt_radtan8<S: TestConstants>() -> PinholeRadtan8<S> {
     PinholeRadtan8::new(
@@ -401,17 +371,13 @@ fn shipped_radtan8<S: TestConstants>() -> Vec<(PinholeRadtan8<S>, RigCamera<S>, 
         .collect()
 }
 
-/// The whole grid, as the C++ tests use it.
+/// Accept every point on the synthetic test grid.
 fn everywhere<S: LieScalar>(_proj: &Vector2<S>) -> bool {
     true
 }
 
-/// basalt's own operational domain for a keypoint: inside the image, and within
-/// `optical_flow_image_safe_radius` of the image centre
-/// (`frame_to_frame_optical_flow.h:508-511`, which masks the black corners of a
-/// fisheye). The radius is a config field, 472 for msd-index, 340 for msd-g2 and
-/// 388 for the Odyssey config RoboCap runs
-/// (`configs/msdmi_config.json`, `msdmg_config.json`, `msdmo_config.json`).
+/// Operational keypoint domain: inside the image and configured safe radius.
+/// The radius masks fisheye corners: 472 for Index, 340 for G2 and 388 for RoboCap.
 fn on_sensor<S: LieScalar>(
     rig: &RigCamera<S>,
     safe_radius: f64,
@@ -430,7 +396,7 @@ const MSDMI_SAFE_RADIUS: f64 = 472.0;
 const MSDMG_SAFE_RADIUS: f64 = 340.0;
 const ROBOCAP_SAFE_RADIUS: f64 = 388.0;
 
-// ─── basalt's own cameras, basalt's own grid ──────────────────────────────
+// Synthetic cameras on the full test grid.
 
 #[test]
 fn pinhole_project_jacobians() {
@@ -486,8 +452,7 @@ fn pinhole_unproject_jacobians() {
     }
 }
 
-/// `f64` only, as in the C++: `KannalaBrandtUnprojectJacobiansFloat` is
-/// commented out (`test_camera.cpp:401-403`).
+/// Check kb4 unprojection Jacobians in f64.
 #[test]
 fn kb4_unproject_jacobians() {
     sweep_unproject_jacobians(&basalt_kb4::<f64>(), everywhere);
@@ -534,13 +499,9 @@ fn shipped_kb4_unproject_jacobians() {
 
 // ─── what unprojection actually delivers on real fisheye calibrations ─────
 
-/// Inside basalt's safe radius the shipped calibrations invert to eleven
-/// digits — with one exception, which is pinned below.
-///
-/// This is the property the frontend depends on: `unproject` builds the
-/// epipolar guess and filters matches, and a bearing that is off by a degree is
-/// a false match. The grid is 41 x 41 x 8 points per camera, coarse enough to
-/// run in milliseconds and dense enough to cover the disc.
+/// Within safe radii, shipped calibrations should invert accurately except for
+/// the explicit regression cases below. Bearing errors affect both epipolar
+/// prediction and filtering, even when projected pixels still look plausible.
 #[test]
 fn the_round_trip_is_exact_inside_the_safe_radius() {
     let mut worst_by_camera: Vec<(String, f64)> = Vec::new();
@@ -635,10 +596,8 @@ fn msd_g2_cam2_does_not_invert_inside_the_safe_radius() {
     assert!((bearing - expected).norm() > 0.12);
 }
 
-/// Outside the safe radius a wide kb4 can invert to a bearing pointing the other
-/// way, and again basalt agrees digit for digit. RoboCap cam1 at 511 px from the
-/// image centre is 123 px beyond the 388 px radius the config masks with, so the
-/// frontend never asks; the estimator stage must keep it that way.
+/// Pin the selected off-axis unprojection result where fixed Newton iterations
+/// leave a bearing error, independently of the ordinary sensor-domain sweep.
 #[test]
 fn robocap_cam1_inverts_backwards_outside_the_safe_radius() {
     let calibration: Calibration<f64> =
@@ -729,7 +688,7 @@ proptest! {
                 CameraEnum::Pinhole(basalt_pinholes::<f64>()[0]),
                 RigCamera {
                     model: CameraEnum::Pinhole(basalt_pinholes::<f64>()[0]),
-                    // `PinholeCamera::getTestResolutions()` (`pinhole_camera.hpp:301`).
+                    // `PinholeCamera::getTestResolutions()`.
                     resolution: [752, 480],
                 },
                 376.0,
@@ -774,7 +733,7 @@ proptest! {
         z in -8.0f64..-0.1,
     ) {
         // kb4 accepts points behind its own plane whenever the radius is large
-        // (`kannala_brandt_camera4.hpp:152`), so the negative-z rejection is
+        // so the negative-z rejection is
         // only meaningful near the optical axis for that model.
         let pinhole: CameraEnum<f64> = CameraEnum::Pinhole(basalt_pinholes::<f64>()[0]);
         let radtan8: CameraEnum<f64> = CameraEnum::PinholeRadtan8(shipped_radtan8::<f64>()[0].0);

--- a/packages/slam-rs/crates/slam-rs/tests/common/mod.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/common/mod.rs
@@ -152,8 +152,7 @@ pub struct Clip {
     pub dataset_name: String,
     /// Added to a frameset timestamp to reach the absolute device clock.
     pub capture_start_time_ns: i64,
-    /// `catalog` (the values the C++ was pushed) or `fixture` (the fork file's
-    /// doubles).
+    /// Calibration values from catalog f32 statics or the fixture JSON doubles.
     pub calibration_source: String,
     pub num_cameras: usize,
     pub framesets: usize,
@@ -220,7 +219,7 @@ pub struct Pgm {
     pub pixels: Vec<u8>,
 }
 
-/// `frame_<NNN>_cam<C>.pgm` under `directory`, in `tools/dump_flow.cpp`'s
+/// `frame_<NNN>_cam<C>.pgm` under `directory`, in 's
 /// layout.
 #[allow(
     dead_code,
@@ -334,8 +333,7 @@ pub static IMU: LazyLock<Vec<ImuRow>> = LazyLock::new(|| {
 });
 
 /// `KannalaBrandtCamera4<Scalar>::getTestProjections()[0]`
-/// (`basalt-headers/include/basalt/camera/kannala_brandt_camera4.hpp:487-495`),
-/// which is what `test_linearization.cpp:19` puts in both camera slots.
+/// which is what puts in both camera slots.
 #[allow(
     dead_code,
     reason = "used by linearize_reference; other binaries compile a subset"
@@ -351,10 +349,7 @@ pub const KB4_TEST_PROJECTION: [f64; 8] = [
     -0.000452646,
 ];
 
-/// xorshift64*, standing in for Eigen's `Random()`.
-///
-/// A Rust test that flakes is worse than one that is merely differently
-/// arbitrary, so nothing here draws from the system generator.
+/// Seeded xorshift64* keeps synthetic tests deterministic.
 #[allow(
     dead_code,
     reason = "used by linearize_reference; other binaries compile a subset"
@@ -379,7 +374,7 @@ impl Rng {
         x.wrapping_mul(0x2545_F491_4F6C_DD1D)
     }
 
-    /// Uniform on `[-1, 1]`, like `Eigen::Matrix::Random()`.
+    /// Uniform on `[-1, 1]`.
     pub fn symmetric(&mut self) -> f64 {
         (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64 * 2.0 - 1.0
     }
@@ -393,7 +388,7 @@ impl Rng {
     }
 }
 
-/// The calibration `get_vo_estimator` builds (`test_linearization.cpp:15-22`):
+/// The calibration `get_vo_estimator` builds :
 /// two camera-to-IMU transforms that are small perturbations of identity, and
 /// [`KB4_TEST_PROJECTION`] in both camera slots.
 ///
@@ -431,7 +426,7 @@ pub fn test_calibration(rng: &mut Rng) -> Calibration<f64> {
 /// The reference the square-root marginalization is checked against: the QR of
 /// `marginalizeHelperSqrtToSqrt` never forms `JᵀJ`, so squaring its output and
 /// comparing with this is the same argument `VoMargSqrtLinearizationTest` makes
-/// about the linearization (`test_linearization.cpp:379-388`), one level up.
+/// about the linearization, one level up.
 #[allow(
     dead_code,
     reason = "used by marg_window; other binaries compile a subset"
@@ -630,9 +625,7 @@ pub fn flow_rig(count: usize) -> Calibration<f64> {
     }
 }
 
-/// basalt's shipped configuration, with the matching guess set to the same
-/// pixel so that `flow_rig`'s cameras — which see identical frames — really do
-/// match.
+/// Use the shipped configuration with same-pixel matching guesses for identical camera frames.
 #[allow(
     dead_code,
     reason = "used by flow_frontend; other binaries compile a subset"

--- a/packages/slam-rs/crates/slam-rs/tests/fast_model.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/fast_model.rs
@@ -18,7 +18,7 @@ mod common;
 
 use common::cornered_bytes;
 
-/// `corner_score_9_scalar` (`kornia fast.rs:838`).
+/// `corner_score_9_scalar` (`kornia fast.rs).
 fn corner_score_9(gray: &[u8], width: usize, x: usize, y: usize) -> u8 {
     let center = i32::from(gray[y * width + x]);
     let mut dark = [0i32; 16];

--- a/packages/slam-rs/crates/slam-rs/tests/fast_model.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/fast_model.rs
@@ -18,7 +18,7 @@ mod common;
 
 use common::cornered_bytes;
 
-/// `corner_score_9_scalar` (`kornia fast.rs).
+/// `corner_score_9_scalar` (kornia's `fast.rs`).
 fn corner_score_9(gray: &[u8], width: usize, x: usize, y: usize) -> u8 {
     let center = i32::from(gray[y * width + x]);
     let mut dark = [0i32; 16];

--- a/packages/slam-rs/crates/slam-rs/tests/flow_frontend.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/flow_frontend.rs
@@ -71,8 +71,8 @@ fn the_first_frame_detects_on_camera_zero_and_matches_into_camera_one() {
     assert!(shared > 0, "camera 1 shares no id with camera 0");
 }
 
-/// `last_keypoint_id` is the global landmark id space (`optical_flow.h:71`,
-/// `:174`): ids are handed out in detection order and never reused.
+/// `last_keypoint_id` is the global landmark id space (
+/// ): ids are handed out in detection order and never reused.
 #[test]
 fn keypoint_ids_are_one_monotonic_space() {
     let mut flow: FrameToFrameOpticalFlow<Pattern51> = frontend(2, FrontendOptions::default());
@@ -131,12 +131,8 @@ fn gated_frontend(cameras: usize, ratio: f32) -> FrameToFrameOpticalFlow<Pattern
     FrameToFrameOpticalFlow::new(gated, &rig(cameras), FrontendOptions::default()).unwrap()
 }
 
-/// The gate's default is basalt's schedule (D75): `addPoints` on every
-/// frameset, so every frameset hands out ids.
-///
-/// This is the control the two tests below are read against — without it, a
-/// gated run that detects rarely could not be told from a rig that has nothing
-/// left to detect.
+/// At the default survivor ratio, detection runs every frameset (D75).
+/// This control distinguishes gated detection from a scene with no new corners.
 #[test]
 fn the_default_config_detects_on_every_frameset() {
     assert_eq!(VioConfig::default().port_redetect_survivor_ratio, 0.0);
@@ -388,7 +384,7 @@ fn redetection_keeps_its_baseline_after_a_rejected_frameset() {
     assert_eq!(faulty.last_keypoint_id(), clean.last_keypoint_id());
 }
 
-/// `updateCellCounts` / `addKeypoint` / `removeKeypoint` (`:707-749`) keep
+/// `updateCellCounts` / `addKeypoint` / `removeKeypoint` keep
 /// `cells` equal to the number of keypoints in each grid cell — except where
 /// `addKeypoints` deliberately double-counts, which cannot happen on camera 0.
 #[test]
@@ -487,9 +483,7 @@ fn two_runs_of_the_same_input_produce_the_same_frame() {
     assert_eq!(frames[0], frames[1]);
 }
 
-/// Trap 17: `getNumCams() >= 2` is a hard precondition in the C++
-/// (`optical_flow.h:210`). The port allows one camera and skips the passes
-/// that need a second.
+/// Single-camera rigs skip stereo passes (trap 17).
 #[test]
 fn a_single_camera_rig_detects_and_skips_matching() {
     let mut flow: FrameToFrameOpticalFlow<Pattern51> = frontend(1, FrontendOptions::default());
@@ -563,8 +557,7 @@ fn a_frameset_of_the_wrong_width_is_refused() {
     );
 }
 
-/// A `min_threshold` of zero or less wedges the detector, in C++ as much as
-/// here, so the frontend refuses the config instead of accepting it.
+/// Refuse non-positive detector minima to prevent an infinite halving loop.
 #[test]
 fn a_config_whose_threshold_ladder_never_ends_is_refused() {
     for min_threshold in [0, -1, i32::MIN] {
@@ -794,12 +787,8 @@ fn a_frame_of_the_wrong_size_commits_nothing() {
     assert!(shared > 0, "the kept frame was not tracked against");
 }
 
-/// Two identical framesets at negative timestamps track each other.
-///
-/// basalt reads `t_ns < 0` as "no previous frame" (`optical_flow.h:172`), so
-/// the port used to detect from scratch on every negative timestamp and hand
-/// out a fresh id space each time. The clock is an `Option` now, so `-2` and
-/// `-1` are ordinary timestamps and the second frameset tracks the first.
+/// An optional clock makes negative timestamps ordinary values.
+/// Two identical frames at negative times must track instead of resetting ids.
 #[test]
 fn identical_frames_at_negative_timestamps_keep_their_ids() {
     let images: [ImageU16; 2] = [dotted_image(0), dotted_image(0)];
@@ -835,7 +824,7 @@ fn identical_frames_at_negative_timestamps_keep_their_ids() {
     );
 }
 
-/// `keypoints.cpp:179`: a mask covering the frame leaves nothing to detect.
+/// a mask covering the frame leaves nothing to detect.
 #[test]
 fn a_mask_over_the_whole_frame_suppresses_detection() {
     let mut flow: FrameToFrameOpticalFlow<Pattern51> = frontend(2, FrontendOptions::default());
@@ -1098,8 +1087,8 @@ fn a_calibration_whose_occupancy_grid_is_past_the_ceiling_is_refused() {
     }
 }
 
-/// Every camera is detected on **its own** grid (`keypoints.cpp:140-144`),
-/// even though the occupancy matrix keeps camera 0's shape (`:119`).
+/// Every camera is detected on **its own** grid,
+/// even though the occupancy matrix keeps camera 0's shape.
 ///
 /// The review's probe: with 50-pixel cells a 200x200 camera starts at 0 and a
 /// 240x240 camera at 20, and those two grids disagree about a corner near

--- a/packages/slam-rs/crates/slam-rs/tests/frame_allocations.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/frame_allocations.rs
@@ -226,8 +226,8 @@ fn copying_the_warp_arrays_costs_nothing_once_warm() {
 /// threshold ladder — every cell of a grid row filters its own columns out of
 /// the same band, see `Band` in `frontend::detect` — over one detection pass per
 /// camera. Each scan costs one `Vec` per row of the band, allocated and freed
-/// (`features/fast.rs:465`, the `row_cap` buffer), plus the one
-/// `fast_detect_rect_u8` returns (`features/cells.rs:141`); 512 is the slack for
+/// (`features/fast.rs, the `row_cap` buffer), plus the one
+/// `fast_detect_rect_u8` returns (`features/cells.rs); 512 is the slack for
 /// everything else a frame touches.
 ///
 /// The count is `cameras x cell rows x rungs x rows-per-band`, which is the

--- a/packages/slam-rs/crates/slam-rs/tests/frame_allocations.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/frame_allocations.rs
@@ -226,8 +226,8 @@ fn copying_the_warp_arrays_costs_nothing_once_warm() {
 /// threshold ladder — every cell of a grid row filters its own columns out of
 /// the same band, see `Band` in `frontend::detect` — over one detection pass per
 /// camera. Each scan costs one `Vec` per row of the band, allocated and freed
-/// (`features/fast.rs, the `row_cap` buffer), plus the one
-/// `fast_detect_rect_u8` returns (`features/cells.rs); 512 is the slack for
+/// (`features/fast.rs`, the `row_cap` buffer), plus the one
+/// `fast_detect_rect_u8` returns (`features/cells.rs`); 512 is the slack for
 /// everything else a frame touches.
 ///
 /// The count is `cameras x cell rows x rungs x rows-per-band`, which is the

--- a/packages/slam-rs/crates/slam-rs/tests/full_clip.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/full_clip.rs
@@ -1,30 +1,11 @@
-//! Replay a **whole** reference segment through the port, in either precision.
+//! Optional whole-clip replay harness.
+//! Read images, IMU samples and calibration from a local clip dump and write
+//! trajectory CSV on the absolute device clock. Accuracy is evaluated outside
+//! this Rust test against ground truth.
 //!
-//! `vio_parity.rs` compares sixty framesets against the C++'s own per-frame
-//! dump, which is what the committed fixtures carry. That is too short to answer
-//! the question this file exists for: on a four-thousand-frameset clip the two
-//! implementations end centimetres apart, and sixty framesets cannot tell a
-//! divergence that grows from one that starts.
-//!
-//! So this runs the same pipeline over a clip dumped by
-//! `tests/tools/dump_clip.py` — every frameset's gray8 pixels, every inertial
-//! sample, and the calibration the C++ reference was handed — and writes the
-//! trajectory as a basalt CSV on the absolute device clock, which is what
-//! `gt.csv` and `basalt_traj.csv` use. The comparison itself is then ordinary
-//! ATE arithmetic outside this crate: nothing here asserts an accuracy number,
-//! because the clip and the reference it would be measured against are both
-//! machine-local.
-//!
-//! ```bash
-//! SLAM_RS_CLIP_DIR=<clip-dir> \
-//! SLAM_RS_CLIP_SCALAR=f64 \
-//! SLAM_RS_CLIP_OUT=<clip-dir>/slam_rs_f64.csv \
-//! SLAM_RS_CLIP_STATS=<clip-dir>/slam_rs_f64_stats.csv \
-//!   cargo test --release --test full_clip -- --nocapture
-//! ```
-//!
-//! Without `SLAM_RS_CLIP_DIR` the test prints why and passes: a clip is 7.5 GB
-//! of PGM for the Index stereo segments and is never committed.
+//! Set `SLAM_RS_CLIP_DIR`, `SLAM_RS_CLIP_SCALAR`, `SLAM_RS_CLIP_OUT` and optionally
+//! `SLAM_RS_CLIP_STATS`, then run `cargo test --release --test full_clip -- --nocapture`.
+//! Without a clip directory the harness reports that it did not replay a clip.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -66,13 +47,8 @@ fn read_imu(path: &Path) -> Vec<ImuRow> {
         .collect()
 }
 
-/// Drive one precision over the whole clip and write the trajectory, and the
-/// per-frameset decisions when a path is given for them.
-///
-/// Every inertial sample is pushed before the first frameset. The retry gate in
-/// `vio_parity.rs` is the evidence that this is the same trajectory a live feed
-/// gives: a frameset the estimator refuses is held and tracked again, so arrival
-/// order cannot reach the poses.
+/// Replay one scalar lane and write trajectory and optional per-frame decisions.
+/// IMU input may be preloaded or delivered per frame to check arrival-order independence.
 fn replay<S: LieScalar>(
     clip: &Clip,
     directory: &Path,
@@ -91,11 +67,8 @@ fn replay<S: LieScalar>(
         },
     )
     .unwrap();
-    // Either the whole window before the first frameset, or the samples each
-    // frameset needs plus the one past it, which is how a live feed arrives.
-    // `vio_parity.rs`'s retry gate says the two give the same trajectory; over a
-    // whole clip that is a claim worth checking rather than assuming, so it is
-    // an option here and the report quotes the comparison.
+    // Select preloaded IMU or per-frame coverage including the first later sample.
+    // Both delivery modes should produce the same trajectory.
     let mut cursor: usize = 0;
     if !streamed {
         for row in imu {
@@ -216,9 +189,8 @@ fn the_whole_clip_replays_into_a_trajectory_csv() {
         .map(PathBuf::from)
         .unwrap_or_else(|| directory.join(format!("slam_rs_{}.csv", scalar.rust_name())));
     let stats: Option<PathBuf> = std::env::var_os("SLAM_RS_CLIP_STATS").map(PathBuf::from);
-    // The clip's own `calib.json` unless another file in it is named: the
-    // provenance of the calibration is itself a perturbation worth measuring,
-    // since the catalog stores float32 where the fork's file has doubles.
+    // Use the clip calibration unless overridden. Catalog f32 statics and calibration
+    // JSON doubles can differ, so the selected calibration is part of the input.
     let calibration: PathBuf = directory
         .join(std::env::var("SLAM_RS_CLIP_CALIB").unwrap_or_else(|_| "calib.json".to_string()));
     println!(

--- a/packages/slam-rs/crates/slam-rs/tests/gpu_detect.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/gpu_detect.rs
@@ -364,8 +364,7 @@ mod numerical_selection {
             ExpectedPath::BandWalk,
         );
 
-        // The port's own cap, checked where the C++ checks its cell budget: the
-        // truncation must fall in the same place in the same scan order.
+        // Capacity truncation must retain detector scan order.
         for budget in [1usize, 7, 40] {
             detection_agrees(
                 DetectionCase {

--- a/packages/slam-rs/crates/slam-rs/tests/gpu_kernels.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/gpu_kernels.rs
@@ -545,7 +545,7 @@ fn the_gpu_tracker_recovers_the_same_shift_as_the_cpu() {
 /// A track onto an unrelated frame fails on both lanes, and fails the same way.
 ///
 /// The CPU suite's `a_mismatched_pair_is_rejected` at the seam: the
-/// forward-backward gate (`frame_to_frame_optical_flow.h:362-364`) is what
+/// forward-backward gate is what
 /// rejects a track onto an image the patch is not in, and it is the one exit
 /// the grid fixture above never takes. A backend that let a failed track
 /// through — or that failed a different set of patches from the CPU's — would
@@ -585,7 +585,7 @@ fn both_lanes_reject_a_track_onto_an_unrelated_frame() {
 /// Two thresholds meet near an edge and the grid fixture is built to stay away
 /// from both: the patch build needs its 52 taps in range at every level, and
 /// each Gauss-Newton step needs the new centre `FILTER_MARGIN = 2` pixels inside
-/// *that level's* image (`frame_to_frame_optical_flow.h:430`). At the coarsest
+/// *that level's* image. At the coarsest
 /// of four levels a 512-pixel frame is 64 wide, so the margin is 16 full-
 /// resolution pixels; this walks a column from 4 to 60 pixels from the left
 /// edge, which crosses it, and asserts the two lanes take the same branch at
@@ -629,7 +629,7 @@ fn both_lanes_agree_at_the_border_margin() {
 /// displaced between 4 and 28 pixels is inside the frame and straddles what
 /// four pyramid levels recover from this texture, so it is the tracker's own
 /// convergence that decides and it decides both ways; a guess at a negative
-/// coordinate is refused before any level runs (`optical_flow.h:346`, the
+/// coordinate is refused before any level runs (the
 /// `t2(0) >= 0 && ... < w` gate). Both lanes must take all three exits
 /// identically.
 #[test]
@@ -773,7 +773,7 @@ fn a_reused_corner_scan_carries_only_the_newest_frame() {
 ///
 /// The corner scanner and the pyramid builder are handed the same pixels once
 /// per camera per frameset — the detector's input *is* level 0
-/// (`keypoints.cpp:152`, `image_pyr.h:73`) — and until the camera index reached
+///  — and until the camera index reached
 /// both seams the GPU scanner had no way to know that, so it uploaded the frame
 /// a second time. This is the test that the sharing is exact rather than merely
 /// cheaper: the same corners at every rung, from a scanner that uploaded zero

--- a/packages/slam-rs/crates/slam-rs/tests/klt_tracker.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/klt_tracker.rs
@@ -158,23 +158,12 @@ fn an_integer_shift_is_recovered() {
     }
 }
 
-/// A sub-pixel shift, up to the pattern's own radius.
-///
-/// The tolerance is not the tracker's convergence — it converges to five
-/// decimal places in three iterations — but the **bias of the fixed point
-/// itself**. `interp` reconstructs the image bilinearly and `interpGrad`
-/// differentiates that reconstruction by central differences
-/// (`image.h:396-469`), so for a shift that is not a whole number of samples
-/// the residual vanishes not at the true shift but a little beside it.
-///
-/// The size of that displacement depends only on the **fractional** part of
-/// the shift, not on its magnitude: on this texture an exactly integer shift
-/// is recovered to `0.0000` px, a shift of 0.02 px to 0.0004, and a shift of
-/// half a pixel to 0.035 on the median patch and 0.13 on the worst — the same
-/// numbers whether the shift is 0.5 or 3.5 pixels. Shortening the texture's
-/// wavelengths raises the floor and lengthening them makes the patches
-/// ill-conditioned instead; basalt's C++ has the same property, because this
-/// is its arithmetic. The gate is therefore the median, with a cap on the tail.
+/// Subpixel tracking has interpolation bias as well as convergence error.
+/// Bilinear values and unit-step central-difference gradients can put the fixed
+/// point beside the true shift. The error depends on fractional shift: integer
+/// shifts recover exactly while half-pixel shifts are harder. Shorter texture
+/// wavelengths raise bias; longer ones weaken conditioning. Check the median
+/// and cap the tail instead of equating bias with optimizer convergence.
 fn sub_pixel_shift_error(dx: f32, dy: f32) -> (f32, f32, usize, usize) {
     let levels: usize = 3;
     let scene: Fixture = fixture(dx, dy, levels);
@@ -213,7 +202,7 @@ fn a_sub_pixel_shift_is_recovered() {
     assert!(worst < 0.2, "worst error {worst}");
 }
 
-/// The forward-backward gate (`frame_to_frame_optical_flow.h:362-364`) is
+/// The forward-backward gate is
 /// what rejects a track onto an unrelated image.
 #[test]
 fn a_mismatched_pair_is_rejected() {

--- a/packages/slam-rs/crates/slam-rs/tests/linearize_reference.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/linearize_reference.rs
@@ -1,43 +1,12 @@
-//! basalt's own linearization tests, ported.
+//! Linearization invariants checked against independent dense algebra.
+//! The dense Schur reference builds `[J_p | J_l]` and eliminates landmarks
+//! explicitly. Compare objective, Hessian, gradient, back-substitution and model
+//! cost decrease. Also check square-root reconstruction identities and QR versus
+//! Cholesky up to row signs, including rank-deficient QR cases.
 //!
-//! `test/src/test_linearization.cpp` has four tests and
-//! `test/src/test_qr.cpp` three. Every one of them checks `ABS_QR` against a
-//! *second implementation* — `LinearizationAbsSC`, `LinearizationRelSC`, or
-//! Eigen's `HouseholderQR` and `LLT`. Only `ABS_QR` is in this port
-//! (decision D13), so the second implementation has to come from somewhere else:
-//!
-//! * **`VoNoMargLinearizationTest`, `VoMargLinearizationTest`** compare the
-//!   error, `H` and `b` of the three linearizations at 1e-8
-//!   (`test_linearization.cpp:147-161`, `:211-225`). Here the reference is
-//!   [`dense_schur_reference`] below: the whole problem written out as one dense
-//!   `[J_p | J_l]` per landmark and eliminated with an explicit Schur complement
-//!   `H = J_pᵀJ_p − J_pᵀJ_l (J_lᵀJ_l)⁻¹ J_lᵀJ_p`. That is what
-//!   `LinearizationAbsSC` computes; it is 40 lines here and it shares no code
-//!   with the thing under test, which is the whole point of the C++ test.
-//! * **`VoMargBacksubstituteTest`** additionally solves `inc = −H⁻¹b` and
-//!   compares the three `l_diff` values (`:290-297`). The reference `l_diff` is
-//!   the model cost change of the same dense system, with the landmark
-//!   increments recovered by Schur back-substitution.
-//! * **`VoMargSqrtLinearizationTest`** is the square-root identity
-//!   `Q₂ᵀJ_p` ᵀ`Q₂ᵀJ_p = H` and `Q₂ᵀJ_p` ᵀ`Q₂ᵀr = b` at 1e-3 / 1e-5
-//!   (`:379-388`). That one needs no second implementation at all and is ported
-//!   as it stands, with basalt's own tolerances.
-//! * **`QRvsLLT`, `QRvsLLTRankDef`** (`test_qr.cpp:9-35`) print `R` from a
-//!   Householder QR next to `Lᵀ` from the Cholesky of `JᵀJ` and assert nothing.
-//!   Ported as the assertion they demonstrate: the two agree row by row up to a
-//!   sign, and the port's own [`slam_rs`] Householder is what builds `R`.
-//! * **`RankDefLeastSquares`** (`:38-119`) is a marginalization test: it drives
-//!   `MargHelper::marginalizeHelperSq*`, which is stage S7. **Not ported here**;
-//!   it belongs with the code it tests.
-//!
-//! The problem itself is basalt's (`test_linearization.cpp:9-76`): six frames,
-//! two cameras sharing `KannalaBrandtCamera4::getTestProjections()[0]`, ten
-//! landmarks hosted per frame, every landmark observed in **every** image, a
-//! pixel of noise on each observation, `huber_thresh = 0.5`,
-//! `obs_std_dev = 2.0`. Eigen's `Random()` is replaced by a seeded xorshift, for
-//! the same reason the IMU tests replace it: `Random()` never reseeds, so the
-//! C++ test is deterministic too, and a Rust test that flakes is worse than one
-//! that is merely differently arbitrary.
+//! The seeded problem has six frames, two kb4 cameras and ten hosted landmarks
+//! per frame, observed across all images. Deterministic noise and fixed robust
+//! weights keep failures reproducible without external fixtures.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -59,7 +28,7 @@ use slam_rs::types::{
 mod common;
 use common::{Rng, test_calibration};
 
-/// The window `get_vo_estimator` builds (`test_linearization.cpp:9-76`), plus
+/// The window `get_vo_estimator` builds, plus
 /// the ordering it fills in.
 struct Problem {
     estimator: BundleAdjustmentBase<f64>,
@@ -67,14 +36,14 @@ struct Problem {
     marg: Option<MargLinData<f64>>,
 }
 
-/// `get_vo_estimator(num_frames, estimator, aom)` (`:9-76`).
+/// `get_vo_estimator(num_frames, estimator, aom)`.
 fn vo_problem(num_frames: usize, seed: u64) -> Problem {
     let mut rng: Rng = Rng::new(seed);
 
-    // `:15-22`: the two camera-to-IMU transforms and both intrinsics.
+    // the two camera-to-IMU transforms and both intrinsics.
     let calib: Calibration<f64> = test_calibration(&mut rng);
 
-    // `:25-26`: the 3-D points, five metres in front.
+    // the 3-D points, five metres in front.
     let points: Vec<Vector3<f64>> = (0..num_frames * 10)
         .map(|_| {
             let mut p: Vector3<f64> = rng.vector3();
@@ -83,7 +52,7 @@ fn vo_problem(num_frames: usize, seed: u64) -> Problem {
         })
         .collect();
 
-    // `:31-40`: the poses.
+    // the poses.
     let mut estimator: BundleAdjustmentBase<f64> =
         BundleAdjustmentBase::new(calib, 2.0, 0.5).unwrap();
     let mut aom: AbsOrderMap = AbsOrderMap::new();
@@ -99,13 +68,13 @@ fn vo_problem(num_frames: usize, seed: u64) -> Problem {
             .insert(i as i64, PoseStateWithLin::new(i as i64, t_w_i, false));
     }
 
-    // `:42-74`: ten landmarks hosted per frame, each seen in every image.
+    // ten landmarks hosted per frame, each seen in every image.
     for i in 0..num_frames {
         for j in 0..10 {
             let kp_idx: usize = 10 * i + j;
             let p3d: Vector3<f64> = points[kp_idx];
 
-            // `:47-52`: the landmark in its host camera's frame.
+            // the landmark in its host camera's frame.
             let t_c_w: Se3<f64> = (poses[i] * estimator.calib.t_i_c[0]).inverse();
             let p3d_cam: Vector3<f64> = t_c_w * p3d;
             let id: LandmarkId = LandmarkId(kp_idx as u64);
@@ -117,7 +86,7 @@ fn vo_problem(num_frames: usize, seed: u64) -> Problem {
             );
             estimator.lmdb.add_landmark(id, &landmark);
 
-            // `:56-73`: an observation in every image of every frame.
+            // an observation in every image of every frame.
             for (f, pose) in poses.iter().enumerate() {
                 for c in 0..2 {
                     let t_c_w: Se3<f64> = (*pose * estimator.calib.t_i_c[c]).inverse();
@@ -130,7 +99,7 @@ fn vo_problem(num_frames: usize, seed: u64) -> Problem {
                         &mut jacobian,
                     );
                     assert!(ok, "the synthetic problem must project");
-                    // `:65`: `Random() / 100` pixels of noise.
+                    // `Random() / 100` pixels of noise.
                     pixel[0] += rng.symmetric() / 100.0;
                     pixel[1] += rng.symmetric() / 100.0;
                     estimator
@@ -149,7 +118,7 @@ fn vo_problem(num_frames: usize, seed: u64) -> Problem {
     }
 }
 
-/// `get_vo_estimator_with_marg` (`test_linearization.cpp:78-100`): the same
+/// `get_vo_estimator_with_marg` : the same
 /// window, plus a prior over the first two frames and both of them frozen at
 /// their linearization point with a non-zero delta.
 fn vo_problem_with_marg(num_frames: usize, seed: u64) -> Problem {
@@ -157,18 +126,17 @@ fn vo_problem_with_marg(num_frames: usize, seed: u64) -> Problem {
     let mut rng: Rng = Rng::new(seed ^ 0x5eed);
 
     let marg_size: usize = 2 * POSE_SIZE;
-    // `:85-89`: `H = 1e6 I`, `b = 10 * Random()`.
+    // `H = 1e6 I`, `b = 10 * Random()`.
     let mut h: DMatrix<f64> = DMatrix::identity(marg_size, marg_size);
     h *= 1e6;
     let b: DVector<f64> =
         DVector::from_iterator(marg_size, (0..marg_size).map(|_| rng.symmetric() * 10.0));
 
-    // `:91-93`.
     let mut order: AbsOrderMap = AbsOrderMap::new();
     order.push(0, POSE_SIZE).unwrap();
     order.push(1, POSE_SIZE).unwrap();
 
-    // `:95-99`: freeze, then drift.
+    // freeze, then drift.
     for frame_id in [0i64, 1] {
         let pose = problem.estimator.frame_poses.get_mut(&frame_id).unwrap();
         pose.set_linearized().unwrap();
@@ -270,7 +238,6 @@ fn dense_schur_reference(
                 continue;
             }
 
-            // `landmark_block_abs_dynamic.hpp:456-470` and `:168-179`.
             let res_squared: f64 = res.norm_squared();
             let weight: f64 = if res_squared <= huber * huber {
                 1.0
@@ -315,7 +282,6 @@ fn dense_schur_reference(
     // The model cost change of the same dense system: recover each landmark's
     // increment by Schur back-substitution, then
     // `l_diff = -(J inc)ᵀ (r + 0.5 (J inc))`
-    // (`landmark_block_abs_dynamic.hpp:276-320`).
     let marg: Option<MargLinData<f64>> = problem.marg.clone();
     let delta: Option<DVector<f64>> = marg
         .as_ref()
@@ -365,7 +331,7 @@ fn linearize(problem: &Problem) -> (f64, LinearizationAbsQR<f64>) {
     (error, lqr)
 }
 
-/// `VoNoMargLinearizationTest` (`test_linearization.cpp:103-162`): the error,
+/// `VoNoMargLinearizationTest` : the error,
 /// `H` and `b` agree with a second implementation to 1e-8.
 #[test]
 fn vo_no_marg_linearization() {
@@ -376,7 +342,7 @@ fn vo_no_marg_linearization() {
 
     let (error_ref, h_ref, b_ref, _) = dense_schur_reference(&problem);
 
-    // basalt's own tolerances (`:155-157`).
+    // Fixed comparison tolerances.
     assert!(
         (error_qr - error_ref).abs() <= 1e-8,
         "{error_qr} vs {error_ref}"
@@ -393,7 +359,7 @@ fn vo_no_marg_linearization() {
     );
 }
 
-/// `VoMargLinearizationTest` (`:165-227`): the same with a marginalization
+/// `VoMargLinearizationTest` : the same with a marginalization
 /// prior and two frozen linearization points.
 #[test]
 fn vo_marg_linearization() {
@@ -411,8 +377,8 @@ fn vo_marg_linearization() {
         (error_qr - error_ref).abs() <= 1e-8,
         "{error_qr} vs {error_ref}"
     );
-    // The prior's `H` is `1e6 I`, so the absolute norm of `H` is around 1e12 and
-    // basalt's own absolute 1e-8 would be a 1e-20 relative demand. Scaled.
+    // Scale tolerance by the information norm: the prior Jacobian `1e6 I` yields
+    // information near `1e12`, where an absolute `1e-8` bound is inappropriate.
     let scale: f64 = h_ref.norm().max(1.0);
     assert!(
         (&h_qr - &h_ref).norm() <= 1e-8 * scale,
@@ -426,7 +392,7 @@ fn vo_marg_linearization() {
     );
 }
 
-/// `VoMargBacksubstituteTest` (`:230-308`): solve, back-substitute, and compare
+/// `VoMargBacksubstituteTest` : solve, back-substitute, and compare
 /// the model cost change against the second implementation.
 #[test]
 fn vo_marg_backsubstitute() {
@@ -440,7 +406,7 @@ fn vo_marg_backsubstitute() {
 
     let (_, _, _, l_diff_of) = dense_schur_reference(&problem);
 
-    // `:290`: `inc = -H.ldlt().solve(b)`.
+    // `inc = -H.ldlt().solve(b)`.
     let inc: DVector<f64> = -h.clone().lu().solve(&b).expect("the system is solvable");
     let l_diff_ref: f64 = l_diff_of(&inc);
 
@@ -462,7 +428,7 @@ fn vo_marg_backsubstitute() {
     );
 
     // The increment really does help: apply it to the poses too and the
-    // reprojection error drops. `:299-306` compares `computeError` across the
+    // reprojection error drops. compares `computeError` across the
     // three estimators; with one estimator, the meaningful statement is that the
     // step the model predicted a decrease for delivers one.
     assert!(l_diff_qr > 0.0, "the solved step must predict a decrease");
@@ -479,8 +445,7 @@ fn vo_marg_backsubstitute() {
     );
 }
 
-/// `VoMargSqrtLinearizationTest` (`:311-394`): the square-root identity
-/// `Q₂ᵀJ_pᵀ Q₂ᵀJ_p = H` and `Q₂ᵀJ_pᵀ Q₂ᵀr = b`, at basalt's own 1e-3 and 1e-5.
+/// Check `Q₂J_pᵀ Q₂J_p = H` and `Q₂J_pᵀ Q₂r = b` at `1e-3` and `1e-5`.
 #[test]
 fn vo_marg_sqrt_linearization() {
     let problem: Problem = vo_problem_with_marg(6, 0x1234_5678);
@@ -492,14 +457,13 @@ fn vo_marg_sqrt_linearization() {
     let (h, b) = lqr.get_dense_h_b(&problem.estimator, &inputs).unwrap();
     let (q2jp, q2r) = lqr.get_dense_q2jp_q2r(&problem.estimator, &inputs).unwrap();
 
-    // `:380-383`.
     let h_diff: f64 = (q2jp.transpose() * &q2jp - &h).norm();
     let b_diff: f64 = (q2jp.transpose() * &q2r - &b).norm();
     assert!(h_diff <= 1e-3, "H differs by {h_diff}");
     assert!(b_diff <= 1e-5, "b differs by {b_diff}");
 }
 
-/// `QRvsLLT` and `QRvsLLTRankDef` (`test_qr.cpp:9-35`), as the assertion they
+/// `QRvsLLT` and `QRvsLLTRankDef`, as the assertion they
 /// demonstrate: for a `10 x 6` `J`, the `R` of a Householder QR and the `Lᵀ` of
 /// the Cholesky of `JᵀJ` agree row by row up to a sign.
 ///
@@ -516,21 +480,19 @@ fn householder_qr_matches_the_cholesky_of_the_normal_equations() {
             }
         }
         if rank_deficient {
-            // `test_qr.cpp:26`: `J.col(2) = J.col(4)`.
+            // `J.col(2) = J.col(4)`.
             let col4: DVector<f64> = j.column(4).into_owned();
             j.set_column(2, &col4);
         }
 
         // The port has no standalone QR — the landmark block eliminates exactly
         // three columns — so the reflections are driven here the way
-        // `performQRHouseholder` drives them (`landmark_block_abs_dynamic.hpp:445-453`).
+        // `performQRHouseholder` drives them.
         let r_qr: DMatrix<f64> = householder_r(&j);
         let ata: DMatrix<f64> = j.transpose() * &j;
 
         if rank_deficient {
-            // `JᵀJ` is singular, so there is no Cholesky; what survives is that
-            // the QR still produces an upper-triangular `R` with `RᵀR = JᵀJ`,
-            // which is the point the C++ test prints.
+            // For singular `JᵀJ`, QR still yields triangular `R` with `RᵀR = JᵀJ`.
             let rtr: DMatrix<f64> = r_qr.transpose() * &r_qr;
             assert!(
                 (&rtr - &ata).norm() <= 1e-9 * ata.norm(),
@@ -634,26 +596,10 @@ fn the_q2_rows_are_orthogonal_to_the_landmark_columns() {
     }
 }
 
-/// `backSubstitute` returns the *linearized* cost decrease, and it is not the
-/// reduced system's decrease alone.
-///
-/// For one block with the orthogonal `Q = [Q₁, Q₂]` and the optimal landmark
-/// increment `R inc_l = −(Q₁ᵀr + Q₁ᵀJ_p inc_p)`, the first three rows of
-/// `Qᵀ J inc` are `−Q₁ᵀr` — so the *updated residual* `Qᵀ J inc + Qᵀ r` is zero
-/// there, which is what "the landmarks move to their own optimum" means — and
-///
-/// ```text
-/// l_diff = 0.5 ‖Q₁ᵀr‖²  −  inc_pᵀ b  −  0.5 inc_pᵀ H inc_p
-/// ```
-///
-/// with `H` and `b` the reduced camera system. The first term does not depend on
-/// the pose increment at all: it is what the landmarks gain by moving to their
-/// own optimum, and it is why basalt's `l_diff` is **nonnegative at `inc = 0`**
-/// — zero exactly when the eliminated residual `Q₁ᵀr` already is.
-/// The identity is `landmark_block_abs_dynamic.hpp:276-320` written out, and
-/// getting the constant term wrong would make every Levenberg-Marquardt gain
-/// ratio wrong in the same direction — which is exactly the kind of bug that
-/// still converges, only worse.
+/// Back-substitution predicts landmark gain as well as reduced camera gain:
+/// `l_diff = 0.5 ‖Q₁ᵀr‖² - inc_pᵀ b - 0.5 inc_pᵀ H inc_p`.
+/// The first term is independent of pose motion and nonnegative at zero increment.
+/// Omitting it biases every LM gain ratio even if the optimizer still converges.
 #[test]
 fn back_substitution_reduces_the_linearized_cost() {
     let mut problem: Problem = vo_problem(3, 0x0f0f_0f0f);
@@ -673,9 +619,7 @@ fn back_substitution_reduces_the_linearized_cost() {
         })
         .sum();
 
-    // The Gauss-Newton step, and basalt's sign convention: the solve gives
-    // `H inc = b`, and the increment applied is its negation
-    // (`sqrt_keypoint_vio.cpp:1450`).
+    // Solve `H inc = b`, then negate the increment before applying it.
     let inc: DVector<f64> = -h.clone().lu().solve(&b).expect("solvable");
     let quadratic: f64 =
         -(inc.transpose() * &b)[(0, 0)] - 0.5 * (inc.transpose() * &h * &inc)[(0, 0)];
@@ -718,16 +662,9 @@ fn back_substitution_reduces_the_linearized_cost() {
     );
 }
 
-/// First-estimate Jacobians (`linearization_abs_qr.cpp:229-232`, trap 7): once a
-/// frame is frozen, moving its current state changes the relative pose's
-/// **value** and leaves `d_rel_d_h` and `d_rel_d_t` exactly as they were.
-///
-/// Note what this does **not** say. `d_res_d_xi` comes out of `linearizePoint`
-/// against the re-evaluated `T_t_h` (`landmark_block_abs_dynamic.hpp:148`), so
-/// the block's own Jacobian columns do move; what is frozen is the pose
-/// composition, which is the only place basalt applies the first-estimate rule.
-/// A test that demanded frozen block columns would be testing a property basalt
-/// does not have.
+/// First-estimate Jacobians freeze relative-pose composition derivatives while
+/// reevaluating the relative-pose value at current states. Reprojection Jacobians
+/// can still change with that value; the complete block columns are not frozen.
 #[test]
 fn freezing_a_state_freezes_its_pose_jacobians_but_not_its_residuals() {
     let base: Problem = vo_problem_with_marg(4, 0x2222_3333);
@@ -806,11 +743,8 @@ fn the_reductions_are_reproducible() {
     }
 }
 
-/// The square-root export writes the prior into the *first* columns of the
-/// stacked system (`linearization_abs_qr.cpp:587-589`), so it is only correct
-/// when the prior's ordering is the window's prefix. C++ checks that in the
-/// Hessian path (`ba_base.cpp:383-388`) and not in the square-root one, where a
-/// disagreeing ordering silently attaches one frame's columns to another.
+/// The square-root prior export requires its ordering to be the window prefix;
+/// otherwise frame columns attach to the wrong variables.
 #[test]
 fn a_prior_ordering_that_disagrees_is_refused_by_both_exports() {
     let mut problem: Problem = vo_problem_with_marg(4, 0x3333_4444);
@@ -835,18 +769,15 @@ fn a_prior_ordering_that_disagrees_is_refused_by_both_exports() {
         lqr.get_dense_h_b(&problem.estimator, &inputs),
         Err(LinearizeError::Ba(BaError::MargOrderMismatch { .. }))
     ));
-    // ...and now so does the square-root path.
+    // and now so does the square-root path.
     assert!(matches!(
         lqr.get_dense_q2jp_q2r(&problem.estimator, &inputs),
         Err(LinearizeError::Ba(BaError::MargOrderMismatch { .. }))
     ));
 }
 
-/// An IMU factor is fifteen columns wide at each end (`imu_block.hpp:21`), and
-/// C++ discards the ordering's block sizes (`linearization_abs_qr.cpp:163-167`)
-/// and computes `start_t + dt` unchecked (`imu_block.hpp:30`). With pose-sized
-/// slots the scatter writes over the neighbouring state; the port refuses at
-/// construction, where it costs nothing.
+/// IMU factors require 15 columns at each endpoint and a non-overflowing end time.
+/// Reject pose-sized slots at construction before scatter can overwrite neighbors.
 #[test]
 fn an_imu_factor_over_pose_sized_slots_is_refused() {
     // A one-nanosecond measurement, so its endpoints are the two frames
@@ -941,7 +872,7 @@ fn an_imu_factor_over_pose_sized_slots_is_refused() {
     ));
 }
 
-/// The block layout arithmetic of `landmark_block_abs_dynamic.hpp:83-96` on
+/// The block layout arithmetic of on
 /// every ordering size, not just the ones the fixture happens to use.
 #[test]
 fn the_block_layout_follows_the_padding_rule() {

--- a/packages/slam-rs/crates/slam-rs/tests/marg_window.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/marg_window.rs
@@ -1,31 +1,9 @@
-//! The sliding-window marginalization mechanics, on a synthetic window.
-//!
-//! `sqrt_keypoint_vio.cpp:896-1178` has no unit test in basalt — the C++ only
-//! exercises it through a whole VIO run — so these are the port's own, written
-//! against properties the C++ code has rather than against a fixture. The
-//! helper itself is pinned coefficient for coefficient in
-//! `tests/marg_oracle.rs`.
-//!
-//! The window is the shape the estimator really marginalizes: two keyframes as
-//! 6-dof pose blocks, three frames as 15-dof states, forty landmarks — thirty
-//! hosted by the keyframe that leaves, ten by the one that stays — and each
-//! observed in every image of the frames inside the ordering plus, for a few of
-//! them, one image of the frame **outside** it, which is the "observation
-//! dropped for marginalization" path of
-//! `landmark_block_abs_dynamic.hpp:70-75`.
-//!
-//! What is checked:
-//!
-//! | test | what it pins |
-//! |---|---|
-//! | `marginalizing_a_keyframe_shrinks_the_window` | the frame maps, the landmark database, the new ordering, `setLinTrue`, the consumed IMU intervals |
-//! | `the_prior_is_the_schur_complement_of_the_window` | `J_mᵀJ_m` is the dense Schur complement of the same system, and the two agree on the kept variables' optimum |
-//! | `the_prior_is_re_anchored_on_the_delta` | `marg_data.b -= marg_data.H * delta` (`:1170-1172`, trap 8) against the un-anchored residual the helper returned |
-//! | `the_prior_error_is_the_quadratic_at_the_delta` | `computeMargPriorError` after `applyInc` equals the quadratic model evaluated at the accumulated delta |
-//! | `a_window_that_disagrees_with_the_prior_is_refused` | the ordering assertions of `:736` and `:758-759` |
-//! | `an_invalid_schedule_is_refused_before_anything_changes` | eight broken schedules, each a typed error with the window bit-identical afterwards |
-//! | `a_window_that_is_not_frozen_is_refused_before_anything_changes` | a valid schedule over a block that is not at its linearization point, either kind, refused with the window bit-identical afterwards |
-//! | `a_frozen_demoted_state_marginalizes` | the control: the same schedule, and the demotion it performs |
+//! Sliding-window marginalization on a synthetic window.
+//! Two pose keyframes, three full states and forty landmarks exercise removals,
+//! demotion and observations outside the ordering. Check the resulting maps and
+//! prior against dense Schur elimination, residual re-anchoring and the quadratic
+//! at accumulated delta. Invalid schedules and unfrozen blocks must be refused
+//! before mutation; a valid frozen demotion must succeed.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -76,7 +54,7 @@ fn pose_at(index: usize, rng: &mut Rng) -> Se3<f64> {
 ///
 /// `prior_covers_state0` chooses between the two shapes the estimator really
 /// sees: a steady-state prior over both keyframes **and** the state that
-/// entered it last (`sqrt_keypoint_vio.cpp:1120-1133` produces exactly that),
+/// entered it last ( produces exactly that),
 /// and an empty prior over the keyframes alone, which is what a window looks
 /// like before the first state has been marginalized.
 fn build_window(seed: u64, prior_covers_state0: bool) -> Window {
@@ -94,7 +72,7 @@ fn build_window(seed: u64, prior_covers_state0: bool) -> Window {
         poses.push(t_w_i);
         if *frame_id == KF0 || *frame_id == KF1 {
             // Both keyframes are in the prior, so both are frozen at their
-            // linearization point (`computeDelta` asserts it, `ba_base.cpp:294`).
+            // linearization point (`computeDelta` asserts it).
             estimator
                 .frame_poses
                 .insert(*frame_id, PoseStateWithLin::new(*frame_id, t_w_i, true));
@@ -170,7 +148,6 @@ fn build_window(seed: u64, prior_covers_state0: bool) -> Window {
     add_landmarks(&mut estimator, &mut rng, 1, 1000, 10);
 
     // The prior. Its ordering is a prefix of the window's, at the same offsets
-    // (`sqrt_keypoint_vio.cpp:736`, `:758-759`).
     let mut order: AbsOrderMap = AbsOrderMap::new();
     order.push(KF0, POSE_SIZE).unwrap();
     order.push(KF1, POSE_SIZE).unwrap();
@@ -224,7 +201,7 @@ fn schedule() -> MarginalizeSchedule {
 }
 
 /// The schedule that demotes: `STATE1` keeps its pose block and loses its
-/// velocity and biases (`:1098-1105`), so `STATE2` becomes the prior's newest
+/// velocity and biases, so `STATE2` becomes the prior's newest
 /// block.
 fn demote_state1() -> MarginalizeSchedule {
     MarginalizeSchedule {
@@ -269,7 +246,7 @@ fn window_debug(window: &Window) -> String {
 
 // ─── the tests ─────────────────────────────────────────────────────────────
 
-/// `sqrt_keypoint_vio.cpp:1085-1137`: what the window looks like afterwards.
+/// what the window looks like afterwards.
 #[test]
 fn marginalizing_a_keyframe_shrinks_the_window() {
     let mut window: Window = build_window(0xB00C, true);
@@ -279,12 +256,12 @@ fn marginalizing_a_keyframe_shrinks_the_window() {
     let out: MarginalizeOutput<f64> = run(&mut window, MarginalizeOptions::default());
 
     // The ordering the marginalization ran over stops at `last_state_to_marg`
-    // (`:745`): two poses and two states, not three.
+    // two poses and two states, not three.
     assert_eq!(out.aom.items(), 4);
     assert_eq!(out.aom.total_size(), 2 * POSE_SIZE + 2 * POSE_VEL_BIAS_SIZE);
     assert!(!out.aom.contains(STATE2), "the newest state is outside it");
 
-    // `:980-1003`: the split covers every column exactly once.
+    // the split covers every column exactly once.
     assert_eq!(
         out.idx_to_keep.len() + out.idx_to_marg.len(),
         out.aom.total_size()
@@ -295,7 +272,6 @@ fn marginalizing_a_keyframe_shrinks_the_window() {
     assert_eq!(out.idx_to_keep.len(), POSE_SIZE + POSE_VEL_BIAS_SIZE);
     assert!(out.numerically_valid);
 
-    // `:1107-1112` and `:1090-1096`.
     assert_eq!(
         window
             .estimator
@@ -315,13 +291,13 @@ fn marginalizing_a_keyframe_shrinks_the_window() {
         vec![STATE1, STATE2]
     );
 
-    // `:1085-1088`, trap 7: the state entering the prior is frozen, and its
+    // trap 7: the state entering the prior is frozen, and its
     // delta is still zero, so it contributes nothing to the re-anchoring.
     let state1 = window.estimator.frame_states.get(&STATE1).unwrap();
     assert!(state1.is_linearized());
     assert_eq!(*state1.delta(), nalgebra::SVector::<f64, 15>::zeros());
 
-    // `:1114`: every landmark hosted by the marginalized keyframe is gone, and
+    // every landmark hosted by the marginalized keyframe is gone, and
     // the ten hosted by the surviving one are not.
     assert_eq!(window.estimator.lmdb.num_landmarks(), 10);
     for id in 0..30u64 {
@@ -330,7 +306,7 @@ fn marginalizing_a_keyframe_shrinks_the_window() {
     for id in 1000..1010u64 {
         assert!(window.estimator.lmdb.landmark_exists(LandmarkId(id)));
     }
-    // ...and no observation is left in a frame that left the window.
+    // and no observation is left in a frame that left the window.
     for targets in window.estimator.lmdb.observations().values() {
         for tcid in targets.keys() {
             assert_ne!(tcid.frame_id, KF0);
@@ -338,13 +314,13 @@ fn marginalizing_a_keyframe_shrinks_the_window() {
         }
     }
 
-    // `:1094`: the interval that started at the marginalized state is consumed.
+    // the interval that started at the marginalized state is consumed.
     assert_eq!(
         window.imu_meas.keys().copied().collect::<Vec<_>>(),
         vec![STATE1]
     );
 
-    // `:1120-1137`: the new prior's ordering is the window that survives.
+    // the new prior's ordering is the window that survives.
     assert_eq!(window.marg.order.items(), 2);
     assert_eq!(window.marg.order.get(KF1), Some((0, POSE_SIZE)));
     assert_eq!(
@@ -365,7 +341,7 @@ fn marginalizing_a_keyframe_shrinks_the_window() {
 /// forms it, takes the dense Schur complement over the same index split, and
 /// checks that the square-root prior squares to it. That is the same argument
 /// `VoMargSqrtLinearizationTest` makes about the linearization
-/// (`test_linearization.cpp:379-388`), one level up.
+/// one level up.
 ///
 /// It also checks the statement that matters to the estimator: the increment
 /// that minimizes the reduced quadratic is the increment the full system would
@@ -387,7 +363,7 @@ fn the_prior_is_the_schur_complement_of_the_window() {
     let b: DVector<f64> = q2jp.transpose() * &q2r;
     let (schur_h, schur_b) = dense_schur(&h, &b, &keep, &marg);
 
-    // Undo the re-anchoring of `:1172` to compare like with like.
+    // Undo the re-anchoring of to compare like with like.
     let delta: DVector<f64> = marginalized
         .estimator
         .compute_delta(&marginalized.marg.order)
@@ -422,7 +398,7 @@ fn the_prior_is_the_schur_complement_of_the_window() {
     // biases, so nine directions carry no information. The solve is therefore
     // damped, with the same `lambda` on both sides — which is what the
     // estimator itself does (`H.diagonal() * lambda`,
-    // `sqrt_keypoint_vio.cpp:1415-1417`), so this compares the increment the
+    // ), so this compares the increment the
     // optimizer would really take.
     let lambda: f64 = 1e-6 * scale;
     let damped = |h: &DMatrix<f64>| -> DMatrix<f64> {
@@ -445,7 +421,7 @@ fn the_prior_is_the_schur_complement_of_the_window() {
     }
 }
 
-/// Trap 8: `marg_data.b -= marg_data.H * delta` (`:1170-1172`).
+/// Trap 8: `marg_data.b -= marg_data.H * delta`.
 ///
 /// The helper hands back a prior linearized at `x = 0`; the estimator stores
 /// priors in the delta-independent form, so the residual has to lose
@@ -456,7 +432,6 @@ fn the_prior_is_re_anchored_on_the_delta() {
     let mut window: Window = build_window(0xB00E, true);
     // Give the surviving keyframe a non-zero delta, so the re-anchoring has
     // something to subtract. `KF1` is frozen, so `applyInc` accumulates
-    // (`imu_types.h:240-248`).
     let inc: Vector6<f64> = Vector6::from_iterator((0..6).map(|k| 0.001 * (k as f64 + 1.0)));
     window
         .estimator
@@ -502,10 +477,10 @@ fn the_prior_is_re_anchored_on_the_delta() {
 }
 
 /// `computeMargPriorError` after an increment is the quadratic model evaluated
-/// at the accumulated delta (`ba_base.cpp:441-465`).
+/// at the accumulated delta.
 ///
 /// The prior is `P(x) = 0.5‖J(delta + x) + r‖²` and `computeMargPriorError`
-/// returns it with the constant `0.5 rᵀr` dropped (`:452-455`), i.e.
+/// returns it with the constant `0.5 rᵀr` dropped, i.e.
 /// `(J delta)ᵀ(0.5 J delta + r)`. The point of the test is that `applyInc` on a
 /// **frozen** frame accumulates into `delta` rather than moving the
 /// linearization point, so the prior sees the increment at all — trap 7 the
@@ -572,7 +547,7 @@ fn the_prior_error_is_the_quadratic_at_the_delta() {
     assert!(e1 > 0.0, "moving away from the linearization point costs");
 }
 
-/// The ordering assertions of `:736` and `:758-759` are typed errors here.
+/// Ordering mismatches return typed errors.
 ///
 /// The schedule's own relationships to the window are
 /// `an_invalid_schedule_is_refused_before_anything_changes`; this is the other
@@ -592,15 +567,9 @@ fn a_window_that_disagrees_with_the_prior_is_refused() {
     );
 }
 
-/// Every relationship the schedule is supposed to have with the window, broken
-/// one at a time: each is a typed error, and each leaves the window **exactly**
-/// as it was.
-///
-/// C++ never checks any of them — `:1090-1112` erases what the sets name in
-/// order, with `frame_states.at()` throwing and `frame_poses.erase()` silently
-/// doing nothing — so a schedule that disagrees with the window took effect
-/// before it was noticed. Eight ways it can disagree are covered here; a
-/// *valid* schedule over a window that is not frozen is the neighbouring test.
+/// Break schedule relationships one at a time. All eight invalid schedules must
+/// return typed errors and leave the window unchanged. Frozen-state validation
+/// is checked separately with an otherwise valid schedule.
 #[test]
 fn an_invalid_schedule_is_refused_before_anything_changes() {
     let unknown: FrameId = 999;
@@ -702,13 +671,8 @@ fn an_invalid_schedule_is_refused_before_anything_changes() {
     }
 }
 
-/// `computeDelta`'s precondition, which C++ only reaches at `:1171` — eighty
-/// lines after `:1090` started rewriting the window (`ba_base.cpp:294`).
-///
-/// The schedule is valid; what is wrong is the window. Both kinds of block the
-/// new prior gets are covered: a state that is about to be demoted into it, and
-/// a pose that simply survives. Either way the refusal is `computeDelta`'s own
-/// error, raised before the first mutation.
+/// Check frozen-state preconditions before mutation for both surviving poses and
+/// states being demoted. A valid schedule does not make an unfrozen block valid.
 #[test]
 fn a_window_that_is_not_frozen_is_refused_before_anything_changes() {
     let refused = |window: &mut Window, sched: &MarginalizeSchedule, frame_id: FrameId| {
@@ -722,7 +686,7 @@ fn a_window_that_is_not_frozen_is_refused_before_anything_changes() {
     };
 
     // The demoted state: `STATE1` is a free variable in the fixture, and
-    // demotion would carry that flag into the new prior (`imu_types.h:206-215`).
+    // demotion would carry that flag into the new prior.
     let mut window: Window = build_window(0xB017, true);
     refused(&mut window, &demote_state1(), STATE1);
 
@@ -737,7 +701,7 @@ fn a_window_that_is_not_frozen_is_refused_before_anything_changes() {
 }
 
 /// The control: freezing that one state, and nothing else, makes the same
-/// schedule marginalize — and what it does is the demotion of `:1098-1105`.
+/// schedule marginalize and demote the selected state.
 #[test]
 fn a_frozen_demoted_state_marginalizes() {
     let mut window: Window = build_window(0xB017, true);
@@ -767,7 +731,6 @@ fn a_frozen_demoted_state_marginalizes() {
 
 /// The stacked square-root system `marginalize` is about to consume, taken
 /// through the public linearizer with the same inputs
-/// (`sqrt_keypoint_vio.cpp:905-942`).
 fn linearized_system(window: &Window) -> (DMatrix<f64>, DVector<f64>) {
     use slam_rs::linearize::{LinearizationAbsQR, LinearizationInputs, LinearizationOptions};
 

--- a/packages/slam-rs/crates/slam-rs/tests/vio_pipeline.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/vio_pipeline.rs
@@ -35,7 +35,7 @@ const LAST_COMMITTED_T_NS: i64 = 37_012_000;
 /// How far the IMU is pushed for the committed run: one frameset interval past
 /// [`LAST_COMMITTED_T_NS`].
 ///
-/// It has to reach *past* the last frameset. `:330-336` closes the last
+/// It has to reach *past* the last frameset. closes the last
 /// preintegration by re-stamping the first sample after the frameset, so a
 /// queue that stops on the frameset leaves the interval short and `track`
 /// reports `NeedMoreImu` for it.
@@ -159,8 +159,8 @@ fn check_pipeline<S: LieScalar>() {
     let estimator = vio.estimator();
     assert_eq!(estimator.snapshot().states.len(), COMMITTED_FRAMESETS);
     assert_eq!(estimator.last_state_t_ns(), LAST_COMMITTED_T_NS);
-    // The first frameset is always a keyframe (`sqrt_keypoint_vio.cpp:61`)
-    // and three framesets cannot reach `opt_started` (`:1207`).
+    // The first frameset is always a keyframe
+    // and three framesets cannot reach `opt_started`.
     let Some(stats) = vio.last_stats() else {
         panic!("three framesets measured, so the last one left stats");
     };
@@ -242,7 +242,7 @@ fn push_imu_through(vio: &mut Vio<f32>, next: usize, horizon: i64) -> usize {
 ///
 /// The frontend checks the size itself and undoes its own passes, but by the
 /// time it looks, `track` has already spent the frontend's preintegration on the
-/// interval (`frame_to_frame_optical_flow.h:157-201` eats the buffer to seed the
+/// interval ( eats the buffer to seed the
 /// KLT), and that cannot be spent again: the retry then predicts from a shorter
 /// interval and the run parts from a clean one by ~6e-8 m within a few
 /// framesets. The first frameset cannot show it — there is no state to predict
@@ -372,7 +372,7 @@ fn a_refused_frameset_is_retried_bit_identically() {
             "frame {frame}: the refused frameset moved the pipeline"
         );
 
-        // Up to the next frameset: past this one, so `:330-336` can close its
+        // Up to the next frameset: past this one, so can close its
         // preintegration, and not past the next, so the next is refused too.
         // The last horizon is the reference run's, so both runs end holding the
         // same samples.

--- a/packages/slam-rs/docs/design-notes.md
+++ b/packages/slam-rs/docs/design-notes.md
@@ -11,20 +11,20 @@ The core is being filled in stage by stage, bottom up. What is in it today:
 
 | Module | What it is |
 |---|---|
-| `lie` | `So3`/`Se3` over any `f32`/`f64` scalar: Sophus's `exp`/`log`, the adjoint, basalt's four SO(3) Jacobians and their inverses, the decoupled SE(3) pair, and the left-multiplied pose increment the estimator runs on. |
+| `lie` | `So3`/`Se3` over any `f32`/`f64` scalar: SO(3) operations through kornia-algebra, the adjoint, four SO(3) Jacobians and their inverses, the decoupled SE(3) pair, and the left-multiplied pose increment the estimator runs on. |
 | `types` | `TimeCamId`, `KeypointId`/`LandmarkId`, `AbsOrderMap`, `PoseState`/`PoseVelState`/`PoseVelBiasState` and the two fixed-linearization wrappers. |
-| `config` | basalt's `VioConfig`, read straight from `data/**/*_config.json`. |
-| `calib` | basalt's `Calibration`: extrinsics, the six shipped camera models, the 9- and 12-parameter IMU bias calibrations, plus a constructor that takes what the Python catalog feed reports. |
+| `config` | `VioConfig`, read from the package's `configs/*_config.json`. |
+| `calib` | `Calibration`: extrinsics, the six shipped camera models, the 9- and 12-parameter IMU bias calibrations, plus a constructor that takes what the Python catalog feed reports. |
 | `camera` | `pinhole`, `kb4` and `pinhole-radtan8` with basalt's 4-D homogeneous `project`/`unproject` and their analytic Jacobians (2x4 point, 2xN parameter, 4x2 and 4xN for unprojection), the `rpmax` and `z >= epsilonSqrt` domain checks, and a `CameraEnum` that dispatches without a vtable. `ds`, `eucm` and `ucm` parse but are rejected here. |
 | `image` | `ImageU16`: an owned flat 16-bit frame with an explicit row stride, the stride-aware `u8 << 8` widening basalt's readers do, and `interp`/`interp_grad`/`in_bounds` reproduced from `image.h` in the same arithmetic order. |
 | `pyramid` | The `PyramidBuilder` stage seam with an associated `Pyramid` type that lends nothing (geometry plus a copy into the caller's buffer), `PyramidU16` (one flat buffer per level, not basalt's packed mipmap) and `CpuPyramidBuilder`, whose `subsample` is bit-exact with `image_pyr.h:99-140`. |
 | `landmark` | `StereographicParam` (`project`/`unproject` and both Jacobians), the three-parameter `Landmark` with its backup pair, and `LandmarkDatabase`: the host->target->landmark adjacency, the `min_num_obs = 2` sweep and `remove_keyframes`. Landmarks live in one id-sorted `Vec` behind a `BTreeMap` index rather than a per-landmark hash map, and every map is a `BTreeMap`, so iteration order is reproducible (D31). |
-| `ba_base` | `BundleAdjustmentBase`: the two window state maps, `get_pose_state_with_lin`, basalt's Huber-weighted `compute_error` with optional outlier collection, `compute_projections`, `compute_delta`, `backup`/`restore`, the reprojection residual and its three Jacobians from `ba_utils.h`, `computeRelPose`, and DLT `triangulate` over a ported Eigen `JacobiSVD`. |
+| `ba_base` | `BundleAdjustmentBase`: the two window state maps, `get_pose_state_with_lin`, basalt's Huber-weighted `compute_error` with optional outlier collection, `compute_projections`, `compute_delta`, `backup`/`restore`, the reprojection residual and its three Jacobians from `ba_utils.h`, `computeRelPose`, and DLT `triangulate` using nalgebra SVD in f64. |
 | `imu` | Preintegration: `IntegratedImuMeasurement<S>` with basalt's midpoint propagation, covariance and bias-Jacobian recurrences, the 9-vector residual and its Jacobians, the LDLT square-root inverse covariance, the between-frames accumulation loop, gravity initialisation, and the 15-row IMU block the estimator whitens. |
 | `frontend` | The optical-flow frontend: `patterns` (Pattern52/51 from `patterns.h`; the other two are unreachable on every shipped config), `se2` (`AffineCompact2` and `Sophus::SE2::exp`), `ldlt` (Eigen's pivoted LDLT at 3x3), `patch` (the streaming inverse-compositional patch build), `tracker` (`PatchSoA`, `FlowTransforms`, the `SourcePatches`/`PatchTracker` stage traits and `CpuPatchTracker`), `detect` (basalt's centred cell grid over kornia-rs's FAST plus OpenCV's suppression), `flow` (`FrameToFrameOpticalFlow`, generic over the builder and tracker) and `parallel` (the explicit thread budget). |
-| `linearize` | The square-root linearization: `LandmarkBlock` (basalt's `[ J_p \| pad \| J_l \| r ]` buffer, the layout arithmetic of `landmark_block_abs_dynamic.hpp:83-96`, the Huber-weighted residual rows, three Householder reflections, back-substitution with its exact model cost change) and `LinearizationAbsQR`, which owns the blocks, the IMU blocks and the marginalization prior and produces `H`, `b`, `Q2Jp`, `Q2r` and `l_diff`. No damping and no Jacobian scaling: the fork comments every call site out and the port carries none of it (D34, D68). Eigen's `makeHouseholder` and `applyHouseholderOnTheLeft` are ported coefficient for coefficient rather than delegated to nalgebra's equivalents (D44). |
+| `linearize` | The square-root linearization: `LandmarkBlock` (basalt's `[ J_p \| pad \| J_l \| r ]` buffer, the layout arithmetic of `landmark_block_abs_dynamic.hpp:83-96`, the Huber-weighted residual rows, three Householder reflections, back-substitution with its exact model cost change) and `LinearizationAbsQR`, which owns the blocks, the IMU blocks and the marginalization prior and produces `H`, `b`, `Q2Jp`, `Q2r` and `l_diff`. No damping and no Jacobian scaling: the fork comments every call site out and the port carries none of it (D34, D68). S34 uses nalgebra reflection and Givens operations with preallocated scratch. |
 | `marg` | Square-root marginalization: `MargHelper`'s rank-revealing flat Householder QR, `marginalizeHelperSqrtToSqrt` — the one routine of the three the shipped path reaches — plus the `marginalize()` mechanics of `sqrt_keypoint_vio.cpp:896-1178` given an explicit keep/marginalize schedule. The two squared-form routines, the complete orthogonal decomposition they inverted the marginalized block with, and `checkMargNullspace`/`checkEigenvalues` are **not** ported: `SqrtKeypointVio::new` refuses `vio_sqrt_marg` off, so nothing on any shipped config reaches them (D68). |
-| `eigen` | What remains of the Eigen ports after D79: `qr` (`makeHouseholder`, `applyHouseholderOnTheLeft`, `makeGivens`, `JacobiRotation`) and `ldlt` (the pivoted LDLT at dynamic size, D41, which the LM step solves through). Their operation order is kept because their last bit reaches a rank test and a finite check; the Jacobi SVD and the BLAS-order reductions that used to live beside them come from nalgebra now (D79). |
+| `qr` | In-place nalgebra reflections and Givens rotations over column-major storage. |
 | `estimator` | The Offline sliding-window driver: `process_frame` (cover, initialise, measure, optimise, marginalize), `schedule` (basalt's keyframe vote, the lazy keyframe budget and the keep/marginalize sets `marg` is given) and `optimize` (the Levenberg-Marquardt loop, with the per-frame `lambda` reset, the `lambda · diag(H)` damping and the shared 7-iteration budget). |
 
 Two conventions in `ba_base` are basalt deviating from its own papers, and the
@@ -40,58 +40,16 @@ reductions are a different matter: they replace
 `tbb::parallel_deterministic_reduce`, whose order is a balanced join tree rather
 than a fold - see the `linearize` module.
 
-Every convention is quoted against the C++ it comes from, file and line, in the
-doc comments. `crates/slam-rs/tests/fixtures/` holds the shipped basalt
-calibration JSON the parsers are tested against, unmodified - the VIO configs
-they run with are the package's own `configs/`, read from there - plus four
-fixtures produced by the C++ fork itself: `pyramid/`, the first frame of the
-smoke reference segment as a PGM next to the four pyramid levels the fork builds
-from it, which the pyramid is checked against byte for byte;
-`camera_oracle.json`, what basalt's camera headers return for ten cameras and
-thirty points each in **both** precisions - pixel, bearing, and in double also
-both projection Jacobians and the unprojection Jacobian - plus six probe pixels
-handed straight to `unproject`, one of them singular; `imu/imu_oracle.json`,
-the delta state, covariance, bias Jacobians, Eigen LDLT and square-root inverse
-covariance of seven preintegration runs, plus what
-`Quaternion::FromTwoVectors` returns for ten accelerometer readings;
-`flow/`, three 960x960 frameset pairs as PGMs beside the keypoints the C++
-frontend produced from eight of them; `linearize/linearize_oracle.json`, four
-small visual-odometry problems (two and three frames, two cameras, three to six
-landmarks with two to four observations each, two of them carrying a
-marginalization prior with both of their first frames frozen at their
-linearization point) with, per landmark block, the layout numbers, the
-linearization error, the whole `storage` buffer after `linearizeLandmark` and
-after `performQR` (the damped and undamped buffers are in the file too, read by
-nothing since D68 dropped the damping stack), the `Q2Jp`/`Q2r` and `JtJ`/`Jtr`
-exports, and
-what `backSubstitute` leaves behind - plus, per problem, what
-`LinearizationAbsQR` returns through its public interface: the error, the dense
-`H` and `b`, the stacked `Q2Jp`/`Q2r` and the total `l_diff`; and
-`lmdb/lmdb_oracle.json`, the
-stereographic chart with both its Jacobians at twelve points, `linearizePoint`'s
-residual, `d_res_d_xi`, `d_res_d_p` and `proj` for five configurations of each of
-the two shipped reference cameras, ten `triangulate` cases with four of them
-placed on basalt's `0 < inv_dist < 3` acceptance gate, 32 more per precision
-sitting on that gate (half of them chosen because the summation order alone
-decides them), 32 probes of `head<3>().squaredNorm()` per precision, and 14
-residuals through the Huber-weighted cost, five of them above the threshold.
+Comments describe the crate's numerical contracts. Tests use synthetic inputs,
+finite differences, dense Schur identities and deterministic replay. S34 removed
+the external fixture and comparison suites; none is required for acceptance.
 
-The camera port reproduces every double to 1e-15 relative (1e-12 for
-unprojections, which run a Newton iteration) and every float **exactly**; the IMU
-port reproduces every double to 1e-14, and to 1e-7 through the whitening, which
-inverts the covariance; the landmark port reproduces the chart and the residual
-to 1e-12 in double and **exactly** in float, triangulation bit for bit on nine of
-the ten double cases, and Eigen's three-coefficient reduction order and the
-Huber-weighted cost of one observation bit for bit in both precisions. The
-linearization port reproduces **every** coefficient of all four problems - the
-QR'd block, `H`, `b`, `Q2Jp`, `Q2r`, the landmark increments and `l_diff` - to
-`6.3e-16` relative in double and `1.4e-6` in float, measured against the array's
-own scale. All six generators live on the fork's `slam-rs-reference` branch, as
-`tools/dump_pyramid.cpp`, `tools/camera_oracle.cpp`, `tools/imu_oracle.cpp`,
-`tools/dump_flow.cpp`, `tools/lmdb_oracle.cpp` and `tools/linearize_oracle.cpp`;
-the monorepo never compiles C++.
+The derivation sections below record why the original algorithms were chosen.
+Their historical comparisons explain those decisions, but do not define today's
+gate. S33 and S34 supersede operation-order requirements and deleted-test claims;
+see the S34 summary at the end for the current numerical implementation.
 
-The IMU fixture earns its keep on one run: the covariance after a single sample
+A useful IMU degeneracy case is this: the covariance after a single sample
 with a still gyroscope and accelerometer is rank deficient, and what basalt does
 with it is decided entirely by `Eigen::LDLT`. Eigen pivots on the *un-updated*
 diagonal, eliminates velocity first and leaves the position pivots at `-1.6e-27`,
@@ -491,7 +449,7 @@ from pathlib import Path
 from slam_rs import _core
 
 calibration = _core.Calibration.from_catalog(feed.cameras, feed.imu)  # the feed's dataclasses
-config = _core.VioConfig.from_json(Path("configs/msdmi_config.json").read_text())  # the file the C++ ran
+config = _core.VioConfig.from_json(Path("configs/msdmi_config.json").read_text())  # the dataset configuration
 config.optical_flow_image_safe_radius = 472.0    # settable per device, though the shipped file carries it
 
 vio = _core.Vio(calibration, config, threads=1)
@@ -500,15 +458,14 @@ result = vio.track(t_ns, [left, right])   # uint8[h, w] per camera
 result.status, result.world_from_rig      # VioStatus, [tx ty tz qx qy qz qw]
 ```
 
-One `track` call is basalt's whole pipeline for one frameset — the frontend's
+One `track` call runs the whole pipeline for one frameset — the frontend's
 own preintegration and pose prediction, `processFrame`, then the estimator's
 `measure` — in the calling thread (Offline mode, D17), so every result is final
 and a repeat run over the same input is bit-identical.
 
-`VioStatus` has two states. basalt's estimator initialises inside the same
+`VioStatus` has two states. The estimator initializes inside the same
 `process_frame` that measures, so a measured frameset always has a state and an
-uncovered one never does: `NeedMoreImu` where basalt would block on its IMU
-queue, `Tracking` otherwise. `NeedMoreImu` moves nothing — not the frontend,
+uncovered one never does: `NeedMoreImu` until the buffer covers the frameset, `Tracking` otherwise. `NeedMoreImu` moves nothing — not the frontend,
 neither IMU buffer, not the estimator — so the frameset is pushed again once its
 samples arrive and tracks as it would have with them all along (D17). A caller
 that drops it instead loses the frame; `replay.py` holds it and retries.
@@ -553,7 +510,7 @@ the rig:
 | `max_keypoints` | `tracker::MAX_CAPACITY` = 1,048,576 | every per-patch buffer is preallocated from it; `Vec::with_capacity(2**63)` panics with `capacity overflow` |
 | `threads` | `parallel::MAX_THREADS` = 1024 | rayon spawns exactly what it is asked for, so 100,000 workers wedge the machine rather than erroring |
 | `optical_flow_levels` | at most 23 reductions, i.e. `tracker::MAX_LEVELS` = 24 stored levels | it multiplies every buffer, each sized with `levels + 1`; a `Vec` whose bytes do not exist **aborts** instead of unwinding |
-| `optical_flow_detection_min_threshold` | at least 1 | the detector halves the FAST threshold until it drops below this, and zero halves to zero for ever — `keypoints.cpp:162,187` has the same non-terminating loop, so basalt hangs on it too |
+| `optical_flow_detection_min_threshold` | at least 1 | integer halving leaves zero unchanged, so a positive minimum prevents an infinite loop |
 | `optical_flow_detection_max_threshold` | at least `min_threshold` | otherwise the ladder never runs and the detector can never add a keypoint |
 | frameset image size | exactly the calibration's, per camera | the camera model, the detection grid and the occupancy matrix are all the calibrated geometry |
 | the calibrated resolution over `optical_flow_detection_grid_size` | `detect::MAX_CELLS` = 1,048,576 cells per camera | the occupancy counts are one `i32` per cell per camera, so a calibration is a memory request too: a one-pixel grid over a 4,294,967,294-pixel-square frame asked for 2^64 counts and `vec![0; rows * columns]` panicked with `capacity overflow` with no image in sight |
@@ -577,38 +534,30 @@ flow.t_ns              # int | None: the last accepted frameset, None before the
 ```
 
 Any `int64` is a timestamp, negative ones included: the frontend's clock is an
-`Option<i64>` rather than basalt's `t_ns = -1` sentinel (`optical_flow.h:172`),
-which read every negative timestamp as "no previous frame" and so restarted
-tracking on each one. Framesets must still arrive strictly in order, and a
+`Option<i64>` so negative timestamps remain valid and do not restart tracking. Framesets must still arrive strictly in order, and a
 refused frameset leaves the frontend exactly as the last accepted one did.
 
 `Calibration.from_catalog` reads `slam_rs.catalog_feed.CameraCalib` and
 `ImuCalib` attribute by attribute and hands them to `Calibration::from_catalog_parts`,
-so the catalog-to-basalt rules — the rotation-matrix check, the model names, the
-isotropic noise densities — are not written a second time in Python. One of
-basalt's own files is read by `Calibration.from_json` or `VioConfig.from_json`,
-which is what the frontend's constructor then takes.
+so rotation validation, model names and isotropic noise conversion stay in Rust.
+`Calibration.from_json` and `VioConfig.from_json` read the JSON formats slam-rs
+accepts, and their objects configure the frontend.
 
 ## The reference set
 
-`reference_segments.toml` freezes ten Monado SLAM Dataset segments — five
-two-camera `msd-index` (KB4 fisheye, 54 Hz) and five four-camera `msd-g2`
-(radtan8, 30 Hz) — in three tiers: **smoke** on every commit, **accuracy** per
-pull request, **long** nightly. A `[[dataset]]` block per catalog dataset pins the
-rig geometry and names the basalt VIO config its segments run with; a `[robocap]`
-section adds the two RoboCap sessions, 15 (1,588 framesets) and 21 (4,648), which
-have no ground truth and are gated against basalt's own output instead. Only
-session 15 carries a reference wall, measured on the cap itself.
+`reference_segments.toml` records catalog segments, dataset geometry, IMU noise,
+clock offsets, decode paths, configuration files and measured baselines.
+The tiers are **smoke** for quick checks, **release** for the release set, and
+**listed** for additional catalog segments. RoboCap sessions carry rig and replay
+metadata but no ground truth, so they cannot receive a ground-truth ATE verdict.
 
-Four things are frozen because the catalog cannot carry them and each one moves
-the numbers: the IMU noise densities and update rate, the camera-to-IMU time
-offset (0 for MSD, 14,902,432 ns for RoboCap), the decode path
-(`cpu_gray8_dav1d_1thread`, worth about 5 cm of ATE against NVDEC RGB), and the
-VIO config, vendored under `configs/` — basalt's constructor defaults are not its
-shipped files, and `vio_marg_lost_landmarks` alone was worth up to 12 cm (C72),
-so `slam_rs.reference.resolved_flow_config` reads the dataset's file and asserts the
-manifest's image safe radius against it. `slam_rs.reference`'s module docstring
-carries the rest of the account, including where the V2 tolerances live and why.
+Each baseline identifies a lane (`cpu` or `gpu`) and profile (`reference` or
+`fast`), plus its host, core digest, frameset count and measurement date.
+The estimator reads the dataset JSON under `configs/`; omitted fields use
+constructor defaults, but the dataset file remains the selected input (C72).
+Pinned noise, camera-to-IMU offsets and decode paths keep replay inputs stable.
+The catalog supplies images, IMU samples and ground truth. No reference bundle
+or filesystem-side dataset fallback is part of the gate.
 
 ```python
 from slam_rs.reference import load_manifest
@@ -617,36 +566,10 @@ manifest = load_manifest()
 segment = manifest.in_tier("smoke")[0]
 ```
 
-### The basalt C++ reference and the gate policy
-
-`tests/reference/msd/<segment>/` holds what the basalt C++ fork produced on each
-segment: `run.json` for all ten (fork commit, deterministic settings, the VIO
-config and calibration actually pushed, timings and the ATE against `gt.csv`),
-`basalt_traj.csv` for the eight smoke and accuracy segments, and `frames.sha256`
-plus a copy of `gt.csv` for the smoke pair so its gate runs with no NAS and no
-catalog. The two long-tier trajectories are 3.4 MB and 4.8 MB and stay out of
-git; `slam_rs.reference_bundle` resolves them from `SLAM_RS_REFERENCE_DIR` (or
-`data/reference/`) and the tests skip with a message naming the variable.
-
-Each segment carries a `gate_policy`, because basalt is not equally good
-everywhere:
-
-| policy | segments | why |
-|---|---|---|
-| `tight` | MIO10, MGO09, MIO07, MGO07 | basalt scores 0.8-2.4 cm; a regression is unambiguous |
-| `standard` | MIO04, MGO14, MIO14, MIPT03 | 8-38 cm, stable; gate relative to basalt's own number, not an absolute threshold |
-| `no_divergence` | MGO01, MGO13 | basalt is near failure: 43 cm and 78 cm here, 68 cm for the C++ binary on the raw files, and **18-32 cm of spread between two legitimate decode paths of the same estimator** — on MGO01 the ordering even flips. Only "kept tracking, did not diverge" is measurable. |
-
-`slam_rs.trajectory.ate` reproduces all ten published C++ figures exactly, and a
-re-decode through `catalog_feed` reproduces the C++ run's per-camera pixel
-digests frame for frame (824 of 824 on MIO10, 428 of 428 on MGO09). That second
-result is the load-bearing one: it means an A/B between the two estimators
-measures the estimator, not the decoder.
-
 ### Two clocks, converted once
 
 The catalog indexes a segment on `video_time`, which is **relative** to
-`capture.start_time_ns`, while every basalt CSV including the `gt.csv` sidecars is
+`capture.start_time_ns`, while exported trajectory CSV is
 on the **absolute** device clock; on the Index smoke segment the two differ by
 10,433,867,587,166 ns, so a trajectory exported on the wrong clock associates with
 nothing at all. The feed works in `video_time` throughout and
@@ -659,11 +582,9 @@ framesets, reading a catalog URL or local `.rrd` files served in process (no
 catalog server needed); its module docstring states the decisions that silently
 change the numbers — the pinned `gray8` dav1d path, the one-query windows whose
 edges land on frames that are keyframes in every camera, the rig shape and the
-two clocks. `slam_rs.trajectory` reads and writes basalt's CSV form (w-first,
-integer nanoseconds) and reports the rigid-aligned ATE the gate is written
-against, in `golden_compare.py`'s own arithmetic rather than the shared
-`simplecv` helper, whose variance floor would reject a stationary rig that the
-fork passes.
+two clocks. `slam_rs.trajectory` reads and writes w-first trajectory CSV with integer
+nanoseconds. ATE uses estimate-driven association and rigid alignment with
+scale fixed at one. No variance floor rejects a stationary rig.
 
 ```bash
 pixi run -e slam-rs-dev --frozen python tools/apps/replay.py \
@@ -674,7 +595,7 @@ Both `--rr-config.headless` and `--rr-config.save` are honoured; in a shell
 without `DISPLAY`, pass `--rr-config.headless` or the spawned viewer wedges the
 recording stream.
 
-### `--stage frontend`, and the C++ overlay
+### `--stage frontend`, and the tracked keypoints
 
 `--stage input` (the default) logs what the estimator is fed. `--stage frontend`
 runs the optical flow over the same framesets and logs what it produced, under
@@ -685,19 +606,10 @@ the dataset's own entity tree so nothing needs a second coordinate convention:
 | `/world/rig_00/cam_MM/pinhole/image` | the frame the frontend tracked, **full resolution** (JPEG), because the keypoints are in its pixels |
 | `.../keypoints` | `Points2D`, 2 px, one stable colour per track id from a hash of the id |
 | `.../trails` | `LineStrips2D`, the last ten positions of every live track, in the track's own colour |
-| `.../cells` | `Boxes2D` over the occupied cells of basalt's centred detection grid |
-| `.../keypoints_cpp` | what the C++ fork's `dump_flow.cpp` produced for the same frameset, in one contrasting magenta |
+| `.../cells` | `Boxes2D` over the occupied cells of the centered detection grid |
 | `/stats/frontend/...` | `num_tracks` and `num_new` per camera, and `frontend_ms` |
 
-The overlay is the parity claim made visible, and it is only ever drawn on the
-recording it came from: the eight committed dumps under
-`crates/slam-rs/tests/fixtures/flow/dumps/` name their segment in
-`dumps/source.json`, and `slam_rs.frontend_log`'s module docstring says why a
-`video_time` timestamp is not an association and what a directory from another
-recording, another rig or no `source.json` gets instead. On the smoke segment the
-port hands out 175 keypoint ids over the first eight framesets where the C++
-hands out 174, and every magenta ring in the viewer carries a coloured port dot
-at its centre bar a handful — the detector gap the flow gate measures.
+The overlays show the frontend's own keypoints and trails on the images it tracked.
 
 A blueprint is sent with the recording: one 2D view per camera plus the counters,
 panels collapsed. The whole 412-frameset smoke segment is 34.5 MiB of `.rrd` and
@@ -708,7 +620,7 @@ pixi run -e slam-rs-dev --frozen python tools/apps/replay.py \
     --stage frontend --rr-config.headless --rr-config.save data/replay-frontend.rrd
 ```
 
-### `--stage vio`, and the three trajectories
+### `--stage vio`, and the two trajectories
 
 `--stage vio` runs the whole pipeline and draws what the estimator decided, under
 the same tree:
@@ -717,25 +629,19 @@ the same tree:
 |---|---|
 | `/world/runs/slam_rs/trajectory` | the estimate so far, one green `LineStrips3D` |
 | `/world/runs/gt/trajectory` | the ground truth up to the cursor, near-white |
-| `/world/runs/basalt_cpp/trajectory` | the C++ reference up to the cursor, orange |
 | `/world/runs/slam_rs/rig` (+ `/cam_MM`) | the estimated rig's current pose, as `Pinhole` frusta from the calibration |
 | `/world/runs/slam_rs/window` | one frustum wireframe per window frame, blue for a keyframe, yellow for a long-term one, grey for a pose block |
 | `/world/runs/slam_rs/marginalized` | the frames the last marginalization removed, the same wireframes faded |
 | `/world/runs/slam_rs/landmarks` | `Points3D` in the world frame, coloured by the keyframe that hosts them |
 | `/world/rig_00/cam_MM/pinhole/keypoints` | the estimator's own frontend output, in the frontend rung's palette |
-| `/stats/vio/...` | landmark, observation and keyframe counts, LM iterations, lambda and the error before and after, the six `stage_ms/*`, `track_ms`, and `ate_cm/{gt,cpp}` |
+| `/stats/vio/...` | landmark, observation and keyframe counts, LM iterations, lambda and the error before and after, the six `stage_ms/*`, `track_ms`, and `ate_cm/gt` |
 
-The three trajectories do not start in one frame — basalt initialises its world
-at the identity with gravity along z, the ground truth is in the capture rig's
-own frame — so the run and the C++ reference carry the rigid alignment onto the
-ground truth as a `Transform3D`, refreshed every 30 framesets, and a run visibly
-settles into place over its first second. All three are drawn only up to the
-cursor and thinned to the frameset cadence: 1.04 MB each over the 412-frameset
-smoke segment, against the 17.20 MB of that recording's 54.13 MB that re-logging
-the 917 Hz ground truth whole cost, and about 100 MB each over a 4,000-frameset
-clip, so a long segment still wants `--max-framesets`. `slam_rs.vio_log`'s module
-docstring carries the reasoning, the visible time range that makes a per-frameset
-segment render as a path, and why the window is wireframes and the rig is not.
+The two trajectories are the estimate and ground truth. The estimator starts
+with its own gravity-aligned world frame; ground truth uses the capture frame.
+A rigid `Transform3D` aligns the estimate to ground truth and refreshes every
+30 framesets. Both paths stop at the cursor, with ground truth sampled at the
+frameset cadence to keep recording size bounded. The rig and window use the
+same alignment. `slam_rs.vio_log` documents the trail visibility and layout.
 
 ```bash
 pixi run -e slam-rs-dev --frozen python tools/apps/replay.py \
@@ -744,59 +650,39 @@ pixi run -e slam-rs-dev --frozen python tools/apps/replay.py \
 
 ## The V2 gate
 
-`tests/test_v2_gate.py` is the milestone (D14, D35, D36, D58). Per gated clip,
-driving `_core.Vio` and the feed directly with nothing logged: every frameset
-resolved, a refusal for want of IMU held and tracked again once the samples
-arrive (D17); at most 2 cm of ATE RMSE against the basalt C++ trajectory fed the
-same decoded pixels, and only where the C++ meets that against itself, which is
-clips under `PATH_BOUND_MAX_CLIP_S` = 100 seconds of replayed footage — on the
-410-second `MIO14` its own two precisions are 4.24 cm apart; against the `gt.csv`
-sidecar, inside **the C++'s own precision band** (`rmse_cm` and `rmse_cm_f64`,
-the same code on the same pixels with `use-double` flipped) or within
-`GT_BAND_RATIO` = 1.2 of the band's worst member, whichever is looser, which is
-the second alone since the ratio is above one — the band is 0.00007 cm wide on
-`MIO10` and 2.3 cm wide on `MIO14`, so "inside the band" on its own would gate
-the tight clips on rounding; and speed, the replay's own feed loop (decode plus
-`track`, nothing logged, the loop the C++ recorded as `run.feed_wall_time_s`)
-within 1.2x the C++ single-thread wall for the same footage (D58), never left
-off. The clauses, the association convention, the `no_divergence` pair's
-exception and the "every named clip is asserted" rule (C56) are stated once in
-the test's own module docstring.
+S34 replaces the C++ comparison gate with ground-truth checks through
+`slam_rs.reference.gate_failures`, covered by `tests/test_gate.py`.
+Every run must have enough tracked and associated poses, zero lost framesets,
+finite poses and measurements, and bounded extent relative to ground truth.
 
-The tolerances live in `slam_rs/reference.py` (`ATE_VS_CPP_CM`,
-`PATH_BOUND_MAX_CLIP_S`, `GT_BAND_RATIO`, `SPEED_TOLERANCE`,
-`DIVERGENCE_FACTOR`), not in the test: they are the milestone's verdict, and the accuracy-band pass
-measured what a meaningful band is (D60). Every row prints what it was judged on:
-`tracked, vs C++ <cm> (bound 2 cm | no bound, <n> s clip), vs GT <cm> (band [f32,
-f64], allowed <cm>), wall, C++ wall, ratio`.
+For a matching lane/profile baseline, ground-truth RMSE may be at most **1.10 ×**
+the manifest baseline. Median tracker time has the same **1.10 ×** limit only
+on the baseline's recorded host. A different host reports timing without a speed
+verdict. Missing or other-lane baselines do not impose accuracy or speed bounds;
+the tracking, association, finiteness and extent checks still apply.
 
-The lanes are D59's iteration rule. The default is the **iteration set** — MIO10
-whole plus the first ten seconds of one two-camera and one four-camera clip,
-about 1,650 framesets — because finding out at the end of a ten-clip run that
-everything failed is the way not to iterate. Either lane runs **shortest clip
-first** and asserts each clip as soon as it is measured, so the first clip that
-misses stops the run with its own row printed and is the one that gets fixed.
+Use the **smoke**, **release** and **listed** manifest tiers to choose clips.
+Baselines belong to their exact lane and profile; one lane's measurements are
+not another lane's limits. No C++ trajectories, precision bands, pixel dumps,
+NAS paths or external reference directories participate.
 
 ```bash
-cd packages/slam-rs
-pytest -m slow -q -s tests/test_v2_gate.py                    # the iteration set
-SLAM_RS_V2_ALL=1 pytest -m slow -q -s tests/test_v2_gate.py   # all ten, whole, shortest first
-SLAM_RS_V2_WINDOW_S=5 SLAM_RS_V2_ALL=1 pytest -m slow -q -s tests/test_v2_gate.py   # all ten, first 5 s each
+pixi run -e slam-rs-dev --frozen python tools/apps/fleet_check.py
+pixi run -e slam-rs-dev --frozen pytest -m slow -q -s tests/test_gate.py
 ```
 
-`SLAM_RS_V2_WINDOW_S` cuts every clip to its first N seconds and recomputes the
-C++'s own ground-truth error over exactly that span, so a windowed run is gated
-against the budget it actually had.
+The slow test queries catalog smoke segments. Catalog input is mandatory for
+catalog tests; an unavailable service is a failure, not a passing skip.
 
 ## Tests
 
-`pytest -q` deselects the `slow` marker and runs in about two seconds on
-synthetic inputs. The slow tests read a reference `.rrd` from the NAS or query the
-catalog, and skip when neither is reachable:
+`pytest -q` runs synthetic tests and deselects `slow`. Rust property and
+regression tests require no external fixture bundle. Slow integration tests
+query the catalog and fail if it is unavailable.
 
 ```bash
-pixi run -e slam-rs-dev --frozen tests   # fast
-cd packages/slam-rs && pytest -m slow -q # NAS + catalog
+pixi run -e slam-rs-dev --frozen tests
+pixi run -e slam-rs-dev --frozen pytest -m slow -q
 ```
 
 ## D70 — one GPU runtime: the CUDA lane is removed; wgpu is the GPU lane
@@ -1058,25 +944,25 @@ stride is comptime per unrolled step.
 The `Dnn` tags in this file and in the README name the project's recorded design decisions. What each one decided, in one line:
 
 - **D09** — FAST detection reuses kornia's grid-cell detector behind a thin wrapper
-- **D14** — Accuracy gate: trajectory-level, against basalt C++ on the same decode path, plus ground truth
+- **D14** — Superseded by S34: catalog ground truth, per-lane/profile manifest baselines, and same-host speed checks.
 - **D17** — Threading: Offline (lockstep) mode first; Realtime mode is an enum value reserved for later
 - **D31** — Deterministic reductions and the thread budget have an explicit Rust mapping
-- **D32** — Panic policy: the core never panics on data; NaN handling mirrors basalt
+- **D32** — Panic policy: the core never panics on data; non-finite handling follows each numerical contract
 - **D34** — The shipped VIO path has the landmark and pose damping machinery disabled; the port mirrors that
-- **D35** — Numeric gate ladder adopted from the paper dossier
-- **D36** — Gate policy per reference segment: tight, standard, no-divergence
+- **D35** — Superseded by S34: catalog ground truth, per-lane/profile manifest baselines, and same-host speed checks.
+- **D36** — Superseded by S34: catalog ground truth, per-lane/profile manifest baselines, and same-host speed checks.
 - **D41** — Eigen's pivoted LDLT semantics are load-bearing and are ported exactly
 - **D44** — Rotation matrices in numerically sensitive paths use Eigen's `toRotationMatrix` operation order
-- **D58** — Runtime parity is part of the stopping line; two parallel stages open
-- **D59** — The iteration loop: one or two short clips, fail-fast on the ten, speed is a gate clause
-- **D60** — The V2 accuracy gate, on the evidence: ground truth inside the C++'s own precision band, the path bound only where the C++ meets it itself, speed on every clip
+- **D58** — Superseded by S34: catalog ground truth, per-lane/profile manifest baselines, and same-host speed checks.
+- **D59** — Superseded by S34: catalog ground truth, per-lane/profile manifest baselines, and same-host speed checks.
+- **D60** — Superseded by S34: catalog ground truth, per-lane/profile manifest baselines, and same-host speed checks.
 - **D64** — Reaffirmed for the GPU lanes: no bit-accuracy; the bar is accuracy inside the band and faster than the CPU lane on the same machine
 - **D68** — The three unreachable blocks go: squared-form marginalization, nullspace diagnostics, the D34 damping stack
 - **D70** — One GPU runtime: the CUDA lane is removed; wgpu is the GPU lane (2026-09-09)
 - **D71** — Exponent-bit finite classification and bounded small-angle trig; the MIO14 replay passes its unchanged accuracy limit (2026-09-09)
 - **D72** — The GPU detector picks one corner per grid cell on the device; the candidate image never comes back (2026-09-09)
 - **D73** — The estimator's LM buffers live on the estimator and its hot loops walk columns; no arithmetic changes (2026-09-10)
-- **D74** — Speed profile: vendored configs stay C++-faithful; `configs/profiles/fast.json` overlays the knobs, `port.*` keys for the ones basalt has no field for (2026-09-10)
+- **D74** — Dataset JSON is the base input; profiles overlay validated keys. S34 makes fast the default and retains reference as the unchanged input.
 - **D75** — Redetect on demand: the fast profile detects when camera 0 holds fewer than 85 % of the last detecting frameset's keypoints (2026-09-10)
 - **D76** — The fast profile solves the window at keyframes and the newest 15-dof state alone between them, falling back to the joint solve when that update declines (2026-09-10)
 - **D77** — The GPU frontend waits once per phase and reserves its queue budget before it enqueues (2026-09-10)
@@ -1085,14 +971,14 @@ The `Dnn` tags in this file and in the README name the project's recorded design
 
 ## D74 — Speed profile
 
-Vendored configs stay C++-faithful (D17), and the Rust default LM cap stays 7.
+Dataset configs remain the base JSON inputs, and the Rust default LM cap stays 7.
 Speed knobs live in `configs/profiles/fast.json`; the first sets
 `config.vio_max_iterations` to 4 (at most five LM steps with the inclusive loop).
-**D76 puts that one back to basalt's 7** once the joint solve runs at keyframes
+**D76 restores the cap to 7** once the joint solve runs at keyframes
 only: with the window solved one frameset in seven, the eight trials buy 0.146 cm
 of MIO10 ATE for about 0.1 ms of mean and nothing on the median.
-The benchmark and tracking tools opt in with `--profile fast`. The default
-`reference` profile is empty and preserves the vendored text. Unknown overlay
+S34 selects `fast` by default in tracking tools. The explicit `reference`
+profile is empty and preserves the dataset JSON text. Unknown overlay
 keys raise `KeyError` so a typo cannot silently change the requested run.
 
 ## D75 — Redetect on demand: the fast profile detects when camera 0 has lost tracks
@@ -1111,8 +997,8 @@ last **detecting** frameset ended with. `configs/profiles/fast.json` sets `0.85`
 nothing else does.
 
 **Why the key is `port.` and not `config.`.** basalt has no field for it, and the
-vendored `configs/*.json` are the documents the C++ reference runs read, key for
-key (`tests/test_cpp_reference.py::test_the_vendored_configs_are_the_ones_the_cpp_runs_used`).
+`configs/*.json` remain the base inputs. Profile tests check the added keys
+and reject unknown overlay entries.
 So no port-only key is written into them: the profile overlay inserts it,
 `slam_rs.reference.PORT_CONFIG_KEYS` allowlists it so a typo is still a
 `KeyError`, and `VioConfig` skips serializing it while it is off — a basalt
@@ -1158,7 +1044,7 @@ the trade is re-openable once the wider clip set has been run — the clips with
 fast-dying tracks (MIO11, MIO07, MGO13) are where a halved landmark count would
 show, and they are not measured here.
 
-- **D74** — Speed profile: vendored configs stay C++-faithful; speed knobs live in `configs/profiles/fast.json`, opted into with `--profile fast` (2026-09-10)
+- **D74** — Dataset JSON is the base input; profiles overlay validated keys. S34 makes fast the default and retains reference as the unchanged input.
 - **D75** — Redetect on demand: the fast profile skips `addPoints` until camera 0 falls under `port.redetect_survivor_ratio` of its last detection (2026-09-10)
 
 ## D76 — The fast profile solves the window at keyframes and the newest state alone between them
@@ -1591,7 +1477,7 @@ the kernels already take base offsets — would take eleven to five.
 ## D79 — Eigen's operation order is no longer a requirement; the library does the arithmetic where it can
 
 Decision, 2026-09-10 (Pablo): the accuracy reference is ATE against ground truth
-on the catalog — D60's ten-clip gate and the fast profile's 1.1x band — not the
+on the catalog — now S34's per-lane/profile baseline gate — not the
 C++ trajectory byte for byte. D44's rule, that an elementary operation whose
 rounding can reach a rank test, a finite check or a triangulation gate reproduces
 Eigen's operation order, is retired wherever a library routine does the job. The
@@ -1604,7 +1490,8 @@ composition still renormalizes, and Sophus's `theta` conventions that
 `Se3::log` depends on stay ported); the patch Hessian's rank-one update is
 nalgebra's `ger`, which is bit-identical to the loop it replaced.
 
-What stays ported is what no library provides in the shape the estimator needs:
+At S33 the remaining local numerical routines were listed below. S34 later
+replaced the dynamic LDLT and elementary QR operations; this list is historical:
 the pivoted dynamic LDLT (D41), the Householder QR of the landmark blocks and the
 marginalization's rank-revealing QR, SE(3) with the decoupled pair and basalt's
 four SO(3) Jacobians and their inverses, and the square-root-marginalization LM
@@ -1615,7 +1502,8 @@ radtan8 model, a stride-aware u16 image path, a policy-configurable cell
 detector, any general QR or pivoted LDLT — and so what would have to grow
 upstream for the rest to follow.
 
-Bit-exact oracle assertions that the swapped arithmetic broke became measured
+Historical S33 validation (the external comparison tests were removed in S34):
+bit-exact oracle assertions that the swapped arithmetic broke became measured
 tolerances, each with its worst observed value in the comment. The one
 substantive rewrite is the marginalization prior's shape assertion in
 `vio_oracle.rs`: on seven of sixty f32 framesets the QR finds one more rank than
@@ -1645,3 +1533,39 @@ merge. Measured for this change against the #254 tip: MIO10 1.5527 -> 1.5532 cm,
 MIO07 2.1023 -> 2.0726 cm, MGO07 2.3749 -> 2.3746 cm, all framesets tracked;
 MIO10 median 1.333 -> 1.327 ms, MIO07 1.516 -> 1.419 ms. Net -289 lines,
 `eigen/svd.rs` and `eigen/blas.rs` gone.
+
+
+## S34 — Independent inputs, numerics and ground-truth acceptance
+
+S34 removed the basalt C++ fixtures, comparison tests, reference bundle resolver,
+reference trajectories, reader fallbacks and viewer comparison overlays. Comments
+now state slam-rs behavior rather than external file locations. Historical
+algorithm derivations above retain attribution; they are not active gate policy.
+
+The gate uses catalog ground truth and manifest baselines for each lane/profile,
+with zero lost framesets and at most 10% more ATE. The 10% median tracker-time
+limit applies only on the baseline host. Catalog integration tests require the
+catalog and fail when it is unavailable; there is no NAS fallback. Explicit local
+recording replay remains a supported user input, separate from the catalog gate.
+
+PR 2 replaced special reduction orders with natural fixed-order arithmetic,
+replaced dynamic LDLT with symmetrically scaled f64 full-pivot nalgebra LU,
+and uses nalgebra reflections and Givens rotations with reusable scratch.
+Absolute QR rank thresholds, fixed Newton iteration counts and the three-attempt
+finite-solve retry policy remain. Small guarded LDLTs retain their congruence
+generalized-inverse contract. Parallel triangulation rays are explicitly refused;
+tests exercise both sides of the inverse-distance cutoff at 3.
+
+The accepted PR 2 measurements are recorded in the
+[numerics report](/tmp/fleet-artifacts/slam-rs/cuvslam/reports/s34/s34-2-numerics.md):
+
+| Clip | Baseline ATE cm | PR 2 ATE cm | Ratio | Tracked / lost |
+|---|---:|---:|---:|---:|
+| MIO10 | 1.553190 | 1.552952 | 0.999847 | 412 / 0 |
+| MIO07 | 2.072640 | 2.114278 | 1.020089 | 4095 / 0 |
+| MGO07 | 2.374601 | 2.375311 | 1.000299 | 1596 / 0 |
+| MIO14 | 5.569799 | 6.013535 | 1.079668 | 22117 / 0 |
+
+All four met the 1.10 accuracy and latency bounds. The report records the
+MIO14 investigation, final replay and saved Viewer pixel evidence. These are
+PR 2 measurements, not new measurements from this documentation-only change.

--- a/packages/slam-rs/slam_rs/_core.pyi
+++ b/packages/slam-rs/slam_rs/_core.pyi
@@ -163,7 +163,7 @@ class VioSnapshot:
     def __repr__(self) -> str: ...
 
 class Vio:
-    """basalt's VIO pipeline, driven one frameset at a time.
+    """The VIO pipeline, driven one frameset at a time.
 
     Offline mode (D17): the frontend and the backend run to completion in the
     calling thread, so every result is final and a repeat run over the same
@@ -184,7 +184,7 @@ class Vio:
         max_keypoints: int | None = None,
         gpu: bool = False,
     ) -> None:
-        """Build the pipeline for one rig; basalt's own files arrive through ``from_json``.
+        """Build the pipeline for one rig; JSON files arrive through ``from_json``.
 
         ``gpu`` runs the frontend's pyramid, patch build and KLT tracker through
         CubeCL on this host's GPU instead of the CPU port. The default is the
@@ -255,17 +255,17 @@ class Vio:
     def __repr__(self) -> str: ...
 
 class VioConfig:
-    """basalt's ``VioConfig``, as ``data/**/*_config.json`` carries it."""
+    """VIO configuration loaded from the package's JSON inputs."""
 
     def __init__(self) -> None:
-        """basalt's own defaults, the ones its constructor sets."""
+        """Default VIO configuration."""
 
     @staticmethod
     def from_json(text: str) -> VioConfig:
-        """Read one of basalt's config files; keys it omits keep their default."""
+        """Read a VIO config JSON file; keys it omits keep their default."""
 
     def to_json(self) -> str:
-        """Write the config back in basalt's shape, ``value0`` wrapper and all."""
+        """Write the config back in the JSON format slam-rs reads, ``value0`` wrapper and all."""
 
     optical_flow_image_safe_radius: float
     """Circular mask that hides a fisheye's black corners, in pixels; 0 disables it."""
@@ -273,18 +273,18 @@ class VioConfig:
     def __repr__(self) -> str: ...
 
 class Calibration:
-    """basalt's camera-IMU calibration: extrinsics, intrinsics and the noise model."""
+    """Camera-IMU calibration: extrinsics, intrinsics and the noise model."""
 
     @staticmethod
     def from_json(text: str) -> Calibration:
-        """Read one of basalt's calibration files."""
+        """Read a calibration JSON file."""
 
     @staticmethod
     def from_catalog(cameras: Sequence[CameraCalib], imu: ImuCalib) -> Calibration:
         """Build the calibration from the feed's dataclasses; ``imu.imu_T_body`` is unused."""
 
     def to_json(self) -> str:
-        """Write the calibration back in basalt's shape, ``value0`` wrapper and all."""
+        """Write the calibration back in the JSON format slam-rs reads, ``value0`` wrapper and all."""
 
     @property
     def camera_count(self) -> int: ...
@@ -330,7 +330,7 @@ class FlowFrame:
     def __repr__(self) -> str: ...
 
 class OpticalFlow:
-    """basalt's ``FrameToFrameOpticalFlow``, driven one frameset at a time.
+    """Frame-to-frame optical flow, driven one frameset at a time.
 
     Pattern 51 only, which is what every shipped config asks for; another
     ``optical_flow_pattern`` raises ``ValueError`` rather than tracking with the
@@ -351,7 +351,7 @@ class OpticalFlow:
         threads: int = 1,
         max_keypoints: int | None = None,
     ) -> None:
-        """Build a frontend for one rig; basalt's own files arrive through ``from_json``.
+        """Build a frontend for one rig; JSON files arrive through ``from_json``.
 
         Raises ``ValueError`` on a config the frontend cannot run — another
         pattern or flow type, a detector threshold ladder that never ends or

--- a/packages/slam-rs/slam_rs/apis/bench_track.py
+++ b/packages/slam-rs/slam_rs/apis/bench_track.py
@@ -157,7 +157,7 @@ class Config:
     dump: Path
     """The ``.npz`` of decoded framesets to replay; a sibling ``.calib.pkl`` carries the calibration."""
     config: Path
-    """The basalt VIO config JSON the reference run used."""
+    """VIO configuration JSON selected for the run."""
     profile: Literal["reference", "fast"] = "fast"
     """Config overlay applied before tracking."""
     lanes: tuple[Lane, ...] = ("cpu", "gpu")

--- a/packages/slam-rs/slam_rs/catalog_feed.py
+++ b/packages/slam-rs/slam_rs/catalog_feed.py
@@ -4,7 +4,7 @@ The feed is the Python half of the estimator's data contract: it reads a segment
 either from a catalog URL or from a local ``.rrd`` served in process, and hands
 the Rust core CPU grayscale images with integer-nanosecond timestamps.
 
-Three decisions are frozen here because each one silently changes the numbers:
+Five decisions are frozen here because each one silently changes the numbers:
 
 * **Pixels.** AV1 samples are muxed without re-encoding and decoded by
   single-threaded dav1d to ``gray8``. The MSD streams are limited-range
@@ -25,7 +25,7 @@ Three decisions are frozen here because each one silently changes the numbers:
   far apart two cameras' frames may be and still be one frameset.
 * **Clocks.** ``video_time`` is the IMU's clock. Frames and ground truth reach it
   by adding ``cam_time_offset_ns``, which is what "added to a camera timestamp to
-  reach the IMU clock" means and what basalt's own RoboCap reader does
+  reach the IMU clock" means and the feed's timestamp rule
   (``frameset_t = median(camera_t) + kCameraToImuOffsetNs``, the IMU untouched).
   MSD's offset is zero, so every MSD number is unchanged by this.
 * **Geometry.** ``Pinhole:image_from_camera`` is column-major, ``Pinhole:resolution``
@@ -71,7 +71,7 @@ DEFAULT_WINDOW_S: float = 60.0
 """Time window a long segment is cut into: a 7.6 s two-camera segment is 8.5 MB, so a 2,000 s one is not one query."""
 
 CameraModelName: TypeAlias = Literal["kb4", "radtan8"]
-"""Projection models V0 supports, named as basalt names them."""
+"""Projection models V0 supports, using the accepted calibration names."""
 
 _MODEL_BY_DISTORTION: dict[str, tuple[CameraModelName, int]] = {"kannala_brandt": ("kb4", 4), "brown_conrady": ("radtan8", 8)}
 """``simplecv.components.DistortionModel`` string to the model and the number of coefficients it uses."""
@@ -107,7 +107,7 @@ class CameraStatics:
     transform_relation: int
     """``Transform3D:relation``; must be :data:`CHILD_FROM_PARENT`."""
     distortion_valid_radius: float | None
-    """basalt's ``rpmax``; present on msd-g2 only."""
+    """The valid radius ``rpmax``; present on msd-g2 only."""
 
 
 @dataclass(slots=True, frozen=True)
@@ -140,7 +140,7 @@ class CameraCalib:
     distortion: Float64[ndarray, " n_coeffs"]
     """Exactly the coefficients the model uses: 4 for kb4, ``k1 k2 p1 p2 k3 k4 k5 k6`` for radtan8."""
     distortion_valid_radius: float | None
-    """basalt's ``rpmax``, when the recording carries one."""
+    """The valid radius ``rpmax``, when the recording carries one."""
     imu_T_cam: Float64[ndarray, "4 4"]
     """Camera pose in the IMU frame: the inverse of the stored ``ChildFromParent`` transform."""
 
@@ -204,20 +204,10 @@ class Frameset:
     """Nearest ground-truth pose as ``[tx, ty, tz, qw, qx, qy, qz]``, or None without a ``gt`` layer."""
 
     def image_digests(self) -> tuple[str, ...]:
-        """Digest of each camera's gray8 bytes, in the same order as :attr:`images`.
+        """Digest each camera's contiguous gray8 buffer in image order.
 
-        This is the unit the basalt C++ reference records in its
-        ``frames.sha256`` (one ``t_ns,cam_index,sha256`` line per decoded frame),
-        so the two decoders can be compared frame by frame rather than only in
-        aggregate. Only the pixel-parity tests and the clip dumper ask for it,
-        which is why it is hashed on demand rather than in the feed loop: that
-        loop is what a gate's wall time and every fleet row's realtime factor
-        measure, and 0.68 ms a frameset of SHA-256 over 2x960x960 is decode plus
-        `track` and something else.
-
-        The array's own buffer is hashed rather than a ``tobytes()`` copy of it —
-        the same bytes and the same digest, and a non-contiguous frame raises
-        here rather than being hashed in a different order.
+        Hash on demand for pixel comparisons and clip dumps, avoiding hashing cost
+        in the feed loop and avoiding a temporary bytes copy.
 
         Returns:
             One hex digest per camera.
@@ -285,7 +275,7 @@ class RigProfile:
 
     False is MSD, whose ``video_time`` is relative to
     ``property:capture:start_time_ns``; RoboCap records the device clock itself,
-    and that is what every basalt CSV beside it carries.
+    and that is what trajectory CSV exports use.
     """
 
     def __post_init__(self) -> None:
@@ -301,7 +291,7 @@ class RigProfile:
 
     @classmethod
     def from_robocap(cls, reference: RobocapReference) -> "RigProfile":
-        """How the RoboCap rig has to be read, from the manifest's record of the C++ lane.
+        """Read the RoboCap rig selection, downscale, clock and pairing rules from the manifest.
 
         Args:
             reference: The manifest's ``[robocap]`` table, which is where the five
@@ -324,14 +314,10 @@ MSD_RIG: RigProfile = RigProfile()
 
 
 def scale_principal_point(value: float, downscale: int) -> float:
-    """One principal-point coordinate at ``1 / downscale`` of its resolution.
+    """Scale a principal-point coordinate by pixel centers.
 
-    The pixel's own centre is what scales, not its index: a pixel at ``c`` covers
-    ``[c, c + 1)`` whose centre is ``c + 0.5``, and the downscaled pixel centre
-    ``(c + 0.5) / d`` is at index ``(c + 0.5) / d - 0.5``. This is the convention
-    the fork's ``basalt_convert_robocap_calib.py`` writes, and reproducing it from
-    the recording's own native statics returns that file's digits exactly
-    (``tests/test_catalog_feed.py``).
+    A pixel at c has center c + 0.5. At downscale d its index becomes
+    (c + 0.5) / d - 0.5. This keeps calibration aligned with area-resampled pixels.
     """
     return (value + 0.5) / downscale - 0.5
 
@@ -535,8 +521,7 @@ def decode_gray(mp4_bytes: bytes, downscale: int = 1) -> Iterator[UInt8[ndarray,
 
     A ``downscale`` above one asks the same ``swscale`` call for the smaller frame
     with ``SWS_AREA``: one conversion, colour and size together, which is the
-    operation basalt's own RoboCap reader performs
-    (``cpu_gray8_swscale_area_downscale3``). Converting first and resampling
+    combined area-resampling operation. Converting first and resampling
     afterwards is a second, different filter and a different trajectory.
 
     Args:
@@ -579,7 +564,7 @@ class _VideoIndex:
     A frameset is one row: its ``video_time``, and the frame each fed camera
     contributes to it. On a hardware-synced rig fed whole that is the identity —
     frameset ``i`` is frame ``i`` of every camera — and on RoboCap it is the
-    nearest-match table basalt's reader builds.
+    nearest-match table built by this feed.
     """
 
     t_ns: Int64[ndarray, " n_framesets"]
@@ -620,7 +605,7 @@ class SegmentFeed:
     """Timestamp of every frameset on the inertial clock, before ``frame_stride`` is applied.
 
     That is ``video_time`` plus :attr:`ImuCalib.cam_time_offset_ns`, which is the
-    clock the estimator, the exported trajectory and every basalt CSV are on.
+    clock the estimator, the exported trajectory and ground-truth CSV exports are on.
     """
     camera_positions: tuple[int, ...]
     """Rig index of each fed camera, in the order a frameset's images arrive."""
@@ -852,19 +837,12 @@ def _window_bounds(index: _VideoIndex, window_ns: int) -> list[tuple[int, int]]:
 
 
 def _frame_nearest_anchor(times: Int64[ndarray, " n_frames"], cursor: int, anchor_t_ns: int, tolerance_ns: int) -> tuple[int | None, int]:
-    """The frame one camera contributes to one anchor, and where its cursor goes if the frameset falls.
+    """Select a camera frame nearest the anchor, breaking ties towards the later frame.
 
-    The camera walks forward from ``cursor`` while the next frame is no farther
-    from the anchor than the current one — ties take the later frame, which is
-    basalt's ``<=`` (``dataset_io_robocap.cpp:422-426``) — and contributes that
-    frame if it sits within ``tolerance_ns`` (inclusive, ``:427``).
-
-    When it does not, the cursor moves only if that nearest frame is *earlier*
-    than the anchor (``:428``): such a frame is farther from every later anchor
-    still, so no anchor can ever take it, while a camera running ahead keeps its
-    frame for the next anchor. The returned cursor is therefore where this camera
-    stands once the frameset falls; a caller whose frameset stands ignores it and
-    moves the cursor past the frame it took (``selected + 1``, ``:439``).
+    Accept the inclusive tolerance. On an incomplete frameset, discard a selected
+    frame only if it is earlier than the anchor: it cannot serve a later anchor.
+    A future frame stays available. On completion, the caller advances past each
+    selected frame so no image is reused.
 
     Args:
         times: The camera's frame timestamps, in time order.
@@ -887,25 +865,14 @@ def _frame_nearest_anchor(times: Int64[ndarray, " n_frames"], cursor: int, ancho
 
 
 def match_framesets(camera_t_ns: Sequence[Int64[ndarray, " n_frames"]], tolerance_ns: int) -> tuple[Int64[ndarray, " n_framesets"], Int64[ndarray, "n_framesets n_cameras"]]:
-    """Group frames into framesets the way basalt's multi-camera reader does.
+    """Group camera frames around camera 0 anchors.
 
-    Camera 0 is the anchor. Every other camera advances to the frame nearest the
-    anchor's, and the frameset exists only if every camera has one within
-    ``tolerance_ns``. Its timestamp is the median of the frames in it, which for
-    an even number of cameras is the lower middle plus half the gap to the upper
-    one — the arithmetic is basalt's, and reproducing it exactly is what makes the
-    port's frameset times equal the C++'s to the nanosecond.
-
-    A frame joins one frameset only: a complete frameset moves every non-anchor
-    cursor past the frame it took (``selected + 1``,
-    ``dataset_io_robocap.cpp:439``). An incomplete one moves a cursor only where
-    that camera's nearest frame is *earlier* than the anchor and can therefore
-    never partner a later one; a camera running ahead keeps its frame for the
-    next anchor.
-
-    An incomplete frameset whose anchor lies inside every camera's own span is an
-    interior drop, and basalt allows one per thousand interior anchors before it
-    calls the run unusable.
+    Every camera must have a nearest frame within the inclusive tolerance.
+    Use the median timestamp; for even counts, use the lower middle plus half
+    the integer gap. Complete framesets consume all selected images once.
+    Incomplete ones discard only frames earlier than the anchor.
+    Allow max(1, ceil(interior_anchors * 0.001)) incomplete interior anchors;
+    exterior anchors do not count against the rig.
 
     Args:
         camera_t_ns: Each fed camera's frame timestamps, in time order.
@@ -937,7 +904,7 @@ def match_framesets(camera_t_ns: Sequence[Int64[ndarray, " n_frames"]], toleranc
         interior: bool = overlap_start <= anchor_t_ns <= overlap_end
         interior_anchors += interior
         row: list[int] = [anchor_index]
-        # Where each camera would land: basalt commits these to the cursors only
+        # Where each camera would land: commit these to the cursors only
         # once the whole frameset stands.
         selected: list[int] = list(cursors)
         for position in range(1, len(camera_t_ns)):
@@ -961,7 +928,7 @@ def match_framesets(camera_t_ns: Sequence[Int64[ndarray, " n_frames"]], toleranc
             raise ValueError(f"frameset timestamps are not strictly increasing: {frameset_t_ns} follows {t_ns[-1]}")
         t_ns.append(frameset_t_ns)
         rows.append(row)
-    # basalt's own allowance, in its own arithmetic: one in a thousand, at least one.
+    # Allow one interior drop per thousand anchors, with a minimum of one.
     allowed_drops: int = max(1, math.ceil(interior_anchors * 0.001))
     if interior_drops > allowed_drops:
         raise ValueError(
@@ -1122,7 +1089,7 @@ def _read_imu(dataset: DatasetEntry, segment_id: str, interpolate_accel: bool, f
         raise ValueError(f"{segment_id}: IMU timestamps are not strictly increasing")
     # MSD logs both sensors on identical timestamps, so pairing is an assertion.
     # RoboCap's two channels run on their own clocks (10,745 gyro against 10,751
-    # accel on session 15), and basalt's reader interpolates the accelerometer
+    # accel on session 15), so interpolate accelerometer values
     # onto the gyroscope's timestamps; the core only ever sees the paired form.
     if not interpolate_accel:
         if not np.array_equal(gyro_t_ns, accel_t_ns):
@@ -1144,8 +1111,7 @@ def pair_accel_onto_gyro(
     A gyroscope sample outside the accelerometer's own span is dropped rather
     than held at an endpoint: ``numpy.interp`` clamps, which would feed the
     estimator a constant acceleration over a stretch it has no measurement for.
-    This is basalt's rule for RoboCap, whose file reader skips a gyroscope sample
-    that has no accelerometer sample on both sides of it.
+    Require accelerometer coverage on both sides of each retained gyroscope sample.
 
     Args:
         gyro_t_ns: Gyroscope timestamps, strictly increasing.
@@ -1160,12 +1126,9 @@ def pair_accel_onto_gyro(
         ValueError: If a channel is too short to interpolate with, or the two
             spans do not overlap, so the paired stream would be empty.
     """
-    # basalt deduplicates both raw channels before it pairs them
-    # (`sort_and_deduplicate`, `dataset_io_robocap.cpp:472`), keeping the first
-    # sample of each equal-timestamp run. That is what its `interval == 0` guard
-    # reads as alpha 0, and it is the whole difference from `numpy.interp`, which
-    # takes the second of a duplicated pair and then interpolates the next
-    # gyroscope sample from the wrong end of the gap.
+    # Deduplicate both channels before pairing, keeping the first
+    # sample of each equal-timestamp run. Keeping the second duplicate would
+    # change interpolation across the following gap.
     first_of_run: Bool[ndarray, " n_accel"] = np.ones(accel_t_ns.size, dtype=bool)
     first_of_run[1:] = np.diff(accel_t_ns) != 0
     accel_t_ns = accel_t_ns[first_of_run]
@@ -1177,8 +1140,8 @@ def pair_accel_onto_gyro(
         )
     inside: Bool[ndarray, " n_gyro"] = (gyro_t_ns >= accel_t_ns[0]) & (gyro_t_ns <= accel_t_ns[-1])
     if not bool(inside.any()):
-        # basalt errors instead of handing the estimator an empty inertial stream
-        # (`dataset_io_robocap.cpp:496`); a rig with no IMU is not this rig.
+        # Refuse an empty inertial stream:
+        # this rig requires paired IMU measurements.
         raise ValueError(
             f"the two inertial channels do not overlap, so nothing pairs: the gyroscope spans "
             f"{int(gyro_t_ns[0])}..{int(gyro_t_ns[-1])} ns and the accelerometer {int(accel_t_ns[0])}..{int(accel_t_ns[-1])} ns"
@@ -1262,12 +1225,10 @@ def _rig_trajectory(table: pa.Table, segment_id: str) -> Trajectory:
 
 
 def select_cameras(statics: pa.Table, camera_count: int, camera_names: tuple[str, ...] | None) -> tuple[int, ...]:
-    """Rig indices of the named cameras, in the caller's order.
+    """Resolve camera names to rig indices in caller order.
 
-    Names are read from each camera node's ``name`` static and compared with
-    hyphens normalised to underscores **on both sides**, because the rig writes
-    ``left-front`` where basalt's driver spells it ``left_front`` and a caller
-    may reasonably spell it either way.
+    Normalize hyphens to underscores on both sides so left-front and left_front
+    select the same recorded camera.
 
     Args:
         statics: Single-row table holding every camera node's statics.

--- a/packages/slam-rs/slam_rs/reference.py
+++ b/packages/slam-rs/slam_rs/reference.py
@@ -20,7 +20,7 @@ DecodePath: TypeAlias = Literal["cpu_gray8_dav1d_1thread", "cpu_gray8_swscale_ar
 The MSD gate is frozen on the single-threaded dav1d ``gray8`` path (D28). RoboCap's
 H.264 streams are decoded on the same one decoder thread but reformatted straight to
 ``gray8`` at a third of their size in one ``swscale`` call with ``SWS_AREA``, which is
-the operation the reference RoboCap reader performs.
+the combined area-resampling operation selected for RoboCap.
 """
 GroundTruthSource: TypeAlias = Literal["lighthouse", "mocap"]
 """How a segment's ground-truth rig poses were measured."""
@@ -75,7 +75,7 @@ modules is a manifest id nobody can rename.
 
 @dataclass(slots=True, frozen=True)
 class ImuParameters:
-    """Continuous-time IMU noise model and clock offset, in basalt's units.
+    """Continuous-time IMU noise model and clock offset, in the estimator's units.
 
     None of this is on the recordings; it comes from the device's own calibration
     file and is frozen here until dataforge logs it onto the IMU node.
@@ -106,7 +106,7 @@ class CaptureProperties:
     num_cameras: int
     """Cameras on the rig."""
     start_time_ns: int
-    """Device-clock time of ``video_time`` zero; add it to reach the clock every basalt CSV uses."""
+    """Device-clock time of ``video_time`` zero; add it to reach the absolute export clock."""
 
 
 @dataclass(slots=True, frozen=True)
@@ -125,7 +125,7 @@ class LayerFingerprint:
 
 @dataclass(slots=True, frozen=True)
 class DatasetProperties:
-    """The rig geometry and basalt config shared by every segment of one dataset.
+    """The rig geometry and VIO config shared by every segment of one dataset.
 
     Calibration is byte-identical across a dataset's segments (33/33 for
     ``msd-index``, 15/15 for ``msd-g2``), so it is recorded once per dataset and
@@ -244,9 +244,9 @@ class RobocapReference:
     video_time_is_absolute: bool
     """Whether ``video_time`` is already the device clock the reference trajectories are on."""
     vio_config: str
-    """basalt VIO config the reference ran, relative to the package root."""
+    """VIO configuration selected for replay, relative to the package root."""
     calibration: str
-    """basalt calibration the reference ran, at :attr:`downscale`, relative to the package root."""
+    """Rig calibration selected for replay, at :attr:`downscale`, relative to the package root."""
     imu: ImuParameters
     """Frozen IMU noise model, from the device's Kalibr calibration."""
     sessions: tuple[RobocapSession, ...]
@@ -293,7 +293,7 @@ class ReferenceManifest:
         raise ValueError(f"{name!r} is not in the reference set; have {[d.name for d in self.datasets]}")
 
     def vio_config_text(self, dataset_name: str, profile: str = "reference") -> str:
-        """The basalt VIO config one dataset's segments run with, as its file's own text.
+        """The VIO config one dataset's segments run with, as its file's own text.
 
         Args:
             dataset_name: Catalog dataset name.

--- a/packages/slam-rs/slam_rs/tracking.py
+++ b/packages/slam-rs/slam_rs/tracking.py
@@ -230,7 +230,7 @@ def check_calibration_matches_recording(basalt: _core.Calibration, cameras: tupl
     if tuple(basalt.resolution) != expected:
         raise ValueError(f"basalt's calibration is {list(basalt.resolution)}, the feed decodes {list(expected)} at downscale {downscale}")
     # `Calibration` exposes no intrinsics accessor, so the comparison goes through
-    # the round trip its own `to_json` writes, which is basalt's shape.
+    # the JSON round trip written by to_json.
     written: dict[str, Any] = json.loads(basalt.to_json())["value0"]
     for camera, lens, extrinsic in zip(cameras, written["intrinsics"], written["T_imu_cam"], strict=True):
         if lens["camera_type"] != camera.model:

--- a/packages/slam-rs/slam_rs/trajectory.py
+++ b/packages/slam-rs/slam_rs/trajectory.py
@@ -1,17 +1,12 @@
-"""EuRoC/basalt trajectory CSVs and the rigid-aligned ATE that gates a run.
+"""Trajectory CSV input/output and rigid-aligned absolute trajectory error.
 
-The arithmetic is the basalt fork's ``golden_compare.py``: nearest-neighbour
-association with a 5 ms tolerance, driven by the estimate, rigid Umeyama
-alignment of the two associated point sets, and RMSE of the residual positions.
-It lives here so the gate, the replay tool and the tests all use one
-implementation.
+The estimate drives nearest-neighbor association within 5 ms. Rigid Umeyama
+alignment fixes scale at one, then positional RMSE measures the residual.
+The gate, replay tool and tests share this implementation.
 
-The file format is basalt's own: a ``#``-prefixed header line, then
-``t_ns, p_x, p_y, p_z, q_w, q_x, q_y, q_z``. Timestamps are integer nanoseconds
-and never pass through a float on the way in or out; the quaternion is
-**w-first** on disk and stays w-first in memory, because that is what both the
-``gt.csv`` sidecars and basalt's writer use. Rerun's XYZW ordering is converted
-exactly once, at the logging boundary.
+CSV columns are t_ns, p_x, p_y, p_z, q_w, q_x, q_y, q_z, with a comment header.
+Timestamps remain integer nanoseconds. Quaternions stay w-first in memory
+and convert to XYZW only at the logging boundary.
 """
 
 from dataclasses import dataclass
@@ -27,7 +22,7 @@ ASSOCIATION_TOLERANCE_NS: int = 5_000_000
 MIN_ASSOCIATED_POSES: int = 10
 """Fewest associations the gate accepts before it calls the comparison meaningless."""
 CSV_HEADER: str = "#timestamp [ns], p_x, p_y, p_z, q_w, q_x, q_y, q_z"
-"""Header basalt's own writer emits, and the one :func:`write_trajectory` reproduces."""
+"""CSV header emitted by :func:`write_trajectory`."""
 
 
 @dataclass(slots=True, frozen=True)
@@ -82,7 +77,7 @@ class AteResult:
     """The rigid transform that took the reference positions onto the estimate's."""
 
     def summary(self) -> str:
-        """The two lines ``golden_compare.py`` prints, in centimetres."""
+        """Pose counts and trajectory errors, in centimetres."""
         return (
             f"poses: estimate={self.n_estimate} reference={self.n_reference} "
             f"associated={self.n_associated} (count delta {self.count_delta:.1%})\n"
@@ -101,9 +96,9 @@ def empty_trajectory() -> Trajectory:
 
 
 def read_trajectory(path: Path) -> Trajectory:
-    """Read a EuRoC/basalt trajectory CSV.
+    """Read a EuRoC-style trajectory CSV.
 
-    Comment lines starting with ``#`` are skipped, which covers both the basalt
+    Comment lines starting with ``#`` are skipped, which covers both the trajectory
     header (``#timestamp [ns], p_x, ...``) and the sidecar header
     (``#timestamp [ns],p_RS_R_x [m], ...``). The timestamp column is parsed as an
     integer directly from the text: routing it through float64 would be exact for
@@ -128,7 +123,7 @@ def read_trajectory(path: Path) -> Trajectory:
 
 
 def write_trajectory(path: Path, trajectory: Trajectory) -> None:
-    """Write a trajectory in basalt's CSV form, timestamps as exact integers.
+    """Write a trajectory in the trajectory CSV format, timestamps as exact integers.
 
     Args:
         path: Destination CSV; parent directories are created.
@@ -147,8 +142,8 @@ def shift_clock(trajectory: Trajectory, offset_ns: int) -> Trajectory:
     """Move a trajectory onto another clock by adding a constant nanosecond offset.
 
     The catalog indexes a segment on ``video_time``, which is relative to
-    ``property:capture:start_time_ns``; every basalt CSV, including the ``gt.csv``
-    sidecars, is on the absolute device clock. On the Index smoke segment the two
+    ``property:capture:start_time_ns``; trajectory CSV exports, including the ``gt.csv``
+    sidecars, are on the absolute device clock. On the Index smoke segment the two
     differ by 10,433,867,587,166 ns, so exporting relative timestamps produces a
     file that associates with **nothing**. This is the one place the conversion
     happens, and it happens at the CSV boundary.
@@ -188,7 +183,7 @@ def shift_clock(trajectory: Trajectory, offset_ns: int) -> Trajectory:
 def associate(reference: Trajectory, candidate: Trajectory, tolerance_ns: int = ASSOCIATION_TOLERANCE_NS) -> Association:
     """Match every reference pose to its nearest candidate pose in time.
 
-    Both trajectories must be sorted by timestamp, as basalt's writer emits them.
+    Both trajectories must be sorted by timestamp.
 
     Args:
         reference: Trajectory whose timestamps drive the association.
@@ -212,16 +207,11 @@ def associate(reference: Trajectory, candidate: Trajectory, tolerance_ns: int = 
 
 
 def rigid_alignment(source: Float64[ndarray, "n 3"], target: Float64[ndarray, "n 3"]) -> SimilarityTransform:
-    """Least-squares rigid transform taking ``source`` onto ``target``, scale fixed at 1.
+    """Least-squares rigid transform from source to target, with scale fixed at one.
 
-    This is ``golden_compare.py``'s inline arithmetic, ported unchanged, because
-    D14 gates on parity with the fork's numbers. In particular there is **no
-    variance floor**: a stationary rig, or a trajectory spanning micrometres,
-    aligns to itself with zero error rather than raising. The shared
-    ``simplecv.ops.umeyama_alignment`` rejects a source variance of 1e-9 or less
-    even when it is not estimating a scale, which would turn those runs into
-    errors instead of the passes the fork reports. That helper cross-checks this
-    one in the tests, on inputs where both are defined.
+    No variance floor is imposed: stationary and micrometre-scale trajectories
+    can align without raising. Tests cross-check the shared Umeyama helper on
+    inputs where both implementations are defined.
 
     Args:
         source: Points to move, one XYZ per row.
@@ -252,25 +242,13 @@ def rigid_alignment(source: Float64[ndarray, "n 3"], target: Float64[ndarray, "n
 
 
 def ate(estimate: Trajectory, reference: Trajectory, tolerance_ns: int = ASSOCIATION_TOLERANCE_NS) -> AteResult:
-    """Rigid-aligned absolute trajectory error of ``estimate`` against ``reference``.
+    """Rigid-aligned absolute trajectory error against the reference trajectory.
 
-    **The estimate drives the association**: each of its poses takes the nearest
-    reference pose within the tolerance, which is how the reference manifest's
-    own C++ numbers were produced and what keeps a 917 Hz ground truth from
-    weighting the metric by its own density. The convention is in this signature
-    on purpose — it used to live only in prose, and the one call site that
-    trusted the old parameter names silently plotted a different metric.
-
-    The alignment fixes the scale at 1: a visual-inertial estimator is metric, so
-    a fitted scale would hide a real error.
-
-    Whether the result is meaningful is the gate's question, not this one's: a
-    two-pose comparison returns a number here and
-    :func:`slam_rs.reference.d60_failures` rejects it there. This needs an
-    association and not a pose count, so an estimate on another clock has
-    nothing to align however many poses it carries: both fleet tools take the
-    refusal's own sentence as a row rather than a traceback, because which clock
-    a trajectory landed on is a fact about that machine.
+    Each estimate pose selects its nearest reference pose within tolerance.
+    Estimate-driven association prevents dense ground truth from changing metric
+    weights. Scale stays one because fitting it would hide a metric VIO error.
+    The metric needs at least one association; the ground-truth gate separately
+    checks coverage and run validity.
 
     Args:
         estimate: Trajectory under test, whose poses drive the association.
@@ -360,12 +338,10 @@ def coverage(reference: Trajectory, candidate: Trajectory) -> float:
 
 
 def extent_m(trajectory: Trajectory) -> float:
-    """The diagonal of a trajectory's bounding box, metres; ``0.0`` when it has no pose.
+    """Bounding-box diagonal in metres, or zero for an empty trajectory.
 
-    What a ``no_divergence`` clip is gated on (D60 clause 5): where basalt itself
-    is near failure a tolerance measures noise, so the run has to have stayed
-    bounded and nothing more. The V2 gate and the fleet tool both read it, which
-    is why it lives beside :func:`ate` rather than in either of them.
+    This diagnostic measures spatial extent; ground-truth acceptance is defined
+    by the manifest baseline gate.
 
     Args:
         trajectory: The trajectory to measure.

--- a/packages/slam-rs/slam_rs/vio_log.py
+++ b/packages/slam-rs/slam_rs/vio_log.py
@@ -36,12 +36,7 @@ RUN_ENTITY: str = "/world/runs/slam_rs"
 GT_ENTITY: str = "/world/runs/gt"
 """The dataset's own ground-truth run, which the base recording already names."""
 VIO_STATS_ENTITY: str = "/stats/vio"
-"""Where the per-frame counters go, off the dataset's own tree and beside the frontend's.
-
-Named for the rung it belongs to, not for what it is: this module already imports
-three names from :mod:`slam_rs.frontend_log`, which has its own ``STATS_ENTITY``
-and its own ``CPP_COLOR`` with different values, and one unqualified import of
-either would have been silently wrong.
+"""Entity path for per-frame VIO counters, separate from dataset and frontend stats.
 """
 
 ESTIMATE_COLOR: tuple[int, int, int] = (70, 220, 130)
@@ -396,7 +391,7 @@ class VioLogger:
         rr.log(f"{VIO_STATS_ENTITY}/lm_lambda", rr.Scalars(snapshot.lm_lambda))
         # The cost the frame started and ended the LM loop at: the pair is the
         # convergence trace, and :func:`vio_blueprint` gives it an axis of its
-        # own. Both are negative on most frames, which is basalt's own convention
+        # own. Both are negative on most frames, following the prior cost convention
         # and not a sign error: the marginalization prior term deliberately drops
         # the 1/2 r^T r (``crates/slam-rs/src/estimator/optimize.rs:71``, D20).
         rr.log(f"{VIO_STATS_ENTITY}/lm_error_before", rr.Scalars(snapshot.lm_error_before))

--- a/packages/slam-rs/tests/conftest.py
+++ b/packages/slam-rs/tests/conftest.py
@@ -150,7 +150,7 @@ def texture() -> TextureFactory:
     """One fixed blocky-noise scene, shifted by whole pixels.
 
     Blocky **noise**, not a lattice: a repeating pattern gives every corner the
-    same score, and basalt's suppression is strictly-greater-than, so a tie kills
+    same score, and the detector's suppression is strictly-greater-than, so a tie kills
     both sides and a perfectly regular scene detects almost nothing.
     """
 

--- a/packages/slam-rs/tests/test_boundary_properties.py
+++ b/packages/slam-rs/tests/test_boundary_properties.py
@@ -1,6 +1,6 @@
 """Property tests of the estimator's inertial boundary, driven through ``slam_rs._core`` (D23).
 
-Hypothesis drives the PyO3 boundary directly: no CLI oracle. Examples are capped
+Hypothesis drives the PyO3 boundary directly: no CLI subprocess. Examples are capped
 so the whole file stays inside the default, seconds-long suite. The image rules
 both entry points share — rank, dtype, layout, the frameset's width and the
 calibrated frame size — are parametrized over ``Vio.track`` and

--- a/packages/slam-rs/tests/test_catalog_feed.py
+++ b/packages/slam-rs/tests/test_catalog_feed.py
@@ -52,7 +52,7 @@ def _kb4_statics(
         distortion_model: ``simplecv.components.DistortionModel`` string to store.
         distortion_coefficients: Fixed-width coefficient list; defaults to msd-index cam0's KB4 values with a zero tail.
         transform_relation: ``Transform3D:relation`` code to store.
-        distortion_valid_radius: basalt's ``rpmax``, when the recording carries one.
+        distortion_valid_radius: The valid radius ``rpmax``, when the recording carries one.
 
     Returns:
         Synthetic statics with the storage conventions the catalog really uses.
@@ -122,14 +122,10 @@ def test_the_extrinsic_is_inverted_only_for_child_from_parent() -> None:
 def _rotate_pinhole_clockwise(
     fx: float, fy: float, cx: float, cy: float, width: int, height: int, rotation_cw_deg: int
 ) -> tuple[float, float, float, float]:
-    """Rotate a landscape pinhole calibration into the frame the images are stored in.
+    """Rotate landscape intrinsics into the stored image orientation.
 
-    msd-g2's video is stored rotated into portrait and its catalog calibration is
-    rotated to match, so this is the arithmetic that reconciles a raw-MSD
-    calibration with a catalog one. The feed itself never needs it — the catalog
-    already stores the rotated values — so it lives here, beside the test that is
-    its only caller: any A/B against a C++ basalt run fed from raw MSD needs the
-    convention, and pinning it keeps it from drifting.
+    The catalog already stores rotated calibration, so this helper is test-only.
+    It checks the relationship between landscape calibration and portrait images.
 
     Args:
         fx: Focal length along x before rotation.
@@ -158,7 +154,7 @@ def _rotate_pinhole_clockwise(
 
 
 def test_the_msd_g2_rotation_arithmetic() -> None:
-    """basalt's landscape msd-g2 calibration, rotated, is the catalog's portrait calibration."""
+    """The landscape msd-g2 calibration, rotated, is the catalog's portrait calibration."""
     landscape_width: int = 640
     landscape_height: int = 480
     # cam0 and cam1 are stored 90 degrees clockwise, cam2 and cam3 270.
@@ -441,6 +437,6 @@ def test_a_replay_export_associates_with_the_catalog_ground_truth(manifest: Refe
     sidecar: Trajectory = shift_clock(truth, segment.capture.start_time_ns)
     # All but the first pose, which sits on the capture's start time — 17 ms
     # before the sidecar's first row, so it has nothing to associate with. The
-    # ground truth does not cover the whole segment (D36).
+    # ground truth does not cover the whole segment.
     assert associate(read_trajectory(exported), sidecar).count == len(estimate) - 1
     assert associate(read_trajectory(relative_export), sidecar).count == 0

--- a/packages/slam-rs/tests/test_config_profiles.py
+++ b/packages/slam-rs/tests/test_config_profiles.py
@@ -16,12 +16,10 @@ def test_reference_profile_preserves_vendored_text() -> None:
 
 
 def test_fast_profile_changes_only_the_lm_cap_and_the_two_port_gates() -> None:
-    """The three keys the fast profile owns, and nothing else moves.
+    """The fast profile changes only its three declared keys.
 
-    Neither ``port.`` key is one of basalt's: they are the port's own
-    redetect-on-demand gate (D75) and its keyframe-gated joint solve (D76), so
-    both are absent from every vendored file and the overlay is the only thing
-    that ever sets them.
+    The port-prefixed keys select demand-based detection (D75) and the
+    keyframe-gated joint solve (D76). Only the overlay supplies them.
     """
     manifest: ReferenceManifest = load_manifest()
     for dataset in manifest.datasets:

--- a/packages/slam-rs/tests/test_dump_clip.py
+++ b/packages/slam-rs/tests/test_dump_clip.py
@@ -1,10 +1,7 @@
-"""What the PC11 dump producer refuses before it opens a segment.
+"""Clip-dump selection errors must be refused before opening a segment.
 
-``tests/tools/dump_clip.py`` is a test-only producer — it writes the ``.npz``
-bundle :mod:`slam_rs.apis.bench_track` replays and the PGM directory the Rust
-lanes and the C++ oracle read — and a whole segment is gigabytes, so what is
-worth a test here is the selection it will not spend a feed on. It is reached as
-a namespace module under ``tests``, the same path pytest and pyrefly are given.
+The test-only producer writes an NPZ input for bench_track and PGM inputs for
+Rust replay. Whole segments are large, so invalid selection must fail early.
 """
 
 from pathlib import Path

--- a/packages/slam-rs/tests/test_frameset_matching.py
+++ b/packages/slam-rs/tests/test_frameset_matching.py
@@ -64,12 +64,10 @@ def test_a_gyroscope_sample_the_accelerometer_does_not_cover_is_dropped() -> Non
 
 
 def test_the_accelerometers_span_is_closed_at_both_ends() -> None:
-    """basalt's endpoints, one nanosecond either side (`dataset_io_robocap.cpp:476-483`).
+    """Keep gyroscope samples exactly at either accelerometer endpoint.
 
-    A gyroscope sample **on** the first accelerometer timestamp interpolates with
-    alpha 0 and one on the last with alpha 1, so both are measurements and both
-    are kept; one nanosecond outside has no accelerometer sample on both sides of
-    it and is dropped rather than clamped.
+    Interpolation uses alpha zero or one there. A sample even one nanosecond
+    outside the span is dropped rather than clamped.
     """
     gyro_t_ns: Int64[ndarray, " 4"] = np.array([49, 50, 150, 151], dtype=np.int64)
     accel: Float64[ndarray, "2 3"] = np.array([[1.0, 1.0, 1.0], [3.0, 3.0, 3.0]])
@@ -80,12 +78,10 @@ def test_the_accelerometers_span_is_closed_at_both_ends() -> None:
 
 
 def test_two_accelerometer_samples_on_one_timestamp_take_the_first() -> None:
-    """basalt deduplicates the raw channel before pairing (`dataset_io_robocap.cpp:472`).
+    """Deduplicate before pairing, keeping the first sample at a timestamp.
 
-    Its `interval == 0` guard reads alpha 0 — the sample *before* — and the
-    deduplication is what makes that the only possible answer.
-    ``numpy.interp`` takes the second of the pair instead, and then interpolates
-    the following gyroscope sample from the wrong end of the gap.
+    This makes a zero-length interval select its earlier sample. Keeping the
+    second duplicate would change interpolation across the next gap.
     """
     paired = pair_accel_onto_gyro(
         np.array([20, 30], dtype=np.int64),
@@ -99,11 +95,10 @@ def test_two_accelerometer_samples_on_one_timestamp_take_the_first() -> None:
 
 
 def test_two_channels_that_do_not_overlap_are_refused() -> None:
-    """basalt errors rather than deliver an empty stream (`dataset_io_robocap.cpp:496`).
+    """Refuse an empty paired inertial stream.
 
-    The two channels have their own clocks, so a segment whose accelerometer
-    stops before its gyroscope starts pairs to nothing. Returning that silently
-    fed the estimator a rig with no inertial data at all.
+    Non-overlapping accelerometer and gyroscope spans cannot supply inertial
+    data to this rig.
     """
     with pytest.raises(ValueError, match=r"gyroscope spans 1000\.\.2000 ns and the accelerometer 10\.\.20 ns"):
         pair_accel_onto_gyro(
@@ -115,7 +110,8 @@ def test_two_channels_that_do_not_overlap_are_refused() -> None:
 
 
 def test_one_accelerometer_sample_is_not_enough_to_interpolate() -> None:
-    """`raw_accel.size() < 2` is basalt's own bar (`dataset_io_robocap.cpp:473`)."""
+    """At least two accelerometer samples are required for interpolation.
+"""
     with pytest.raises(ValueError, match="two accelerometer samples"):
         pair_accel_onto_gyro(np.array([10], dtype=np.int64), np.ones((1, 3)), np.array([10], dtype=np.int64), np.ones((1, 3)))
 
@@ -139,17 +135,15 @@ def test_the_pairing_boundary_is_typed() -> None:
 
 
 def test_the_named_cameras_come_back_in_the_callers_order() -> None:
-    """RoboCap's rig order is not the C++'s: cam_04, cam_00, cam_01, cam_05."""
+    """Select RoboCap cameras in manifest order: cam_04, cam_00, cam_01, cam_05.
+"""
     statics: pa.Table = camera_name_statics(["left_front", "right_front", "left_eye", "right_eye", "left", "right"])
     assert select_cameras(statics, 6, ("left", "left_front", "right_front", "right")) == (4, 0, 1, 5)
     assert select_cameras(statics, 6, None) == (0, 1, 2, 3, 4, 5)
 
 
 def test_a_hyphenated_name_matches_the_underscored_one() -> None:
-    """The rig writes ``left-front`` where basalt's driver spells it ``left_front``.
-
-    Both sides are normalised, so a manifest that spells a camera the way the
-    recording itself does selects it rather than being refused.
+    """Hyphen and underscore spellings must select the same recorded camera.
     """
     statics: pa.Table = camera_name_statics(["left-front", "right-front"])
     assert select_cameras(statics, 2, ("left_front",)) == (0,)
@@ -171,11 +165,10 @@ def test_two_cameras_answering_to_one_name_is_refused() -> None:
 
 
 def test_the_matcher_reproduces_basalts_median_on_robocaps_first_frameset() -> None:
-    """Session 15's four cameras start 59 us apart and basalt calls that 70258640500 ns.
+    """Four Session 15 timestamps spanning 59 us have median 70258640500 ns.
 
-    An even camera count takes the lower middle plus half the gap to the upper
-    one, which is neither the mean nor either middle value, and it is what the
-    NAS `slam` layer's own first row carries.
+    For an even camera count, use lower middle plus half the gap, not the mean
+    or either middle value.
     """
     left: Int64[ndarray, " 2"] = np.array([70258648000, 70291970222], dtype=np.int64)
     left_front: Int64[ndarray, " 2"] = np.array([70258633000, 70291955222], dtype=np.int64)
@@ -210,12 +203,10 @@ def test_a_camera_that_misses_the_anchor_drops_the_frameset() -> None:
 
 
 def test_a_frame_belongs_to_one_frameset() -> None:
-    """basalt consumes the frame it took, so the next anchor cannot have it again.
+    """A completed frameset consumes each selected image once.
 
-    Cursors move to ``selected + 1`` once every camera is inside the tolerance
-    (`dataset_io_robocap.cpp:439`). Leaving them on the selected frame fed the
-    estimator the same image twice under two frameset timestamps, which is a
-    measurement the rig never made.
+    Advance cursors to selected + 1 only after every camera meets tolerance;
+    otherwise the same image could acquire two frameset timestamps.
     """
     anchors: Int64[ndarray, " 2"] = np.array([100, 180], dtype=np.int64)
     partner: Int64[ndarray, " 1"] = np.array([140], dtype=np.int64)
@@ -226,17 +217,11 @@ def test_a_frame_belongs_to_one_frameset() -> None:
 
 
 def test_a_camera_selected_for_an_incomplete_frameset_keeps_its_frame() -> None:
-    """A provisional selection is thrown away with the frameset it was for.
+    """Discard provisional selections when the full frameset is incomplete.
 
-    The C++ moves the cursors only after ``complete``
-    (`dataset_io_robocap.cpp:439`), so a camera picked for a frameset that then
-    fell keeps its frame. Anchor 100 takes camera 1's 150 (|150 - 100| = 50, the
-    inclusive edge) but camera 2's only frame is 200, which is 100 away, so the
-    frameset falls. Anchor 200 then takes camera 1's 150 (index 0, again the
-    inclusive edge) and camera 2's 200 (index 0): one frameset, whose three-camera
-    median of (200, 150, 200) is 200 — the matcher adds no offset of its own, the
-    caller applies ``cam_time_offset_ns``. Committing camera 1's selection after
-    anchor 100 would exhaust that camera and leave the rig with no frameset.
+    Camera 1 at 150 can still partner anchor 200 after anchor 100 fails because
+    camera 2 is at 200. Committing it early would exhaust the camera.
+    The median is 200; clock offsets are applied by the caller.
     """
     anchors: Int64[ndarray, " 2"] = np.array([100, 200], dtype=np.int64)
     cameras: list[Int64[ndarray, " 1"]] = [np.array([150], dtype=np.int64), np.array([200], dtype=np.int64)]
@@ -247,11 +232,8 @@ def test_a_camera_selected_for_an_incomplete_frameset_keeps_its_frame() -> None:
 
 
 def test_a_frame_the_anchor_is_too_early_for_waits_for_the_next_anchor() -> None:
-    """A camera ahead of the anchor keeps its frame; one behind it is consumed.
-
-    The C++ advances the cursor past the nearest frame only when that frame is
-    *earlier* than the anchor (`dataset_io_robocap.cpp:428`), because a late
-    camera's frame is still the right partner for the anchor after this one.
+    """On failure, consume only a nearest frame earlier than the anchor.
+    A camera ahead of the anchor retains a potential partner for the next one.
     """
     anchors: Int64[ndarray, " 2"] = np.array([100, 200], dtype=np.int64)
     partner: Int64[ndarray, " 1"] = np.array([190], dtype=np.int64)
@@ -262,25 +244,11 @@ def test_a_frame_the_anchor_is_too_early_for_waits_for_the_next_anchor() -> None
 
 
 def test_a_frame_no_later_anchor_can_reach_is_consumed_on_the_spot() -> None:
-    """The one matcher rule whose effect never reaches the output, tested where it lives.
+    """Check stale-frame cursor advancement at the per-camera step.
 
-    `dataset_io_robocap.cpp:428` moves a camera's cursor past its nearest frame
-    when that frame is out of tolerance *and* earlier than the anchor. Anchors
-    only increase, so such a frame is farther from every later anchor still and
-    no frameset can ever take it. That also makes the rule invisible in
-    `match_framesets`'s output: leaving the cursor on the stale frame costs only
-    the nearest-frame walk, which re-reaches the same frame at the next anchor.
-    So it is pinned on the per-camera step instead, hand-computed:
-
-    * frames (0, 1000), cursor 0, anchor 100, tolerance 20 — the walk stays on 0
-      (|1000 - 100| = 900 is no closer than |0 - 100| = 100), 100 > 20 drops the
-      frameset, and 0 < 100, so the cursor moves to 1 and 0 is gone.
-    * frame (200) alone, same anchor — 100 > 20 drops it too, but 200 > 100, so
-      the cursor stays on 0 and 200 waits for the next anchor.
-    * frames (90, 110), same anchor — the walk ties onto 110, |110 - 100| = 10 is
-      inside the tolerance, and the cursor stays where it was: the caller commits
-      ``selected + 1`` only once the whole frameset stands.
-    * cursor 1 on a one-frame camera — exhausted, and it stays exhausted.
+    A frame earlier than an out-of-tolerance anchor cannot serve any later anchor.
+    Advancing past it saves work without changing final framesets. Future frames
+    stay available, ties select the later frame, and exhausted cursors stay exhausted.
     """
     assert _frame_nearest_anchor(np.array([0, 1000], dtype=np.int64), 0, 100, 20) == (None, 1)
     assert _frame_nearest_anchor(np.array([200], dtype=np.int64), 0, 100, 20) == (None, 0)
@@ -305,11 +273,7 @@ def test_a_tie_takes_the_later_frame() -> None:
 
 
 def test_interior_drops_are_allowed_one_in_a_thousand() -> None:
-    """A run that drops more interior framesets than basalt tolerates is not a run.
-
-    `dataset_io_robocap.cpp:458` allows ``max(1, ceil(interior * 0.001))``
-    incomplete framesets whose anchor lies inside every camera's own span; more
-    than that is a rig whose cameras are not the same recording.
+    """Refuse more than max(1, ceil(interior * 0.001)) incomplete interior anchors.
     """
     anchors: Int64[ndarray, " 4"] = np.array([1000, 1100, 1200, 1300], dtype=np.int64)
     # Four interior anchors allow one drop: this partner misses the third anchor.
@@ -325,7 +289,7 @@ def test_the_drop_allowance_rounds_up_past_a_thousand_anchors() -> None:
     """Past a thousand interior anchors the ceil, not the floor of one, sets the bar.
 
     The allowance is ``max(1, ceil(interior * 0.001))``
-    (`dataset_io_robocap.cpp:458`), so 1,001 interior anchors allow
+    , so 1,001 interior anchors allow
     ceil(1.001) = 2 drops. The anchors here are 0, 100, ... 100,000 and the
     partner is the same list minus two of its interior frames, which keeps its
     first and last frame and therefore keeps all 1,001 anchors interior: 999
@@ -344,15 +308,10 @@ def test_the_drop_allowance_rounds_up_past_a_thousand_anchors() -> None:
 
 
 def test_only_a_drop_inside_every_cameras_span_counts_against_the_run() -> None:
-    """An anchor no camera could partner is not the rig's fault, and is not counted.
+    """Count anchors and drops only inside the common camera time span.
 
-    Both counters are gated on ``overlap_start <= anchor <= overlap_end``
-    (`dataset_io_robocap.cpp:410` for the anchors, `:436` for the drops). The
-    anchors here are 0, 10, 20, 30, 40 and the one partner has 20 and 30, so the
-    overlap is [20, 30]: two interior anchors, both complete, and the misses at
-    0, 10 and 40 are exterior. Counting those would be 3 drops of 5 anchors
-    against an allowance of max(1, ceil(0.005)) = 1, and this rig — a partner
-    camera that simply started late and stopped early — would be refused.
+    A camera starting late or stopping early must not turn exterior anchors into
+    interior-drop failures.
     """
     anchors: Int64[ndarray, " 5"] = np.array([0, 10, 20, 30, 40], dtype=np.int64)
     t_ns, frame_index = match_framesets([anchors, np.array([20, 30], dtype=np.int64)], 1)
@@ -368,7 +327,8 @@ def test_frameset_timestamps_must_strictly_increase() -> None:
 
 
 def test_a_camera_with_no_frames_is_named() -> None:
-    """basalt refuses the rig rather than the frameset (`dataset_io_robocap.cpp:380`)."""
+    """Refuse invalid rig input before matching framesets.
+"""
     with pytest.raises(ValueError, match="camera 1 has no frames"):
         match_framesets([np.array([100, 200], dtype=np.int64), np.array([], dtype=np.int64)], 50)
 
@@ -384,10 +344,7 @@ def test_the_matcher_needs_a_camera() -> None:
 
 
 def test_the_profile_comes_from_the_manifest_not_the_code(manifest: ReferenceManifest) -> None:
-    """One place says what the C++ ran, and the profile only reads it.
-
-    All four fields, each against the manifest's own value: the tolerance and the
-    pairing rule were constants in the tool, which left the claim half true.
+    """The rig profile reads camera, downscale, tolerance and pairing fields from one manifest.
     """
     profile = RigProfile.from_robocap(manifest.robocap)
     assert profile.camera_names == manifest.robocap.camera_names == ("left", "left_front", "right_front", "right")

--- a/packages/slam-rs/tests/test_frontend_boundary.py
+++ b/packages/slam-rs/tests/test_frontend_boundary.py
@@ -61,7 +61,7 @@ def test_the_calibration_comes_across_field_by_field(camera: CameraFactory, imu:
     calibration: _core.Calibration = _core.Calibration.from_catalog([camera(0, 0.0), camera(1, 0.1)], imu)
     assert calibration.camera_count == 2
     assert calibration.resolution == [(calibrated, calibrated), (calibrated, calibrated)]
-    # basalt's own JSON is the round trip, so a reader can check what was pushed.
+    # JSON round-tripping exposes the exact configuration passed to the core.
     assert _core.Calibration.from_json(calibration.to_json()).resolution == calibration.resolution
 
 
@@ -175,7 +175,7 @@ def test_the_frame_reports_shapes_the_stub_promises(camera: CameraFactory, front
         assert frame.positions(index).shape == (count, 2)
         assert frame.positions(index).dtype == np.float32
         assert frame.transforms(index).shape == (count, 2, 3)
-        # The occupancy grid is camera 0's for every camera, as basalt's is.
+        # Occupancy uses camera 0's grid for every camera.
         assert frame.occupancy(index).shape == (cells, cells)
         assert frame.occupancy(index).dtype == np.int32
     # The 2x3 warp starts at the identity with the keypoint's pixel in the last column.
@@ -217,8 +217,8 @@ def probe_detector(calibration_json: str, config_json: str) -> subprocess.Comple
     """Run :data:`DETECTOR_PROBE` against one config, or fail the test on a hang.
 
     Args:
-        calibration_json: The rig's calibration as basalt's JSON.
-        config_json: One of basalt's configs as text.
+        calibration_json: The rig's calibration as JSON.
+        config_json: A VIO config as text.
 
     Returns:
         The finished process, so the caller can assert on its output.
@@ -233,7 +233,7 @@ def probe_detector(calibration_json: str, config_json: str) -> subprocess.Comple
 
 
 def config_with(key: str, value: int) -> str:
-    """basalt's default config as text, with one integer field replaced."""
+    """Default VIO configuration as text, with one integer field replaced."""
     document: dict = json.loads(_core.VioConfig().to_json())
     assert key in document["value0"], f"{key} is not a config field: {sorted(document['value0'])}"
     document["value0"][key] = value
@@ -250,12 +250,9 @@ def test_the_shipped_config_detects_on_a_blank_frame_and_returns(camera: CameraF
 
 @pytest.mark.parametrize("min_threshold", [0, -1, -(2**31)])
 def test_a_detector_threshold_ladder_that_never_ends_is_refused(camera: CameraFactory, imu: ImuCalib, min_threshold: int) -> None:
-    """``min_threshold <= 0`` hangs the detector — and basalt's own — so it is refused.
-
-    ``keypoints.cpp:162,187`` halves the FAST threshold by integer division while
-    it is at or above ``min_threshold``: zero halves to zero for ever. The C++ has
-    the same non-terminating loop; the port refuses the config instead of running
-    it, and floors its own last rung as a second line.
+    """Refuse a non-positive detector threshold minimum.
+    Integer halving leaves zero unchanged, so the loop could never end.
+    The detector also floors its last rung to protect direct callers.
     """
     calibration: str = _core.Calibration.from_catalog([camera(0, 0.0)], imu).to_json()
     finished: subprocess.CompletedProcess[str] = probe_detector(
@@ -366,10 +363,8 @@ def test_a_frame_of_the_wrong_size_leaves_the_frontend_as_it_was(
 @settings(max_examples=10, deadline=None)
 @given(start=st.integers(min_value=-(10**12), max_value=-1))
 def test_identical_frames_at_negative_timestamps_keep_their_ids(frontend: FrontendFactory, texture: TextureFactory, start: int) -> None:
-    """basalt reads ``t_ns < 0`` as "no previous frame"; the port's clock is an Option.
-
-    Two identical framesets used to share **zero** ids at ``(-2, -1)`` and 14 of
-    16 at ``(0, 1)``: the negative timestamp made every frameset the first one.
+    """An optional frontend clock preserves negative timestamps.
+    Identical frames at (-2, -1) must track rather than start a new id space.
     """
     negative: _core.OpticalFlow = frontend(1)
     first: _core.FlowFrame = negative.process(start, [texture(0, 0)])

--- a/packages/slam-rs/tests/test_frontend_log.py
+++ b/packages/slam-rs/tests/test_frontend_log.py
@@ -1,19 +1,8 @@
-"""What the frontend's Rerun layer promises: colours, and what ``log`` writes.
+"""Check frontend logging entity paths, times, colors and trails in saved chunks.
 
-The logging contract is checked against a recording, not against a mock. Each
-test initialises the global recording :class:`slam_rs.frontend_log.FrontendLogger`
-logs into (D03: the tools own no :class:`rerun.RecordingStream`), saves it to a
-temp file, and reads the chunks back with
-:class:`rerun.experimental.RrdReader` — the same rows a viewer would receive. So
-an entity path, a ``video_time`` value or a trail that never reached the file
-fails here.
-
-The frames are the synthetic 200x200 textures of :mod:`conftest` rather than the
-committed 960x960 fixtures: the fixtures are the Rust parity gate's, and four
-framesets of them through the frontend cost more than this whole Python suite.
-Reading the recording back is :mod:`conftest`'s :func:`read_rows`, which the
-estimator's logging suite drives too; the aliases below are declared here
-because ``tests`` is not on the typechecker's search path.
+Tests log into the global recording, save it and read back with RrdReader.
+Small synthetic textures keep these checks fast. Chunk inspection validates
+the recording contract; viewer pixels are checked separately.
 """
 
 from collections.abc import Callable

--- a/packages/slam-rs/tests/test_import.py
+++ b/packages/slam-rs/tests/test_import.py
@@ -25,11 +25,8 @@ def test_core_reports_a_version() -> None:
 
 
 def test_a_frame_without_imu_needs_more_imu(pipeline: PipelineFactory, texture: TextureFactory) -> None:
-    """basalt blocks on its IMU queue here; Offline mode says so and returns (D17).
-
-    Nothing moves: the coverage test comes before the frontend, so the refused
-    frameset may be pushed again once its samples arrive and the result is the
-    one a run that had them all along would have produced.
+    """Insufficient IMU coverage returns before any frontend mutation (D17).
+    Retrying after samples arrive must match a run that had them from the start.
     """
     vio: _core.Vio = pipeline(2)
     assert vio.camera_count == 2

--- a/packages/slam-rs/tests/test_reference.py
+++ b/packages/slam-rs/tests/test_reference.py
@@ -131,11 +131,11 @@ def test_robocap_carries_s15_and_no_ground_truth(manifest: ReferenceManifest) ->
 
 
 def test_robocap_names_the_configuration_the_cpp_ran(manifest: ReferenceManifest) -> None:
-    """The four cameras, the downscale, the two rig rules and basalt's own two files, all present."""
+    """The four cameras, the downscale, the two rig rules and the two configured JSON files, all present."""
     assert manifest.robocap.camera_names == ("left", "left_front", "right_front", "right")
     assert manifest.robocap.downscale == 3
     assert manifest.robocap.decode_path == "cpu_gray8_swscale_area_downscale3"
-    # basalt's `dataset_io_robocap.cpp` tolerance, and the pairing its reader does
+    # The manifest defines frameset tolerance and inertial pairing.
     # because the two inertial channels are on their own clocks.
     assert manifest.robocap.frameset_tolerance_ns == 1_000_000
     assert manifest.robocap.interpolate_accel_onto_gyro is True
@@ -164,7 +164,7 @@ def test_a_selector_the_manifest_cannot_satisfy_is_a_typed_error(manifest: Refer
 
 
 def test_flow_config_loads_the_datasets_own_basalt_config(manifest: ReferenceManifest) -> None:
-    """What the estimator is built with is the file, not basalt's constructor defaults.
+    """What the estimator is built with is the file, not constructor defaults.
 
     The difference is one key — ``vio_marg_lost_landmarks``, true in both MSD
     files and false in the constructor (C72) — so the assertion is on the config
@@ -221,7 +221,7 @@ def test_resolved_flow_config_hands_back_the_very_string_it_parsed(manifest: Ref
 
 
 def test_every_dataset_names_a_vendored_config_that_parses(manifest: ReferenceManifest) -> None:
-    """Both files are checked in beside the manifest and are basalt's own shape."""
+    """Both files are checked in beside the manifest and use the accepted JSON formats."""
     for dataset in manifest.datasets:
         path: Path = manifest.package_root / dataset.vio_config
         assert path.is_file(), dataset.name

--- a/packages/slam-rs/tests/test_robocap_probe.py
+++ b/packages/slam-rs/tests/test_robocap_probe.py
@@ -1,10 +1,8 @@
-"""The RoboCap rig's own calibration, and the probe's cross-check against it.
+"""RoboCap calibration and recording geometry must agree.
 
-The recording stores 1920x1080 frames and the C++ ran 640x360, so the feed's
-downscale has to reproduce basalt's own converted calibration digit for digit,
-and the probe refuses a calibration file that describes another rig. The matcher,
-the inertial pairing and the camera subset are in ``test_frameset_matching``;
-the feed's MSD path is in ``test_catalog_feed``.
+The feed downsamples 1920x1080 images to 640x360 with matching intrinsics.
+The probe refuses a calibration for another rig. Separate tests check
+frameset matching, IMU pairing and camera selection.
 """
 
 import json
@@ -31,7 +29,7 @@ from slam_rs.reference import ImuParameters, ReferenceManifest, RobocapSession
 from slam_rs.tracking import check_calibration_matches_recording
 
 # The four fed cameras' native intrinsics exactly as the recording carries them,
-# in the C++'s order. float32 statics, so the digits stop where float32 does.
+# in manifest camera order. Statics carry float32 precision.
 ROBOCAP_INTRINSICS: tuple[tuple[float, float, float, float], ...] = (
     (625.53564453125, 626.1504516601562, 999.440185546875, 539.0486450195312),
     (636.4360961914062, 634.7124633789062, 956.2034301757812, 525.4381103515625),
@@ -123,11 +121,8 @@ def robocap_statics(
 
 
 def test_downscaling_the_recording_reproduces_basalts_own_calibration(manifest: ReferenceManifest) -> None:
-    """The recording's native statics at downscale 3 are the C++'s own 640x360 file.
-
-    The two come from one Kalibr tree by different routes — the fork's converter
-    wrote the file, the ``dataforge`` conversion wrote the statics — so this is
-    the check that the port is fed the rig the C++ was fed.
+    """Recording statics at downscale three must match the 640x360 calibration JSON.
+    Both describe the same Kalibr rig through different conversion paths.
     """
     basalt: _core.Calibration = _core.Calibration.from_json((manifest.package_root / manifest.robocap.calibration).read_text())
     assert list(basalt.resolution) == [(640, 360)] * 4
@@ -232,10 +227,8 @@ def test_the_probe_refuses_a_calibration_whose_imu_is_not_the_manifests(manifest
 
 @pytest.mark.slow
 def test_the_feed_opens_the_real_robocap_rig(manifest: ReferenceManifest) -> None:
-    """Four of six cameras, 640x360, framesets on the C++'s own clock, both channels paired.
-
-    The one test that proves the whole read rather than its pieces: it needs the
-    NAS, so it sits behind ``slow`` like every other reference read.
+    """Read four of six cameras at 640x360 with matched clocks and paired IMU.
+    This whole-feed integration test needs the catalog and is marked slow.
     """
     session: RobocapSession = manifest.robocap.session("s00000015")
     with open_segment(CatalogSegment(manifest.catalog_url, "robocap", session.segment_id), manifest.robocap.imu, profile=RigProfile.from_robocap(manifest.robocap)) as feed:
@@ -247,7 +240,7 @@ def test_the_feed_opens_the_real_robocap_rig(manifest: ReferenceManifest) -> Non
         assert [(camera.width, camera.height) for camera in feed.cameras] == [(640, 360)] * 4
         assert all(camera.model == "kb4" for camera in feed.cameras)
         assert all(len(camera.distortion) == 4 for camera in feed.cameras)
-        # The frameset count and clock are basalt's own, to the nanosecond.
+        # Check frameset count and exact nanosecond timestamps.
         assert len(feed.frame_t_ns) == 1588
 
         frameset = next(feed.framesets())

--- a/packages/slam-rs/tests/test_tracking.py
+++ b/packages/slam-rs/tests/test_tracking.py
@@ -137,10 +137,8 @@ def test_a_run_that_never_tracked_still_reports_what_it_held(
 
 
 def test_the_estimator_is_configured_from_basalts_own_two_files(manifest: ReferenceManifest) -> None:
-    """C72: the RoboCap number is agreement with the C++, so the port is fed the C++'s own configuration.
-
-    Both files are committed beside the manifest, so this needs no NAS — which
-    is also why the cap can run the lane at all.
+    """The RoboCap estimator uses the two configuration files named by its manifest.
+    Both files are checked into the package, so configuration needs no external bundle.
     """
     calibration: _core.Calibration
     flow: _core.VioConfig

--- a/packages/slam-rs/tests/test_trajectory.py
+++ b/packages/slam-rs/tests/test_trajectory.py
@@ -148,7 +148,7 @@ def test_the_ported_alignment_agrees_with_simplecvs_on_well_conditioned_input(
 
 
 def test_shift_clock_moves_a_trajectory_onto_the_absolute_device_clock() -> None:
-    """The one conversion between video_time and the clock every basalt CSV uses."""
+    """The one conversion between video_time and the absolute export clock."""
     offset_ns: int = 10_433_867_587_166
     positions: Float64[ndarray, "5 3"] = np.arange(15, dtype=np.float64).reshape(5, 3)
     relative: Trajectory = _trajectory(np.array([0, 17_504_134, 100, 2**53 + 1, 2**54 + 3], dtype=np.int64), positions)

--- a/packages/slam-rs/tests/tools/dump_clip.py
+++ b/packages/slam-rs/tests/tools/dump_clip.py
@@ -1,41 +1,13 @@
-"""Dump a whole reference segment to disk so the Rust lanes can replay it offline.
+"""Dump catalog inputs for optional offline Rust replay and isolated timing.
 
-`crates/slam-rs/tests/full_clip.rs` needs three things the committed fixtures only
-carry for sixty framesets: every frameset's pixels, every inertial sample, and the
-calibration the C++ reference was actually handed. This writes all three into one
-directory:
+The directory holds clip metadata, calibration JSON, IMU CSV/JSON, frame hashes,
+gray8 PGMs and integer timestamps. The optional NPZ and calibration pickle
+feed bench_track without decoding in its timing loop. NPZ holds frames in
+memory, so bound benchmark dumps with max_framesets.
 
-```
-<clip>/clip.json              segment, clock, frameset timestamps, camera shapes
-<clip>/calib.json             basalt-shaped calibration, from the catalog statics
-<clip>/imu.csv                t_ns,gx,gy,gz,ax,ay,az on the video_time clock
-<clip>/frames.sha256          the C++ reference's own format, absolute timestamps
-<clip>/frame_<NNN>_cam<C>.pgm tools/dump_flow.cpp's layout, gray8
-<clip>/timestamps.txt         the same layout's frameset clock, one per line
-<clip>/imu.json               the same samples as imu.csv, in the fork's shape
-<clip>/clip.npz               `--npz`: the same framesets as one array bundle
-<clip>/clip.npz.calib.pkl     `--npz`: the feed's own `CameraCalib`/`ImuCalib`
-```
-
-The last pair is what `slam_rs.apis.bench_track` replays: that harness times
-`Vio.track` with no decoder and no Rerun, so it needs the pixels as one array
-and the calibration as the dataclasses the feed built — this is the tool that
-writes them, and `--npz` holds every frame in memory, so a bench dump wants
-`--max-framesets`.
-
-The last two are what the fork's `basalt_vio_oracle <frames-dir> <calib.json>
-<config.json> <out.json> [n]` reads, so one dump feeds both the port's own lane
-and the C++ oracle that isolates the backend from the frontend.
-
-The pixels come off the frozen `cpu_gray8_dav1d_1thread` decode path, so
-`frames.sha256` is comparable line by line with the reference run's file — which
-is the check that both implementations are fed the same clip. `--calibration
-fixture` swaps in the fork's `data/msd/msd*_calib.json` doubles instead of the
-catalog's float32-stored values, which is how the port's sensitivity to that
-difference is measured.
-
-A whole segment is large: MIO07 is 4,095 framesets of 960x960 stereo, 7.5 GB.
-Nothing here is committed and the directory is meant to be deleted afterwards.
+Catalog calibration uses f32 statics; fixture calibration uses the checked-in
+JSON doubles. Keeping this explicit permits sensitivity measurements.
+A full MIO07 stereo dump is about 7.5 GB and is not committed.
 """
 
 import hashlib
@@ -54,10 +26,10 @@ from slam_rs.catalog_feed import CameraCalib, CatalogSegment, Frameset, SegmentF
 from slam_rs.reference import ReferenceManifest, ReferenceSegment, load_manifest, resolved_flow_config
 
 FIXTURES: Path = Path(__file__).resolve().parents[2] / "crates/slam-rs/tests/fixtures"
-"""Where the fork's own MSD calibration files sit in this repository."""
+"""Directory holding MSD calibration JSON files."""
 
 DEVICE_CALIBRATION: dict[str, str] = {"msd-index": "msdmi_calib.json", "msd-g2": "msdmg_calib.json"}
-"""Catalog dataset to the fork calibration file that carries the same rig in doubles."""
+"""Catalog dataset to its calibration JSON with double-precision values."""
 
 
 @dataclass(slots=True)
@@ -69,7 +41,7 @@ class Config:
     output: Path
     """Directory the clip is written to; created if missing."""
     calibration: Literal["catalog", "fixture"] = "catalog"
-    """``catalog`` writes the float32-stored values the C++ reference was pushed; ``fixture`` writes the fork file's doubles."""
+    """``catalog`` writes float32 statics; ``fixture`` writes calibration-file doubles."""
     max_framesets: int | None = None
     """Stop after this many framesets; None dumps the whole segment."""
     npz: bool = False
@@ -79,19 +51,16 @@ class Config:
 
 
 def eigen_quaternion_xyzw(rotation: Float64[ndarray, "3 3"]) -> Float64[ndarray, " 4"]:
-    """Eigen's ``Quaterniond(Matrix3d)``, term for term.
+    """Convert a rotation matrix using trace and largest-diagonal quaternion branches.
 
-    ``vit_tracker.cpp:288`` builds the camera extrinsic this way from the 4x4 the
-    driver pushes, and the matrix it is given is not exactly orthonormal — the
-    catalog stores float32. Different conversions disagree in the last bits on
-    such a matrix, so this reproduces the one the reference actually ran rather
-    than calling a library.
+    Catalog matrices are stored in f32 and can be slightly non-orthogonal.
+    The explicit conversion keeps deterministic rounding without normalization.
 
     Args:
         rotation: Rotation block of ``imu_T_cam``.
 
     Returns:
-        The quaternion as ``[qx, qy, qz, qw]``, unnormalised exactly as Eigen leaves it.
+        The quaternion as ``[qx, qy, qz, qw]``, without normalization.
     """
     quaternion: Float64[ndarray, " 4"] = np.zeros(4, dtype=np.float64)
     trace: float = float(rotation.trace())
@@ -120,19 +89,17 @@ def eigen_quaternion_xyzw(rotation: Float64[ndarray, "3 3"]) -> Float64[ndarray,
 
 
 def catalog_calibration(feed: SegmentFeed, fork_file: dict[str, Any]) -> dict[str, Any]:
-    """A basalt calibration file holding the catalog's own geometry.
+    """Build calibration JSON using catalog intrinsics, resolution and extrinsics.
 
-    The intrinsics, resolutions and extrinsics are the values the C++ reference
-    was handed through the VIT C API; everything else — the noise model, the
-    update rate, the time offset — is not on the recording and stays as the fork
-    file has it.
+    Noise, update rate and time offset remain from the calibration file because
+    the recording does not carry them.
 
     Args:
         feed: Open segment feed, whose cameras carry the catalog geometry.
-        fork_file: The fork's ``msd*_calib.json``, already unwrapped from ``value0``.
+        fork_file: The calibration JSON, already unwrapped from ``value0``.
 
     Returns:
-        The ``value0`` body of a basalt calibration file.
+        The ``value0`` body of a calibration JSON file.
     """
     calibration: dict[str, Any] = dict(fork_file)
     poses: list[dict[str, float]] = []
@@ -181,11 +148,8 @@ def write_pgm(path: Path, image: UInt8[ndarray, "h w"]) -> None:
 
 
 def write_oracle_inputs(output: Path, frame_t_ns: list[int], imu_lines: list[str]) -> None:
-    """Write the two files `basalt_vio_oracle` reads beside the PGMs.
-
-    The tool takes the frameset clock as one integer per line and the inertial
-    window as JSON. Both are the values already written to ``clip.json`` and
-    ``imu.csv``, in the shape ``tools/vio_oracle.cpp`` parses.
+    """Write integer frameset timestamps and IMU JSON beside the PGMs.
+    These duplicate the clock and samples in clip.json and imu.csv for replay tools.
 
     Args:
         output: Clip directory.

--- a/packages/slam-rs/tools/apps/fleet_check.py
+++ b/packages/slam-rs/tools/apps/fleet_check.py
@@ -1,4 +1,4 @@
-"""CLI shim: run the reference smoke clips on this machine and report the D60 verdict beside them."""
+"""CLI shim: run the reference smoke clips on this machine and report the ground-truth verdict beside them."""
 
 from slam_rs.apis import run
 from slam_rs.apis.fleet_check import Config, main


### PR DESCRIPTION
S34 PR 4 of 4, stacked on #260. Prose only: **no code, identifier, JSON key, config file or runtime string changes**. The gate filters the diff of every `.rs` / `.py` file for non-comment lines and finds none; Rust release tests, clippy on both feature sets, rustdoc (zero warnings before and after), ruff, pyrefly and the 217 fast Python tests pass unchanged.

## What
- Rust source and test comments (58 files) describe the algorithms and invariants of this crate instead of citing basalt source lines: about 2,000 lines rewritten, 2,700 citation-only lines deleted. Module headers that still described deleted fixture suites or the arithmetic #261 replaced were corrected too. The reviewer's P2 on `camera_jacobians.rs` (coverage claims from deleted oracle tests) is fixed.
- Python docstrings and comments (22 files) in package terms: the feed, tracking, trajectory, viewer logging and the reference module; the `_core.pyi` stub docstrings follow the Rust docs.
- `docs/design-notes.md`: the "basalt C++ reference and gate policy" section, the C++ keypoint overlay and the `basalt_cpp` trajectory rows are gone; "the reference set" and "the gate" describe the catalog-only manifest, tiers, per-lane baselines and host-bound speed clause; superseded decision lines (D14, D36, D58, D59, D60, D74) say what replaced them; the algorithm derivations stay; a new S34 section summarises the four PRs with the per-clip numbers from the #261 and #260 reports.
- README and `configs/README`: the JSON configs and profiles as slam-rs inputs.

83 files, +2,346 / -5,281. The word "basalt" falls from 555 to 111 occurrences in the package; every remaining one is listed with its reason in the worker report (test helper identifiers such as `basalt_kb4`, RoboCap dataset vocabulary, design-note decision bodies that name the algorithm's source).

Merge order for the stack: #259 -> #261 -> #260 -> this.