### PR TITLE
slam-rs: any RoboCap session replays from the catalog

### DIFF
--- a/packages/slam-rs/slam_rs/apis/robocap_probe.py
+++ b/packages/slam-rs/slam_rs/apis/robocap_probe.py
@@ -59,6 +59,8 @@ def main(config: Config) -> None:
     """
     manifest: ReferenceManifest = load_manifest()
     session: RobocapSession = manifest.robocap.session(config.session)
+    if not manifest.robocap.is_listed(config.session):
+        print(f"{config.session} is not in the manifest: replaying it from the catalog with no regression reference")
     offset_ns: int = manifest.robocap.imu.cam_time_offset_ns
     output_csv: Path = config.output_csv if config.output_csv is not None else Path("data") / f"robocap-{session.session_id}" / "slam_rs.csv"
     calibration: _core.Calibration

--- a/packages/slam-rs/slam_rs/reference.py
+++ b/packages/slam-rs/slam_rs/reference.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 import math
+import re
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
@@ -211,7 +212,6 @@ class ReferenceSegment:
     imu: ImuParameters
     """Frozen IMU noise model for this device."""
 
-
     def baseline_for(self, lane: Literal["cpu", "gpu"], profile: Literal["reference", "fast"]) -> Baseline | None:
         """Return the unique baseline for this execution lane and profile."""
         return next((row for row in self.baseline if row.lane == lane and row.profile == profile), None)
@@ -238,6 +238,8 @@ class RobocapSession:
 class RobocapReference:
     """RoboCap rig parameters. This dataset has no ground truth."""
 
+    device_id: str
+    """The device whose sessions the catalog holds: segment ids are ``robocap__<device_id>__<session_id>``."""
     has_ground_truth: bool
     """Always false: RoboCap has no measured ground truth."""
     decode_path: DecodePath
@@ -262,15 +264,24 @@ class RobocapReference:
     """The measured sessions, in manifest order."""
 
     def session(self, session_id: str) -> RobocapSession:
-        """The session with this id.
+        """The session with this id: the listed one, or any other session of this device on the catalog.
+
+        An unlisted session has no regression reference; the tools report it unscored.
 
         Raises:
-            ValueError: If the manifest has no such session.
+            ValueError: If the id is not shaped like a RoboCap session id.
         """
         for session in self.sessions:
             if session.session_id == session_id:
                 return session
-        raise ValueError(f"{session_id!r} is not a RoboCap session in the manifest; have {[s.session_id for s in self.sessions]}")
+        if re.fullmatch(r"s\d{8}", session_id) is None:
+            raise ValueError(
+                f"{session_id!r} is not a RoboCap session id (expected s00000015-style); listed: {[s.session_id for s in self.sessions]}"
+            )
+        return RobocapSession(reference_csv=None, session_id=session_id, segment_id=f"robocap__{self.device_id}__{session_id}")
+
+    def is_listed(self, session_id: str) -> bool:
+        return any(session.session_id == session_id for session in self.sessions)
 
 
 @dataclass(slots=True, frozen=True)
@@ -413,6 +424,7 @@ def _imu(block: dict[str, Any]) -> ImuParameters:
 def _robocap(robocap_block: dict[str, Any]) -> RobocapReference:
     """Read the RoboCap rig and catalog session table."""
     return RobocapReference(
+        device_id=str(robocap_block["device_id"]),
         has_ground_truth=bool(robocap_block["has_ground_truth"]),
         decode_path=_one_of(robocap_block["decode_path"], DECODE_PATH_BY_NAME, "decode path", "robocap"),
         camera_names=tuple(str(name) for name in robocap_block["camera_names"]),
@@ -557,7 +569,9 @@ def gate_failures(measurement: Measurement, baseline: Baseline | None) -> list[s
         failures.append(f"lost: {measurement.lost} of {measurement.framesets} framesets")
     if measurement.associated < MIN_ASSOCIATED_POSES:
         failures.append(f"associated: only {measurement.associated} poses matched ground truth")
-    if not measurement.poses_finite or not all(math.isfinite(value) for value in (measurement.gt_rmse_cm, measurement.extent_m, measurement.truth_extent_m, measurement.median_tracker_ms)):
+    if not measurement.poses_finite or not all(
+        math.isfinite(value) for value in (measurement.gt_rmse_cm, measurement.extent_m, measurement.truth_extent_m, measurement.median_tracker_ms)
+    ):
         failures.append("finite: poses and measurements must be finite")
     if measurement.extent_m > DIVERGENCE_FACTOR * measurement.truth_extent_m:
         failures.append(f"divergence: estimate spans {measurement.extent_m:.2f} m, truth {measurement.truth_extent_m:.2f} m")

--- a/packages/slam-rs/tests/test_reference.py
+++ b/packages/slam-rs/tests/test_reference.py
@@ -123,6 +123,14 @@ def test_the_msd_imu_block_is_basalts(manifest: ReferenceManifest) -> None:
         assert segment.imu.cam_time_offset_ns == 0
 
 
+def test_any_robocap_session_of_the_device_replays_without_a_reference(manifest: ReferenceManifest) -> None:
+    listed = manifest.robocap.session("s00000015")
+    assert listed.reference_csv is not None and manifest.robocap.is_listed("s00000015")
+    other = manifest.robocap.session("s00000099")
+    assert other.segment_id == f"robocap__{manifest.robocap.device_id}__s00000099"
+    assert other.reference_csv is None and not manifest.robocap.is_listed("s00000099")
+
+
 def test_robocap_carries_s15_and_no_ground_truth(manifest: ReferenceManifest) -> None:
     assert [session.session_id for session in manifest.robocap.sessions] == ["s00000015"]
     assert manifest.robocap.has_ground_truth is False
@@ -157,8 +165,8 @@ def test_a_selector_the_manifest_cannot_satisfy_is_a_typed_error(manifest: Refer
     """
     with pytest.raises(ValueError, match="MIO10_typo.*MIO10_short_2_panorama"):
         manifest.by_id("MIO10_typo")
-    with pytest.raises(ValueError, match="s00000099.*s00000015"):
-        manifest.robocap.session("s00000099")
+    with pytest.raises(ValueError, match="s15.*s00000015"):
+        manifest.robocap.session("s15")
     with pytest.raises(ValueError, match="msd-nope.*msd-index"):
         manifest.dataset("msd-nope")
 


### PR DESCRIPTION
Same fix as #258, for RoboCap. `robocap_probe.py --session sNNNNNNNN` only accepted the one session the manifest lists (s15, the one with a checked-in regression reference); the catalog holds many more sessions of the same device. Now any `s`-plus-eight-digits id resolves to `robocap__<device_id>__<session>` on the catalog; an unlisted session has no regression reference and the probe says so and reports it unscored. A malformed id still errors, naming the shape and the listed sessions.

`RobocapReference` gains `device_id` (already in the manifest) and `is_listed`. 3 files, +31 / -7. ruff, pyrefly, 258 fast tests.