### PR TITLE
slam-rs: per-host gate baselines, Mac mini and Spark rows, Metal-lane docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,9 @@ linux-64 (pixi 0.70.x) and move back to a public release once the fix ships.
 
 ## Gotchas
 
+- **slam-rs bare Cargo / rust-analyzer bootstrap** — run `pixi run -e slam-rs-dev --frozen slam-rs-patch-deps` once per fresh checkout (`slam-rs-osx-dev` on macOS). Cargo's path override needs the prepared `target/patch/` tree; the Pixi Cargo tasks prepare it automatically. The bump runbook is beside `[patch.crates-io]` in the package's `Cargo.toml`.
+- **slam-rs offline patch tests need their own cache** — from `packages/slam-rs`, run `pixi run -e slam-rs-dev --frozen cargo fetch --locked --manifest-path target/patch/cubecl-common-0.11.0-pre.3/Cargo.toml` once per Cargo home before `slam-rs-patch-test` (`slam-rs-osx-dev` on macOS). The prepared crate resolves standalone; an offline `test-log` miss means this cache is incomplete.
+
 - **Never use pip** — all dependency management goes through Pixi
 - **`hf download` not `huggingface-cli`** — conda's huggingface_hub provides `hf`, not `huggingface-cli`
 - **gradio from PyPI, not conda** — conda's gradio package has missing transitive deps

--- a/packages/slam-rs/README.md
+++ b/packages/slam-rs/README.md
@@ -247,27 +247,30 @@ takes 63 minutes on the fast profile against 81 on the reference. The ten-clip
 gate's hardest clip, `MIO14_moving_props`, reads 9.72 cm on the reference (D71)
 and 6.37 cm on the fast profile.
 
-The same tip on the fleet, fast profile, tracker median in ms for
-`MIO10` / `MIO07` / `MGO07`, one unpinned pass with decode in the same process:
+The fleet's fast-profile tracker medians below are milliseconds for
+`MIO10` / `MIO07` / `MGO07`. Ratios compare GPU with CPU on the same host.
+The 5090 values are the reference rows in `gate.toml`; GB10 and M4 use the
+median of three matched runs per lane from S36. These are different measurement
+sessions, not a cross-machine timing budget.
 
-| device | backend | fast, ms | fast over reference | trajectory against the 5090 |
+| device | backend | GPU vs CPU fast medians, ms | CPU/GPU | ≥1.2x, accuracy in band |
 |---|---|---|---|---|
-| RTX 5090, x86-64 | Vulkan | 2.0 / 2.7 / 3.1 | 2.0x / 1.8x / 2.2x | the baseline |
-| GB10 (Spark), aarch64 | Vulkan | 2.9 / 3.2 / 4.8 | 1.85x / 1.9x / 2.1x | byte-identical, both profiles |
-| RTX 3060, x86-64 | Vulkan | 14.7 / 14.9 / 20.2 | 1.4x / 1.5x / 1.7x | inside the band, last-bit drift |
-| Apple M4 (Mac mini) | Metal | 18.8 / 18.6 / 21.2 | 1.2x / 1.2x / 1.2x | inside the band, within 0.04 cm |
+| RTX 5090, x86-64 | Vulkan | 2.02 / 2.70 / 3.08 vs 5.60 / 5.94 / 9.76 | 2.77x / 2.20x / 3.17x | pass; ten-clip ratios span 2.0–3.2x |
+| GB10 (Spark), aarch64 | Vulkan | 2.88 / 3.07 / 4.75 vs 5.35 / 5.42 / 9.00 | 1.86x / 1.76x / 1.90x | pass |
+| Apple M4 (Mac mini) | Metal | 4.59 / 4.76 / 5.97 vs 4.93 / 5.06 / 8.48 | 1.07x / 1.06x / 1.42x | MIO10 and MIO07 miss; MGO07 passes |
+| RTX 3060, x86-64 | Vulkan | not re-run since the S32 tip; box needs a driver reboot | — | not measured |
 
-Every row tracks every frameset. The 3060 stayed at its idle clock for the run,
-so its numbers are that operating point, not the card's. The Mac is correct and
-slow for a measured reason: a synchronising read costs 7 ms of host time on
-Metal against 0.12 ms on the 5090, and the frontend makes two a frameset. The
-Pi 5 and the RK3588 cap have not run this tip.
+The Metal lane's two sleeps are fixed: wgpu 30 replaces the HAL's 1 ms
+completion polling, and our CubeCL patch parks and wakes the idle device
+worker. The upload copy fix also ships. The Mac's two-camera clips still need
+about 0.5 ms less tracker time to meet the 1.2x margin. MIO14's unchanged Mac
+ATE is checked against its own host row. Passing that regression gate does not
+establish the GPU/CPU speed margin.
 
-Historical design notes — the portability table and the fleet
-numbers with the Metal diagnosis:
-[the portable lane](docs/design-notes.md#the-portable-lane-and-the-two-silent-failures),
-[where it runs](docs/design-notes.md#where-the-portable-lane-runs),
-[the fast profile across the fleet](docs/design-notes.md#the-fast-profile-across-the-fleet).
+See [S36 — the Metal lane's two sleeps](docs/design-notes.md#s36--the-metal-lanes-two-sleeps)
+for the reports, measured budget, rejected experiments and remaining work.
+The [S32 fleet table](docs/design-notes.md#the-fast-profile-across-the-fleet)
+remains as historical evidence.
 
 ## Tests and gates
 
@@ -301,7 +304,8 @@ consistency, exported clocks, and the smoke gate.
 The ground-truth gate requires zero lost framesets, at least
 `MIN_ASSOCIATED_POSES` estimate poses associated with ground truth, finite
 measurements, and an estimated extent no greater than `DIVERGENCE_FACTOR`
-times the truth's extent. With a matching baseline, RMSE must be at most
+times the truth's extent. The gate prefers a baseline for the host, lane and profile; if absent, it uses
+the first row for that lane/profile. With that baseline, RMSE must be at most
 `1.10 * baseline.gt_rmse_cm`. A missing lane/profile baseline prints "no baseline"
 and leaves accuracy ungated; tracking and validity clauses still apply.
 
@@ -322,15 +326,41 @@ The tiers are `smoke` (MIO10, MGO09), `release` (MIO07, MGO07, MIO14), and
 `listed` (the other five). The two hold-out flags remain excluded from tuning.
 The historical design notes are retained separately in `docs/design-notes.md`.
 
+### Patched dependencies
+
+`slam-rs-patch-deps` verifies the CubeCL archive SHA256, applies the checked-in
+channel park patch into `target/patch/`, and checks the prepared files on reuse.
+A process lock makes concurrent preparation safe. Cargo consumes that tree
+through `[patch.crates-io]`; the Pixi Cargo tasks prepare it first.
+
+Bare Cargo and rust-analyzer need this once per fresh checkout:
+
+```bash
+pixi run -e slam-rs-dev --frozen slam-rs-patch-deps
+# macOS: use -e slam-rs-osx-dev
+```
+
+`slam-rs-patch-test` resolves the prepared crate as a standalone package and
+runs offline. Fill each Cargo home's cache once from the package directory:
+
+```bash
+pixi run -e slam-rs-dev --frozen cargo fetch --locked --manifest-path target/patch/cubecl-common-0.11.0-pre.3/Cargo.toml
+pixi run -e slam-rs-dev --frozen slam-rs-patch-test
+```
+
+Use `slam-rs-osx-dev` on macOS. A missing `test-log` offline error means that
+cache is incomplete. The version-bump runbook is beside `[patch.crates-io]`
+in `Cargo.toml`.
+
 ## What is next
 
 Not in this branch, in the order they are likely to matter:
 
-- **Metal.** The M4 runs the lane correctly and pays 7 ms per synchronising read
-  and ten times the 5090's device time per kernel. The fix is a lower-latency
-  completion path in the read routine, gated to Metal, and per-adapter workgroup
-  shapes chosen at start-up; the 5090 A/B harness stays the gate, so that path
-  is untouched.
+- **Metal.** Close the two-camera 1.2x gap. Measure persistent staging and
+  in-place `ComputeClient::write` uploads, then the cold read hand-off. A
+  SIMD-local KLT reduction redesign is a later option; changed reduction order
+  must pass accuracy gates on every lane. Four KLT iterations and a simple
+  32-thread mapping were tested and rejected.
 - **A second core.** One core was the rule for this branch. The between-keyframes
   solve and the frontend's host work are independent enough to overlap.
 - **The Python seam.** 0.14 ms a frameset between the feed and `Vio.track`,

--- a/packages/slam-rs/docs/design-notes.md
+++ b/packages/slam-rs/docs/design-notes.md
@@ -427,19 +427,135 @@ idle clock (P8, 210 MHz) for the whole run, so its absolute numbers are that
 operating point, not the card's. The Pi 5 and the RK3588 cap have not run this
 tip: both were unreachable on the day.
 
-**Why the Mac is slow.** Two independent causes, measured on the M4 with the
-seam counters of `gpu/seam.rs` and the device timestamps. A synchronising read
-costs **7.05 ms** of host time on Metal — the slope over 0, 1, 2 and 4 empty
-four-byte reads a frameset — against 0.115 ms on the 5090, and the frontend
-makes two a frameset, so about 14 of the Mac's 19 ms is completion latency in
-`cubecl-wgpu`'s read path (flush, map a staging buffer, wake the poll thread,
-wait on its callback). Independently, the kernels run **4.31 ms** of device time
-a frameset against 0.44 on the 5090 (KLT 425 µs a launch against 49, the FAST
-score 293 against 12.5): the workgroup shapes were chosen on NVIDIA. Uploads are
-1.4 ms. The task ceiling has no effect from 1 to 64. What a fix would have to
-do: a lower-latency completion path gated to Metal, and per-adapter workgroup
-shapes chosen from the device properties at start-up, so the 5090's path stays
-untouched; the 5090 A/B harness remains the gate. Neither is started.
+**Why the Mac is slow (S32 diagnosis).** The original empty-read and serialized
+kernel probes found a large completion delay. They did not establish a fast
+replay budget or prove that workgroup width caused the remaining cost.
+[S36 below](#s36--the-metal-lanes-two-sleeps) identifies the two sleeps,
+records their fixes, and replaces that budget with same-run measurements.
+
+## S36 — the Metal lane's two sleeps
+
+The Metal lane started near 18.8 / 18.7 / 21.3 ms on fast MIO10 / MIO07 /
+MGO07. Two independent sleeps caused most of the delay. wgpu-hal 29's Metal
+`wait` polled command-buffer status with a 1 ms sleep. wgpu 30 fixes that
+upstream (gfx-rs/wgpu#9328), reached here through CubeCL 0.11.0-pre.3.
+CubeCL's device-channel worker also idled with a 150 µs `nanosleep`.
+Across 1,000 measurements, macOS stretched it to 1.36 ms; Linux took about
+0.2 ms. A cold batch hand-off paid that delay, not every individual enqueue.
+Our worker patch uses park/unpark with a 10 ms safety timeout. The timeout
+also bounds teardown when the last client drops. Source and timing evidence:
+[s36-3-backoff.md](/tmp/fleet-artifacts/slam-rs/cuvslam/reports/s36/s36-3-backoff.md)
+and the corrections in
+[s36-8-validate-claims.md](/tmp/fleet-artifacts/slam-rs/cuvslam/reports/s36/s36-8-validate-claims.md).
+
+### How the fix ships
+
+`patches/cubecl-common-0.11.0-pre.3-channel-park.patch` is applied to a
+checksummed registry archive by `slam-rs-patch-deps`. Cargo's
+`[patch.crates-io]` selects the prepared tree under `target/patch/`.
+Preparation takes a process lock, verifies the archive hash even for cached
+downloads, and checks prepared files on reuse. Changed files cause repair.
+The Cargo tasks depend on preparation; the GPU test task also builds the
+Python extension so it cannot test a stale core. Bare Cargo and rust-analyzer
+need the prepare task once per checkout. The standalone offline patch test
+needs `cargo fetch --locked` for its manifest once per Cargo home, including
+its `test-log` test dependency. The bump runbook is the comment beside the
+Cargo override.
+
+Pablo chose a small checked-in patch, following the brush precedent, rather
+than a maintained fork, an upstream worker PR, or a vendored crate. The
+worker fix is not upstream at this decision point. This choice does not claim
+that Pixi cannot apply source patches: its tasks can, and rattler-build has
+recipe patches. Cargo still needs its own source override. Moving this
+package to pixi-build would be a separate workflow change.
+See [s36-6-patch-wiring.md](/tmp/fleet-artifacts/slam-rs/cuvslam/reports/s36/s36-6-patch-wiring.md)
+and [s36-9-wiring-hardening.md](/tmp/fleet-artifacts/slam-rs/cuvslam/reports/s36/s36-9-wiring-hardening.md).
+
+### Matched results and the rule
+
+The fixes, including PR #268's upload copy, are on main `8a2e9408`.
+The M4 and GB10 cells below are medians of three matched run medians per lane.
+Clip order is MIO10 / MIO07 / MGO07; time is tracker-call milliseconds.
+
+| host/device | GPU fast | CPU fast | CPU/GPU | ≥1.2x |
+|---|---|---|---|---|
+| Mac mini M4, Metal | 4.59 / 4.76 / 5.97 | 4.93 / 5.06 / 8.48 | 1.07x / 1.06x / 1.42x | fail / fail / pass |
+| Spark GB10, Vulkan | 2.88 / 3.07 / 4.75 | 5.35 / 5.42 / 9.00 | 1.86x / 1.76x / 1.90x | pass / pass / pass |
+
+The 5090's ten `gate.toml` reference rows span 2.0–3.2x against its own CPU
+lane. The 3060 has not been re-run since S32; its box needs a driver reboot.
+5090 trajectories stayed byte-identical throughout S36, and the park patch
+removed the stereo-stage regression from the compiler bump. These facts do
+not turn the historical MIO07 cuVSLAM absolute speed miss into a pass.
+Sources: the final Mac table in
+[s36-10-mac-attribution.md](/tmp/fleet-artifacts/slam-rs/cuvslam/reports/s36/s36-10-mac-attribution.md),
+[s36-11-gb10-coverage.md](/tmp/fleet-artifacts/slam-rs/cuvslam/reports/s36/s36-11-gb10-coverage.md),
+and S36-8 sections C and E3. Those reports retain their original publication
+status; the merge happened later.
+
+D64's rule is accuracy inside the band and faster than the CPU lane on the
+same machine; it did not specify 1.2x. Pablo's 2026-09-11 acceptance margin
+makes that at least 1.2x, with 1.5x retained as a research goal. These matched
+GPU/CPU comparisons are separate from the 1.10x regression limits in the
+manifest. The Mac's two-camera clips need another 0.486 / 0.543 ms to reach
+1.2x; MGO07 already meets it. A passing fleet regression row alone does not
+prove this speedup requirement.
+
+### The remaining budget
+
+Use real frames from the same run. S36-10 measured a 4.66 ms frontend:
+about 4.0 ms in reads, 0.57 ms in uploads, and 0.05 ms in host bookkeeping.
+About 2.2 ms of GPU compute sits inside those read spans. The rest includes
+readiness, transfer and scheduling; it is not all removable overhead.
+PR #268 reduced caller upload time to about 0.21 ms. The estimator median is
+about 0.15 ms, with a 0.87 ms mean because full window solves occupy the tail.
+These rounded medians describe the scale; only per-frame exclusive sums
+form an exact budget. Nested worker and GPU spans must not be added twice.
+
+S36-8 corrected the earlier subtraction of a default-config kernel fixture
+from a fast catalog replay. Never subtract across rigs, configurations or
+separate timing harnesses. The outer CubeCL profile token also missed later
+passes; the corrected probe sums every pass without forcing per-kernel sync.
+A 64-thread KLT group does not establish an occupancy problem on an M4.
+The tested fixture dispatched batches of 67 / 25 / 25 points, not its
+3,000-point capacity. These are latency observations, not GPU-counter proof
+of a bandwidth or occupancy limit.
+
+Four KLT iterations failed accuracy on Mac MIO10 (1.795 cm over 1.708 cm)
+and 5090 MIO14 (8.330 cm over 6.615 cm). A valid 32-thread mapping preserved
+all taps and reduction order, with all 660 paired FlowFrames identical, but
+had no gain: 3.417 vs 3.481 ms in the paired seam. Neither experiment ships.
+
+The open levers and estimates from S36-10 are:
+
+- Persistent staging and in-place `ComputeClient::write` uploads. Worker
+  staging writes cost about 0.4 ms, partly inside reads. Estimated saving is
+  0–0.2 ms, pending a prototype; buffer lifetime and ordering need tests.
+- The cold read hand-off and cached transfer resources. Estimated saving is
+  0–0.3 ms, not the whole loaded read. Temporal results determine stereo work,
+  so merging the two reads needs a design change. Together with uploads,
+  budget 1–2 engineering days to test these paths.
+- SIMD-local KLT reductions, point-major storage and multiple points per
+  group. Budget 2–4 days if the host paths resist improvement. Reduction
+  order changes, so every lane needs accuracy gates. No measured speedup is
+  promised. The rejected 32-thread mapping is not this redesign.
+
+### Baselines belong to a host
+
+`baseline_for(lane, profile, host)` prefers the matching host row, otherwise
+it returns the first row for that lane/profile, or None. Reference rows stay
+first. Accuracy and speed both use the selected row; speed is gated only
+when its host matches. The loader rejects duplicate `(lane, profile, host)`
+keys and accepts distinct hosts. Hypothesis tests cover lookup, fallback,
+report allowances, speed gating and duplicate handling.
+
+Mac MIO14 is 6.7605 cm both before and after S36. The old lookup compared it
+with the 5090's 6.0135 cm, exceeding the 1.10x limit despite no Mac regression.
+The Mac row now supplies its own accuracy reference. This changes the
+reference selection, not the multiplier or the GPU/CPU acceptance rule.
+Five GPU/fast rows each cover Mac mini and Spark smoke/release clips; measured
+hostnames, core hashes, repeat selection and before/after gate outputs are in
+[s36-13-wrapup.md](/tmp/fleet-artifacts/slam-rs/cuvslam/reports/s36/s36-13-wrapup.md).
 
 ## Python API
 
@@ -968,6 +1084,10 @@ The `Dnn` tags in this file and in the README name the project's recorded design
 - **D77** — The GPU frontend waits once per phase and reserves its queue budget before it enqueues (2026-09-10)
 - **D78** — One stage's download carries another's buffers: camera 0's cell selection rides the temporal tracks' read (2026-09-10)
 - **D79** — Eigen's operation order is no longer a requirement: nalgebra and kornia-algebra do the arithmetic where they can; the gate is ATE on the catalog (2026-09-10)
+- **D80** — D64 remains the GPU rule: accuracy inside the band and faster than the CPU lane on the same machine (2026-09-11)
+- **D81** — Prefer a host/lane/profile baseline; fall back to the first lane/profile row, and gate speed only on the selected row's host (2026-09-11)
+- **D82** — Ship the CubeCL worker fix as a checksummed archive plus local patch, prepared under a process lock and selected by Cargo; no maintained fork or upstream worker PR (2026-09-11)
+- **D83** — Require at least 1.2x GPU/CPU speedup on the same machine with accuracy in band; 1.5x is a research goal, separate from the 1.10x regression limits (2026-09-11)
 
 ## D74 — Speed profile
 

--- a/packages/slam-rs/gate.toml
+++ b/packages/slam-rs/gate.toml
@@ -86,7 +86,7 @@ measured_on = "2026-09-11"
 [[segment.baseline]]
 profile = "fast"
 lane = "gpu"
-host = "pablos-Mac-mini.attlocal.net"
+host = "pablos-Mac-mini"
 core_sha256 = "f9e8de94c0d8487be97975aa2ae5074199dee3aeb7ea5686b56648e03ec46697"
 framesets = 412
 gt_rmse_cm = 1.5522034136049176
@@ -137,7 +137,7 @@ measured_on = "2026-09-11"
 [[segment.baseline]]
 profile = "fast"
 lane = "gpu"
-host = "pablos-Mac-mini.attlocal.net"
+host = "pablos-Mac-mini"
 core_sha256 = "f9e8de94c0d8487be97975aa2ae5074199dee3aeb7ea5686b56648e03ec46697"
 framesets = 4095
 gt_rmse_cm = 1.9568602203894594
@@ -219,7 +219,7 @@ measured_on = "2026-09-11"
 [[segment.baseline]]
 profile = "fast"
 lane = "gpu"
-host = "pablos-Mac-mini.attlocal.net"
+host = "pablos-Mac-mini"
 core_sha256 = "f9e8de94c0d8487be97975aa2ae5074199dee3aeb7ea5686b56648e03ec46697"
 framesets = 22117
 gt_rmse_cm = 6.760486560379599
@@ -301,7 +301,7 @@ measured_on = "2026-09-11"
 [[segment.baseline]]
 profile = "fast"
 lane = "gpu"
-host = "pablos-Mac-mini.attlocal.net"
+host = "pablos-Mac-mini"
 core_sha256 = "f9e8de94c0d8487be97975aa2ae5074199dee3aeb7ea5686b56648e03ec46697"
 framesets = 107
 gt_rmse_cm = 0.977432899968199
@@ -352,7 +352,7 @@ measured_on = "2026-09-11"
 [[segment.baseline]]
 profile = "fast"
 lane = "gpu"
-host = "pablos-Mac-mini.attlocal.net"
+host = "pablos-Mac-mini"
 core_sha256 = "f9e8de94c0d8487be97975aa2ae5074199dee3aeb7ea5686b56648e03ec46697"
 framesets = 1596
 gt_rmse_cm = 2.3730025688882708

--- a/packages/slam-rs/gate.toml
+++ b/packages/slam-rs/gate.toml
@@ -83,6 +83,16 @@ gt_rmse_cm = 1.5529520149042326
 median_tracker_ms = 2.6653200038708746
 measured_on = "2026-09-11"
 
+[[segment.baseline]]
+profile = "fast"
+lane = "gpu"
+host = "pablos-Mac-mini.attlocal.net"
+core_sha256 = "f9e8de94c0d8487be97975aa2ae5074199dee3aeb7ea5686b56648e03ec46697"
+framesets = 412
+gt_rmse_cm = 1.5522034136049176
+median_tracker_ms = 4.52908399165608
+measured_on = "2026-09-11"
+
 [[segment]]
 dataset_name = "msd-index"
 segment_id = "msd-index__MIO_others__MIO07_mapping_easy"
@@ -122,6 +132,16 @@ core_sha256 = "1623c1a27566195085de23dfce4079206b196fdce3ab3c25977f5fed2a73fd64"
 framesets = 4095
 gt_rmse_cm = 2.1142785579360597
 median_tracker_ms = 2.792225976008922
+measured_on = "2026-09-11"
+
+[[segment.baseline]]
+profile = "fast"
+lane = "gpu"
+host = "pablos-Mac-mini.attlocal.net"
+core_sha256 = "f9e8de94c0d8487be97975aa2ae5074199dee3aeb7ea5686b56648e03ec46697"
+framesets = 4095
+gt_rmse_cm = 1.9568602203894594
+median_tracker_ms = 4.713709000498056
 measured_on = "2026-09-11"
 
 [[segment]]
@@ -196,6 +216,16 @@ gt_rmse_cm = 6.013535364329924
 median_tracker_ms = 2.8554160380735993
 measured_on = "2026-09-11"
 
+[[segment.baseline]]
+profile = "fast"
+lane = "gpu"
+host = "pablos-Mac-mini.attlocal.net"
+core_sha256 = "f9e8de94c0d8487be97975aa2ae5074199dee3aeb7ea5686b56648e03ec46697"
+framesets = 22117
+gt_rmse_cm = 6.760486560379599
+median_tracker_ms = 4.754333000164479
+measured_on = "2026-09-11"
+
 [[segment]]
 dataset_name = "msd-index"
 segment_id = "msd-index__MIPT_thrill_of_the_fight__MIPT03_thrillofthefight_fight_2"
@@ -268,6 +298,16 @@ gt_rmse_cm = 0.9776211447928401
 median_tracker_ms = 4.472988017369062
 measured_on = "2026-09-11"
 
+[[segment.baseline]]
+profile = "fast"
+lane = "gpu"
+host = "pablos-Mac-mini.attlocal.net"
+core_sha256 = "f9e8de94c0d8487be97975aa2ae5074199dee3aeb7ea5686b56648e03ec46697"
+framesets = 107
+gt_rmse_cm = 0.977432899968199
+median_tracker_ms = 5.933708045631647
+measured_on = "2026-09-11"
+
 [[segment]]
 dataset_name = "msd-g2"
 segment_id = "msd-g2__MGO_others__MGO07_mapping_easy"
@@ -307,6 +347,16 @@ core_sha256 = "1623c1a27566195085de23dfce4079206b196fdce3ab3c25977f5fed2a73fd64"
 framesets = 1596
 gt_rmse_cm = 2.3744948975377578
 median_tracker_ms = 4.621212981874123
+measured_on = "2026-09-11"
+
+[[segment.baseline]]
+profile = "fast"
+lane = "gpu"
+host = "pablos-Mac-mini.attlocal.net"
+core_sha256 = "f9e8de94c0d8487be97975aa2ae5074199dee3aeb7ea5686b56648e03ec46697"
+framesets = 1596
+gt_rmse_cm = 2.3730025688882708
+median_tracker_ms = 6.099437508964911
 measured_on = "2026-09-11"
 
 [[segment]]

--- a/packages/slam-rs/gate.toml
+++ b/packages/slam-rs/gate.toml
@@ -73,6 +73,16 @@ gt_rmse_cm = 1.5485685474815554
 median_tracker_ms = 5.595673341304064
 measured_on = "2026-09-10"
 
+[[segment.baseline]]
+profile = "fast"
+lane = "gpu"
+host = "spark-9232"
+core_sha256 = "1623c1a27566195085de23dfce4079206b196fdce3ab3c25977f5fed2a73fd64"
+framesets = 412
+gt_rmse_cm = 1.5529520149042326
+median_tracker_ms = 2.6653200038708746
+measured_on = "2026-09-11"
+
 [[segment]]
 dataset_name = "msd-index"
 segment_id = "msd-index__MIO_others__MIO07_mapping_easy"
@@ -103,6 +113,16 @@ framesets = 4095
 gt_rmse_cm = 2.204437636028058
 median_tracker_ms = 5.943018011748791
 measured_on = "2026-09-10"
+
+[[segment.baseline]]
+profile = "fast"
+lane = "gpu"
+host = "spark-9232"
+core_sha256 = "1623c1a27566195085de23dfce4079206b196fdce3ab3c25977f5fed2a73fd64"
+framesets = 4095
+gt_rmse_cm = 2.1142785579360597
+median_tracker_ms = 2.792225976008922
+measured_on = "2026-09-11"
 
 [[segment]]
 dataset_name = "msd-index"
@@ -166,6 +186,16 @@ gt_rmse_cm = 6.627831893039312
 median_tracker_ms = 5.983363371342421
 measured_on = "2026-09-10"
 
+[[segment.baseline]]
+profile = "fast"
+lane = "gpu"
+host = "spark-9232"
+core_sha256 = "1623c1a27566195085de23dfce4079206b196fdce3ab3c25977f5fed2a73fd64"
+framesets = 22117
+gt_rmse_cm = 6.013535364329924
+median_tracker_ms = 2.8554160380735993
+measured_on = "2026-09-11"
+
 [[segment]]
 dataset_name = "msd-index"
 segment_id = "msd-index__MIPT_thrill_of_the_fight__MIPT03_thrillofthefight_fight_2"
@@ -228,6 +258,16 @@ gt_rmse_cm = 0.9774597452318616
 median_tracker_ms = 10.065324138849974
 measured_on = "2026-09-10"
 
+[[segment.baseline]]
+profile = "fast"
+lane = "gpu"
+host = "spark-9232"
+core_sha256 = "1623c1a27566195085de23dfce4079206b196fdce3ab3c25977f5fed2a73fd64"
+framesets = 107
+gt_rmse_cm = 0.9776211447928401
+median_tracker_ms = 4.472988017369062
+measured_on = "2026-09-11"
+
 [[segment]]
 dataset_name = "msd-g2"
 segment_id = "msd-g2__MGO_others__MGO07_mapping_easy"
@@ -258,6 +298,16 @@ framesets = 1596
 gt_rmse_cm = 2.3729583686544053
 median_tracker_ms = 9.75686265155673
 measured_on = "2026-09-10"
+
+[[segment.baseline]]
+profile = "fast"
+lane = "gpu"
+host = "spark-9232"
+core_sha256 = "1623c1a27566195085de23dfce4079206b196fdce3ab3c25977f5fed2a73fd64"
+framesets = 1596
+gt_rmse_cm = 2.3744948975377578
+median_tracker_ms = 4.621212981874123
+measured_on = "2026-09-11"
 
 [[segment]]
 dataset_name = "msd-g2"

--- a/packages/slam-rs/slam_rs/apis/fleet_check.py
+++ b/packages/slam-rs/slam_rs/apis/fleet_check.py
@@ -62,7 +62,7 @@ class ClipResult:
     @property
     def speed_gated(self) -> bool:
         """Only measurements from the same host, lane, and profile gate speed."""
-        return self.baseline is not None and self.measurement.hostname == self.baseline.host
+        return self.baseline is not None and self.measurement.hostname.split(".")[0] == self.baseline.host
 
     @property
     def failures(self) -> tuple[str, ...]:

--- a/packages/slam-rs/slam_rs/apis/fleet_check.py
+++ b/packages/slam-rs/slam_rs/apis/fleet_check.py
@@ -102,7 +102,8 @@ def measure(
     scoring: ScoringResult = score_trajectory(run.estimate, run.ground_truth)
     against_gt: AteResult | None = scoring.result
     lane: Lane = this_lane(gpu)
-    baseline: Baseline | None = segment.baseline_for(lane, profile)
+    hostname: str = this_machine().hostname
+    baseline: Baseline | None = segment.baseline_for(lane, profile, hostname)
     return ClipResult(
         segment_id=segment.segment_id,
         measurement=Measurement(
@@ -115,7 +116,7 @@ def measure(
             truth_extent_m=extent_m(run.ground_truth),
             poses_finite=nonfinite_position_text(run.estimate) is None,
             median_tracker_ms=run.median_tracker_ms,
-            hostname=this_machine().hostname,
+            hostname=hostname,
             lane=lane,
             profile=profile,
         ),

--- a/packages/slam-rs/slam_rs/machine.py
+++ b/packages/slam-rs/slam_rs/machine.py
@@ -27,7 +27,7 @@ class Machine:
     """The host a row was measured on."""
 
     hostname: str
-    """What the machine calls itself."""
+    """Short host name, without a domain suffix."""
     arch: str
     """``platform.machine()``: the port is built for ``x86_64`` and ``aarch64``."""
     libc: str
@@ -65,7 +65,7 @@ def this_peak_rss_mb() -> float:
 
 def this_machine() -> Machine:
     """What this host is, as a row names it."""
-    return Machine(hostname=platform.node(), arch=platform.machine(), libc=this_libc(), cores=os.cpu_count() or 0)
+    return Machine(hostname=platform.node().split(".")[0], arch=platform.machine(), libc=this_libc(), cores=os.cpu_count() or 0)
 
 
 def this_temperature_c(root: Path = Path("/")) -> float | None:

--- a/packages/slam-rs/slam_rs/reference.py
+++ b/packages/slam-rs/slam_rs/reference.py
@@ -99,7 +99,7 @@ class Baseline:
     lane: Literal["gpu", "cpu"]
     """Execution lane."""
     host: str
-    """Host on which tracker time was measured."""
+    """Short host name on which tracker time was measured (no domain suffix)."""
     core_sha256: str
     """Digest of the measured extension."""
     framesets: int
@@ -135,7 +135,7 @@ class ReferenceSegment:
         reference: Baseline | None = None
         for row in self.baseline:
             if row.lane == lane and row.profile == profile:
-                if row.host == host:
+                if row.host == host.split(".")[0]:
                     return row
                 if reference is None:
                     reference = row
@@ -357,6 +357,8 @@ def load_manifest(path: Path = MANIFEST_PATH) -> ReferenceManifest:
             raise ValueError(f"{where}: unknown dataset {segment.dataset_name!r}")
         baseline_keys: set[tuple[str, str, str]] = set()
         for baseline in segment.baseline:
+            if "." in baseline.host:
+                raise ValueError(f"{where}: [segment.baseline] host {baseline.host!r} must be short (no domain suffix)")
             key: tuple[str, str, str] = (baseline.lane, baseline.profile, baseline.host)
             if key in baseline_keys:
                 raise ValueError(f"{where}: [segment.baseline] duplicate baseline {key}")
@@ -421,6 +423,6 @@ def gate_failures(measurement: Measurement, baseline: Baseline | None) -> list[s
     if baseline is not None:
         if measurement.gt_rmse_cm > GATE_RATIO * baseline.gt_rmse_cm:
             failures.append(f"accuracy: {measurement.gt_rmse_cm:.3f} cm exceeds {GATE_RATIO * baseline.gt_rmse_cm:.3f} cm")
-        if measurement.hostname == baseline.host and measurement.median_tracker_ms > GATE_RATIO * baseline.median_tracker_ms:
+        if measurement.hostname.split(".")[0] == baseline.host and measurement.median_tracker_ms > GATE_RATIO * baseline.median_tracker_ms:
             failures.append(f"speed: {measurement.median_tracker_ms:.3f} ms exceeds {GATE_RATIO * baseline.median_tracker_ms:.3f} ms")
     return failures

--- a/packages/slam-rs/slam_rs/reference.py
+++ b/packages/slam-rs/slam_rs/reference.py
@@ -130,9 +130,16 @@ class ReferenceSegment:
     baseline: tuple[Baseline, ...] = ()
     """Measurements by profile and execution lane."""
 
-    def baseline_for(self, lane: Literal["cpu", "gpu"], profile: Literal["reference", "fast"]) -> Baseline | None:
-        """Return the unique baseline for this execution lane and profile."""
-        return next((row for row in self.baseline if row.lane == lane and row.profile == profile), None)
+    def baseline_for(self, lane: Literal["cpu", "gpu"], profile: Literal["reference", "fast"], host: str) -> Baseline | None:
+        """Prefer this host's row; otherwise use the first row for the lane/profile."""
+        reference: Baseline | None = None
+        for row in self.baseline:
+            if row.lane == lane and row.profile == profile:
+                if row.host == host:
+                    return row
+                if reference is None:
+                    reference = row
+        return reference
 
 
 @serde(type_check=coerce, deny_unknown_fields=True)
@@ -348,9 +355,9 @@ def load_manifest(path: Path = MANIFEST_PATH) -> ReferenceManifest:
         identifiers.add(segment.segment_id)
         if segment.dataset_name not in dataset_names:
             raise ValueError(f"{where}: unknown dataset {segment.dataset_name!r}")
-        baseline_keys: set[tuple[str, str]] = set()
+        baseline_keys: set[tuple[str, str, str]] = set()
         for baseline in segment.baseline:
-            key: tuple[str, str] = (baseline.profile, baseline.lane)
+            key: tuple[str, str, str] = (baseline.lane, baseline.profile, baseline.host)
             if key in baseline_keys:
                 raise ValueError(f"{where}: [segment.baseline] duplicate baseline {key}")
             baseline_keys.add(key)

--- a/packages/slam-rs/tests/test_fleet_check.py
+++ b/packages/slam-rs/tests/test_fleet_check.py
@@ -10,7 +10,8 @@ import pytest
 from slam_rs.apis import fleet_check
 from slam_rs.apis.fleet_check import ClipResult, Config, main, measure
 from slam_rs.catalog_feed import CatalogSegment
-from slam_rs.reference import ReferenceManifest, ReferenceSegment
+from slam_rs.machine import this_machine
+from slam_rs.reference import Baseline, ReferenceManifest, ReferenceSegment
 from slam_rs.tracking import SegmentRun
 from slam_rs.trajectory import Trajectory, shift_clock
 
@@ -45,7 +46,12 @@ def test_scoring_uses_ground_truth_and_rejects_wrong_clock(
     )
     monkeypatch.setattr(fleet_check, "resolve_catalog_segments", lambda sources, **_kwargs: tuple(replace(source, has_ground_truth=True) for source in sources))
     monkeypatch.setattr(fleet_check, "run_segment", lambda *_args, **_kwargs: run)
-    result: ClipResult = measure(manifest, manifest.segments[0])
+    reference: Baseline = manifest.segments[0].baseline[0]
+    host_baseline: Baseline = replace(reference, lane="cpu", profile="fast", host=this_machine().hostname, gt_rmse_cm=3.0)
+    segment: ReferenceSegment = replace(manifest.segments[0], baseline=(replace(host_baseline, host="reference-host"), host_baseline))
+    result: ClipResult = measure(manifest, segment)
+    assert result.baseline == host_baseline
+    assert result.speed_gated
     assert result.measurement.associated == (30 if clock_offset == 0 else 0)
     assert bool(result.failures) == bool(clock_offset)
     output: Path = tmp_path / "new" / "fleet.json"

--- a/packages/slam-rs/tests/test_fleet_check.py
+++ b/packages/slam-rs/tests/test_fleet_check.py
@@ -1,6 +1,7 @@
 """Synthetic scoring tests; no recording or external source is needed."""
 
 import json
+import platform
 from dataclasses import replace
 from pathlib import Path
 
@@ -32,10 +33,12 @@ def test_measure_rejects_mismatched_source_before_replay(
         measure(manifest, segment, source=source)
 
 
+@pytest.mark.parametrize("suffix", ["", ".attlocal.net", ".office.example"])
 @pytest.mark.parametrize("clock_offset", [0, 100_000_000_000])
 def test_scoring_uses_ground_truth_and_rejects_wrong_clock(
-    manifest: ReferenceManifest, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, clock_offset: int
+    manifest: ReferenceManifest, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, clock_offset: int, suffix: str
 ) -> None:
+    monkeypatch.setattr(platform, "node", lambda: f"pablos-Mac-mini{suffix}")
     truth: Trajectory = Trajectory(
         t_ns=np.arange(30, dtype=np.int64) * 10_000_000,
         position_m=np.random.default_rng(7).normal(size=(30, 3)),
@@ -68,6 +71,9 @@ def test_scoring_uses_ground_truth_and_rejects_wrong_clock(
         "gt_allowed_cm", "baseline_gt_rmse_cm", "median_tracker_ms", "speed_gated", "verdict",
     ]
     assert "NaN" not in output.read_text()
+    assert this_machine().hostname == "pablos-Mac-mini"
+    assert result.measurement.hostname == "pablos-Mac-mini"
+    assert json.loads(output.read_text())["machine"]["hostname"] == "pablos-Mac-mini"
     if clock_offset:
         assert json.loads(output.read_text())["clips"][0]["gt_rmse_cm"] is None
     assert json.loads(output.read_text())["config_sha256"] == {manifest.segments[0].dataset_name: "a" * 64}

--- a/packages/slam-rs/tests/test_gate.py
+++ b/packages/slam-rs/tests/test_gate.py
@@ -110,3 +110,21 @@ def test_host_baseline_preferred_with_reference_fallback(manifest: ReferenceMani
     assert result.speed_gated is present
     assert result.baseline_gt_rmse_cm == (30.0 if present else 10.0)
     assert result.gt_allowed_cm == (33.0 if present else 11.0)
+
+
+@pytest.mark.parametrize("suffix", ["", ".attlocal.net", ".office.example"])
+@given(error=st.sampled_from([30.0, 34.0]), cost=st.sampled_from([40.0, 45.0]))
+def test_host_suffix_preserves_baseline_and_gate(
+    manifest: ReferenceManifest, suffix: str, error: float, cost: float
+) -> None:
+    host_row: Baseline = replace(BASELINE, host="pablos-Mac-mini", gt_rmse_cm=30.0, median_tracker_ms=40.0)
+    segment = replace(manifest.segments[0], baseline=(BASELINE, host_row))
+    measurement: Measurement = replace(PASSING, hostname=f"pablos-Mac-mini{suffix}", gt_rmse_cm=error, median_tracker_ms=cost)
+    chosen: Baseline | None = segment.baseline_for("gpu", "fast", measurement.hostname)
+    assert chosen == host_row
+    result: ClipResult = ClipResult(segment.segment_id, measurement, 1.0, 1.0, "0" * 64, None, chosen)
+    assert result.gt_allowed_cm == 33.0
+    assert result.speed_gated
+    failures: list[str] = gate_failures(measurement, chosen)
+    assert any(message.startswith("accuracy:") for message in failures) == (error == 34.0)
+    assert any(message.startswith("speed:") for message in failures) == (cost == 45.0)

--- a/packages/slam-rs/tests/test_gate.py
+++ b/packages/slam-rs/tests/test_gate.py
@@ -7,6 +7,7 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
+from slam_rs.apis.fleet_check import ClipResult
 from slam_rs.reference import Baseline, Measurement, ReferenceManifest, gate_failures
 
 BASELINE: Baseline = Baseline("fast", "gpu", "baseline-host", "0" * 64, 100, 10.0, 20.0, "2026-09-10")
@@ -58,7 +59,7 @@ def test_baseline_resolution_matches_both_lane_and_profile(
 ) -> None:
     segment = replace(manifest.segments[0], baseline=(BASELINE,))
     measurement: Measurement = replace(PASSING, lane=lane, profile=profile, gt_rmse_cm=100.0, median_tracker_ms=100.0)
-    failures: list[str] = gate_failures(measurement, segment.baseline_for(lane, profile))
+    failures: list[str] = gate_failures(measurement, segment.baseline_for(lane, profile, measurement.hostname))
     if lane == "gpu" and profile == "fast":
         assert [message.split(":")[0] for message in failures] == ["accuracy", "speed"]
     else:
@@ -93,3 +94,19 @@ def test_catalog_smoke_gate(manifest: ReferenceManifest) -> None:
 def test_mismatched_baseline_is_a_caller_error(baseline: Baseline) -> None:
     with pytest.raises(ValueError, match=f"baseline {baseline.lane}/{baseline.profile}.*measurement gpu/fast"):
         gate_failures(PASSING, baseline)
+
+
+@given(host=st.text(alphabet="abcdefghijklmnopqrstuvwxyz", min_size=1), present=st.booleans())
+def test_host_baseline_preferred_with_reference_fallback(manifest: ReferenceManifest, host: str, present: bool) -> None:
+    host_row: Baseline = replace(BASELINE, host=host, gt_rmse_cm=30.0, median_tracker_ms=40.0)
+    segment = replace(manifest.segments[0], baseline=(BASELINE, host_row) if present else (BASELINE,))
+    chosen: Baseline | None = segment.baseline_for("gpu", "fast", host)
+    assert chosen == (host_row if present else BASELINE)
+    measurement: Measurement = replace(PASSING, hostname=host, gt_rmse_cm=30.0, median_tracker_ms=100.0)
+    failures: list[str] = gate_failures(measurement, chosen)
+    assert any(message.startswith("accuracy:") for message in failures) is not present
+    assert any(message.startswith("speed:") for message in failures) is present
+    result: ClipResult = ClipResult(segment.segment_id, measurement, 1.0, 1.0, "0" * 64, None, chosen)
+    assert result.speed_gated is present
+    assert result.baseline_gt_rmse_cm == (30.0 if present else 10.0)
+    assert result.gt_allowed_cm == (33.0 if present else 11.0)

--- a/packages/slam-rs/tests/test_reference.py
+++ b/packages/slam-rs/tests/test_reference.py
@@ -295,3 +295,11 @@ def test_gate_refuses_an_unknown_dataset_with_table_and_path(tmp_path: Path) -> 
     broken.write_text(MANIFEST_PATH.read_text().replace('dataset_name = "msd-index"', 'dataset_name = "missing"', 1))
     with pytest.raises(ValueError, match="unknown-dataset.toml.*segment.*missing"):
         load_manifest(broken)
+
+
+@pytest.mark.parametrize("suffix", [".attlocal.net", ".office.example"])
+def test_dotted_baseline_host_is_rejected(tmp_path: Path, suffix: str) -> None:
+    path: Path = tmp_path / "dotted-host.toml"
+    path.write_text(MANIFEST_PATH.read_text().replace('host = "pablo-dl-server"', f'host = "pablo-dl-server{suffix}"', 1))
+    with pytest.raises(ValueError, match=r"dotted-host.toml.*host.*short.*no"):
+        load_manifest(path)

--- a/packages/slam-rs/tests/test_reference.py
+++ b/packages/slam-rs/tests/test_reference.py
@@ -2,10 +2,13 @@
 
 import json
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 from slam_rs import _core, reference
 from slam_rs.reference import (
@@ -245,6 +248,25 @@ def test_duplicate_baseline_is_rejected(tmp_path: Path) -> None:
     path.write_text(text[:end] + "\n" + text[start:end] + text[end:])
     with pytest.raises(ValueError, match="duplicate baseline"):
         load_manifest(path)
+
+
+@given(host=st.text(alphabet="abcdefghijklmnopqrstuvwxyz", min_size=1), duplicate=st.booleans())
+def test_baseline_duplicates_include_host(host: str, duplicate: bool) -> None:
+    text: str = MANIFEST_PATH.read_text()
+    start: int = text.index("[[segment.baseline]]")
+    end: int = text.index("\n[", start + 1)
+    row: str = text[start:end]
+    if not duplicate:
+        row = "\n".join(f'host = "{host}"' if line.startswith("host = ") else line for line in row.splitlines())
+    with TemporaryDirectory() as directory:
+        path: Path = Path(directory) / "hosts.toml"
+        path.write_text(text[:end] + "\n" + row + text[end:])
+        if duplicate:
+            with pytest.raises(ValueError, match="duplicate baseline"):
+                load_manifest(path)
+        else:
+            parsed: ReferenceManifest = load_manifest(path)
+            assert parsed.segments[0].baseline[1].host == host
 
 
 def test_gate_round_trips_through_toml(manifest: ReferenceManifest) -> None:


### PR DESCRIPTION
## What
1. **Per-host baselines.** `baseline_for(lane, profile, host)` prefers the row measured on the running host and falls back to the reference host's row (the 5090). Accuracy and speed both use the chosen row; speed stays gated only when the row's host is the measuring host. Hypothesis tests cover the lookup and the loader's duplicate check (now keyed by lane, profile, host). No change on the 5090.
2. **Rows for the Spark (GB10, Vulkan) and the Mac mini (M4, Metal)**, GPU lane, fast profile, smoke + release tiers (MIO10, MGO09, MIO07, MGO07, MIO14): two passes each, agreeing within 5%, core hash recorded. With the rows in place both hosts pass all five segments with speed gated, including the Mac's MIO14 (6.7605 cm on main before and after this stage; previously judged against the 5090's 6.0135 and falsely red).
3. **Docs.** README fleet table and Metal paragraphs updated to the after-state; design notes gain "S36 — the Metal lane's two sleeps" (causes, the park patch and how it ships, the same-run budget and the validation's corrections, rejected experiments, open levers) and decisions D80–D83; AGENTS.md gains the prepare-task / bare-cargo bootstrap gotcha and the `cargo fetch --locked` note for `slam-rs-patch-test`.

## Numbers (fast profile, tracker median ms, GPU vs same-host CPU)
| host | MIO10 | MIO07 | MGO07 | ratio |
|---|---|---|---|---|
| RTX 5090 (Vulkan) | 2.0 / 5.6 | 2.7 / 5.9 | 3.1 / 9.8 | 2.2–3.2x |
| Spark GB10 (Vulkan, arm64) | 2.9 / 5.4 | 3.1 / 5.4 | 4.8 / 9.0 | 1.8–1.9x |
| Mac mini M4 (Metal) | 4.6 / 4.9 | 4.8 / 5.1 | 6.0 / 8.5 | 1.06–1.42x |

## Gates
271 fast tests, lint, typecheck, deadcode, `pixi lock --check`; both hosts' smoke + release tiers pass with the rows. No Rust or Cargo changes. Codex read-only review running; a known item it will confirm: the Mac row's host name is the network-qualified name and should be normalised to the short host name before merge.

Report: `/tmp/fleet-artifacts/slam-rs/cuvslam/reports/s36/s36-13-wrapup.md` on pablo-dl-server.