### PR TITLE
slam-rs: uploads copy straight into owned aligned bytes

### DIFF
--- a/packages/slam-rs/crates/slam-rs/src/gpu/seam.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/seam.rs
@@ -84,7 +84,7 @@ thread_local! {
 pub static LAUNCH: Meter = Meter {
     value: &LAUNCH_VALUE,
 };
-/// `create_from_slice`: a logical allocation and a host-to-device write.
+/// An owned byte copy, a logical allocation and a host-to-device write.
 pub static UPLOAD: Meter = Meter {
     value: &UPLOAD_VALUE,
 };

--- a/packages/slam-rs/crates/slam-rs/src/gpu/submission.rs
+++ b/packages/slam-rs/crates/slam-rs/src/gpu/submission.rs
@@ -115,7 +115,13 @@ pub(super) fn upload<R: cubecl::prelude::Runtime>(
     bytes: &[u8],
 ) -> cubecl::server::Handle {
     reserve(client, 1);
-    seam::UPLOAD.measure(|| client.create_from_slice(bytes))
+    seam::UPLOAD.measure(|| {
+        // Copy directly into aligned owned storage; create_from_slice copies
+        // through two Vecs before allocating this same aligned storage.
+        let mut data = cubecl::bytes::Bytes::from_elems(Vec::<u8>::new());
+        data.extend_from_byte_slice(bytes);
+        client.create(data)
+    })
 }
 
 /// A failed device read as a typed error, with the runtime's own reason logged.
@@ -188,11 +194,8 @@ pub(super) fn read_blocking<R: cubecl::prelude::Runtime>(
 
 /// One frame on the device, and how many pixels it holds.
 ///
-/// `create_from_slice` is CubeCL 0.10's only host-to-device write, it allocates
-/// a buffer the size of the slice, and it copies the payload **twice** on the
-/// host before the bus sees it (`slice.to_vec()`, then
-/// `Bytes::from_bytes_vec(data.to_vec())` inside `do_create_from_slices`). So
-/// the upload is exactly as long as the frame and nothing more: an unstrided
+/// The upload owns one aligned copy of the slice before submitting it to
+/// CubeCL. It is exactly as long as the frame and nothing more: an unstrided
 /// frame goes straight out of the caller's buffer with no staging copy at all,
 /// and only a strided one — dav1d's shape — is repacked row by row into
 /// `scratch`, which the caller owns so the per-frame path never allocates.

--- a/packages/slam-rs/crates/slam-rs/tests/frame_allocations.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/frame_allocations.rs
@@ -67,6 +67,7 @@ thread_local! {
     static ALLOCATIONS: Cell<usize> = const { Cell::new(0) };
     static REALLOCATIONS: Cell<usize> = const { Cell::new(0) };
     static DEALLOCATIONS: Cell<usize> = const { Cell::new(0) };
+    static ALLOCATED_BYTES: Cell<usize> = const { Cell::new(0) };
 }
 
 /// Add one to `counter`, but only on a thread that is measuring.
@@ -90,6 +91,9 @@ struct Counting;
 unsafe impl GlobalAlloc for Counting {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         count(&ALLOCATIONS);
+        if COUNTING.try_with(Cell::get).unwrap_or(false) {
+            let _ = ALLOCATED_BYTES.try_with(|slot| slot.set(slot.get() + layout.size()));
+        }
         unsafe { System.alloc(layout) }
     }
 
@@ -100,6 +104,9 @@ unsafe impl GlobalAlloc for Counting {
 
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
         count(&REALLOCATIONS);
+        if COUNTING.try_with(Cell::get).unwrap_or(false) {
+            let _ = ALLOCATED_BYTES.try_with(|slot| slot.set(slot.get() + new_size));
+        }
         unsafe { System.realloc(ptr, layout, new_size) }
     }
 }
@@ -131,6 +138,7 @@ fn measure<T>(body: impl FnOnce() -> T) -> (T, Allocations) {
     ALLOCATIONS.set(0);
     REALLOCATIONS.set(0);
     DEALLOCATIONS.set(0);
+    ALLOCATED_BYTES.set(0);
     COUNTING.set(true);
     let value: T = body();
     COUNTING.set(false);
@@ -140,6 +148,31 @@ fn measure<T>(body: impl FnOnce() -> T) -> (T, Allocations) {
         deallocations: DEALLOCATIONS.get(),
     };
     (value, counted)
+}
+
+/// Preparing an image owns one pixel copy, with room for small queue metadata.
+#[cfg(feature = "gpu-wgpu")]
+#[test]
+fn preparing_a_gpu_image_allocates_only_one_pixel_copy() {
+    use slam_rs::gpu::{GpuPyramidBuilder, GpuRuntime, gpu_client};
+    use slam_rs::pyramid::PyramidBuilder;
+
+    let image = ImageU16::from_u8_strided(&vec![173; 960 * 960], 960, 960, 960).unwrap();
+    let mut builder: GpuPyramidBuilder<GpuRuntime> =
+        GpuPyramidBuilder::new(gpu_client().unwrap(), &[[0.0, 0.0]]);
+    builder
+        .prepare_images(std::slice::from_ref(&image))
+        .unwrap();
+    measure(|| {
+        builder
+            .prepare_images(std::slice::from_ref(&image))
+            .unwrap()
+    });
+    let bytes = ALLOCATED_BYTES.get();
+    assert!(
+        bytes < 960 * 960 * size_of::<u16>() + 16_384,
+        "allocated {bytes} bytes"
+    );
 }
 
 // ── the frontend under test ───────────────────────────────────────────────

--- a/packages/slam-rs/crates/slam-rs/tests/frame_allocations.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/frame_allocations.rs
@@ -120,6 +120,7 @@ struct Allocations {
     allocations: usize,
     reallocations: usize,
     deallocations: usize,
+    allocated_bytes: usize,
 }
 
 impl Allocations {
@@ -146,6 +147,7 @@ fn measure<T>(body: impl FnOnce() -> T) -> (T, Allocations) {
         allocations: ALLOCATIONS.get(),
         reallocations: REALLOCATIONS.get(),
         deallocations: DEALLOCATIONS.get(),
+        allocated_bytes: ALLOCATED_BYTES.get(),
     };
     (value, counted)
 }
@@ -163,12 +165,12 @@ fn preparing_a_gpu_image_allocates_only_one_pixel_copy() {
     builder
         .prepare_images(std::slice::from_ref(&image))
         .unwrap();
-    measure(|| {
+    let (_, counted) = measure(|| {
         builder
             .prepare_images(std::slice::from_ref(&image))
             .unwrap()
     });
-    let bytes = ALLOCATED_BYTES.get();
+    let bytes = counted.allocated_bytes;
     assert!(
         bytes < 960 * 960 * size_of::<u16>() + 16_384,
         "allocated {bytes} bytes"

--- a/packages/slam-rs/crates/slam-rs/tests/gpu_kernels.rs
+++ b/packages/slam-rs/crates/slam-rs/tests/gpu_kernels.rs
@@ -110,6 +110,24 @@ fn the_gpu_pyramid_is_bit_exact_with_the_cpu() {
     assert_levels_equal(&cpu, &gpu, "960x960");
 }
 
+#[test]
+fn prepared_gpu_pixels_survive_reusing_the_source_image() {
+    let mut image = textured_image(96, 96, 0.0, 0.0);
+    let mut builder = GpuPyramidBuilder::new(gpu_client().unwrap(), &[[0.0, 0.0]]);
+    let mut pyramid = builder.allocate(96, 96, 1).unwrap();
+    let expected = image.clone();
+    builder
+        .prepare_images(std::slice::from_ref(&image))
+        .unwrap();
+    image
+        .fill_from_u8_strided(&vec![0; 96 * 96], 96, 96, 96)
+        .unwrap();
+    builder.build(0, &image, &mut pyramid).unwrap();
+    let mut actual = ImageU16::default();
+    pyramid.copy_level_into(0, &mut actual).unwrap();
+    assert_eq!(actual.data(), expected.data());
+}
+
 /// A pyramid of level 0 alone is refused rather than allocated empty.
 ///
 /// With `optical_flow_levels = 0` the odd buffer holds no level, and

--- a/packages/slam-rs/tests/test_metal_python_host.py
+++ b/packages/slam-rs/tests/test_metal_python_host.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from fixture_types import RigFactory, TextureFactory
-from jaxtyping import UInt8
+from fixture_types import IMU_PERIOD_NS, RigFactory, TextureFactory, gravity_batch
+from jaxtyping import Int64, UInt8
 from numpy import ndarray
 
 from slam_rs import _core
@@ -45,8 +45,8 @@ def run_probe(calibration_json: str, image_path: Path) -> None:
     image: UInt8[ndarray, "h w"] = np.load(image_path, allow_pickle=False)
     for step in range(12):
         t_ns: int = step * 50_000_000
-        for sample_ns in range(t_ns, t_ns + 50_000_000, 1_000_000):
-            vio.push_imu(sample_ns, [0.0, 0.0, 0.0], [0.0, 0.0, 9.81])
+        samples: Int64[ndarray, " n_samples"] = np.arange(t_ns, t_ns + 50_000_000, IMU_PERIOD_NS, dtype=np.int64)
+        vio.push_imu_batch(samples, *gravity_batch(samples))
         left: UInt8[ndarray, "h w"] = np.ascontiguousarray(np.roll(image, step, axis=1))
         right: UInt8[ndarray, "h w"] = np.ascontiguousarray(np.roll(image, step + 1, axis=1))
         vio.track(t_ns, [left, right])


### PR DESCRIPTION
## What
The GPU upload helper handed CubeCL a slice, which `create_from_slice` copied twice (two Vecs, then aligned storage). It now builds one aligned owned `Bytes` and hands ownership to `client.create`. Seven implementation lines; no pixel value, ordering, queue order or kernel arithmetic changes. Applies to every wgpu backend (Vulkan and Metal); the CPU lane is untouched.

## Evidence
- Paired one-process comparison on the M4 Mac mini, legacy vs candidate alternating: all 350 FlowFrame pairs byte-identical; median saving **0.147 ms per frameset** (2.214 -> 2.068 ms on the seam fixture). In real MIO10 fast replays the upload spans fell from ~0.56 to ~0.21 ms per frame.
- RTX 5090, A/B harness: byte-identical trajectories and states on MIO10 (3 rounds), MIO07, MGO07. Medians -5.5% / -7.4% / -4.9% against the saved pre-#267 base (that delta includes #267's own gain; the Mac paired test is the isolated number). The harness prints `SPEED FAIL` on MIO07: that clause compares to a frozen cuVSLAM reference, not to main.
- New tests: `frame_allocations.rs` bounds upload preparation to one image plus 16 KiB (was 5.5 MB for a 1.8 MB image); `gpu_kernels.rs` checks prepared pixels survive source mutation.
- Codex read-only review: no P1/P2 (`/tmp/fleet-artifacts/slam-rs/reviews/s36-10-codex-review.md`).

## Context
Attribution report `/tmp/fleet-artifacts/slam-rs/cuvslam/reports/s36/s36-10-mac-attribution.md` (pablo-dl-server): Mac mini GPU vs CPU lane after this change: MIO10 4.59 vs 4.93 ms (1.07x), MIO07 4.76 vs 5.06 (1.06x), MGO07 5.97 vs 8.48 (1.42x). A cleanup pass over the S36 changes may add commits to this branch before merge.