### PR TITLE
slam-rs: the Metal lane stops paying 7 ms per read (CubeCL 0.11.0-pre.3, wgpu 30)

### DIFF
--- a/packages/slam-rs/Cargo.lock
+++ b/packages/slam-rs/Cargo.lock
@@ -143,6 +143,8 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+ "portable-atomic",
+ "portable-atomic-util",
 ]
 
 [[package]]
@@ -156,6 +158,80 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "awint"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a8f298efd080b0d3e1ee1723b5d88ecc0d78805fad347e09b76dbd4dadbe37"
+dependencies = [
+ "awint_core",
+ "awint_dag",
+ "awint_ext",
+ "awint_macro_internals",
+ "awint_macros",
+]
+
+[[package]]
+name = "awint_core"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c24d226d9faa090abec192c8ad1ea74635e6cc94000c72a95ceb60cf691428c3"
+dependencies = [
+ "awint_internals",
+ "const_fn",
+]
+
+[[package]]
+name = "awint_dag"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc5377016f3077b18304da4233a28626ea069047ca84c9bc8c8b81b659f11032"
+dependencies = [
+ "awint_ext",
+ "awint_macro_internals",
+ "awint_macros",
+ "smallvec",
+]
+
+[[package]]
+name = "awint_ext"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ff843cdefdd48fbe9bc11292a902b7921ff37433ed4124fa02136f83186f58"
+dependencies = [
+ "awint_core",
+ "const_fn",
+]
+
+[[package]]
+name = "awint_internals"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6209d7873685ac95ee41c4b63fe29bff9b2e1106de65d05b106b2b769c178575"
+dependencies = [
+ "const_fn",
+]
+
+[[package]]
+name = "awint_macro_internals"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b519a9cd37bf73e44e29b3779ca90246412b56db4af4e96d959f5082bb8bdcc"
+dependencies = [
+ "awint_ext",
+ "proc-macro2",
+ "triple_arena",
+]
+
+[[package]]
+name = "awint_macros"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518a133c2163e8f021f708d7278af27dd6c1bcee96ea672a2d825b13a6931818"
+dependencies = [
+ "awint_macro_internals",
+]
 
 [[package]]
 name = "backtrace"
@@ -179,26 +255,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bindgen"
-version = "0.71.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 2.1.3",
- "shlex 1.3.0",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
 dependencies = [
  "bit-vec 0.9.1",
 ]
@@ -253,6 +309,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "buildid"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8e278b5bdc31756d01d65c17662e23692e0dbaa19e65adae9b58fc4683bc09"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "winapi",
 ]
 
 [[package]]
@@ -308,15 +376,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "caseless"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
-dependencies = [
- "unicode-normalization",
-]
-
-[[package]]
 name = "cc"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,16 +384,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex 2.0.1",
-]
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom 7.1.3",
+ "shlex",
 ]
 
 [[package]]
@@ -385,17 +435,6 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
-dependencies = [
- "glob",
- "libc",
- "libloading 0.8.9",
 ]
 
 [[package]]
@@ -456,17 +495,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "comrak"
-version = "0.39.1"
+name = "combine"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fefab951771fc3beeed0773ce66a4f7b706273fc6c4c95b08dd1615744abcf5"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
- "caseless",
- "entities",
+ "bytes",
  "memchr",
- "slug",
- "typed-arena",
- "unicode_categories",
 ]
 
 [[package]]
@@ -476,7 +511,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+ "portable-atomic",
 ]
+
+[[package]]
+name = "const_fn"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413d67b29ef1021b4d60f4aa1e925ca031751e213832b4b1d588fae623c05c60"
 
 [[package]]
 name = "constcat"
@@ -486,18 +528,18 @@ checksum = "136d3e02915a2cea4d74caa8681e2d44b1c3254bdbf17d11d41d587ff858832c"
 
 [[package]]
 name = "convert_case"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "convert_case"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -569,13 +611,14 @@ dependencies = [
 
 [[package]]
 name = "cubecl"
-version = "0.10.0"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd203fef6e359472e4cb8f6c0ef3eca062815a1edd560eb6d6c1d5c1397838d9"
+checksum = "a06ee1b26156c419065287f3c4e36bf9d85490bfd4fdb8d05da14e2eea3f3b91"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
  "cubecl-cuda",
+ "cubecl-environment",
  "cubecl-hip",
  "cubecl-ir",
  "cubecl-runtime",
@@ -586,53 +629,39 @@ dependencies = [
 
 [[package]]
 name = "cubecl-common"
-version = "0.10.0"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc956c2dcc993f16f748d03bfdbd900f75cab4d469f4e5d8924f8ee128e861ad"
+checksum = "4d40f7451ab096a127c58b03d76b6d30f4fc757ac13d8e2f17ed5bb20ffda4bc"
 dependencies = [
- "backtrace",
  "bytemuck",
- "cfg-if",
  "cfg_aliases",
- "ciborium",
+ "cubecl-environment",
  "derive-new",
  "derive_more",
- "dirs",
- "embassy-futures",
- "embassy-time",
  "float4",
  "float8",
- "futures-lite",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "log",
  "num-traits",
- "oneshot",
- "parking_lot",
  "portable-atomic",
  "portable-atomic-util",
- "rand 0.10.2",
- "sanitize-filename",
  "serde",
- "serde_bytes",
- "serde_json",
- "spin",
- "toml",
+ "spin 0.12.3",
  "tynm",
- "wasm-bindgen-futures",
- "web-time",
  "xxhash-rust",
 ]
 
 [[package]]
 name = "cubecl-core"
-version = "0.10.0"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7522e7acf25d7848032c7b5270780f9f2abe84e13c7ed6345aa27ba70c312ca"
+checksum = "551294f8c23fe433237753d39d62a15ad8a550898c1237e09ba25247d69c28e5"
 dependencies = [
  "bitflags",
  "bytemuck",
  "cubecl-common",
+ "cubecl-environment",
  "cubecl-ir",
  "cubecl-macros",
  "cubecl-runtime",
@@ -642,10 +671,13 @@ dependencies = [
  "enumset",
  "float-ord",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
+ "itertools",
  "log",
+ "num-integer",
  "num-traits",
  "paste",
+ "pliron",
  "serde",
  "serde_json",
  "variadics_please",
@@ -653,53 +685,61 @@ dependencies = [
 
 [[package]]
 name = "cubecl-cpp"
-version = "0.10.0"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411af04828cbf4583ecd388579fb30cd7a644eec19a334bb8f0d9d08522e1458"
+checksum = "8341e7f1ce405f112396703fd7de6bd42b974209fabce7d1f17c3ff8e01c7820"
 dependencies = [
  "bytemuck",
  "cubecl-common",
  "cubecl-core",
+ "cubecl-environment",
  "cubecl-opt",
  "cubecl-runtime",
  "derive-new",
+ "derive_more",
  "half",
- "itertools 0.14.0",
+ "itertools",
  "log",
+ "num-traits",
+ "paste",
+ "pliron",
+ "sanitize-filename",
+ "thiserror",
 ]
 
 [[package]]
 name = "cubecl-cpu"
-version = "0.10.0"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f572143f54e42a49ee0635a4ec36005f639e62be029e4f49890c808985981b35"
+checksum = "85a0870e2cde1b41ee24e965f4bd217308f3f93ae68c6f6c0f34fe69b3ce4c52"
 dependencies = [
- "bytemuck",
+ "crossbeam-utils",
  "cubecl-common",
  "cubecl-core",
- "cubecl-opt",
+ "cubecl-environment",
+ "cubecl-llvm",
  "cubecl-runtime",
  "cubecl-std",
  "derive-new",
- "half",
+ "libc",
  "log",
- "paste",
- "serde",
+ "pliron",
+ "spin 0.12.3",
  "sysinfo",
- "tracel-llvm",
- "tracel-llvm-bundler",
+ "winapi",
 ]
 
 [[package]]
 name = "cubecl-cuda"
-version = "0.10.0"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b0a69ff45688d322ad8e92c8bf645167b9ca490fa8fa087fc6adac8c5e46be"
+checksum = "b85b83ac2b0f4744a498144c78aafe2cd932f3fd44403bae35a75d3075d1b80c"
 dependencies = [
  "bytemuck",
  "cubecl-common",
  "cubecl-core",
  "cubecl-cpp",
+ "cubecl-environment",
  "cubecl-runtime",
  "cudarc",
  "derive-new",
@@ -709,15 +749,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "cubecl-hip"
-version = "0.10.0"
+name = "cubecl-environment"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6b510a9348f06ecd56b32cf10eb6241639e927a87f5c09ec61cc7a7610d5a3"
+checksum = "4fe477132eb035351d3d7c087c1488d8fec6f6d0c5d7a2e01bdc80d3892fbbb3"
+dependencies = [
+ "async-channel",
+ "backtrace",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "ciborium",
+ "embassy-futures",
+ "embassy-time",
+ "etcetera",
+ "foldhash 0.2.0",
+ "futures-lite",
+ "hashbrown 0.17.1",
+ "log",
+ "oneshot",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rand 0.10.2",
+ "rusqlite",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "spin 0.12.3",
+ "toml",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
+name = "cubecl-hip"
+version = "0.11.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cee8446506fcb7405a44e09b94f0b391c356aa8032cf61107108e3aeab90f293"
 dependencies = [
  "bytemuck",
  "cubecl-common",
  "cubecl-core",
  "cubecl-cpp",
+ "cubecl-environment",
  "cubecl-hip-sys",
  "cubecl-runtime",
  "derive-new",
@@ -739,11 +814,13 @@ dependencies = [
 
 [[package]]
 name = "cubecl-ir"
-version = "0.10.0"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d28a897a40c8ee6c57a8b8d76d8823ba2e97f4c2b83db9338f17a0752132d486"
+checksum = "4c41f16f481daa6c63e472c1d64eb86e19ef7444faf13d1f5ae4048e95f73659"
 dependencies = [
+ "bumpalo",
  "cubecl-common",
+ "cubecl-environment",
  "cubecl-macros-internal",
  "derive-new",
  "derive_more",
@@ -752,147 +829,197 @@ dependencies = [
  "fnv",
  "foldhash 0.2.0",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
+ "internment",
+ "itertools",
+ "num",
  "num-traits",
+ "pliron",
+ "pliron-spirv",
  "portable-atomic",
+ "rustc_apfloat",
  "serde",
+ "spin 0.12.3",
+ "thiserror",
  "variadics_please",
 ]
 
 [[package]]
-name = "cubecl-macros"
-version = "0.10.0"
+name = "cubecl-llvm"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77aa6df563e8e6a0926d2e9eeacb968737940a0e1ae9be819f6a65a341006e12"
+checksum = "6d723c338c56b17ee4371dcf3e0d540d925803768abfeea925bd610245b1de5b"
+dependencies = [
+ "cubecl-core",
+ "cubecl-environment",
+ "cubecl-opt",
+ "cubecl-runtime",
+ "derive-new",
+ "half",
+ "llvm-sys",
+ "pliron",
+ "pliron-llvm",
+ "tracel-llvm-bundler",
+]
+
+[[package]]
+name = "cubecl-macros"
+version = "0.11.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b4166fb3d4c957bf5e8896f1528370992f748cfdefbb85e33375c6d23cfa67f"
 dependencies = [
  "cubecl-common",
- "darling 0.23.0",
+ "darling 0.24.1",
  "derive-new",
+ "derive_more",
  "ident_case",
  "inflections",
+ "itertools",
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "cubecl-macros-internal"
-version = "0.10.0"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a515651a5a91e25d87f71f311f80a088e6cf815798b9922560a97636da6b8740"
+checksum = "cb92a100b15ca723fa6255ca31275a322aecace4973d7cc91d52cb6813fdf91a"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.1",
+ "inflections",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "cubecl-opt"
-version = "0.10.0"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a599c6c3efefdcee8636994c90e58ef696c7efbed2d18b5b5ad8d5f29923abb"
+checksum = "380a3b3be616cf47a91ede0f98df9720dcd6ddae492b8b245016f9677dd18945"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
+ "cubecl-environment",
  "cubecl-ir",
+ "derive-new",
  "float-ord",
+ "hashbrown 0.17.1",
+ "itertools",
  "log",
  "num",
- "petgraph",
+ "pliron",
  "smallvec",
  "stable-vec",
+ "thiserror",
  "type-map",
 ]
 
 [[package]]
 name = "cubecl-runtime"
-version = "0.10.0"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68491bf5b3e997ae36bdc4e63b4ccd6d2f0e86b3b596a5d7a48d2b9e92622a0"
+checksum = "f075823e77db30a6522fcde2b5ea4431fea3ac63e1dc43b4f0f1f920f5d60ab9"
 dependencies = [
  "ahash",
- "async-channel",
+ "buildid",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
  "cubecl-common",
+ "cubecl-environment",
  "cubecl-ir",
  "cubecl-zspace",
  "derive-new",
  "derive_more",
- "dirs",
  "enumset",
- "hashbrown 0.16.1",
+ "futures-util",
+ "hashbrown 0.17.1",
+ "itertools",
  "log",
  "md5",
+ "pliron",
  "serde",
  "serde_json",
- "spin",
  "thiserror",
  "toml",
  "wasm-bindgen-futures",
- "web-time",
 ]
 
 [[package]]
 name = "cubecl-spirv"
-version = "0.10.0"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd12ded588654255e94e3d80a58e0988fdf50dd6b80365795072b04b99884f88"
+checksum = "a4763912d17cbdd93c63b7e0d5450ffa1881bbcfbba4576adbb94a23854cccaf"
 dependencies = [
  "bitflags",
  "cubecl-common",
  "cubecl-core",
+ "cubecl-environment",
+ "cubecl-ir",
  "cubecl-opt",
  "cubecl-runtime",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
+ "itertools",
+ "paste",
+ "pliron",
+ "pliron-spirv",
+ "sanitize-filename",
  "serde",
  "tracel-rspirv",
 ]
 
 [[package]]
 name = "cubecl-std"
-version = "0.10.0"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b391b584a4897683dd9fc0767f96337ac712b733126ce0f68a9ee8a2df073d2d"
+checksum = "a7f58a4dbaaf596d9931585934b095c9b2e7ea0c41fcc84228e848315ed6e0e4"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
+ "cubecl-environment",
  "cubecl-runtime",
  "half",
  "num-traits",
  "paste",
  "serde",
- "spin",
+ "spin 0.12.3",
  "variadics_please",
 ]
 
 [[package]]
 name = "cubecl-wgpu"
-version = "0.10.0"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3663c6e1a86187172b2cee495b6b533e7d91a2cb37e26f421649e315fe4c3a"
+checksum = "68a70096df8a1a1a327ffcc3327bbc4a9b2ba461c25e0e7863806721f8601664"
 dependencies = [
  "ash",
- "async-channel",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
  "cubecl-common",
  "cubecl-core",
  "cubecl-cpp",
+ "cubecl-environment",
  "cubecl-ir",
+ "cubecl-opt",
  "cubecl-runtime",
  "cubecl-spirv",
  "derive-new",
  "derive_more",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
+ "itertools",
  "log",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+ "pliron",
  "sanitize-filename",
+ "thiserror",
  "tracel-ash",
  "wasm-bindgen-futures",
  "wgpu",
@@ -900,9 +1027,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-zspace"
-version = "0.10.0"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04054d95698afab785a4dda9f949e297831dd9e4cc6d036a93e6603f88e88b07"
+checksum = "2bee1ebdfc423d5395e1158cdf73554cd7b2db726c0d2b0ac356c7349193fa04"
 dependencies = [
  "derive-new",
  "serde",
@@ -930,12 +1057,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
 ]
 
 [[package]]
@@ -953,15 +1080,15 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -977,13 +1104,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core 0.24.1",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1019,12 +1146,6 @@ dependencies = [
  "syn 2.0.119",
  "unicode-xid",
 ]
-
-[[package]]
-name = "deunicode"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "digest"
@@ -1097,6 +1218,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,12 +1292,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "entities"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
-
-[[package]]
 name = "enumset"
 version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,6 +1330,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1347,8 @@ checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
  "parking",
  "pin-project-lite",
+ "portable-atomic",
+ "portable-atomic-util",
 ]
 
 [[package]]
@@ -1221,6 +1360,18 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1243,12 +1394,6 @@ name = "find-msvc-tools"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
-
-[[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "float-ord"
@@ -1451,12 +1596,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21fef0953c54fd3de2f44b743fbf77e044c81a25faee03636dfccc0d35135e23"
 
 [[package]]
-name = "glob"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
-
-[[package]]
 name = "glow"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1489,26 +1628,6 @@ dependencies = [
  "presser",
  "thiserror",
  "windows",
-]
-
-[[package]]
-name = "gpu-descriptor"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
-dependencies = [
- "bitflags",
- "gpu-descriptor-types",
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "gpu-descriptor-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -1550,6 +1669,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1562,8 +1683,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1571,6 +1690,22 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a596f1b20ed2cc5ecac41a164aaebc7258057060f06c0cf7a2ba3991ee7990fb"
+dependencies = [
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "heck"
@@ -1585,10 +1720,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
-name = "hexf-parse"
-version = "0.2.1"
+name = "hi_sparse_bitset"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+checksum = "c8ea23b8660d31548406606b3d479883a93235d13dc112ffe33fb13aa681e876"
+dependencies = [
+ "rustversion",
+ "wide 0.7.33",
+]
 
 [[package]]
 name = "http"
@@ -1814,6 +1953,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
+name = "internment"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636d4b0f6a39fd684effe2a73f5310df16a3fa7954c26d36833e98f44d1977a2"
+dependencies = [
+ "hashbrown 0.15.5",
+ "serde",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1827,18 +1985,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -1948,7 +2097,7 @@ dependencies = [
  "num-traits",
  "rayon",
  "thiserror",
- "wide",
+ "wide 1.7.0",
 ]
 
 [[package]]
@@ -1960,6 +2109,12 @@ dependencies = [
  "rayon",
  "thiserror",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -2024,6 +2179,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3045e122bd98aef8ec3ad58ce84f0791f64e70163d1a02710af4aa11a4d54cc5"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77060ebe535362c3da75682cd17b0431017b6e7c5661e714fc69a7ad017d1301"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2040,6 +2226,20 @@ name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "llvm-sys"
+version = "221.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e52e36cd9eef0d5c4ba35c751c252f207642293009bb774185f84f678c7683c"
+dependencies = [
+ "anyhow",
+ "cc",
+ "lazy_static",
+ "libc",
+ "regex-lite",
+ "semver",
+]
 
 [[package]]
 name = "lock_api"
@@ -2085,12 +2285,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2111,29 +2305,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "naga"
-version = "29.0.4"
+name = "mutants"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
+checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
+
+[[package]]
+name = "naga"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a616d2fb8c89516ac2723a581f69d6c18576046bed761bd6b305e5618e6ae130"
 dependencies = [
  "arrayvec",
- "bit-set 0.9.1",
+ "bit-set 0.10.0",
  "bitflags",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
  "half",
- "hashbrown 0.16.1",
- "hexf-parse",
+ "hashbrown 0.17.1",
  "indexmap",
  "libm",
  "log",
+ "naga-types",
  "num-traits",
  "once_cell",
  "rustc-hash 1.1.0",
  "spirv",
  "thiserror",
  "unicode-ident",
+]
+
+[[package]]
+name = "naga-types"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590afbf58a6f4f62873cd5cff4468061844bafa1cdf399cc954537c22d768d49"
+dependencies = [
+ "hashbrown 0.17.1",
+ "indexmap",
+ "rustc-hash 1.1.0",
+ "thiserror",
 ]
 
 [[package]]
@@ -2204,16 +2416,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys 0.3.1",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -2354,6 +2556,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,6 +2580,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags",
+ "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2381,6 +2597,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-metal"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2388,7 +2615,20 @@ checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
  "bitflags",
  "block2",
+ "dispatch2",
  "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
  "objc2-foundation",
 ]
 
@@ -2401,6 +2641,7 @@ dependencies = [
  "bitflags",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
  "objc2-metal",
 ]
@@ -2425,6 +2666,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "once_vec"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b61fbf7ec37342ce171d9f5e3b82be74bda6c4e84e3b28338a03d553913e6aa"
 
 [[package]]
 name = "oneshot"
@@ -2489,18 +2736,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "petgraph"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
-dependencies = [
- "fixedbitset",
- "hashbrown 0.15.5",
- "indexmap",
- "serde",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2511,6 +2746,76 @@ name = "pkg-config"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
+name = "pliron"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e51eb8628227038376c81dcb1752db90a90af24a1e38b27582c7dab235149d7"
+dependencies = [
+ "awint",
+ "combine",
+ "downcast-rs",
+ "dyn-clone",
+ "hashbrown 0.17.1",
+ "hi_sparse_bitset",
+ "indexmap",
+ "inventory",
+ "linkme",
+ "log",
+ "once_vec",
+ "pliron-derive",
+ "regex",
+ "rustc-hash 2.1.3",
+ "rustc_apfloat",
+ "slotmap",
+ "smallvec",
+ "spin 0.10.1",
+ "thiserror",
+ "utf8-chars",
+]
+
+[[package]]
+name = "pliron-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f878ccd6bfd39a9373175774b96785daab296dc1870bc72ff7d285151f613a56"
+dependencies = [
+ "combine",
+ "convert_case 0.11.0",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "rustc-hash 2.1.3",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "pliron-llvm"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511535a077e4f72f83c437cde2636a6f525809a370b3078c0d1d5d53612ad052"
+dependencies = [
+ "bitflags",
+ "llvm-sys",
+ "log",
+ "pliron",
+ "thiserror",
+]
+
+[[package]]
+name = "pliron-spirv"
+version = "0.14.1+sdk-1.4.357.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2919774bd35911798e824286a15c2c3c6fedbfd56d06a33e071dc1af5d5e7030"
+dependencies = [
+ "derive-new",
+ "derive_more",
+ "itertools",
+ "pliron",
+ "thiserror",
+ "tracel-rspirv",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2556,12 +2861,12 @@ checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.37"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
 dependencies = [
  "proc-macro2",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2853,6 +3158,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "recasting"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3f51d3a1399f13fa081d97345d0fdf08597fe78558fc8539d0e67412f83b26"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2894,6 +3205,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
@@ -2963,6 +3280,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2979,6 +3321,16 @@ name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_apfloat"
+version = "0.2.3+llvm-462a31f5a5ab"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "486c2179b4796f65bfe2ee33679acf0927ac83ecf583ad6c91c3b4570911b9ad"
+dependencies = [
+ "bitflags",
+ "smallvec",
+]
 
 [[package]]
 name = "rustc_version"
@@ -3060,6 +3412,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "safe_arch"
@@ -3187,12 +3548,6 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
@@ -3206,7 +3561,7 @@ dependencies = [
  "approx",
  "num-complex",
  "num-traits",
- "wide",
+ "wide 1.7.0",
 ]
 
 [[package]]
@@ -3262,16 +3617,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slug"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
-dependencies = [
- "deunicode",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3297,6 +3642,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spin"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0134f9043ed38b087ac4f7d4af44c79e2c9e5094421fe3164f435ce585953b10"
+dependencies = [
+ "lock_api",
  "portable-atomic",
 ]
 
@@ -3307,6 +3661,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3394,15 +3760,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.4"
+version = "0.39.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
+ "objc2-open-directory",
  "windows",
 ]
 
@@ -3623,23 +3990,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracel-llvm"
-version = "20.1.4-7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982535db9eb1a30ac0f2c50239a0eec3e5cf50993a88e92b04747bd2f4d365b2"
-dependencies = [
- "tracel-mlir-rs",
- "tracel-mlir-sys",
-]
-
-[[package]]
 name = "tracel-llvm-bundler"
-version = "20.1.4-7"
+version = "22.1.4-6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c75b8e477cb8d49d907afab029ca74d48459f5b88c27bdb4c6cd6acb5e61977"
+checksum = "de376825263c1a1e0af395cb7e04e82099c2fe16724235d313ab803b33bba87b"
 dependencies = [
  "anyhow",
  "bytes",
+ "cc",
  "constcat",
  "dirs",
  "liblzma",
@@ -3653,63 +4011,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracel-mlir-rs"
-version = "20.1.4-7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a478a35efd68d0ba73f747adfb7923b121c64e7f5be9cd8364ca1dcb772d5c"
-dependencies = [
- "tracel-mlir-rs-macros",
- "tracel-mlir-sys",
-]
-
-[[package]]
-name = "tracel-mlir-rs-macros"
-version = "20.1.4-7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a94f36868c3b10b1825945223d99d106c73f4d249f063caa4651deeb9379344"
-dependencies = [
- "comrak",
- "convert_case 0.8.0",
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.119",
- "tracel-llvm-bundler",
- "tracel-tblgen-rs",
- "unindent",
-]
-
-[[package]]
-name = "tracel-mlir-sys"
-version = "20.1.4-7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f26d31af0c225a6d2e3d65d012fd6de848c9fc776897b152ee83b7d1bd15c4"
-dependencies = [
- "tracel-llvm-bundler",
-]
-
-[[package]]
 name = "tracel-rspirv"
-version = "0.12.1+sdk-1.4.341.0"
+version = "0.14.1+sdk-1.4.357.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1653aa21b867351f48c51f1063a2f872f8e82931951cae469d8a53aa4d7d72e8"
+checksum = "d1f062140c2875c072de7ab05019970906105a9a2c971af922b8d16bd3b5cbea"
 dependencies = [
  "bitflags",
+ "pliron",
  "rustc-hash 2.1.3",
  "serde",
-]
-
-[[package]]
-name = "tracel-tblgen-rs"
-version = "20.1.4-7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00d2581070380418ccc33b500f3739e4d4869421fdb477fcea51ff97c6253a52"
-dependencies = [
- "bindgen",
- "cc",
- "paste",
- "thiserror",
- "tracel-llvm-bundler",
 ]
 
 [[package]]
@@ -3732,6 +4042,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "triple_arena"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee55b64228381514ddc4ad004e631ccf45e594e428d13ce197697ce56ef1c55"
+dependencies = [
+ "recasting",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3743,7 +4062,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a21cdb0fc8f85c98b1ec812bc4cd69faf6c0fa2fc17d44ea3c2cdd38dc08e999"
 dependencies = [
- "nom 8.0.0",
+ "nom",
 ]
 
 [[package]]
@@ -3754,12 +4073,6 @@ checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
  "rustc-hash 2.1.3",
 ]
-
-[[package]]
-name = "typed-arena"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"
@@ -3780,15 +4093,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3807,16 +4111,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unicode_categories"
-version = "0.1.1"
+name = "unsynn"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+checksum = "501a7adf1a4bd9951501e5c66621e972ef8874d787628b7f90e64f936ef7ec0a"
+dependencies = [
+ "mutants",
+ "proc-macro2",
+ "rustc-hash 2.1.3",
+]
 
 [[package]]
 name = "untrusted"
@@ -3837,6 +4140,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8-chars"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92498c67ea3511b37eccff13b573ed871faf0ce9c4056ab032bd01a681f445a0"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3850,14 +4162,19 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "variadics_please"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b6d82be61465f97d42bd1d15bf20f3b0a3a0905018f38f9d6f6962055b0b5c"
+checksum = "b53d0f7f2d0182759a549f1f313ce16b07d8f9ba93098157b5fa10ee3e61117f"
 dependencies = [
- "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "unsynn",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -4012,9 +4329,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "29.0.4"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e8840e1ba2881d4cbb18d2147627a56af426ff064c0401eb0c8410c6325d07"
+checksum = "527ccdf43dd5b2e8676eed9984ce00e2bbb0a1b85b70c1969dcb6cd2eb55ab9e"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -4022,7 +4339,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "js-sys",
  "log",
  "naga",
@@ -4042,21 +4359,22 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "29.0.4"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
+checksum = "14c018fce9b6270aa203c2fdd56f3cce996713534bd757e4ea58c8560b121f14"
 dependencies = [
  "arrayvec",
- "bit-set 0.9.1",
+ "bit-set 0.10.0",
  "bit-vec 0.9.1",
  "bitflags",
  "bytemuck",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "log",
  "naga",
+ "naga-types",
  "once_cell",
  "parking_lot",
  "portable-atomic",
@@ -4075,41 +4393,41 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "29.0.4"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e39e26c4c0e07589e67d18546cf79ff45383659fc72fca4dd293358a0347f3"
+checksum = "061f3d319a40d39d00b1ecc2c33b89fe21d4e6fe01859df3500a3a8ecccd6b68"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "29.0.4"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e09be551dc939498bdd5f6b2c66e55ab275dad25825267a08605a80fc9f0af"
+checksum = "d98b86cf4abf524a902dd35f18ca6a3f08fc2ae9847c8f10b48e30491b1f0b86"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "29.0.4"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e592c1bbef6ad047647ae6e666ebd8cee7a32bb4544d9700ec96cbf73230257"
+checksum = "7586165fd5f6d881cb9ce4bb71f40d6caab2c0f1837e3fc1d9788a197fb6004f"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "29.0.4"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ace1c17727311c22a46e4e3faf56ea6de81af99dcc839bdfb54857b94d448d"
+checksum = "b6b7fb58561a792bc237628ba0792e332de418fefe145f13b5ed8201e6d52f58"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set 0.9.1",
+ "bit-set 0.10.0",
  "bitflags",
  "block2",
  "bytemuck",
@@ -4118,17 +4436,18 @@ dependencies = [
  "glow",
  "glutin_wgl_sys",
  "gpu-allocator",
- "gpu-descriptor",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "js-sys",
  "khronos-egl",
  "libc",
  "libloading 0.8.9",
  "log",
  "naga",
+ "naga-types",
  "ndk-sys",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
  "objc2-metal",
  "objc2-quartz-core",
@@ -4143,6 +4462,7 @@ dependencies = [
  "raw-window-metal",
  "renderdoc-sys",
  "smallvec",
+ "static_assertions",
  "thiserror",
  "wasm-bindgen",
  "wayland-sys",
@@ -4156,9 +4476,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-naga-bridge"
-version = "29.0.4"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95226013f547544b223281cd16a4fb549aa9dcb562adbda0faae4c73ffbbc161"
+checksum = "d2f62e73117bb7a62bfd9c5a5841438a823f6566c6442a808ee269d2d055c081"
 dependencies = [
  "naga",
  "wgpu-types",
@@ -4166,16 +4486,28 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "29.0.4"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84bf84cd9ca8ca45e2b223a3868f1adf9bfc0c66aeac212e76ee7e40fdadf8f5"
+checksum = "99dad6f1fbdbbdb4c278a6508b059d44688f5cebddf78d005a46a31340269286"
 dependencies = [
  "bitflags",
  "bytemuck",
  "js-sys",
  "log",
+ "naga-types",
  "raw-window-handle",
+ "static_assertions",
  "web-sys",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch 0.7.4",
 ]
 
 [[package]]
@@ -4185,7 +4517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cf05ca94c9fba0c51316899caa1d1e74a064fc310a5efa7375e614343d415be"
 dependencies = [
  "bytemuck",
- "safe_arch",
+ "safe_arch 1.2.0",
 ]
 
 [[package]]

--- a/packages/slam-rs/Cargo.lock
+++ b/packages/slam-rs/Cargo.lock
@@ -630,8 +630,6 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d40f7451ab096a127c58b03d76b6d30f4fc757ac13d8e2f17ed5bb20ffda4bc"
 dependencies = [
  "bytemuck",
  "cfg_aliases",

--- a/packages/slam-rs/Cargo.toml
+++ b/packages/slam-rs/Cargo.toml
@@ -43,17 +43,17 @@ kornia-imgproc = { git = "https://github.com/kornia/kornia-rs", rev = "e2148e864
 # because upstream's are `f32`-only or coupled (S33 audit A, row 5).
 kornia-algebra = { git = "https://github.com/kornia/kornia-rs", rev = "e2148e864a1b63a8fe094b89175273ef08823183", default-features = false }
 
-# The GPU phase (decision D21, D70). CubeCL 0.10 stable with the optional
+# The GPU phase (decision D21, D70). CubeCL 0.11 prerelease with the optional
 # wgpu runtime; the default CPU build has no GPU dependency.
-cubecl = "0.10"
+cubecl = "=0.11.0-pre.3"
 # No `features` here: which shader compiler cubecl-wgpu builds is decided per
 # target in `crates/slam-rs/Cargo.toml`, because `spirv` and `msl` are not the
 # same lane on the same platform (see the two target sections there).
-cubecl-wgpu = "0.10"
+cubecl-wgpu = "=0.11.0-pre.3"
 
 # Probe wgpu before constructing a CubeCL client, whose bring-up can panic.
 # This feature subset adds nothing to cubecl-wgpu's compiled feature set.
-wgpu = { version = "29", default-features = false }
+wgpu = { version = "30", default-features = false }
 
 # The estimator must never panic on data: errors are typed and returned.
 [workspace.lints.clippy]

--- a/packages/slam-rs/Cargo.toml
+++ b/packages/slam-rs/Cargo.toml
@@ -90,10 +90,11 @@ codegen-units = 1
 # error: failed to load source for dependency `cubecl-common`
 # Caused by: failed to read `<package>/target/patch/cubecl-common-0.11.0-pre.3/Cargo.toml`
 # Caused by: No such file or directory (os error 2)
-# Fix: pixi run --frozen -e slam-rs-dev slam-rs-patch-deps
+# Fix: pixi run -e slam-rs-dev slam-rs-patch-deps
+# rust-analyzer: run that command once per checkout before opening the workspace.
 # (macOS: use -e slam-rs-osx-dev).
 # Bump: update version + archive sha256 in slam_rs/apis/prepare_patched_deps.py,
-# rebase the patch, update this path and the Pixi task output, run the prepare
+# rebase the patch, update this path and the Pixi patch-test command, run the prepare
 # task, then regenerate Cargo.lock with cargo update -p cubecl-common.
 [patch.crates-io]
 cubecl-common = { path = "target/patch/cubecl-common-0.11.0-pre.3" }

--- a/packages/slam-rs/Cargo.toml
+++ b/packages/slam-rs/Cargo.toml
@@ -78,3 +78,20 @@ opt-level = 2
 [profile.release]
 lto = "thin"
 codegen-units = 1
+
+# Replace the idle device-channel 150 µs backoff with notified parking:
+# Mac two-camera seam 10.81 -> 3.34 ms; RTX 5090 stereo 0.378 -> 0.231 ms.
+# Source patch: patches/cubecl-common-0.11.0-pre.3-channel-park.patch.
+# The slam-rs-patch-deps Pixi task creates this manifest-relative directory;
+# CARGO_TARGET_DIR does not move target/patch.
+# Bare cargo before preparation fails with:
+# error: failed to load source for dependency `cubecl-common`
+# Caused by: failed to read `<package>/target/patch/cubecl-common-0.11.0-pre.3/Cargo.toml`
+# Caused by: No such file or directory (os error 2)
+# Fix: pixi run --frozen -e slam-rs-dev slam-rs-patch-deps
+# (macOS: use -e slam-rs-osx-dev).
+# Bump: update version + archive sha256 in slam_rs/apis/prepare_patched_deps.py,
+# rebase the patch, update this path and the Pixi task output, run the prepare
+# task, then regenerate Cargo.lock with cargo update -p cubecl-common.
+[patch.crates-io]
+cubecl-common = { path = "target/patch/cubecl-common-0.11.0-pre.3" }

--- a/packages/slam-rs/Cargo.toml
+++ b/packages/slam-rs/Cargo.toml
@@ -5,6 +5,8 @@
 [workspace]
 resolver = "3"
 members = ["crates/slam-rs", "crates/slam-rs-py", "crates/slam-rs-cli"]
+# Run the patched dependency's own unit tests as a standalone crate.
+exclude = ["target/patch/cubecl-common-0.11.0-pre.3"]
 
 [workspace.package]
 version = "0.1.0"

--- a/packages/slam-rs/crates/slam-rs/Cargo.toml
+++ b/packages/slam-rs/crates/slam-rs/Cargo.toml
@@ -22,8 +22,8 @@ gpu-core = ["dep:cubecl"]
 #
 # `exclusive-memory-only` — one wgpu buffer per handle instead of slices of a
 # shared page — is not a tuning choice, it is what makes the lane correct on
-# the cap. cubecl-wgpu 0.10 aligns its memory pool to the adapter's
-# `min_uniform_buffer_offset_alignment` (`runtime.rs:292`) and then binds those
+# the cap. cubecl-wgpu 0.11.0-pre.3 still aligns its memory pool to the adapter's
+# `min_uniform_buffer_offset_alignment` (`runtime.rs:307`) and then binds those
 # slices as *storage* buffers, so on any adapter whose
 # `min_storage_buffer_offset_alignment` is the larger of the two, every slice
 # past the first is an invalid binding. The RK3588's Mali G610 asks for 64 and
@@ -56,8 +56,8 @@ wgpu = { workspace = true, optional = true }
 # which of those compilers is *built* is a cargo feature, and the two the fleet
 # needs cannot both be on for one platform: `spirv` adds ash and a SPIR-V
 # assembler and only ever fires on a Vulkan adapter, while `msl`'s backend is
-# `#[cfg(target_os = "macos")]` inside cubecl-wgpu and never fires anywhere
-# else. So the choice is per **target**, not per cargo feature of ours: one
+# gated to Apple targets inside cubecl-wgpu. So the choice is per **target**,
+# not per cargo feature of ours: one
 # `--features gpu-wgpu` build line works on the Mac, the Spark, the Pi and the
 # cap, and no caller has to know which compiler its host will use.
 #
@@ -66,8 +66,10 @@ wgpu = { workspace = true, optional = true }
 # the Metal compiler is built, so a device that fails cubecl's family check
 # falls back to WGSL, which has no `u8`, and every kernel touching a bool stops
 # compiling. Our kernels bind no bool array (only `u8`, `u16`, `f32` and
-# `usize`), and cubecl-wgpu 0.10's Metal path has no family check — it takes
-# any Metal adapter — so the per-target form is safe and needs no flag.
+# `usize`). cubecl-wgpu 0.11.0-pre.3 requires Metal3, Apple7 or Mac2 family
+# support plus a successful MSL 3.2 canary (`backend/metal.rs:122`); otherwise
+# `AutoCompiler` falls back to WGSL (`compiler/base.rs:170`). Our storage probe
+# rejects that fallback, so the per-target form still needs no flag.
 #
 # WGSL is what is left if neither fires, and it is not a lane: its compiler has
 # no `u16` or `u8` and panics on cubecl's worker thread while every launch

--- a/packages/slam-rs/crates/slam-rs/Cargo.toml
+++ b/packages/slam-rs/crates/slam-rs/Cargo.toml
@@ -53,10 +53,10 @@ wgpu = { workspace = true, optional = true }
 
 # `cubecl-wgpu` chooses its shader compiler from the adapter's backend at run
 # time — Vulkan takes SPIR-V, Metal takes MSL, anything else takes WGSL — but
-# which of those compilers is *built* is a cargo feature, and the two the fleet
-# needs cannot both be on for one platform: `spirv` adds ash and a SPIR-V
-# assembler and only ever fires on a Vulkan adapter, while `msl`'s backend is
-# gated to Apple targets inside cubecl-wgpu. So the choice is per **target**,
+# which of those compilers is *built* is a cargo feature. We select features
+# per target to avoid requiring the Vulkan SDK on macOS and compiling unused
+# shader backends. `msl` is gated to Apple targets inside cubecl-wgpu.
+# So the choice is per **target**,
 # not per cargo feature of ours: one
 # `--features gpu-wgpu` build line works on the Mac, the Spark, the Pi and the
 # cap, and no caller has to know which compiler its host will use.

--- a/packages/slam-rs/crates/slam-rs/src/gpu/kernels/cell_select.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/kernels/cell_select.rs
@@ -151,10 +151,12 @@ fn fast_cell_select_kernel(
 
     // `NO_CELL_WINNER`; see the assertion beside `KEY_ROW_SHIFT`.
     let mut key = 4_294_967_295u32;
-    let mut y = first_y + usize::cast_from(UNIT_POS_Y);
-    while y < last_y {
-        let mut x = first_x + usize::cast_from(UNIT_POS_X);
-        while x < last_x {
+    // CubeCL 0.11 emits C++ lambdas for `while` conditions. wgpu's MSL
+    // passthrough leaves the language version unset, which
+    // can reject lambdas in Python even when the Rust test executable works.
+    // Stepped ranges emit plain `for` loops with the same visits and order.
+    for y in range_stepped(first_y + usize::cast_from(UNIT_POS_Y), last_y, SELECT_DIM_Y) {
+        for x in range_stepped(first_x + usize::cast_from(UNIT_POS_X), last_x, SELECT_DIM_X) {
             let score = cell_candidate(
                 kept, width, x, y, first_x, last_x, first_y, last_y, threshold,
             );
@@ -297,9 +299,7 @@ fn fast_cell_select_kernel(
                     }
                 }
             }
-            x += SELECT_DIM_X;
         }
-        y += SELECT_DIM_Y;
     }
 
     // Integer minimum is associative and commutative, so this tree is the same

--- a/packages/slam-rs/crates/slam-rs/src/gpu/kernels/cell_select.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/kernels/cell_select.rs
@@ -53,7 +53,7 @@ const _: () = assert!(crate::frontend::detect::NO_CELL_WINNER == 4_294_967_295);
 #[cube]
 #[allow(clippy::too_many_arguments)]
 fn cell_candidate(
-    kept: &Array<u8>,
+    kept: &[u8],
     width: usize,
     x: usize,
     y: usize,
@@ -63,7 +63,7 @@ fn cell_candidate(
     last_y: usize,
     threshold: u32,
 ) -> u32 {
-    let mut value: u32 = 0u32;
+    let mut value = 0u32;
     if x >= first_x && x < last_x && y >= first_y && y < last_y {
         let score = u32::cast_from(kept[y * width + x]);
         if score > threshold {
@@ -106,8 +106,8 @@ fn cell_candidate(
 #[cube(launch, launch_unchecked)]
 #[allow(clippy::too_many_arguments)]
 fn fast_cell_select_kernel(
-    kept: &Array<u8>,
-    best: &mut Array<u32>,
+    kept: &[u8],
+    best: &mut [u32],
     width: usize,
     height: usize,
     cell: usize,
@@ -150,7 +150,7 @@ fn fast_cell_select_kernel(
     let edge_y = f32::cast_from(height) - SELECT_EDGE - 1.0f32;
 
     // `NO_CELL_WINNER`; see the assertion beside `KEY_ROW_SHIFT`.
-    let mut key: u32 = 4_294_967_295u32;
+    let mut key = 4_294_967_295u32;
     let mut y = first_y + usize::cast_from(UNIT_POS_Y);
     while y < last_y {
         let mut x = first_x + usize::cast_from(UNIT_POS_X);
@@ -162,7 +162,7 @@ fn fast_cell_select_kernel(
                 // OpenCV's rule: strictly greater than all eight neighbours, a
                 // neighbour that is not a candidate scoring zero. Both sides
                 // strict, so a plateau of equal scores yields nothing.
-                let mut rival: u32 = 0u32;
+                let mut rival = 0u32;
                 rival = max(
                     rival,
                     cell_candidate(
@@ -305,7 +305,7 @@ fn fast_cell_select_kernel(
     // Integer minimum is associative and commutative, so this tree is the same
     // answer as the ascending serial reduction the float kernels are obliged to
     // use — and every barrier is cube-uniform.
-    let mut reduce = SharedMemory::<u32>::new(SELECT_SLOTS);
+    let mut reduce = Shared::<[u32]>::new_slice(SELECT_SLOTS);
     reduce[unit] = key;
     sync_cube();
     #[unroll]
@@ -365,13 +365,9 @@ pub(crate) fn launch_fast_cell_select<R: Runtime>(
         fast_cell_select_kernel::launch_unchecked::<R>(
             client,
             CubeCount::Static(geometry.cells_x as u32, geometry.cells_y as u32, 1),
-            CubeDim {
-                x: SELECT_DIM_X as u32,
-                y: SELECT_DIM_Y as u32,
-                z: 1,
-            },
-            ArrayArg::from_raw_parts(kept.0.clone(), kept.1),
-            ArrayArg::from_raw_parts(best.0.clone(), best.1),
+            CubeDim::new_3d(SELECT_DIM_X as u32, SELECT_DIM_Y as u32, 1),
+            BufferArg::from_raw_parts(kept.0.clone(), kept.1),
+            BufferArg::from_raw_parts(best.0.clone(), best.1),
             geometry.width,
             geometry.height,
             geometry.cell,

--- a/packages/slam-rs/crates/slam-rs/src/gpu/kernels/fast.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/kernels/fast.rs
@@ -30,9 +30,9 @@ pub(crate) const RING_BIAS: usize = 3;
 /// and two widths before any of this runs.
 #[cube(launch, launch_unchecked)]
 fn fast_score_kernel(
-    frame: &Array<u16>,
-    ring: &Array<u32>,
-    score: &mut Array<u8>,
+    frame: &[u16],
+    ring: &[u32],
+    score: &mut [u8],
     width: usize,
     height: usize,
     margin: usize,
@@ -72,11 +72,11 @@ fn fast_score_kernel(
         let row = y + usize::cast_from(ring[k]) - RING_BIAS;
         let column = x + usize::cast_from(ring[16usize + k]) - RING_BIAS;
         let p = u32::cast_from(frame[row * width + column]) >> 8u32;
-        let mut below: u32 = 0u32;
+        let mut below = 0u32;
         if center > p {
             below = center - p;
         }
-        let mut above: u32 = 0u32;
+        let mut above = 0u32;
         if p > center {
             above = p - center;
         }
@@ -87,8 +87,8 @@ fn fast_score_kernel(
     // Step by 2: each iteration shares the seven-element core `[k+1 .. k+8]`
     // between the arc starting at `k` and the one starting at `k+1`, which is
     // the canonical FAST-9 structure and the order kornia sums it in.
-    let mut dark_score: u32 = 0u32;
-    let mut bright_score: u32 = 0u32;
+    let mut dark_score = 0u32;
+    let mut bright_score = 0u32;
     #[unroll]
     for step in 0..8usize {
         let k = 2usize * step;
@@ -132,8 +132,8 @@ const FILTER_LAST: usize = FILTER_LANES - 1;
 #[cube(launch, launch_unchecked)]
 #[allow(clippy::too_many_arguments)]
 fn fast_localmax_kernel(
-    score: &Array<u8>,
-    kept: &mut Array<u8>,
+    score: &[u8],
+    kept: &mut [u8],
     width: usize,
     height: usize,
     margin: usize,
@@ -150,11 +150,11 @@ fn fast_localmax_kernel(
     let mut survivor = value;
     if use_filter == 1usize && x >= margin && x < filtered_end {
         let lane = (x - margin) % FILTER_LANES;
-        let mut left: u32 = 0u32;
+        let mut left = 0u32;
         if lane != 0usize {
             left = u32::cast_from(score[slot - 1usize]);
         }
-        let mut right: u32 = 0u32;
+        let mut right = 0u32;
         if lane != FILTER_LAST {
             right = u32::cast_from(score[slot + 1usize]);
         }
@@ -183,9 +183,9 @@ pub(crate) fn launch_fast_score<R: Runtime>(
             client,
             cubes,
             units,
-            ArrayArg::from_raw_parts(frame.0.clone(), frame.1),
-            ArrayArg::from_raw_parts(ring.0.clone(), ring.1),
-            ArrayArg::from_raw_parts(score.0.clone(), score.1),
+            BufferArg::from_raw_parts(frame.0.clone(), frame.1),
+            BufferArg::from_raw_parts(ring.0.clone(), ring.1),
+            BufferArg::from_raw_parts(score.0.clone(), score.1),
             width,
             height,
             margin,
@@ -212,8 +212,8 @@ pub(crate) fn launch_fast_localmax<R: Runtime>(
             client,
             cubes,
             units,
-            ArrayArg::from_raw_parts(score.0.clone(), score.1),
-            ArrayArg::from_raw_parts(kept.0.clone(), kept.1),
+            BufferArg::from_raw_parts(score.0.clone(), score.1),
+            BufferArg::from_raw_parts(kept.0.clone(), kept.1),
             width,
             height,
             margin,
@@ -235,20 +235,14 @@ pub(crate) const MASK_BITS: usize = 32;
 /// the CPU one. With a bitmask the host reads one word per thirty-two columns
 /// and only touches the score where a bit is set.
 #[cube(launch, launch_unchecked)]
-fn fast_mask_kernel(
-    kept: &Array<u8>,
-    mask: &mut Array<u32>,
-    width: usize,
-    height: usize,
-    words: usize,
-) {
+fn fast_mask_kernel(kept: &[u8], mask: &mut [u32], width: usize, height: usize, words: usize) {
     let word = usize::cast_from(ABSOLUTE_POS_X);
     let y = usize::cast_from(ABSOLUTE_POS_Y);
     if word >= words || y >= height {
         terminate!();
     }
     let first = word * MASK_BITS;
-    let mut bits: u32 = 0u32;
+    let mut bits = 0u32;
     for bit in 0..MASK_BITS {
         let x = first + bit;
         if x < width && kept[y * width + x] != 0u8 {
@@ -274,8 +268,8 @@ pub(crate) fn launch_fast_mask<R: Runtime>(
             client,
             cubes,
             units,
-            ArrayArg::from_raw_parts(kept.0.clone(), kept.1),
-            ArrayArg::from_raw_parts(mask.0.clone(), mask.1),
+            BufferArg::from_raw_parts(kept.0.clone(), kept.1),
+            BufferArg::from_raw_parts(mask.0.clone(), mask.1),
             width,
             height,
             words,

--- a/packages/slam-rs/crates/slam-rs/src/gpu/kernels/layout.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/kernels/layout.rs
@@ -46,7 +46,7 @@ pub(crate) const SOPHUS_EPSILON: f32 = <f32 as crate::lie::LieScalar>::SOPHUS_EP
 /// A device buffer and the element count the kernel will see in it.
 ///
 /// Spelled once rather than at each of the launcher parameters below, all of
-/// which take exactly this: the count is a promise `ArrayArg::from_raw_parts`
+/// which take exactly this: the count is a promise `BufferArg::from_raw_parts`
 /// cannot check, so keeping it beside the handle is what makes the promise
 /// visible at the call site.
 pub(crate) type Buffer<'a> = (&'a cubecl::server::Handle, usize);
@@ -64,11 +64,7 @@ pub(crate) fn tile_2d(width: usize, height: usize) -> (CubeCount, CubeDim) {
             (height as u32).div_ceil(TILE_H),
             1,
         ),
-        CubeDim {
-            x: TILE_W,
-            y: TILE_H,
-            z: 1,
-        },
+        CubeDim::new_3d(TILE_W, TILE_H, 1),
     )
 }
 
@@ -100,11 +96,7 @@ pub(crate) fn linear_1d(count: usize) -> (CubeCount, CubeDim) {
             cubes.div_ceil(MAX_CUBES_PER_DIM),
             1,
         ),
-        CubeDim {
-            x: LINEAR_UNITS,
-            y: 1,
-            z: 1,
-        },
+        CubeDim::new_3d(LINEAR_UNITS, 1, 1),
     )
 }
 

--- a/packages/slam-rs/crates/slam-rs/src/gpu/kernels/patch.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/kernels/patch.rs
@@ -167,11 +167,11 @@ fn ldlt_solve3(mat: &Array<f32>, transpositions: &Array<usize>, rhs: &mut Array<
 #[cube(launch, launch_unchecked)]
 #[allow(clippy::too_many_arguments)]
 fn patch_build_kernel(
-    pyramid_a: &Array<u16>,
-    pyramid_b: &Array<u16>,
-    meta: &Array<u32>,
-    positions: &Array<f32>,
-    store: &mut Array<f32>,
+    pyramid_a: &[u16],
+    pyramid_b: &[u16],
+    meta: &[u32],
+    positions: &[f32],
+    store: &mut [f32],
     capacity: usize,
     taps: usize,
     num_levels: usize,
@@ -200,12 +200,12 @@ fn patch_build_kernel(
         terminate!();
     }
 
-    let mut values = SharedMemory::<f32>::new(TAP_SLOTS);
-    let mut grad_x = SharedMemory::<f32>::new(TAP_SLOTS);
-    let mut grad_y = SharedMemory::<f32>::new(TAP_SLOTS);
-    let mut grad_t = SharedMemory::<f32>::new(TAP_SLOTS);
-    let mut okflag = SharedMemory::<usize>::new(TAP_SLOTS);
-    let mut red = SharedMemory::<f32>::new(16usize);
+    let mut values = Shared::<[f32]>::new_slice(TAP_SLOTS);
+    let mut grad_x = Shared::<[f32]>::new_slice(TAP_SLOTS);
+    let mut grad_y = Shared::<[f32]>::new_slice(TAP_SLOTS);
+    let mut grad_t = Shared::<[f32]>::new_slice(TAP_SLOTS);
+    let mut okflag = Shared::<[usize]>::new_slice(TAP_SLOTS);
+    let mut red = Shared::<[f32]>::new_slice(16usize);
 
     // `const Scalar scale = 1 << level`.
     let scale = f32::cast_from(1usize << level);
@@ -265,7 +265,7 @@ fn patch_build_kernel(
 
     if tap == 0usize {
         let mut sum = 0.0f32;
-        let mut valid_points: u32 = 0u32;
+        let mut valid_points = 0u32;
         let mut sum_x = 0.0f32;
         let mut sum_y = 0.0f32;
         let mut sum_t = 0.0f32;
@@ -358,7 +358,7 @@ fn patch_build_kernel(
         let value = values[tap];
         store[(level * taps + tap) * capacity + patch] = value;
         let finite = is_finite(p0) && is_finite(p1) && is_finite(p2) && is_finite(value);
-        let mut flag: usize = 0usize;
+        let mut flag = 0usize;
         if finite {
             flag = 1usize;
         }
@@ -376,7 +376,7 @@ fn patch_build_kernel(
                 finite = false;
             }
         }
-        let mut valid: f32 = 0.0f32;
+        let mut valid = 0.0f32;
         if red[1usize] > f32::new(f32::EPSILON) && finite {
             valid = 1.0f32;
         }
@@ -405,16 +405,12 @@ pub(crate) fn launch_patch_build<R: Runtime>(
         patch_build_kernel::launch_unchecked::<R>(
             client,
             CubeCount::Static(shape.count as u32, shape.num_levels as u32, 1),
-            CubeDim {
-                x: TAP_UNITS,
-                y: 1,
-                z: 1,
-            },
-            ArrayArg::from_raw_parts(pyramid.0.clone(), pyramid.1),
-            ArrayArg::from_raw_parts(pyramid.2.clone(), pyramid.3),
-            ArrayArg::from_raw_parts(meta.0.clone(), meta.1),
-            ArrayArg::from_raw_parts(positions.0.clone(), positions.1),
-            ArrayArg::from_raw_parts(store.0.clone(), store.1),
+            CubeDim::new_3d(TAP_UNITS, 1, 1),
+            BufferArg::from_raw_parts(pyramid.0.clone(), pyramid.1),
+            BufferArg::from_raw_parts(pyramid.2.clone(), pyramid.3),
+            BufferArg::from_raw_parts(meta.0.clone(), meta.1),
+            BufferArg::from_raw_parts(positions.0.clone(), positions.1),
+            BufferArg::from_raw_parts(store.0.clone(), store.1),
             shape.capacity,
             shape.taps,
             shape.num_levels,

--- a/packages/slam-rs/crates/slam-rs/src/gpu/kernels/pyramid.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/kernels/pyramid.rs
@@ -32,7 +32,7 @@ fn reflect_low(twice: usize, k: usize) -> usize {
 #[cube]
 #[allow(clippy::too_many_arguments)]
 fn subsample_band(
-    src: &Array<u16>,
+    src: &[u16],
     row_base: usize,
     c0: usize,
     c1: usize,
@@ -54,8 +54,8 @@ fn subsample_band(
 #[cube(launch, launch_unchecked)]
 #[allow(clippy::too_many_arguments)]
 fn subsample_kernel(
-    src: &Array<u16>,
-    dst: &mut Array<u16>,
+    src: &[u16],
+    dst: &mut [u16],
     src_base: usize,
     src_width: usize,
     src_height: usize,
@@ -105,8 +105,8 @@ pub(crate) fn launch_subsample<R: Runtime>(
             client,
             cubes,
             units,
-            ArrayArg::from_raw_parts(src.0.clone(), src.1),
-            ArrayArg::from_raw_parts(dst.0.clone(), dst.1),
+            BufferArg::from_raw_parts(src.0.clone(), src.1),
+            BufferArg::from_raw_parts(dst.0.clone(), dst.1),
             source.base,
             source.width,
             source.height,

--- a/packages/slam-rs/crates/slam-rs/src/gpu/kernels/sampling.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/kernels/sampling.rs
@@ -18,13 +18,13 @@ pub(crate) fn in_bounds(x: f32, y: f32, border: f32, width: usize, height: usize
 
 /// One pixel of a level, as `f32`.
 #[cube]
-fn at(image: &Array<u16>, base: usize, stride: usize, x: usize, y: usize) -> f32 {
+fn at(image: &[u16], base: usize, stride: usize, x: usize, y: usize) -> f32 {
     f32::cast_from(image[base + y * stride + x])
 }
 
 /// Bilinear sampling with the CPU implementation's multiplication grouping and sum order.
 #[cube]
-pub(crate) fn interp(image: &Array<u16>, base: usize, stride: usize, x: f32, y: f32) -> f32 {
+pub(crate) fn interp(image: &[u16], base: usize, stride: usize, x: f32, y: f32) -> f32 {
     let ix = usize::cast_from(x);
     let iy = usize::cast_from(y);
     let dx = x - f32::cast_from(ix);
@@ -45,20 +45,20 @@ pub(crate) fn interp(image: &Array<u16>, base: usize, stride: usize, x: f32, y: 
 /// twelve pixels are read (`ix - 1` through `ix + 2`, `iy - 1` through
 /// `iy + 2`) and why the caller must have satisfied `in_bounds(x, y, 1)`.
 ///
-/// Three `&mut SharedMemory` parameters rather than a returned triple: a
+/// Three `&mut Shared` parameters rather than a returned triple: a
 /// `#[cube]` function returns one value, and the caller wants these in shared
 /// memory anyway so unit 0 can reduce over them.
 #[cube]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn interp_grad_into(
-    image: &Array<u16>,
+    image: &[u16],
     base: usize,
     stride: usize,
     x: f32,
     y: f32,
-    values: &mut SharedMemory<f32>,
-    grad_x: &mut SharedMemory<f32>,
-    grad_y: &mut SharedMemory<f32>,
+    values: &mut Shared<[f32]>,
+    grad_x: &mut Shared<[f32]>,
+    grad_y: &mut Shared<[f32]>,
     slot: usize,
 ) {
     let ix = usize::cast_from(x);
@@ -107,7 +107,7 @@ pub(crate) fn interp_grad_into(
 /// the even allocation to be made once at `allocate` rather than replaced every
 /// frame.
 #[cube(launch, launch_unchecked)]
-fn probe_kernel<N: Numeric>(src: &Array<N>, dst: &mut Array<N>, count: usize) {
+fn probe_kernel<N: Numeric>(src: &[N], dst: &mut [N], count: usize) {
     let index = usize::cast_from(ABSOLUTE_POS);
     if index >= count {
         terminate!();
@@ -121,7 +121,7 @@ fn probe_kernel<N: Numeric>(src: &Array<N>, dst: &mut Array<N>, count: usize) {
 /// `launch_unchecked`. It runs once per process, off the per-frame path, and it
 /// is the kernel whose whole job is to prove the runtime is sound: bounds checks
 /// off is the wrong shape for that, and 256 elements cost nothing either way.
-/// The `unsafe` that remains is `ArrayArg::from_raw_parts`, which every launcher
+/// The `unsafe` that remains is `BufferArg::from_raw_parts`, which every launcher
 /// needs to name a handle's element count, not the launch.
 pub(crate) fn launch_probe<N: Numeric, R: Runtime>(
     client: &ComputeClient<R>,
@@ -136,8 +136,8 @@ pub(crate) fn launch_probe<N: Numeric, R: Runtime>(
             client,
             cubes,
             units,
-            ArrayArg::from_raw_parts(src.0.clone(), src.1),
-            ArrayArg::from_raw_parts(dst.0.clone(), dst.1),
+            BufferArg::from_raw_parts(src.0.clone(), src.1),
+            BufferArg::from_raw_parts(dst.0.clone(), dst.1),
             count,
         );
     }
@@ -162,8 +162,8 @@ pub(crate) fn launch_copy_level0<R: Runtime>(
             client,
             cubes,
             units,
-            ArrayArg::from_raw_parts(src.0.clone(), src.1),
-            ArrayArg::from_raw_parts(dst.0.clone(), dst.1),
+            BufferArg::from_raw_parts(src.0.clone(), src.1),
+            BufferArg::from_raw_parts(dst.0.clone(), dst.1),
             count,
         );
     }

--- a/packages/slam-rs/crates/slam-rs/src/gpu/kernels/track.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/kernels/track.rs
@@ -21,7 +21,8 @@ use cubecl::prelude::*;
 /// MIO14 GT ATE is 9.48 cm with sin+cos and 9.72 cm with sine only (D71). Normalization
 /// and fused multiply-add can still differ from the CPU by an ulp.
 #[cube]
-fn compose_se2_exp(state: &mut SharedMemory<f32>, t0: f32, t1: f32, theta: f32) {
+#[allow(clippy::assign_op_pattern)] // Preserve the floating-point addition order.
+fn compose_se2_exp(state: &mut Shared<[f32]>, t0: f32, t1: f32, theta: f32) {
     let cos_theta = f32::cos(theta);
     let sin_theta = trig::sin(theta);
     let length = f32::sqrt(cos_theta * cos_theta + sin_theta * sin_theta);
@@ -65,13 +66,13 @@ fn compose_se2_exp(state: &mut SharedMemory<f32>, t0: f32, t1: f32, theta: f32) 
     unused_assignments
 )]
 fn klt_kernel(
-    pyramid_a: &Array<u16>,
-    pyramid_b: &Array<u16>,
-    meta: &Array<u32>,
-    store: &Array<f32>,
+    pyramid_a: &[u16],
+    pyramid_b: &[u16],
+    meta: &[u32],
+    store: &[f32],
     // Compose the warp in place through one read/write binding. Binding the same
     // buffer separately as read-only and read/write is invalid on some wgpu adapters.
-    transforms: &mut Array<f32>,
+    transforms: &mut [f32],
     capacity: usize,
     taps: usize,
     num_levels: usize,
@@ -89,17 +90,17 @@ fn klt_kernel(
     let row_stride = taps * capacity;
     let pattern = num_levels * 4usize;
 
-    let mut residual = SharedMemory::<f32>::new(TAP_SLOTS);
-    let mut product_0 = SharedMemory::<f32>::new(TAP_SLOTS);
-    let mut product_1 = SharedMemory::<f32>::new(TAP_SLOTS);
-    let mut product_2 = SharedMemory::<f32>::new(TAP_SLOTS);
-    let mut okflag = SharedMemory::<usize>::new(TAP_SLOTS);
+    let mut residual = Shared::<[f32]>::new_slice(TAP_SLOTS);
+    let mut product_0 = Shared::<[f32]>::new_slice(TAP_SLOTS);
+    let mut product_1 = Shared::<[f32]>::new_slice(TAP_SLOTS);
+    let mut product_2 = Shared::<[f32]>::new_slice(TAP_SLOTS);
+    let mut okflag = Shared::<[usize]>::new_slice(TAP_SLOTS);
     // 0..6 the running warp, 6 the tap sum, 7 the in-bounds tap count,
     // 8 the level scale.
-    let mut state = SharedMemory::<f32>::new(16usize);
+    let mut state = Shared::<[f32]>::new_slice(16usize);
     // 0 the running validity, 1 whether this level was entered alive,
     // 2 whether the guess passed the bounds test at all.
-    let mut alive = SharedMemory::<usize>::new(4usize);
+    let mut alive = Shared::<[usize]>::new_slice(4usize);
 
     if tap == 0usize {
         let guess_x = transforms[4usize * count + patch];
@@ -115,7 +116,7 @@ fn klt_kernel(
         {
             inside = false;
         }
-        let mut entered: usize = 0usize;
+        let mut entered = 0usize;
         if inside {
             entered = 1usize;
         }
@@ -164,7 +165,7 @@ fn klt_kernel(
                 let warped_x = state[0usize] * tap_x + state[1usize] * tap_y + state[4usize];
                 let warped_y = state[2usize] * tap_x + state[3usize] * tap_y + state[5usize];
                 if in_bounds(warped_x, warped_y, PATCH_BORDER, width, height) {
-                    let mut sampled: f32 = 0.0f32;
+                    let mut sampled = 0.0f32;
                     if parity == 0usize {
                         sampled = interp(pyramid_a, base, width, warped_x, warped_y);
                     } else {
@@ -181,7 +182,7 @@ fn klt_kernel(
 
             if sampling && tap == 0usize {
                 let mut sum = 0.0f32;
-                let mut valid_points: u32 = 0u32;
+                let mut valid_points = 0u32;
                 for i in 0..taps {
                     if okflag[i] == 1usize {
                         sum += residual[i];
@@ -219,7 +220,7 @@ fn klt_kernel(
             sync_cube();
 
             if solving && tap == 0usize {
-                let mut residuals: u32 = 0u32;
+                let mut residuals = 0u32;
                 for i in 0..taps {
                     if okflag[i] == 1usize {
                         residuals += 1u32;
@@ -315,9 +316,9 @@ fn klt_kernel(
 #[cube(launch, launch_unchecked)]
 #[allow(clippy::too_many_arguments)]
 fn prepare_backward_kernel(
-    forward: &Array<f32>,
-    offsets: &Array<f32>,
-    out: &mut Array<f32>,
+    forward: &[f32],
+    offsets: &[f32],
+    out: &mut [f32],
     count: usize,
     offset_x_base: usize,
     offset_y_base: usize,
@@ -343,10 +344,10 @@ fn prepare_backward_kernel(
 // Use `!(dist2 < max)` so a NaN fails the distance guard.
 #[allow(clippy::too_many_arguments, clippy::neg_cmp_op_on_partial_ord)]
 fn finish_kernel(
-    forward: &Array<f32>,
-    backward: &Array<f32>,
-    positions: &Array<f32>,
-    out: &mut Array<f32>,
+    forward: &[f32],
+    backward: &[f32],
+    positions: &[f32],
+    out: &mut [f32],
     count: usize,
     pos_x_base: usize,
     pos_y_base: usize,
@@ -368,7 +369,7 @@ fn finish_kernel(
             ok = false;
         }
     }
-    let mut flag: f32 = 0.0f32;
+    let mut flag = 0.0f32;
     if ok {
         flag = 1.0f32;
     }
@@ -397,16 +398,12 @@ pub(crate) fn launch_klt<R: Runtime>(
         klt_kernel::launch_unchecked::<R>(
             client,
             CubeCount::Static(shape.count as u32, 1, 1),
-            CubeDim {
-                x: TAP_UNITS,
-                y: 1,
-                z: 1,
-            },
-            ArrayArg::from_raw_parts(pyramid.0.clone(), pyramid.1),
-            ArrayArg::from_raw_parts(pyramid.2.clone(), pyramid.3),
-            ArrayArg::from_raw_parts(meta.0.clone(), meta.1),
-            ArrayArg::from_raw_parts(store.0.clone(), store.1),
-            ArrayArg::from_raw_parts(transforms.0.clone(), transforms.1),
+            CubeDim::new_3d(TAP_UNITS, 1, 1),
+            BufferArg::from_raw_parts(pyramid.0.clone(), pyramid.1),
+            BufferArg::from_raw_parts(pyramid.2.clone(), pyramid.3),
+            BufferArg::from_raw_parts(meta.0.clone(), meta.1),
+            BufferArg::from_raw_parts(store.0.clone(), store.1),
+            BufferArg::from_raw_parts(transforms.0.clone(), transforms.1),
             shape.capacity,
             shape.taps,
             shape.num_levels,
@@ -434,9 +431,9 @@ pub(crate) fn launch_prepare_backward<R: Runtime>(
             client,
             cubes,
             units,
-            ArrayArg::from_raw_parts(forward.0.clone(), forward.1),
-            ArrayArg::from_raw_parts(offsets.0.clone(), offsets.1),
-            ArrayArg::from_raw_parts(out.0.clone(), out.1),
+            BufferArg::from_raw_parts(forward.0.clone(), forward.1),
+            BufferArg::from_raw_parts(offsets.0.clone(), offsets.1),
+            BufferArg::from_raw_parts(out.0.clone(), out.1),
             count,
             bases.x,
             bases.y,
@@ -463,10 +460,10 @@ pub(crate) fn launch_finish<R: Runtime>(
             client,
             cubes,
             units,
-            ArrayArg::from_raw_parts(forward.0.clone(), forward.1),
-            ArrayArg::from_raw_parts(backward.0.clone(), backward.1),
-            ArrayArg::from_raw_parts(positions.0.clone(), positions.1),
-            ArrayArg::from_raw_parts(out.0.clone(), out.1),
+            BufferArg::from_raw_parts(forward.0.clone(), forward.1),
+            BufferArg::from_raw_parts(backward.0.clone(), backward.1),
+            BufferArg::from_raw_parts(positions.0.clone(), positions.1),
+            BufferArg::from_raw_parts(out.0.clone(), out.1),
             count,
             bases.x,
             bases.y,

--- a/packages/slam-rs/crates/slam-rs/src/gpu/runtime.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/runtime.rs
@@ -201,6 +201,7 @@ fn probe_availability() -> Result<(), GpuError> {
         power_preference: wgpu::PowerPreference::HighPerformance,
         force_fallback_adapter: false,
         compatible_surface: None,
+        apply_limit_buckets: false,
     });
     match cubecl::future::block_on(request) {
         Ok(_) => Ok(()),

--- a/packages/slam-rs/crates/slam-rs/src/gpu/runtime/tests.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/runtime/tests.rs
@@ -21,7 +21,7 @@ fn a_failed_device_read_is_a_typed_error_at_every_stage() {
     let what: &str = "the tracker result";
     let error: cubecl::server::ServerError = cubecl::server::ServerError::Generic {
         reason: "the device is gone".to_owned(),
-        backtrace: cubecl::backtrace::BackTrace::default(),
+        backtrace: Default::default(),
     };
     assert_eq!(
         read_failed(what, &error),

--- a/packages/slam-rs/crates/slam-rs/src/gpu/submission.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/submission.rs
@@ -2,7 +2,8 @@
 
 use super::{GpuError, seam};
 
-/// CubeCL 0.10.0's private `custom_channel::CHANNEL_MAX_TASK` is 32.
+/// CubeCL 0.11.0-pre.3's private `custom_channel::CHANNEL_MAX_TASK` is 32
+/// (`cubecl-common/src/device/handle/channel.rs`).
 /// Recheck this value when upgrading CubeCL; it is not exported by the runtime.
 pub const CHANNEL_TASKS: usize = 32;
 
@@ -19,7 +20,7 @@ thread_local! {
 /// one-task stage, so even a pyramid larger than the budget is split safely.
 /// Leave one channel slot for the blocking flush or download itself.
 ///
-/// CubeCL clones share `utilities.properties` (0.10.0 `client.rs`), so its
+/// CubeCL clones share `utilities.properties` (0.11.0-pre.3 `client.rs`), so its
 /// address identifies their device's queue. A stale address can only retain an
 /// old count and cause an early flush. Runtime type separates backend types.
 /// Each device must have one producer thread; a read resets only that device.
@@ -141,10 +142,10 @@ fn download<R: cubecl::prelude::Runtime>(
     if super::runtime::armed(super::runtime::BLOCKING_READ) {
         return Err(cubecl::server::ServerError::Generic {
             reason: "the device is gone".to_owned(),
-            backtrace: cubecl::backtrace::BackTrace::default(),
+            backtrace: Default::default(),
         });
     }
-    cubecl::reader::read_sync(client.read_async(handles))
+    cubecl::future::reader::read_sync(client.read_async(handles))
 }
 
 /// One blocking download of every handle at once, and the protocol around it.

--- a/packages/slam-rs/crates/slam-rs/tests/gpu_kernels.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/gpu_kernels.rs
@@ -968,6 +968,10 @@ mod absent_gpu {
 
     /// No Vulkan ICD: the loader enumerates nothing and wgpu has no adapter.
     #[cfg(feature = "gpu-wgpu")]
+    #[cfg_attr(
+        target_os = "macos",
+        ignore = "requires the Vulkan ICD loader; Metal ignores VK_DRIVER_FILES"
+    )]
     #[test]
     fn a_wgpu_host_with_no_adapter_is_a_typed_error() {
         const NAME: &str = "absent_gpu::a_wgpu_host_with_no_adapter_is_a_typed_error";

--- a/packages/slam-rs/crates/slam-rs/tests/gpu_kernels.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/gpu_kernels.rs
@@ -1016,7 +1016,7 @@ mod absent_gpu {
 }
 
 #[cubecl::prelude::cube(launch_unchecked)]
-fn finite_probe(input: &cubecl::prelude::Array<f32>, output: &mut cubecl::prelude::Array<u32>) {
+fn finite_probe(input: &[f32], output: &mut [u32]) {
     use cubecl::prelude::*;
     let i = ABSOLUTE_POS;
     if i < 12 {
@@ -1054,8 +1054,8 @@ fn finite_predicates_match_ieee_classification() {
             &client,
             CubeCount::Static(1, 1, 1),
             CubeDim::new_1d(32),
-            ArrayArg::from_raw_parts(input, 12),
-            ArrayArg::from_raw_parts(output.clone(), 12),
+            BufferArg::from_raw_parts(input, 12),
+            BufferArg::from_raw_parts(output.clone(), 12),
         );
     }
     let bytes = client.read_one(output).unwrap();
@@ -1074,10 +1074,7 @@ fn finite_predicates_match_ieee_classification() {
 mod trig;
 
 #[cubecl::prelude::cube(launch_unchecked)]
-fn small_angle_probe(
-    input: &cubecl::prelude::Array<f32>,
-    output: &mut cubecl::prelude::Array<f32>,
-) {
+fn small_angle_probe(input: &[f32], output: &mut [f32]) {
     use cubecl::prelude::*;
     let i = ABSOLUTE_POS;
     if i < input.len() {
@@ -1104,8 +1101,8 @@ fn small_angle_trig_stays_within_two_ulps_of_the_cpu() {
             &client,
             CubeCount::Static(values.len().div_ceil(256) as u32, 1, 1),
             CubeDim::new_1d(256),
-            ArrayArg::from_raw_parts(input, values.len()),
-            ArrayArg::from_raw_parts(output.clone(), values.len() * 2),
+            BufferArg::from_raw_parts(input, values.len()),
+            BufferArg::from_raw_parts(output.clone(), values.len() * 2),
         );
     }
     let bytes = client.read_one(output).unwrap();

--- a/packages/slam-rs/patches/cubecl-common-0.11.0-pre.3-channel-park.patch
+++ b/packages/slam-rs/patches/cubecl-common-0.11.0-pre.3-channel-park.patch
@@ -1,0 +1,277 @@
+# Park the idle worker after its existing spin/yield budgets and unpark it after batch publication, flush, and shutdown. Install the worker handle before exposing clients, preserve wake tokens across the empty-check/park race, and recheck shutdown padding before parking. Keep the client full-queue backoff unchanged; retain a 10 ms fallback for unnotified last-client drops.
+# 
+# On Apple M4, a diagnostic version reduced the two-camera frontend seam from 10.81 to 3.34 ms. On RTX 5090 Vulkan, the stereo stage fell from 0.378 to 0.231 ms with byte-identical trajectories. These measurements motivate the notification protocol; they are not portable latency guarantees.
+# 
+# Test publication across the check/park boundary, parked shutdown draining, and eight concurrent producers. Extend the timeout only in these tests so polling cannot mask missing notifications.
+
+diff --git a/src/device/handle/channel.rs b/src/device/handle/channel.rs
+index b5893c23..2221842c 100644
+--- a/src/device/handle/channel.rs
++++ b/src/device/handle/channel.rs
+@@ -848,11 +848,13 @@ mod custom_channel {
+     /// Gives a hot window to absorb back-to-back submits without any syscall.
+     const SPIN_BUDGET_SERVER: u32 = 8192;
+     /// Number of `thread::yield_now` calls after the spin budget is exhausted,
+-    /// before the server drops to sleeping.
++    /// before the server parks.
+     const YIELD_BUDGET_SERVER: u32 = 64;
+-    /// Sleep duration once both the spin and yield budgets are exhausted.
+-    /// Bounds the wake-up latency from a fully idle state.
+-    const SLEEP_STEP_SERVER: Duration = Duration::from_micros(150);
++    /// Safety net for last-client drops, which do not send a notification.
++    /// Published batches wake the server directly; this is not a polling interval
++    /// on the submission path. Ten milliseconds bounds unattended teardown
++    /// without the frequent wakeups of a short sleep.
++    const PARK_TIMEOUT_SERVER: Duration = Duration::from_millis(10);
+ 
+     /// The client has the buffer to fill plus we add a factor of two to account for the double
+     /// buffering approach.
+@@ -911,6 +913,9 @@ mod custom_channel {
+                 })
+                 .unwrap();
+ 
++            // Install the handle before exposing any client. The worker may
++            // already be parked; its first producer can still wake it.
++            state.worker.set(thread.thread().clone()).unwrap();
+             (Self { state }, thread)
+         }
+ 
+@@ -919,6 +924,7 @@ mod custom_channel {
+         /// server keeps draining until the last one is gone.
+         pub fn request_shutdown(&self) {
+             self.state.shutdown.store(true, Ordering::Release);
++            self.state.wake_server();
+         }
+ 
+         /// Atomically reserves a slot in the buffer and writes the task.
+@@ -940,7 +946,10 @@ mod custom_channel {
+                 }
+ 
+                 self.state.init_task_at(index, func);
+-                self.state.enqueued_count.fetch_add(1, Ordering::SeqCst);
++                let count = self.state.enqueued_count.fetch_add(1, Ordering::SeqCst) + 1;
++                if count == CHANNEL_MAX_TASK as u32 {
++                    self.state.wake_server();
++                }
+                 return Ok(());
+             }
+         }
+@@ -948,6 +957,7 @@ mod custom_channel {
+         /// Forces a flush by filling the remaining buffer with no-op tasks.
+         pub fn flush(&self) {
+             self.state.pad_with_noops();
++            self.state.wake_server();
+         }
+     }
+ 
+@@ -957,6 +967,8 @@ mod custom_channel {
+         /// Written by the server thread (Release) after swapping buffers,
+         /// read by client threads (Acquire) before writing tasks.
+         queue_ptr: AtomicPtr<Task>,
++        /// Set before the first client is exposed to producers.
++        worker: std::sync::OnceLock<std::thread::Thread>,
+         /// Next available index for writing.
+         available_index: AtomicU32,
+         /// Number of tasks successfully written and ready for processing.
+@@ -969,6 +981,14 @@ mod custom_channel {
+     }
+ 
+     impl State {
++        /// Publish queue/shutdown state before calling this. `unpark` retains a
++        /// token if the worker has not parked yet, closing the check/park race.
++        fn wake_server(&self) {
++            if let Some(worker) = self.worker.get() {
++                worker.unpark();
++            }
++        }
++
+         /// Fills the rest of the current queue with no-op tasks so a partially
+         /// filled buffer reaches [`CHANNEL_MAX_TASK`] and the server swaps it in.
+         ///
+@@ -1046,6 +1066,10 @@ mod custom_channel {
+         client_buf: usize,
+         buffers: [TaskBuffer; 2],
+         ready_to_execute: bool,
++        #[cfg(test)]
++        before_park: Option<std::boxed::Box<dyn FnOnce() + Send>>,
++        #[cfg(test)]
++        park_timeout: Duration,
+     }
+ 
+     impl Server {
+@@ -1054,6 +1078,7 @@ mod custom_channel {
+ 
+             let state = Arc::new(State {
+                 queue_ptr: AtomicPtr::new(buffers[0].tasks.as_mut_ptr()),
++                worker: std::sync::OnceLock::new(),
+                 available_index: AtomicU32::new(0),
+                 enqueued_count: AtomicU32::new(0),
+                 shutdown: AtomicBool::new(false),
+@@ -1065,6 +1090,10 @@ mod custom_channel {
+                 client_buf: 0,
+                 buffers,
+                 ready_to_execute: false,
++                #[cfg(test)]
++                before_park: None,
++                #[cfg(test)]
++                park_timeout: PARK_TIMEOUT_SERVER,
+             }
+         }
+ 
+@@ -1098,10 +1127,27 @@ mod custom_channel {
+                     {
+                         return;
+                     }
++                    // Shutdown can itself publish padding after the queue check
++                    // above. Process that batch without waiting for a producer.
++                    if self.state.enqueued_count.load(Ordering::Acquire) >= CHANNEL_MAX_TASK as u32
++                    {
++                        continue;
++                    }
+                     if idle_count < SPIN_BUDGET_SERVER + YIELD_BUDGET_SERVER {
+                         std::thread::yield_now();
+                     } else {
+-                        std::thread::sleep(SLEEP_STEP_SERVER);
++                        // Every return (token, timeout, or spurious wake) goes
++                        // through the queue and shutdown checks before parking
++                        // again. No other park call consumes our wake token here.
++                        #[cfg(test)]
++                        if let Some(before_park) = self.before_park.take() {
++                            before_park();
++                        }
++                        #[cfg(test)]
++                        let timeout = self.park_timeout;
++                        #[cfg(not(test))]
++                        let timeout = PARK_TIMEOUT_SERVER;
++                        std::thread::park_timeout(timeout);
+                     }
+                 }
+                 idle_count = idle_count.saturating_add(1);
+@@ -1172,6 +1218,124 @@ mod custom_channel {
+             self.state.available_index.store(0, Ordering::SeqCst);
+         }
+     }
++
++    #[cfg(test)]
++    mod park_tests {
++        use super::*;
++        use crate::device::{DeviceId, DeviceServiceStage};
++        use std::sync::{Barrier, mpsc};
++        use std::thread;
++
++        // Hold the actual worker after its empty-queue check, immediately before
++        // parking. A long test-only timeout prevents polling from hiding a lost
++        // notification; completion must arrive within one second instead.
++        fn at_park() -> (DeviceClient, thread::JoinHandle<()>, Arc<AtomicBool>) {
++            let mut server = Server::new(RunnerId {
++                device: DeviceId::new(0, 0),
++                stage: DeviceServiceStage::Upstream,
++            });
++            let (ready_tx, ready_rx) = mpsc::channel();
++            let release = Arc::new(AtomicBool::new(false));
++            let release_worker = release.clone();
++            server.before_park = Some(std::boxed::Box::new(move || {
++                ready_tx.send(()).unwrap();
++                // Blocking channels may use park internally and consume the
++                // very token this test is checking. Spin at this test hook.
++                while !release_worker.load(Ordering::Acquire) {
++                    thread::yield_now();
++                }
++            }));
++            server.park_timeout = Duration::from_secs(60);
++            let state = server.state.clone();
++            let thread = thread::spawn(move || server.start());
++            state.worker.set(thread.thread().clone()).unwrap();
++            ready_rx.recv_timeout(Duration::from_secs(5)).unwrap();
++            (DeviceClient { state }, thread, release)
++        }
++
++        fn finish(client: DeviceClient, thread: thread::JoinHandle<()>) {
++            client.request_shutdown();
++            drop(client);
++            // The last Arc drop is intentionally only timeout-backed in normal
++            // operation. Explicitly wake after it so tests need not wait 60 s.
++            thread.thread().unpark();
++            thread.join().unwrap();
++        }
++
++        #[test]
++        fn published_batch_racing_park_keeps_its_wake_token() {
++            for flush in [false, true] {
++                let (client, thread, release) = at_park();
++                let (tx, rx) = mpsc::channel();
++                client.enqueue(move || tx.send(()).unwrap()).unwrap();
++                if flush {
++                    client.flush();
++                } else {
++                    for _ in 1..CHANNEL_MAX_TASK {
++                        client.enqueue(|| ()).unwrap();
++                    }
++                }
++                release.store(true, Ordering::Release);
++                let result = rx.recv_timeout(Duration::from_secs(1));
++                finish(client, thread);
++                result.expect("publish before park must retain a wake token");
++            }
++        }
++
++        #[test]
++        fn shutdown_wakes_a_parked_worker_and_drains_partial_work() {
++            let (client, thread, release) = at_park();
++            release.store(true, Ordering::Release);
++            thread::sleep(Duration::from_millis(20));
++            let (tx, rx) = mpsc::channel();
++            client.enqueue(move || tx.send(()).unwrap()).unwrap();
++            client.request_shutdown();
++            let result = rx.recv_timeout(Duration::from_secs(1));
++            finish(client, thread);
++            result.expect("shutdown must wake and drain without waiting for timeout");
++        }
++
++        #[test]
++        fn concurrent_producers_publish_every_task_once() {
++            let (client, thread, release) = at_park();
++            release.store(true, Ordering::Release);
++            thread::sleep(Duration::from_millis(20));
++            let barrier = Arc::new(Barrier::new(8));
++            let (tx, rx) = mpsc::channel();
++            let mut producers = Vec::new();
++            for producer in 0..8 {
++                let client = client.clone();
++                let barrier = barrier.clone();
++                let tx = tx.clone();
++                producers.push(thread::spawn(move || {
++                    barrier.wait();
++                    for task in 0..128 {
++                        let tx = tx.clone();
++                        client
++                            .enqueue(move || tx.send(producer * 128 + task).unwrap())
++                            .unwrap();
++                        if task % 7 == 0 {
++                            client.flush();
++                        }
++                    }
++                    client.flush();
++                }));
++            }
++            let mut received = Vec::new();
++            for _ in 0..1024 {
++                received.push(
++                    rx.recv_timeout(Duration::from_secs(1))
++                        .expect("producer wakeup lost"),
++                );
++            }
++            for producer in producers {
++                producer.join().unwrap();
++            }
++            finish(client, thread);
++            received.sort_unstable();
++            assert_eq!(received, (0..1024).collect::<Vec<_>>());
++        }
++    }
+ }
+ 
+ #[cfg(test)]
+-- 
+2.55.0
+

--- a/packages/slam-rs/slam_rs/apis/prepare_patched_deps.py
+++ b/packages/slam-rs/slam_rs/apis/prepare_patched_deps.py
@@ -1,0 +1,93 @@
+"""Materialize checksummed Cargo archives and local patches before Cargo runs."""
+
+import hashlib
+import io
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class PatchedCrate:
+    """Pinned archive and its crate-relative patch."""
+
+    name: str
+    """Crates.io package name."""
+    version: str
+    """Exact published version."""
+    sha256: str
+    """Expected archive digest."""
+    patch: str
+    """Patch path relative to the SLAM package."""
+
+
+PATCHED_CRATES: tuple[PatchedCrate, ...] = (
+    PatchedCrate(
+        'cubecl-common',
+        '0.11.0-pre.3',
+        '4d40f7451ab096a127c58b03d76b6d30f4fc757ac13d8e2f17ed5bb20ffda4bc',
+        'patches/cubecl-common-0.11.0-pre.3-channel-park.patch',
+    ),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Config:
+    """Prepare the dependencies of this source checkout."""
+
+    package_dir: Path = Path(__file__).resolve().parents[2]
+    """SLAM package containing Cargo.toml and patches/."""
+
+
+def prepare(crate: PatchedCrate, package_dir: Path, cargo_home: Path) -> None:
+    """Verify, extract and patch one crate; retain a matching prepared tree."""
+    package_dir = package_dir.resolve()
+    stem: str = f'{crate.name}-{crate.version}'
+    destination: Path = package_dir / 'target/patch' / stem
+    patch: Path = package_dir / crate.patch
+    # An opaque fingerprint avoids parsing a marker schema: compare exact bytes.
+    fingerprint: str = f'{crate.sha256}\n{hashlib.sha256(patch.read_bytes()).hexdigest()}\n'
+    marker: Path = destination / '.prepared-sha256'
+    if marker.is_file() and marker.read_text() == fingerprint and (destination / 'Cargo.toml').is_file():
+        print(f'{stem}: unchanged')
+        return
+    cached: Path | None = next((cargo_home / 'registry/cache').glob(f'*/{stem}.crate'), None)
+    archive: bytes
+    if cached is not None:
+        archive = cached.read_bytes()
+    else:
+        with urllib.request.urlopen(f'https://static.crates.io/crates/{crate.name}/{stem}.crate', timeout=60) as response:
+            archive = response.read()
+    if hashlib.sha256(archive).hexdigest() != crate.sha256:
+        raise ValueError(f'{stem}: archive SHA256 mismatch')
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=f'.{stem}-', dir=destination.parent) as temporary:
+        staging: Path = Path(temporary)
+        with tarfile.open(fileobj=io.BytesIO(archive)) as tar:
+            tar.extractall(staging, filter='data')
+        extracted: Path = staging / stem
+        # Do not discover the enclosing worktree: git otherwise skips paths
+        # beneath its ignored target directory while returning success.
+        subprocess.run(
+            ['git', 'apply', '-p1', f'--directory={stem}', str(patch)],
+            cwd=staging,
+            env=dict(os.environ, GIT_CEILING_DIRECTORIES=str(staging.parent)),
+            check=True,
+        )
+        (extracted / '.prepared-sha256').write_text(fingerprint)
+        if destination.exists():
+            shutil.rmtree(destination)
+        extracted.rename(destination)
+    print(f'{stem}: prepared ({"cache" if cached is not None else "download"})')
+
+
+def main(config: Config) -> None:
+    """Prepare every pinned patch using Cargo's configured archive cache."""
+    cargo_home: Path = Path(os.environ.get('CARGO_HOME', str(Path.home() / '.cargo')))
+    for crate in PATCHED_CRATES:
+        prepare(crate, config.package_dir, cargo_home)

--- a/packages/slam-rs/slam_rs/apis/prepare_patched_deps.py
+++ b/packages/slam-rs/slam_rs/apis/prepare_patched_deps.py
@@ -36,6 +36,10 @@ PATCHED_CRATES: tuple[PatchedCrate, ...] = (
 )
 
 
+# src/device/handle/channel.rs at CubeCL fork commit 93d463c9.
+CHANNEL_SHA256: str = '75e4b83cb12ad4bfa07b2e72c8e7fafdb363c00f98682174f03dafc8f5e849d7'
+
+
 @dataclass(frozen=True, slots=True)
 class Config:
     """Prepare the dependencies of this source checkout."""

--- a/packages/slam-rs/slam_rs/apis/prepare_patched_deps.py
+++ b/packages/slam-rs/slam_rs/apis/prepare_patched_deps.py
@@ -1,9 +1,9 @@
 """Materialize checksummed Cargo archives and local patches before Cargo runs."""
 
+import fcntl
 import hashlib
 import io
 import os
-import shutil
 import subprocess
 import tarfile
 import tempfile
@@ -53,41 +53,45 @@ def prepare(crate: PatchedCrate, package_dir: Path, cargo_home: Path) -> None:
     package_dir = package_dir.resolve()
     stem: str = f'{crate.name}-{crate.version}'
     destination: Path = package_dir / 'target/patch' / stem
-    patch: Path = package_dir / crate.patch
-    # An opaque fingerprint avoids parsing a marker schema: compare exact bytes.
-    fingerprint: str = f'{crate.sha256}\n{hashlib.sha256(patch.read_bytes()).hexdigest()}\n'
-    marker: Path = destination / '.prepared-sha256'
-    if marker.is_file() and marker.read_text() == fingerprint and (destination / 'Cargo.toml').is_file():
-        print(f'{stem}: unchanged')
-        return
-    cached: Path | None = next((cargo_home / 'registry/cache').glob(f'*/{stem}.crate'), None)
-    archive: bytes
-    if cached is not None:
-        archive = cached.read_bytes()
-    else:
-        with urllib.request.urlopen(f'https://static.crates.io/crates/{crate.name}/{stem}.crate', timeout=60) as response:
-            archive = response.read()
-    if hashlib.sha256(archive).hexdigest() != crate.sha256:
-        raise ValueError(f'{stem}: archive SHA256 mismatch')
+    # POSIX-only: the repository has Linux and macOS lanes, no Windows lane.
+    # Keep this inode beside the destination; never unlink a lock with waiters.
     destination.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.TemporaryDirectory(prefix=f'.{stem}-', dir=destination.parent) as temporary:
-        staging: Path = Path(temporary)
-        with tarfile.open(fileobj=io.BytesIO(archive)) as tar:
-            tar.extractall(staging, filter='data')
-        extracted: Path = staging / stem
-        # Do not discover the enclosing worktree: git otherwise skips paths
-        # beneath its ignored target directory while returning success.
-        subprocess.run(
-            ['git', 'apply', '-p1', f'--directory={stem}', str(patch)],
-            cwd=staging,
-            env=dict(os.environ, GIT_CEILING_DIRECTORIES=str(staging.parent)),
-            check=True,
-        )
-        (extracted / '.prepared-sha256').write_text(fingerprint)
-        if destination.exists():
-            shutil.rmtree(destination)
-        extracted.rename(destination)
-    print(f'{stem}: prepared ({"cache" if cached is not None else "download"})')
+    with (destination.parent / f'.{stem}.lock').open('a') as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        patch: Path = package_dir / crate.patch
+        # An opaque fingerprint avoids parsing a marker schema: compare exact bytes.
+        fingerprint: str = f'{crate.sha256}\n{hashlib.sha256(patch.read_bytes()).hexdigest()}\n'
+        marker: Path = destination / '.prepared-sha256'
+        if marker.is_file() and marker.read_text() == fingerprint and (destination / 'Cargo.toml').is_file():
+            print(f'{stem}: unchanged')
+            return
+        cached: Path | None = next((cargo_home / 'registry/cache').glob(f'*/{stem}.crate'), None)
+        archive: bytes
+        if cached is not None:
+            archive = cached.read_bytes()
+        else:
+            with urllib.request.urlopen(f'https://static.crates.io/crates/{crate.name}/{stem}.crate', timeout=60) as response:
+                archive = response.read()
+        if hashlib.sha256(archive).hexdigest() != crate.sha256:
+            raise ValueError(f'{stem}: archive SHA256 mismatch')
+        with tempfile.TemporaryDirectory(prefix=f'.{stem}-', dir=destination.parent) as temporary:
+            staging: Path = Path(temporary)
+            with tarfile.open(fileobj=io.BytesIO(archive)) as tar:
+                tar.extractall(staging, filter='data')
+            extracted: Path = staging / stem
+            # Do not discover the enclosing worktree: git otherwise skips paths
+            # beneath its ignored target directory while returning success.
+            subprocess.run(
+                ['git', 'apply', '-p1', f'--directory={stem}', str(patch)],
+                cwd=staging,
+                env=dict(os.environ, GIT_CEILING_DIRECTORIES=str(staging.parent)),
+                check=True,
+            )
+            (extracted / '.prepared-sha256').write_text(fingerprint)
+            if destination.exists():
+                destination.rename(staging / "previous")
+            extracted.rename(destination)
+        print(f'{stem}: prepared ({"cache" if cached is not None else "download"})')
 
 
 def main(config: Config) -> None:

--- a/packages/slam-rs/slam_rs/apis/prepare_patched_deps.py
+++ b/packages/slam-rs/slam_rs/apis/prepare_patched_deps.py
@@ -48,6 +48,22 @@ class Config:
     """SLAM package containing Cargo.toml and patches/."""
 
 
+def content_fingerprint(tree: Path, patch: Path) -> str:
+    """Hash the manifest and every old/new file named by the shipped diff."""
+    paths: set[str] = {'Cargo.toml'}
+    for line in patch.read_text().splitlines():
+        if line.startswith(('--- a/', '+++ b/')):
+            paths.add(line[6:])
+    entries: list[str] = []
+    for name in sorted(paths):
+        path: Path = tree / name
+        if not path.resolve().is_relative_to(tree.resolve()):
+            raise ValueError(f'patch path escapes prepared tree: {name}')
+        digest: str = hashlib.sha256(path.read_bytes()).hexdigest() if path.is_file() else 'missing'
+        entries.append(f'{name}: {digest}\n')
+    return ''.join(entries)
+
+
 def prepare(crate: PatchedCrate, package_dir: Path, cargo_home: Path) -> None:
     """Verify, extract and patch one crate; retain a matching prepared tree."""
     package_dir = package_dir.resolve()
@@ -62,9 +78,11 @@ def prepare(crate: PatchedCrate, package_dir: Path, cargo_home: Path) -> None:
         # An opaque fingerprint avoids parsing a marker schema: compare exact bytes.
         fingerprint: str = f'{crate.sha256}\n{hashlib.sha256(patch.read_bytes()).hexdigest()}\n'
         marker: Path = destination / '.prepared-sha256'
-        if marker.is_file() and marker.read_text() == fingerprint and (destination / 'Cargo.toml').is_file():
-            print(f'{stem}: unchanged')
-            return
+        if marker.is_file():
+            if marker.read_text() == fingerprint + content_fingerprint(destination, patch):
+                print(f'{stem}: unchanged')
+                return
+            print(f'{stem}: inputs or prepared content mismatch; re-preparing')
         cached: Path | None = next((cargo_home / 'registry/cache').glob(f'*/{stem}.crate'), None)
         archive: bytes
         if cached is not None:
@@ -87,7 +105,7 @@ def prepare(crate: PatchedCrate, package_dir: Path, cargo_home: Path) -> None:
                 env=dict(os.environ, GIT_CEILING_DIRECTORIES=str(staging.parent)),
                 check=True,
             )
-            (extracted / '.prepared-sha256').write_text(fingerprint)
+            (extracted / '.prepared-sha256').write_text(fingerprint + content_fingerprint(extracted, patch))
             if destination.exists():
                 destination.rename(staging / "previous")
             extracted.rename(destination)

--- a/packages/slam-rs/tests/test_metal_python_host.py
+++ b/packages/slam-rs/tests/test_metal_python_host.py
@@ -14,9 +14,10 @@ from slam_rs import _core
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(sys.platform != "darwin" or _core.gpu_backend != "wgpu", reason="requires a macOS wgpu build")
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires macOS Metal")
 def test_python_host_metal_detects_stereo_features(rig: RigFactory, texture: TextureFactory, tmp_path: Path) -> None:
     """Construction alone misses shader compilation in the first detection pass."""
+    assert _core.gpu_backend == "wgpu", "the Metal gate requires a freshly built wgpu core"
     image_path: Path = tmp_path / "texture.npy"
     np.save(image_path, texture(0, 0))
     result: subprocess.CompletedProcess[str] = subprocess.run(

--- a/packages/slam-rs/tests/test_metal_python_host.py
+++ b/packages/slam-rs/tests/test_metal_python_host.py
@@ -1,0 +1,60 @@
+"""Exercise Metal detection through the Python host, with an external hang guard."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+from fixture_types import RigFactory, TextureFactory
+from jaxtyping import UInt8
+from numpy import ndarray
+
+from slam_rs import _core
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(sys.platform != "darwin" or _core.gpu_backend != "wgpu", reason="requires a macOS wgpu build")
+def test_python_host_metal_detects_stereo_features(rig: RigFactory, texture: TextureFactory, tmp_path: Path) -> None:
+    """Construction alone misses shader compilation in the first detection pass."""
+    image_path: Path = tmp_path / "texture.npy"
+    np.save(image_path, texture(0, 0))
+    result: subprocess.CompletedProcess[str] = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve()), rig(2).to_json(), str(image_path)],
+        capture_output=True,
+        text=True,
+        timeout=120.0,
+        check=False,
+    )
+    if result.returncode == 77:
+        pytest.skip("wgpu found no Metal adapter on this host")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "detected stereo features" in result.stdout
+
+
+def run_probe(calibration_json: str, image_path: Path) -> None:
+    """Feed inertial samples and the fixture's textured stereo scene to Vio."""
+    try:
+        vio: _core.Vio = _core.Vio(_core.Calibration.from_json(calibration_json), _core.VioConfig(), gpu=True)
+    except ValueError as error:
+        if "wgpu found no metal adapter on this host" in str(error):
+            sys.exit(77)
+        raise
+    assert vio.gpu
+    image: UInt8[ndarray, "h w"] = np.load(image_path, allow_pickle=False)
+    for step in range(12):
+        t_ns: int = step * 50_000_000
+        for sample_ns in range(t_ns, t_ns + 50_000_000, 1_000_000):
+            vio.push_imu(sample_ns, [0.0, 0.0, 0.0], [0.0, 0.0, 9.81])
+        left: UInt8[ndarray, "h w"] = np.ascontiguousarray(np.roll(image, step, axis=1))
+        right: UInt8[ndarray, "h w"] = np.ascontiguousarray(np.roll(image, step + 1, axis=1))
+        vio.track(t_ns, [left, right])
+        frame: _core.FlowFrame | None = vio.flow_frame()
+        if frame is not None and len(frame.ids(0)) > 0 and len(frame.ids(1)) > 0:
+            print("detected stereo features")
+            return
+    raise AssertionError("no stereo frontend output after twelve textured framesets")
+
+
+if __name__ == "__main__":
+    run_probe(sys.argv[1], Path(sys.argv[2]))

--- a/packages/slam-rs/tests/test_prepare_patched_deps.py
+++ b/packages/slam-rs/tests/test_prepare_patched_deps.py
@@ -98,3 +98,19 @@ def test_real_patch_and_locked_cargo_resolution(tmp_path: Path) -> None:
     assert len(packages) == 1
     assert packages[0]['source'] is None
     assert Path(packages[0]['manifest_path']).resolve() == (package_dir / 'target/patch' / stem / 'Cargo.toml').resolve()
+
+
+def test_concurrent_preparation(tmp_path: Path, crate: PatchedCrate) -> None:
+    """All eight callers can use a fresh destination after preparation."""
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Barrier
+
+    barrier: Barrier = Barrier(8)
+
+    def caller(number: int) -> str:
+        barrier.wait(timeout=10)
+        prepare(crate, tmp_path, tmp_path / 'cargo')
+        return (tmp_path / 'target/patch/example-1.0/hello.txt').read_text()
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        assert list(pool.map(caller, range(8))) == ['after\n'] * 8

--- a/packages/slam-rs/tests/test_prepare_patched_deps.py
+++ b/packages/slam-rs/tests/test_prepare_patched_deps.py
@@ -1,0 +1,62 @@
+"""Preparation works from a Cargo cache without network access."""
+
+import hashlib
+import io
+import subprocess
+import tarfile
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from slam_rs.apis.prepare_patched_deps import PatchedCrate, prepare
+
+
+@pytest.fixture
+def crate(tmp_path: Path) -> PatchedCrate:
+    cache: Path = tmp_path / 'cargo/registry/cache/test'
+    cache.mkdir(parents=True)
+    archive: Path = cache / 'example-1.0.crate'
+    with tarfile.open(archive, 'w:gz') as tar:
+        for name, content in [('Cargo.toml', '[package]\n'), ('hello.txt', 'before\n')]:
+            entry: tarfile.TarInfo = tarfile.TarInfo(f'example-1.0/{name}')
+            entry.size = len(content)
+            tar.addfile(entry, io.BytesIO(content.encode()))
+    patch: Path = tmp_path / 'change.patch'
+    patch.write_text('diff --git a/hello.txt b/hello.txt\n--- a/hello.txt\n+++ b/hello.txt\n@@ -1 +1 @@\n-before\n+after\n')
+    crate: PatchedCrate = PatchedCrate('example', '1.0', hashlib.sha256(archive.read_bytes()).hexdigest(), 'change.patch')
+    return crate
+
+
+def test_applies_cached_archive(tmp_path: Path, crate: PatchedCrate) -> None:
+    prepare(crate, tmp_path, tmp_path / 'cargo')
+    assert (tmp_path / 'target/patch/example-1.0/hello.txt').read_text() == 'after\n'
+
+
+def test_matching_inputs_are_a_noop(tmp_path: Path, crate: PatchedCrate) -> None:
+    prepare(crate, tmp_path, tmp_path / 'cargo')
+    output: Path = tmp_path / 'target/patch/example-1.0/hello.txt'
+    before: int = output.stat().st_mtime_ns
+    prepare(crate, tmp_path, tmp_path / 'cargo')
+    assert output.stat().st_mtime_ns == before
+
+
+def test_patch_change_reextracts_archive(tmp_path: Path, crate: PatchedCrate) -> None:
+    prepare(crate, tmp_path, tmp_path / 'cargo')
+    patch: Path = tmp_path / crate.patch
+    patch.write_text(patch.read_text().replace('+after', '+changed'))
+    prepare(crate, tmp_path, tmp_path / 'cargo')
+    assert (tmp_path / 'target/patch/example-1.0/hello.txt').read_text() == 'changed\n'
+
+
+def test_bad_archive_digest_is_refused(tmp_path: Path, crate: PatchedCrate) -> None:
+    with pytest.raises(ValueError, match='archive SHA256 mismatch'):
+        prepare(replace(crate, sha256='0' * 64), tmp_path, tmp_path / 'cargo')
+    assert not (tmp_path / 'target/patch/example-1.0').exists()
+
+
+def test_applies_inside_ignored_git_target(tmp_path: Path, crate: PatchedCrate) -> None:
+    subprocess.run(['git', 'init', '-q', str(tmp_path.parent)], check=True)
+    (tmp_path / '.gitignore').write_text('target/\n')
+    prepare(crate, tmp_path, tmp_path / 'cargo')
+    assert (tmp_path / 'target/patch/example-1.0/hello.txt').read_text() == 'after\n'

--- a/packages/slam-rs/tests/test_prepare_patched_deps.py
+++ b/packages/slam-rs/tests/test_prepare_patched_deps.py
@@ -2,14 +2,18 @@
 
 import hashlib
 import io
+import json
+import os
+import shutil
 import subprocess
 import tarfile
+import urllib.error
 from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
-from slam_rs.apis.prepare_patched_deps import PatchedCrate, prepare
+from slam_rs.apis.prepare_patched_deps import CHANNEL_SHA256, PATCHED_CRATES, PatchedCrate, prepare
 
 
 @pytest.fixture
@@ -60,3 +64,37 @@ def test_applies_inside_ignored_git_target(tmp_path: Path, crate: PatchedCrate) 
     (tmp_path / '.gitignore').write_text('target/\n')
     prepare(crate, tmp_path, tmp_path / 'cargo')
     assert (tmp_path / 'target/patch/example-1.0/hello.txt').read_text() == 'after\n'
+
+
+@pytest.mark.skipif(shutil.which('cargo') is None, reason='real patch smoke test requires cargo on PATH')
+def test_real_patch_and_locked_cargo_resolution(tmp_path: Path) -> None:
+    """The shipped patch matches the fork and Cargo uses the prepared crate."""
+    package_dir: Path = Path(__file__).resolve().parents[1]
+    cargo_home: Path = Path(os.environ.get('CARGO_HOME', str(Path.home() / '.cargo')))
+    crate: PatchedCrate = PATCHED_CRATES[0]
+    patch: Path = tmp_path / crate.patch
+    patch.parent.mkdir(parents=True)
+    shutil.copyfile(package_dir / crate.patch, patch)
+    try:
+        # A fresh destination exercises extraction and the real patch even when
+        # the checkout already has a matching preparation marker.
+        prepare(crate, tmp_path, cargo_home)
+        prepare(crate, package_dir, cargo_home)
+    except (urllib.error.URLError, TimeoutError) as error:
+        pytest.skip(f'pinned crate archive is not cached and download is unavailable: {error}')
+    stem: str = f'{crate.name}-{crate.version}'
+    channel: Path = tmp_path / 'target/patch' / stem / 'src/device/handle/channel.rs'
+    assert hashlib.sha256(channel.read_bytes()).hexdigest() == CHANNEL_SHA256
+    result: subprocess.CompletedProcess[str] = subprocess.run(
+        # CubeCL is optional; select its lane so it appears in the resolved graph.
+        ['cargo', 'metadata', '--locked', '--offline', '--format-version', '1', '--features', 'slam-rs/gpu-wgpu'],
+        cwd=package_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    # Raw JSON is intentional here: this is a contract test of Cargo's output.
+    packages = [package for package in json.loads(result.stdout)['packages'] if package['name'] == crate.name]
+    assert len(packages) == 1
+    assert packages[0]['source'] is None
+    assert Path(packages[0]['manifest_path']).resolve() == (package_dir / 'target/patch' / stem / 'Cargo.toml').resolve()

--- a/packages/slam-rs/tests/test_prepare_patched_deps.py
+++ b/packages/slam-rs/tests/test_prepare_patched_deps.py
@@ -85,6 +85,8 @@ def test_real_patch_and_locked_cargo_resolution(tmp_path: Path) -> None:
     stem: str = f'{crate.name}-{crate.version}'
     channel: Path = tmp_path / 'target/patch' / stem / 'src/device/handle/channel.rs'
     assert hashlib.sha256(channel.read_bytes()).hexdigest() == CHANNEL_SHA256
+    main_channel: Path = package_dir / 'target/patch' / stem / 'src/device/handle/channel.rs'
+    assert hashlib.sha256(main_channel.read_bytes()).hexdigest() == CHANNEL_SHA256
     result: subprocess.CompletedProcess[str] = subprocess.run(
         # CubeCL is optional; select its lane so it appears in the resolved graph.
         ['cargo', 'metadata', '--locked', '--offline', '--format-version', '1', '--features', 'slam-rs/gpu-wgpu'],
@@ -114,3 +116,20 @@ def test_concurrent_preparation(tmp_path: Path, crate: PatchedCrate) -> None:
 
     with ThreadPoolExecutor(max_workers=8) as pool:
         assert list(pool.map(caller, range(8))) == ['after\n'] * 8
+
+
+@pytest.mark.parametrize('filename', ['hello.txt', 'Cargo.toml'])
+@pytest.mark.parametrize('remove', [False, True])
+def test_repairs_prepared_files(tmp_path: Path, crate: PatchedCrate, filename: str, remove: bool, capsys: pytest.CaptureFixture[str]) -> None:
+    """An intact input marker must not hide edited or missing prepared files."""
+    prepare(crate, tmp_path, tmp_path / 'cargo')
+    output: Path = tmp_path / 'target/patch/example-1.0' / filename
+    digest: str = hashlib.sha256(output.read_bytes()).hexdigest()
+    if remove:
+        output.unlink()
+    else:
+        output.write_text('tampered\n')
+    capsys.readouterr()
+    prepare(crate, tmp_path, tmp_path / 'cargo')
+    assert hashlib.sha256(output.read_bytes()).hexdigest() == digest
+    assert 'prepared content mismatch' in capsys.readouterr().out

--- a/packages/slam-rs/tools/prepare_patched_deps.py
+++ b/packages/slam-rs/tools/prepare_patched_deps.py
@@ -1,0 +1,6 @@
+import tyro
+
+from slam_rs.apis.prepare_patched_deps import Config, main
+
+if __name__ == '__main__':
+    main(tyro.cli(Config))

--- a/pixi.toml
+++ b/pixi.toml
@@ -2524,7 +2524,7 @@ description = "Lint the portable wgpu lane, tests included, with warnings denied
 # CubeCL pool and every test in one binary shares one client; cargo runs
 # binaries one after another, which is what keeps both deterministic.
 [feature.slam-rs.tasks.slam-rs-wgpu-test]
-depends-on = ["slam-rs-patch-deps"]
+depends-on = ["slam-rs-wgpu-build"]
 cmd = "cargo test --locked --offline -p slam-rs --features gpu-wgpu --test gpu_kernels -- --list | grep -c ': test' && cargo test --locked --offline -p slam-rs --features gpu-wgpu --test gpu_detect -- --list | grep -c ': test' && cargo test --locked --offline -p slam-rs --features gpu-wgpu --test gpu_seam_bench -- --list | grep -c ': test' && cargo test --locked --offline -p slam-rs --features gpu-wgpu --test frame_allocations -- --list | grep -c ': test' && cargo test --locked --offline -p slam-rs --features gpu-wgpu --test gpu_pool -- --list | grep -c ': test' && cargo test --locked --offline --workspace --features slam-rs/gpu-wgpu && python -m pytest -q -m slow tests/test_metal_python_host.py"
 cwd = "packages/slam-rs"
 description = "Run workspace tests with wgpu, checking that all five GPU integration binaries contain tests"

--- a/pixi.toml
+++ b/pixi.toml
@@ -2503,7 +2503,7 @@ description = "Lint the portable wgpu lane, tests included, with warnings denied
 # CubeCL pool and every test in one binary shares one client; cargo runs
 # binaries one after another, which is what keeps both deterministic.
 [feature.slam-rs.tasks.slam-rs-wgpu-test]
-cmd = "cargo test --locked --offline -p slam-rs --features gpu-wgpu --test gpu_kernels -- --list | grep -c ': test' && cargo test --locked --offline -p slam-rs --features gpu-wgpu --test gpu_detect -- --list | grep -c ': test' && cargo test --locked --offline -p slam-rs --features gpu-wgpu --test gpu_seam_bench -- --list | grep -c ': test' && cargo test --locked --offline -p slam-rs --features gpu-wgpu --test frame_allocations -- --list | grep -c ': test' && cargo test --locked --offline -p slam-rs --features gpu-wgpu --test gpu_pool -- --list | grep -c ': test' && cargo test --locked --offline --workspace --features slam-rs/gpu-wgpu"
+cmd = "cargo test --locked --offline -p slam-rs --features gpu-wgpu --test gpu_kernels -- --list | grep -c ': test' && cargo test --locked --offline -p slam-rs --features gpu-wgpu --test gpu_detect -- --list | grep -c ': test' && cargo test --locked --offline -p slam-rs --features gpu-wgpu --test gpu_seam_bench -- --list | grep -c ': test' && cargo test --locked --offline -p slam-rs --features gpu-wgpu --test frame_allocations -- --list | grep -c ': test' && cargo test --locked --offline -p slam-rs --features gpu-wgpu --test gpu_pool -- --list | grep -c ': test' && cargo test --locked --offline --workspace --features slam-rs/gpu-wgpu && python -m pytest -q -m slow tests/test_metal_python_host.py"
 cwd = "packages/slam-rs"
 description = "Run workspace tests with wgpu, checking that all five GPU integration binaries contain tests"
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -2451,6 +2451,11 @@ depends-on = ["slam-rs-patch-deps"]
 cmd = "cargo build --release -p slam-rs-py && cp target/release/$CORE_CDYLIB slam_rs/_core.so"
 cwd = "packages/slam-rs"
 inputs = [
+    "packages/slam-rs/patches/**",
+    "packages/slam-rs/slam_rs/apis/prepare_patched_deps.py",
+    "packages/slam-rs/tools/prepare_patched_deps.py",
+    "packages/slam-rs/target/patch/cubecl-common-0.11.0-pre.3/**",
+    "packages/slam-rs/target/patch/cubecl-common-0.11.0-pre.3/.prepared-sha256",
     "packages/slam-rs/Cargo.toml",
     "packages/slam-rs/Cargo.lock",
     "packages/slam-rs/.cargo/config.toml",
@@ -2532,6 +2537,11 @@ depends-on = ["slam-rs-patch-deps"]
 cmd = "cargo build --release -p slam-rs-py --features gpu-wgpu && cp target/release/$CORE_CDYLIB slam_rs/_core.so"
 cwd = "packages/slam-rs"
 inputs = [
+    "packages/slam-rs/patches/**",
+    "packages/slam-rs/slam_rs/apis/prepare_patched_deps.py",
+    "packages/slam-rs/tools/prepare_patched_deps.py",
+    "packages/slam-rs/target/patch/cubecl-common-0.11.0-pre.3/**",
+    "packages/slam-rs/target/patch/cubecl-common-0.11.0-pre.3/.prepared-sha256",
     "packages/slam-rs/Cargo.toml",
     "packages/slam-rs/Cargo.lock",
     "packages/slam-rs/.cargo/config.toml",

--- a/pixi.toml
+++ b/pixi.toml
@@ -2472,8 +2472,14 @@ cmd = "cargo clippy --workspace --all-targets -- -D warnings"
 cwd = "packages/slam-rs"
 description = "Run clippy over the whole Rust workspace"
 
-[feature.slam-rs.tasks.slam-rs-rust-test]
+[feature.slam-rs.tasks.slam-rs-patch-test]
 depends-on = ["slam-rs-patch-deps"]
+cmd = "cargo test --locked --offline --manifest-path target/patch/cubecl-common-0.11.0-pre.3/Cargo.toml park"
+cwd = "packages/slam-rs"
+description = "Run the patched CubeCL channel park tests"
+
+[feature.slam-rs.tasks.slam-rs-rust-test]
+depends-on = ["slam-rs-patch-test"]
 cmd = "cargo test --workspace"
 cwd = "packages/slam-rs"
 description = "Run the Rust test suite (unit tests + proptest)"

--- a/pixi.toml
+++ b/pixi.toml
@@ -2439,7 +2439,15 @@ CORE_CDYLIB = "lib_core.dylib"
 # cargo never runs during `pixi lock`/`pixi install`: the extension is built by
 # this task and dropped next to the Python sources, where hatchling's editable
 # .pth already looks (the dpvo / mast3r-slam in-place pattern).
+[feature.slam-rs.tasks.slam-rs-patch-deps]
+cmd = "python tools/prepare_patched_deps.py"
+cwd = "packages/slam-rs"
+inputs = ["packages/slam-rs/patches/**", "packages/slam-rs/slam_rs/apis/prepare_patched_deps.py", "packages/slam-rs/tools/prepare_patched_deps.py"]
+outputs = ["packages/slam-rs/target/patch/cubecl-common-0.11.0-pre.3/Cargo.toml"]
+description = "Prepare checksummed Cargo dependencies with local patches"
+
 [feature.slam-rs.tasks.slam-rs-build]
+depends-on = ["slam-rs-patch-deps"]
 cmd = "cargo build --release -p slam-rs-py && cp target/release/$CORE_CDYLIB slam_rs/_core.so"
 cwd = "packages/slam-rs"
 inputs = [
@@ -2454,11 +2462,13 @@ outputs = ["packages/slam-rs/slam_rs/_core.so"]
 description = "Build the Rust VIO core and install slam_rs._core in place"
 
 [feature.slam-rs.tasks.slam-rs-clippy]
+depends-on = ["slam-rs-patch-deps"]
 cmd = "cargo clippy --workspace --all-targets -- -D warnings"
 cwd = "packages/slam-rs"
 description = "Run clippy over the whole Rust workspace"
 
 [feature.slam-rs.tasks.slam-rs-rust-test]
+depends-on = ["slam-rs-patch-deps"]
 cmd = "cargo test --workspace"
 cwd = "packages/slam-rs"
 description = "Run the Rust test suite (unit tests + proptest)"
@@ -2487,6 +2497,7 @@ description = "Build the core, then run the package tests"
 # Clippy checks GPU code and tests with warnings denied; the default lane
 # does not compile these optional modules.
 [feature.slam-rs.tasks.slam-rs-wgpu-clippy]
+depends-on = ["slam-rs-patch-deps"]
 cmd = "cargo clippy -p slam-rs --features gpu-wgpu --all-targets -- -D warnings"
 cwd = "packages/slam-rs"
 description = "Lint the portable wgpu lane, tests included, with warnings denied"
@@ -2503,11 +2514,13 @@ description = "Lint the portable wgpu lane, tests included, with warnings denied
 # CubeCL pool and every test in one binary shares one client; cargo runs
 # binaries one after another, which is what keeps both deterministic.
 [feature.slam-rs.tasks.slam-rs-wgpu-test]
+depends-on = ["slam-rs-patch-deps"]
 cmd = "cargo test --locked --offline -p slam-rs --features gpu-wgpu --test gpu_kernels -- --list | grep -c ': test' && cargo test --locked --offline -p slam-rs --features gpu-wgpu --test gpu_detect -- --list | grep -c ': test' && cargo test --locked --offline -p slam-rs --features gpu-wgpu --test gpu_seam_bench -- --list | grep -c ': test' && cargo test --locked --offline -p slam-rs --features gpu-wgpu --test frame_allocations -- --list | grep -c ': test' && cargo test --locked --offline -p slam-rs --features gpu-wgpu --test gpu_pool -- --list | grep -c ': test' && cargo test --locked --offline --workspace --features slam-rs/gpu-wgpu && python -m pytest -q -m slow tests/test_metal_python_host.py"
 cwd = "packages/slam-rs"
 description = "Run workspace tests with wgpu, checking that all five GPU integration binaries contain tests"
 
 [feature.slam-rs.tasks.slam-rs-wgpu-doc]
+depends-on = ["slam-rs-patch-deps"]
 cmd = 'RUSTDOCFLAGS="-D warnings" cargo doc --locked --offline --no-deps -p slam-rs -p slam-rs-py --features slam-rs/gpu-wgpu'
 cwd = "packages/slam-rs"
 description = "Build wgpu Rust documentation with warnings denied"
@@ -2515,6 +2528,7 @@ description = "Build wgpu Rust documentation with warnings denied"
 # The same core on the portable lane, for measuring it: `--gpu` then selects
 # wgpu, the only GPU runtime (D70).
 [feature.slam-rs.tasks.slam-rs-wgpu-build]
+depends-on = ["slam-rs-patch-deps"]
 cmd = "cargo build --release -p slam-rs-py --features gpu-wgpu && cp target/release/$CORE_CDYLIB slam_rs/_core.so"
 cwd = "packages/slam-rs"
 inputs = [

--- a/pixi.toml
+++ b/pixi.toml
@@ -2440,10 +2440,9 @@ CORE_CDYLIB = "lib_core.dylib"
 # this task and dropped next to the Python sources, where hatchling's editable
 # .pth already looks (the dpvo / mast3r-slam in-place pattern).
 [feature.slam-rs.tasks.slam-rs-patch-deps]
+# Always verify prepared content, including when task inputs have not changed.
 cmd = "python tools/prepare_patched_deps.py"
 cwd = "packages/slam-rs"
-inputs = ["packages/slam-rs/patches/**", "packages/slam-rs/slam_rs/apis/prepare_patched_deps.py", "packages/slam-rs/tools/prepare_patched_deps.py"]
-outputs = ["packages/slam-rs/target/patch/cubecl-common-0.11.0-pre.3/Cargo.toml"]
 description = "Prepare checksummed Cargo dependencies with local patches"
 
 [feature.slam-rs.tasks.slam-rs-build]


### PR DESCRIPTION
## Why
On the M4 Mac mini the portable GPU lane ran MIO10 at 18.8 ms per frameset because every synchronising read cost 7 ms of host time (S32-E6). The cause is located: wgpu-hal 29's Metal `wait` polls the command buffer status with a 1 ms `thread::sleep` loop; wgpu 30 waits on a condition variable (gfx-rs/wgpu#9328). wgpu 30 is only reachable through CubeCL 0.11.0-pre.3, so this PR is that bump plus the API fallout, with no change to kernels' arithmetic, launch shapes or read points.

## What changed
- `cubecl`/`cubecl-wgpu` pinned `=0.11.0-pre.3`, `wgpu` 30 (resolves 30.0.1). Launch args move to slices/`BufferArg`, `SharedMemory<T>` to `Shared<[T]>`, `CubeDim::new_3d`, reader under `future::reader`. Cargo.toml comments re-verified against the 0.11 sources (Metal family check now exists; the exclusive-memory alignment workaround is still needed).
- One kernel control-flow rewrite: CubeCL 0.11 emits C++ lambdas for `while` conditions and Metal rejected the generated cell-selection shader when loaded from the Python process (the Rust test binary compiled it). The two selector loops became `range_stepped` with the same visits and order.
- The no-Vulkan-adapter test is marked inapplicable on macOS (it disables Vulkan ICDs; Metal ignores that).

## Numbers
Mac mini (M4), fast profile, tracker median ms / ATE cm, catalog replay:

| clip | Metal before | Metal after | Mac CPU lane | accuracy |
|---|---|---|---|---|
| MIO10 | 18.69 / 1.552 | 8.10 / 1.552 | 4.98 / 1.553 | in band |
| MIO07 | 18.85 / 1.957 | 8.14 / 1.957 | 5.10 / 2.092 | in band |
| MGO07 | 21.34 / 2.373 | 9.26 / 2.373 | 8.58 / 2.375 | in band |
| MIO14 | not measured | 7.97 / 6.760 | not measured | **6.76 > 6.61 limit (1.12x the 5090 baseline)** |

Seam bench, two cameras: reads 18.4 -> 9.3 ms, whole 20.3 -> 10.3 ms. Isolated empty-read slope 7.05 -> 1.35 ms per read (5.2x, not the 60x hoped for): a native sample shows the remaining fixed cost in CubeCL 0.11's device-channel worker, which idles on a 150 us `nanosleep`.

RTX 5090, Vulkan, A/B harness against main's core: **byte-identical trajectories and states on MIO10/MIO07/MGO07**; latency +12% / +7.6% / +2.5% (MIO10 1.363 -> 1.526 ms), all of it in the stereo stage (0.24 -> 0.37 ms), the one read-bearing stage on that lane.

## Status: draft, gates failed on purpose
Passing: fmt, clippy (both feature sets), 402 workspace tests, strict rustdoc, the locked wgpu GPU task on Linux (450 tests) and on the Mac (449, 2 ignored), 257 Python tests, byte identity on the 5090.
Failing: the 5090 speed clause (two-camera +8-12%), the Mac MIO14 accuracy band (no before-number exists for it on the Mac), and the S36 target (Metal >= 1.5x the Mac CPU lane).
Follow-ups under investigation before this leaves draft: the 150 us channel sleep (likely both the Mac's residual 1.35 ms/read and the 5090 stereo regression), one read per frameset instead of two, device time per kernel on the new compiler stack, MIO14 before-number on the Mac.

Report with every command: `/tmp/fleet-artifacts/slam-rs/cuvslam/reports/s36/s36-1-metal-readback.md` on pablo-dl-server.